### PR TITLE
Invalid require directive is generated in autoload_real.php if phar file is included in autoload.files option

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -294,6 +294,10 @@ EOF;
             $baseDir = '$vendorDir . ';
         }
 
+        if(preg_match('/\.phar$/', $path)){
+            $baseDir = '"phar://" . ' . $baseDir;
+        }
+
         return $baseDir.var_export($path, true);
     }
 


### PR DESCRIPTION
Example: https://github.com/iron-io/iron_mq_php/blob/master/composer.json
