### PR TITLE
Downloader interface refactoring

### DIFF
--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -75,6 +75,41 @@ class DownloadManager
     }
 
     /**
+     * Returns downloader for already installed package.
+     *
+     * @param   PackageInterface    $package    package instance
+     *
+     * @return  DownloaderInterface
+     *
+     * @throws  InvalidArgumentException        if package has no installation source specified
+     * @throws  LogicException                  if specific downloader used to load package with
+     *                                          wrong type
+     */
+    public function getDownloaderForInstalledPackage(PackageInterface $package)
+    {
+        $installationSource = $package->getInstallationSource();
+
+        if ('dist' === $installationSource) {
+            $downloader = $this->getDownloader($package->getDistType());
+        } elseif ('source' === $installationSource) {
+            $downloader = $this->getDownloader($package->getSourceType());
+        } else {
+            throw new \InvalidArgumentException(
+                'Package '.$package.' seems not been installed properly'
+            );
+        }
+
+        if ($installationSource !== $downloader->getInstallationSource()) {
+            throw new \LogicException(sprintf(
+                'Downloader "%s" is a %s type downloader and can not be used to download %s',
+                get_class($downloader), $downloader->getInstallationSource(), $installationSource
+            ));
+        }
+
+        return $downloader;
+    }
+
+    /**
      * Downloads package into target dir.
      *
      * @param   PackageInterface    $package        package instance
@@ -90,22 +125,17 @@ class DownloadManager
         $distType     = $package->getDistType();
 
         if (!($preferSource && $sourceType) && $distType) {
-            $downloader = $this->getDownloader($distType);
             $package->setInstallationSource('dist');
-            $downloader->distDownload($package, $targetDir);
-
-            return;
-        }
-
-        if ($sourceType) {
-            $downloader = $this->getDownloader($sourceType);
+        } elseif ($sourceType) {
             $package->setInstallationSource('source');
-            $downloader->sourceDownload($package, $targetDir);
-
-            return;
+        } else {
+            throw new \InvalidArgumentException(
+                'Package '.$package.' should have source or dist specified'
+            );
         }
 
-        throw new \InvalidArgumentException('Package should have dist or source specified');
+        $downloader = $this->getDownloaderForInstalledPackage($package);
+        $downloader->download($package, $targetDir);
     }
 
     /**
@@ -119,15 +149,10 @@ class DownloadManager
      */
     public function update(PackageInterface $initial, PackageInterface $target, $targetDir)
     {
-        if (null === $installationType = $initial->getInstallationSource()) {
-            throw new \InvalidArgumentException(
-                'Package '.$initial.' was not been installed propertly and can not be updated'
-            );
-        }
+        $downloader = $this->getDownloaderForInstalledPackage($initial);
+        $installationSource = $initial->getInstallationSource();
 
-        $useSource = 'source' === $installationType;
-
-        if (!$useSource) {
+        if ('dist' === $installationSource) {
             $initialType = $initial->getDistType();
             $targetType  = $target->getDistType();
         } else {
@@ -135,15 +160,12 @@ class DownloadManager
             $targetType  = $target->getSourceType();
         }
 
-        $downloader = $this->getDownloader($initialType);
-
         if ($initialType === $targetType) {
-            $target->setInstallationSource($installationType);
-            $method = $useSource ? 'sourceUpdate' : 'distUpdate';
-            $downloader->$method($initial, $target, $targetDir);
+            $target->setInstallationSource($installationSource);
+            $downloader->update($initial, $target, $targetDir);
         } else {
             $downloader->remove($initial, $targetDir);
-            $this->download($target, $targetDir, $useSource);
+            $this->download($target, $targetDir, 'source' === $installationSource);
         }
     }
 
@@ -155,14 +177,7 @@ class DownloadManager
      */
     public function remove(PackageInterface $package, $targetDir)
     {
-        if (null === $installationType = $package->getInstallationSource()) {
-            throw new \InvalidArgumentException(
-                'Package '.$package.' was not been installed propertly and can not be removed'
-            );
-        }
-
-        $useSource = 'source' === $installationType;
-        $downloaderType = $useSource ? $package->getSourceType() : $package->getDistType();
-        $this->getDownloader($downloaderType)->remove($package, $targetDir);
+        $downloader = $this->getDownloaderForInstalledPackage($package);
+        $downloader->remove($package, $targetDir);
     }
 }

