### PR TITLE
Resolve symbolic link for selfupdate

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -52,6 +52,10 @@ EOT
             $localFilename = realpath($_SERVER['argv'][0]) ?: $_SERVER['argv'][0];
             $tempFilename = dirname($localFilename) . '/' . basename($localFilename, '.phar').'-temp.phar';
 
+            while (is_link($localFilename)) {
+                $localFilename = readlink($localFilename);
+            }
+
             $rfs->copy('getcomposer.org', $remoteFilename, $tempFilename);
 
             if (!file_exists($tempFilename)) {


### PR DESCRIPTION
When you have a symbolic link for composer.phar (for example composer.phar -> composer) and call "composer selfupdate", the symbolic link is replaced by the updated composer.phar.

This change resolves the symbolic links until a "real" file is found.
