### PR TITLE
pminnieur

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -83,7 +83,7 @@ class ClassLoader
      * Loads the given class or interface.
      *
      * @param string $class The name of the class
-     * @return Boolean True, if loaded
+     * @return Boolean|null True, if loaded
      */
     public function loadClass($class)
     {
@@ -91,8 +91,6 @@ class ClassLoader
             require $file;
             return true;
         }
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
At all, there's not much to say. I just want the `ClassLoader` to be compatible w/ the [`Doctrine\Common\Annotations\AnnotationRegistry`](https://github.com/doctrine/common/blob/master/lib/Doctrine/Common/Annotations/AnnotationRegistry.php#L83) so that it can be used as an annotation class loader. This pull requests enables support.
