### PR TITLE
Add HTTP Basic auth handling when quering a Composer Repo

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -229,7 +229,6 @@ class RemoteFilesystem
                 }
 
                 throw new TransportException('The "'.$this->fileUrl.'" file could not be downloaded ('.trim($message).')', $messageCode);
-                break;
 
             case STREAM_NOTIFY_AUTH_RESULT:
                 if (403 === $messageCode) {


### PR DESCRIPTION
Dealing with a HTTP basic auth protected Composer Repo (e.g. private Satis Repo) was not possible as an Composer\Downloader\TransportException gets thrown when Composer tries to download the packages.json file. 

The PR fixes that by extending the fetchFile() method of the ComposerRepository class. In case the remote resource responds with a 401 we ask the user for the access credentials and retry querying the resource again.
