### PR TITLE
Added php.ini path to error message #1052

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -34,7 +34,17 @@ class ZipDownloader extends ArchiveDownloader
     protected function extract($file, $path)
     {
         if (!class_exists('ZipArchive')) {
-            $error = 'You need the zip extension enabled to use the ZipDownloader';
+            // php.ini path is added to the error message to help users find the correct file
+            $iniPath = php_ini_loaded_file();
+
+            if ($iniPath) {
+                $iniMessage = 'The php.ini used by your command-line PHP is: ' . $iniPath;
+            } else {
+                $iniMessage = 'A php.ini file does not exist. You will have to create one.';
+            }
+
+            $error = "You need the zip extension enabled to use the ZipDownloader.\n".
+                $iniMessage;
 
             // try to use unzip on *nix
             if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
@@ -44,6 +54,7 @@ class ZipDownloader extends ArchiveDownloader
                 }
 
                 $error = "Could not decompress the archive, enable the PHP zip extension or install unzip.\n".
+                    $iniMessage . "\n" .
                     'Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput();
             }
 


### PR DESCRIPTION
Hey everyone, I just wanted to start my contribution with something simple.
I have resolved #1052

Message used is consistent with message from composer installer (http://getcomposer.org/installer)
I wasn't sure about line endings, but "\n" is consistent with the rest of the file.

It works when ZipArchive extension is missing and when fallback to linux unzip doesn't work
