### PR TITLE
Allow autoloading empty paths

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -218,8 +218,9 @@ class ClassLoader
         foreach ($this->prefixes as $prefix => $dirs) {
             if (0 === strpos($class, $prefix)) {
                 foreach ($dirs as $dir) {
-                    if (file_exists($dir . DIRECTORY_SEPARATOR . $classPath)) {
-                        return $dir . DIRECTORY_SEPARATOR . $classPath;
+                    $fileName = ($dir ? $dir . DIRECTORY_SEPARATOR : '') . $classPath;
+                    if (file_exists($fileName)) {
+                        return $fileName;
                     }
                 }
             }


### PR DESCRIPTION
This issue manifested itself with PSR-0 autoload defined for a script
in the root package. That script could not be run because the file was
not PSR-0 autoloadable.

The issue is that the ClassLoader always does "$dir/$classPath", which
if $dir is empty will make an absolute path which obviously does not exist.

This change modifies the class loader to allow for empty paths.
