### PR TITLE
Simplified & fixed ConsoleIO->overwrite

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -84,8 +84,6 @@ class FileDownloader implements DownloaderInterface
         if ($checksum && hash_file('sha1', $fileName) !== $checksum) {
             throw new \UnexpectedValueException('The checksum verification of the file failed (downloaded from '.$url.')');
         }
-
-        $this->io->write('');
     }
 
     /**

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -98,7 +98,7 @@ class RemoteFilesystem
         $ctx = StreamContextFactory::getContext($options, array('notification' => array($this, 'callbackGet')));
 
         if ($this->progress) {
-            $this->io->overwrite("    Downloading: <comment>connection...</comment>", false);
+            $this->io->write("    Downloading: <comment>connection...</comment>", false);
         }
 
         if (null !== $fileName) {

--- a/tests/Composer/Test/IO/ConsoleIOTest.php
+++ b/tests/Composer/Test/IO/ConsoleIOTest.php
@@ -53,35 +53,35 @@ class ConsoleIOTest extends TestCase
     {
         $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
         $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+
         $outputMock->expects($this->at(0))
             ->method('write')
-            ->with($this->equalTo("\x08"), $this->equalTo(false));
-        $outputMock->expects($this->at(19))
+            ->with($this->equalTo('something (<question>strlen = 23</question>)'));
+        $outputMock->expects($this->at(1))
             ->method('write')
-            ->with($this->equalTo("\x08"), $this->equalTo(false));
-        $outputMock->expects($this->at(20))
+            ->with($this->equalTo(str_repeat("\x08", 23)), $this->equalTo(false));
+        $outputMock->expects($this->at(2))
             ->method('write')
-            ->with($this->equalTo('some information'), $this->equalTo(false));
-        $outputMock->expects($this->at(21))
+            ->with($this->equalTo('shorter (<comment>12</comment>)'), $this->equalTo(false));
+        $outputMock->expects($this->at(3))
             ->method('write')
-            ->with($this->equalTo(' '), $this->equalTo(false));
-        $outputMock->expects($this->at(24))
+            ->with($this->equalTo(str_repeat(' ', 11)), $this->equalTo(false));
+        $outputMock->expects($this->at(4))
             ->method('write')
-            ->with($this->equalTo(' '), $this->equalTo(false));
-        $outputMock->expects($this->at(25))
+            ->with($this->equalTo(str_repeat("\x08", 11)), $this->equalTo(false));
+        $outputMock->expects($this->at(5))
             ->method('write')
-            ->with($this->equalTo("\x08"), $this->equalTo(false));
-        $outputMock->expects($this->at(28))
+            ->with($this->equalTo(str_repeat("\x08", 12)), $this->equalTo(false));
+        $outputMock->expects($this->at(6))
             ->method('write')
-            ->with($this->equalTo("\x08"), $this->equalTo(false));
-        $outputMock->expects($this->at(29))
-            ->method('write')
-            ->with($this->equalTo(''));
+            ->with($this->equalTo('something longer than initial (<info>34</info>)'));
 
         $helperMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
 
         $consoleIO = new ConsoleIO($inputMock, $outputMock, $helperMock);
-        $consoleIO->overwrite('some information', true, 20);
+        $consoleIO->write('something (<question>strlen = 23</question>)');
+        $consoleIO->overwrite('shorter (<comment>12</comment>)', false);
+        $consoleIO->overwrite('something longer than initial (<info>34</info>)');
     }
 
     public function testAsk()


### PR DESCRIPTION
I've been getting garbage output on both linux & windows when composer tried to display downloading progress, so I've fixed ConsoleIO->overwrite. Main points:
- adjusted overwrite() to actually remember and overwrite LAST message as specified in OutputInterface phpDoc (instead of just backspacing 80 chars)
- replaced for loops with str_repeat - easier to read and faster
- strip and don't count <formatting> inside messages when calculating back/white spaces
- account for case when $messages is an array (not used/tested, but may be useful later)
- removed extra blank line when downloading package (between 'Package x/y (v)' and 'Unpacking archive'

Tested on both linux & windows, UnitTests also updated and passing.
