### PR TITLE
Removed a PHP notice when dumping the autoloader

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -85,7 +85,7 @@ EOF;
         // add custom psr-0 autoloading if the root package has a target dir
         $targetDirLoader = null;
         $mainAutoload = $mainPackage->getAutoload();
-        if ($mainPackage->getTargetDir() && $mainAutoload['psr-0']) {
+        if ($mainPackage->getTargetDir() && !empty($mainAutoload['psr-0'])) {
             $levels = count(explode('/', trim(strtr($mainPackage->getTargetDir(), '\\', '/'), '/')));
             $prefixes = implode(', ', array_map(function ($prefix) {
                 return var_export($prefix, true);

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -164,6 +164,28 @@ class AutoloadGeneratorTest extends TestCase
         $this->assertFileEquals(__DIR__.'/Fixtures/autoload_real_target_dir.php', $this->vendorDir.'/composer/autoload_realTargetDir.php');
     }
 
+    public function testMainPackageAutoloadingWithTargetDirAndNoPsr()
+    {
+        $package = new Package('a', '1.0', '1.0');
+        $package->setAutoload(array(
+            'classmap' => array('composersrc/'),
+        ));
+        $package->setTargetDir('Main/Foo/');
+
+        $this->repository->expects($this->once())
+            ->method('getPackages')
+            ->will($this->returnValue(array()));
+
+        $this->vendorDir .= '/subdir';
+
+        $this->fs->ensureDirectoryExists($this->vendorDir.'/composer');
+        $this->fs->ensureDirectoryExists($this->workingDir.'/src');
+
+        $this->createClassFile($this->workingDir);
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', false, 'TargetDirNoPsr');
+        $this->assertAutoloadFiles('classmap2', $this->vendorDir.'/composer', 'classmap');
+    }
+
     public function testVendorsAutoloading()
     {
         $package = new Package('a', '1.0', '1.0');


### PR DESCRIPTION
This occured when the root package has a target-dir but does not have
configure a PSR-0 autoloader.
Fixes #1028
