### PR TITLE
Enable local git repositories

### DIFF
--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -39,7 +39,7 @@ class GitDriver extends VcsDriver
     public function initialize()
     {
         if (static::isLocalUrl($this->url)) {
-            $this->repoDir = $this->url;
+            $this->repoDir = str_replace('file://', '', $this->url);
         } else {
             $this->repoDir = sys_get_temp_dir() . '/composer-' . preg_replace('{[^a-z0-9.]}i', '-', $this->url) . '/';
 


### PR DESCRIPTION
Function proc_open doesn't accept a scheme for the current working directory. Therefor the GitDriver can't work with local repository paths in the from of 'file://*'. As I opened this pull request I saw that igorw already created an issue for it (#348).
