### PR TITLE
Rule literals are sorted, so first literal added is not first retrieved

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -1352,7 +1352,7 @@ class Solver
             }
 
             // conflict
-            list($newLevel, $newRule, $why) = $this->analyze($level, $rule);
+            list($learnLiteral, $newLevel, $newRule, $why) = $this->analyze($level, $rule);
 
             assert($newLevel > 0);
             assert($newLevel < $level);
@@ -1369,9 +1369,8 @@ class Solver
             $this->watch2OnHighest($newRule);
             $this->addWatchesToRule($newRule);
 
-            $literals = $newRule->getLiterals();
-            $this->addDecision($literals[0], $level);
-            $this->decisionQueue[] = $literals[0];
+            $this->addDecision($learnLiteral, $level);
+            $this->decisionQueue[] = $learnLiteral;
             $this->decisionQueueWhy[] = $newRule;
         }
 
@@ -1437,7 +1436,6 @@ class Solver
 
             $l1retry = true;
             while ($l1retry) {
-
                 $l1retry = false;
 
                 if (!$num && !--$l1num) {
@@ -1483,7 +1481,7 @@ class Solver
         assert($learnedLiterals[0] !== null);
         $newRule = new Rule($learnedLiterals, Rule::RULE_LEARNED, $why);
 
-        return array($ruleLevel, $newRule, $why);
+        return array($learnedLiterals[0], $ruleLevel, $newRule, $why);
     }
 
     private function analyzeUnsolvableRule($problem, $conflictRule, &$lastWeakWhy)
@@ -2029,7 +2027,7 @@ class Solver
     {
         echo "DecisionQueue: \n";
         foreach ($this->decisionQueue as $i => $literal) {
-            echo '    ' . $literal . ' ' . $this->decisionQueueWhy[$i]."\n";
+            echo '    ' . $literal . ' ' . $this->decisionQueueWhy[$i]." level ".$this->decisionMap[$literal->getPackageId()]."\n";
         }
         echo "\n";
     }

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -622,6 +622,33 @@ class SolverTest extends TestCase
         }
     }
 
+    public function testLearnLiteralsWithSortedRuleLiterals()
+    {
+        $this->repo->addPackage($packageTwig2 = $this->getPackage('twig/twig', '2.0'));
+        $this->repo->addPackage($packageTwig16 = $this->getPackage('twig/twig', '1.6'));
+        $this->repo->addPackage($packageTwig15 = $this->getPackage('twig/twig', '1.5'));
+        $this->repo->addPackage($packageSymfony = $this->getPackage('symfony/symfony', '2.0'));
+        $this->repo->addPackage($packageTwigBridge = $this->getPackage('symfony/twig-bridge', '2.0'));
+
+        $packageTwigBridge->setRequires(array(
+            new Link('symfony/twig-bridge', 'twig/twig', $this->getVersionConstraint('<', '2.0'), 'requires'),
+        ));
+
+        $packageSymfony->setReplaces(array(
+            new Link('symfony/symfony', 'symfony/twig-bridge', $this->getVersionConstraint('==', '2.0'), 'replaces'),
+        ));
+
+        $this->reposComplete();
+
+        $this->request->install('symfony/twig-bridge');
+        $this->request->install('twig/twig');
+
+        $this->checkSolverResult(array(
+            array('job' => 'install', 'package' => $packageTwig16),
+            array('job' => 'install', 'package' => $packageTwigBridge),
+        ));
+    }
+
     protected function reposComplete()
     {
         $this->pool->addRepository($this->repoInstalled);


### PR DESCRIPTION
The problem was essentially that after trying twig-bridge with twig/twig dev-master it would realise they are incompatible and try to learn a rule ( - twig/twig-dev-master| - symfony/twig-bridge) - which means they conflict. However we store rule literals sorted for easier comparison so the rule actually ended up being ( - symfony/twig-bridge | - twig/twig-dev-master).

So because of the incorrect order rather than removing twig/twig dev-master and trying with a different version of twig which might work with twig-bridge it decided to remove twig-bridge even though that was the basis for checking twig versions. This double assignment of twig-bridge to be installed & removed triggered the assertion.

Fixes #477
