### PR TITLE
Display curl SSL errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Since Composer works with the current working directory it is possible to instal
 in a system wide way.
 
 1. Change into a directory in your path like `cd /usr/local/bin`
-2. Get Composer `curl -s https://getcomposer.org/installer | php`
+2. Get Composer `curl -sS https://getcomposer.org/installer | php`
 3. Make the phar executable `chmod a+x composer.phar`
 4. Change into a project directory `cd /path/to/my/project`
 5. Use Composer as you normally would `composer.phar install`

--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -63,7 +63,7 @@ Linux and OSX.
 To actually get Composer, we need to do two things. The first one is installing
 Composer (again, this means downloading it into your project):
 
-    $ curl -s https://getcomposer.org/installer | php
+    $ curl -sS https://getcomposer.org/installer | php
 
 This will just check a few PHP settings and then download `composer.phar` to
 your working directory. This file is the Composer binary. It is a PHAR (PHP
@@ -73,7 +73,7 @@ line, amongst other things.
 You can install Composer to a specific directory by using the `--install-dir`
 option and providing a target directory (it can be an absolute or relative path):
 
-    $ curl -s https://getcomposer.org/installer | php -- --install-dir=bin
+    $ curl -sS https://getcomposer.org/installer | php -- --install-dir=bin
 
 #### Globally
 
@@ -83,7 +83,7 @@ executable and invoke it without `php`.
 
 You can run these commands to easily access `composer` from anywhere on your system:
 
-    $ curl -s https://getcomposer.org/installer | php
+    $ curl -sS https://getcomposer.org/installer | php
     $ sudo mv composer.phar /usr/local/bin/composer
 
 Then, just run `composer` in order to run Composer instead of `php composer.phar`.

--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -4,7 +4,7 @@
 
 To install Composer, you just need to download the `composer.phar` executable.
 
-    $ curl -s https://getcomposer.org/installer | php
+    $ curl -sS https://getcomposer.org/installer | php
 
 For the details, see the [Introduction](00-intro.md) chapter.
 
@@ -17,7 +17,7 @@ This should give you a list of available commands.
 > **Note:** You can also perform the checks only without downloading Composer
 > by using the `--check` option. For more information, just use `--help`.
 >
->     $ curl -s https://getcomposer.org/installer | php -- --help
+>     $ curl -sS https://getcomposer.org/installer | php -- --help
 
 ## `composer.json`: Project Setup
 

--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -11,7 +11,7 @@ This is a list of common pitfalls on using Composer, and how to avoid them.
    latest version**. See [self-update](../03-cli.md#self-update) for details.
 
 2. Make sure you have no problems with your setup by running the installer's
-   checks via `curl -s https://getcomposer.org/installer | php -- --check`.
+   checks via `curl -sS https://getcomposer.org/installer | php -- --check`.
 
 3. Ensure you're **installing vendors straight from your `composer.json`** via
    `rm -rf vendor && composer update -v` when troubleshooting, excluding any

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -19,7 +19,7 @@ function includeIfExists($file)
 
 if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
     echo 'You must set up the project dependencies, run the following commands:'.PHP_EOL.
-        'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
+        'curl -sS https://getcomposer.org/installer | php'.PHP_EOL.
         'php composer.phar install'.PHP_EOL;
     exit(1);
 }


### PR DESCRIPTION
`curl -s` not only hides the progress bar, it also hides errors. `-S` makes the errors show up again.
