### PR TITLE
Throws descriptive exception when legacy paths cannot be read.

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -100,7 +100,11 @@ class Factory
                             continue;
                         }
                     }
-                    foreach (glob($oldPathMatch) as $child) {
+                    $oldPathMatches = glob($oldPathMatch);
+                    if (false === $oldPathMatches) {
+                        throw new Exception('Could not read legacy paths. Perhaps open_basedir restriction is in effect.');
+                    }
+                    foreach ($oldPathMatches as $child) {
                         @rename($child, $dir.'/'.basename($child));
                     }
                     @unlink($oldPath);


### PR DESCRIPTION
When a system with an open_basedir in effect attempts to glob dirs outside of the restriction, a generic exception is not caught.

$ php ./composer.phar install -v

[ErrorException]
Invalid argument supplied for foreach()

Exception trace:
 () at phar:///[...]/symfony/composer.phar/src/Composer/Factory.php:103
[...]
