### PR TITLE
Added a small clarification to the 05-repositories article.

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -161,7 +161,8 @@ project to use the patched version. If the library is on GitHub (this is the
 case most of the time), you can simply fork it there and push your changes to
 your fork. After that you update the project's `composer.json`. All you have
 to do is add your fork as a repository and update the version constraint to
-point to your custom branch.
+point to your custom branch. For version constraint naming conventions see 
+[Libraries](02-libraries.md) for more information.
 
 Example assuming you patched monolog to fix a bug in the `bugfix` branch:
 


### PR DESCRIPTION
To make it clearer how to use version constraints when making use
of your own VCS repository. ThIs tripped me up for a few hours. 
