### PR TITLE
Update AutoloadGenerator.php

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -320,7 +320,7 @@ EOF;
         }
 
         if (preg_match('/\.phar$/', $path)){
-            $baseDir = "'phar://' . '" . $baseDir;
+            $baseDir = "'phar://' . " . $baseDir;
         }
 
         return $baseDir.var_export($path, true);


### PR DESCRIPTION
This should fix an issue with this commit:
https://github.com/composer/composer/commit/87a42c2f01936e6fd8973fac159dc8117114bebc

This commit is causing a parse error in autoload_namespaces.php:
return array(
    'zsql' => 'phar://' . '$vendorDir . '/jbboehr/zsql/build/zsql.phar',

A similar problem happens when using autoload.files as well.

This is what I'm using in composer.json, for reference:

  "autoload": {
    "psr-0": {
      "zsql": "build/zsql.phar"
    }
  },
