### PR TITLE
Fix checksum verification

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -232,6 +232,6 @@ class FileDownloader implements DownloaderInterface
             return $package->getName().'/'.$package->getDistReference().'.'.$package->getDistType();
         }
 
-        return $package->getName().'/'.$package->getVersion().'-'.$package->getDistReference().'.'.$package->getDistType();
+        return $package->getName().'/'.$package->getVersion().'-'.$package->getDistReference().'-'.$package->getDistSha1Checksum().'.'.$package->getDistType();
     }
 }


### PR DESCRIPTION
We use satis with "skip-dev": false
When we do composer update and the reference of a package is for example "dev-master" instead of a hash. In that case I think the getCacheKey method https://github.com/composer/composer/blob/master/src/Composer/Downloader/FileDownloader.php#L232  must be fixed by appending the getDistSha1Checksum().
The cache key now stays the same on each package update, only the url and the shasum is changed which leads to a checksum verification failure because he uses the cached zip file and the new shasum.

So we need to append the $package->getDistSha1Checksum() to the cache key? Or maybe the $package->getDistUrl()?
