### PR TITLE
Added check for SVN WebDAV auth request

### DIFF
--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -100,7 +100,8 @@ class Svn
         }
 
         // the error is not auth-related
-        if (false === stripos($output, 'Could not authenticate to server:')) {
+        if (false === stripos($output, 'Could not authenticate to server:')
+            && false === stripos($output, 'svn: E170001:')) {
             throw new \RuntimeException($output);
         }
 


### PR DESCRIPTION
When repo is SVN and is handled over WebDAV, the authorization error code is `E170001`, but the error message can be other than "authorization failed" if Subversion is installed in another language.
http://subversion.apache.org/docs/api/latest/group__svn__dav__error.html#gada0137a4ffc40251d2fce8ba06ca2e14, http://svn.apache.org/repos/asf/subversion/trunk/subversion/bindings/javahl/src/org/tigris/subversion/javahl/ErrorCodes.java.
