### PR TITLE
Use github protocols setting for push urls

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -380,7 +380,8 @@ class GitDownloader extends VcsDownloader
     {
         // set push url for github projects
         if (preg_match('{^(?:https?|git)://github.com/([^/]+)/([^/]+?)(?:\.git)?$}', $package->getSourceUrl(), $match)) {
-            $pushUrl = 'git@github.com:'.$match[1].'/'.$match[2].'.git';
+            $protocols = $this->config->get('github-protocols');
+            $pushUrl = $protocols[0] === 'git' ? 'git@github.com:'.$match[1].'/'.$match[2].'.git' : $package->getSourceUrl();
             $cmd = sprintf('git remote set-url --push origin %s', escapeshellarg($pushUrl));
             $this->process->execute($cmd, $ignoredOutput, $path);
         }


### PR DESCRIPTION
Currently, the push url of all the packages downloaded from github use the ssh protocol, This pull request allows the developers who want to push directly from the vendor directory to use the first-choice protocol they have defined in the _github-protocols_ configuration setting, including the recommanded https method.   
