### PR TITLE
ExtensionInstaller

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -66,10 +66,16 @@ class Factory
         }
 
         $vendorDir = getenv('COMPOSER_VENDOR_DIR') ?: $packageConfig['config']['vendor-dir'];
+
         if (!isset($packageConfig['config']['bin-dir'])) {
             $packageConfig['config']['bin-dir'] = $vendorDir.'/bin';
         }
         $binDir = getenv('COMPOSER_BIN_DIR') ?: $packageConfig['config']['bin-dir'];
+
+        if (!isset($packageConfig['config']['ext-dir'])) {
+            $packageConfig['config']['ext-dir'] = $vendorDir.'/ext';
+        }
+        $extDir = getenv('COMPOSER_EXT_DIR') ?: $packageConfig['config']['ext-dir'];
 
         // setup process timeout
         $processTimeout = getenv('COMPOSER_PROCESS_TIMEOUT') ?: $packageConfig['config']['process-timeout'];
@@ -92,7 +98,7 @@ class Factory
         $dm = $this->createDownloadManager($io);
 
         // initialize installation manager
-        $im = $this->createInstallationManager($rm, $dm, $vendorDir, $binDir, $io);
+        $im = $this->createInstallationManager($rm, $dm, $vendorDir, $binDir, $extDir, $io);
 
         // purge packages if they have been deleted on the filesystem
         $this->purgePackages($rm, $im);
@@ -175,10 +181,11 @@ class Factory
         return $dm;
     }
 
-    protected function createInstallationManager(Repository\RepositoryManager $rm, Downloader\DownloadManager $dm, $vendorDir, $binDir, IOInterface $io)
+    protected function createInstallationManager(Repository\RepositoryManager $rm, Downloader\DownloadManager $dm, $vendorDir, $binDir, $extDir, IOInterface $io)
     {
         $im = new Installer\InstallationManager($vendorDir);
         $im->addInstaller(new Installer\LibraryInstaller($vendorDir, $binDir, $dm, $rm->getLocalRepository(), $io, null));
+        $im->addInstaller(new Installer\ExtensionInstaller($vendorDir, $binDir, $extDir, $dm, $rm->getLocalRepository(), $io));
         $im->addInstaller(new Installer\InstallerInstaller($vendorDir, $binDir, $dm, $rm->getLocalRepository(), $io, $im));
         $im->addInstaller(new Installer\MetapackageInstaller($rm->getLocalRepository(), $io));
 

--- a/src/Composer/Installer/ExtensionInstaller.php
+++ b/src/Composer/Installer/ExtensionInstaller.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Installer;
+
+use Composer\IO\IOInterface;
+use Composer\Downloader\DownloadManager;
+use Composer\Repository\WritableRepositoryInterface;
+use Composer\Package\PackageInterface;
+
+/**
+ * PHP Extension Installer.
+ *
+ * @author Igor Wiedler <igor@wiedler.ch>
+ */
+class ExtensionInstaller extends LibraryInstaller
+{
+    protected $extDir;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct($vendorDir, $binDir, $extDir, DownloadManager $dm, WritableRepositoryInterface $repository, IOInterface $io, $type = 'extension')
+    {
+        parent::__construct($vendorDir, $binDir, $dm, $repository, $io, $type);
+
+        $this->extDir = $extDir;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function install(PackageInterface $package)
+    {
+        parent::install($package);
+
+        $this->compileExtension($package);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function update(PackageInterface $initial, PackageInterface $target)
+    {
+        parent::update($initial, $target);
+
+        $this->cleanExtension($package);
+        $this->compileExtension($package);
+    }
+
+    protected function initializeDirs()
+    {
+        parent::initializeDirs();
+
+        $this->filesystem->ensureDirectoryExists($this->extDir);
+        $this->extDir = realpath($this->extDir);
+    }
+
+    private function compileExtension(PackageInterface $package)
+    {
+        $path = $this->getInstallPath($package);
+        $command = sprintf('cd %s; phpize && ./configure && make', escapeshellarg($path));
+        passthru($command);
+
+        $modulesDir = $this->getInstallPath($package).'/modules';
+        foreach (new \FilesystemIterator($modulesDir) as $file) {
+            copy($file, $this->extDir.'/'.$file->getBasename());
+        }
+    }
+
+    private function cleanExtension(PackageInterface $package)
+    {
+        $path = $this->getInstallPath($package);
+        $command = sprintf('cd %s; make clean', escapeshellarg($path));
+        passthru($command);
+    }
+}

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -32,8 +32,8 @@ class LibraryInstaller implements InstallerInterface
     protected $downloadManager;
     protected $repository;
     protected $io;
-    private $type;
-    private $filesystem;
+    protected $type;
+    protected $filesystem;
 
     /**
      * Initializes library installer.


### PR DESCRIPTION
Add an ExtensionInstaller for installing PHP C extensions from source

This PR simply copies the compiled extensions into `vendor/ext`. You can then set the `extension_dir` directive in php.ini to point to that.

It makes a few assumptions about the extensions' package:
- user has `phpize` and `make` in the `PATH`
- you can cd into the directory and run `phpize && ./configure && make`
- the compiled extensions go into `modules` (afaik standard for php extensions)
## Sample composer.json

```
{
    "repositories": [
        {
            "type": "package",
            "package": {
                "name": "mkoppanen/php-zmq",
                "type": "extension",
                "version": "1.0.0",
                "source": {
                    "url": "https://github.com/mkoppanen/php-zmq",
                    "type": "git",
                    "reference": "master"
                }
            }
        },
        {
            "packagist": false
        }
    ],
    "require": {
        "mkoppanen/php-zmq": "1.0.0"
    }
```
## TODO
- windows support
- docs
- discuss php.ini generation
