### PR TITLE
Provide ability to override namespace paths in development

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -37,6 +37,10 @@ function init() {
 
     $map = require __DIR__.'/autoload_namespaces.php';
 
+    if (file_exists($override = __DIR__.'/autoload_namespaces_override.php')) {
+        $map = array_merge($map, require $override);
+    }
+
     foreach ($map as $namespace => $path) {
         $loader->add($namespace, $path);
     }


### PR DESCRIPTION
Check for the existence of `autoload_namespaces_overrides.php`. The format of this file is identical to `autoload_namespaces.php`. If it exists, it is read in and merged over top of the existing map from `autoload_namespaces.php`.

This would allow for easy testing against local code to test changes before the local code is committed and pushed to upstream repositories.
### Example

Your project has a dependency on Yaml. Yaml needs some new functionality or it has a bug and you've fixed it in your local copy checked out somewhere else in your development environment. You don't want to check the code in and push upstream just to see if your composer project now works. You also don't want to tweak `composer.json` just for testing purposes.

With this PR, you create `vendor/.composer/autoload_namespaces_overrides.php` with the following content:

``` php
<?php
return array(
    'Symfony\\Component\\Yaml' => '/home/deveuser/sf2-components/Yaml',
)
```

The can see the local code works. You can feel confident in pushing the code to the repository and you can then safely do a `composer update` to get the changes the usual way.
