### PR TITLE
fixed very evil 'tip' tag oversight in bitbucket driver

### DIFF
--- a/src/Composer/Repository/Vcs/HgBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/HgBitbucketDriver.php
@@ -127,6 +127,7 @@ class HgBitbucketDriver extends VcsDriver
             foreach ($tagsData as $tag => $data) {
                 $this->tags[$tag] = $data['raw_node'];
             }
+            unset($this->tags['tip']);
         }
 
         return $this->tags;


### PR DESCRIPTION
The HgDriver already does the right thing, I suppose someone (me?) just didn't think of tip in the BitbucketDriver. This fixes composer/packagist#285 as well.

If possible, I'd like to see this deployed ASAP, but it seems for that we need to update packagist to Symfony 2.3 (as Composer's dev-master requires 2.3). I can PR a fix for that as well, but I can't really test the whole application.
