### PR TITLE
fixed svn packages installation with explicit revisions

### DIFF
--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -29,7 +29,7 @@ class SvnDownloader extends VcsDownloader
         $url =  $package->getSourceUrl();
         $ref =  $package->getSourceReference();
 
-        if (is_numeric($ref) && 'source' == $package->getInstallationSource()) {
+        if (is_numeric($ref)) {
             //source reference is an explicit commit
             $version = $package->getPrettyVersion();
             $vcsPath = str_replace(array('dev-','.x-dev'), '', $version);
@@ -54,7 +54,7 @@ class SvnDownloader extends VcsDownloader
         $url = $target->getSourceUrl();
         $ref = $target->getSourceReference();
 
-        if (is_numeric($ref) && 'source' == $target->getInstallationSource()) {
+        if (is_numeric($ref)) {
             //source reference is an explicit commit
             $version = $target->getPrettyVersion();
             $vcsPath = str_replace(array('dev-','.x-dev'), '', $version);


### PR DESCRIPTION
fixed a bug with svn-package requirements on an exact commit.

before it trys to download something like that:

_package exists as branch 0.3 in revision 4711_

`https://svn.example.com/package/4711` thats obviously wrong...

now it downloads the correct path:

`https://svn.example.com/package/branches/0.3@4711`
