### PR TITLE
fixes autoload problem with commands for just installed packages

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -207,8 +207,9 @@ EOT
         }
 
         if ($noScripts === false) {
-            // dispatch event
+            // TODO: improve autoloader refreshing
             require($this->getComposer()->getConfig()->get('vendor-dir').'/autoload.php');
+            // dispatch event
             $this->getComposer()->getEventDispatcher()->dispatchCommandEvent(ScriptEvents::POST_CREATE_PROJECT_CMD, $installDevPackages);
         }
 


### PR DESCRIPTION
Now the event occurs after autoloader is generated and refreshed.
So we can run methods from PHP classes which just have been installed.
