### PR TITLE
Remove left over of commit-time code in locker

### DIFF
--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -282,15 +282,6 @@ class Locker
             $spec = $this->dumper->dump($package);
             unset($spec['version_normalized']);
 
-            if ($package->isDev()) {
-                if ('git' === $package->getSourceType() && $path = $this->installationManager->getInstallPath($package)) {
-                    $process = new ProcessExecutor();
-                    if (0 === $process->execute('git log -n1 --pretty=%ct '.escapeshellarg($package->getSourceReference()), $output, $path)) {
-                        $spec['time'] = trim($output);
-                    }
-                }
-            }
-
             $locked[] = $spec;
         }
 


### PR DESCRIPTION
Originally added in c9ef7479c4a399e37a8bf48c9c94fc9de6d7f460 but no longer required as the commit time is available from the package.
