### PR TITLE
Off by one error in the solver - 1 cannot be false

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -1477,7 +1477,7 @@ class Solver
 
                 $l1retry = false;
 
-                if (!$num && !$l1num) {
+                if (!$num && !--$l1num) {
                     // all level 1 literals done
                     break 2;
                 }


### PR DESCRIPTION
Fixes #133, #160, #162, #177, #289
