### PR TITLE
Fixed Composer\Autoload\ClassLoader::findFile failure return value inconsistency.

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -167,7 +167,7 @@ class ClassLoader
         }
 
         if (isset($this->classMap[$class])) {
-            return $this->classMap[$class];
+            return $this->classMap[$class] ?: null;
         }
 
         if (false !== $pos = strrpos($class, '\\')) {


### PR DESCRIPTION
Normally on a first run, the there is no return value, resulting in `null`, on a second check on the same file, the classmap will contain a value of false. If we set the classMap result to `null` the isset won't work anymore, so when `false` it now returns `null`, consistently.
