### PR TITLE
Add APC support to Composer

### DIFF
--- a/src/Composer/Autoload/ApcClassLoader.php
+++ b/src/Composer/Autoload/ApcClassLoader.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Autoload;
+
+/**
+ * ApcClassLoader implements a wrapping autoloader cached in APC.
+ *
+ * @author Rob Loach (http://robloach.net)
+ */
+class ApcClassLoader extends ClassLoader
+{
+    /**
+     * The APC namespace prefix to use.
+     *
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * Constructor.
+     *
+     * @param string $prefix  The APC namespace prefix to use.
+     */
+    public function __construct($prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * Finds the path to the file where the class is defined.
+     *
+     * @param string $class The name of the class
+     *
+     * @return string|false The path if found, false otherwise
+     */
+    public function findFile($class)
+    {
+        if (false === $file = apc_fetch($this->prefix.$class)) {
+            apc_store($this->prefix.$class, $file = parent::findFile($class));
+        }
+
+        return $file;
+    }
+}

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -11,6 +11,10 @@ class ComposerAutoloaderInitFilesAutoloadOrder
         if ('Composer\Autoload\ClassLoader' === $class) {
             require __DIR__ . '/ClassLoader.php';
         }
+        elseif ('Composer\Autoload\ApcClassLoader' === $class) {
+            require __DIR__ . '/ApcClassLoader.php';
+        }
+
     }
 
     public static function getLoader()
@@ -20,7 +24,12 @@ class ComposerAutoloaderInitFilesAutoloadOrder
         }
 
         spl_autoload_register(array('ComposerAutoloaderInitFilesAutoloadOrder', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        if (extension_loaded('apc')) {
+            self::$loader = $loader = new \Composer\Autoload\ApcClassLoader('FilesAutoloadOrder');
+        }
+        else {
+            self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        }
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoloadOrder', 'loadClassLoader'));
 
         $vendorDir = dirname(__DIR__);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -11,6 +11,9 @@ class ComposerAutoloaderInitFilesAutoload
         if ('Composer\Autoload\ClassLoader' === $class) {
             require __DIR__ . '/ClassLoader.php';
         }
+        elseif ('Composer\Autoload\ApcClassLoader' === $class) {
+            require __DIR__ . '/ApcClassLoader.php';
+        }
     }
 
     public static function getLoader()
@@ -20,7 +23,12 @@ class ComposerAutoloaderInitFilesAutoload
         }
 
         spl_autoload_register(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        if (extension_loaded('apc')) {
+            self::$loader = $loader = new \Composer\Autoload\ApcClassLoader('FilesAutoload');
+        }
+        else {
+            self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        }
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
         $vendorDir = dirname(__DIR__);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -11,6 +11,9 @@ class ComposerAutoloaderInitIncludePath
         if ('Composer\Autoload\ClassLoader' === $class) {
             require __DIR__ . '/ClassLoader.php';
         }
+        elseif ('Composer\Autoload\ApcClassLoader' === $class) {
+            require __DIR__ . '/ApcClassLoader.php';
+        }
     }
 
     public static function getLoader()
@@ -20,7 +23,12 @@ class ComposerAutoloaderInitIncludePath
         }
 
         spl_autoload_register(array('ComposerAutoloaderInitIncludePath', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        if (extension_loaded('apc')) {
+            self::$loader = $loader = new \Composer\Autoload\ApcClassLoader('IncludePath');
+        }
+        else {
+            self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        }
         spl_autoload_unregister(array('ComposerAutoloaderInitIncludePath', 'loadClassLoader'));
 
         $vendorDir = dirname(__DIR__);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -11,6 +11,9 @@ class ComposerAutoloaderInitTargetDir
         if ('Composer\Autoload\ClassLoader' === $class) {
             require __DIR__ . '/ClassLoader.php';
         }
+        elseif ('Composer\Autoload\ApcClassLoader' === $class) {
+            require __DIR__ . '/ApcClassLoader.php';
+        }
     }
 
     public static function getLoader()
@@ -20,7 +23,12 @@ class ComposerAutoloaderInitTargetDir
         }
 
         spl_autoload_register(array('ComposerAutoloaderInitTargetDir', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        if (extension_loaded('apc')) {
+            self::$loader = $loader = new \Composer\Autoload\ApcClassLoader('TargetDir');
+        }
+        else {
+            self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        }
         spl_autoload_unregister(array('ComposerAutoloaderInitTargetDir', 'loadClassLoader'));
 
         $vendorDir = dirname(__DIR__);


### PR DESCRIPTION
Add APC support to the Composer ClassLoader. This uses ApcClassLoader when the APC extension is available, which I'm not quite sure is the desired design, but there it is.
