### PR TITLE
Force empty lock files to contain a JSON object

### DIFF
--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -154,7 +154,7 @@ class InstallCommand
 
     protected function storeLockFile(array $content)
     {
-        file_put_contents('composer.lock', json_encode($content)."\n");
+        file_put_contents('composer.lock', json_encode($content, JSON_FORCE_OBJECT)."\n");
         echo '> composer.lock dumped'.PHP_EOL;
     }
 }


### PR DESCRIPTION
By default it will make it an array, since PHP does not distinguish between
arrays and hash(map)s.
