### PR TITLE
PHP 5.3.2 segmentation fault fix

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -937,7 +937,11 @@ class Solver
             $this->installedMap[$package->getId()] = $package;
         }
 
-        $this->decisionMap = new \SplFixedArray($this->pool->getMaxId() + 1);
+        if (version_compare(PHP_VERSION, '5.3.2', '>')) {
+            $this->decisionMap = new \SplFixedArray($this->pool->getMaxId() + 1);
+        } else {
+            $this->decisionMap = array_fill(0, $this->pool->getMaxId() + 1, 0);
+        }
 
         foreach ($this->jobs as $job) {
             switch ($job['cmd']) {


### PR DESCRIPTION
For some reason, using the SqlFixedArray causes a Segmentation Fault during an install or update.  Changing to a simple array fixes this issue, but in turn uses more memory.  Which is why there is the version test.

This is a fix for #211 and has been verified working on a CentOS 5.6 machine running PHP 5.3.2
