### PR TITLE
[ClassMapGenerator] Faster implementation

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -12,6 +12,7 @@
  */
 
 namespace Composer\Autoload;
+
 use Symfony\Component\Finder\Finder;
 
 /**


### PR DESCRIPTION
- Finder -> faster, especially with native implementations,
- Less LOC = Less bugs,
- Depends on symfony/symfony#6249 (ie finder >= 2.2-dev)

**As stated in the commit comment, should wait for 6249 to be merged & composer to depend on 2.2-dev+**
