### PR TITLE
Added stability flag to the install code: doc/articles/handling-private-packages-with-satis.md

### DIFF
--- a/doc/articles/handling-private-packages-with-satis.md
+++ b/doc/articles/handling-private-packages-with-satis.md
@@ -7,7 +7,7 @@
 Satis can be used to host the metadata of your company's private packages, or
 your own. It basically acts as a micro-packagist. You can get it from
 [GitHub](http://github.com/composer/satis) or install via CLI:
-`composer.phar create-project composer/satis`.
+`composer.phar create-project composer/satis --stability=dev`.
 
 ## Setup
 


### PR DESCRIPTION
I've added the stability flag to this article, it was a little confusing as to why satis didn't install correctly using this article. Turned out the github composer/satis README had the answer so i've put it here also.

Matt
