### PR TITLE
Compile has a message to tell.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,5 +5,7 @@ require __DIR__.'/../src/bootstrap.php';
 
 use Composer\Compiler;
 
+error_reporting(~0); ini_set('display_errors', 1);
+
 $compiler = new Compiler();
 $compiler->compile();

--- a/bin/composer
+++ b/bin/composer
@@ -5,6 +5,8 @@ require __DIR__.'/../src/bootstrap.php';
 
 use Composer\Console\Application;
 
+error_reporting(~0); ini_set('display_errors', 1);
+
 // run the command application
 $application = new Application();
 $application->run();


### PR DESCRIPTION
The `compile` command does not give much info about what it does. This pull request adds an error message if something throwed an exception or just displays a simple `Done.` if things went smooth.

Example error message:

```
ERROR: (UnexpectedValueException) creating archive "composer.phar" disabled by the php.ini setting phar.readonly
```

(that one is fixed with `php -d phar.readonly=0 bin/compile`)
