### PR TITLE
Implicitly create composer.json in require command

### DIFF
--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -54,7 +54,7 @@ EOT
     {
         $file = Factory::getComposerFile();
 
-        if (!file_exists($file) && !file_put_contents($file, "{}\n")) {
+        if (!file_exists($file) && !file_put_contents($file, "{\n}\n")) {
             $output->writeln('<error>'.$file.' could not be created.</error>');
 
             return 1;


### PR DESCRIPTION
This allows shorteninig install instructions if you do not want to use init
(because it is interactive) and you do not want to use create-project (there
is no skeleton, or you do not want to use a skeleton).
