### PR TITLE
Link-resolve tmp dir in tests

### DIFF
--- a/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
@@ -29,7 +29,7 @@ class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
     {
         $fs = new Filesystem;
 
-        $this->sources = sys_get_temp_dir().
+        $this->sources = realpath(sys_get_temp_dir()).
             '/composer_archiver_test'.uniqid(mt_rand(), true);
 
         $fileTree = array(


### PR DESCRIPTION
On OSX the temp dir is within /var, which is a symlink to /private/var.
If this is not resolved, the comparison will fail when comparing to the result of `git archive` in testGitExcludes().
