### PR TITLE
Clarify custom installer names/interfaces

### DIFF
--- a/doc/articles/custom-installers.md
+++ b/doc/articles/custom-installers.md
@@ -55,10 +55,7 @@ package that has the [type][1] `composer-installer`.
 A basic Installer would thus compose of two files:
 
 1. the package file: composer.json
-2. The Installer class, i.e.: `Composer\Installer\MyInstaller.php`
-
-> **NOTE**: _The namespace does not need to be `Composer\Installer`, it must
-> only implement the right interface._
+2. The Installer class, e.g.: `My\Project\Composer\Installer.php`, containing a class that implements `Composer\Installer\InstallerInterface˚.
 
 ### composer.json
 


### PR DESCRIPTION
"i.e." is an abbreviation for "id est", meaning "that is". The intention here is probably "e.g.", "exempli gratia", meaning "for example".

Also gave non-`Composer\` example path and added the name of the interface an installer should implement (it's mentioned later in the article, but it's useful to mention it early).
