### PR TITLE
removes sudo from global installation

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -84,7 +84,7 @@ executable and invoke it without `php`.
 You can run these commands to easily access `composer` from anywhere on your system:
 
     $ curl -sS https://getcomposer.org/installer | php
-    $ sudo mv composer.phar /usr/local/bin/composer
+    $ mv composer.phar /usr/local/bin/composer
 
 Then, just run `composer` in order to run Composer instead of `php composer.phar`.
 


### PR DESCRIPTION
The /usr/local/bin folder shouldn't require sudo access.
