### PR TITLE
Fallback to include `vendor/.composer/autoload.php` for `bin/composer`

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-if ((!@include __DIR__.'/../vendor/.composer/autoload.php') and (!@include 'vendor/.composer/autoload.php')) {
+if ((!@include __DIR__.'/../../../.composer/autoload.php') and (!@include __DIR__.'/../vendor/.composer/autoload.php')) {
     die('You must set up the project dependencies, run the following commands:
 wget http://getcomposer.org/composer.phar
 php composer.phar install


### PR DESCRIPTION
When Composer is a dependency for a project the `vendor/bin/composer` script will not run as it is looking for `__DIR__.'/../vendor'` which likely will not exist and is in fact incorrect in this situation even if it does. What I believe is intended is for the script to include the packages `vendor/.composer/autoload.php`.

This operates under the assumption that the script will be run from the package root of whatever has Composer as a dependency. I'm not sure how else we could do this, though. As I understand it, `__DIR__`, `__FILE__`, and the like are all realpathed so symlinks will mess it up everytime. In any event, since `bin-dir` can be configured, we cannot guarantee where the bin will be installed anyway.

Long story short, this may not be the best way to handle this but I figure it is a good start. Happy to discuss.
