### PR TITLE
Update minimum-stability documentation

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -481,7 +481,7 @@ your project dependencies. Specific changes to the stability requirements of
 a given package can be done in `require` or `require-dev` (see
 [package links](#package-links)).
 
-Available options are `dev`, `alpha`, `beta`, and `stable`.
+Available options are `dev`, `alpha`, `beta`, `RC`, and `stable`.
 
 ### repositories <span>(root-only)</span>
 


### PR DESCRIPTION
Fix the minimum-stability documentation about defaulting to `stable`. This also updates the link to the documentation about it rather than just the discussion.
