### PR TITLE
Version Parsing: Consider <x.y.z to be <x.y.z-dev

### DIFF
--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -25,7 +25,7 @@ use Composer\Package\LinkConstraint\VersionConstraint;
  */
 class VersionParser
 {
-    private static $modifierRegex = '[._-]?(?:(beta|b|RC|alpha|a|patch|pl|p)(?:[.-]?(\d+))?)?([.-]?dev)?';
+    private static $modifierRegex = '[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)(?:[.-]?(\d+))?)?([.-]?dev)?';
 
     /**
      * Returns the stability of a version
@@ -121,6 +121,9 @@ class VersionParser
         // add version modifiers if a version was matched
         if (isset($index)) {
             if (!empty($matches[$index])) {
+                if ('stable' === $matches[$index]) {
+                    return $version;
+                }
                 $mod = array('{^pl?$}i', '{^rc$}i');
                 $modNormalized = array('patch', 'RC');
                 $version .= '-'.preg_replace($mod, $modNormalized, strtolower($matches[$index]))
@@ -283,6 +286,10 @@ class VersionParser
 
                 if (!empty($stabilityModifier) && $this->parseStability($version) === 'stable') {
                     $version .= '-' . $stabilityModifier;
+                } elseif ('<' === $matches[1]) {
+                    if (!preg_match('/-stable$/', strtolower($matches[2]))) {
+                        $version .= '-dev';
+                    }
                 }
 
                 return array(new VersionConstraint($matches[1] ?: '=', $version));

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -195,7 +195,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             'not equal'         => array('<>1.0.0',     new VersionConstraint('<>', '1.0.0.0')),
             'not equal/2'       => array('!=1.0.0',     new VersionConstraint('!=', '1.0.0.0')),
             'greater than'      => array('>1.0.0',      new VersionConstraint('>', '1.0.0.0')),
-            'lesser than'       => array('<1.2.3.4',    new VersionConstraint('<', '1.2.3.4')),
+            'lesser than'       => array('<1.2.3.4',    new VersionConstraint('<', '1.2.3.4-dev')),
             'less/eq than'      => array('<=1.2.3',     new VersionConstraint('<=', '1.2.3.0')),
             'great/eq than'     => array('>=1.2.3',     new VersionConstraint('>=', '1.2.3.0')),
             'equals'            => array('=1.2.3',      new VersionConstraint('=', '1.2.3.0')),
@@ -209,6 +209,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             'regression #550'   => array('dev-some-fix',    new VersionConstraint('=', 'dev-some-fix')),
             'regression #935'   => array('dev-CAPS',        new VersionConstraint('=', 'dev-CAPS')),
             'ignores aliases'   => array('dev-master as 1.0.0', new VersionConstraint('=', '9999999-dev')),
+            'lesser than override'       => array('<1.2.3.4-stable',    new VersionConstraint('<', '1.2.3.4')),
         );
     }
 


### PR DESCRIPTION
> Consider `<x.y.z` to be `<x.y.z-dev.` Because in 99% of the cases that's what the intent is. Could be overriden with `<x.y.z-stable`. — @Seldaek #643

First pass at attempting to address this type of version parsing. I was a little sketched out by my solution for the `-stable` part. Open to suggestions.

I also added this `-dev` magic to `<=`, but not sure that is desired.
