### PR TITLE
Specific schema validation failure messages (fixes issue #1616)

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -24,6 +24,7 @@ use Composer\Composer;
 use Composer\Factory;
 use Composer\IO\IOInterface;
 use Composer\IO\ConsoleIO;
+use Composer\Json\JsonValidationException;
 use Composer\Util\ErrorHandler;
 
 /**


### PR DESCRIPTION
Fixes https://github.com/composer/composer/issues/1616 by adding the error messages from the JSON validator to the outgoing exception message.
