### PR TITLE
Made the `show` command more scripting friendly

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -46,6 +46,7 @@ class ShowCommand extends Command
                 new InputOption('available', 'a', InputOption::VALUE_NONE, 'List available packages only'),
                 new InputOption('self', 's', InputOption::VALUE_NONE, 'Show the root package information'),
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Enables display of dev-require packages.'),
+                new InputOption('name-only', 'N', InputOption::VALUE_NONE, 'List package names only'),
             ))
             ->setHelp(<<<EOT
 The show command displays detailed information about a package, or
@@ -147,7 +148,11 @@ EOT
                 }
                 ksort($packages[$type]);
                 foreach ($packages[$type] as $package) {
-                    $output->writeln(($tree ? '  ' : '').$package->getPrettyName().' '.($showVersion ? '['.$this->versionParser->formatVersion($package).']' : '').' <comment>:</comment> '. strtok($package->getDescription(), "\r\n"));
+                    if ($input->getOption('name-only')) {
+                        $output->writeln(($tree ? '  ' : '').$package->getPrettyName());
+                    } else {
+                        $output->writeln(($tree ? '  ' : '').$package->getPrettyName().' '.($showVersion ? '['.$this->versionParser->formatVersion($package).']' : '').' <comment>:</comment> '. strtok($package->getDescription(), "\r\n"));
+                    }
                 }
                 if ($tree) {
                     $output->writeln('');


### PR DESCRIPTION
Added the --available (-a) and the --name-only (-N) options to the
show to command to make the output more suitable for (shell)
scripting (Bash completion of packages comes to mind).

The --available (-a) option will list only the  available packages,
similar to the --installed and --platform options.

The --name-only (-N) option will only show package names in the
listing (omitting version and description).

Additionally changed the output formatting when limiting the
package list result to remove the hierarchy when only one type is
being showed. This facilitates parsing of a list of packages (for
example for shell scripting and completion).
