### PR TITLE
[WIP] Fix permissions on COMPOSER_HOME:

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -42,12 +42,18 @@ class Factory
             }
         }
 
-        // Protect directory against web access
-        if (!file_exists($home . '/.htaccess')) {
-            if (!is_dir($home)) {
-                @mkdir($home, 0777, true);
+        if (!is_dir($home)) {
+            @mkdir($home, 0700, true);
+        } else {
+            $check = stat($home);
+            if (false !== $check) {
+                $mode = sprintf("%o", ($check['mode'] & 000777));
+                if ($mode != '700') {
+                    // we could tell the user to secure this directory
+                    // but there is no OutputInterface here
+                    // thoughs?
+                }
             }
-            @file_put_contents($home . '/.htaccess', 'Deny from all');
         }
 
         $config = new Config();


### PR DESCRIPTION
- The current fix is more obscure than secure
  - not everyone runs Apache (or even a webserver)
  - this commit ensure rwx is only for the current user
  - uses a stat() call to gather 'mode', but no output yet

(Best _use-case_ for the current state of the code: I can delete the `$COMPOSER_HOME` of another user just by issuing something like, `rm -rf /home/user/.composer`.)
