### PR TITLE
Add internal support for multiple default composer repositories.

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -17,6 +17,7 @@ use Composer\Installer;
 use Composer\Installer\ProjectInstaller;
 use Composer\IO\IOInterface;
 use Composer\Repository\ComposerRepository;
+use Composer\Repository\CompositeRepository;
 use Composer\Repository\FilesystemRepository;
 use Composer\Repository\InstalledFilesystemRepository;
 use Symfony\Component\Console\Input\InputArgument;
@@ -85,7 +86,7 @@ EOT
 
         $config = Factory::createConfig();
         if (null === $repositoryUrl) {
-            $sourceRepo = new ComposerRepository(array('url' => 'http://packagist.org'), $io, $config);
+            $sourceRepo = new CompositeRepository(Factory::createComposerRepositories($io, $config));
         } elseif ("json" === pathinfo($repositoryUrl, PATHINFO_EXTENSION)) {
             $sourceRepo = new FilesystemRepository(new JsonFile($repositoryUrl, new RemoteFilesystem($io)));
         } elseif (0 === strpos($repositoryUrl, 'http')) {

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -228,9 +228,9 @@ EOT
 
         // init repos
         if (!$this->repos) {
-            $this->repos = new CompositeRepository(array(
-                new PlatformRepository,
-                new ComposerRepository(array('url' => 'http://packagist.org'), $this->getIO(), Factory::createConfig())
+            $this->repos = new CompositeRepository(array_merge(
+                array(new PlatformRepository),
+                Factory::createComposerRepositories($this->getIO(), Factory::createConfig())
             ));
         }
 

--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -53,10 +53,10 @@ EOT
             $installedRepo = new CompositeRepository(array($localRepo, $platformRepo));
             $repos = new CompositeRepository(array_merge(array($installedRepo), $composer->getRepositoryManager()->getRepositories()));
         } else {
-            $output->writeln('No composer.json found in the current directory, showing packages from packagist.org');
+            $defaultRepos = Factory::createComposerRepositories($this->getIO(), Factory::createConfig());
+            $output->writeln('No composer.json found in the current directory, showing packages from ' . str_replace('http://', '', implode(', ', array_keys($defaultRepos))));
             $installedRepo = $platformRepo;
-            $packagist = new ComposerRepository(array('url' => 'http://packagist.org'), $this->getIO(), Factory::createConfig());
-            $repos = new CompositeRepository(array($installedRepo, $packagist));
+            $repos = new CompositeRepository(array_merge(array($installedRepo), $defaultRepos));
         }
 
         $tokens = $input->getArgument('tokens');

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -64,10 +64,10 @@ EOT
             $installedRepo = new CompositeRepository(array($localRepo, $platformRepo));
             $repos = new CompositeRepository(array_merge(array($installedRepo), $composer->getRepositoryManager()->getRepositories()));
         } else {
-            $output->writeln('No composer.json found in the current directory, showing packages from packagist.org');
+            $defaultRepos = Factory::createComposerRepositories($this->getIO(), Factory::createConfig());
+            $output->writeln('No composer.json found in the current directory, showing packages from ' . str_replace('http://', '', implode(', ', array_keys($defaultRepos))));
             $installedRepo = $platformRepo;
-            $packagist = new ComposerRepository(array('url' => 'http://packagist.org'), $this->getIO(), Factory::createConfig());
-            $repos = new CompositeRepository(array($installedRepo, $packagist));
+            $repos = new CompositeRepository(array_merge(array($installedRepo), $defaultRepos));
         }
 
         // show single package or single version

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Package\Loader;
 
+use Composer\Factory;
 use Composer\Package\Version\VersionParser;
 use Composer\Repository\RepositoryManager;
 
@@ -59,10 +60,14 @@ class RootPackageLoader extends ArrayLoader
             $package->setAliases($aliases);
         }
 
