### PR TITLE
Recommend actual version as constraint with installers.

### DIFF
--- a/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md
+++ b/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md
@@ -15,7 +15,7 @@ WordPress theme:
         "name": "you/themename",
         "type": "wordpress-theme",
         "require": {
-            "composer/installers": "*"
+            "composer/installers": "~1.0"
         }
     }
 


### PR DESCRIPTION
Ref composer/installers#58

Recommend users to use `~1.0` rather than `*` as a constraint with `composer/installers`. Thanks!
