### PR TITLE
Ensure packages in additional installed repository are not updated

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -560,8 +560,14 @@ class Installer
         $constraint->setPrettyString($rootPackage->getPrettyVersion());
         $request->install($rootPackage->getName(), $constraint);
 
+        $installedPackages = $platformRepo->getPackages();
+        if ($this->additionalInstalledRepository) {
+            $additionalInstalledPackages = $this->additionalInstalledRepository->getPackages();
+            $installedPackages = array_merge($installedPackages, $additionalInstalledPackages);
+        }
+
         // fix the version of all platform packages to prevent the solver trying to remove those
-        foreach ($platformRepo->getPackages() as $package) {
+        foreach ($installedPackages as $package) {
             $constraint = new VersionConstraint('=', $package->getVersion());
             $constraint->setPrettyString($package->getPrettyVersion());
 


### PR DESCRIPTION
The underlying assumption of the additional installed repository is that those packages are installed in such a way that they cannot be updated. Prior to this fix they were still candidates for change. This ensures that they are treated like platform and root packages and are not candidates for update.

If the `Installer` has `additionalInstalledRepository` those packages will be added to the list of packages that are installed.
