### PR TITLE
It is possible to set an "install-dir" option for a package now

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -123,6 +123,11 @@ class LibraryInstaller implements InstallerInterface
      */
     public function getInstallPath(PackageInterface $package)
     {
+        $installDir = $package->getInstallDir();
+        if (isset($installDir))
+        {
+            return $installDir;
+        }
         $targetDir = $package->getTargetDir();
         return ($this->directory ? $this->directory.'/' : '') . $package->getName() . ($targetDir ? '/'.$targetDir : '');
     }

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -27,6 +27,7 @@ abstract class BasePackage implements PackageInterface
     protected $prettyName;
     protected $repository;
     protected $id;
+    protected $installDir;
 
     /**
      * All descendants' constructors should call this parent constructor
@@ -90,6 +91,16 @@ abstract class BasePackage implements PackageInterface
     public function getId()
     {
         return $this->id;
+    }
+
+    public function setInstallDir($dir)
+    {
+        $this->installDir = $dir;
+    }
+
+    public function getInstallDir()
+    {
+        return $this->installDir;
     }
 
     /**

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -53,6 +53,10 @@ class ArrayLoader
             $package->setTargetDir($config['target-dir']);
         }
 
+        if (isset($config['install-dir'])) {
+            $package->setInstallDir($config['install-dir']);
+        }
+
         if (isset($config['repositories'])) {
             $repositories = array();
             foreach ($config['repositories'] as $repoName => $repo) {


### PR DESCRIPTION
I was not satisfied with the target-dir option because you could customize
the path behind the vendor/ directory.

This let's you completely customize the path needed for your custom
package. So you can specify paths directly on top level and are not forced
to install your packages under the vendor/ directory.

Example:

{
    "name": "my-project",
    "version": "1.0.0",
    "repositories": {
        "MyRepo": {
            "package": {
                "name": "mypackage",
                "version": "1.0",
                "install-dir": "lib/src/mypackage"
                "source": {
                    "url": "https://github.com/awesomepackages/mypackage.git",
                    "type": "git",
                    "reference": "some-tag"
                }
            }
        }
    },
    "require": {
        "mypackage" : "1.0"
    }
}
