### PR TITLE
Use Archive_Tar to extract PEAR packages

### DIFF
--- a/src/Composer/Downloader/PearPackageExtractor.php
+++ b/src/Composer/Downloader/PearPackageExtractor.php
@@ -13,6 +13,7 @@
 namespace Composer\Downloader;
 
 use Composer\Util\Filesystem;
+use Composer\Util\Tar;
 
 /**
  * Extractor for pear packages.
@@ -55,8 +56,8 @@ class PearPackageExtractor
         $extractionPath = $target.'/tarball';
 
         try {
-            $archive = new \PharData($this->file);
-            $archive->extractTo($extractionPath, null, true);
+            $archive = new Tar($this->file);
+            $archive->extract($extractionPath);
 
             if (!is_file($this->combine($extractionPath, '/package.xml'))) {
                 throw new \RuntimeException('Invalid PEAR package. It must contain package.xml file.');

--- a/src/Composer/Util/Tar.php
+++ b/src/Composer/Util/Tar.php
@@ -1,11 +1,5 @@
 <?php
-/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
-
 /**
- * File::CSV
- *
- * PHP versions 4 and 5
- *
  * Copyright (c) 1997-2008,
  * Vincent Blavet <vincent@phpconcept.net>
  * All rights reserved.
@@ -39,7 +33,7 @@
  * @link      http://pear.php.net/package/Archive_Tar
  */
 
-require_once 'PEAR.php';
+namespace Composer\Util;
 
 define('ARCHIVE_TAR_ATT_SEPARATOR', 90001);
 define('ARCHIVE_TAR_END_BLOCK', pack("a512", ''));
@@ -52,7 +46,7 @@ define('ARCHIVE_TAR_END_BLOCK', pack("a512", ''));
 * @license http://www.opensource.org/licenses/bsd-license.php New BSD License
 * @version $Revision$
 */
-class Archive_Tar extends PEAR
+class Tar
 {
     /**
     * @var string Name of the Tar
@@ -110,9 +104,8 @@ class Archive_Tar extends PEAR
     *
     * @access public
     */
-    function Archive_Tar($p_tarname, $p_compress = null)
+    function __construct($p_tarname, $p_compress = null)
     {
-        $this->PEAR();
         $this->_compress = false;
         $this->_compress_type = 'none';
         if (($p_compress === null) || ($p_compress == '')) {
@@ -176,13 +169,12 @@ class Archive_Tar extends PEAR
     // }}}
 
     // {{{ destructor
-    function _Archive_Tar()
+    function __destruct()
     {
         $this->_close();
         // ----- Look for a local copy to delete
         if ($this->_temp_tarname != '')
             @unlink($this->_temp_tarname);
-        $this->_PEAR();
     }
     // }}}
 


### PR DESCRIPTION
The PharData class cannot extract archives with "blocks of zeros".
See this issue on Horde: http://bugs.horde.org/ticket/11682

Archive_Tar is used by PEAR in [`PEAR_Installer::install`](https://github.com/pear/pear-core/blob/master/PEAR/Installer.php#L1118) to extract files.

The class has been imported from it's [Git repository](https://github.com/pear/Archive_Tar/blob/master/Archive/Tar.php) and modified to support PSR-0 and PHP 5.3

Example of composer.json failing:

```
{
    "repositories": [
        {
            "type": "pear",
            "url": "http://pear.horde.org"
        }
    ],
    "require": {
        "pear-pear.horde.org/horde_text_diff": "2.0.0"
    }
}
```

Related to #984
