### PR TITLE
specifying root dir for value in composer.json

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -246,7 +246,7 @@ Example:
 
     {
         "autoload: {
-            "classmap": ["src/", "lib/"]
+            "classmap": ["."]
         }
     }
 


### PR DESCRIPTION
Was told to specify root dir with `"classmap": [ "" ],`

This person had been using Composer for awhile, so I'm guessing it might be worth diversifying the examples?
