### PR TITLE
Fix unlink(folder) failure on Windows using removeDirectory()

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -17,6 +17,7 @@ use Composer\Json\JsonFile;
 use Composer\IO\IOInterface;
 use Composer\Repository\ComposerRepository;
 use Composer\Repository\RepositoryManager;
+use Composer\Util\Filesystem;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\RemoteFilesystem;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -86,6 +87,7 @@ class Factory
             'cache-vcs-dir' => array('/cache.git' => '/*', '/cache.hg' => '/*'),
             'cache-files-dir' => array('/cache.files' => '/*'),
         );
+        $filesystem = new Filesystem();
         foreach ($legacyPaths as $key => $oldPaths) {
             foreach ($oldPaths as $oldPath => $match) {
                 $dir = $config->get($key);
@@ -105,7 +107,7 @@ class Factory
                             @rename($child, $dir.'/'.basename($child));
                         }
                     }
-                    @unlink($oldPath);
+                    $filesystem->removeDirectory($oldPath);
                 }
             }
         }


### PR DESCRIPTION
When using Windows (tested on Vista), `unlink` -ing a directory will fail. This is used in `Composer\Factory::createConfig()` when updating legacy paths and attempting to remove the old directories.

This PR uses removeDirectory() from `Composer\Utils\Filesystem`, rather than the native `rmdir()` in case the directory is not empty.
