### PR TITLE
Fix missing support for the symfony-bundle package type.

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -27,6 +27,7 @@ $dm->setDownloader('zip',  new Downloader\ZipDownloader());
 // initialize installation manager
 $im = new Installer\InstallationManager();
 $im->setInstaller('library', new Installer\LibraryInstaller('vendor', $dm, $rm->getLocalRepository()));
+$im->setInstaller('symfony-bundle', new Installer\LibraryInstaller('vendor/bundles', $dm, $rm->getLocalRepository()));
 
 // load package
 $loader  = new Package\Loader\JsonLoader();


### PR DESCRIPTION
This PR makes it possibile to use the _symfony-bundle_ package type described in the [documentation of Composer](http://packagist.org/about). As previously discussed on #composer-dev, using `Composer\Installer\LibraryInstaller` to handle the installation of packages that specify the _symfony-bundle_ type is actually just a temporary solution while waiting to better define how packages shipping Symfony bundles should be treated.
