### PR TITLE
fixed escaping the path (it's no cmdline argument anymore)

### DIFF
--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -26,9 +26,8 @@ class HgDownloader extends VcsDownloader
     {
         $url = escapeshellarg($package->getSourceUrl());
         $ref = escapeshellarg($package->getSourceReference());
-        $path = escapeshellarg($path);
         $this->io->write("    Cloning ".$package->getSourceReference());
-        $command = sprintf('hg clone %s %s', $url, $path);
+        $command = sprintf('hg clone %s %s', $url, escapeshellarg($path));
         if (0 !== $this->process->execute($command, $ignoredOutput)) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
         }
@@ -45,7 +44,6 @@ class HgDownloader extends VcsDownloader
     {
         $url = escapeshellarg($target->getSourceUrl());
         $ref = escapeshellarg($target->getSourceReference());
-        $path = escapeshellarg($path);
         $this->io->write("    Updating to ".$target->getSourceReference());
         $command = sprintf('hg pull %s && hg up %s', $url, $ref);
         if (0 !== $this->process->execute($command, $ignoredOutput, $path)) {


### PR DESCRIPTION
Commit `8b8dc1fd7017` broke the hg support for us. Symfony Process quits while running `composer update`:

```
Reading C:/Users/Christoph/AppData/Local/Composer/repo/https---packagist.org/provider-pimple$pimple.json from cache
  - Installing webvariants/internal-package (dev-default 3b55cca78dd0)
    Cloning 3b55cca78dd0
Executing command (CWD): hg clone "https://internal.repositories.host.org/internal-package/" "vendor/internal-package"
Executing command ("vendor/internal-package"): hg up "3b55cca78dd0" <-- note the escaped path here



  [ErrorException]
  proc_open(): CreateProcess failed, error code - 267
```

This PR fixes the escaping for the path when it's not used inside of a cmdline string.
