### PR TITLE
topics/get-io

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -547,6 +547,16 @@ class Installer
         return $normalizedAliases;
     }
 
+    /**
+     * The instance of IOInterface currently used by Composer.
+     *
+     * @return IOInterface
+     */
+    public function getIO()
+    {
+        return $this->io;
+    }
+
     private function aliasPlatformPackages(PlatformRepository $platformRepo, $aliases)
     {
         foreach ($aliases as $package => $versions) {


### PR DESCRIPTION
Allow fetching of the IOInterface of the installer. This would be useful for alternative interfaces like a future ArrayInterface.
