### PR TITLE
Allow whitespace in installers - fix for issue #2071

### DIFF
--- a/src/Composer/Installer/InstallerInstaller.php
+++ b/src/Composer/Installer/InstallerInstaller.php
@@ -91,7 +91,7 @@ class InstallerInstaller extends LibraryInstaller
         foreach ($classes as $class) {
             if (class_exists($class, false)) {
                 $code = file_get_contents($classLoader->findFile($class));
-                $code = preg_replace('{^class\s+(\S+)}mi', 'class $1_composer_tmp'.self::$classCounter, $code);
+                $code = preg_replace('{^(\s*)class\s+(\S+)}mi', '$1class $2_composer_tmp'.self::$classCounter, $code);
                 eval('?>'.$code);
                 $class .= '_composer_tmp'.self::$classCounter;
                 self::$classCounter++;


### PR DESCRIPTION
Custom installers can have the class definition indented.
