### PR TITLE
Fix the exception "Invalid argument supplied for foreach()"

### DIFF
--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -25,6 +25,7 @@ class Request
     public function __construct(Pool $pool)
     {
         $this->pool = $pool;
+        $this->jobs = array();
     }
 
     public function install($packageName, LinkConstraintInterface $constraint = null)


### PR DESCRIPTION
When the install command is run several times one after the other I get this error. It was thrown because the $jobs attribute of the Request class was null and not an empty array.
