### PR TITLE
Get specific config values from the config command

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -54,6 +54,7 @@ class ConfigCommand extends Command
                 new InputOption('global', 'g', InputOption::VALUE_NONE, 'Apply command to the global config file'),
                 new InputOption('editor', 'e', InputOption::VALUE_NONE, 'Open editor'),
                 new InputOption('unset', null, InputOption::VALUE_NONE, 'Unset the given setting-key'),
+                new InputOption('get', null, InputOption::VALUE_NONE, 'Get current value for setting-key'),
                 new InputOption('list', 'l', InputOption::VALUE_NONE, 'List configuration settings'),
                 new InputOption('file', 'f', InputOption::VALUE_REQUIRED, 'If you want to choose a different composer.json or config.json', 'composer.json'),
                 new InputArgument('setting-key', null, 'Setting key'),
@@ -88,6 +89,13 @@ You can always pass more than one option. As an example, if you want to edit the
 global config.json file.
 
     <comment>%command.full_name% --editor --global</comment>
+
+If you want to know the value for a specific setting-key, you can use the
+<info>--get</info> option.
+
+For example, to get the vendor directory configuration value:
+
+    <comment>%command.full_name% --get vendor-dir</comment>
 EOT
             )
         ;
@@ -164,6 +172,12 @@ EOT
 
         $settingKey = $input->getArgument('setting-key');
         if (!$settingKey) {
+            return 0;
+        }
+
+        if ($input->getOption('get')) {
+            $output->writeln($this->config->get($settingKey));
+
             return 0;
         }
 


### PR DESCRIPTION
A better alternative to `composer config --list | grep vendor-dir` suitable for scripting Composer.

It returns resolved results. For example, `composer config --get bin-dir` will return `vendor/bin` instead of `{$vendor-dir}/bin`.
