### PR TITLE
SplFixedArray issue also affects PHP 5.3.3

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -937,7 +937,7 @@ class Solver
             $this->installedMap[$package->getId()] = $package;
         }
 
-        if (version_compare(PHP_VERSION, '5.3.2', '>')) {
+        if (version_compare(PHP_VERSION, '5.3.3', '>')) {
             $this->decisionMap = new \SplFixedArray($this->pool->getMaxId() + 1);
         } else {
             $this->decisionMap = array_fill(0, $this->pool->getMaxId() + 1, 0);


### PR DESCRIPTION
This is related to #211 - PHP 5.3.3 has the same issue as 5.3.2 when using the SplFixedArray.  I've increased version number check to include 5.3.3.
