### PR TITLE
Fixed class normalization for class map case.

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -162,12 +162,12 @@ class ClassLoader
      */
     public function findFile($class)
     {
-        if (isset($this->classMap[$class])) {
-            return $this->classMap[$class];
-        }
-
         if ('\\' == $class[0]) {
             $class = substr($class, 1);
+        }
+
+        if (isset($this->classMap[$class])) {
+            return $this->classMap[$class];
         }
 
         if (false !== $pos = strrpos($class, '\\')) {


### PR DESCRIPTION
In case if class will be prepended with "\" (backslash), remote it for the class map case also.
