### PR TITLE
Minor formatting issue when reporting Problems

### DIFF
--- a/src/Composer/DependencyResolver/SolverProblemsException.php
+++ b/src/Composer/DependencyResolver/SolverProblemsException.php
@@ -32,7 +32,7 @@ class SolverProblemsException extends \RuntimeException
     {
         $text = "\n";
         foreach ($this->problems as $i => $problem) {
-            $text .= "  Problem ".($i+1).$problem->getPrettyString($this->installedMap)."\n";
+            $text .= "  Problem ".($i+1).": ".$problem->getPrettyString($this->installedMap)."\n";
         }
 
         return $text;


### PR DESCRIPTION
Before:

```
Problem 1The requested package $foo could not be found.
```

After

```
Problem 1: The requested package $foo could not be found.
```
