### PR TITLE
Added global --working-dir option

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -93,13 +93,31 @@ class Application extends BaseApplication
             $startTime = microtime(true);
         }
 
+        $oldWorkingDir = getcwd();
+        $this->switchWorkingDir($input);
+
         $result = parent::doRun($input, $output);
+
+        chdir($oldWorkingDir);
 
         if (isset($startTime)) {
             $output->writeln('<info>Memory usage: '.round(memory_get_usage() / 1024 / 1024, 2).'MB (peak: '.round(memory_get_peak_usage() / 1024 / 1024, 2).'MB), time: '.round(microtime(true) - $startTime, 2).'s');
         }
 
         return $result;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @throws \RuntimeException
+     */
+    private function switchWorkingDir(InputInterface $input)
+    {
+        $workingDir = $input->getParameterOption(array('--working-dir', '-d'), getcwd());
+        if (!is_dir($workingDir)) {
+            throw new \RuntimeException('Invalid working directoy specified.');
+        }
+        chdir($workingDir);
     }
 
     /**


### PR DESCRIPTION
This is a lightweight attempt to address issue #503.

I've added a global option `--working-dir` with shortcut `-d` that allows to run any composer command as if composer was called from the specified working directory. Instead of

``` bash
cd /path/to/my/project
php /path/to/composer.phar install
```

I can now simply run

``` bash
php /path/to/composer.phar install -d /path/to/my/project
```

Internally, composer switches to the given directory before executing the the specified command.
