### PR TITLE
[Repository] tweaked for performance

### DIFF
--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -41,12 +41,10 @@ class ArrayRepository implements RepositoryInterface
         $versionParser = new VersionParser();
         $version = $versionParser->normalize($version);
         $name = strtolower($name);
+        $packages = $this->getPackages();
+        $uniqueName = $name.'-'.$version;
 
-        foreach ($this->getPackages() as $package) {
-            if ($name === $package->getName() && $version === $package->getVersion()) {
-                return $package;
-            }
-        }
+        return isset($packages[$uniqueName]) ? $packages[$uniqueName] : null;
     }
 
     /**
@@ -79,15 +77,9 @@ class ArrayRepository implements RepositoryInterface
      */
     public function hasPackage(PackageInterface $package)
     {
-        $packageId = $package->getUniqueName();
+        $packages = $this->getPackages();
 
-        foreach ($this->getPackages() as $repoPackage) {
-            if ($packageId === $repoPackage->getUniqueName()) {
-                return true;
-            }
-        }
-
-        return false;
+        return isset($packages[$package->getUniqueName()]);
     }
 
     /**
@@ -101,7 +93,8 @@ class ArrayRepository implements RepositoryInterface
             $this->initialize();
         }
         $package->setRepository($this);
-        $this->packages[] = $package;
+
+        $this->packages += array($package->getUniqueName() => $package);
 
         // create alias package on the fly if needed
         if ($package->getAlias()) {
@@ -124,15 +117,7 @@ class ArrayRepository implements RepositoryInterface
      */
     public function removePackage(PackageInterface $package)
     {
-        $packageId = $package->getUniqueName();
-
-        foreach ($this->getPackages() as $key => $repoPackage) {
-            if ($packageId === $repoPackage->getUniqueName()) {
-                array_splice($this->packages, $key, 1);
-
-                return;
-            }
-        }
+        unset($this->packages[$package->getUniqueName()]);
     }
 
     /**

--- a/tests/Composer/Test/Repository/ArrayRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ArrayRepositoryTest.php
@@ -38,7 +38,7 @@ class ArrayRepositoryTest extends TestCase
         $repo->removePackage($this->getPackage('foo', '1'));
 
         $this->assertEquals(1, count($repo));
-        $this->assertEquals(array($package), $repo->getPackages());
+        $this->assertEquals(array($package->getUniqueName() => $package), $repo->getPackages());
     }
 
     public function testHasPackage()

--- a/tests/Composer/Test/Repository/CompositeRepositoryTest.php
+++ b/tests/Composer/Test/Repository/CompositeRepositoryTest.php
@@ -82,19 +82,21 @@ class CompositeRepositoryTest extends TestCase
     public function testGetPackages()
     {
         $arrayRepoOne = new ArrayRepository;
-        $arrayRepoOne->addPackage($this->getPackage('foo', '1'));
+        $firstPackage = $this->getPackage('foo', '1');
+        $arrayRepoOne->addPackage($firstPackage);
 
         $arrayRepoTwo = new ArrayRepository;
-        $arrayRepoTwo->addPackage($this->getPackage('bar', '1'));
+        $secondPackage = $this->getPackage('bar', '1');
+        $arrayRepoTwo->addPackage($secondPackage);
 
         $repo = new CompositeRepository(array($arrayRepoOne, $arrayRepoTwo));
 
         $packages = $repo->getPackages();
         $this->assertCount(2, $packages, "Should get two packages");
-        $this->assertEquals("foo", $packages[0]->getName(), "First package should have name of 'foo'");
-        $this->assertEquals("1", $packages[0]->getPrettyVersion(), "First package should have pretty version of '1'");
-        $this->assertEquals("bar", $packages[1]->getName(), "Second package should have name of 'bar'");
-        $this->assertEquals("1", $packages[1]->getPrettyVersion(), "Second package should have pretty version of '1'");
+        $this->assertEquals("foo", $packages[$firstPackage->getUniqueName()]->getName(), "First package should have name of 'foo'");
+        $this->assertEquals("1", $packages[$firstPackage->getUniqueName()]->getPrettyVersion(), "First package should have pretty version of '1'");
+        $this->assertEquals("bar", $packages[$secondPackage->getUniqueName()]->getName(), "Second package should have name of 'bar'");
+        $this->assertEquals("1", $packages[$secondPackage->getUniqueName()]->getPrettyVersion(), "Second package should have pretty version of '1'");
     }
 
     public function testAddRepository()

--- a/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
@@ -37,9 +37,10 @@ class FilesystemRepositoryTest extends TestCase
         $packages = $repository->getPackages();
 
         $this->assertSame(1, count($packages));
-        $this->assertSame('package1', $packages[0]->getName());
-        $this->assertSame('1.0.0.0-beta', $packages[0]->getVersion());
-        $this->assertSame('vendor', $packages[0]->getType());
+        $this->assertSame('package1', $packages['package1-1.0.0.0-beta']->getName());
+        $this->assertSame('1.0.0.0-beta', $packages['package1-1.0.0.0-beta']->getVersion());
+        $this->assertSame('vendor', $packages['package1-1.0.0.0-beta']->getType());
+        $this->assertSame('package1-1.0.0.0-beta', $packages['package1-1.0.0.0-beta']->getUniqueName());
     }
 
     /**


### PR DESCRIPTION
Updating repo is pretty slow on my computer so I tried to find bottlenecks with xhprof.

Found out that an update for composer repo was calling 
ArrayRepository::hasPackage 161 times 
BasePackage::getUniqueName **614187 times** !!

So i tried to refactor a bit

on my windows box : 
Before : 15s
After : 10s

On linux : 
Before : 6s
After : 3.8s
