### PR TITLE
Use the config object to define the vendor dir and not the installation manager

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Autoload;
 
+use Composer\Config;
 use Composer\Installer\InstallationManager;
 use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;
@@ -24,12 +25,14 @@ use Composer\Util\Filesystem;
  */
 class AutoloadGenerator
 {
-    public function dump(RepositoryInterface $localRepo, PackageInterface $mainPackage, InstallationManager $installationManager, $targetDir)
+    public function dump(Config $config, RepositoryInterface $localRepo, PackageInterface $mainPackage, InstallationManager $installationManager, $targetDir)
     {
         $filesystem = new Filesystem();
-        $filesystem->ensureDirectoryExists($installationManager->getVendorPath());
+        $filesystem->ensureDirectoryExists($config->get('vendor-dir'));
+        $vendorPath = strtr(realpath($config->get('vendor-dir')), '\\', '/');
+        $targetDir = $vendorPath.'/'.$targetDir;
         $filesystem->ensureDirectoryExists($targetDir);
-        $vendorPath = strtr(realpath($installationManager->getVendorPath()), '\\', '/');
+
         $relVendorPath = $filesystem->findShortestPath(getcwd(), $vendorPath, true);
         $vendorPathCode = $filesystem->findShortestPathCode(realpath($targetDir), $vendorPath, true);
         $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, realpath($targetDir), true);

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -105,7 +105,7 @@ class Config
                 // convert foo-bar to COMPOSER_FOO_BAR and check if it exists since it overrides the local config
                 $env = 'COMPOSER_' . strtoupper(strtr($key, '-', '_'));
 
-                return $this->process(getenv($env) ?: $this->config[$key]);
+                return rtrim($this->process(getenv($env) ?: $this->config[$key]), '/\\');
 
             case 'home':
                 return rtrim($this->process($this->config[$key]), '/\\');

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -21,6 +21,7 @@ use Composer\DependencyResolver\Solver;
 use Composer\DependencyResolver\SolverProblemsException;
 use Composer\Downloader\DownloadManager;
 use Composer\Installer\InstallationManager;
+use Composer\Config;
 use Composer\Installer\NoopInstaller;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
@@ -47,6 +48,11 @@ class Installer
      * @var IOInterface
      */
     protected $io;
+
+    /**
+     * @var Config
+     */
+    protected $config;
 
     /**
      * @var PackageInterface
@@ -105,6 +111,7 @@ class Installer
      * Constructor
      *
      * @param IOInterface         $io
+     * @param Config              $config
      * @param PackageInterface    $package
      * @param DownloadManager     $downloadManager
      * @param RepositoryManager   $repositoryManager
@@ -113,9 +120,10 @@ class Installer
      * @param EventDispatcher     $eventDispatcher
      * @param AutoloadGenerator   $autoloadGenerator
      */
-    public function __construct(IOInterface $io, PackageInterface $package, DownloadManager $downloadManager, RepositoryManager $repositoryManager, Locker $locker, InstallationManager $installationManager, EventDispatcher $eventDispatcher, AutoloadGenerator $autoloadGenerator)
+    public function __construct(IOInterface $io, Config $config, PackageInterface $package, DownloadManager $downloadManager, RepositoryManager $repositoryManager, Locker $locker, InstallationManager $installationManager, EventDispatcher $eventDispatcher, AutoloadGenerator $autoloadGenerator)
     {
         $this->io = $io;
+        $this->config = $config;
         $this->package = $package;
         $this->downloadManager = $downloadManager;
         $this->repositoryManager = $repositoryManager;
@@ -201,7 +209,7 @@ class Installer
             // write autoloader
             $this->io->write('<info>Generating autoload files</info>');
             $localRepos = new CompositeRepository($this->repositoryManager->getLocalRepositories());
-            $this->autoloadGenerator->dump($localRepos, $this->package, $this->installationManager, $this->installationManager->getVendorPath() . '/composer');
+            $this->autoloadGenerator->dump($this->config, $localRepos, $this->package, $this->installationManager, 'composer');
 
             if ($this->runScripts) {
                 // dispatch post event
@@ -561,6 +569,7 @@ class Installer
 
         return new static(
             $io,
+            $composer->getConfig(),
             $composer->getPackage(),
             $composer->getDownloadManager(),
             $composer->getRepositoryManager(),
@@ -639,6 +648,19 @@ class Installer
     public function setRunScripts($runScripts = true)
     {
         $this->runScripts = (boolean) $runScripts;
+
+        return $this;
+    }
+
+    /**
+     * set the config instance
+     *
+     * @param  Config    $config
+     * @return Installer
+     */
+    public function setConfig(Config $config)
+    {
+        $this->config = $config;
 
         return $this;
     }

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -35,29 +35,6 @@ class InstallationManager
 {
     private $installers = array();
     private $cache = array();
-    private $vendorPath;
-
-    /**
-     * Creates an instance of InstallationManager
-     *
-     * @param  string                    $vendorDir Relative path to the vendor directory
-     * @throws \InvalidArgumentException
-     */
-    public function __construct($vendorDir = 'vendor')
-    {
-        $fs = new Filesystem();
-
-        if ($fs->isAbsolutePath($vendorDir)) {
-            $basePath = getcwd();
-            $relativePath = $fs->findShortestPath($basePath.'/file', $vendorDir);
-            if ($fs->isAbsolutePath($relativePath)) {
-                throw new \InvalidArgumentException("Vendor dir ($vendorDir) must be accessible from the directory ($basePath).");
-            }
-            $this->vendorPath = $relativePath;
-        } else {
-            $this->vendorPath = rtrim($vendorDir, '/');
-        }
-    }
 
     /**
      * Adds installer
@@ -215,21 +192,6 @@ class InstallationManager
         $installer = $this->getInstaller($package->getType());
 
         return $installer->getInstallPath($package);
-    }
-
-    /**
-     * Returns the vendor path
-     *
-     * @param  boolean $absolute Whether or not to return an absolute path
-     * @return string  path
-     */
-    public function getVendorPath($absolute = false)
-    {
-        if (!$absolute) {
-            return $this->vendorPath;
-        }
-
-        return getcwd().DIRECTORY_SEPARATOR.$this->vendorPath;
     }
 
     private function notifyInstall(PackageInterface $package)

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -24,21 +24,6 @@ class InstallationManagerTest extends \PHPUnit_Framework_TestCase
         $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
     }
 
-    public function testVendorDirOutsideTheWorkingDir()
-    {
-        $manager = new InstallationManager(realpath(getcwd().'/../'));
-        $this->assertSame('../', $manager->getVendorPath());
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testVendorDirNotAccessible()
-    {
-        $manager = new InstallationManager('/oops');
-        $this->assertSame('../', $manager->getVendorPath());
-    }
-
     public function testAddGetInstaller()
     {
         $installer = $this->createInstallerMock();
@@ -63,7 +48,6 @@ class InstallationManagerTest extends \PHPUnit_Framework_TestCase
     {
         $manager = $this->getMockBuilder('Composer\Installer\InstallationManager')
             ->setMethods(array('install', 'update', 'uninstall'))
-            ->setConstructorArgs(array('vendor'))
             ->getMock();
 
         $installOperation = new InstallOperation($this->createPackageMock());
@@ -224,18 +208,6 @@ class InstallationManagerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $manager->uninstall($this->repository, $operation);
-    }
-
-    public function testGetVendorPathAbsolute()
-    {
-        $manager = new InstallationManager('vendor');
-        $this->assertEquals(getcwd().DIRECTORY_SEPARATOR.'vendor', $manager->getVendorPath(true));
-    }
-
-    public function testGetVendorPathRelative()
-    {
-        $manager = new InstallationManager('vendor');
-        $this->assertEquals('vendor', $manager->getVendorPath());
     }
 
     private function createInstallerMock()

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -55,7 +55,7 @@ class InstallerTest extends TestCase
         $eventDispatcher = $this->getMockBuilder('Composer\Script\EventDispatcher')->disableOriginalConstructor()->getMock();
         $autoloadGenerator = $this->getMock('Composer\Autoload\AutoloadGenerator');
 
-        $installer = new Installer($io, clone $rootPackage, $downloadManager, $repositoryManager, $locker, $installationManager, $eventDispatcher, $autoloadGenerator);
+        $installer = new Installer($io, $config, clone $rootPackage, $downloadManager, $repositoryManager, $locker, $installationManager, $eventDispatcher, $autoloadGenerator);
         $result = $installer->run();
         $this->assertTrue($result);
 


### PR DESCRIPTION
Minor architectural cleanup I've been meaning to do for a while
