### PR TITLE
Fixed an issue with set HTTP proxy and PHP 5.4

### DIFF
--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -70,7 +70,7 @@ final class StreamContextFactory
 
                 // Preserve headers if already set in default options
                 if (isset($defaultOptions['http']['header'])) {
-                    $defaultOptions['http']['header'] .= "Proxy-Authorization: Basic {$auth}\r\n";
+                    $defaultOptions['http']['header'][] = "Proxy-Authorization: Basic {$auth}";
                 } else {
                     $options['http']['header'] = "Proxy-Authorization: Basic {$auth}\r\n";
                 }


### PR DESCRIPTION
Hi! 

There exist a problem in Composer if a user have set an HTTP_PROXY environment variable.

To be exact, when I'm trying to do `php composer.phar install` with such environment, there's `RuntimeException`:

```
[RuntimeException]
Could not read composer.json

Array to string conversion
```

My PHP version:

```
c:\>php -v
PHP 5.4.3 (cli) (built: May  8 2012 00:51:31)
Copyright (c) 1997-2012 The PHP Group
Zend Engine v2.4.0, Copyright (c) 1998-2012 Zend Technologies
```

This pull request fixes this issue.
