### PR TITLE
fix when composite repo has no delegates

### DIFF
--- a/src/Composer/Repository/CompositeRepository.php
+++ b/src/Composer/Repository/CompositeRepository.php
@@ -91,7 +91,7 @@ class CompositeRepository implements RepositoryInterface
             $packages[] = $repository->findPackages($name, $version);
         }
 
-        return call_user_func_array('array_merge', $packages);
+        return $packages ? call_user_func_array('array_merge', $packages) : array();
     }
 
     /**
@@ -105,7 +105,7 @@ class CompositeRepository implements RepositoryInterface
             $matches[] = $repository->search($query, $mode);
         }
 
-        return call_user_func_array('array_merge', $matches);
+        return $matches ? call_user_func_array('array_merge', $matches) : array();
     }
 
     /**
@@ -133,7 +133,7 @@ class CompositeRepository implements RepositoryInterface
             $packages[] = $repository->getPackages();
         }
 
-        return call_user_func_array('array_merge', $packages);
+        return $packages ? call_user_func_array('array_merge', $packages) : array();
     }
 
     /**

--- a/tests/Composer/Test/Repository/CompositeRepositoryTest.php
+++ b/tests/Composer/Test/Repository/CompositeRepositoryTest.php
@@ -125,4 +125,22 @@ class CompositeRepositoryTest extends TestCase
 
         $this->assertEquals(2, count($repo), "Should return '2' for count(\$repo)");
     }
+
+    /**
+     * @dataProvider provideMethodCalls
+     */
+    public function testNoRepositories($method, $args)
+    {
+        $repo = new CompositeRepository(array());
+        call_user_func_array(array($repo, $method), $args);
+    }
+
+    public function provideMethodCalls()
+    {
+        return array(
+            array('findPackages', array('foo')),
+            array('search', array('foo')),
+            array('getPackages', array()),
+        );
+    }
 }


### PR DESCRIPTION
You can't call `array_merge()` with no parameters.
