### PR TITLE
Append "/packages.json" to URLs of composer repositories only when not already present

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -191,7 +191,9 @@ class ComposerRepository extends ArrayRepository implements NotifiableRepository
         }
 
         try {
-            if ($parts = parse_url($this->url) and isset($parts['path']) and strpos($parts['path'], '/packages.json') !== false) {
+            $jsonUrlParts = parse_url($this->url);
+
+            if (isset($jsonUrlParts['path']) and strpos($jsonUrlParts['path'], '/packages.json') !== false) {
                 $jsonUrl = $this->url;
             } else {
                 $jsonUrl = $this->url . '/packages.json';


### PR DESCRIPTION
This patch changes the `ComposerRepository` to only add the `/packages.json` path to the URL when it's not already in the URL. The reason behind this, is that we need to pass query parameters after `packages.json` so we can put `packages.json` as non-public file to S3 and use [Query Parameter Authentication](http://docs.amazonwebservices.com/AmazonS3/latest/dev/S3_QSAuth.html).
