### PR TITLE
notifyInstall no longer exists

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -184,7 +184,7 @@ EOT
         $projectInstaller = new ProjectInstaller($directory, $dm);
         $projectInstaller->install(new InstalledFilesystemRepository(new JsonFile('php://memory')), $package);
         if ($package->getRepository() instanceof NotifiableRepositoryInterface) {
-            $package->getRepository()->notifyInstall($package);
+            $package->getRepository()->markForNotification($package);
         }
         $installedFromVcs = 'source' === $package->getInstallationSource();
 


### PR DESCRIPTION
Looking at the last commit notifyInstall has now been replaced by markForNotification seems like one place has been missed
