### PR TITLE
Added ErrorException handler.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,3 +18,7 @@ spl_autoload_register(function($class)
     }
 });
 
+function exception_error_handler($errno, $errstr, $errfile, $errline ) {
+    throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+}
+set_error_handler("exception_error_handler");


### PR DESCRIPTION
Changed errors to exceptions, because:
- This will probably used in a symfony environment (I'm guessing)
- Errors are difficult to handle.
