### PR TITLE
ComposerAutoloaderInitXXX::getLoader behaves like a ClassLoader singleton

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -372,9 +372,15 @@ require __DIR__ . '/ClassLoader.php';
 
 class ComposerAutoloaderInit$suffix
 {
+    private static \$loader;
+
     public static function getLoader()
     {
-        \$loader = new \\Composer\\Autoload\\ClassLoader();
+        if (null !== static::\$loader) {
+            return static::\$loader;
+        }
+
+        static::\$loader = \$loader = new \\Composer\\Autoload\\ClassLoader();
         \$vendorDir = $vendorPathCode;
         \$baseDir = $appBaseDirCode;
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -6,9 +6,15 @@ require __DIR__ . '/ClassLoader.php';
 
 class ComposerAutoloaderInitFilesAutoloadOrder
 {
+    private static $loader;
+
     public static function getLoader()
     {
-        $loader = new \Composer\Autoload\ClassLoader();
+        if (null !== static::$loader) {
+            return static::$loader;
+        }
+
+        static::$loader = $loader = new \Composer\Autoload\ClassLoader();
         $vendorDir = dirname(__DIR__);
         $baseDir = dirname($vendorDir);
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -6,9 +6,15 @@ require __DIR__ . '/ClassLoader.php';
 
 class ComposerAutoloaderInitFilesAutoload
 {
+    private static $loader;
+
     public static function getLoader()
     {
-        $loader = new \Composer\Autoload\ClassLoader();
+        if (null !== static::$loader) {
+            return static::$loader;
+        }
+
+        static::$loader = $loader = new \Composer\Autoload\ClassLoader();
         $vendorDir = dirname(__DIR__);
         $baseDir = dirname($vendorDir);
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -6,9 +6,15 @@ require __DIR__ . '/ClassLoader.php';
 
 class ComposerAutoloaderInitTargetDir
 {
+    private static $loader;
+
     public static function getLoader()
     {
-        $loader = new \Composer\Autoload\ClassLoader();
+        if (null !== static::$loader) {
+            return static::$loader;
+        }
+
+        static::$loader = $loader = new \Composer\Autoload\ClassLoader();
         $vendorDir = dirname(__DIR__);
         $baseDir = dirname($vendorDir);
 


### PR DESCRIPTION
Calling ComposerAutoloaderInit::getLoader twice when a package requires a .php file containing functions, lead to the functions to be declared twice, and cause an error.

In my case, using behat + symfony2extension + assetic@master, the error that occured:

```
PHP Fatal error:  Cannot redeclare assetic_init() (previously declared in vendor/kriswallsmith/assetic/src/functions.php:20) in /vendor/kriswallsmith/assetic/src/functions.php on line 26

Fatal error: Cannot redeclare assetic_init() (previously declared in /vendor/kriswallsmith/assetic/src/functions.php:20) in /vendor/kriswallsmith/assetic/src/functions.php on line 26
```

I've sent a PR to assetic https://github.com/kriswallsmith/assetic/pull/302 , but IMHO, this would be easier if composer solved this.

This PR is a quick fix I found, not sure if this is the way to go ?
