### PR TITLE
Change permission of bin links if they exist and are already links

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -151,7 +151,7 @@ class LibraryInstaller implements InstallerInterface
                     // likely leftover from a previous install, make sure
                     // that the target is still executable in case this
                     // is a fresh install of the vendor.
-                    chmod($link, 0777);
+                    chmod($link, 0755);
                 }
                 $this->io->write('Skipped installation of '.$bin.' for package '.$package->getName().', name conflicts with an existing file');
                 continue;
@@ -162,14 +162,14 @@ class LibraryInstaller implements InstallerInterface
                 // add unixy support for cygwin and similar environments
                 if ('.bat' !== substr($bin, -4)) {
                     file_put_contents($link, $this->generateUnixyProxyCode($bin, $link));
-                    chmod($link, 0777);
+                    chmod($link, 0755);
                     $link .= '.bat';
                 }
                 file_put_contents($link, $this->generateWindowsProxyCode($bin, $link));
             } else {
                 symlink($bin, $link);
             }
-            chmod($link, 0777);
+            chmod($link, 0755);
         }
     }
 


### PR DESCRIPTION
I was noticing that the execute permissions were not sticking when force reinstalling ( `rm -rf vendor composer.lock` ) a projects that had overridden `bin-dir` configuration setting.

Turns out first `composer install` created the link and made the link's target executable. On future runs of install or update, the link already exists so the whole process was skipped. In the case that a fresh zipball (that does not retain file permissions) had been extracted the target of the link was no longer executable.

I'm not sure if `is_link` is appropriate for Windows, but I'm hoping it will just always return false? Open to suggestions for tweaking this further if needed.
