### PR TITLE
Fix a small bug where some PEAR channels' category link href doesn't con...

### DIFF
--- a/src/Composer/Repository/PearRepository.php
+++ b/src/Composer/Repository/PearRepository.php
@@ -53,6 +53,9 @@ class PearRepository extends ArrayRepository
         foreach ($categories as $category) {
             $categoryLink = $category->getAttribute("xlink:href");
             $categoryLink = str_replace("info.xml", "packages.xml", $categoryLink);
+            if ($categoryLink[0] != '/') {
+                $categoryLink = '/' . $categoryLink;
+            }
             $packagesXML = $this->requestXml($this->url . $categoryLink);
 
             $packages = $packagesXML->getElementsByTagName('p');


### PR DESCRIPTION
...tain a starting forward slash

Small bug with some Googlecode hosted channels - the category link may not contain a starting forward slash so it creates an invalid URL for the host when Composer tries to append it to the channel URL.
