### PR TITLE
Do not show suggested packages

### DIFF
--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -87,7 +87,7 @@ EOT
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
             ->setDevMode(!$input->getOption('no-dev'))
-            ->setNoSuggest($input->getOption('no-dev', $this->getOption('no-suggest')))
+            ->setNoSuggest($input->getOption('no-dev') || $input->getOption('no-suggest'))
             ->setRunScripts(!$input->getOption('no-scripts'))
             ->setOptimizeAutoloader($input->getOption('optimize-autoloader'))
         ;

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -38,6 +38,7 @@ class InstallCommand extends Command
                 new InputOption('no-custom-installers', null, InputOption::VALUE_NONE, 'Disables all custom installers.'),
                 new InputOption('no-scripts', null, InputOption::VALUE_NONE, 'Skips the execution of all scripts defined in composer.json file.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
+                new InputOption('no-suggest', null, InputOption::VALUE_NONE, 'Do not output suggested packages.'),
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump')
             ))
@@ -86,6 +87,7 @@ EOT
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
             ->setDevMode(!$input->getOption('no-dev'))
+            ->setNoSuggest($input->getOption('no-dev', $this->getOption('no-suggest')))
             ->setRunScripts(!$input->getOption('no-scripts'))
             ->setOptimizeAutoloader($input->getOption('optimize-autoloader'))
         ;

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -39,6 +39,7 @@ class UpdateCommand extends Command
                 new InputOption('no-custom-installers', null, InputOption::VALUE_NONE, 'Disables all custom installers.'),
                 new InputOption('no-scripts', null, InputOption::VALUE_NONE, 'Skips the execution of all scripts defined in composer.json file.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
+                new InputOption('no-suggest', null, InputOption::VALUE_NONE, 'Do not output suggested packages..'),
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump')
             ))
@@ -90,6 +91,7 @@ EOT
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
             ->setDevMode(!$input->getOption('no-dev'))
+            ->setNoSuggest($input->getOption('no-suggest'))
             ->setRunScripts(!$input->getOption('no-scripts'))
             ->setOptimizeAutoloader($input->getOption('optimize-autoloader'))
             ->setUpdate(true)

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1012,7 +1012,7 @@ class Installer
      */
     public function setNoSuggest($noSuggest = true)
     {
-        $this->noSuggest = $true;
+        $this->noSuggest = $noSuggest;
 
         return $this;
     }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -99,6 +99,7 @@ class Installer
     protected $optimizeAutoloader = false;
     protected $devMode = false;
     protected $dryRun = false;
+    protected $noSuggest = false;
     protected $verbose = false;
     protected $update = false;
     protected $runScripts = true;
@@ -215,16 +216,18 @@ class Installer
         }
         $this->installationManager->notifyInstalls();
 
-        // output suggestions
-        foreach ($this->suggestedPackages as $suggestion) {
-            $target = $suggestion['target'];
-            foreach ($installedRepo->getPackages() as $package) {
-                if (in_array($target, $package->getNames())) {
-                    continue 2;
+        // output suggestions only --no-suggest is not set
+        if (!$this->noSuggest) {
+            foreach ($this->suggestedPackages as $suggestion) {
+                $target = $suggestion['target'];
+                foreach ($installedRepo->getPackages() as $package) {
+                    if (in_array($target, $package->getNames())) {
+                        continue 2;
+                    }
                 }
-            }
 
-            $this->io->write($suggestion['source'].' suggests installing '.$suggestion['target'].' ('.$suggestion['reason'].')');
+                $this->io->write($suggestion['source'].' suggests installing '.$suggestion['target'].' ('.$suggestion['reason'].')');
+            }
         }
 
         if (!$this->dryRun) {
@@ -997,6 +1000,19 @@ class Installer
     public function setVerbose($verbose = true)
     {
         $this->verbose = (boolean) $verbose;
+
+        return $this;
+    }
+
+    /**
+     * Do not show suggested packages.
+     *
+     * @param  boolean   $noSuggest
+     * @return Installer
+     */
+    public function setNoSuggest($noSuggest = true)
+    {
+        $this->noSuggest = $true;
 
         return $this;
     }

--- a/tests/Composer/Test/Fixtures/installer/suggest-disabled.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-disabled.test
@@ -1,0 +1,29 @@
+--TEST--
+Suggestions are not displayed if --no-suggest is used.
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "suggest": { "b/b": "an obscure reason" } },
+                { "name": "c/c", "version": "1.0.0", "replace": { "b/b": "1.0.0" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0",
+        "b/b": "1.0.0"
+    }
+}
+--RUN--
+install --no-suggest
+--EXPECT-OUTPUT--
+<info>Loading composer repositories with package information</info>
+<info>Installing dependencies</info>
+<info>Writing lock file</info>
+<info>Generating autoload files</info>
+
+--EXPECT--
+Installing a/a (1.0.0)
+Installing c/c (1.0.0)


### PR DESCRIPTION
Installer::setNoSuggest() now controls if suggested packages should be
listed or not.

When using InstallCommand the setNoSuggest method is determained by
--no-dev option or --no-suggest option to limit the output when
installing for a production environment.

When using UpdateCommand it is only determained by the --no-suggest option.

Fix #2066