### PR TITLE
Allow composer to handle dists for Git repositories

### DIFF
--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -124,6 +124,18 @@ class GitDriver extends VcsDriver
      */
     public function getDist($identifier)
     {
+        if (isset($this->repoConfig['dist'])) {
+            $label = array_search($identifier, $this->getTags()) ?: $identifier;
+            $infos = $this->getComposerInformation($identifier);
+
+            return array(
+                'type' => 'zip',
+                'url' => sprintf($this->repoConfig['dist'], $infos['version']),
+                'reference' => $label,
+                'shasum' => null
+            );
+        }
+
         return null;
     }
 


### PR DESCRIPTION
This patch adds the support of dist archives to standard git repositories (via `GitDriver`).

This is usefull for people using satis and their own infrastructure to host repositories and wanting to publish dists archives.

This PR introduces a new attributes for VCS repositories :

``` json
{
    "name": "Satis Repository",
    "homepage": "http://satis.local",
    "repositories": [
        {
            "type": "vcs",
            "url": "git@server.git:my-project.git",
            "dist": "http://satis.local/dists/my-project-%s.zip"
        }
    ]
}
```

Composer will automatically expand the given URL and append the branch/tag name to the file name.
