### PR TITLE
Added support for additional Script parameters to install and update commands

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -48,6 +48,11 @@ For any given event:
 and command-line executables commands.
 - PHP classes containing defined callbacks must be autoloadable via Composer's
 autoload functionality.
+- Scripts and callbacks can be configured by adding commandline parameters:
+`composer install --script-param="name1:key1=value1"`
+`composer install --script-param="value2"` (key will be equal to value2)
+Multiple parameters can be added:
+`composer install --script-param="name1:key1=value1" --script-param="value2"`
 
 Script definition example:
 
@@ -59,7 +64,8 @@ Script definition example:
             ],
             "post-install-cmd": [
                 "MyVendor\\MyClass::warmCache",
-                "phpunit -c app/"
+                "phpunit -c app/",
+                "myscript {name1} {value2}"
             ]
         }
     }
@@ -78,6 +84,7 @@ that might be used to execute the PHP callbacks:
         public static function postUpdate(Event $event)
         {
             $composer = $event->getComposer();
+            $params = $event->getScriptParams();
             // do stuff
         }
 
@@ -101,3 +108,4 @@ PHP callback. This `Event` object has getters for other contextual objects:
 - `getName()`: returns the name of the event being fired as a string
 - `getIO()`: returns the current input/output stream which implements
 `Composer\IO\IOInterface` for writing to the console
