### PR TITLE
Remove the warning of copy() in FileDownloader

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -104,7 +104,7 @@ abstract class FileDownloader implements DownloaderInterface
         stream_context_set_params($ctx, array("notification" => array($this, 'callbackGet')));
 
         $this->io->overwrite("    Downloading: <comment>connection...</comment>", false);
-        copy($url, $fileName, $ctx);
+        @copy($url, $fileName, $ctx);
         $this->io->overwrite("    Downloading");
 
         if (!file_exists($fileName)) {


### PR DESCRIPTION
Remove the Warning, because the notification is managed in the <code>callbackGet</code> method
