### PR TITLE
Require aliases from root packages, not original packages

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -436,14 +436,6 @@ class Installer
                 $package->getRepository()->addPackage($aliasPackage = new AliasPackage($package, $alias['alias_normalized'], $alias['alias']));
                 $aliasPackage->setRootPackageAlias(true);
             }
-            foreach ($this->repositoryManager->getLocalRepositories() as $repo) {
-                foreach ($repo->findPackages($alias['package'], $alias['version']) as $package) {
-                    $package->setAlias($alias['alias_normalized']);
-                    $package->setPrettyAlias($alias['alias']);
-                    $package->getRepository()->addPackage($aliasPackage = new AliasPackage($package, $alias['alias_normalized'], $alias['alias']));
-                    $aliasPackage->setRootPackageAlias(true);
-                }
-            }
         }
 
         return $aliases;

--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -80,7 +80,7 @@ class VersionParser
 
         // ignore aliases and just assume the alias is required instead of the source
         if (preg_match('{^([^,\s]+) +as +([^,\s]+)$}', $version, $match)) {
-            $version = $match[2];
+            $version = $match[1];
         }
 
         // match master-like branches

--- a/tests/Composer/Test/Fixtures/installer/aliased-priority-conflicting.test
+++ b/tests/Composer/Test/Fixtures/installer/aliased-priority-conflicting.test
@@ -22,7 +22,7 @@ Aliases take precedence over default package even if default is selected
             "package": [
                 {
                     "name": "a/a", "version": "dev-master",
-                    "require": { "a/req": "1.*" }
+                    "require": { "a/req": "dev-master" }
                 },
                 {
                     "name": "a/b", "version": "dev-master",
@@ -43,7 +43,7 @@ Aliases take precedence over default package even if default is selected
     }
 }
 --EXPECT--
+Marking a/req (dev-master feat.f) as installed, alias of a/req (dev-feature-foo feat.f)
 Installing a/req (dev-feature-foo feat.f)
-Marking a/req (dev-master feat.f) as installed, alias of a/req (dev-master feat.f)
 Installing a/b (dev-master)
 Installing a/a (dev-master)

--- a/tests/Composer/Test/Fixtures/installer/aliased-priority.test
+++ b/tests/Composer/Test/Fixtures/installer/aliased-priority.test
@@ -45,9 +45,9 @@ Aliases take precedence over default package
     }
 }
 --EXPECT--
-Installing a/c (dev-feature-foo feat.f)
-Marking a/c (dev-master feat.f) as installed, alias of a/c (dev-feature-foo feat.f)
 Installing a/b (dev-master forked)
 Marking a/b (1.0.x-dev forked) as installed, alias of a/b (dev-master forked)
+Marking a/c (dev-master feat.f) as installed, alias of a/c (dev-feature-foo feat.f)
 Installing a/a (dev-master master)
+Installing a/c (dev-feature-foo feat.f)
 Marking a/a (1.0.x-dev master) as installed, alias of a/a (dev-master master)

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -54,7 +54,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             'parses branches'   => array('1.x-dev',             '1.9999999.9999999.9999999-dev'),
             'parses arbitrary'  => array('dev-feature-foo',     'dev-feature-foo'),
             'parses arbitrary2' => array('DEV-FOOBAR',          'dev-foobar'),
-            'ignores aliases'   => array('dev-master as 1.0.0', '1.0.0.0'),
+            'ignores aliases'   => array('dev-master as 1.0.0', '9999999-dev'),
         );
     }
 
@@ -156,7 +156,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             'accepts master/2'  => array('dev-master',      new VersionConstraint('=', '9999999-dev')),
             'accepts arbitrary' => array('dev-feature-a',   new VersionConstraint('=', 'dev-feature-a')),
             'regression #550'   => array('dev-some-fix',    new VersionConstraint('=', 'dev-some-fix')),
-            'ignores aliases'   => array('dev-master as 1.0.0', new VersionConstraint('=', '1.0.0.0')),
+            'ignores aliases'   => array('dev-master as 1.0.0', new VersionConstraint('=', '9999999-dev')),
         );
     }
 


### PR DESCRIPTION
Makes sure aliases always get installed.
