### PR TITLE
Added $this->io to the creation of composer installers

### DIFF
--- a/src/Composer/Installer/InstallerInstaller.php
+++ b/src/Composer/Installer/InstallerInstaller.php
@@ -97,7 +97,7 @@ class InstallerInstaller extends LibraryInstaller
         }
 
         $extra = $package->getExtra();
-        $installer = new $class($this->vendorDir, $this->binDir, $this->downloadManager, $this->repository);
+        $installer = new $class($this->vendorDir, $this->binDir, $this->downloadManager, $this->repository, $this->io);
         $this->installationManager->addInstaller($installer);
     }
 }


### PR DESCRIPTION
Added $this->io to the creation of composer installers to match signature of LibraryInstaller; this will enable users to extend LibraryInstaller and use the same facilities
