### PR TITLE
Failing tests showing a regression @753a8345cb4

### DIFF
--- a/tests/Composer/Test/Fixtures/installer/circular-dependency.test
+++ b/tests/Composer/Test/Fixtures/installer/circular-dependency.test
@@ -1,0 +1,58 @@
+--TEST--
+Circular dependencies are possible between packages
+--COMPOSER--
+{
+    "name": "root/package",
+    "type": "library",
+    "minimum-stability": "dev",
+    "require": {
+        "required/package": "1.0"
+    },
+    "replace": {
+        "provided/dependency": "self.version"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "required/package",
+                    "version": "1.0",
+                    "type": "library",
+                    "source": { "reference": "some.branch", "type": "git", "url": "" },
+                    "require": {
+                        "provided/dependency": "2.*"
+                    }
+                }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "root/package",
+                    "version": "2.0-dev",
+                    "type": "library",
+                    "source": { "reference": "other.branch", "type": "git", "url": "" },
+                    "replace": {
+                        "provided/dependency": "self.version"
+                    }
+                }
+            ]
+        }
+    ]
+}
+--INSTALLED--
+[
+    { "name": "root/package", "version": "2.0-dev" }
+]
+--RUN--
+install
+--EXPECT--
+Installing required/package (1.0)
+Uninstalling root/package (2.0-dev)


### PR DESCRIPTION
This PR adds a test that shows a regression at @753a8345cb44f8a5a5610a7d33fcb46642c69062 that currently [causes zf2 builds to fail](https://travis-ci.org/zendframework/zf2/jobs/6727287)

Was merged into master at @faa419cc0e8e65beb3f335062440cc62c78c9ee8