+        $defaultRepositories = array_keys(Factory::$defaultComposerRepositories);
+
         if (isset($config['repositories'])) {
             foreach ($config['repositories'] as $index => $repo) {
-                if (isset($repo['packagist']) && $repo['packagist'] === false) {
-                    continue;
+                foreach ($defaultRepositories as $name) {
+                    if (isset($repo[$name]) && $repo[$name] === false) {
+                        continue 2;
+                    }
                 }
                 if (!is_array($repo)) {
                     throw new \UnexpectedValueException('Repository '.$index.' should be an array, '.gettype($repo).' given');

--- a/tests/Composer/Test/FactoryTest.php
+++ b/tests/Composer/Test/FactoryTest.php
@@ -16,14 +16,31 @@ use Composer\Factory;
 
 class FactoryTest extends \PHPUnit_Framework_TestCase
 {
+    protected $defaultComposerRepositories;
+
+    protected function setUp()
+    {
+        $this->defaultComposerRepositories = Factory::$defaultComposerRepositories;
+    }
+
+    protected function tearDown()
+    {
+        Factory::$defaultComposerRepositories = $this->defaultComposerRepositories;
+        unset($this->defaultComposerRepositories);
+    }
+
     /**
      * @dataProvider dataAddPackagistRepository
      */
-    public function testAddPackagistRepository($expected, $config)
+    public function testAddPackagistRepository($expected, $config, $defaults = null)
     {
+        if (null !== $defaults) {
+            Factory::$defaultComposerRepositories = $defaults;
+        }
+
         $factory = new Factory();
 
-        $ref = new \ReflectionMethod($factory, 'addPackagistRepository');
+        $ref = new \ReflectionMethod($factory, 'addComposerRepositories');
         $ref->setAccessible(true);
 
         $this->assertEquals($expected, $ref->invoke($factory, $config));
@@ -58,6 +75,29 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
                 array('packagist' => true),
                 array('type' => 'pear', 'url' => 'http://pear.composer.org')
             )
+        );
+
+        $multirepo = array(
+            'example.com' => 'http://example.com',
+            'packagist' => 'http://packagist.org',
+        );
+
+        $data[] = array(
+            $f(
+                array('type' => 'composer', 'url' => 'http://example.com'),
+                array('type' => 'composer', 'url' => 'http://packagist.org')
+            ),
+            $f(),
+            $multirepo,
+        );
+
+        $data[] = array(
+            $f(
+                array('type' => 'composer', 'url' => 'http://packagist.org'),
+                array('type' => 'composer', 'url' => 'http://example.com')
+            ),
+            $f(array('packagist' => true)),
+            $multirepo,
         );
 
         return $data;

--- a/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Package\Loader;
+
+use Composer\Package\Loader\RootPackageLoader;
+use Composer\Repository\RepositoryManager;
+
+class RootPackageLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAllowsDisabledDefaultRepository()
+    {
+        $loader = new RootPackageLoader(
+            new RepositoryManager(
+                $this->getMock('Composer\\IO\\IOInterface'),
+                $this->getMock('Composer\\Config')
+            )
+        );
+
+        $repos = array(array('packagist' => false));
+        $package = $loader->load(array('repositories' => $repos));
+
+        $this->assertEquals($repos, $package->getRepositories());
+    }
+}


### PR DESCRIPTION
Bug fix: no
Feature addition: unofficially?
Backwards compatibility break: no
[![Build Status](https://secure.travis-ci.org/dpb587/composer.png?branch=multiple-repos)](http://travis-ci.org/dpb587/composer)

I implemented composer in a corporate environment where we setup a local composer server with some of our internal packages and mirrors, but we did not want the maintenance of a full packagist/satis mirror nor the hassle of explicitly adding our repository to every `composer.json` file we use.

This simplifies the patches we use before we recompile for deployment to our systems and developers. So our only patch would then be adding the following to the top of `bin/composer`:

```
use Composer\Factory;

Factory::$defaultComposerRepositories = array_merge(
    array('example' => 'http://intranet.example.com/composer'),
    Factory::$defaultComposerRepositories
);
```

As far as implementation goes the `static` usage for configuration seems unfortunate, but if you have better suggestions I can update the PR with changes. I wasn't sure the best way to test the commands, so I manually tested by creating an empty directory without `composer.json`, switching to it, and running through the four touched commands to make sure they picked up the custom repository from `Factory`. I realize this patch probably isn't a common use case right now (or perhaps there's a fully different recommended practice?), but I figured I'd submit it just in case you think others might find it useful.

We (and I, personally) have found composer very useful, even as young as it is -- so thanks!
