### PR TITLE
Root requires are not taken into account in locked installs, fixes #669

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -141,10 +141,14 @@ class Installer
         }
 
         // create installed repo, this contains all local packages + platform packages (php & extensions)
+        $installedRootPackage = clone $this->package;
+        $installedRootPackage->setRequires(array());
+        $installedRootPackage->setDevRequires(array());
+
         $repos = array_merge(
             $this->repositoryManager->getLocalRepositories(),
             array(
-                new InstalledArrayRepository(array($this->package)),
+                new InstalledArrayRepository(array($installedRootPackage)),
                 new PlatformRepository(),
             )
         );

--- a/tests/Composer/Test/Fixtures/installer/aliased-priority.test
+++ b/tests/Composer/Test/Fixtures/installer/aliased-priority.test
@@ -47,8 +47,8 @@ Aliases take precedence over default package
 --RUN--
 install
 --EXPECT--
-Installing a/b (dev-master forked)
 Marking a/b (1.0.x-dev forked) as installed, alias of a/b (dev-master forked)
+Installing a/b (dev-master forked)
 Marking a/c (dev-master feat.f) as installed, alias of a/c (dev-feature-foo feat.f)
 Installing a/a (dev-master master)
 Installing a/c (dev-feature-foo feat.f)

--- a/tests/Composer/Test/Fixtures/installer/install-from-empty-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/install-from-empty-lock.test
@@ -1,0 +1,32 @@
+--TEST--
+Requirements from the composer file are not installed if the lock file is present
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "required", "version": "1.0.0" },
+                { "name": "newly-required", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "required": "1.0.0",
+        "newly-required": "1.0.0"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        { "package": "required", "version": "1.0.0" }
+    ],
+    "packages-dev": null,
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": []
+}
+--RUN--
+install
+--EXPECT--
+Installing required (1.0.0)


### PR DESCRIPTION
Also includes a fix to the test runner for lock files support
