### PR TITLE
Init command - diacritical marks in author name

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -35,7 +35,7 @@ class InitCommand extends Command
 
     public function parseAuthorString($author)
     {
-        if (preg_match('/^(?P<name>[- \.,\w\'’]+) <(?P<email>.+?)>$/u', $author, $match)) {
+        if (preg_match('/^(?P<name>[- \.,\p{L}\'’]+) <(?P<email>.+?)>$/u', $author, $match)) {
             if ($this->isValidEmail($match['email'])) {
                 return array(
                     'name'  => trim($match['name']),

--- a/tests/Composer/Test/Command/InitCommandTest.php
+++ b/tests/Composer/Test/Command/InitCommandTest.php
@@ -25,6 +25,14 @@ class InitCommandTest extends TestCase
         $this->assertEquals('john@example.com', $author['email']);
     }
 
+    public function testParseValidUtf8AuthorString()
+    {
+        $command = new InitCommand;
+        $author = $command->parseAuthorString('Matti Meikäläinen <matti@example.com>');
+        $this->assertEquals('Matti Meikäläinen', $author['name']);
+        $this->assertEquals('matti@example.com', $author['email']);
+    }
+
     public function testParseEmptyAuthorString()
     {
         $command = new InitCommand;


### PR DESCRIPTION
Allow to use diacritical marks in author name (UTF-8).
Current command return an error when you pass full name with non-english characters.
