### PR TITLE
Add default http(s) ports to proxy configuration if they are missing.

### DIFF
--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -37,7 +37,11 @@ final class StreamContextFactory
             $proxy = isset($_SERVER['http_proxy']) ? $_SERVER['http_proxy'] : $_SERVER['HTTP_PROXY'];
 
             // http(s):// is not supported in proxy
-            $proxy = str_replace(array('http://', 'https://'), array('tcp://', 'ssl://'), $proxy);
+            if ('http://' == substr($proxy, 0, 7)) {
+                $proxy = 'tcp://' . rtrim(substr($proxy, 7), '/') . (parse_url($proxy, PHP_URL_PORT) ? '' : ':80');
+            } else if ('https://' == substr($proxy, 0, 8)) {
+                $proxy = 'ssl://' . rtrim(substr($proxy, 8), '/') . (parse_url($proxy, PHP_URL_PORT) ? '' : ':443');
+            }
 
             if (0 === strpos($proxy, 'ssl:') && !extension_loaded('openssl')) {
                 throw new \RuntimeException('You must enable the openssl extension to use a proxy over https');

--- a/tests/Composer/Test/Util/StreamContextFactoryTest.php
+++ b/tests/Composer/Test/Util/StreamContextFactoryTest.php
@@ -57,7 +57,7 @@ class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testHttpProxy()
     {
-        $_SERVER['http_proxy'] = 'http://username:password@proxyserver.net:port/';
+        $_SERVER['http_proxy'] = 'http://username:password@proxyserver.net:3128/';
         $_SERVER['HTTP_PROXY'] = 'http://proxyserver/';
 
         $context = StreamContextFactory::getContext(array('http' => array('method' => 'GET')));
@@ -66,22 +66,39 @@ class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('http://proxyserver/', $_SERVER['HTTP_PROXY']);
 
         $this->assertEquals(array('http' => array(
-            'proxy' => 'tcp://username:password@proxyserver.net:port/',
+            'proxy' => 'tcp://username:password@proxyserver.net:3128',
             'request_fulluri' => true,
             'method' => 'GET',
         )), $options);
     }
 
-    public function testSSLProxy()
+    public function testHttpProxyWithoutPort()
     {
-        $_SERVER['http_proxy'] = 'https://proxyserver/';
+        $_SERVER['http_proxy'] = 'http://username:password@proxyserver.net';
+
+        $context = StreamContextFactory::getContext(array('http' => array('method' => 'GET')));
+        $options = stream_context_get_options($context);
+
+        $this->assertEquals(array('http' => array(
+            'proxy' => 'tcp://username:password@proxyserver.net:80',
+            'request_fulluri' => true,
+            'method' => 'GET',
+        )), $options);
+    }
+
+    /**
+     * @dataProvider dataSSLProxy
+     */
+    public function testSSLProxy($expected, $proxy)
+    {
+        $_SERVER['http_proxy'] = $proxy;
 
         if (extension_loaded('openssl')) {
             $context = StreamContextFactory::getContext();
             $options = stream_context_get_options($context);
 
-            $this->assertSame(array('http' => array(
-                'proxy' => 'ssl://proxyserver/',
+            $this->assertEquals(array('http' => array(
+                'proxy' => $expected,
                 'request_fulluri' => true,
             )), $options);
         } else {
@@ -92,5 +109,13 @@ class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
                 $this->assertInstanceOf('RuntimeException', $e);
             }
         }
+    }
+
+    public function dataSSLProxy()
+    {
+        return array(
+            array('ssl://proxyserver:443', 'https://proxyserver/'),
+            array('ssl://proxyserver:8443', 'https://proxyserver:8443'),
+        );
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
[![Build Status](https://secure.travis-ci.org/dpb587/composer.png?branch=fix-implicit-proxy-ports)](http://travis-ci.org/dpb587/composer)

Some systems I've used this on didn't have the port defined in `http_proxy`. This patch will add 80/443 to http/https, respectively, if the proxy is getting converted to protocols and is missing a port. In addition to the updated unit tests, I manually tested with an http proxy (but didn't have ready access to a secure proxy).

Symptoms were either of the following two messages:

```
Could not read http://packagist.org/packages.json, either you or the remote host is probably offline
// or
http://packagist.org could not be loaded, package information was loaded from the local cache and may be out of date
```
