### PR TITLE
Fixed highlighting of installed version in the output of composer show

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -258,12 +258,18 @@ EOT
         }
 
         uasort($versions, 'version_compare');
-        $versions = implode(', ', array_keys(array_reverse($versions)));
+        $versions = array_keys(array_reverse($versions));
 
         // highlight installed version
         if ($installedRepo->hasPackage($package)) {
-            $versions = str_replace($package->getPrettyVersion(), '<info>* ' . $package->getPrettyVersion() . '</info>', $versions);
+            $installedVersion = $package->getPrettyVersion();
+            $key = array_search($installedVersion, $versions);
+            if (FALSE !== $key) {
+                $versions[$key] = '<info>* ' . $installedVersion . '</info>';
+            }
         }
+
+        $versions = implode(', ', $versions);
 
         $output->writeln('<info>versions</info> : ' . $versions);
     }


### PR DESCRIPTION
In the output of the command 'composer show [packages]', several versions may be highlighted as the installed version. For example if the installed version is '2.4.13' and other versions are available, which contain '2.4.13' in their name as '2.4.13.x-dev' or 'dev-2.4.13'.

This pull request fixes this problem.
