### PR TITLE
AutoloadGenerator.php miscalculates the path

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -111,11 +111,12 @@ EOF;
             foreach ($package->getAutoload() as $type => $mapping) {
                 foreach ($mapping as $namespace => $path) {
                     $autoloads[$type][] = array(
-                        'namespace'   => $namespace,
-                        'path'      => $installPath.'/'.$path,
+                        'namespace' => $namespace,
+                        'path'      => empty($installPath) ? $path : $installPath.'/'.$path,
                     );
                 }
             }
+
         }
 
         foreach ($autoloads as $type => $maps) {


### PR DESCRIPTION
Add tenary check to make sure relative specified paths arent seen as
absolute.

Fixses #94
