### PR TITLE
Remove unused variable $dialog from RequireCommand::configure

### DIFF
--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -70,8 +70,6 @@ EOT
             return 1;
         }
 
-        $dialog = $this->getHelperSet()->get('dialog');
-
         $json = new JsonFile($file);
         $composer = $json->read();
         $composerBackup = file_get_contents($json->getPath());


### PR DESCRIPTION
I traced the get and getHelperSet to Symfony's Console\Command and Console\Helper\HelperSet, and there was only stored variables being retrieved (no actions being done that'd require these functions to be called).
