### PR TITLE
Restoring FileDownloader constructor compatibility in ZipDownloader

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -14,6 +14,7 @@ namespace Composer\Downloader;
 
 use Composer\Package\PackageInterface;
 use Composer\Util\ProcessExecutor;
+use Composer\IO\IOInterface;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -22,9 +23,10 @@ class ZipDownloader extends FileDownloader
 {
     protected $process;
 
-    public function __construct(ProcessExecutor $process = null)
+    public function __construct(IOInterface $io, $ProcessExecutor $process = null)
     {
         $this->process = $process ?: new ProcessExecutor;
+        parent::__construct($io);
     }
 
     protected function extract($file, $path)


### PR DESCRIPTION
This addresses #221 which was basically fixed by f5ac5b9, but introduced this exception

```
Catchable fatal error: Argument 1 passed to Composer\Downloader\ZipDownloader::__construct() must be an instance of Composer\Util\ProcessExecutor, instance of Composer\IO\ConsoleIO given, called in phar:///usr/local/bin/composer.phar/src/Composer/Factory.php on line 2 and defined in phar:///usr/local/bin/composer.phar/src/Composer/Downloader/ZipDownloader.php on line 2
```

because the constructor is overriden and it's signature has changed.

Please take a detailed look as i couldn't test it. Tried to compile a phar of my changes for testing, but bin/compile tells me to install the dependencies using composer.phar first - but i have only the broken version installed.
