### PR TITLE
Duplicated call of doInstall() method for dev mode.

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -184,13 +184,8 @@ class Installer
 
         try {
             $this->suggestedPackages = array();
-            if (!$this->doInstall($this->repositoryManager->getLocalRepository(), $installedRepo, $aliases)) {
+            if (!$this->doInstall($this->repositoryManager->getLocalDevRepository(), $installedRepo, $aliases, $this->devMode)) {
                 return false;
-            }
-            if ($this->devMode) {
-                if (!$this->doInstall($this->repositoryManager->getLocalDevRepository(), $installedRepo, $aliases, true)) {
-                    return false;
-                }
             }
         } catch (\Exception $e) {
             $this->installationManager->notifyInstalls();


### PR DESCRIPTION
It seems like the code contains duplicated call of doInstall(): if $this->devMode == true, the doInstall() will be called twice. If it must not be done, I have attached respective pull request.
