### PR TITLE
added source-reference for root-package to lock file

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -120,6 +120,7 @@ EOT
         chdir($directory);
 
         $composer = Factory::create($io);
+        $composer->setPackage(clone $package);
         $installer = Installer::create($io, $composer);
 
         $installer

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -178,6 +178,7 @@ class Installer
             // write lock
             if ($this->update || !$this->locker->isLocked()) {
                 $updatedLock = $this->locker->setLockData(
+                    $this->package->getSourceReference(),
                     $this->repositoryManager->getLocalRepository()->getPackages(),
                     $this->devMode ? $this->repositoryManager->getLocalDevRepository()->getPackages() : null,
                     $aliases,

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -166,16 +166,18 @@ class Locker
     /**
      * Locks provided data into lockfile.
      *
+     * @param string $sourceReference the source reference for the root package
      * @param array $packages array of packages
      * @param mixed $packages array of dev packages or null if installed without --dev
      * @param array $aliases array of aliases
      *
      * @return Boolean
      */
-    public function setLockData(array $packages, $devPackages, array $aliases, $minimumStability, array $stabilityFlags)
+    public function setLockData($sourceReference, array $packages, $devPackages, array $aliases, $minimumStability, array $stabilityFlags)
     {
         $lock = array(
             'hash' => $this->hash,
+            'source-reference' => $sourceReference,
             'packages' => null,
             'packages-dev' => null,
             'aliases' => $aliases,

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -159,9 +159,10 @@ class LockerTest extends \PHPUnit_Framework_TestCase
                 'aliases' => array(),
                 'minimum-stability' => 'dev',
                 'stability-flags' => array(),
+                'source-reference' => 'foo',
             ));
 
-        $locker->setLockData(array($package1, $package2), array(), array(), 'dev', array());
+        $locker->setLockData('foo', array($package1, $package2), array(), array(), 'dev', array());
     }
 
     public function testLockBadPackages()
@@ -179,7 +180,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('LogicException');
 
-        $locker->setLockData(array($package1), array(), array(), 'dev', array());
+        $locker->setLockData('foo', array($package1), array(), array(), 'dev', array());
     }
 
     public function testIsFresh()


### PR DESCRIPTION
This also adds the `source-reference` for the root package in addition to the dependent packages.

For example, this is useful if you use `create-project` to initialize a project to know which concrete source version has been picked.
