### PR TITLE
fixed Bitbucket's broken API

### DIFF
--- a/src/Composer/Repository/Vcs/HgBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/HgBitbucketDriver.php
@@ -44,7 +44,7 @@ class HgBitbucketDriver extends VcsDriver
     public function getRootIdentifier()
     {
         if (null === $this->rootIdentifier) {
-            $resource = $this->getScheme() . '://api.bitbucket.org/1.0/repositories/'.$this->owner.'/'.$this->repository.'/tags';
+            $resource = $this->getScheme() . '://bitbucket.org/api/1.0/repositories/'.$this->owner.'/'.$this->repository.'/tags';
             $repoData = JsonFile::parseJson($this->getContents($resource), $resource);
             if (array() === $repoData) {
                 throw new \RuntimeException('This does not appear to be a mercurial repository, use '.$this->url.'.git if this is a git bitbucket repository');
@@ -90,16 +90,22 @@ class HgBitbucketDriver extends VcsDriver
     public function getComposerInformation($identifier)
     {
         if (!isset($this->infoCache[$identifier])) {
-            $resource = $this->getScheme() . '://bitbucket.org/'.$this->owner.'/'.$this->repository.'/raw/'.$identifier.'/composer.json';
-            $composer = $this->getContents($resource);
-            if (!$composer) {
+            $resource = $this->getScheme() . '://bitbucket.org/api/1.0/repositories/'.$this->owner.'/'.$this->repository.'/src/'.$identifier.'/composer.json';
+            $repoData = JsonFile::parseJson($this->getContents($resource), $resource);
+
+            // Bitbucket does not send different response codes for found and
+            // not found files, so we have to check the response structure.
+            // found:     {node: ..., data: ..., size: ..., ...}
+            // not found: {node: ..., files: [...], directories: [...], ...}
+
+            if (!array_key_exists('data', $repoData)) {
                 return;
             }
 
-            $composer = JsonFile::parseJson($composer, $resource);
+            $composer = JsonFile::parseJson($repoData['data'], $resource);
 
             if (!isset($composer['time'])) {
-                $resource = $this->getScheme() . '://api.bitbucket.org/1.0/repositories/'.$this->owner.'/'.$this->repository.'/changesets/'.$identifier;
+                $resource = $this->getScheme() . '://bitbucket.org/api/1.0/repositories/'.$this->owner.'/'.$this->repository.'/changesets/'.$identifier;
                 $changeset = JsonFile::parseJson($this->getContents($resource), $resource);
                 $composer['time'] = $changeset['timestamp'];
             }
@@ -115,7 +121,7 @@ class HgBitbucketDriver extends VcsDriver
     public function getTags()
     {
         if (null === $this->tags) {
-            $resource = $this->getScheme() . '://api.bitbucket.org/1.0/repositories/'.$this->owner.'/'.$this->repository.'/tags';
+            $resource = $this->getScheme() . '://bitbucket.org/api/1.0/repositories/'.$this->owner.'/'.$this->repository.'/tags';
             $tagsData = JsonFile::parseJson($this->getContents($resource), $resource);
             $this->tags = array();
             foreach ($tagsData as $tag => $data) {
@@ -132,7 +138,7 @@ class HgBitbucketDriver extends VcsDriver
     public function getBranches()
     {
         if (null === $this->branches) {
-            $resource = $this->getScheme() . '://api.bitbucket.org/1.0/repositories/'.$this->owner.'/'.$this->repository.'/branches';
+            $resource = $this->getScheme() . '://bitbucket.org/api/1.0/repositories/'.$this->owner.'/'.$this->repository.'/branches';
             $branchData = JsonFile::parseJson($this->getContents($resource), $resource);
             $this->branches = array();
             foreach ($branchData as $branch => $data) {


### PR DESCRIPTION
This PR changes the way the `composer.json` is fetched. This endpoint always returns JSON which eventually contains a `data` key containing the actual file content -- if it was found. Otherwise the response contains the file and directory list.
- JSON for [no composer.json found](https://bitbucket.org/api/1.0/repositories/SallyCMS/sallycms-core/src/253567e4262791753d848713960b6db613526eda/composer.json)
- JSON for [file found](https://bitbucket.org/api/1.0/repositories/SallyCMS/sallycms-core/src/tip/composer.json)

This is basically untested, as I have no quick idea on how to test this out.
