### PR TITLE
According to GH API changelog: `master_branch` becomes `default_branch`.

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -216,7 +216,7 @@ class GitHubDriver extends VcsDriver
             }
             try {
                 $repoData = JsonFile::parseJson($this->getContents($repoDataUrl));
-                $this->rootIdentifier = $repoData['master_branch'] ?: 'master';
+                $this->rootIdentifier = $repoData['default_branch'] ?: 'master';
             } catch (TransportException $e) {
                 switch($e->getCode()) {
                     case 401:


### PR DESCRIPTION
After latest changes in GH API every call via composer ends with: `Undefined index: master_branch`
