### PR TITLE
Add root package to installed.json

### DIFF
--- a/tests/Composer/Test/Fixtures/installer/SAMPLE
+++ b/tests/Composer/Test/Fixtures/installer/SAMPLE
@@ -14,5 +14,7 @@
 install
 --EXPECT-LOCK--
 <composer.lock file after the run>
+--EXPECT-INSTALLED--
+<installed.json file after the run>
 --EXPECT--
 <output (stringified operations)>

--- a/tests/Composer/Test/Fixtures/installer/install-root-version-changes.test
+++ b/tests/Composer/Test/Fixtures/installer/install-root-version-changes.test
@@ -1,0 +1,74 @@
+--TEST--
+Install results in root package version change
+--COMPOSER--
+{
+    "version": "1.0.2",
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    }
+}
+--INSTALLED--
+[
+    {
+        "name": "a/a",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0.0",
+        "type": "library"
+    },
+    {
+        "name": "__root__",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0.0",
+        "type": "library",
+        "minimum-stability": "stable",
+        "repositories": [
+            {
+                "type": "package",
+                "package": [
+                    { "name": "a/a", "version": "1.0.0" }
+                ]
+            }
+        ],
+        "require": {
+            "a/a": "1.0.0"
+        }
+    }
+]
+--RUN--
+install
+--EXPECT-INSTALLED--
+[
+    {
+        "name": "a/a",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0.0",
+        "type": "library"
+    },
+    {
+        "name": "__root__",
+        "version": "1.0.2",
+        "version_normalized": "1.0.2.0",
+        "type": "library",
+        "minimum-stability": "stable",
+            "repositories": [
+                {
+                    "type": "package",
+                    "package": [
+                        { "name": "a/a", "version": "1.0.0" }
+                    ]
+                }
+            ],
+            "require": {
+                "a/a": "1.0.0"
+            }
+    }
+]
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/install-simple.test
+++ b/tests/Composer/Test/Fixtures/installer/install-simple.test
@@ -16,5 +16,32 @@ Installs a simple package with exact match requirement
 }
 --RUN--
 install
+--EXPECT-INSTALLED--
+[
+    {
+        "name": "a/a",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0.0",
+        "type": "library"
+    },
+    {
+        "name": "__root__",
+        "version": "dev-root-installed",
+        "version_normalized": "dev-root-installed",
+        "type": "library",
+        "repositories": [
+            {
+                "type": "package",
+                "package": [
+                    { "name": "a/a", "version": "1.0.0" }
+                ]
+            }
+        ],
+        "require": {
+            "a/a": "1.0.0"
+        },
+        "minimum-stability": "stable"
+    }
+]
 --EXPECT--
 Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/update-all.test
+++ b/tests/Composer/Test/Fixtures/installer/update-all.test
@@ -35,6 +35,58 @@ Updates updateable packages
 ]
 --RUN--
 update --dev
+--EXPECT-INSTALLED--
+[
+    {
+        "name": "a/c",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0.0",
+        "type": "library"
+    },
+    {
+        "name": "a/a",
+        "version": "1.0.1",
+        "version_normalized": "1.0.1.0",
+        "type": "library"
+    },
+    {
+        "name": "a/b",
+        "version": "2.0.0",
+        "version_normalized": "2.0.0.0",
+        "type": "library"
+    },
+    {
+        "name": "__root__",
+        "version": "dev-root-installed",
+        "version_normalized": "dev-root-installed",
+        "type": "library",
+        "minimum-stability": "stable",
+        "repositories": [
+            {
+                "type": "package",
+                "package": [
+                    { "name": "a/a", "version": "1.0.0" },
+                    { "name": "a/a", "version": "1.0.1" },
+                    { "name": "a/a", "version": "1.1.0" },
+
+                    { "name": "a/b", "version": "1.0.0" },
+                    { "name": "a/b", "version": "1.0.1" },
+                    { "name": "a/b", "version": "2.0.0" },
+
+                    { "name": "a/c", "version": "1.0.0" },
+                    { "name": "a/c", "version": "2.0.0" }
+                ]
+            }
+        ],
+        "require": {
+            "a/a": "1.0.*",
+            "a/c": "1.*"
+        },
+        "require-dev": {
+            "a/b": "*"
+        }
+    }
+]
 --EXPECT--
 Updating a/a (1.0.0) to a/a (1.0.1)
 Updating a/b (1.0.0) to a/b (2.0.0)

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -136,7 +136,7 @@ class InstallerTest extends TestCase
     /**
      * @dataProvider getIntegrationTests
      */
-    public function testIntegration($file, $message, $condition, $composerConfig, $lock, $installed, $run, $expectLock, $expectOutput, $expect)
+    public function testIntegration($file, $message, $condition, $composerConfig, $lock, $installed, $run, $expectLock, $expectInstalled, $expectOutput, $expect)
     {
         if ($condition) {
             eval('$res = '.$condition.';');
@@ -163,8 +163,10 @@ class InstallerTest extends TestCase
             ->method('exists')
             ->will($this->returnValue(true));
 
+        $localRepositoryMock = new InstalledFilesystemRepositoryMock($jsonMock);
+
         $repositoryManager = $composer->getRepositoryManager();
-        $repositoryManager->setLocalRepository(new InstalledFilesystemRepositoryMock($jsonMock));
+        $repositoryManager->setLocalRepository($localRepositoryMock);
 
         $lockJsonMock = $this->getMockBuilder('Composer\Json\JsonFile')->disableOriginalConstructor()->getMock();
         $lockJsonMock->expects($this->any())
@@ -182,6 +184,15 @@ class InstallerTest extends TestCase
                     // need to do assertion outside of mock for nice phpunit output
                     // so store value temporarily in reference for later assetion
                     $actualLock = $hash;
+                }));
+        }
+
+        if ($expectInstalled) {
+            $actualInstalled = array();
+            $jsonMock->expects($this->any())
+                ->method('write')
+                ->will($this->returnCallback(function ($installed) use (&$actualInstalled) {
+                    $actualInstalled = $installed;
                 }));
         }
 
