### PR TITLE
Prevent seeing dev versions as equal when they are not, fixes #848

### DIFF
--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -49,7 +49,7 @@ class DefaultPolicy implements PolicyInterface
 
     public function selectPreferedPackages(Pool $pool, array $installedMap, array $literals)
     {
-        $packages = $this->groupLiteralsByNamePreferInstalled($pool,$installedMap, $literals);
+        $packages = $this->groupLiteralsByNamePreferInstalled($pool, $installedMap, $literals);
 
         foreach ($packages as &$literals) {
             $policy = $this;

--- a/src/Composer/Package/LinkConstraint/VersionConstraint.php
+++ b/src/Composer/Package/LinkConstraint/VersionConstraint.php
@@ -58,6 +58,11 @@ class VersionConstraint extends SpecificConstraint
         $isProviderEqualOp = '==' === $provider->operator;
         $isProviderNonEqualOp = '!=' === $provider->operator;
 
+        // dev- versions can not be compared with version_compare
+        if ('dev-' === substr($provider->version, 0, 4) && 'dev-' === substr($this->version, 0, 4)) {
+            return $isEqualOp && $isProviderEqualOp && $provider->version === $this->version ? true : false;
+        }
+
         // '!=' operator is match when other operator is not '==' operator or version is not match
         // these kinds of comparisons always have a solution
         if ($isNonEqualOp || $isProviderNonEqualOp) {

--- a/tests/Composer/Test/Package/LinkConstraint/VersionConstraintTest.php
+++ b/tests/Composer/Test/Package/LinkConstraint/VersionConstraintTest.php
@@ -33,6 +33,7 @@ class VersionConstraintTest extends \PHPUnit_Framework_TestCase
             array('!=', '1', '<=', '1'),
             array('!=', '1', '>',  '1'),
             array('!=', '1', '>=', '1'),
+            array('==', 'dev-foo-bar', '==', 'dev-foo-bar'),
         );
     }
 
@@ -61,6 +62,7 @@ class VersionConstraintTest extends \PHPUnit_Framework_TestCase
             array('==', '2', '<', '2'),
             array('!=', '1', '==', '1'),
             array('==', '1', '!=', '1'),
+            array('==', 'dev-foo-dist', '==', 'dev-foo-zist'),
         );
     }
 


### PR DESCRIPTION
I think it makes sense that the only case we want to select a dev- version is on an exact match (i.e. the two constraints having == & branch names are actually equal), this won't prevent selecting the master branch with `>1` and other ranges since that's converted to 9999999-dev.
