### PR TITLE
Check for github token from git config even when running in non-interactive mode

### DIFF
--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -51,13 +51,6 @@ class GitHub
      */
     public function authorizeOAuth($originUrl, $message = null)
     {
-        // if available use token from git config
-        if (0 === $this->process->execute('git config github.accesstoken', $output)) {
-            $this->io->setAuthorization($originUrl, trim($output), 'x-oauth-basic');
-
-            return;
-        }
-
         $attemptCounter = 0;
 
         if ($message) {


### PR DESCRIPTION
Even if Composer is invoked in non-interactive mode it should try to get a GitHub access token from `git config` as this would be a common use case, and is certainly ours.

I notice this code was moved to a Github Util, I moved it back for easy of invocation from the driver prior to erroring due to being in non-interactive mode, but could do the same as the `authorizeOAuth` helper method and have the git config instantiate a GitHelp util first.
