### PR TITLE
Return different error code for SolverProblemsException

### DIFF
--- a/src/Composer/DependencyResolver/SolverProblemsException.php
+++ b/src/Composer/DependencyResolver/SolverProblemsException.php
@@ -25,7 +25,7 @@ class SolverProblemsException extends \RuntimeException
         $this->problems = $problems;
         $this->installedMap = $installedMap;
 
-        parent::__construct($this->createMessage());
+        parent::__construct($this->createMessage(), 2);
     }
 
     protected function createMessage()

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -75,6 +75,7 @@ class SolverTest extends TestCase
         } catch (SolverProblemsException $e) {
             $problems = $e->getProblems();
             $this->assertEquals(1, count($problems));
+            $this->assertEquals(2, $e->getCode());
             $this->assertEquals("\n    - The requested package b could not be found in any version, there may be a typo in the package name.", $problems[0]->getPrettyString());
         }
     }


### PR DESCRIPTION
To make it easier for external tools to detect SolverProblems and react to them accordingly, this PR introduces a new exit code.
