### PR TITLE
After mesage "Installing dependencies" composer dies silently.

### DIFF
--- a/src/Composer/DependencyResolver/RuleSet.php
+++ b/src/Composer/DependencyResolver/RuleSet.php
@@ -55,7 +55,7 @@ class RuleSet implements \IteratorAggregate, \Countable
     public function add(Rule $rule, $type)
     {
         if (!isset(self::$types[$type])) {
-            throw OutOfBoundsException('Unknown rule type: ' . $type);
+            throw new \OutOfBoundsException('Unknown rule type: ' . $type);
         }
 
         if (!isset($this->rules[$type])) {

--- a/src/Composer/DependencyResolver/RuleSetIterator.php
+++ b/src/Composer/DependencyResolver/RuleSetIterator.php
@@ -88,6 +88,7 @@ class RuleSetIterator implements \Iterator
 
     public function valid()
     {
-        return isset($this->rules[$this->currentType][$this->currentOffset]);
+        return isset($this->rules[$this->currentType])
+               && isset($this->rules[$this->currentType][$this->currentOffset]);
     }
 }


### PR DESCRIPTION
Just tried composer to get a fresh symfony2. When going with [this composer.json](https://github.com/KnpLabs/symfony-with-composer/blob/c2af6e783c1c44e08da4727f36cf5ab558a6554f/composer.json) after running 
`php composer.phar install`
it just writes "Installing dependencies" and do nothing.

When i remove 

<pre>
        "symfony/assetic-bundle": "*",
        "sensio/generator-bundle": "2.0.*",
        "sensio/framework-extra-bundle": "2.0.*",
        "sensio/distribution-bundle": "2.0.*",
        "jms/security-extra-bundle": "1.0.*"
</pre>

everything going fine.

Found that php is just silently failing after going to [this foreach](https://github.com/composer/composer/blob/855b1cb9d3cf744aaf0b18e2af4c2e1b8cde9108/src/Composer/DependencyResolver/Solver.php#L1060) .

php: PHP 5.3.2-1ubuntu4.11 with Suhosin-Patch (cli) (built: Dec 13 2011 18:49:27) 
composer: latest from git (126c57d07cdc5d0c749cd5ca0bc691804b5d4bf0)

Attached pull request fixes this error, but i can't reproduce this behavior in tests (they run ok with one incomplete). So maybe it's a bug somewhere else.
