### PR TITLE
Tests fail when Mercurial or git aren't available

### DIFF
--- a/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
@@ -101,6 +101,11 @@ class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
 
     public function testGitExcludes()
     {
+        // Ensure that git is available for testing.
+        if (!$this->getProcessAvailable('git')) {
+            return $this->markTestSkipped('git is not available.');
+        }
+
         file_put_contents($this->sources.'/.gitignore', implode("\n", array(
             '# gitignore rules with comments and blank lines',
             '',
@@ -140,6 +145,10 @@ class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
 
     public function testHgExcludes()
     {
+        // Ensure that Mercurial is available for testing.
+        if (!$this->getProcessAvailable('hg')) {
+            return $this->markTestSkipped('Mercurial is not available.');
+        }
         file_put_contents($this->sources.'/.hgignore', implode("\n", array(
             '# hgignore rules with comments, blank lines and syntax changes',
             '',
@@ -205,5 +214,21 @@ class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
         $actualFiles = $this->getArchivableFiles();
 
         $this->assertEquals($expectedFiles, $actualFiles);
+    }
+
+    /**
+     * Check whether or not the given process is available.
+     *
+     * @param string $process The name of the binary to test.
+     *
+     * @return boolean True if the process is available, false otherwise.
+     */
+    protected function getProcessAvailable($process)
+    {
+        // Check if the command is found. The 127 exit code is returned when the
+        // command is not found.
+        $process = new Process($process);
+
+        return $process->run() !== 127;
     }
 }


### PR DESCRIPTION
Skip Mercurial/git tests when those systems arn't available.

Noticed that tests were failing since I don't have Mercurial installed. This PR makes it so that it checks whether git or Mercurial are installed before running tests that use them. If they arn't available, it just marks the test as skipped.

With this applied, running `phpunit -v` without Mercurial installed, results in the following:

```
Time: 3 seconds, Memory: 32.50Mb

There was 1 skipped test:

1) Composer\Test\Package\Archiver\ArchivableFilesFinderTest::testHgExcludes
Mercurial is not available.

tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php:150
/usr/share/php/PHPUnit/TextUI/Command.php:192
/usr/share/php/PHPUnit/TextUI/Command.php:130
OK, but incomplete or skipped tests!
Tests: 944, Assertions: 1671, Skipped: 1.
```
