### PR TITLE
Allow the PHP5.5-build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: php
 
-php: 
+php:
   - 5.3.3
   - 5.3
   - 5.4
   - 5.5
+
+matrix:
+  allow_failures:
+    - php: 5.5
 
 before_script: composer install
 


### PR DESCRIPTION
PHP5.5 is not officially released, so making it part of
the overall build-success seems not useful. It can be
simply re-enabled, when PHP5.5 is released, or as
soon as the builds doesn't fail anymore.
