### PR TITLE
fixes a bug when root package has a 'files' autoload entry

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -127,6 +127,10 @@ EOF;
         $filesCode = "";
         $autoloads['files'] = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($autoloads['files']));
         foreach ($autoloads['files'] as $functionFile) {
+            if ( ! $filesystem->isAbsolutePath($functionFile)) {
+                $functionFile = dirname($vendorPath) . '/'. $functionFile;
+            }
+
             $filesCode .= '    require __DIR__ . '. var_export('/'.$filesystem->findShortestPath($vendorPath, $functionFile), true).";\n";
         }
 
@@ -181,6 +185,7 @@ EOF;
                 if (!is_array($mapping)) {
                     continue;
                 }
+
                 foreach ($mapping as $namespace => $paths) {
                     foreach ((array) $paths as $path) {
                         $autoloads[$type][$namespace][] = empty($installPath) ? $path : $installPath.'/'.$path;

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -64,7 +64,7 @@ class Filesystem
     public function findShortestPath($from, $to, $directories = false)
     {
         if (!$this->isAbsolutePath($from) || !$this->isAbsolutePath($to)) {
-            throw new \InvalidArgumentException('from and to must be absolute paths');
+            throw new \InvalidArgumentException(sprintf('$from (%s) and $to (%s) must be absolute paths.', $from, $to));
         }
 
         $from = lcfirst(rtrim(strtr($from, '\\', '/'), '/'));
@@ -105,7 +105,7 @@ class Filesystem
     public function findShortestPathCode($from, $to, $directories = false)
     {
         if (!$this->isAbsolutePath($from) || !$this->isAbsolutePath($to)) {
-            throw new \InvalidArgumentException('from and to must be absolute paths');
+            throw new \InvalidArgumentException(sprintf('$from (%s) and $to (%s) must be absolute paths.', $from, $to));
         }
 
         $from = lcfirst(strtr($from, '\\', '/'));


### PR DESCRIPTION
When the root package has a "files" autoload entry, the file's path is not absolute resulting in an error when trying to make the path relative.
