### PR TITLE
Fix fatal on show command

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -78,7 +78,7 @@ EOT
 
             $this->printMeta($input, $output, $package, $installedRepo, $repos);
             $this->printLinks($input, $output, $package, 'requires');
-            $this->printLinks($input, $output, $package, 'recommends');
+            $this->printLinks($input, $output, $package, 'devRequires');
             $this->printLinks($input, $output, $package, 'replaces');
             return;
         }


### PR DESCRIPTION
"show" command was calling MemoryPackage::getRecommends method which was renamed to getDevRequires.
