### PR TITLE
Validate autoload options are of a supported type

### DIFF
--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -179,7 +179,15 @@ class ValidatingArrayLoader implements LoaderInterface
             }
         }
 
-        // TODO validate autoload
+        if ($this->validateArray('autoload') && !empty($this->config['autoload'])) {
+            $types = array('psr-0', 'classmap', 'files');
+            foreach ($this->config['autoload'] as $type => $typeConfig) {
+                if (!in_array($type, $types)) {
+                    $this->errors[] = 'autoload : invalid value ('.$type.'), must be one of '.implode(', ', $types);
+                    unset($this->config['autoload'][$type]);
+                }
+            }
+        }
 
         // TODO validate dist
         // TODO validate source

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -234,6 +234,28 @@ class ValidatingArrayLoaderTest extends \PHPUnit_Framework_TestCase
                     'support.source : invalid value, must be a string',
                 )
             ),
+            array(
+                array(
+                    'name' => 'foo/bar',
+                    'autoload' => 'strings',
+                ),
+                array(
+                    'autoload : should be an array, string given'
+                )
+            ),
+            array(
+                array(
+                    'name' => 'foo/bar',
+                    'autoload' => array(
+                        'psr0' => array(
+                            'foo' => 'src',
+                        ),
+                    ),
+                ),
+                array(
+                    'autoload : invalid value (psr0), must be one of psr-0, classmap, files'
+                )
+            ),
         );
     }
 


### PR DESCRIPTION
Checks to ensure that the autoload options are one of the three supported autoload types. If the list of supported types is already in the system somewhere I can update this code to use those instead.

closes #952
