### PR TITLE
Fixed chmod for binary link in unixy proxy envs

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -209,6 +209,7 @@ class LibraryInstaller implements InstallerInterface
                 }
                 if (!file_exists($link)) {
                     file_put_contents($link, $this->generateWindowsProxyCode($binPath, $link));
+                    chmod($link, 0777 & ~umask());
                 }
             } else {
                 $cwd = getcwd();
@@ -218,12 +219,12 @@ class LibraryInstaller implements InstallerInterface
                     $relativeBin = $this->filesystem->findShortestPath($link, $binPath);
                     chdir(dirname($link));
                     symlink($relativeBin, $link);
+                    chmod($link, 0777 & ~umask());
                 } catch (\ErrorException $e) {
                     file_put_contents($link, $this->generateUnixyProxyCode($binPath, $link));
                 }
                 chdir($cwd);
             }
-            chmod($link, 0777 & ~umask());
         }
     }
 


### PR DESCRIPTION
This should solve issue #1270

I was only able to reproduce that issue on the same environment as mentioned by @KeKs0r, meaning Koding.com. It looks like that environment triggers generateUnixyProxyCode(). As that method is called, file at $link might not exist, therefore chmod there does not make sense.
