### PR TITLE
Resolve symbolic link in self-update command

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -49,7 +49,7 @@ EOT
             $output->writeln(sprintf("Updating to version <info>%s</info>.", $latest));
 
             $remoteFilename = $protocol . '://getcomposer.org/composer.phar';
-            $localFilename = $_SERVER['argv'][0];
+            $localFilename = realpath($_SERVER['argv'][0]) ?: $_SERVER['argv'][0];
             $tempFilename = dirname($localFilename) . '/' . basename($localFilename, '.phar').'-temp.phar';
 
             $rfs->copy('getcomposer.org', $remoteFilename, $tempFilename);


### PR DESCRIPTION
I'm using composer as a symbolic link to the composer.phar. When I update it the link will be overwritten by the new version not the original composer.phar. This PR fixes that.
