### PR TITLE
added regex check on keywords

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -25,6 +25,7 @@
             "type": "array",
             "items": {
                 "type": "string",
+                "pattern": "[A-Za-z0-9 ._-]+",
                 "description": "A tag/keyword that this package relates to."
             }
         },


### PR DESCRIPTION
a small addition to the schema. Don't know if it was not added by choice. Sorry if so...

I've added the keywords in this way (by mistake)

``` json
{
    "keywords": ["symfony, phpunit"]
}
```

**composer validate** worked, but packagist complain about the wrong format of the keywords. This should solve the problem and validate correctly.
