### PR TITLE
Add install-prefer-dev-mode flag to prefere to install dev packages when running composer install

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -633,6 +633,8 @@ The following options are supported:
   updates when in non-interactive mode. `true` will always discard changes in
   vendors, while `"stash"` will try to stash and reapply. Use this for CI
   servers or deploy scripts if you tend to have modified vendors.
+* **install-prefer-dev-mode:** Defaults to `false`; If true the composer will install dev
+  packages on install command.
 
 Example:
 

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -175,6 +175,10 @@
                 "discard-changes": {
                     "type": ["string", "boolean"],
                     "description": "The default style of handling dirty updates, defaults to false and can be any of true, false or \"stash\"."
+                },
+                "install-prefer-dev-mode": {
+                    "type": "boolean",
+                    "description": "By default installs require-dev packages, defaults to false."
                 }
             }
         },

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -287,6 +287,10 @@ EOT
                     return $val !== 'false' && (bool) $val;
                 }
             ),
+            'install-prefer-dev-mode' => array(
+                $booleanValidator,
+                $booleanNormalizer
+            ),
         );
         $multiConfigValues = array(
             'github-protocols' => array(

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -80,12 +80,21 @@ EOT
             $preferDist = $input->getOption('prefer-dist');
         }
 
+        $preferDev = $composer->getConfig()->get('install-prefer-dev-mode');
+        if ($input->getOption('dev')) {
+            $preferDev = $input->getOption('dev');
+        }
+
+        if ($input->getOption('no-dev')) {
+            $preferDev = false;
+        }
+
         $install
             ->setDryRun($input->getOption('dry-run'))
             ->setVerbose($input->getOption('verbose'))
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
-            ->setDevMode($input->getOption('dev'))
+            ->setDevMode($preferDev)
             ->setRunScripts(!$input->getOption('no-scripts'))
             ->setOptimizeAutoloader($input->getOption('optimize-autoloader'))
         ;

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -35,6 +35,7 @@ class Config
         'cache-files-ttl' => null, // fallback to cache-ttl
         'cache-files-maxsize' => '300MiB',
         'discard-changes' => false,
+        'install-prefer-dev-mode' => false,
     );
 
     public static $defaultRepositories = array(


### PR DESCRIPTION
Add install-prefer-dev-mode flag to prefere to install dev packages when running composer install

Maybe you would like to set this setting on development machine so you don't need to pass --dev all the time when you are running composer install
