### PR TITLE
Fixes the autoload_namespaces generator 

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -330,7 +330,11 @@ EOF;
         $baseDir = '';
         if (strpos($path, $vendorPath) === 0) {
             $path = substr($path, strlen($vendorPath));
-            $baseDir = '$vendorDir . ';
+            $baseDir = '$vendorDir';
+
+            if ($path !== false) {
+                $baseDir .= " . ";
+            }
         } else {
             $path = $filesystem->normalizePath($filesystem->findShortestPath($basePath, $path, true));
             if (!$filesystem->isAbsolutePath($path)) {
@@ -343,7 +347,7 @@ EOF;
             $baseDir = "'phar://' . " . $baseDir;
         }
 
-        return $baseDir.var_export($path, true);
+        return $baseDir . (($path !== false) ? var_export($path, true) : "");
     }
 
     protected function getAutoloadFile($vendorPathToTargetDirCode, $suffix)


### PR DESCRIPTION
This fixes issue #2186 by doing a check on the path after the substr and only exporting it's value if it is not false.
