### PR TITLE
Semantic Version Parsing: ~version

### DIFF
--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -245,6 +245,28 @@ class VersionParser
             return array();
         }
 
+        if (preg_match('{^~(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.(\d+))?$}', $constraint, $matches)) {
+            if (isset($matches[4])) {
+                $highVersion = $matches[1] . '.' . $matches[2] . '.' . ($matches[3] + 1) . '.0-dev';
+                $lowVersion = $matches[1] . '.' . $matches[2] . '.' . $matches[3]. '.' . $matches[4];
+            } elseif (isset($matches[3])) {
+                $highVersion = $matches[1] . '.' . ($matches[2] + 1) . '.0.0-dev';
+                $lowVersion = $matches[1] . '.' . $matches[2] . '.' . $matches[3]. '.0';
+            } else {
+                $highVersion = ($matches[1] + 1) . '.0.0.0-dev';
+                if (isset($matches[2])) {
+                    $lowVersion = $matches[1] . '.' . $matches[2] . '.0.0';
+                } else {
+                    $lowVersion = $matches[1] . '.0.0.0';
+                }
+            }
+
+            return array(
+                new VersionConstraint('>=', $lowVersion),
+                new VersionConstraint('<', $highVersion),
+            );
+        }
+
         // match wildcard constraints
         if (preg_match('{^(\d+)(?:\.(\d+))?(?:\.(\d+))?\.[x*]$}', $constraint, $matches)) {
             if (isset($matches[3])) {

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -240,6 +240,31 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @dataProvider tildeConstraints
+     */
+    public function testParseTildeWildcard($input, $min, $max)
+    {
+        $parser = new VersionParser;
+        if ($min) {
+            $expected = new MultiConstraint(array($min, $max));
+        } else {
+            $expected = $max;
+        }
+
+        $this->assertSame((string) $expected, (string) $parser->parseConstraints($input));
+    }
+
+    public function tildeConstraints()
+    {
+        return array(
+            array('~1',       new VersionConstraint('>=', '1.0.0.0'), new VersionConstraint('<', '2.0.0.0-dev')),
+            array('~1.2',     new VersionConstraint('>=', '1.2.0.0'), new VersionConstraint('<', '2.0.0.0-dev')),
+            array('~1.2.3',   new VersionConstraint('>=', '1.2.3.0'), new VersionConstraint('<', '1.3.0.0-dev')),
+            array('~1.2.3.4', new VersionConstraint('>=', '1.2.3.4'), new VersionConstraint('<', '1.2.4.0-dev')),
+        );
+    }
+
     public function testParseConstraintsMulti()
     {
         $parser = new VersionParser;


### PR DESCRIPTION
Implemented according to #643 and used the following versions as a test case as defined by @Seldaek:
- "~1.2.3.4" = ">=1.2.3.4 <1.2.4.0-dev"
- "~1.2.3" = ">=1.2.3 <1.3.0-dev"
- "~1.2" = ">=1.2.0 <2.0.0-dev"
- "~1" = ">=1.0.0 <2.0.0-dev"

This was by no means done simply because I want to ask Composer to update to depend on Symfony ~2.1 components. Honest. :)
