### PR TITLE
Fixed problem with the base path for custom composer file

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -53,8 +53,9 @@ return $__composer_autoload_init();
 EOF;
 
         $filesystem = new Filesystem();
-        $vendorPath = strtr(realpath($installationManager->getVendorPath()), '\\', '/');
-        $relVendorPath = $filesystem->findShortestPath(getcwd(), $vendorPath);
+        $vendorPath = strtr(realpath($installationManager->getVendorPath(true)), '\\', '/');
+        $basePath = $installationManager->getBasePath();
+        $relVendorPath = $filesystem->findShortestPath($basePath, $vendorPath);
         $vendorDirCode = $filesystem->findShortestPathCode(realpath($targetDir), $vendorPath, true);
 
         $namespacesFile = <<<EOF
@@ -71,7 +72,7 @@ EOF;
         $packageMap = $this->buildPackageMap($installationManager, $mainPackage, $localRepo->getPackages());
         $autoloads = $this->parseAutoloads($packageMap);
 
-        $appBaseDir = $filesystem->findShortestPathCode($vendorPath, getcwd(), true);
+        $appBaseDir = $filesystem->findShortestPathCode($vendorPath, $basePath, true);
         $appBaseDir = str_replace('__DIR__', '$vendorDir', $appBaseDir);
 
         if (isset($autoloads['psr-0'])) {

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -49,6 +49,8 @@ class Factory
             throw new \InvalidArgumentException($message.PHP_EOL.$instructions);
         }
 
+        $basePath = dirname($composerFile);
+
         // Configuration defaults
         $composerConfig = array(
             'vendor-dir' => 'vendor',
@@ -100,7 +102,7 @@ class Factory
         $dm = $this->createDownloadManager($io);
 
         // initialize installation manager
-        $im = $this->createInstallationManager($rm, $dm, $vendorDir, $binDir, $io);
+        $im = $this->createInstallationManager($rm, $dm, $vendorDir, $binDir, $basePath, $io);
 
         // init locker
         $lockFile = substr($composerFile, -5) === '.json' ? substr($composerFile, 0, -4).'lock' : $composerFile . '.lock';
@@ -152,9 +154,9 @@ class Factory
         return $dm;
     }
 
-    protected function createInstallationManager(Repository\RepositoryManager $rm, Downloader\DownloadManager $dm, $vendorDir, $binDir, IOInterface $io)
+    protected function createInstallationManager(Repository\RepositoryManager $rm, Downloader\DownloadManager $dm, $vendorDir, $binDir, $basePath, IOInterface $io)
     {
-        $im = new Installer\InstallationManager($vendorDir);
+        $im = new Installer\InstallationManager($vendorDir, $basePath);
         $im->addInstaller(new Installer\LibraryInstaller($vendorDir, $binDir, $dm, $rm->getLocalRepository(), $io, null));
         $im->addInstaller(new Installer\InstallerInstaller($vendorDir, $binDir, $dm, $rm->getLocalRepository(), $io, $im));
 

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -20,7 +20,7 @@ use Composer\Test\TestCase;
 class AutoloadGeneratorTest extends TestCase
 {
     public $vendorDir;
-    private $workingDir;
+    public $workingDir;
     private $im;
     private $repository;
     private $generator;
@@ -35,9 +35,6 @@ class AutoloadGeneratorTest extends TestCase
         $this->vendorDir = $this->workingDir.DIRECTORY_SEPARATOR.'composer-test-autoload';
         $this->ensureDirectoryExistsAndClear($this->vendorDir);
 
-        $this->dir = getcwd();
-        chdir($this->workingDir);
-
         $this->im = $this->getMockBuilder('Composer\Installer\InstallationManager')
             ->disableOriginalConstructor()
             ->getMock();
@@ -50,6 +47,11 @@ class AutoloadGeneratorTest extends TestCase
             ->method('getVendorPath')
             ->will($this->returnCallback(function () use ($that) {
                 return $that->vendorDir;
+            }));
+        $this->im->expects($this->any())
+            ->method('getBasePath')
+            ->will($this->returnCallback(function () use ($that) {
+                return $that->workingDir;
             }));
 
         $this->repository = $this->getMock('Composer\Repository\RepositoryInterface');
@@ -66,7 +68,6 @@ class AutoloadGeneratorTest extends TestCase
         } elseif (is_dir($this->vendorDir)) {
             $this->fs->removeDirectory($this->vendorDir);
         }
-        chdir($this->dir);
     }
 
     public function testMainPackageAutoloading()

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -218,6 +218,12 @@ class InstallationManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('vendor', $manager->getVendorPath());
     }
 
+    public function testGetVendorPathAbsoluteForCustomComposerFile()
+    {
+        $manager = new InstallationManager('vendor2', __DIR__.'/Fixtures/installer-v1');
+        $this->assertEquals(__DIR__.'/Fixtures/installer-v1'.DIRECTORY_SEPARATOR.'vendor2', $manager->getVendorPath(true));
+    }
+
     private function createInstallerMock()
     {
         return $this->getMockBuilder('Composer\Installer\InstallerInterface')


### PR DESCRIPTION
If the COMPOSER env variable is set, then the paths are relative to the current working dir, instead the dir with composer file.

[![Build Status](https://secure.travis-ci.org/hason/composer.png?branch=basepath)](http://travis-ci.org/hason/composer)
