### PR TITLE
Fix Repository::filterPackages() callback

### DIFF
--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -118,7 +118,7 @@ class ArrayRepository implements RepositoryInterface
     public function filterPackages($callback, $class = 'Composer\Package\Package')
     {
         foreach ($this->getPackages() as $package) {
-            if (false === $callback($package)) {
+            if (false === call_user_func($callback, $package)) {
                 return false;
             }
         }

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -135,11 +135,11 @@ class ComposerRepository extends ArrayRepository implements NotifiableRepository
         }
 
         foreach ($this->rawData as $package) {
-            if (false === $callback($package = $this->loader->load($package, $class))) {
+            if (false === call_user_func($callback, $package = $this->loader->load($package, $class))) {
                 return false;
             }
             if ($package->getAlias()) {
-                if (false === $callback($this->createAliasPackage($package))) {
+                if (false === call_user_func($callback, $this->createAliasPackage($package))) {
                     return false;
                 }
             }

--- a/tests/Composer/Test/Repository/ArrayRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ArrayRepositoryTest.php
@@ -17,6 +17,13 @@ use Composer\Test\TestCase;
 
 class ArrayRepositoryTest extends TestCase
 {
+    protected $callbackCount;
+
+    public function setUp()
+    {
+        $this->callbackCount = 0;
+    }
+
     public function testAddPackage()
     {
         $repo = new ArrayRepository;
@@ -65,5 +72,23 @@ class ArrayRepositoryTest extends TestCase
         $bar = $repo->findPackages('bar');
         $this->assertCount(2, $bar);
         $this->assertEquals('bar', $bar[0]->getName());
+    }
+
+    public function testFilterPackages()
+    {
+        $repo = new ArrayRepository();
+        $repo->addPackage($this->getPackage('foo', '1'));
+        $repo->addPackage($this->getPackage('bar', '2'));
+        $repo->addPackage($this->getPackage('bar', '3'));
+
+        $return = $repo->filterPackages(array($this, 'callback'));
+
+        $this->assertTrue($return);
+        $this->assertEquals(3, $this->callbackCount);
+    }
+
+    public function callback()
+    {
+        $this->callbackCount++;
     }
 }


### PR DESCRIPTION
Fix for #1079

I run PHP 5.3 and got the same issue when the `$callback` is `array($object, 'method')`.
