### PR TITLE
CRITICAL: Include classmap in phar, only require classmap if it exists.

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -44,9 +44,11 @@ return call_user_func(function() {
         $loader->add($namespace, $path);
     }
 
-    $classMap = require __DIR__.'/autoload_classmap.php';
-    if ($classMap) {
-        $loader->addClassMap($classMap);
+    if (file_exists(__DIR__.'/autoload_classmap.php')) {
+        $classMap = require __DIR__.'/autoload_classmap.php';
+        if ($classMap) {
+            $loader->addClassMap($classMap);
+        }
     }
 
     $loader->register();

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -81,6 +81,7 @@ class Compiler
 
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/ClassLoader.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/autoload.php'));
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/autoload_classmap.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/autoload_namespaces.php'));
         $this->addComposerBin($phar);
 


### PR DESCRIPTION
@lsmith77 reported that composer current ( getcomposer.org/composer.phar ) was not working. Verified. Tracked it down to new classmap changes. Specifically, `autoload_classmap.php` was not included in the phar and the autoloader was requiring it. I've fixed this in two ways, ensure that the classmap is included in the phar (even though this probably isn't required since composer likely will never use it) and check to see if autoload_classmap.php exists before requiring it.

In any event, this should fix the immediate problem of the compiled phar not working.
