### PR TITLE
Download PEAR packages via HTTPS scheme if PEAR channel uses HTTPS

### DIFF
--- a/src/Composer/Repository/PearRepository.php
+++ b/src/Composer/Repository/PearRepository.php
@@ -107,7 +107,7 @@ class PearRepository extends ArrayRepository
                 // distribution url must be read from /r/{packageName}/{version}.xml::/r/g:text()
                 // but this location is 'de-facto' standard
                 $urlBits = parse_url($this->url);
-                $scheme = ('https' === $urlBits['scheme'] && extension_loaded('openssl')) ? 'https' : 'http';
+                $scheme = (isset($urlBits['scheme']) && 'https' === $urlBits['scheme'] && extension_loaded('openssl')) ? 'https' : 'http';
                 $distUrl = "{$scheme}://{$packageDefinition->getChannelName()}/get/{$packageDefinition->getPackageName()}-{$version}.tgz";
 
                 $requires = array();


### PR DESCRIPTION
When using PEAR channels only available via HTTPS, Composer discovers the channel correctly with HTTPS. But when downloading the packages the URL scheme was hard-coded to "http". This breaks downloading packages for HTTPS-only PEAR channels.

The fix just uses HTTPS if the PEAR channel has a HTTPS scheme and OpenSSL is available.
