### PR TITLE
added error handler for notice and warnings

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -144,8 +144,6 @@ class Application extends BaseApplication
      */
     public function handleError($level, $message, $file, $line, $context = null )
     {
-        throw new \ErrorException('['.$file.'] '.$message.' line '.$line);
-
-        return false;
+        throw new \ErrorException($message, 0, $level, $file, $line);
     }
 }


### PR DESCRIPTION
this PR fixes #225...

it adds a custom `errorHandler` for Notices, Warnings and Deprecatetes and throws an `Exception` instead
