### PR TITLE
[BugFix] require command

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -140,6 +140,7 @@ to the command.
 * **--prefer-dist:** Install packages from `dist` when available.
 * **--dev:** Add packages to `require-dev`.
 * **--no-update:** Disables the automatic update of the dependencies.
+* **--no-dev-update:** Disable the automatic update of packages in the `require-dev`.
 * **--no-progress:** Removes the progress display that can mess with some
   terminals or scripts which don't handle backspace characters.
 

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -39,6 +39,7 @@ class RequireCommand extends InitCommand
                 new InputOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist even for dev versions.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
                 new InputOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies.'),
+                new InputOption('no-dev-update', null, InputOption::VALUE_NONE, 'Disable update of require-dev.'),
             ))
             ->setHelp(<<<EOT
 The require command adds required packages to your composer.json and installs them
@@ -107,7 +108,7 @@ EOT
             ->setVerbose($input->getOption('verbose'))
             ->setPreferSource($input->getOption('prefer-source'))
             ->setPreferDist($input->getOption('prefer-dist'))
-            ->setDevMode($input->getOption('dev'))
+            ->setDevMode(!$input->getOption('no-dev-update'))
             ->setUpdate(true)
             ->setUpdateWhitelist(array_keys($requirements));
         ;


### PR DESCRIPTION
When running the require command, it will run the update command. By default it will set DevMode to true, which will install all the development dependencies. Development dependencies should only be installed if the --dev option is passed to the require command.
