### PR TITLE
fixed #790

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -233,7 +233,7 @@ EOF;
         foreach ($packageMap as $item) {
             list($package, $installPath) = $item;
 
-            if (null !== $package->getTargetDir()) {
+            if (null !== $package->getTargetDir() && strlen($package->getTargetDir()) > 0) {
                 $installPath = substr($installPath, 0, -strlen('/'.$package->getTargetDir()));
             }
 


### PR DESCRIPTION
simple strlen to avoid truncate of target-dir when the composer.json has 

```
"target-dir": ""  <- empty string

```
