### PR TITLE
Invalid tag issue - using vcs type Git

### DIFF
--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -166,7 +166,7 @@ class GitDriver extends VcsDriver
         if (null === $this->tags) {
             $this->process->execute('git tag', $output, $this->repoDir);
             $output = $this->process->splitLines($output);
-            $this->tags = $output ? array_combine($output, $output) : array();
+            $this->tags = $output ? array_filter(array_combine($output, $output)) : array();
         }
 
         return $this->tags;


### PR DESCRIPTION
Invalid tag issue - parsing "git tag" output produces array with extra item.
