### PR TITLE
Fix downloading HTTPS dists through Proxy errors

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -102,10 +102,9 @@ class RemoteFilesystem
             $this->io->write("    Downloading: <comment>connection...</comment>", false);
         }
 
+        $result = @file_get_contents($fileUrl, false, $ctx);
         if (null !== $fileName) {
-            $result = @copy($fileUrl, $fileName, $ctx);
-        } else {
-            $result = @file_get_contents($fileUrl, false, $ctx);
+            $result = @file_put_contents($fileName, $result) ? true : false;
         }
 
         // fix for 5.4.0 https://bugs.php.net/bug.php?id=61336


### PR DESCRIPTION
This fixes a problem that didn't allow me to download dists in an environment that was behind a proxy server.

The following **fails**:

``` php
<?php copy($fileUrl, $fileName, $ctx); ?>
```

It gave me:

> failed to open stream: Cannot connect to HTTPS server through proxy

I realized that it wasn't simply "HTTPS through proxy" that was a problem when I remembered that a good chunk of the exploration commands were happening over HTTPS. Only difference was `copy` versus `file_get_contents`.

Not sure why this should matter, but it is difference between working and not in one of my environments. (PHP 5.3.2 bug perhaps?)