+- `getScriptParams()`: returns an array of commandline parameters added with --script-param

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -14,6 +14,7 @@ namespace Composer\Command;
 
 use Composer\Installer;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -39,7 +40,8 @@ class InstallCommand extends Command
                 new InputOption('no-scripts', null, InputOption::VALUE_NONE, 'Skips the execution of all scripts defined in composer.json file.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
                 new InputOption('verbose', 'v', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
-                new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump')
+                new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
+                new InputOption('script-param', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add parameters that can be used for scripts.')
             ))
             ->setHelp(<<<EOT
 The <info>install</info> command reads the composer.lock file from
@@ -87,6 +89,7 @@ EOT
             ->setPreferDist($preferDist)
             ->setDevMode($input->getOption('dev'))
             ->setRunScripts(!$input->getOption('no-scripts'))
+            ->setScriptParams($input->getOption('script-param'))
             ->setOptimizeAutoloader($input->getOption('optimize-autoloader'))
         ;
 

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -14,7 +14,6 @@ namespace Composer\Command;
 
 use Composer\Installer;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -39,7 +39,8 @@ class UpdateCommand extends Command
                 new InputOption('no-scripts', null, InputOption::VALUE_NONE, 'Skips the execution of all scripts defined in composer.json file.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
                 new InputOption('verbose', 'v', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
-                new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump')
+                new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
+                new InputOption('script-param', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add parameters that can be used for scripts.')
             ))
             ->setHelp(<<<EOT
 The <info>update</info> command reads the composer.json file from the
@@ -90,6 +91,7 @@ EOT
             ->setPreferDist($preferDist)
             ->setDevMode(!$input->getOption('no-dev'))
             ->setRunScripts(!$input->getOption('no-scripts'))
+            ->setScriptParams($input->getOption('script-param'))
             ->setOptimizeAutoloader($input->getOption('optimize-autoloader'))
             ->setUpdate(true)
             ->setUpdateWhitelist($input->getArgument('packages'))

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -942,15 +942,15 @@ class Installer
     /**
      * set optional additional parameters for scripts
      *
-     * @param  array   $scriptParams
+     * @param  array        $scriptParams
      * @return Installer
      */
-    public function setScriptParams( array $scriptParams = array() )
+    public function setScriptParams(array $scriptParams = array())
     {
-        foreach( $scriptParams as $param ) {
+        foreach ($scriptParams as $param) {
             $param = explode(':',$param);
             $key = array_shift($param);
-            $this->scriptParams[$key] = ( count($param)>0 ? implode(':',$param) : $key );
+            $this->scriptParams[$key] = count($param)>0 ? implode(':', $param) : $key;
         }
 
         return $this;

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -106,6 +106,11 @@ class Installer
     /**
      * @var array
      */
+    protected $scriptParams = array();
+
+    /**
+     * @var array
+     */
     protected $suggestedPackages;
 
     /**
@@ -196,7 +201,7 @@ class Installer
         if ($this->runScripts) {
             // dispatch pre event
             $eventName = $this->update ? ScriptEvents::PRE_UPDATE_CMD : ScriptEvents::PRE_INSTALL_CMD;
-            $this->eventDispatcher->dispatchCommandEvent($eventName, $this->devMode);
+            $this->eventDispatcher->dispatchCommandEvent($eventName, $this->devMode, $this->scriptParams);
         }
 
         try {
@@ -278,7 +283,7 @@ class Installer
             if ($this->runScripts) {
                 // dispatch post event
                 $eventName = $this->update ? ScriptEvents::POST_UPDATE_CMD : ScriptEvents::POST_INSTALL_CMD;
-                $this->eventDispatcher->dispatchCommandEvent($eventName, $this->devMode);
+                $this->eventDispatcher->dispatchCommandEvent($eventName, $this->devMode, $this->scriptParams);
             }
         }
 
@@ -464,7 +469,7 @@ class Installer
 
             $event = 'Composer\Script\ScriptEvents::PRE_PACKAGE_'.strtoupper($operation->getJobType());
             if (defined($event) && $this->runScripts) {
-                $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $operation);
+                $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $operation, $this->scriptParams);
             }
 
             // not installing from lock, force dev packages' references if they're in root package refs
@@ -493,7 +498,7 @@ class Installer
 
             $event = 'Composer\Script\ScriptEvents::POST_PACKAGE_'.strtoupper($operation->getJobType());
             if (defined($event) && $this->runScripts) {
-                $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $operation);
+                $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $operation, $this->scriptParams);
             }
 
             if (!$this->dryRun) {
@@ -930,6 +935,23 @@ class Installer
     public function setRunScripts($runScripts = true)
     {
         $this->runScripts = (boolean) $runScripts;
+
+        return $this;
+    }
+
+    /**
+     * set optional additional parameters for scripts
+     *
+     * @param  array   $scriptParams
+     * @return Installer
+     */
+    public function setScriptParams( array $scriptParams = array() )
+    {
+        foreach( $scriptParams as $param ) {
+            $param = explode(':',$param);
+            $key = array_shift($param);
+            $this->scriptParams[$key] = ( count($param)>0 ? implode(':',$param) : $key );
+        }
 
         return $this;
     }

--- a/src/Composer/Script/Event.php
+++ b/src/Composer/Script/Event.php
@@ -43,7 +43,7 @@ class Event
     private $devMode;
 
     /**
-     * @var array $scriptParams An array of parameters as additional parameters for Scripts
+     * @var array An array of parameters as additional parameters for Scripts
      */
     private $scriptParams;
 
@@ -51,11 +51,11 @@ class Event
     /**
      * Constructor.
      *
-     * @param string      $name     The event name
-     * @param Composer    $composer The composer object
-     * @param IOInterface $io       The IOInterface object
-     * @param boolean     $devMode  Whether or not we are in dev mode
-     * @param array       $scriptParams  Additional parameters for scripts added on commandline
+     * @param string      $name         The event name
+     * @param Composer    $composer     The composer object
+     * @param IOInterface $io           The IOInterface object
+     * @param boolean     $devMode      Whether or not we are in dev mode
+     * @param array       $scriptParams Additional parameters for scripts added on commandline
      */
     public function __construct($name, Composer $composer, IOInterface $io, $devMode = false, array $scriptParams = array() )
     {
@@ -106,9 +106,8 @@ class Event
         return $this->devMode;
     }
 
-
     /**
-     * Return optional additional script params
+     * Return optional additional script params.
      *
      * @return array
      */
@@ -116,6 +115,5 @@ class Event
     {
         return $this->scriptParams;
     }
-
 
 }

--- a/src/Composer/Script/Event.php
+++ b/src/Composer/Script/Event.php
@@ -43,19 +43,27 @@ class Event
     private $devMode;
 
     /**
+     * @var array $scriptParams An array of parameters as additional parameters for Scripts
+     */
+    private $scriptParams;
+
+
+    /**
      * Constructor.
      *
      * @param string      $name     The event name
      * @param Composer    $composer The composer object
      * @param IOInterface $io       The IOInterface object
      * @param boolean     $devMode  Whether or not we are in dev mode
+     * @param array       $scriptParams  Additional parameters for scripts added on commandline
      */
-    public function __construct($name, Composer $composer, IOInterface $io, $devMode = false)
+    public function __construct($name, Composer $composer, IOInterface $io, $devMode = false, array $scriptParams = array() )
     {
         $this->name = $name;
         $this->composer = $composer;
         $this->io = $io;
         $this->devMode = $devMode;
+        $this->scriptParams = $scriptParams;
     }
 
     /**
@@ -97,4 +105,17 @@ class Event
     {
         return $this->devMode;
     }
+
+
+    /**
+     * Return optional additional script params
+     *
+     * @return array
+     */
+    public function getScriptParams()
+    {
+        return $this->scriptParams;
+    }
+
+
 }

--- a/src/Composer/Script/EventDispatcher.php
+++ b/src/Composer/Script/EventDispatcher.php
@@ -85,7 +85,7 @@ class EventDispatcher
      * @param boolean $devMode      Whether or not we are in dev mode
      * @param array   $scriptParams Additional script parameters added on commandline
      */
-    public function dispatchCommandEvent($eventName, $devMode, array $scriptParams = array() )
+    public function dispatchCommandEvent($eventName, $devMode, array $scriptParams = array())
     {
         $this->doDispatch(new CommandEvent($eventName, $this->composer, $this->io, $devMode, $scriptParams));
     }

--- a/src/Composer/Script/EventDispatcher.php
+++ b/src/Composer/Script/EventDispatcher.php
@@ -12,7 +12,6 @@
 
 namespace Composer\Script;
 
-use Composer\Autoload\AutoloadGenerator;
 use Composer\IO\IOInterface;
 use Composer\Composer;
 use Composer\DependencyResolver\Operation\OperationInterface;
@@ -54,8 +53,8 @@ class EventDispatcher
     /**
      * Dispatch a script event.
      *
-     * @param string  $eventName The constant in ScriptEvents
-     * @param Event $event
+     * @param string $eventName The constant in ScriptEvents
+     * @param Event  $event
      */
     public function dispatch($eventName, Event $event = null)
     {
@@ -69,10 +68,10 @@ class EventDispatcher
     /**
      * Dispatch a package event.
      *
-     * @param string             $eventName The constant in ScriptEvents
-     * @param boolean            $devMode   Whether or not we are in dev mode
-     * @param OperationInterface $operation The package being installed/updated/removed
-     * @param array   $scriptParams  Additional script parameters added on commandline
+     * @param string             $eventName    The constant in ScriptEvents
+     * @param boolean            $devMode      Whether or not we are in dev mode
+     * @param OperationInterface $operation    The package being installed/updated/removed
+     * @param array              $scriptParams Additional script parameters added on commandline
      */
     public function dispatchPackageEvent($eventName, $devMode, OperationInterface $operation, array $scriptParams = array() )
     {
@@ -82,9 +81,9 @@ class EventDispatcher
     /**
      * Dispatch a command event.
      *
-     * @param string  $eventName The constant in ScriptEvents
-     * @param boolean $devMode   Whether or not we are in dev mode
-     * @param array   $scriptParams  Additional script parameters added on commandline
+     * @param string  $eventName    The constant in ScriptEvents
+     * @param boolean $devMode      Whether or not we are in dev mode
+     * @param array   $scriptParams Additional script parameters added on commandline
      */
     public function dispatchCommandEvent($eventName, $devMode, array $scriptParams = array() )
     {
@@ -122,13 +121,12 @@ class EventDispatcher
                     throw $e;
                 }
             } else {
-                $m = array();
-                if ( preg_match_all( '/\{(.*)\}/U', $callable, $m ) ) {
+                if (preg_match_all('/\{(.*)\}/U', $callable, $m)) {
                     $scriptParams = $event->getScriptParams();
 
-                    foreach ( $m[0] as $i => $find ) {
-                        $replace = ( isset($scriptParams[$m[1][$i]]) ? $scriptParams[$m[1][$i]] : '' );
-                        $callable = str_replace( $find, $replace, $callable );
+                    foreach ($m[0] as $i => $find) {
+                        $replace = isset($scriptParams[$m[1][$i]]) ? $scriptParams[$m[1][$i]] : '';
+                        $callable = str_replace($find, $replace, $callable);
                     }
                 }
 

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -178,7 +178,7 @@ class RemoteFilesystem
             $result = (bool) file_put_contents($fileName, $result);
             restore_error_handler();
             if (false === $result) {
-                throw new TransportException('The "'.$fileUrl.'" file could not be written to '.$fileName.': '.$errorMessage);
+                throw new TransportException('The "'.$this->fileUrl.'" file could not be written to '.$fileName.': '.$errorMessage);
             }
         }
 
@@ -188,7 +188,7 @@ class RemoteFilesystem
         }
 
         if (false === $this->result) {
-            $e = new TransportException('The "'.$fileUrl.'" file could not be downloaded: '.$errorMessage, $errorCode);
+            $e = new TransportException('The "'.$this->fileUrl.'" file could not be downloaded: '.$errorMessage, $errorCode);
             if (!empty($http_response_header[0])) {
                 $e->setHeaders($http_response_header);
             }


### PR DESCRIPTION
This pull request is an attempt at allowing scripts to have parameters defined at runtime. 
An example would be to use  >composer install --script-tag="env:--env=prod" on production.

Scripts would then be configured in composer.json with "myscript {env}".

PHP Callbacks would have access to the parameters through the Event object:
$event->getScriptParams();

There are some decisions that need review in my opinion:
-- Is it desirable to add the scriptParams to the Event constructor?
-- Would the InstallCommand and UpdateCommand need more explanation?
-- Is the help page correctly altered?
-- Are there tests needed? I could not find a good place to add tests for this...