### PR TITLE
Validate camelcase

### DIFF
--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -109,6 +109,17 @@ EOT
             $warnings[] = 'No license specified, it is recommended to do so';
         }
 
+        if (preg_match('/[A-Z]/', $manifest['name'])) {
+            $suggestName = preg_replace('/(([a-z])([A-Z])|([A-Z])([A-Z][a-z]))/', '\\2\\4-\\3\\5', $manifest['name']);
+            $suggestName = strtolower($suggestName);
+
+            $warnings[] = sprintf(
+                'Name "%s" is not valid. Name should not be camelCased. May we suggest "%s" instead?',
+                $manifest['name'],
+                $suggestName
+            );
+        }
+
         // output errors/warnings
         if (!$errors && !$publishErrors && !$warnings) {
             $output->writeln('<info>' . $file . ' is valid</info>');


### PR DESCRIPTION
Fixes #159.

Will output something in the lines of 

```
Name "something/MYName" is not valid. Name should not be camelCased. May we suggest "something/my-name" instead?
```
