### PR TITLE
Changed 'break' to 'continue 2' in 'update'

### DIFF
--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -93,7 +93,7 @@ EOT
                 foreach ($installedPackages as $package) {
                     if ($package->getName() === $link->getTarget()) {
                         $request->update($package->getName(), new VersionConstraint('=', $package->getVersion()));
-                        break;
+                        continue 2;
                     }
                 }
 


### PR DESCRIPTION
I ran into this while working on #229. I believe that the `break` was causing both both `update()` _and_ `install()` to be called on previously installed packages. I started to run into some errors today on `master` that were resolved by this change.

I could be way off here, I'm not sure what sort of implications this might have. I just know that making this change _looks_ to make sense and actually fixed the problem I was seeing on update.
