### PR TITLE
Fixed InitCommand::addVendorIgnore

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -451,7 +451,7 @@ EOT
         return $parser->parseNameVersionPairs($requirements);
     }
 
-    protected function addVendorIgnore($ignoreFile, $vendor = 'vendor')
+    protected function addVendorIgnore($ignoreFile, $vendor = '/vendor/')
     {
         $contents = "";
         if (file_exists($ignoreFile)) {


### PR DESCRIPTION
`vendor` should be prefixed by a `/`.
If it's not, all vendor dirs will be excluded from git scm.
Here, we want to exclude only `/vendor/` dir.
