### PR TITLE
Fix case where PHP's symlink returns false without any error or warning.

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -217,7 +217,9 @@ class LibraryInstaller implements InstallerInterface
                     // when using it in smbfs mounted folder
                     $relativeBin = $this->filesystem->findShortestPath($link, $binPath);
                     chdir(dirname($link));
-                    symlink($relativeBin, $link);
+                    if (false === symlink($relativeBin, $link)) {
+                        throw new \ErrorException();
+                    }
                 } catch (\ErrorException $e) {
                     file_put_contents($link, $this->generateUnixyProxyCode($binPath, $link));
                 }


### PR DESCRIPTION
This should solve issue #1270

I've reproduced this error in a Mediatemple's (gs) Grid-Service hosting sandbox when trying to run "composer update" in a symfony2 v2.2.1 project.

Why?
Since doctrine orm 2.3.0 a symlink is created at "$SYMFONY_ROOT/bin/", that's why this is not reproduced for doctrine orm <= 2.2.3

Also I could not "composer update" the composer project in order to hack this issue because "seld/jsonlint (1.1.1)" also creates a symlink. Extracting the composer.phar did the trick for me to start debugging.

How?
It's expected symlinks might not work like this comment implies:
    // under linux symlinks are not always supported for example
    // when using it in smbfs mounted folder

What the code didn't expect was the possibility to return FALSE without any error thrown, this was happening in (mt)'s environment. Calling error_get_last() right after this "false symlink" returns NULL. There is nothing to handle.

Hope it helps everyone. Now my symfony2 project runs flawless @ (mt) using this branch.
