### PR TITLE
Added addLink and removeLink to Configuration Source Interface

### DIFF
--- a/src/Composer/Config/ConfigSourceInterface.php
+++ b/src/Composer/Config/ConfigSourceInterface.php
@@ -13,15 +13,57 @@
 namespace Composer\Config;
 
 /**
+ * Configuration Source Interface
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Beau Simensen <beau@dflydev.com>
  */
 interface ConfigSourceInterface
 {
+    /**
+     * Add a repository
+     *
+     * @param string $name   Name
+     * @param array  $config Configuration
+     */
     public function addRepository($name, $config);
 
+    /**
+     * Remove a repository
+     *
+     * @param string $name
+     */
     public function removeRepository($name);
 
+    /**
+     * Add a config setting
+     *
+     * @param string $name  Name
+     * @param string $value Value
+     */
     public function addConfigSetting($name, $value);
 
+    /**
+     * Remove a config setting
+     *
+     * @param string $name
+     */
     public function removeConfigSetting($name);
+
+    /**
+     * Add a package link
+     *
+     * @param string $type  Type (require, require-dev, provide, suggest, replace, conflict)
+     * @param string $name  Name
+     * @param string $value Value
+     */
+    public function addLink($type, $name, $value);
+
+    /**
+     * Remove a package link
+     *
+     * @param string $type Type (require, require-dev, provide, suggest, replace, conflict)
+     * @param string $name Name
+     */
+    public function removeLink($type, $name);
 }

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -12,22 +12,33 @@
 
 namespace Composer\Config;
 
-use Composer\Json\JsonManipulator;
 use Composer\Json\JsonFile;
