### PR TITLE
Small enhancement of test to test more stable version strings

### DIFF
--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -319,7 +319,10 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
     public function stabilityProvider()
     {
         return array(
+            array('stable', '1'),
             array('stable', '1.0'),
+            array('stable', '3.2.1'),
+            array('stable', 'v3.2.1'),
             array('dev',    'v2.0.x-dev'),
             array('dev',    'v2.0.x-dev#abc123'),
             array('dev',    'v2.0.x-dev#trunk/@123'),


### PR DESCRIPTION
I noticed some strings that are rather common were not in the test for considering them stable or not so I added them. Tests still run as expected.
