### PR TITLE
Minor PSR-2 fix for /bin/composer

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -16,8 +16,10 @@ if (function_exists('ini_set')) {
         switch($unit) {
             case 'g':
                 $value *= 1024;
+                //no break (cumulative multiplier)
             case 'm':
                 $value *= 1024;
+                //no break (cumulative multiplier)
             case 'k':
                 $value *= 1024;
         }


### PR DESCRIPTION
> There MUST be a comment such as
> `// no break` when fall-through is intentional in a non-empty `case` body.

Not a big deal, but thought I'd submit it anyway. Thanks!
