### PR TITLE
Remove unused variable $version from RootPackageLoad::load

### DIFF
--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -61,8 +61,6 @@ class RootPackageLoader extends ArrayLoader
             }
 
             $config['version'] = $version;
-        } else {
-            $version = $config['version'];
         }
 
         $realPackage = $package = parent::load($config, $class);


### PR DESCRIPTION
$version is not referenced anywhere past the removed declaration.
