### PR TITLE
rm git clone target dir before clone

### DIFF
--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -51,6 +51,7 @@ abstract class VcsDownloader implements DownloaderInterface
         }
 
         $this->io->write("  - Package <info>" . $package->getName() . "</info> (<comment>" . $package->getPrettyVersion() . "</comment>)");
+        $this->filesystem->removeDirectory($path);
         $this->doDownload($package, $path);
         $this->io->write('');
     }


### PR DESCRIPTION
This is a temporary solution to the git clone target "directory exists" problem during succeeding install attempts after first install failure.

It basically just ensures that the target git clone directory is not present before cloning.

This will probably be permanently addressed once issue #363 is fixed.
