### PR TITLE
[ZipDowloader] Proper exception usage

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -22,7 +22,7 @@ class ZipDownloader extends FileDownloader
     protected function extract($file, $path)
     {
         if (!class_exists('ZipArchive')) {
-            throw new \UnexpectedValueException('You need the zip extension enabled to use the ZipDownloader');
+            throw new \RuntimeException('You need the zip extension enabled to use the ZipDownloader');
         }
 
         $zipArchive = new \ZipArchive();


### PR DESCRIPTION
Use `RuntimeException` instead of `UnexpectedValueException` when zip extension is not enabled
