### PR TITLE
Detect version based on tag if HEAD points to a tag.

### DIFF
--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -185,7 +185,7 @@ class RootPackageLoader extends ArrayLoader
     private function guessGitVersion(array $config)
     {
         // try to fetch current version from git branch as a tag
-        if (0 === $this->process->execute('git describe --exact-match', $output)) {
+        if (0 === $this->process->execute('git describe --exact-match --tags', $output)) {
             return $this->versionParser->normalize(rtrim($output));
         }
 

--- a/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
@@ -69,7 +69,7 @@ class RootPackageLoaderTest extends \PHPUnit_Framework_TestCase
 
         /* Can do away with this mock object when https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81 is fixed */
         $processExecutor = new ProcessExecutorMock(function($command, &$output = null, $cwd = null) use ($self) {
-            $self->assertEquals('git describe --exact-match', $command);
+            $self->assertEquals('git describe --exact-match --tags', $command);
 
             $output = "v2.0.5-alpha2";
 


### PR DESCRIPTION
This is useful for applications that rely on the root package to have its actual version when it is being used. For example, checking out `v2.0.0-alpha3` and running `composer install`, the `RootPackageLoader` will still return `2.0.x-dev` as the version.

Not entirely sure `normalize` is what I should use here. Hope so. :)

---

Potential downside to this solution: If the working directory has modifications that are not checked in, it would be possible to get back a specific tagged version `v2.0.0-alpha3` when in this particular case `2.0.x-dev` might actually be more appropriate.

I think this might be an edge case and it might actually be expected. Some build processes may actually alter the files after checking out a tag to update embedded version information. This would intentionally dirty the working directory and if this were not allowed one would not be able to use Composer to get the current version of an application.

Another option would be to somehow make this optional. (`--allow-dirty` or `--no-dirty` or something) This could be far more complicated.
