### PR TITLE
Attempt to fix GitHub 404 treated as auth challenges for non-private repos

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -81,7 +81,7 @@ class GitHubDriver extends VcsDriver implements VcsDriverInterface
     public function getComposerInformation($identifier)
     {
         if (!isset($this->infoCache[$identifier])) {
-            $composer = $this->getContents($this->getScheme() . '://raw.github.com/'.$this->owner.'/'.$this->repository.'/'.$identifier.'/composer.json');
+            $composer = $this->getContents($this->getScheme() . '://raw.github.com/'.$this->owner.'/'.$this->repository.'/'.$identifier.'/composer.json', false);
             if (!$composer) {
                 throw new \UnexpectedValueException('Failed to retrieve composer information for identifier '.$identifier.' in '.$this->getUrl());
             }
@@ -89,7 +89,7 @@ class GitHubDriver extends VcsDriver implements VcsDriverInterface
             $composer = JsonFile::parseJson($composer);
 
             if (!isset($composer['time'])) {
-                $commit = json_decode($this->getContents($this->getScheme() . '://api.github.com/repos/'.$this->owner.'/'.$this->repository.'/commits/'.$identifier), true);
+                $commit = json_decode($this->getContents($this->getScheme() . '://api.github.com/repos/'.$this->owner.'/'.$this->repository.'/commits/'.$identifier, false), true);
                 $composer['time'] = $commit['commit']['committer']['date'];
             }
             $this->infoCache[$identifier] = $composer;
@@ -104,7 +104,7 @@ class GitHubDriver extends VcsDriver implements VcsDriverInterface
     public function getTags()
     {
         if (null === $this->tags) {
-            $tagsData = json_decode($this->getContents($this->getScheme() . '://api.github.com/repos/'.$this->owner.'/'.$this->repository.'/tags'), true);
+            $tagsData = json_decode($this->getContents($this->getScheme() . '://api.github.com/repos/'.$this->owner.'/'.$this->repository.'/tags', false), true);
             $this->tags = array();
             foreach ($tagsData as $tag) {
                 $this->tags[$tag['name']] = $tag['commit']['sha'];
@@ -120,7 +120,7 @@ class GitHubDriver extends VcsDriver implements VcsDriverInterface
     public function getBranches()
     {
         if (null === $this->branches) {
-            $branchData = json_decode($this->getContents($this->getScheme() . '://api.github.com/repos/'.$this->owner.'/'.$this->repository.'/branches'), true);
+            $branchData = json_decode($this->getContents($this->getScheme() . '://api.github.com/repos/'.$this->owner.'/'.$this->repository.'/branches', false), true);
             $this->branches = array();
             foreach ($branchData as $branch) {
                 $this->branches[$branch['name']] = $branch['commit']['sha'];

--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -60,12 +60,13 @@ abstract class VcsDriver
      * Get the remote content.
      *
      * @param string $url The URL of content
+     * @param boolean $firstCall Consider this the first call for driver instance?
      *
      * @return mixed The result
      */
-    protected function getContents($url)
+    protected function getContents($url, $firstCall = true)
     {
-        $rfs = new RemoteFilesystem($this->io);
+        $rfs = new RemoteFilesystem($this->io, $firstCall);
         return $rfs->getContents($this->url, $url, false);
     }
 

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -33,10 +33,12 @@ class RemoteFilesystem
      * Constructor.
      *
      * @param IOInterface  $io  The IO instance
+     * @param boolean $firstCall Consider this the first call for driver instance?
      */
-    public function __construct(IOInterface $io)
+    public function __construct(IOInterface $io, $firstCall = true)
     {
         $this->io = $io;
+        $this->firstCall = $firstCall;
     }
 
     /**
@@ -83,9 +85,11 @@ class RemoteFilesystem
      *
      * @throws \RuntimeException When the file could not be downloaded
      */
-    protected function get($originUrl, $fileUrl, $fileName = null, $progress = true, $firstCall = true)
+    protected function get($originUrl, $fileUrl, $fileName = null, $progress = true, $firstCall = null)
     {
-        $this->firstCall = $firstCall;
+        if (null !== $firstCall) {
+            $this->firstCall = $firstCall;
+        }
         $this->bytesMax = 0;
         $this->result = null;
         $this->originUrl = $originUrl;


### PR DESCRIPTION
I don't know if it is really as simple as this, but it appears to work for case where GitHub returns legit 404 for an invalid repository and requests password for private repository and does nothing at all for 404 during parts of discovery process where 404 might be legit (i.e., looking for composer.json in branches that do not have composer.json ).

This solution may be too naive. Anything more than this may require some heavy lifting and trying to understand why `RemoteFilesystem` has to be instantiated for each get request instead of reusing it for all requests for a given instance of a `VcsDriver`.

Refs #411
