### PR TITLE
Fixed detection of hidden password input capability

### DIFF
--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -139,9 +139,8 @@ class ConsoleIO implements IOInterface
         }
 
         // for other OS with shell_exec (hide the answer)
+        $command = "/usr/bin/env bash -c 'echo OK'";
         if (rtrim(shell_exec($command)) === 'OK') {
-            $command = "/usr/bin/env bash -c 'echo OK'";
-
             $this->write($question, false);
 
             $command = "/usr/bin/env bash -c 'read -s mypassword && echo \$mypassword'";


### PR DESCRIPTION
Just a little fix in `ConsoleIO::askAndHideAnswer()` method to correctly detect OSes that support input hiding via bash.
