### PR TITLE
Use the locked package for the update operation

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -394,9 +394,7 @@ class Installer
                         && $lockedPackage->getSourceReference()
                         && $lockedPackage->getSourceReference() !== $package->getSourceReference()
                     ) {
-                        $newPackage = clone $package;
-                        $newPackage->setSourceReference($lockedPackage->getSourceReference());
-                        $operations[] = new UpdateOperation($package, $newPackage);
+                        $operations[] = new UpdateOperation($package, $lockedPackage);
 
                         break;
                     }


### PR DESCRIPTION
Fixes #879. I tracked this issue down to using a clone of the current package with an altered source reference for the update operation. Altered to use the package from the lock file and everything seems to work fine.
