### PR TITLE
Scripts can now be "dev-aware"

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -179,7 +179,7 @@ class Installer
         if ($this->runScripts) {
             // dispatch pre event
             $eventName = $this->update ? ScriptEvents::PRE_UPDATE_CMD : ScriptEvents::PRE_INSTALL_CMD;
-            $this->eventDispatcher->dispatchCommandEvent($eventName);
+            $this->eventDispatcher->dispatchCommandEvent($eventName, $this->devMode);
         }
 
         $this->suggestedPackages = array();
@@ -227,7 +227,7 @@ class Installer
             if ($this->runScripts) {
                 // dispatch post event
                 $eventName = $this->update ? ScriptEvents::POST_UPDATE_CMD : ScriptEvents::POST_INSTALL_CMD;
-                $this->eventDispatcher->dispatchCommandEvent($eventName);
+                $this->eventDispatcher->dispatchCommandEvent($eventName, $this->devMode);
             }
         }
 
@@ -487,7 +487,7 @@ class Installer
 
             $event = 'Composer\Script\ScriptEvents::PRE_PACKAGE_'.strtoupper($operation->getJobType());
             if (defined($event) && $this->runScripts) {
-                $this->eventDispatcher->dispatchPackageEvent(constant($event), $operation);
+                $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $operation);
             }
 
             // not installing from lock, force dev packages' references if they're in root package refs
@@ -516,7 +516,7 @@ class Installer
 
             $event = 'Composer\Script\ScriptEvents::POST_PACKAGE_'.strtoupper($operation->getJobType());
             if (defined($event) && $this->runScripts) {
-                $this->eventDispatcher->dispatchPackageEvent(constant($event), $operation);
+                $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $operation);
             }
 
             if (!$this->dryRun) {

--- a/src/Composer/Script/Event.php
+++ b/src/Composer/Script/Event.php
@@ -38,17 +38,24 @@ class Event
     private $io;
 
     /**
+     * @var boolean Dev mode flag
+     */
+    private $devMode;
+
+    /**
      * Constructor.
      *
      * @param string      $name     The event name
      * @param Composer    $composer The composer object
      * @param IOInterface $io       The IOInterface object
+     * @param boolean     $devMode  Whether or not we are in dev mode
      */
-    public function __construct($name, Composer $composer, IOInterface $io)
+    public function __construct($name, Composer $composer, IOInterface $io, $devMode)
     {
         $this->name = $name;
         $this->composer = $composer;
         $this->io = $io;
+        $this->devMode = $devMode;
     }
 
     /**
@@ -79,5 +86,15 @@ class Event
     public function getIO()
     {
         return $this->io;
+    }
+
+    /**
+     * Return the dev mode flag
+     *
+     * @return boolean
+     */
+    public function isDevMode()
+    {
+        return $this->devMode;
     }
 }

--- a/src/Composer/Script/EventDispatcher.php
+++ b/src/Composer/Script/EventDispatcher.php
@@ -55,21 +55,23 @@ class EventDispatcher
      * Dispatch a package event.
      *
      * @param string             $eventName The constant in ScriptEvents
+     * @param boolean            $devMode   Whether or not we are in dev mode
      * @param OperationInterface $operation The package being installed/updated/removed
      */
-    public function dispatchPackageEvent($eventName, OperationInterface $operation)
+    public function dispatchPackageEvent($eventName, $devMode, OperationInterface $operation)
     {
-        $this->doDispatch(new PackageEvent($eventName, $this->composer, $this->io, $operation));
+        $this->doDispatch(new PackageEvent($eventName, $this->composer, $this->io, $devMode, $operation));
     }
 
     /**
      * Dispatch a command event.
      *
-     * @param string $eventName The constant in ScriptEvents
+     * @param string  $eventName The constant in ScriptEvents
+     * @param boolean $devMode   Whether or not we are in dev mode
      */
-    public function dispatchCommandEvent($eventName)
+    public function dispatchCommandEvent($eventName, $devMode)
     {
-        $this->doDispatch(new CommandEvent($eventName, $this->composer, $this->io));
+        $this->doDispatch(new CommandEvent($eventName, $this->composer, $this->io, $devMode));
     }
 
     /**

--- a/src/Composer/Script/PackageEvent.php
+++ b/src/Composer/Script/PackageEvent.php
@@ -34,11 +34,12 @@ class PackageEvent extends Event
      * @param string             $name      The event name
      * @param Composer           $composer  The composer objet
      * @param IOInterface        $io        The IOInterface object
+     * @param boolean            $devMode   Whether or not we are in dev mode
      * @param OperationInterface $operation The operation object
      */
-    public function __construct($name, Composer $composer, IOInterface $io, OperationInterface $operation)
+    public function __construct($name, Composer $composer, IOInterface $io, $devMode, OperationInterface $operation)
     {
-        parent::__construct($name, $composer, $io);
+        parent::__construct($name, $composer, $io, $devMode);
         $this->operation = $operation;
     }
 

--- a/tests/Composer/Test/Script/EventDispatcherTest.php
+++ b/tests/Composer/Test/Script/EventDispatcherTest.php
@@ -32,7 +32,7 @@ class EventDispatcherTest extends TestCase
             ->method('write')
             ->with('<error>Script Composer\Test\Script\EventDispatcherTest::call handling the post-install-cmd event terminated with an exception</error>');
 
-        $dispatcher->dispatchCommandEvent("post-install-cmd");
+        $dispatcher->dispatchCommandEvent("post-install-cmd", false);
     }
 
     /**
@@ -60,7 +60,7 @@ class EventDispatcherTest extends TestCase
             ->method('execute')
             ->with($command);
 
-        $dispatcher->dispatchCommandEvent("post-install-cmd");
+        $dispatcher->dispatchCommandEvent("post-install-cmd", false);
     }
 
     public function testDispatcherCanExecuteCliAndPhpInSameEventScriptStack()
@@ -95,7 +95,7 @@ class EventDispatcherTest extends TestCase
             ->with('Composer\Test\Script\EventDispatcherTest', 'someMethod')
             ->will($this->returnValue(true));
 
-        $dispatcher->dispatchCommandEvent("post-install-cmd");
+        $dispatcher->dispatchCommandEvent("post-install-cmd", false);
     }
 
     private function getDispatcherStubForListenersTest($listeners, $io)


### PR DESCRIPTION
As far as I can see scripts added to the `scripts` section of the composer.json file has no way of detecting whether or not composer was triggered with the `--dev` option. This PR includes an `isDev()` method in the `IOInterface` (and implemented in `ConsoleIO` and `NullIO`) that can be used to check for this.

If there already is a way to achieve this, feel free to tell me to RTFM and close the PR. 
