### PR TITLE
Use full diagnose command name

### DIFF
--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -7,7 +7,7 @@ This is a list of common pitfalls on using Composer, and how to avoid them.
 
 ## General
 
-1. Before asking anyone, run [`composer diag`](../03-cli.md#diag) to check
+1. Before asking anyone, run [`composer diagnose`](../03-cli.md#diagnose) to check
    for common problems. If it all checks out, proceed to the next steps.
 
 2. When facing any kind of problems using Composer, be sure to **work with the


### PR DESCRIPTION
While the `diag` command works, the link doesn't. It's probably better to use the full name in both cases. 
