### PR TITLE
Fix for Bug #1368, improper call to non-existent notifyInstall()

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -184,7 +184,7 @@ EOT
         $projectInstaller = new ProjectInstaller($directory, $dm);
         $projectInstaller->install(new InstalledFilesystemRepository(new JsonFile('php://memory')), $package);
         if ($package->getRepository() instanceof NotifiableRepositoryInterface) {
-            $package->getRepository()->notifyInstall($package);
+            $package->getRepository()->notifyInstalls(array($package));
         }
         $installedFromVcs = 'source' === $package->getInstallationSource();
 


### PR DESCRIPTION
This fixes a call to a non-existent method. I tested it and it properly performed create-project actions for symfony2. Please take a look and make sure it is logically sound, though - I didn't get very much sleep last night :)
