### PR TITLE
fixes #801 show logs in --verbose mode for source packages

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -224,4 +224,15 @@ class GitDownloader extends VcsDownloader
             $this->process->execute($cmd, $ignoredOutput, $path);
         }
     }
+
+    protected function getCommitLogs($sourceReference, $targetReference, $path)
+    {
+        $command = sprintf('cd %s && git log %s..%s --pretty=format:"%%h - %%an: %%s"', escapeshellarg($path), $sourceReference, $targetReference);
+
+        if (0 !== $this->process->execute($command, $output)) {
+            throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
+        }
+
+        return $output;
+    }
 }

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -59,4 +59,15 @@ class HgDownloader extends VcsDownloader
             throw new \RuntimeException('Source directory ' . $path . ' has uncommitted changes');
         }
     }
+
+    protected function getCommitLogs($sourceReference, $targetReference, $path)
+    {
+        $command = sprintf('cd %s && hg log -r %s:%s --style compact', escapeshellarg($path), $sourceReference, $targetReference);
+
+        if (0 !== $this->process->execute($command, $output)) {
+            throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
+        }
+
+        return $output;
+    }
 }

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -79,4 +79,15 @@ class SvnDownloader extends VcsDownloader
             );
         }
     }
+
+    protected function getCommitLogs($sourceReference, $targetReference, $path)
+    {
+        $command = sprintf('cd %s && svn log -r%s:%s --incremental', escapeshellarg($path), $sourceReference, $targetReference);
+
+        if (0 !== $this->process->execute($command, $output)) {
+            throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
+        }
+
+        return $output;
+    }
 }

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -65,9 +65,25 @@ abstract class VcsDownloader implements DownloaderInterface
             throw new \InvalidArgumentException('Package '.$target->getPrettyName().' is missing reference information');
         }
 
-        $this->io->write("  - Updating <info>" . $target->getName() . "</info> (<comment>" . $target->getPrettyVersion() . "</comment>)");
+        if ($initial->getPrettyVersion() == $target->getPrettyVersion()) {
+            $from = $initial->getSourceReference();
+            $to = $target->getSourceReference();
+        } else {
+            $from = $initial->getPrettyVersion();
+            $to = $target->getPrettyVersion();
+        }
+
+        $this->io->write("  - Updating <info>" . $target->getName() . "</info> from (<comment>" . $from . "</comment>) to (<comment>" . $to . "</comment>)");
+
         $this->enforceCleanDirectory($path);
         $this->doUpdate($initial, $target, $path);
+
+        //print the commit logs if in verbose mode
+        if ($this->io->isVerbose()) {
+            $logs = $this->getCommitLogs($initial->getSourceReference(), $target->getSourceReference(), $path);
+            $this->io->write($logs);
+        }
+
         $this->io->write('');
     }
 
@@ -106,4 +122,14 @@ abstract class VcsDownloader implements DownloaderInterface
      * @throws \RuntimeException if the directory is not clean
      */
     abstract protected function enforceCleanDirectory($path);
+
+    /**
+     * fetches the commit logs between to commits
+     *
+     * @param string $sourceReference   the source reference
+     * @param string $targetReference   the target reference
+     * @param string $path              the package path
+     * @return string
+     */
+    abstract protected function getCommitLogs($sourceReference, $targetReference, $path);
 }


### PR DESCRIPTION
this PR fixes #801

in `--verbose` mode the `VcsDownloaders` will also print die logs between the commits.

i couldnt setup a scenario to test the output within composer, but it should be fine.
