### PR TITLE
Allowing prefix overriding in autoloader

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -84,12 +84,17 @@ class ClassLoader
     public function add($prefix, $paths, $prepend = false)
     {
         if (!$prefix) {
-            foreach ((array) $paths as $path) {
-                if ($prepend) {
-                    array_unshift($this->fallbackDirs, $path);
-                } else {
-                    $this->fallbackDirs[] = $path;
-                }
+            if ($prepend) {
+                $this->fallbackDirs = array_merge(
+                    (array) $paths,
+                    $this->fallbackDirs
+                );
+            }
+            else {
+                $this->fallbackDirs = array_merge(
+                    $this->fallbackDirs,
+                    (array) $paths
+                );
             }
 
             return;
@@ -121,7 +126,7 @@ class ClassLoader
     public function set($prefix, $paths)
     {
         if (!$prefix) {
-            $this->fallbackDirs = (array) $path;
+            $this->fallbackDirs = (array) $paths;
 
             return;
         }


### PR DESCRIPTION
This resolves #1319 and also provides a way to achieve #1299.

You can now chose to prepend new directories for a prefix (or as a fallback) rather than append. I have also added a `set` method that can be used to just replace any directories set for a prefix (or fallbacks).
