### PR TITLE
Add ability to use a Regexp when updating packages

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -96,9 +96,9 @@ If you just want to update a few packages and not all, you can list them as such
 
     $ php composer.phar update vendor/package vendor/package2
 
-You can also use a Regular expression pattern to update a bunch of packages at once:
+You can also use wildcards to update a bunch of packages at once:
 
-    $ php composer.phar update vendor.*
+    $ php composer.phar update vendor/*
 
 ### Options
 

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -625,7 +625,9 @@ class Installer
         }
 
         foreach($this->updateWhitelist as $whiteListedPattern => $void) {
-            if(preg_match("#^".$whiteListedPattern."$#i", $package->getName())) {
+            $cleanedWhiteListedPattern = str_replace('\*', '.*', preg_quote($whiteListedPattern));
+
+            if(preg_match("#^".$cleanedWhiteListedPattern."$#i", $package->getName())) {
                 return true;
             }
         }

--- a/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns.test
+++ b/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns.test
@@ -12,7 +12,8 @@ Update with a package whitelist only updates those corresponding to the pattern
                 { "name": "notexact/TestPackage", "version": "2.0" },
                 { "name": "all/Package1", "version": "2.0" },
                 { "name": "all/Package2", "version": "2.0" },
-                { "name": "another/another", "version": "2.0" }
+                { "name": "another/another", "version": "2.0" },
+                { "name": "no/regexp", "version": "2.0" }
             ]
         }
     ],
@@ -23,7 +24,8 @@ Update with a package whitelist only updates those corresponding to the pattern
         "notexact/TestPackage": "*.*",
         "all/Package1": "*.*",
         "all/Package2": "*.*",
-        "another/another": "*.*"
+        "another/another": "*.*",
+        "no/regexp": "*.*"
     }
 }
 --INSTALLED--
@@ -34,10 +36,11 @@ Update with a package whitelist only updates those corresponding to the pattern
     { "name": "notexact/TestPackage", "version": "1.0" },
     { "name": "all/Package1", "version": "1.0" },
     { "name": "all/Package2", "version": "1.0" },
-    { "name": "another/another", "version": "1.0" }
+    { "name": "another/another", "version": "1.0" },
+    { "name": "no/regexp", "version": "1.0" }
 ]
 --RUN--
-update vendor/Test.* exact/Test-Package notexact/Test all.*
+update vendor/Test* exact/Test-Package notexact/Test all/* no/reg?xp
 --EXPECT--
 Updating vendor/Test-Package (1.0) to vendor/Test-Package (2.0)
 Updating exact/Test-Package (1.0) to exact/Test-Package (2.0)


### PR DESCRIPTION
Hi,

   Thought it could be convenient to be able to update all the packages from one vendor.

   This PR actually activate the usage of Regular expressions in the update command.

   We can call, for example:

```
  composer update vendor/.*
```

Hope you will find it useful.

Thank you

Aurélien
