### PR TITLE
Use local mirror of git repository in GitDownloader

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -22,6 +22,7 @@ class Config
     public static $defaultConfig = array(
         'process-timeout' => 300,
         'cache-ttl' => 15552000, // 6 months
+        'git-shared' => false, // use --shared for git clone in the downloader
         'vendor-dir' => 'vendor',
         'bin-dir' => '{$vendor-dir}/bin',
         'notify-on-install' => true,
@@ -124,11 +125,15 @@ class Config
                 return (int) $this->config[$key];
 
             case 'cache-files-ttl':
+            case 'cache-vcs-ttl':
                 if (isset($this->config[$key])) {
                     return (int) $this->config[$key];
                 }
 
                 return (int) $this->config['cache-ttl'];
+
+            case 'git-shared':
+                return (bool) $this->config['git-shared'];
 
             case 'home':
                 return rtrim($this->process($this->config[$key]), '/\\');

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -13,6 +13,7 @@
 namespace Composer\Downloader;
 
 use Composer\Package\PackageInterface;
+use Composer\Repository\Vcs\GitDriver;
 use Composer\Util\GitHub;
 
 /**
@@ -37,7 +38,7 @@ class GitDownloader extends VcsDownloader
             return sprintf($command, escapeshellarg($url), escapeshellarg($path), escapeshellarg($ref));
         };
 
-        $this->runCommand($commandCallable, $package->getSourceUrl(), $path);
+        $this->runCommand($commandCallable, $this->getLocalRepository($package->getSourceUrl()), $path);
         $this->setPushUrl($package, $path);
 
         $this->updateToCommit($path, $ref, $package->getPrettyVersion(), $package->getReleaseDate());
@@ -64,7 +65,7 @@ class GitDownloader extends VcsDownloader
             return sprintf($command, escapeshellarg($path), escapeshellarg($url), escapeshellarg($ref));
         };
 
-        $this->runCommand($commandCallable, $target->getSourceUrl());
+        $this->runCommand($commandCallable, $this->getLocalRepository($target->getSourceUrl()));
         $this->updateToCommit($path, $ref, $target->getPrettyVersion(), $target->getReleaseDate());
     }
 
@@ -360,5 +361,25 @@ class GitDownloader extends VcsDownloader
         }
 
         return $output;
+    }
+
+    /**
+     * Get local mirrored repository.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    protected function getLocalRepository($url)
+    {
+        $driver = new GitDriver(
+            array('url' => $url),
+            $this->io,
+            $this->config,
+            $this->process
+        );
+        $driver->initialize();
+
+        return $driver->getRepoDir();
     }
 }

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -29,7 +29,8 @@ class GitDownloader extends VcsDownloader
     public function doDownload(PackageInterface $package, $path)
     {
         $ref = $package->getSourceReference();
-        $command = 'git clone %s %s && cd %2$s && git remote add composer %1$s && git fetch composer';
+        $shared = $this->config->get('git-shared') ? '--shared' : '';
+        $command = 'git clone ' . $shared  . ' %s %s && cd %2$s && git remote add composer %1$s && git fetch composer';
         $this->io->write("    Cloning ".$ref);
 
         // added in git 1.7.1, prevents prompting the user

--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -124,6 +124,18 @@ class GitDriver extends VcsDriver
     }
 
     /**
+     * Get repository directory
+     * Available after init
+     *
+     * @return string Repository path
+     * @see initialize()
+     */
+    public function getRepoDir()
+    {
+        return $this->repoDir;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getComposerInformation($identifier)


### PR DESCRIPTION
Simple Implementation of #1323

Clone repository from mirrored local one instead of remote.

I tested few scenarios and got the following results on my linux VM with symfony-standard dev project:
* current composer version: ~196s for composer install
* mirror + reference: ~57s
* mirror + direct clone from mirror: ~25s

Does anyone see any drawbacks of this type of solution?
Any comments about using GitDriver in downloader?