### PR TITLE
Move loader creation to avoid creating it more than once, unified the way

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -43,16 +43,11 @@ class ComposerRepository extends ArrayRepository
             throw new \UnexpectedValueException('Could not parse package list from the '.$this->url.' repository');
         }
 
+        $loader = new ArrayLoader($this->repositoryManager);
         foreach ($packages as $data) {
-            $this->createPackages($data);
-        }
-    }
-
-    private function createPackages($data)
-    {
-        foreach ($data['versions'] as $rev) {
-            $loader = new ArrayLoader($this->repositoryManager);
-            $this->addPackage($loader->load($rev));
+            foreach ($data['versions'] as $rev) {
+                $this->addPackage($loader->load($rev));
+            }
         }
     }
 }

--- a/src/Composer/Repository/GitRepository.php
+++ b/src/Composer/Repository/GitRepository.php
@@ -58,12 +58,7 @@ class GitRepository extends ArrayRepository
             throw new \InvalidArgumentException('Could not find repository at url '.$this->url);
         }
 
-        $this->createPackage($config);
-    }
-
-    protected function createPackage($data)
-    {
         $loader = new ArrayLoader($this->repositoryManager);
-        $this->addPackage($loader->load($data));
+        $this->addPackage($loader->load($config));
     }
 }

--- a/src/Composer/Repository/PackageRepository.php
+++ b/src/Composer/Repository/PackageRepository.php
@@ -47,8 +47,8 @@ class PackageRepository extends ArrayRepository
             $this->config = array($this->config);
         }
 
+        $loader = new ArrayLoader($this->repositoryManager);
         foreach ($this->config as $package) {
-            $loader = new ArrayLoader($this->repositoryManager);
             $package = $loader->load($package);
             $this->addPackage($package);
         }

--- a/src/Composer/Repository/PearRepository.php
+++ b/src/Composer/Repository/PearRepository.php
@@ -57,6 +57,7 @@ class PearRepository extends ArrayRepository
             $packagesXML = $this->requestXml($this->url . $categoryLink);
 
             $packages = $packagesXML->getElementsByTagName('p');
+            $loader = new ArrayLoader($this->repositoryManager);
             foreach ($packages as $package) {
                 $packageName = $package->nodeValue;
 
@@ -101,7 +102,6 @@ class PearRepository extends ArrayRepository
                         }
                     }
 
-                    $loader = new ArrayLoader($this->repositoryManager);
                     $this->addPackage($loader->load($packageData));
                 }
             }


### PR DESCRIPTION
Move loader creation to avoid creating it more than once, unified the way packages are loading across repository classes
