### PR TITLE
Reword custom directory FAQ

### DIFF
--- a/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md
+++ b/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md
@@ -1,10 +1,9 @@
-# How do I install a package in a custom directory?
+# How do I install a package to a custom path for my framework?
 
-Composer can be configured to install packages to a folder other than the
-default `vendor` folder. A simple way is to use the
-[composer/installers](https://github.com/composer/installers) package and if
-you are using a framework, chances are a custom directory has been already
-configured for you.
+Each framework may have one or many different required package installation
+paths. Composer can be configured to install packages to a folder other than
+the default `vendor` folder by using
+[composer/installers](https://github.com/composer/installers).
 
 If you are a **package author** and want your package installed to a custom
 directory, simply require `composer/installers` and set the appropriate `type`.
@@ -25,11 +24,11 @@ Now when your theme is installed with Composer it will be placed into
 [current supported types](https://github.com/composer/installers#current-supported-types)
 for your package.
 
-As a **package consumer** you can set or override the install path for each
-package with the `installer-paths` extra. A useful example would be for a
-Drupal multisite setup where the package should be installed into your sites
-subdirectory. Here we are overriding the install path for a module that uses
-composer/installers:
+As a **package consumer** you can set or override the install path for a package
+that requires composer/installers by configuring the `installer-paths` extra. A
+useful example would be for a Drupal multisite setup where the package should be
+installed into your sites subdirectory. Here we are overriding the install path
+for a module that uses composer/installers:
 
     {
         "extra": {
@@ -41,3 +40,6 @@ composer/installers:
 
 Now the package would be installed to your folder location, rather than the default
 composer/installers determined location.
+
+> **Note:** You cannot use this to change the path of any package. This is only
+> applicable to packages that require `composer/installers`.


### PR DESCRIPTION
Fixes #943

Rewording the custom directory FAQ to indicate it only applies to packages using `composer/installers`.

@igorw Please let me know if this is better worded or any more changes are needed. Thanks!
