### PR TITLE
Added a branch alias for dev-master.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
     "autoload": {
         "psr-0": { "Composer": "src/" }
     },
-    "bin": ["bin/composer"]
+    "bin": ["bin/composer"],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    }
 }


### PR DESCRIPTION
So projects that depend on Composer can start targeting `1.0-dev` instead of `dev-master` or `*`.
