### PR TITLE
"conflict" does not work for non-trivial constraints

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -309,6 +309,11 @@ if `install` is run with `--dev` or if `update` is run without `--no-dev`.
 Lists packages that conflict with this version of this package. They
 will not be allowed to be installed together with your package.
 
+Note that when specifying ranges like "<1.0, >= 1.1" in a `conflict` link,
+this will state a conflict with all versions that are less than 1.0 *and* equal
+or newer than 1.1 at the same time, which is probably not what you want. You
+probably want to go for "<1.0 | >= 1.1" in this case.
+
 #### replace
 
 Lists packages that are replaced by this package. This allows you to fork a


### PR DESCRIPTION
This file (made up to illustrate the problem)

```
{
    "require": {
        "symfony/symfony": "*"
    },

    "conflict": {
        "symfony/symfony": "< 2.2.0, >= 2.3.0-dev"
    }
}
```

... should install the best 2.2 Symfony release. At least @igorw briefly confirmed on IRC that it should behave as one would expect.

The problem is that the version parser will generate a MultiConstraint for the "conflict" entry. In turn, the `RuleSetGenerator` will [find all packages](https://github.com/composer/composer/blob/master/src/Composer/DependencyResolver/RuleSetGenerator.php#L167) that match this constraint and add those as conflicting targets. 

Obviously, no package will match < 2.2 and >=2.3 and so no conflict rule will be created.

Here's a quick proof of concept patch that shows that turning around the MultiConstraint into a kind of disjunctive constraint solves the issue, i. e. (currently) installs Symfony 2.2.3: https://gist.github.com/mpdude/5825777.

The problem is that this change would prevent you from having e.g. ```>= 1.0.0-dev, < 1.2.0-dev" to say your package is incompatible with the 1.0 and 1.1 series of something. (A single clause like "< 1.2.0-dev" is not an issue.)

Another possible solution that would probably require some (major?) schema/parser extension would be 

```
   "conflict": { 
       "symfony/symfony": [ "< 2.2.0", ">= 2.3.0-dev" ]
   }
```

... only for the "conflict" key? Does not sound good to me either.
