### PR TITLE
Support for zsh, ksh and csh shells in ConsoleIO.

### DIFF
--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -164,13 +164,13 @@ class ConsoleIO implements IOInterface
 
         // handle other OSs with bash/zsh/ksh/csh if available to hide the answer
         $test = "/usr/bin/env %s -c 'echo OK' 2> /dev/null";
-        foreach(array('bash', 'zsh', 'ksh', 'csh') as $sh){
-            if('OK' === rtrim(shell_exec(sprintf($test, $sh)))){
+        foreach (array('bash', 'zsh', 'ksh', 'csh') as $sh) {
+            if ('OK' === rtrim(shell_exec(sprintf($test, $sh)))) {
                 $shell = $sh;
                 break;
             }
         }
-        if(isset($shell)){
+        if (isset($shell)) {
             $this->write($question, false);
             $readCmd = ($shell === 'csh') ? 'set mypassword = $<' : 'read mypassword';
             $command = sprintf("/usr/bin/env %s -c 'stty -echo; %s; stty echo; echo \$mypassword'", $shell, $readCmd);


### PR DESCRIPTION
This PR adds support for zsh, ksh and csh shells to the `ConsoleIO::askAndHideAnswer` method.

It is also possible to easily add support for other shells (as long as they support standard `stty -echo` and `read` commands; for example _fish_ doesn't).
