### PR TITLE
Added "--prefer-dist" option to create-project command

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -194,11 +194,10 @@ EOT
 
         $installer->run();
 
-        if (!$keepVcs && (
+        if (!$keepVcs && $installedFromVcs && (
             !$io->isInteractive() ||
             $io->askConfirmation('<info>Do you want to remove the exisitng VCS (.git, .svn..) history?</info> [<comment>Y,n</comment>]? ', true)
             )
-            && (!$preferDist || $installedFromVcs)
         ) {
             $finder = new Finder();
             $finder->depth(1)->directories()->in(getcwd())->ignoreVCS(false)->ignoreDotFiles(false);


### PR DESCRIPTION
The `--prefer-dist` option is already available for `install` and `update`. This patch adds support in the `create-project` command as well.
