### PR TITLE
Added realpath for $this->repoDir assignment

### DIFF
--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -34,7 +34,7 @@ class GitDriver extends VcsDriver
     public function initialize()
     {
         if (static::isLocalUrl($this->url)) {
-            $this->repoDir = str_replace('file://', '', $this->url);
+            $this->repoDir = realpath(str_replace('file://', '', $this->url));
         } else {
             $this->repoDir = $this->config->get('cache-vcs-dir') . '/' . preg_replace('{[^a-z0-9.]}i', '-', $this->url) . '/';
 


### PR DESCRIPTION
If you have a repository entry with a url like so: "file://../localLibrary/" and run 'composer update' (or install) the following happens:

```
Failed to execute git clone "file://../localLibrary" "E:\CODE\project\vendor/localLibrary" 
&& cd "E:\CODE\project\vendor/localLibrary" 
&& git remote add composer "file://../localLibrary" 
&& git fetch composer

fatal: 'C:/Program Files (x86)/Git/mpl' does not appear to be a git repository
fatal: Could not read from remote repository.
```

The path becomes relative to git itself when the remote is added, thus we should use the full path resolved by realpath()
