### PR TITLE
Added the binary in the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,6 @@
     },
     "autoload": {
         "psr-0": { "Composer": "src/" }
-    }
+    },
+    "bin": ["bin/composer"]
 }


### PR DESCRIPTION
This adds the composer binary in composer.json. Should `bin/compile` be added too ?
