### PR TITLE
Fix unintentional manipulation of release dates

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -136,8 +136,7 @@ class ArrayLoader implements LoaderInterface
 
         if (!empty($config['time'])) {
             try {
-                $date = new \DateTime($config['time']);
-                $date->setTimezone(new \DateTimeZone('UTC'));
+                $date = new \DateTime($config['time'], new \DateTimeZone('UTC'));
                 $package->setReleaseDate($date);
             } catch (\Exception $e) {
             }


### PR DESCRIPTION
Calling `setTimezone` after creating the `DateTime` object causes transitions to be applied.  #1126 is almost certainly related.
