### PR TITLE
Fixed the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/finder": ">2.0,<2.2-dev",
         "symfony/process": ">2.0,<2.2-dev"
     },
-    "recommends": {
+    "recommend": {
         "ext-zip": "*"
     },
     "autoload": {


### PR DESCRIPTION
`recommends` is not handled by Composer and ignored silently.

Having such an error in Composer itself is very miss-leading.
