### PR TITLE
PEAR - Bug with shell shebang ?

### DIFF
--- a/src/Composer/Installer/PearInstaller.php
+++ b/src/Composer/Installer/PearInstaller.php
@@ -55,6 +55,10 @@ class PearInstaller extends LibraryInstaller
         $isWindows = defined('PHP_WINDOWS_VERSION_BUILD');
         $php_bin = $this->binDir . ($isWindows ? '/composer-php.bat' : '/composer-php');
 
+        if (!$isWindows) {
+            $php_bin = '/usr/bin/env ' . $php_bin;
+        }
+
         $installPath = $this->getInstallPath($package);
         $vars = array(
             'os' => $isWindows ? 'windows' : 'linux',
@@ -161,7 +165,7 @@ class PearInstaller extends LibraryInstaller
         return
             "#!/usr/bin/env sh\n".
             "SRC_DIR=`pwd`\n".
-            "BIN_DIR=`dirname $(readlink -f $0)`\n".
+            "BIN_DIR=`dirname $0`\n".
             "VENDOR_DIR=\$BIN_DIR/".escapeshellarg($binToVendor)."\n".
             "DIRS=\"\"\n".
             "for vendor in \$VENDOR_DIR/*; do\n".


### PR DESCRIPTION
When I launch a script with ./vendor/bin/phpcs it doesn't work

``` json

{
    "name": "project/quality",
    "autoload": {
        "psr-0": { "": "src/" }
    },
    "repositories": [
        {
            "type": "pear",
            "url": "http://pear.php.net"
        }
    ],
    "require": {
        "pear-pear/PHP_CodeSniffer": "*"
    },
    "minimum-stability": "dev"
}
```

The console output

```
$ ./vendor/bin/phpcs src/./vendor/bin/phpcs: line 2: ?php: No such file or directory
./vendor/bin/phpcs: line 3: /Applications: is a directory
./vendor/bin/phpcs: line 4: ./composer.json: Permission denied
./vendor/bin/phpcs: line 5: ./composer.json: Permission denied
./vendor/bin/phpcs: line 6: ./composer.json: Permission denied
./vendor/bin/phpcs: line 7: ./composer.json: Permission denied
./vendor/bin/phpcs: line 8: ./composer.json: Permission denied
./vendor/bin/phpcs: line 9: ./composer.json: Permission denied
./vendor/bin/phpcs: line 10: ./composer.json: Permission denied
./vendor/bin/phpcs: line 11: syntax error near unexpected token `newline'
./vendor/bin/phpcs: line 11: ` * @author    Greg Sherwood <gsherwood@squiz.net>'
```
