### PR TITLE
ArchiveDownloader to support packages with a single file

### DIFF
--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -47,10 +47,9 @@ abstract class ArchiveDownloader extends FileDownloader
             if (1 === count($contentDir)) {
                 $contentDir = $contentDir[0];
 
-                if(is_file($contentDir)){
+                if (is_file($contentDir)) {
                     rename($contentDir, $path . '/' . basename($contentDir));
-                }
-                else{
+                } else {
                     
                     // Rename the content directory to avoid error when moving up
                     // a child folder with the same name


### PR DESCRIPTION
So far downloading it would fail with "not a directory" error, because of a file being unarchived and treated as a directory, and not being deleted afterwards.

For example http://sourceforge.net/projects/rssphp/files/rssphp/v1/rss_php.v1.zip/download

I've added fix to support that, see below
