### PR TITLE
Travis using PHPUnit version from require-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 5.4
   - 5.5
 
-before_script: composer install --prefer-source
+before_script: 
+    - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+    - composer install --dev --prefer-source
 
-script: phpunit -c tests/complete.phpunit.xml
+script: ./vendor/bin/phpunit -c tests/complete.phpunit.xml


### PR DESCRIPTION
in order not to use system version of PHPUnit and have unexpected bugs - it could be better to invoke PHPUnit from development dependencies
