### PR TITLE
Add another svn auth failed string to check (older svn server version)

### DIFF
--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -108,6 +108,7 @@ class Svn
 
         // the error is not auth-related
         if (false === stripos($output, 'Could not authenticate to server:')
+            && false === stripos($output, 'authorization failed')
             && false === stripos($output, 'svn: E170001:')) {
             throw new \RuntimeException($output);
         }


### PR DESCRIPTION
Found another string indicating failed authentication when using svn. The full message returned (urls masked) looks like this:

cmd: svn ls --verbose --non-interactive  'http://svn.host.com/svn/path'
response: svn: OPTIONS of 'http://svn.host.com/svn/path': authorization failed (http://svn.host.com)
