### PR TITLE
Updated lockfile message for "composer install" command

### DIFF
--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -108,7 +108,7 @@ EOT
                 $request->install($link->getTarget(), $link->getConstraint());
             }
         } elseif ($composer->getLocker()->isLocked()) {
-            $output->writeln('<info>Found lockfile. Reading.</info>');
+            $output->writeln('<info>Installing from lockfile.</info> (Run "composer update" to add or update packages)');
 
             foreach ($composer->getLocker()->getLockedPackages() as $package) {
                 $constraint = new VersionConstraint('=', $package->getVersion());


### PR DESCRIPTION
The behaviour of the lockfile was a little confusing to me. I assumed if I added a new dependency I should run 'composer install' again. It was not immediately obvious from the output of the install command what was going on and I was confused why my new package had not been installed.

I understand that a better fix would be to compare composer.json to the lockfile, but until that has been implemented this will maybe help some newbies out.

Changed from:

```
<info>Found lockfile. Reading.</info>
```

... to:

```
<info>Installing from lockfile.</info> (Run "composer update" to add or update packages)
```
