### PR TITLE
Rename HelpCommand to AboutCommand

### DIFF
--- a/src/Composer/Command/AboutCommand.php
+++ b/src/Composer/Command/AboutCommand.php
@@ -18,15 +18,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class HelpCommand extends Command
+class AboutCommand extends Command
 {
     protected function configure()
     {
         $this
-            ->setName('help')
-            ->setDescription('')
+            ->setName('about')
+            ->setDescription('Short information about Composer')
             ->setHelp(<<<EOT
-<info>php composer.phar help</info>
+<info>php composer.phar about</info>
 EOT
             )
         ;

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -63,7 +63,7 @@ class Application extends BaseApplication
      */
     protected function registerCommands()
     {
-        $this->add(new Command\HelpCommand());
+        $this->add(new Command\AboutCommand());
         $this->add(new Command\InstallCommand());
         $this->add(new Command\UpdateCommand());
         $this->add(new Command\DebugPackagesCommand());


### PR DESCRIPTION
Because of the native Symfony\Component\Console\Command\HelpCommand it
is not possible to have a custom HelpCommand unless a lot of code is
duplicated. Therefor change the HelpCommand to AboutCommand.
