### PR TITLE
Fix bug on authorization of file download for the private repositories

### DIFF
--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -79,6 +79,7 @@ abstract class VcsDriver
         } else if (null !== $this->io->getLastUsername()) {
             $authStr = base64_encode($this->io->getLastUsername() . ':' . $this->io->getLastPassword());
             $params['http'] = array('header' => "Authorization: Basic $authStr\r\n");
+            $this->io->setAuthorization($this->url, $this->io->getLastUsername(), $this->io->getLastPassword());
         }
 
         $ctx = stream_context_create($params);


### PR DESCRIPTION
When there are multiple private repositories accessible by the same user, the search retrieves the file `composer.json` with the last login/password but does not transfer the authorization to the file download system. Only the login/password of the first private repository is transferred.
