### PR TITLE
Allow unicode characters for author in "composer init" command.

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -33,7 +33,7 @@ class InitCommand extends Command
 
     public function parseAuthorString($author)
     {
-        if (preg_match('/^(?P<name>[- \.,a-z0-9]+) <(?P<email>.+?)>$/i', $author, $match)) {
+        if (preg_match('/^(?P<name>[- \.,\w]+) <(?P<email>.+?)>$/u', $author, $match)) {
             if (!function_exists('filter_var') || $match['email'] === filter_var($match['email'], FILTER_VALIDATE_EMAIL)) {
                 return array(
                     'name'  => trim($match['name']),


### PR DESCRIPTION
The composer.json file accept unicode characters, but the regex validating author string in `init` command is too restrictive.

```
composer init --author="Jérôme <jerome@example.org>"
```

Note: Don't know where I can add tests on it.
