### PR TITLE
Add detect_unicode=0 workaround to shebang

### DIFF
--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -110,7 +110,7 @@ class Compiler
     private function getStub()
     {
         return <<<'EOF'
-#!/usr/bin/env php
+#!/usr/bin/env php -d detect_unicode=0
 <?php
 /*
  * This file is part of Composer.


### PR DESCRIPTION
Since there doesn't appear to be a workaround for https://github.com/composer/composer/issues/85 and it's a _really_ awful bug to run into the first time you try to use composer, it seems like the easiest thing to do is just add this arg to the shebang.

Recompiling the phar with this change fixes the issue for me on OSX. It won't cover the case where someone runs `php composer.phar`, but it works on any global installations.
