### PR TITLE
Created asset installer, unit tests and updated documentation

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -76,6 +76,10 @@ Out of the box, composer supports two types:
   `symfony/bundle-installer` package, which every bundle would depend on.
   Whenever you install a bundle, it will fetch the installer and register it, in
   order to be able to install the bundle.
+- **asset:** A package of type `asset` will copy the files to the path as
+  provided in the `asset-dir` element of the `extra` section instead of
+  `vendor/package-name`. If the `asset-dir` element is absent it will act
+  identical to the `library` type.
 
 Only use a custom type if you need custom logic during installation. It is
 recommended to omit this field and have it just default to `library`.

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -179,6 +179,7 @@ class Factory
     {
         $im = new Installer\InstallationManager($vendorDir);
         $im->addInstaller(new Installer\LibraryInstaller($vendorDir, $binDir, $dm, $rm->getLocalRepository(), $io, null));
+        $im->addInstaller(new Installer\AssetInstaller($vendorDir, $binDir, $dm, $rm->getLocalRepository(), $io));
         $im->addInstaller(new Installer\InstallerInstaller($vendorDir, $binDir, $dm, $rm->getLocalRepository(), $io, $im));
         $im->addInstaller(new Installer\MetapackageInstaller($rm->getLocalRepository(), $io));
 

--- a/src/Composer/Installer/AssetInstaller.php
+++ b/src/Composer/Installer/AssetInstaller.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Installer;
+
+use Composer\IO\IOInterface;
+use Composer\Downloader\DownloadManager;
+use Composer\Repository\WritableRepositoryInterface;
+use Composer\Package\PackageInterface;
+
+/**
+ * Asset installation manager.
+ *
+ * The asset installation manager functions identical to the LibraryInstaller
+ * with one exception:
+ *
+ *     If the 'extra' section in the package definition contains an element
+ *     'asset-dir' then the installation location will be changed to
+ *     'asset-dir'+TargetDir instead of VendorDir+PackageName+TargetDir.
+ *
+ * Should the asset-dir be omitted then this installer will function and as such
+ * function identical the 'library' type.
+ *
+ * @author Mike van Riel <mike.vanriel@naenius.com>
+ */
+class AssetInstaller extends LibraryInstaller
+{
+    /**
+     * Initializes asset installer.
+     *
+     * @param string                      $vendorDir  relative path for packages home
+     * @param string                      $binDir     relative path for binaries
+     * @param DownloadManager             $dm         download manager
+     * @param WritableRepositoryInterface $repository repository controller
+     * @param IOInterface                 $io         io instance
+     *
+     * @see self::getInstallPath() for the determination of the vendor and bin path.
+     * @see \Composer\Factory::createInstallationManager for the instantiation.
+     */
+    public function __construct(
+        $vendorDir, $binDir, DownloadManager $dm,
+        WritableRepositoryInterface $repository, IOInterface $io
+    ) {
+        parent::__construct($vendorDir, $binDir, $dm, $repository, $io, 'asset');
+    }
+
+    /**
+     * Returns the asset-dir + target dir if asset-dir is provided in the extra.
+     *
+     * @param PackageInterface $package Package instance.
+     *
+     * @return string
+     */
+    public function getInstallPath(PackageInterface $package)
+    {
+        $extra = $package->getExtra();
+        if (isset($extra['asset-dir'])) {
+            $this->vendorDir = $extra['asset-dir'];
+            $this->initializeVendorDir();
+
+            $targetDir = $package->getTargetDir();
+            return ($this->vendorDir ? $this->vendorDir : '')
+                . ($targetDir ? '/' . $targetDir : '');
+        }
+
+        return parent::getInstallPath($package);
+    }
+}

--- a/tests/Composer/Test/Installer/AssetInstallerTest.php
+++ b/tests/Composer/Test/Installer/AssetInstallerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Installer;
+
+use Composer\Installer\AssetInstaller;
+use Composer\DependencyResolver\Operation;
+use Composer\Util\Filesystem;
+use Composer\Test\TestCase;
+
+/**
+ * Asset installation manager test.
+ *
+ * @author Mike van Riel <mike.vanriel@naenius.com>
+ *
+ * @see Composer\Installer\AssetInstaller for a description of the business
+ *     logic in the class description.
+ */
+class AssetInstallerTest extends TestCase
+{
+    private $vendorDir;
+    private $binDir;
+    private $dm;
+    private $repository;
+    private $io;
+    private $fs;
+
+    protected function setUp()
+    {
+        $this->fs = new Filesystem;
+
+        $this->vendorDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'composer-test-vendor';
+        $this->ensureDirectoryExistsAndClear($this->vendorDir);
+
+        $this->binDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'composer-test-bin';
+        $this->ensureDirectoryExistsAndClear($this->binDir);
+
+        $this->dm = $this->getMockBuilder('Composer\Downloader\DownloadManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->repository = $this->getMockBuilder('Composer\Repository\WritableRepositoryInterface')
+            ->getMock();
+
+        $this->io = $this->getMockBuilder('Composer\IO\IOInterface')
+            ->getMock();
+    }
+
+    protected function tearDown()
+    {
+        $this->fs->removeDirectory($this->vendorDir);
+        $this->fs->removeDirectory($this->binDir);
+    }
+
+    public function testGetInstallPath()
+    {
+        $asset_dir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'assets';
+        $extra = array('asset-dir' => $asset_dir);
+
+        $asset = new AssetInstaller($this->vendorDir, $this->binDir, $this->dm, $this->repository, $this->io);
+        $package = $this->createPackageMock();
+
+        $package
+            ->expects($this->exactly(2))
+            ->method('getTargetDir')
+            ->will($this->returnValue(null));
+
+        $package_with_asset_dir = clone $package;
+        $package_with_asset_dir
+            ->expects($this->once())
+            ->method('getExtra')
+            ->will($this->returnValue($extra));
+
+        // if no asset-dir is provided; continue providing default behaviour
+        $this->assertEquals($this->vendorDir.'/'.$package->getName(), $asset->getInstallPath($package));
+
+        // if asset-dir is provided; replace vendor-dir+packagename with asset-dir
+        $this->assertEquals($asset_dir, $asset->getInstallPath($package_with_asset_dir));
+    }
+
+    public function testGetInstallPathWithTargetDir()
+    {
+        $asset_dir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR .'assets';
+        $extra = array('asset-dir' => $asset_dir);
+
+        $asset = new AssetInstaller($this->vendorDir, $this->binDir, $this->dm, $this->repository, $this->io);
+        $package = $this->createPackageMock();
+
+        $package
+            ->expects($this->exactly(2))
+            ->method('getTargetDir')
+            ->will($this->returnValue('Some/Namespace'));
+        $package
+            ->expects($this->any())
+            ->method('getPrettyName')
+            ->will($this->returnValue('foo/bar'));
+
+        $package_with_asset_dir = clone $package;
+        $package_with_asset_dir
+            ->expects($this->once())
+            ->method('getExtra')
+            ->will($this->returnValue($extra));
+
+        // if no asset-dir is provided; continue providing default behaviour
+        $this->assertEquals($this->vendorDir.'/'.$package->getPrettyName().'/Some/Namespace', $asset->getInstallPath($package));
+
+        // if asset-dir is provided; replace vendor-dir+packagename with asset-dir
+        $this->assertEquals($asset_dir . '/Some/Namespace', $asset->getInstallPath($package_with_asset_dir));
+    }
+
+    private function createPackageMock()
+    {
+        return $this->getMockBuilder('Composer\Package\MemoryPackage')
+            ->setConstructorArgs(array(md5(rand()), '1.0.0.0', '1.0.0'))
+            ->getMock();
+    }
+}


### PR DESCRIPTION
Added a new type 'asset' with which you can define a specific location (relative to the composer.json) instead of the vendor-dir+package-name.

Possible vector with which to solve #524.

By adding an element `asset-dir` in the `extra` section of the package definition will the package install itself to a different location. This can be used to, for example, package twitter bootstrap and have it install onto a specific folder (such as /web).

Included in this PR is the source, an update to the documentation and a unit test.
