### PR TITLE
Added variables in composer.json

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -335,6 +335,12 @@
                     "format": "uri"
                 }
             }
+        },
+        "variables": {
+            "type": "object",
+            "description": "This is a hash of variable name (keys) and value (values) that can be referenced in the composer.json.",
+            "additionalProperties": true
         }
+
     }
 }

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -92,7 +92,7 @@ class JsonFile
             throw new \RuntimeException('Could not read '.$this->path."\n\n".$e->getMessage());
         }
 
-        return static::parseJson($json, $this->path);
+        return $this->replaceVariables(static::parseJson($json, $this->path));
     }
 
     /**
@@ -309,5 +309,23 @@ class JsonFile
         }
 
         throw new ParsingException('"'.$file.'" does not contain valid JSON'."\n".$result->getMessage(), $result->getDetails());
+    }
+
+    /**
+     * @param $json
+     * @return mixed
+     */
+    private function replaceVariables($json)
+    {
+        if (isset($json['variables'])) {
+            $variables = $json['variables'];
+            array_walk_recursive($json, function(&$version) use($variables) {
+                foreach ($variables as $key => $variable) {
+                    $version = ($version === '%' . $key . '%') ? $variable : $version;
+                }
+            });
+        }
+
+        return $json;
     }
 }

--- a/tests/Composer/Test/Json/Fixtures/composer.json
+++ b/tests/Composer/Test/Json/Fixtures/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "composer/composer",
+    "description": "%var3.value%",
+    "require": {
+        "a/b": "%var1.value%"
+    },
+    "require-dev": {
+        "c/d": "%var2.value%"
+    },
+    "variables": {
+        "var1.value": "v1.0.0",
+        "var2.value": "v2.0.0",
+        "var3.value": "description"
+    }
+}

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -198,6 +198,30 @@ class JsonFileTest extends \PHPUnit_Framework_TestCase
         $this->assertJsonFormat('"\\u018c"', $data, 0);
     }
 
+    public function testReplaceVariables()
+    {
+        $expected = array(
+            'name'        => 'composer/composer',
+            'description' => 'description',
+            'require'     => array(
+                'a/b' => 'v1.0.0',
+            ),
+            'require-dev' => array(
+                'c/d' => 'v2.0.0',
+            ),
+            'variables'   => array(
+                'var1.value' => 'v1.0.0',
+                'var2.value' => 'v2.0.0',
+                'var3.value' => 'description',
+            ),
+        );
+
+        $file = new JsonFile(__DIR__.'/Fixtures/composer.json');
+        $json = $file->read();
+        $this->assertEquals($expected, $json);
+    }
+
+
     private function expectParseException($text, $json)
     {
         try {


### PR DESCRIPTION
Variables can be referenced in the composer.json.

An example:

``` json
{
    "require": {
        "symfony/console": "%symfony.version%",
        "symfony/process": "%symfony.version%",
        "symfony/yaml": "%symfony.version%",
        "symfony/filesystem": "%symfony.version%"
    },
    "variables": {
        "symfony.version": "v2.3.1"
    }
}
```
