### PR TITLE
Rename cache dirs to consolidate them by purpose

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -49,6 +49,11 @@ class Cache
         }
     }
 
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
     public function getRoot()
     {
         return $this->root;

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -26,6 +26,10 @@ class Config
         'bin-dir' => '{$vendor-dir}/bin',
         'notify-on-install' => true,
         'github-protocols' => array('git', 'https', 'http'),
+        'cache-dir' => '{$home}/cache',
+        'cache-files-dir' => '{$cache-dir}/files',
+        'cache-repo-dir' => '{$cache-dir}/repo',
+        'cache-vcs-dir' => '{$cache-dir}/vcs',
     );
 
     public static $defaultRepositories = array(
@@ -115,6 +119,10 @@ class Config
             case 'vendor-dir':
             case 'bin-dir':
             case 'process-timeout':
+            case 'cache-dir':
+            case 'cache-files-dir':
+            case 'cache-repo-dir':
+            case 'cache-vcs-dir':
                 // convert foo-bar to COMPOSER_FOO_BAR and check if it exists since it overrides the local config
                 $env = 'COMPOSER_' . strtoupper(strtr($key, '-', '_'));
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -72,7 +72,7 @@ class ComposerRepository extends ArrayRepository implements NotifiableRepository
         $this->url = $repoConfig['url'];
         $this->baseUrl = rtrim(preg_replace('{^(.*)(?:/packages.json)?(?:[?#].*)?$}', '$1', $this->url), '/');
         $this->io = $io;
-        $this->cache = new Cache($io, $config->get('home').'/cache/'.preg_replace('{[^a-z0-9.]}i', '-', $this->url));
+        $this->cache = new Cache($io, $config->get('cache-repo-dir').'/'.preg_replace('{[^a-z0-9.]}i', '-', $this->url));
         $this->loader = new ArrayLoader();
     }
 

--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -36,7 +36,7 @@ class GitDriver extends VcsDriver
         if (static::isLocalUrl($this->url)) {
             $this->repoDir = str_replace('file://', '', $this->url);
         } else {
-            $this->repoDir = $this->config->get('home') . '/cache.git/' . preg_replace('{[^a-z0-9.]}i', '-', $this->url) . '/';
+            $this->repoDir = $this->config->get('cache-vcs-dir') . '/' . preg_replace('{[^a-z0-9.]}i', '-', $this->url) . '/';
 
             $fs = new Filesystem();
             $fs->ensureDirectoryExists(dirname($this->repoDir));

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -50,7 +50,7 @@ class GitHubDriver extends VcsDriver
         $this->owner = $match[1];
         $this->repository = $match[2];
         $this->originUrl = 'github.com';
-        $this->cache = new Cache($this->io, $this->config->get('home').'/cache.github/'.$this->owner.'/'.$this->repository);
+        $this->cache = new Cache($this->io, $this->config->get('cache-repo-dir').'/'.$this->originUrl.'/'.$this->owner.'/'.$this->repository);
 
         $this->fetchRootIdentifier();
     }

--- a/src/Composer/Repository/Vcs/HgDriver.php
+++ b/src/Composer/Repository/Vcs/HgDriver.php
@@ -36,7 +36,7 @@ class HgDriver extends VcsDriver
         if (static::isLocalUrl($this->url)) {
             $this->repoDir = str_replace('file://', '', $this->url);
         } else {
-            $cacheDir = $this->config->get('home') . '/cache.hg';
+            $cacheDir = $this->config->get('cache-vcs-dir');
             $this->repoDir = $cacheDir . '/' . preg_replace('{[^a-z0-9]}i', '-', $this->url) . '/';
 
             $fs = new Filesystem();

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -63,7 +63,7 @@ class SvnDriver extends VcsDriver
             $this->baseUrl = substr($this->url, 0, $pos);
         }
 
-        $this->cache = new Cache($this->io, $this->config->get('home').'/cache.svn/'.preg_replace('{[^a-z0-9.]}i', '-', $this->baseUrl));
+        $this->cache = new Cache($this->io, $this->config->get('cache-repo-dir').'/'.preg_replace('{[^a-z0-9.]}i', '-', $this->baseUrl));
 
         $this->getBranches();
         $this->getTags();


### PR DESCRIPTION
- Move git/hg stuff into `$cache-dir/vcs` (those are hard requirements, if the cache is not writable the git/hg drivers are unusable)
- Move svn/composer/github stuff into `$cache-dir/repo` (those are real caches, things should run fine but slower if they are not writable)
- Move files (zip) cache into `$cache-dir/files` (this is also a real cache)

Additionally, it splits things off into a new cache-dir option instead of re-using home, so that it is possible to configure a common cache dir for multiple users of one machine. On windows the cache dir is moved out of the Roaming dir so that it should work better for people on windows domains. On unix the cache dir is just inside the composer home dir by default (~/.composer/cache).

It also moves existing dirs to the new locations to avoid leaving crap behind.

TODO: docs
