### PR TITLE
Change the order of the include paths

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -300,7 +300,7 @@ HEADER;
         if ($useIncludePath) {
             $file .= <<<'INCLUDE_PATH'
     $includePaths = require $composerDir . '/include_paths.php';
-    array_unshift($includePaths, get_include_path());
+    array_push($includePaths, get_include_path());
     set_include_path(join(PATH_SEPARATOR, $includePaths));
 
 

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -338,7 +338,7 @@ class AutoloadGeneratorTest extends TestCase
         );
     }
 
-    public function testIncludePathsAreAppendedInAutoloadFile()
+    public function testIncludePathsArePrependedInAutoloadFile()
     {
         $package = new MemoryPackage('a', '1.0', '1.0');
         $packages = array();
@@ -361,7 +361,7 @@ class AutoloadGeneratorTest extends TestCase
         require($this->vendorDir."/autoload.php");
 
         $this->assertEquals(
-            $oldIncludePath.PATH_SEPARATOR.$this->vendorDir."/a/a/lib",
+            $this->vendorDir."/a/a/lib".PATH_SEPARATOR.$oldIncludePath,
             get_include_path()
         );
 


### PR DESCRIPTION
Composer installed libraries should have precedence over other libraries in the
system (like PEAR installed libraries).

Made composer prepend it's include_path configuration instead of appending it.
