### PR TITLE
[Autoload] remove closures because of a bug in APC

### DIFF
--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -95,7 +95,7 @@ class AutoloadGeneratorTest extends TestCase
 
         $this->createClassFile($this->workingDir);
 
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer');
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', '_1');
         $this->assertAutoloadFiles('main', $this->vendorDir.'/composer');
         $this->assertAutoloadFiles('classmap', $this->vendorDir.'/composer', 'classmap');
     }
@@ -120,7 +120,7 @@ class AutoloadGeneratorTest extends TestCase
 
         $this->createClassFile($this->vendorDir);
 
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer');
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', '_2');
         $this->assertAutoloadFiles('main3', $this->vendorDir.'/composer');
         $this->assertAutoloadFiles('classmap3', $this->vendorDir.'/composer', 'classmap');
     }
@@ -140,7 +140,7 @@ class AutoloadGeneratorTest extends TestCase
         $this->vendorDir .= '/subdir';
         mkdir($this->vendorDir.'/composer', 0777, true);
         $this->createClassFile($this->workingDir);
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer');
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', '_3');
         $this->assertAutoloadFiles('main2', $this->vendorDir.'/composer');
         $this->assertAutoloadFiles('classmap2', $this->vendorDir.'/composer', 'classmap');
     }
@@ -157,7 +157,7 @@ class AutoloadGeneratorTest extends TestCase
             ->method('getPackages')
             ->will($this->returnValue(array()));
 
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer');
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', 'TargetDir');
         $this->assertFileEquals(__DIR__.'/Fixtures/autoload_target_dir.php', $this->vendorDir.'/autoload.php');
     }
 
@@ -177,7 +177,7 @@ class AutoloadGeneratorTest extends TestCase
             ->will($this->returnValue($packages));
 
         mkdir($this->vendorDir.'/composer', 0777, true);
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer');
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', '_5');
         $this->assertAutoloadFiles('vendors', $this->vendorDir.'/composer');
         $this->assertTrue(file_exists($this->vendorDir.'/composer/autoload_classmap.php'), "ClassMap file needs to be generated, even if empty.");
     }
@@ -204,7 +204,7 @@ class AutoloadGeneratorTest extends TestCase
         file_put_contents($this->vendorDir.'/b/b/src/b.php', '<?php class ClassMapBar {}');
         file_put_contents($this->vendorDir.'/b/b/lib/c.php', '<?php class ClassMapBaz {}');
 
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer');
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', '_6');
         $this->assertTrue(file_exists($this->vendorDir.'/composer/autoload_classmap.php'), "ClassMap file needs to be generated.");
         $this->assertEquals(
             array(
@@ -241,7 +241,7 @@ class AutoloadGeneratorTest extends TestCase
         file_put_contents($this->vendorDir.'/b/b/test.php', '<?php class ClassMapBar {}');
         file_put_contents($this->vendorDir.'/c/c/foo/test.php', '<?php class ClassMapBaz {}');
 
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer');
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', '_7');
         $this->assertTrue(file_exists($this->vendorDir.'/composer/autoload_classmap.php'), "ClassMap file needs to be generated.");
         $this->assertEquals(
             array(
@@ -273,7 +273,7 @@ class AutoloadGeneratorTest extends TestCase
         file_put_contents($this->vendorDir.'/a/a/test.php', '<?php function testFilesAutoloadGeneration1() {}');
         file_put_contents($this->vendorDir.'/b/b/test2.php', '<?php function testFilesAutoloadGeneration2() {}');
 
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer');
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', 'FilesAutoload');
         $this->assertFileEquals(__DIR__.'/Fixtures/autoload_functions.php', $this->vendorDir.'/autoload.php');
 
         include $this->vendorDir . '/autoload.php';
@@ -297,7 +297,7 @@ class AutoloadGeneratorTest extends TestCase
             ->will($this->returnValue($packages));
 
         mkdir($this->vendorDir.'/composer', 0777, true);
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer');
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', '_9');
         $this->assertAutoloadFiles('override_vendors', $this->vendorDir.'/composer');
     }
 
@@ -325,7 +325,7 @@ class AutoloadGeneratorTest extends TestCase
 
         mkdir($this->vendorDir."/composer", 0777, true);
 
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, "composer");
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, "composer", '_10');
 
         $this->assertFileEquals(__DIR__.'/Fixtures/include_paths.php', $this->vendorDir.'/composer/include_paths.php');
         $this->assertEquals(
@@ -354,7 +354,7 @@ class AutoloadGeneratorTest extends TestCase
 
         mkdir($this->vendorDir."/composer", 0777, true);
 
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, "composer");
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, "composer", '_11');
 
         $oldIncludePath = get_include_path();
 
@@ -382,7 +382,7 @@ class AutoloadGeneratorTest extends TestCase
 
         mkdir($this->vendorDir."/composer", 0777, true);
 
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, "composer");
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, "composer", '_12');
 
         $this->assertFalse(file_exists($this->vendorDir."/composer/include_paths.php"));
     }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_functions.php
