### PR TITLE
Satis configuration file description

### DIFF
--- a/doc/articles/handling-private-packages-with-satis.md
+++ b/doc/articles/handling-private-packages-with-satis.md
@@ -13,10 +13,8 @@ your own. It basically acts as a micro-packagist. You can get it from
 
 For example let's assume you have a few packages you want to reuse across your
 company but don't really want to open-source. You would first define a Satis
-configuration, a json file with an arbitrary name that is basically a stripped-down version of a
-`composer.json` file. It contains a few repositories, and then you use the require
-key to say which packages it should dump in the static repository it creates, or
-use require-all to select all of them.
+configuration: a json file with an arbitrary name that lists your curated 
+[repositories](../05-repositories.md).
 
 Here is an example configuration, you see that it holds a few VCS repositories,
 but those could be any types of [repositories](../05-repositories.md). Then it


### PR DESCRIPTION
Tiny change. Better upfront description of what a Satis configuration file actually is. Was previously not clear the filename didn't matter until further down.
