### PR TITLE
Removed caching of non-existent classes from the 

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -241,6 +241,6 @@ class ClassLoader
             return $file;
         }
 
-        return $this->classMap[$class] = false;
+        return false;
     }
 }


### PR DESCRIPTION
I think caching that a class doesn't exist in `this->classMap[$class]` is the wrong behaviour.

I've been using some dynamic code creation and ran into an issue caused by the Composer ClassLoader caching the fact that a class doesn't exist.

The code for checking whether a class needs to be generated looks like this:

```
if (class_exists($classNameRequired) == false)
{
    //Writes the file $classNameRequired.".php"
    generateClass($classNameRequired);
}

return new $classNameRequired;
```

Because the file for the class doesn't exist when class_exists is called, the ClassLoader obviously fails to find it, but then also caches the fact that it doesn't exist, so doesn't try and find it again, after the class has been generated.

This change shouldn't change the behaviour of the ClassLoader for the vast majority of people. The only people for who the behaviour of the ClassLoader would change negatively are those who:
- Check that if class exists with class_exists.
- Generate that class.
- Call class_exists again with the same class name.

That should be a tiny number of people.

Also I don't think caching the fact that classes don't exist actually gives a performance boost for the vast majority of use cases. i.e. if anyone just writes:

$object = new NonExistantClass(); 

Their code will just stop right there. It would only be those who are repeatedly calling class_exists for the same non-existant class that would see a slow down.
