### PR TITLE
Allow authenticated downloads from api.github.com

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -87,8 +87,7 @@ class FileDownloader implements DownloaderInterface
         $processUrl = $this->processUrl($package, $url);
         $processHost = parse_url($processUrl, PHP_URL_HOST);
 
-        if (strpos($processHost, 'github.com') === strlen($pcoessHost))
-        {
+        if (strpos($processHost, 'github.com') === (strlen($processHost) - 10)) {
             $processHost = 'github.com';
         }
 


### PR DESCRIPTION
A common use case for downloading from GitHub is to use their API to download automatically generated zipballs and tarballs of tags and branches, e.g. per: https://help.github.com/articles/downloading-files-from-the-command-line