@@ -5,24 +5,32 @@ if (!class_exists('Composer\\Autoload\\ClassLoader', false)) {
     require __DIR__ . '/composer' . '/ClassLoader.php';
 }
 
-return call_user_func(function() {
-    $loader = new \Composer\Autoload\ClassLoader();
-    $composerDir = __DIR__ . '/composer';
+if (!class_exists('ComposerAutoloaderInitFilesAutoload', false)) {
+    class ComposerAutoloaderInitFilesAutoload
+    {
+        public static function getLoader()
+        {
+            $loader = new \Composer\Autoload\ClassLoader();
+            $composerDir = __DIR__ . '/composer';
 
-    $map = require $composerDir . '/autoload_namespaces.php';
-    foreach ($map as $namespace => $path) {
-        $loader->add($namespace, $path);
+            $map = require $composerDir . '/autoload_namespaces.php';
+            foreach ($map as $namespace => $path) {
+                $loader->add($namespace, $path);
+            }
+
+            $classMap = require $composerDir . '/autoload_classmap.php';
+            if ($classMap) {
+                $loader->addClassMap($classMap);
+            }
+
+            $loader->register();
+
+            require $vendorDir . '/a/a/test.php';
+            require $vendorDir . '/b/b/test2.php';
+
+            return $loader;
+        }
     }
+}
 
-    $classMap = require $composerDir . '/autoload_classmap.php';
-    if ($classMap) {
-        $loader->addClassMap($classMap);
-    }
-
-    $loader->register();
-
-    require $vendorDir . '/a/a/test.php';
-    require $vendorDir . '/b/b/test2.php';
-
-    return $loader;
-});
+return ComposerAutoloaderInitFilesAutoload::getLoader();

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_target_dir.php
@@ -5,38 +5,49 @@ if (!class_exists('Composer\\Autoload\\ClassLoader', false)) {
     require __DIR__ . '/composer' . '/ClassLoader.php';
 }
 
-return call_user_func(function() {
-    $loader = new \Composer\Autoload\ClassLoader();
-    $composerDir = __DIR__ . '/composer';
+if (!class_exists('ComposerAutoloaderInitTargetDir', false)) {
+    class ComposerAutoloaderInitTargetDir
+    {
+        public static function getLoader()
+        {
+            $loader = new \Composer\Autoload\ClassLoader();
+            $composerDir = __DIR__ . '/composer';
 
-    $map = require $composerDir . '/autoload_namespaces.php';
-    foreach ($map as $namespace => $path) {
-        $loader->add($namespace, $path);
-    }
-
-    $classMap = require $composerDir . '/autoload_classmap.php';
-    if ($classMap) {
-        $loader->addClassMap($classMap);
-    }
-
-    spl_autoload_register(function($class) {
-        $dir = dirname(__DIR__) . '/';
-        $prefixes = array('Main\\Foo', 'Main\\Bar');
-        foreach ($prefixes as $prefix) {
-            if (0 !== strpos($class, $prefix)) {
-                continue;
+            $map = require $composerDir . '/autoload_namespaces.php';
+            foreach ($map as $namespace => $path) {
+                $loader->add($namespace, $path);
             }
-            $path = $dir . implode('/', array_slice(explode('\\', $class), 2)).'.php';
-            if (!$path = stream_resolve_include_path($path)) {
-                return false;
-            }
-            require $path;
 
-            return true;
+            $classMap = require $composerDir . '/autoload_classmap.php';
+            if ($classMap) {
+                $loader->addClassMap($classMap);
+            }
+
+            spl_autoload_register(array('ComposerAutoloaderInitTargetDir', 'autoload'));
+
+            $loader->register();
+
+            return $loader;
         }
-    });
 
-    $loader->register();
+        public static function autoload($class)
+        {
+            $dir = dirname(__DIR__) . '/';
+            $prefixes = array('Main\\Foo', 'Main\\Bar');
+            foreach ($prefixes as $prefix) {
+                if (0 !== strpos($class, $prefix)) {
+                    continue;
+                }
+                $path = $dir . implode('/', array_slice(explode('\\', $class), 2)).'.php';
+                if (!$path = stream_resolve_include_path($path)) {
+                    return false;
+                }
+                require $path;
 
-    return $loader;
-});
+                return true;
+            }
+        }
+    }
+}
+
+return ComposerAutoloaderInitTargetDir::getLoader();


### PR DESCRIPTION
This PR intend to fix #959

The 2 closures are replaced by static methods of a `ComposerAutoloaderInit` class.

I had to add an optional suffix for the test (i.e. `ComposerAutoloaderInit_1`) because otherwise the first declared class would prevent further tests from running as the class could not be re-declared.

I have tested the PR with Symfony and the generated autoloader is working fine.

@schmittjoh, @fabpot, @epicwhale Any feedback ?

_(related issue: symfony/symfony#1541)_