--- a/src/Composer/Downloader/DownloaderInterface.php
+++ b/src/Composer/Downloader/DownloaderInterface.php
@@ -23,20 +23,19 @@ use Composer\Package\PackageInterface;
 interface DownloaderInterface
 {
     /**
-     * Downloads specific package into specific folder from dist.
+     * Returns installation source (either source or dist).
      *
-     * @param   PackageInterface    $package    package instance
-     * @param   string              $path       download path
+     * @return  string                          "source" or "dist"
      */
-    function distDownload(PackageInterface $package, $path);
+    function getInstallationSource();
 
     /**
-     * Downloads specific package into specific folder from source.
+     * Downloads specific package into specific folder.
      *
      * @param   PackageInterface    $package    package instance
      * @param   string              $path       download path
      */
-    function sourceDownload(PackageInterface $package, $path);
+    function download(PackageInterface $package, $path);
 
     /**
      * Updates specific package in specific folder from initial to target version.
@@ -45,16 +44,7 @@ interface DownloaderInterface
      * @param   PackageInterface    $target     updated package
      * @param   string              $path       download path
      */
-    function distUpdate(PackageInterface $initial, PackageInterface $target, $path);
-
-    /**
-     * Updates specific package in specific folder from initial to target version.
-     *
-     * @param   PackageInterface    $initial    initial package
-     * @param   PackageInterface    $target     updated package
-     * @param   string              $path       download path
-     */
-    function sourceUpdate(PackageInterface $initial, PackageInterface $target, $path);
+    function update(PackageInterface $initial, PackageInterface $target, $path);
 
     /**
      * Removes specific package from specific folder.

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -24,50 +24,19 @@ abstract class FileDownloader implements DownloaderInterface
     /**
      * {@inheritDoc}
      */
-    public function distDownload(PackageInterface $package, $path)
+    public function getInstallationSource()
     {
-        $this->download($package->getDistUrl(), $path, $package->getDistSha1Checksum());
+        return 'dist';
     }
 
     /**
      * {@inheritDoc}
      */
-    public function sourceDownload(PackageInterface $package, $path)
+    public function download(PackageInterface $package, $path)
     {
-        $this->download($package->getSourceUrl(), $path);
-    }
+        $url = $package->getDistUrl();
+        $checksum = $package->getDistSha1Checksum();
 
-    /**
-     * {@inheritDoc}
-     */
-    public function distUpdate(PackageInterface $initial, PackageInterface $target, $path)
-    {
-        $fs = new Util\Filesystem();
-        $fs->remove($path);
-        $this->download($target->getDistUrl(), $path, $target->getDistSha1Checksum());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function sourceUpdate(PackageInterface $initial, PackageInterface $target, $path)
-    {
-        $fs = new Util\Filesystem();
-        $fs->remove($path);
-        $this->download($target->getSourceUrl(), $path);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function remove(PackageInterface $package, $path)
-    {
-        $fs = new Util\Filesystem();
-        $fs->remove($path);
-    }
-
-    public function download($url, $path, $checksum = null)
-    {
         if (!is_dir($path)) {
             if (file_exists($path)) {
                 throw new \UnexpectedValueException($path.' exists and is not a directory');
@@ -110,6 +79,25 @@ abstract class FileDownloader implements DownloaderInterface
             }
             rmdir($contentDir);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function update(PackageInterface $initial, PackageInterface $target, $path)
+    {
+        $fs = new Util\Filesystem();
+        $fs->remove($path);
+        $this->download($target, $path);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function remove(PackageInterface $package, $path)
+    {
+        $fs = new Util\Filesystem();
+        $fs->remove($path);
     }
 
     /**

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -22,17 +22,15 @@ class GitDownloader implements DownloaderInterface
     /**
      * {@inheritDoc}
      */
-    public function distDownload(PackageInterface $package, $path)
+    public function getInstallationSource()
     {
-        $url = escapeshellarg($package->getDistUrl());
-        $ref = escapeshellarg($package->getDistReference());
-        system(sprintf('git archive --format=tar --prefix=%s --remote=%s %s | tar -xf -', $path, $url, $ref));
+        return 'source';
     }
 
     /**
      * {@inheritDoc}
      */
-    public function sourceDownload(PackageInterface $package, $path)
+    public function download(PackageInterface $package, $path)
     {
         if (!$package->getSourceReference()) {
             throw new \InvalidArgumentException('The given package is missing reference information');
@@ -46,15 +44,7 @@ class GitDownloader implements DownloaderInterface
     /**
      * {@inheritDoc}
      */
-    public function distUpdate(PackageInterface $initial, PackageInterface $target, $path)
-    {
-        throw new \Exception('Updating dist installs from git is not implemented yet');
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function sourceUpdate(PackageInterface $initial, PackageInterface $target, $path)
+    public function update(PackageInterface $initial, PackageInterface $target, $path)
     {
         if (!$target->getSourceReference()) {
             throw new \InvalidArgumentException('The given package is missing reference information');


### PR DESCRIPTION
Restricts downloaders to be able to download only one single source type (`dist` or `source`). By doing this, we're able to provide much cleaner and realiable downloaders interface.

Usage of `archive` instead of `clone` is really a url option, rather than specific download type.
