### PR TITLE
Fixed package name for stability test in ComposerRepository

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -262,7 +262,7 @@ class ComposerRepository extends ArrayRepository implements NotifiableRepository
                         }
                     }
                 } else {
-                    if (!$pool->isPackageAcceptable($version['name'], VersionParser::parseStability($version['version']))) {
+                    if (!$pool->isPackageAcceptable(strtolower($version['name']), VersionParser::parseStability($version['version']))) {
                         continue;
                     }
 


### PR DESCRIPTION
composer.json>

```
"require": {
    "natxet/CssMin": "dev-master"
}
```

Output:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package natxet/cssmin dev-master could not be found.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```
