### PR TITLE
Configure VCS drivers list

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -308,6 +308,18 @@ EOT
                     return $vals;
                 }
             ),
+            'vcs-drivers' => array(
+                function ($vals) {
+                    if (!is_array($vals)) {
+                        return 'array expected';
+                    }
+
+                    return true;
+                },
+                function ($vals) {
+                    return $vals;
+                }
+            )
         );
 
         foreach ($uniqueConfigValues as $name => $callbacks) {

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -25,6 +25,8 @@ class Config
         'preferred-install' => 'auto',
         'notify-on-install' => true,
         'github-protocols' => array('git', 'https'),
+        // svn must be last because identifying a subversion server for sure is practically impossible
+        'vcs-drivers' => array('git-hub', 'git-bitbucket', 'git', 'hg-bitbucket', 'hg', 'svn'),
         'vendor-dir' => 'vendor',
         'bin-dir' => '{$vendor-dir}/bin',
         'cache-dir' => '{$home}/cache',


### PR DESCRIPTION
We installed and set up GitLab and Packagist, added private repository from GitLab into our Packagist; everything works fine, except one moment: package's "dist" value is always null and composer.phar is not able to download package as zip-file from GitLab.

This changes will allow to add VCS-driver to Packagist instance via composer's global config file and to have not-null "dist" values for private repositories.