### PR TITLE
Undefined offset: 3 when gethostbyname fails

### DIFF
--- a/src/Composer/Util/NoProxyPattern.php
+++ b/src/Composer/Util/NoProxyPattern.php
@@ -132,8 +132,6 @@ class NoProxyPattern
         $high = $i | (~$mask & 0xFFFFFFFF);
 
         // Now split the ip we're checking against up into classes
-        echo 'ip: ';
-        var_dump($ip);
         list($a, $b, $c, $d) = explode('.', $ip);
 
         // Now convert the ip we're checking against to an int


### PR DESCRIPTION
When running composer update without an internet connection (for example when using satis as a central repository), sometimes it fails with:

```
[ErrorException]     
  Undefined offset: 3  

Exception trace:
 () at phar:///usr/bin/composer.phar/src/Composer/Util/NoProxyPattern.php:131
 Composer\Util\ErrorHandler::handle() at phar:///usr/bin/composer.phar/src/Composer/Util/NoProxyPattern.php:131
 Composer\Util\NoProxyPattern::inCIDRBlock() at phar:///usr/bin/composer.phar/src/Composer/Util/NoProxyPattern.php:76
 Composer\Util\NoProxyPattern->test() at phar:///usr/bin/composer.phar/src/Composer/Util/StreamContextFactory.php:70
```

Not sure if the proposed fix is ok, please take a look if you can.

Thank you
