### PR TITLE
[ClassLoader] Optimization: condition that do not belong in a loop

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -180,9 +180,9 @@ class ClassLoader
 
         $classPath .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
 
-        foreach ($this->prefixes as $prefix => $dirs) {
-			if (0 === strpos($class, $prefix)) {
-				foreach ($dirs as $dir) {
+        foreach ($this->prefixes as $prefix => $dirs) {    
+            if (0 === strpos($class, $prefix)) {
+                foreach ($dirs as $dir) {
                     if (file_exists($dir . DIRECTORY_SEPARATOR . $classPath)) {
                         return $dir . DIRECTORY_SEPARATOR . $classPath;
                     }


### PR DESCRIPTION
Why is this foreach outside the condition of verification of the namespace?

Should not it be better that the conditions are outside of this foreach, since these conditions will always return the same result for any item covered by this foreach?

(Note : this PR was copied from the one I made several months ago on the same subject for symfony/symfony#1942)

Cheers
