### PR TITLE
Add support for PEAR dependency groups

### DIFF
--- a/src/Composer/Repository/PearRepository.php
+++ b/src/Composer/Repository/PearRepository.php
@@ -74,7 +74,7 @@ class PearRepository extends ArrayRepository
                     }
                     $this->addPackage($loader->load($rev));
                     if ($this->io->isVerbose()) {
-                        $this->io->write('Loaded '.$packageData['name'].' '.$packageData['version']);
+                        $this->io->write('Loaded '.$rev['name'].' '.$rev['version']);
                     }
                 }
             }


### PR DESCRIPTION
PEAR package can have different "groups" of dependencies for different set of features.
This PR adds support for groups with creating separate packages for PEAR dependency groups as "packageName-groupName".
