### PR TITLE
Enable php_openssl.dll in php.ini

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -109,7 +109,7 @@ composer.phar:
     C:\Users\username>cd C:\bin
     C:\bin>php -r "eval('?>'.file_get_contents('https://getcomposer.org/installer'));"
     
-> **Note:** If the above fails due to file_get_contents, enable php_openssl.dll in php.ini
+> **Note:** If the above fails due to file_get_contents, use the `http` url or enable php_openssl.dll in php.ini
 
 Create a new `.bat` file alongside composer:
 


### PR DESCRIPTION
it specifies to enable the extension php_openssl.dll in php.ini. When php_openssl.gll is disabled, the command show an error in the function file_get_contents but not specify that is necesary to enable php.ini.
