### PR TITLE
Fix installer that create vendor and bin directory even if --dry-run par...

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -53,10 +53,8 @@ class LibraryInstaller implements InstallerInterface
         $this->type = $type;
 
         $this->filesystem = new Filesystem();
-        $this->filesystem->ensureDirectoryExists($vendorDir);
-        $this->filesystem->ensureDirectoryExists($binDir);
-        $this->vendorDir = realpath($vendorDir);
-        $this->binDir = realpath($binDir);
+        $this->vendorDir = rtrim($vendorDir, '/');
+        $this->binDir = rtrim($binDir, '/');
     }
 
     /**
@@ -82,6 +80,9 @@ class LibraryInstaller implements InstallerInterface
     {
         $downloadPath = $this->getInstallPath($package);
 
+        $this->filesystem->ensureDirectoryExists($this->vendorDir);
+        $this->filesystem->ensureDirectoryExists($this->binDir);
+
         // remove the binaries if it appears the package files are missing
         if (!is_readable($downloadPath) && $this->repository->hasPackage($package)) {
             $this->removeBinaries($package);
@@ -104,6 +105,9 @@ class LibraryInstaller implements InstallerInterface
         }
 
         $downloadPath = $this->getInstallPath($initial);
+
+        $this->filesystem->ensureDirectoryExists($this->vendorDir);
+        $this->filesystem->ensureDirectoryExists($this->binDir);
 
         $this->removeBinaries($initial);
         $this->downloadManager->update($initial, $target, $downloadPath);


### PR DESCRIPTION
Fix installer that create vendor and bin directory even if --dry-run parameter provided
- Move directories creation from constructor to "install" and "update" method
- Tests for LibraryInstaller

P.s. Sorry for coding style but i dont really know which one You use :)