+use Composer\Json\JsonManipulator;
 
 /**
+ * JSON Configuration Source
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Beau Simensen <beau@dflydev.com>
  */
 class JsonConfigSource implements ConfigSourceInterface
 {
     private $file;
     private $manipulator;
 
+    /**
+     * Constructor
+     *
+     * @param JsonFile $file
+     */
     public function __construct(JsonFile $file)
     {
         $this->file = $file;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function addRepository($name, $config)
     {
         $this->manipulateJson('addRepository', $name, $config, function (&$config, $repo, $repoConfig) {
@@ -35,6 +46,9 @@ class JsonConfigSource implements ConfigSourceInterface
         });
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function removeRepository($name)
     {
         $this->manipulateJson('removeRepository', $name, function (&$config, $repo) {
@@ -42,6 +56,9 @@ class JsonConfigSource implements ConfigSourceInterface
         });
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function addConfigSetting($name, $value)
     {
         $this->manipulateJson('addConfigSetting', $name, $value, function (&$config, $key, $val) {
@@ -49,10 +66,33 @@ class JsonConfigSource implements ConfigSourceInterface
         });
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function removeConfigSetting($name)
     {
         $this->manipulateJson('removeConfigSetting', $name, function (&$config, $key) {
             unset($config['config'][$key]);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addLink($type, $name, $value)
+    {
+        $this->manipulateJson('addLink', $type, $name, $value, function (&$config, $key) {
+            $config[$type][$name] = $value;
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeLink($type, $name)
+    {
+        $this->manipulateJson('removeSubNode', $type, $name, function (&$config, $key) {
+            unset($config[$type][$name]);
         });
     }
 

--- a/tests/Composer/Test/Config/Fixtures/addLink/conflict-from-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/conflict-from-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "conflict": {
+        "my-vend/my-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/conflict-from-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/conflict-from-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/conflict-from-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/conflict-from-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*",
+        "my-vend/my-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/provide-from-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/provide-from-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "provide": {
+        "my-vend/my-lib-interface": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/provide-from-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/provide-from-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-lib-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/provide-from-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/provide-from-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*",
+        "my-vend/my-lib-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/replace-from-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/replace-from-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "replace": {
+        "my-vend/other-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/replace-from-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/replace-from-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "my-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/replace-from-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/replace-from-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*",
+        "my-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/require-dev-from-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/require-dev-from-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require-dev": {
+        "my-vend/my-lib-tests": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/require-dev-from-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/require-dev-from-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/require-dev-from-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/require-dev-from-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*",
+        "my-vend/my-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/require-from-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/require-from-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-lib": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/require-from-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/require-from-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/require-from-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/require-from-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*",
+        "my-vend/my-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/suggest-from-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/suggest-from-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "suggest": {
+        "my-vend/my-optional-extension": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/suggest-from-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/suggest-from-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/addLink/suggest-from-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/addLink/suggest-from-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*",
+        "my-vend/my-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/composer-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/composer-empty.json
@@ -1,0 +1,4 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT"
+}

--- a/tests/Composer/Test/Config/Fixtures/composer-one-of-everything.json
+++ b/tests/Composer/Test/Config/Fixtures/composer-one-of-everything.json
@@ -1,0 +1,22 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/composer-two-of-everything.json
+++ b/tests/Composer/Test/Config/Fixtures/composer-two-of-everything.json
@@ -1,0 +1,28 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/conflict-to-empty-after.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/conflict-to-empty-after.json
@@ -1,0 +1,6 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "conflict": {
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/conflict-to-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/conflict-to-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "conflict": {
+        "my-vend/my-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/conflict-to-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/conflict-to-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/conflict-to-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/conflict-to-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*",
+        "my-vend/my-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/provide-to-empty-after.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/provide-to-empty-after.json
@@ -1,0 +1,6 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "provide": {
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/provide-to-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/provide-to-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "provide": {
+        "my-vend/my-lib-interface": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/provide-to-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/provide-to-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-lib-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/provide-to-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/provide-to-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*",
+        "my-vend/my-lib-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/replace-to-empty-after.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/replace-to-empty-after.json
@@ -1,0 +1,6 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "replace": {
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/replace-to-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/replace-to-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "replace": {
+        "my-vend/other-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/replace-to-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/replace-to-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "my-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/replace-to-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/replace-to-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*",
+        "my-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/require-dev-to-empty-after.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/require-dev-to-empty-after.json
@@ -1,0 +1,6 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require-dev": {
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/require-dev-to-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/require-dev-to-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require-dev": {
+        "my-vend/my-lib-tests": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/require-dev-to-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/require-dev-to-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/require-dev-to-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/require-dev-to-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*",
+        "my-vend/my-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/require-to-empty-after.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/require-to-empty-after.json
@@ -1,0 +1,6 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/require-to-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/require-to-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-lib": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/require-to-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/require-to-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/require-to-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/require-to-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*",
+        "my-vend/my-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/suggest-to-empty-after.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/suggest-to-empty-after.json
@@ -1,0 +1,6 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "suggest": {
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/suggest-to-empty.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/suggest-to-empty.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "suggest": {
+        "my-vend/my-optional-extension": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/suggest-to-oneOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/suggest-to-oneOfEverything.json
@@ -1,0 +1,23 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/Fixtures/removeLink/suggest-to-twoOfEverything.json
+++ b/tests/Composer/Test/Config/Fixtures/removeLink/suggest-to-twoOfEverything.json
@@ -1,0 +1,29 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "require": {
+        "my-vend/my-other-lib": "1.*",
+        "my-vend/my-yet-another-lib": "1.*"
+    },
+    "require-dev": {
+        "my-vend/my-other-lib-tests": "1.*",
+        "my-vend/my-yet-another-lib-tests": "1.*"
+    },
+    "provide": {
+        "my-vend/my-other-interface": "1.*",
+        "my-vend/my-yet-another-interface": "1.*"
+    },
+    "suggest": {
+        "my-vend/my-other-optional-extension": "1.*",
+        "my-vend/my-yet-another-optional-extension": "1.*",
+        "my-vend/my-optional-extension": "1.*"
+    },
+    "replace": {
+        "other-vend/other-app": "1.*",
+        "other-vend/yet-another-app": "1.*"
+    },
+    "conflict": {
+        "my-vend/my-other-old-app": "1.*",
+        "my-vend/my-yet-another-old-app": "1.*"
+    }
+}

--- a/tests/Composer/Test/Config/JsonConfigSourceTest.php
+++ b/tests/Composer/Test/Config/JsonConfigSourceTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Json;
+
+use Composer\Config\JsonConfigSource;
+use Composer\Json\JsonFile;
+use Composer\Util\Filesystem;
+
+/**
+ * JsonConfigSource Test
+ *
+ * @author Beau Simensen <beau@dflydev.com>
+ */
+class JsonConfigSourceTest extends \PHPUnit_Framework_TestCase
+{
+    private $workingDir;
+
+    protected function fixturePath($name)
+    {
+        return __DIR__.'/Fixtures/'.$name;
+    }
+
+    protected function setUp()
+    {
+        $this->fs = new Filesystem;
+        $this->workingDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'cmptest';
+        $this->fs->ensureDirectoryExists($this->workingDir);
+    }
+
+    protected function tearDown()
+    {
+        if (is_dir($this->workingDir)) {
+            $this->fs->removeDirectory($this->workingDir);
+        }
+    }
+
+    protected function addLinkDataArguments($type, $name, $value, $fixtureBasename, $before)
+    {
+        return array(
+            $before,
+            $type,
+            $name,
+            $value,
+            $this->fixturePath('addLink/'.$fixtureBasename.'.json'),
+        );
+
+    }
+
+    /**
+     * Provide data for testAddLink
+     *
+     * @return array
+     */
+    public function provideAddLinkData()
+    {
+        $empty = $this->fixturePath('composer-empty.json');
+        $oneOfEverything = $this->fixturePath('composer-one-of-everything.json');
+        $twoOfEverything = $this->fixturePath('composer-two-of-everything.json');
+
+        return array(
+
+            $this->addLinkDataArguments('require', 'my-vend/my-lib', '1.*', 'require-from-empty', $empty),
+            $this->addLinkDataArguments('require', 'my-vend/my-lib', '1.*', 'require-from-oneOfEverything', $oneOfEverything),
+            $this->addLinkDataArguments('require', 'my-vend/my-lib', '1.*', 'require-from-twoOfEverything', $twoOfEverything),
+
+            $this->addLinkDataArguments('require-dev', 'my-vend/my-lib-tests', '1.*', 'require-dev-from-empty', $empty),
+            $this->addLinkDataArguments('require-dev', 'my-vend/my-lib-tests', '1.*', 'require-dev-from-oneOfEverything', $oneOfEverything),
+            $this->addLinkDataArguments('require-dev', 'my-vend/my-lib-tests', '1.*', 'require-dev-from-twoOfEverything', $twoOfEverything),
+
+            $this->addLinkDataArguments('provide', 'my-vend/my-lib-interface', '1.*', 'provide-from-empty', $empty),
+            $this->addLinkDataArguments('provide', 'my-vend/my-lib-interface', '1.*', 'provide-from-oneOfEverything', $oneOfEverything),
+            $this->addLinkDataArguments('provide', 'my-vend/my-lib-interface', '1.*', 'provide-from-twoOfEverything', $twoOfEverything),
+
+            $this->addLinkDataArguments('suggest', 'my-vend/my-optional-extension', '1.*', 'suggest-from-empty', $empty),
+            $this->addLinkDataArguments('suggest', 'my-vend/my-optional-extension', '1.*', 'suggest-from-oneOfEverything', $oneOfEverything),
+            $this->addLinkDataArguments('suggest', 'my-vend/my-optional-extension', '1.*', 'suggest-from-twoOfEverything', $twoOfEverything),
+
+            $this->addLinkDataArguments('replace', 'my-vend/other-app', '1.*', 'replace-from-empty', $empty),
+            $this->addLinkDataArguments('replace', 'my-vend/other-app', '1.*', 'replace-from-oneOfEverything', $oneOfEverything),
+            $this->addLinkDataArguments('replace', 'my-vend/other-app', '1.*', 'replace-from-twoOfEverything', $twoOfEverything),
+
+            $this->addLinkDataArguments('conflict', 'my-vend/my-old-app', '1.*', 'conflict-from-empty', $empty),
+            $this->addLinkDataArguments('conflict', 'my-vend/my-old-app', '1.*', 'conflict-from-oneOfEverything', $oneOfEverything),
+            $this->addLinkDataArguments('conflict', 'my-vend/my-old-app', '1.*', 'conflict-from-twoOfEverything', $twoOfEverything),
+        );
+    }
+
+    /**
+     * Test addLink()
+     *
+     * @param string $sourceFile     Source file
+     * @param string $type           Type (require, require-dev, provide, suggest, replace, conflict)
+     * @param string $name           Name
+     * @param string $value          Value
+     * @param string $compareAgainst File to compare against after making changes
+     *
+     * @dataProvider provideAddLinkData
+     */
+    public function testAddLink($sourceFile, $type, $name, $value, $compareAgainst)
+    {
+        $composerJson = $this->workingDir.'/composer.json';
+        copy($sourceFile, $composerJson);
+        $jsonConfigSource = new JsonConfigSource(new JsonFile($composerJson));
+
+        $jsonConfigSource->addLink($type, $name, $value);
+
+        $this->assertFileEquals($compareAgainst, $composerJson);
+    }
+
+    protected function removeLinkDataArguments($type, $name, $fixtureBasename, $after = null)
+    {
+        return array(
+            $this->fixturePath('removeLink/'.$fixtureBasename.'.json'),
+            $type,
+            $name,
+            $after ?: $this->fixturePath('removeLink/'.$fixtureBasename.'-after.json'),
+        );
+
+    }
+
+    /**
+     * Provide data for testRemoveLink
+     *
+     * @return array
+     */
+    public function provideRemoveLinkData()
+    {
+        $oneOfEverything = $this->fixturePath('composer-one-of-everything.json');
+        $twoOfEverything = $this->fixturePath('composer-two-of-everything.json');
+
+        return array(
+            $this->removeLinkDataArguments('require', 'my-vend/my-lib', 'require-to-empty'),
+            $this->removeLinkDataArguments('require', 'my-vend/my-lib', 'require-to-oneOfEverything', $oneOfEverything),
+            $this->removeLinkDataArguments('require', 'my-vend/my-lib', 'require-to-twoOfEverything', $twoOfEverything),
+
+            $this->removeLinkDataArguments('require-dev', 'my-vend/my-lib-tests', 'require-dev-to-empty'),
+            $this->removeLinkDataArguments('require-dev', 'my-vend/my-lib-tests', 'require-dev-to-oneOfEverything', $oneOfEverything),
+            $this->removeLinkDataArguments('require-dev', 'my-vend/my-lib-tests', 'require-dev-to-twoOfEverything', $twoOfEverything),
+
+            $this->removeLinkDataArguments('provide', 'my-vend/my-lib-interface', 'provide-to-empty'),
+            $this->removeLinkDataArguments('provide', 'my-vend/my-lib-interface', 'provide-to-oneOfEverything', $oneOfEverything),
+            $this->removeLinkDataArguments('provide', 'my-vend/my-lib-interface', 'provide-to-twoOfEverything', $twoOfEverything),
+
+            $this->removeLinkDataArguments('suggest', 'my-vend/my-optional-extension', 'suggest-to-empty'),
+            $this->removeLinkDataArguments('suggest', 'my-vend/my-optional-extension', 'suggest-to-oneOfEverything', $oneOfEverything),
+            $this->removeLinkDataArguments('suggest', 'my-vend/my-optional-extension', 'suggest-to-twoOfEverything', $twoOfEverything),
+
+            $this->removeLinkDataArguments('replace', 'my-vend/other-app', 'replace-to-empty'),
+            $this->removeLinkDataArguments('replace', 'my-vend/other-app', 'replace-to-oneOfEverything', $oneOfEverything),
+            $this->removeLinkDataArguments('replace', 'my-vend/other-app', 'replace-to-twoOfEverything', $twoOfEverything),
+
+            $this->removeLinkDataArguments('conflict', 'my-vend/my-old-app', 'conflict-to-empty'),
+            $this->removeLinkDataArguments('conflict', 'my-vend/my-old-app', 'conflict-to-oneOfEverything', $oneOfEverything),
+            $this->removeLinkDataArguments('conflict', 'my-vend/my-old-app', 'conflict-to-twoOfEverything', $twoOfEverything),
+        );
+    }
+
+    /**
+     * Test removeLink()
+     *
+     * @param string $sourceFile     Source file
+     * @param string $type           Type (require, require-dev, provide, suggest, replace, conflict)
+     * @param string $name           Name
+     * @param string $compareAgainst File to compare against after making changes
+     *
+     * @dataProvider provideRemoveLinkData
+     */
+    public function testRemoveLink($sourceFile, $type, $name, $compareAgainst)
+    {
+        $composerJson = $this->workingDir.'/composer.json';
+        copy($sourceFile, $composerJson);
+        $jsonConfigSource = new JsonConfigSource(new JsonFile($composerJson));
+
+        $jsonConfigSource->removeLink($type, $name);
+
+        $this->assertFileEquals($compareAgainst, $composerJson);
+    }
+}


### PR DESCRIPTION
- Added `addLink()` and `removeLink()` to `ConfigSourceInterface`
- Added `addLink()` and `removeLink()` implementations to `JsonConfigSource`
- Added tests (+ a ton of fixtures) for `JsonConfigSource`
- Added additional docblocks
- Minor PSR-1/PSR-2 fixes here and there

I put a lot of work into the testing. I wasn't sure it was required as it sorta felt like I was just testing `JsonManipulator`, but who knows what is going to be going on in the future? This should hopefully future proof it as far as testing is concerned, especially if the links are handled/validated by `JsonManipulator` (or whatever) on a case-by-case basis in the future?

Anyway, it is kind of nice to know that "given this is the composer.json before, that is what it will look like after," so maybe it was worth it.

If we don't need it I can take it out. 

I'll work on adding commands (`require foo/project --dev --remove`, `provide foo/interface`, etc.) once this gets merged.
