### PR TITLE
Require command to perform a search if no version information is provided

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -336,7 +336,7 @@ EOT
         $output->writeln('');
 
         $validator = function ($selection) use ($matches) {
-            if ('' === $selection) {
+            if (null === $selection) {
                 return null;
             }
 


### PR DESCRIPTION
When using the composer require command, if you dont provide a version currently it asks you for one.  In some cases the user may not know the version they want.  This pull request adjusts the console command so that if the user provides no input when asked about a version a search is done so the user can choose one of the results.
