### PR TITLE
Allow use of Github OAuth2 token stored in git config

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -351,9 +351,7 @@ class GitHubDriver extends VcsDriver
     protected function authorizeOAuth()
     {
         // If available use token from git config
-        exec('git config github.accesstoken', $output, $returnCode);
-        if ($returnCode === 0 && !empty($output[0]))
-        {
+        if (0 === $this->process->execute('git config github.accesstoken', $output)) {
             $this->io->write('Using Github OAuth token stored in git config (github.accesstoken)');
             $this->io->setAuthorization($this->originUrl, $output[0], 'x-oauth-basic');
             return;


### PR DESCRIPTION
There is an existing convention of storing your Github API OAuth access token in your git config, under the section `github` and key `accesstoken`.

This patch makes a quick shell out to `git config` to try and get the token from there and then uses it during the request (without storing it permanently in Composer's config, to avoid having a stale token stored in Composer while it's instead updated by the user in their git config)
