### PR TITLE
Replace backslashes in Window directories for config --list

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -40,7 +40,7 @@ class Factory
         $cacheDir = getenv('COMPOSER_CACHE_DIR');
         if (!$home) {
             if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-                $home = getenv('APPDATA') . '/Composer';
+                $home = str_replace('\\', '/', getenv('APPDATA')) . '/Composer';
             } else {
                 $home = rtrim(getenv('HOME'), '/') . '/.composer';
             }
@@ -52,6 +52,7 @@ class Factory
                 } else {
                     $cacheDir = getenv('APPDATA') . '/Composer/cache';
                 }
+                $cacheDir = str_replace('\\', '/', $cacheDir);
             } else {
                 $cacheDir = $home.'/cache';
             }


### PR DESCRIPTION
On Windows running config -g --list produces output with back- and forward-slashes:

```
[cache-dir] C:\Users\Name\AppData\Local/Composer
```

This PR replaces the back-slashes with forward-slashes.
