### PR TITLE
fixed detection of inactive branches in hg

### DIFF
--- a/src/Composer/Repository/Vcs/HgDriver.php
+++ b/src/Composer/Repository/Vcs/HgDriver.php
@@ -169,7 +169,7 @@ class HgDriver extends VcsDriver
 
             $this->process->execute('hg branches', $output, $this->repoDir);
             foreach ($this->process->splitLines($output) as $branch) {
-                if ($branch && preg_match('(^([^\s]+)\s+\d+:(.*)$)', $branch, $match)) {
+                if ($branch && preg_match('(^([^\s]+)\s+\d+:([a-f0-9]+))', $branch, $match)) {
                     $branches[$match[1]] = $match[2];
                 }
             }


### PR DESCRIPTION
In Mercurial, when opening a new branch, the parent branch is shown as "(inactive)", because it's no head anymore. So `hg branches` shows

```
Q:\AddOns\varisale>hg branches
backend-orders              1049:aa9472b58494
default                     1047:e772ac06d34a (inactive)
product-links               1037:42efd5c4df80 (inactive)
hmethod-taxes                998:7e9aec45957f (inactive)
```

The original implementation did not expect anything else than the changeset hash after the double colon. This fixes it, so that the regex only reads the following alphanumerical characters and ignores anything that might follow them.

I need to be able to select an "old" branch, which, if you look at https://bitbucket.org/webvariants/varisale/commits, is not really old, but just the starting point for developing a new feature (and not an abandoned branch). Otherwise, if requiring `dev-default`, I get the feature branch `backend-orders`, which breaks my project.

This does not appear to happen with bookmarks, where the active one is marked with a leading `*`.
