### PR TITLE
do not output the xcopy summary

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -159,7 +159,7 @@ class Filesystem
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             // Try to copy & delete - this is a workaround for random "Access denied" errors.
             $command = sprintf('xcopy %s %s /E /I /Q', escapeshellarg($source), escapeshellarg($target));
-            if (0 === $this->processExecutor->execute($command)) {
+            if (0 === $this->processExecutor->execute($command, $output)) {
                 $this->remove($source);
 
                 return;


### PR DESCRIPTION
Since `xcopy` is used on Windows, every time I do an install/update, I get an output like this:

```
Loading composer repositories with package information
Installing dependencies
  - Installing jasny/db-mysql (v1.1.1)
    Loading from cache
33 Datei(en) kopiert
23 Datei(en) kopiert
2 Datei(en) kopiert
2 Datei(en) kopiert
```

This change makes the process component capture the output. It's required because `xcopy` always prints its summary, even with `/Q` (Windows 7 SP1).
