### PR TITLE
allow FileDownloader to use username:password@ info when downloading 

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -99,7 +99,13 @@ class RemoteFilesystem
         $this->progress = $progress;
         $this->lastProgress = null;
 
+        // capture username/password from URL if there is one
+        if (preg_match('{^https?://(.+):(.+)@([^/]+)}i', $fileUrl, $match)) {
+            $this->io->setAuthentication($originUrl, urldecode($match[1]), urldecode($match[2]));
+        }
+
         $options = $this->getOptionsForUrl($originUrl, $additionalOptions);
+
         if ($this->io->isDebug()) {
             $this->io->write('Downloading '.$fileUrl);
         }

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\RemoteFilesystem;
+use Installer\Exception;
 
 class RemoteFilesystemTest extends \PHPUnit_Framework_TestCase
 {
@@ -141,6 +142,19 @@ class RemoteFilesystemTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals(404, $e->getCode());
             $this->assertContains('HTTP/1.1 404 Not Found', $e->getMessage());
         }
+    }
+
+
+    public function testCaptureAuthenticationParamsFromUrl()
+    {
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io
+        ->expects($this->once())
+        ->method('setAuthentication')
+        ;
+
+        $fs = new RemoteFilesystem($io);
+        $fs->getContents('example.com', 'http://user:pass@www.example.com/something');
     }
 
     public function testGetContents()


### PR DESCRIPTION
allow FileDownloader to use username:password@ info when downloading through https.

while searching for a solution to another problem i figured that it is not possible to download files which require authentication and credentials were provided in the url itself.
http://username:password@example.com/file.zip did not work before.

btw: why is there a $originUrl and a $fileUrl in the RemoteFilesystem? 
i couldn't figure out the usecase.
