### PR TITLE
Added exit(1) when 'You must set up the project dependencies'

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -18,9 +18,10 @@ function includeIfExists($file)
 }
 
 if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
-    die('You must set up the project dependencies, run the following commands:'.PHP_EOL.
+    echo 'You must set up the project dependencies, run the following commands:'.PHP_EOL.
         'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
-        'php composer.phar install'.PHP_EOL);
+        'php composer.phar install'.PHP_EOL;
+    exit(1);
 }
 
 return $loader;


### PR DESCRIPTION
If composer cannot execute composer dump-autoload (and others), because dependencies are not properly configured, it should exit with status code 1 so scripts or tools like capifony can get the exit code and stop execution or act based on the error. Otherwise it goes as if all went OK.

This PR adds exit(1) to the src/bootstrap.php file.
