### PR TITLE
Wrong variable used for foreach. Fixes issue 674.

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -731,7 +731,7 @@ class Solver
             }
         }
 
-        foreach ($this->decisionMap as $packageId => $decision) {
+        foreach ($allDecidedMap as $packageId => $decision) {
             if ($packageId === 0) {
                 continue;
             }


### PR DESCRIPTION
Using $allDecidedMap = $this->decisionMap; with SplFixedArray seems to create a Reference.
Whereas php 5.3.3 using the array itself we work with a clone causing issues in the mapping process
