### PR TITLE
[InstallerTest] Fixed return status was always 0

### DIFF
--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -197,7 +197,7 @@ class InstallerTest extends TestCase
         $application->get('install')->setCode(function ($input, $output) use ($installer) {
             $installer->setDevMode($input->getOption('dev'));
 
-            return $installer->run();
+            return $installer->run() ? 0 : 1;
         });
 
         $application->get('update')->setCode(function ($input, $output) use ($installer) {
@@ -206,7 +206,7 @@ class InstallerTest extends TestCase
                 ->setUpdate(true)
                 ->setUpdateWhitelist($input->getArgument('packages'));
 
-            return $installer->run();
+            return $installer->run() ? 0 : 1;
         });
 
         if (!preg_match('{^(install|update)\b}', $run)) {


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/pborreli/composer.png?branch=master)](http://travis-ci.org/pborreli/composer)

`setCode` overrides the code defined in the execute() method

`execute` method always have to return a numeric statusCode, if not it is replaced by 0.

```
return is_numeric($statusCode) ? $statusCode : 0;
```

In our case `run` method was returning false or true so it was always converted to 0, so this assertion couldn't fail.
