### PR TITLE
Fixed .bat proxy generator

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -264,13 +264,9 @@ class LibraryInstaller implements InstallerInterface
             }
         }
 
-        return "@echo off\r\n".
-            "pushd .\r\n".
-            "cd %~dp0\r\n".
-            "cd ".escapeshellarg(dirname($binPath))."\r\n".
-            "set BIN_TARGET=%CD%\\".basename($binPath)."\r\n".
-            "popd\r\n".
-            $caller." \"%BIN_TARGET%\" %*\r\n";
+        return "@ECHO OFF\r\n".
+            "SET BIN_TARGET=%~dp0\\".escapeshellarg(dirname($binPath)).basename($binPath)."\r\n".
+            "{$caller} \"%BIN_TARGET%\" %*\r\n";
     }
 
     protected function generateUnixyProxyCode($bin, $link)


### PR DESCRIPTION
Changed `src/Composer/Installer/LibraryInstaller.php` to generate proper `.bat` for proxying commands to library `.bat` or `.exe`.

Detailed explanation:
https://github.com/robmorgan/phinx/issues/23#issuecomment-9844841
