### PR TITLE
casted requirments to array in require command

### DIFF
--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -73,7 +73,7 @@ EOT
 
         $requireKey = $input->getOption('dev') ? 'require-dev' : 'require';
         $baseRequirements = array_key_exists($requireKey, $composer) ? $composer[$requireKey] : array();
-        $requirements = $this->formatRequirements($requirements);
+        $requirements = (array) $this->formatRequirements($requirements);
 
         if (!$this->updateFileCleanly($json, $baseRequirements, $requirements, $requireKey)) {
             foreach ($requirements as $package => $version) {


### PR DESCRIPTION
When using the require command without package parameters and entering in the interactive mode, if the specified package name isn't found, the formatRequirements from the parent command returns an stdClass, wich causes an error later because an array is expected.
