### PR TITLE
Share write permission on cached Git repositories on filesystem

### DIFF
--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -45,13 +45,18 @@ class GitDriver extends VcsDriver
 
             // update the repo if it is a valid git repository
             if (is_dir($this->repoDir) && 0 === $this->process->execute('git remote', $output, $this->repoDir)) {
+                $umask = umask(0);
                 $this->process->execute('git remote update --prune origin', $output, $this->repoDir);
+                umask($umask);
             } else {
                 // clean up directory and do a fresh clone into it
                 $fs = new Filesystem();
                 $fs->removeDirectory($this->repoDir);
 
+                $umask = umask(0);
                 $command = sprintf('git clone --mirror %s %s', escapeshellarg($this->url), escapeshellarg($this->repoDir));
+                umask($umask);
+
                 if (0 !== $this->process->execute($command, $output)) {
                     $output = $this->process->getErrorOutput();
 


### PR DESCRIPTION
I'm using satis on a mutualised server. The `satis build` command clones Git repositories into `/tmp/composer-...`
Many users can execute this satis command, but other users cannot write files (chmod is 644).

Currently I have to `sudo rm`cached repositories.

This PR give permissions `-rw-rw-rw-` to repositories.
