### PR TITLE
Made ClassLoader more extensible by changing the private properties to protected

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -42,10 +42,10 @@ namespace Composer\Autoload;
  */
 class ClassLoader
 {
-    private $prefixes = array();
-    private $fallbackDirs = array();
-    private $useIncludePath = false;
-    private $classMap = array();
+    protected $prefixes = array();
+    protected $fallbackDirs = array();
+    protected $useIncludePath = false;
+    protected $classMap = array();
 
     public function getPrefixes()
     {


### PR DESCRIPTION
It would be nice if it were easier to extend the ClassLoader class rather than having to write your own autoloader if you want to change the way the findFiles() method works, so I changed the private properties to protected.

Example use case: In my app, I want to put the libraries specific to my app in a `lib` directory but without having the pointless folder `lib/MyApp` since all classes in the `lib` directory will belong to the `MyApp` namespace. I wrote my own autoloader because there seems to be no way to do that with Composer other than by using the classmap property, which is inconvenient for development because you have to run `composer.phar install` every time you add a new file.

I think it would be even nicer if Composer's autoloading was more configurable to begin with (support for lower case directory names would be nice, e.g. "controllers" rather than "Controllers") but making the ClassLoader more extensible is a good start.
