### PR TITLE
Fix config writing illegal Json strings

### DIFF
--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -61,10 +61,6 @@ class JsonConfigSource implements ConfigSourceInterface
      */
     public function addConfigSetting($name, $value)
     {
-        if (is_string($value)) {
-            $json = '{"'.$name.'": "'.$value.'"}';
-            JsonFile::parseJson($json, $name);
-        }
         $this->manipulateJson('addConfigSetting', $name, $value, function (&$config, $key, $val) {
             $config['config'][$key] = $val;
         });

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -281,7 +281,7 @@ class JsonManipulator
             return $out . implode(','.$this->newline, $elems) . $this->newline . str_repeat($this->indent, $depth + 1) . '}';
         }
 
-        return JsonFile::encode($data);
+        return JsonFile::encode(addcslashes($data, '\\'));
     }
 
     protected function detectIndenting()


### PR DESCRIPTION
Input string values for config settings are used without being checked (unlike int and bool values), which means that illegal Json values like unescaped backslashes will be saved in the config.json and break future config usage.

For example, calling `config -g cache-files-dir C:\Users\Name\ComposerCache` produces the following entry:

```
"cache-files-dir": "C:\Users\Name\ComposerCache"
```

This PR fixes the issue by parsing the string first. I am not sure if I have put this in the correct place, so feel free to amend, delete or whatever.
