### PR TITLE
Added "pre-autoload-dump" event.

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -30,6 +30,8 @@ Composer fires the following named events during its execution process:
 - **post-package-update**: occurs after a package is updated.
 - **pre-package-uninstall**: occurs before a package has been uninstalled.
 - **post-package-uninstall**: occurs after a package has been uninstalled.
+- **pre-autoload-dump**: occurs before the autoloader is dumped, either
+  during `install`/`update`, or via the `dump-autoload` command.
 - **post-autoload-dump**: occurs after the autoloader is dumped, either
   during `install`/`update`, or via the `dump-autoload` command.
 

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -283,9 +283,13 @@
                     "type": ["array", "string"],
                     "description": "Occurs after a package has been uninstalled, contains one or more Class::method callables or shell commands."
                 },
+                "pre-autoload-dump": {
+                    "type": ["array", "string"],
+                    "description": "Occurs before the autoloader is dumped, contains one or more Class::method callables or shell commands."
+                },
                 "post-autoload-dump": {
                     "type": ["array", "string"],
-                    "description": "Occurs after a the autoloader is dumped, contains one or more Class::method callables or shell commands."
+                    "description": "Occurs after the autoloader is dumped, contains one or more Class::method callables or shell commands."
                 }
             }
         },

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -39,6 +39,8 @@ class AutoloadGenerator
 
     public function dump(Config $config, InstalledRepositoryInterface $localRepo, PackageInterface $mainPackage, InstallationManager $installationManager, $targetDir, $scanPsr0Packages = false, $suffix = '')
     {
+        $this->eventDispatcher->dispatch(ScriptEvents::PRE_AUTOLOAD_DUMP);
+
         $filesystem = new Filesystem();
         $filesystem->ensureDirectoryExists($config->get('vendor-dir'));
         $basePath = $filesystem->normalizePath(getcwd());

--- a/src/Composer/Script/ScriptEvents.php
+++ b/src/Composer/Script/ScriptEvents.php
@@ -111,6 +111,15 @@ class ScriptEvents
     const POST_PACKAGE_UNINSTALL = 'post-package-uninstall';
 
     /**
+     * The PRE_AUTOLOAD_DUMP event occurs before the autoload file is generated.
+     *
+     * The event listener method receives a Composer\Script\Event instance.
+     *
+     * @var string
+     */
+    const PRE_AUTOLOAD_DUMP = 'pre-autoload-dump';
+
+    /**
      * The POST_AUTOLOAD_DUMP event occurs after the autoload file has been generated.
      *
      * The event listener method receives a Composer\Script\Event instance.

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -619,10 +619,15 @@ EOF;
         $this->assertFalse(file_exists($this->vendorDir."/composer/include_paths.php"));
     }
 
-    public function testEventIsDispatchedAfterAutoloadDump()
+    public function testPreAndPostEventsAreDispatchedDuringAutoloadDump()
     {
         $this->eventDispatcher
-            ->expects($this->once())
+            ->expects($this->at(0))
+            ->method('dispatch')
+            ->with(ScriptEvents::PRE_AUTOLOAD_DUMP, false);
+
+        $this->eventDispatcher
+            ->expects($this->at(1))
             ->method('dispatch')
             ->with(ScriptEvents::POST_AUTOLOAD_DUMP, false);
 


### PR DESCRIPTION
This event is fired before the autoload file is generated, for either an install or update command.

To give some insight into a potential use case. In the Laravel framework, we compile common classes using Michael Dowling's class compiler (https://github.com/mtdowling/ClassPreloader). We do this POST autoload generation. It would be helpful for us to be able to clear out the old file PRE autoload generation.

Tests pass and documentation updated as well.
