### PR TITLE
Update 04-schema.md

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -513,7 +513,7 @@ and `stable`.
 When this is enabled, Composer will prefer more stable packages over unstable
 ones when finding compatible stable packages is possible. If you require a
 dev version or only alphas are available for a package, those will still be
-selected granted that the minimum-stability allows for it.
+selected granted that the minimum-stability allows for it. Use `"prefer-stable": true` to enable.
 
 ### repositories <span>(root-only)</span>
 


### PR DESCRIPTION
Added example line for how to enable prefer-stable. Some other examples in the document show options enabled using the string "true" and since this is not the case for prefer-stable I added an example to avoid confusion.
