### PR TITLE
PECL-UUID does not define a version constant, use phpversion() instead

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -90,7 +90,7 @@ class PlatformRepository extends ArrayRepository
                     break;
 
                 case 'uuid':
-                    $prettyVersion = UUID_VERSION;
+                    $prettyVersion = phpversion('uuid');
                     break;
 
                 case 'xsl':


### PR DESCRIPTION
Should fix issue #823.
