### PR TITLE
Fix for recursion problem with wrong http basic auth credentials

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -112,6 +112,7 @@ class RemoteFilesystem
 
         $errorMessage = '';
         $errorCode = 0;
+        $result = false;
         set_error_handler(function ($code, $msg) use (&$errorMessage) {
             if ($errorMessage) {
                 $errorMessage .= "\n";
@@ -188,7 +189,7 @@ class RemoteFilesystem
         if ($this->retry) {
             $this->retry = false;
 
-            return $this->get($this->originUrl, $this->fileUrl, $this->fileName, $this->progress);
+            return $this->get($this->originUrl, $this->fileUrl, $additionalOptions, $this->fileName, $this->progress);
         }
 
         if (false === $result) {


### PR DESCRIPTION
I got an "array_replace_recursive(): Argument #2 is not an array" error after supplying wrong http basic auth credentials multiple times. After fixing that problem I got another error saying "Undefined variable: result" which I could fix by pre-defining the variable (although I do not see a reason for doing so).
