### PR TITLE
Created a new autoloader able to manage all composer class maps at once

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -354,9 +354,14 @@ require __DIR__ . '/ClassLoader.php';
 
 class ComposerAutoloaderInit$suffix
 {
+    public static \$loader;
+    
     public static function getLoader()
     {
-        \$loader = new \\Composer\\Autoload\\ClassLoader();
+        if(self::\$loader == null){
+            self::\$loader = new \\Composer\\Autoload\\ClassLoader();
+            self::\$loader->register();
+        }
         \$vendorDir = $vendorPathCode;
         \$baseDir = $appBaseDirCode;
 
@@ -377,7 +382,7 @@ INCLUDE_PATH;
             $file .= <<<'PSR0'
         $map = require __DIR__ . '/autoload_namespaces.php';
         foreach ($map as $namespace => $path) {
-            $loader->add($namespace, $path);
+            self::$loader->add($namespace, $path);
         }
 
 
@@ -388,26 +393,24 @@ PSR0;
             $file .= <<<'CLASSMAP'
         $classMap = require __DIR__ . '/autoload_classmap.php';
         if ($classMap) {
-            $loader->addClassMap($classMap);
+            self::$loader->addClassMap($classMap);
         }
-
 
 CLASSMAP;
         }
 
         if ($targetDirLoader) {
             $file .= <<<REGISTER_AUTOLOAD
-        spl_autoload_register(array('ComposerAutoloaderInit$suffix', 'autoload'));
 
+        spl_autoload_register(array('ComposerAutoloaderInit$suffix', 'autoload'));
 
 REGISTER_AUTOLOAD;
 
         }
 
         $file .= <<<METHOD_FOOTER
-        \$loader->register();
 $filesCode
-        return \$loader;
+        return self::\$loader;
     }
 
 METHOD_FOOTER;

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -6,27 +6,30 @@ require __DIR__ . '/ClassLoader.php';
 
 class ComposerAutoloaderInitFilesAutoload
 {
+    public static $loader;
+    
     public static function getLoader()
     {
-        $loader = new \Composer\Autoload\ClassLoader();
+        if(self::$loader == null){
+            self::$loader = new \Composer\Autoload\ClassLoader();
+            self::$loader->register();
+        }
         $vendorDir = dirname(__DIR__);
         $baseDir = dirname($vendorDir);
 
         $map = require __DIR__ . '/autoload_namespaces.php';
         foreach ($map as $namespace => $path) {
-            $loader->add($namespace, $path);
+            self::$loader->add($namespace, $path);
         }
 
         $classMap = require __DIR__ . '/autoload_classmap.php';
         if ($classMap) {
-            $loader->addClassMap($classMap);
+            self::$loader->addClassMap($classMap);
         }
-
-        $loader->register();
 
         require $vendorDir . '/a/a/test.php';
         require $vendorDir . '/b/b/test2.php';
 
-        return $loader;
+        return self::$loader;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -6,27 +6,30 @@ require __DIR__ . '/ClassLoader.php';
 
 class ComposerAutoloaderInitTargetDir
 {
+    public static $loader;
+    
     public static function getLoader()
     {
-        $loader = new \Composer\Autoload\ClassLoader();
+        if(self::$loader == null){
+            self::$loader = new \Composer\Autoload\ClassLoader();
+            self::$loader->register();
+        }
         $vendorDir = dirname(__DIR__);
         $baseDir = dirname($vendorDir);
 
         $map = require __DIR__ . '/autoload_namespaces.php';
         foreach ($map as $namespace => $path) {
-            $loader->add($namespace, $path);
+            self::$loader->add($namespace, $path);
         }
 
         $classMap = require __DIR__ . '/autoload_classmap.php';
         if ($classMap) {
-            $loader->addClassMap($classMap);
+            self::$loader->addClassMap($classMap);
         }
 
         spl_autoload_register(array('ComposerAutoloaderInitTargetDir', 'autoload'));
 
-        $loader->register();
-
-        return $loader;
+        return self::$loader;
     }
 
     public static function autoload($class)


### PR DESCRIPTION
Hi,
This is a work in progress pull request.

I'm working on a ComposerAutoloaderInit that uses a static loader.

The advantages would be that you can load as many composer "autoload.php" files and use only one loader.

It doesn't work for the moment for some reasons :
- the generated code is not generic any project could use an other Init class
- there is an Hard coded **DIR** that makes it impossible to load other classes

The objective behind this is that in my case, I have a home made framework (based on CodeIgniter) that is adapter to make some HMVC

and some modules need some external dependencies.
so they have a composer.json file

and I don't want to make one big composer.json file at the root of my project because the modules are not always loaded. So I don't need these classes / namespaces in my classmap

The idea is simply that there is only one initialized class that manages all composer autoloading stuff, I don't need to have 2, 3, 4 or more composer classes that each manage a subset of my classes.

Tell me if it's an interesting thing for you and I'll work on the last parts that don't work for the moment
