### PR TITLE
Removed the Symfony2 tests from the phar archive

### DIFF
--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -71,6 +71,7 @@ class Compiler
         $finder->files()
             ->ignoreVCS(true)
             ->name('*.php')
+            ->exclude('Tests')
             ->in(__DIR__.'/../../vendor/symfony/')
             ->in(__DIR__.'/../../vendor/seld/jsonlint/src/')
             ->in(__DIR__.'/../../vendor/justinrainbow/json-schema/src/')


### PR DESCRIPTION
Components' tests are now distributed with the code, making the
archive far bigger if we don't exclude them.
