### PR TITLE
Adding composer security:check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "seld/jsonlint": "1.*",
         "symfony/console": "~2.1@dev",
         "symfony/finder": "~2.1",
-        "symfony/process": "~2.1@dev"
+        "symfony/process": "~2.1@dev",
+        "sensiolabs/security-checker": "~1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7.10"

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -25,6 +25,8 @@ use Composer\Factory;
 use Composer\IO\IOInterface;
 use Composer\IO\ConsoleIO;
 use Composer\Util\ErrorHandler;
+use SensioLabs\Security\Command\SecurityCheckerCommand;
+use SensioLabs\Security\SecurityChecker;
 
 /**
  * The console application that handles the commands
@@ -182,6 +184,7 @@ class Application extends BaseApplication
         $commands[] = new Command\RequireCommand();
         $commands[] = new Command\DumpAutoloadCommand();
         $commands[] = new Command\StatusCommand();
+        $commands[] = new SecurityCheckerCommand(new SecurityChecker());
 
         if ('phar:' === substr(__FILE__, 0, 5)) {
             $commands[] = new Command\SelfUpdateCommand();


### PR DESCRIPTION
It adds a really nice feature and it fits perfectly inside composer as the base file for the check is created by composer itself

If vulnerabilities are found, it shows : 

```
$ ../composer/bin/composer security:check
Security Report
===============

The checker detected 2 package(s) that have known* vulnerabilities in
your project. We recommend you to check the related security advisories
and upgrade these dependencies.

symfony/http-foundation (v2.0.18)
---------------------------------

CVE-2012-6431: Routes behind a firewall are accessible even when not logged in
               http://symfony.com/blog/security-release-symfony-2-0-20-and-2-1-5
-released

xxx-xxxx-xxxx: Request::getClientIp() when the trust proxy mode is enabled
               http://symfony.com/blog/security-release-symfony-2-0-19-and-2-1-4


symfony/security (v2.0.18)
--------------------------

CVE-2012-6431: Routes behind a firewall are accessible even when not logged in
               http://symfony.com/blog/security-release-symfony-2-0-20-and-2-1-5
-released


* Disclaimer: This checker can only detect vulnerabilities that are referenced
              in the SensioLabs security advisories database.

```

If not : 

```
$ bin/composer security:check
Security Report
===============

No known* vulnerabilities detected.

* Disclaimer: This checker can only detect vulnerabilities that are referenced
              in the SensioLabs security advisories database.
```

What do you think ?
