### PR TITLE
Use tag as package version if built off of a tag

### DIFF
--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -41,6 +41,11 @@ class Compiler
         }
         $this->version = trim($process->getOutput());
 
+        $process = new Process('git describe --tags HEAD');
+        if ($process->run() == 0) {
+            $this->version = trim($process->getOutput());
+        }
+
         $phar = new \Phar($pharFile, 0, 'composer.phar');
         $phar->setSignatureAlgorithm(\Phar::SHA1);
 


### PR DESCRIPTION
For example, when `bin/compile` is run when checked out in master, it will use pretty sha like usual. If `bin/compile` is run after `checkout 1.0.0-alpha1`, version becomes **1.0.0-alpha1**.

This will only work for as long as Composer is regularly tagged with non-annotated tags. We'll need to add another check if there is a possibility that we'll have mixed non-annotated/annotated tags.

If you like this and want to try out further enhancements to the package version string, let me know. For Sculpin I updated my compiler to include branch name as well. I can do something similar if this sounds useful to anyone. This is probably only useful if there is a possibility of branch specific releases other than off of master expected. (1.0-dev, 1.1-dev, 1.2-dev, etc.)

> Sculpin version master-dev-59662cb
