### PR TITLE
SVN Auth doesn't work with german svn errors

### DIFF
--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -100,7 +100,7 @@ class Svn
         }
 
         // the error is not auth-related
-        if (false === stripos($output, 'authorization failed:')) {
+        if (false === stripos($output, 'Could not authenticate to server:')) {
             throw new \RuntimeException($output);
         }
 


### PR DESCRIPTION
The string to match a failed svn authorization is different on german svn servers. 

It's "...Autorisierung schlug fehl: Could not authenticate to server: ..." instead of "...authorization failed: Could not authenticate to server: ..."

So I changed the part of the string used to match failed svn authorization and tested it on a german svn server.

Please verify it still works on english servers before merging.

thanks @ [till](https://github.com/till) for pointing me in the right direction!
