### PR TITLE
Added reference to --dev option in show command documentation

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -142,6 +142,7 @@ specific version.
 
 * **--installed:** Will list the packages that are installed.
 * **--platform:** Will list only platform packages (php & extensions).
+* **--dev:** Will include dev-required packages when combined with **--installed** or **--platform**.
 
 ## depends
 


### PR DESCRIPTION
Displays the `--dev` option among the available options for the show command in the Cli section

Related to #1197