@@ -233,6 +244,10 @@ class InstallerTest extends TestCase
             $this->assertEquals($expectLock, $actualLock);
         }
 
+        if ($expectInstalled) {
+            $this->assertEquals($expectInstalled, $actualInstalled);
+        }
+
         $installationManager = $composer->getInstallationManager();
         $this->assertSame($expect, implode("\n", $installationManager->getTrace()));
 
@@ -262,6 +277,7 @@ class InstallerTest extends TestCase
                 (?:--INSTALLED--\s*(?P<installed>'.$content.'))?\s*
                 --RUN--\s*(?P<run>.*?)\s*
                 (?:--EXPECT-LOCK--\s*(?P<expectLock>'.$content.'))?\s*
+                (?:--EXPECT-INSTALLED--\s*(?P<expectInstalled>'.$content.'))?\s*
                 (?:--EXPECT-OUTPUT--\s*(?P<expectOutput>'.$content.'))?\s*
                 --EXPECT--\s*(?P<expect>.*?)\s*
             $}xs';
@@ -270,6 +286,7 @@ class InstallerTest extends TestCase
             $installedDev = array();
             $lock = array();
             $expectLock = array();
+            $expectInstalled = array();
 
             if (preg_match($pattern, $test, $match)) {
                 try {
@@ -289,6 +306,9 @@ class InstallerTest extends TestCase
                     if (!empty($match['expectLock'])) {
                         $expectLock = JsonFile::parseJson($match['expectLock']);
                     }
+                    if (!empty($match['expectInstalled'])) {
+                        $expectInstalled = JsonFile::parseJson($match['expectInstalled']);
+                    }
                     $expectOutput = $match['expectOutput'];
                     $expect = $match['expect'];
                 } catch (\Exception $e) {
@@ -298,7 +318,7 @@ class InstallerTest extends TestCase
                 die(sprintf('Test "%s" is not valid, did not match the expected format.', str_replace($fixturesDir.'/', '', $file)));
             }
 
-            $tests[] = array(str_replace($fixturesDir.'/', '', $file), $message, $condition, $composer, $lock, $installed, $run, $expectLock, $expectOutput, $expect);
+            $tests[] = array(str_replace($fixturesDir.'/', '', $file), $message, $condition, $composer, $lock, $installed, $run, $expectLock, $expectInstalled, $expectOutput, $expect);
         }
 
         return $tests;

--- a/tests/Composer/Test/Mock/InstalledFilesystemRepositoryMock.php
+++ b/tests/Composer/Test/Mock/InstalledFilesystemRepositoryMock.php
@@ -18,8 +18,4 @@ class InstalledFilesystemRepositoryMock extends InstalledFilesystemRepository
     public function reload()
     {
     }
-
-    public function write()
-    {
-    }
 }


### PR DESCRIPTION
Use case is embedding composer. It is extremely useful to know the package information for the package that has has embedded Composer.

The root package will be added to the local repository (installed.json) as the final step of the installation process.

Special handling was required to ensure that the root package did not ever end up in the lock. Packages matching the root package name will be filtered from both the required and dev required package lists.

The installer fixtures were updated to account for `--EXPECT-INSTALLED--` similar to how the lock file handling is currently handled.

The mock installed filesystem repository was updated to allow the write method to pass thru.

Two of the simpler tests, one for install, one for update, were updated to account for the new installed behavior.

All tests pass.

---

For some additional context, I'm working with this for my [Embedded Composer](https://github.com/dflydev/dflydev-embedded-composer) project and currently have the following hacky workaround to make things kinda work:

```php
<?php
$classLoader = require(__DIR__.'./vendor/autoload.php');

use Composer\Package\Package;
use Dflydev\EmbeddedComposer\Core\EmbeddedComposer;
use Symfony\Component\Console\Input\ArgvInput;

$input = new ArgvInput;

$projectDir = $input->getParameterOption('--project-dir') ?: '.';

// This package should accurately represent the package that contains
// the application being run.
$package = new Package('my/app', '2.0.5', '2.0.5');

$embeddedComposer = new EmbeddedComposer(
    $classLoader,
    $projectDir,
    $package
);

$embeddedComposer->processExternalAutoloads();

// Composer is now ready to load local packages as well as the packages
// that make up the calling application.
```

I'd like to be able to change this to something more like:

```php
<?php
$embeddedComposer = new EmbeddedComposer(
    $classLoader,
    $projectDir,
    'my/package'
);
```

This would break the version tracking stuff out to Composer and would allow me to just specify the root package's name and the version can be captured from the version of the package with that name embedded in installed.json.