### PR TITLE
Enforce stricter package names

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -171,6 +171,12 @@ EOT
                 // package names must be in the format foo/bar
                 $name = $name . '/' . $name;
             }
+        } else {
+            if (!preg_match('{^[a-z0-9_.-]+/[a-z0-9_.-]+$}', $name)) {
+                throw new \InvalidArgumentException(
+                    'The package name '.$name.' is invalid, it should be lowercase and have a vendor name, a forward slash, and a package name, matching: [a-z0-9_.-]+/[a-z0-9_.-]+'
+                );
+            }
         }
 
         $name = $dialog->askAndValidate(


### PR DESCRIPTION
Packagist does not allow adding package names with uppercase letters, this adjusts the `composer init` command to enforce the same restriction and to not suggest package names that aren't allowed.
