### PR TITLE
Implement generate-classmap command

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -49,6 +49,14 @@ return call_user_func(function() {
         $loader->addClassMap($classMap);
     }
 
+    $generatedClassMapPath = __DIR__.'/autoload_generatedclassmap.php';
+    if (true === @is_readable($generatedClassMapPath)) {
+        $generatedClassMap = require $generatedClassMapPath;
+        if ($generatedClassMap) {
+            $loader->addClassMap($generatedClassMap);
+        }
+    }
+
     $loader->register();
 
     return $loader;

--- a/src/Composer/Command/GenerateClassMapCommand.php
+++ b/src/Composer/Command/GenerateClassMapCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Command;
+
+use Composer\Composer;
+use Composer\Autoload\AutoloadGenerator;
+use Composer\Autoload\ClassMapGenerator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Alexander Deruwe <alexander.deruwe@gmail.com>
+ */
+class GenerateClassMapCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('generate-classmap')
+            ->setDescription('Generate complete class map for autoload')
+            ->setHelp(<<<EOT
+The generate-classmap command analyzes your composer.json and
+generates an up-to-date class map for quick autoloading.
+EOT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $composer = $this->getComposer();
+        $dirs = $this->getDirsToBeMapped($composer);
+        $destination = $composer->getInstallationManager()->getVendorPath().'/.composer/autoload_generatedclassmap.php';
+
+        ClassMapGenerator::dump($dirs, $destination);
+    }
+
+    private function getDirsToBeMapped(Composer $composer)
+    {
+        $localRepository = $composer->getRepositoryManager()->getLocalRepository();
+        $generator = new AutoloadGenerator();
+        $packageMap = $generator->buildPackageMap($composer->getInstallationManager(), $composer->getPackage(), $localRepository->getPackages());
+        $autoloads = $generator->parseAutoloads($packageMap);
+        $dirs = array();
+
+        foreach ($autoloads['psr-0'] as $namespace => $destinations) {
+            $dirs = array_merge($dirs, $destinations);
+        }
+
+        return $dirs;
+    }
+}

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -113,6 +113,7 @@ class Application extends BaseApplication
         $this->add(new Command\SearchCommand());
         $this->add(new Command\ValidateCommand());
         $this->add(new Command\ShowCommand());
+        $this->add(new Command\GenerateClassMapCommand());
 
         if ('phar:' === substr(__FILE__, 0, 5)) {
             $this->add(new Command\SelfUpdateCommand());


### PR DESCRIPTION
Command to generate a class map. Should fix #127.
Will be used by autoload.php if present, with psr-0 as fall-back.
