### PR TITLE
Add PSR-4 class loader. (tests needed)

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -323,7 +323,7 @@ class ClassLoader
             ;
         } else {
             // PEAR-like class name
-            $logicalPathPsr0 = strtr($class, '_', DIRECTORY_SEPARATOR);
+            $logicalPathPsr0 = strtr($class, '_', DIRECTORY_SEPARATOR) . '.php';
         }
 
         if (isset($this->prefixesPsr0[$first])) {


### PR DESCRIPTION
This PR changes the class loader to support PSR-4 alongside PSR-0, as discussed in
https://github.com/composer/composer/issues/1884

It does not introduce any tests. (in fact I did not find any tests for PSR-0 either)
It does not introduce any mechanics to actually activate PSR-4 via composer.json.

It also introduces a few other changes, see inline comments.
