### PR TITLE
Optimize classmap generation by avoiding the use of token_get_all()

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -93,9 +93,10 @@ class ClassMapGenerator
     private static function findClasses($path)
     {
         $contents = php_strip_whitespace($path);
+        $traits = version_compare(PHP_VERSION, '5.4', '<') ? '' : '|trait';
 
         try {
-            if (!preg_match('{\b(?:class|interface|trait)\b}i', $contents)) {
+            if (!preg_match('{\b(?:class|interface'.$traits.')\b}i', $contents)) {
                 return array();
             }
 
@@ -104,7 +105,7 @@ class ClassMapGenerator
             // strip strings
             $contents = preg_replace('{"[^"\\\\]*(\\\\.[^"\\\\]*)*"|\'[^\'\\\\]*(\\\\.[^\'\\\\]*)*\'}', 'null', $contents);
 
-            preg_match_all('{(?:\b(?<![\$:>])(?<type>class|interface|trait)\s+(?<name>\S+)|\b(?<![\$:>])(?<ns>namespace)\s+(?<nsname>[^\s;{}\\\\]+(?:\s*\\\\\s*[^\s;{}\\\\]+)*))}i', $contents, $matches);
+            preg_match_all('{(?:\b(?<![\$:>])(?<type>class|interface'.$traits.')\s+(?<name>\S+)|\b(?<![\$:>])(?<ns>namespace)(?<nsname>\s+[^\s;{}\\\\]+(?:\s*\\\\\s*[^\s;{}\\\\]+)*|\s*\{))}i', $contents, $matches);
             $classes = array();
 
             $namespace = '';


### PR DESCRIPTION
First of all this seems way faster than iterating over all tokens, but especially it reduces memory usage drastically for very large files (i.e. tcpdf problem in #1246)

To try this, you can run this in one of your projects:

```
wget http://getcomposer.org/composer.phar
wget http://getcomposer.org/composer-classmap.phar
php composer.phar dump -o --profile && md5sum vendor/composer/autoload_classmap.php
php composer-classmap.phar dump -o --profile && md5sum vendor/composer/autoload_classmap.php

```

Then please paste the output you got in here, especially if the md5 hashes don't match in which case also posting your composer.json would be nice.
