### PR TITLE
Support local repo

### DIFF
--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -188,6 +188,7 @@ class GitDriver extends VcsDriver
         // local filesystem
         if (static::isLocalUrl($url)) {
             $process = new ProcessExecutor();
+            $url = str_replace('file://', '', $url);
             // check whether there is a git repo in that path
             if ($process->execute('git tag', $output, $url) === 0) {
                 return true;


### PR DESCRIPTION
This reverts #703 and fixes the bug with local repositories using `file://` without breaking things when the local repo is not a git repo.
