### PR TITLE
[BUG] Fix error when moving up a directory content

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -111,6 +111,13 @@ abstract class FileDownloader implements DownloaderInterface
         $contentDir = glob($path . '/*');
         if (1 === count($contentDir)) {
             $contentDir = $contentDir[0];
+
+            // Rename the content directory to avoid error when moving up
+            // a child folder with the same name
+            $temporaryName = md5(time().rand());
+            rename($contentDir, $temporaryName);
+            $contentDir = $temporaryName;
+
             foreach (array_merge(glob($contentDir . '/.*'), glob($contentDir . '/*')) as $file) {
                 if (trim(basename($file), '.')) {
                     rename($file, $path . '/' . basename($file));


### PR DESCRIPTION
This fixes a bug on downloaded archives when you try to move a folder to its parent which have the same name. For instance, on Unix, you can't do that:

```
$ mv test/test test
mv: test/test and test/test are identical
```

Composer may encounter this problem after having extracted an archive with only one folder (because all its content is moved to the parent).

Manual example with GeSHi library:

```
$ wget http://sourceforge.net/projects/geshi/files/geshi/GeSHi%201.0.8.10/GeSHi-1.0.8.10.zip/download
$ unzip GeSHi-1.0.8.10.zip
$ mv geshi/geshi geshi
mv: geshi/geshi and geshi/geshi are identical
```

Note that the `unzip` command creates here a `geshi` folder, which also contains a `geshi` folder... (Directory Inception).

And with Composer:

``` json
{
    "repositories": {
        "geshi": {
            "package": {
                "name": "geshi/geshi",
                "version": "1.0.8.10",
                "dist": {
                    "url":  "http://sourceforge.net/projects/geshi/files/geshi/GeSHi%201.0.8.10/GeSHi-1.0.8.10.zip/download",
                    "type": "zip"
                }
            }
        }
    },

    "require": {
        "geshi/geshi": "*"
    }
}
```

It results in annoying errors:

```
$ php composer.phar install
Installing dependencies
  - Package geshi/geshi (1.0.8.10)
    Downloading                                                                 
    Unpacking archive
    Cleaning up
PHP Warning:  rename(/private/tmp/test/vendor/geshi/geshi/geshi/geshi,/private/tmp/test/vendor/geshi/geshi/geshi): Directory not empty in phar:///private/tmp/test/composer.phar/src/Composer/Downloader/FileDownloader.php on line 2

Warning: rename(/private/tmp/test/vendor/geshi/geshi/geshi/geshi,/private/tmp/test/vendor/geshi/geshi/geshi): Directory not empty in phar:///private/tmp/test/composer.phar/src/Composer/Downloader/FileDownloader.php on line 2
PHP Warning:  rmdir(/private/tmp/test/vendor/geshi/geshi/geshi): Directory not empty in phar:///private/tmp/test/composer.phar/src/Composer/Downloader/FileDownloader.php on line 2

Warning: rmdir(/private/tmp/test/vendor/geshi/geshi/geshi): Directory not empty in phar:///private/tmp/test/composer.phar/src/Composer/Downloader/FileDownloader.php on line 2

Writing lock file
Generating autoload files
```

Thus, I simply fixed it by renaming the wrapper directory before moving its content. 
