### PR TITLE
Introduce "title" property to schema

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -8,6 +8,10 @@
             "description": "Package name, including 'vendor-name/' prefix.",
             "required": true
         },
+        "title": {
+            "type": "string",
+            "description": "Package title, a concise human-readable title for the package.",
+        },
         "type": {
             "description": "Package type, either 'library' for common packages, 'composer-installer' for custom installers, 'metapackage' for empty packages, or a custom type defined by whatever project this package applies to.",
             "type": "string"


### PR DESCRIPTION
Introduce a new property "title" which can contain a concise human-readable
title for the package. Backwards compatibility: If a "title" property exists,
it is used as a label in listings. If it's empty, the package name could be
used as a fallback. But in the end it's up to the application which
information is displayed.

Fixes: #1140
