### PR TITLE
Make mercurial dev-branches updateable

### DIFF
--- a/src/Composer/Repository/Vcs/HgDriver.php
+++ b/src/Composer/Repository/Vcs/HgDriver.php
@@ -130,6 +130,7 @@ class HgDriver extends VcsDriver implements VcsDriverInterface
                     $tags[$match[1]] = $match[2];
                 }
             }
+            unset($tags['tip']);
 
             $this->tags = $tags;
         }


### PR DESCRIPTION
Although the tag "tip" does not provide a valid package version (see VersionParser), the implementation of HgDriver::getSource uses tip as the preferred label for the branch that tip is currently on.

This is not a problem at first hand because you can install a new package correctly with "tip" as source reference.

The problem is that any new revision on that branch won't lead to a new package, because the package will always refer to the same reference "tip".

Therefore you cannot update your project to the new version with "composer update".
