### PR TITLE
Support namespace roots mapped to subdirectories.

### DIFF
--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -169,7 +169,7 @@ class AutoloadGeneratorTest extends TestCase
     {
         $package = new Package('a', '1.0', '1.0');
         $package->setAutoload(array(
-            'psr-0' => array('Main\\Foo' => '', 'Main\\Bar' => ''),
+            'psr-0' => array('Main\\Foo' => '', 'Main\\Bar' => '', 'Main\\Boo' => 'altroot/'),
             'classmap' => array('Main/Foo/src', 'lib'),
             'files' => array('foo.php', 'Main/Foo/bar.php'),
         ));
@@ -182,11 +182,13 @@ class AutoloadGeneratorTest extends TestCase
         $this->fs->ensureDirectoryExists($this->vendorDir.'/a');
         $this->fs->ensureDirectoryExists($this->workingDir.'/src');
         $this->fs->ensureDirectoryExists($this->workingDir.'/lib');
+        $this->fs->ensureDirectoryExists($this->workingDir.'/altroot');
 
         file_put_contents($this->workingDir.'/src/rootfoo.php', '<?php class ClassMapFoo {}');
         file_put_contents($this->workingDir.'/lib/rootbar.php', '<?php class ClassMapBar {}');
         file_put_contents($this->workingDir.'/foo.php', '<?php class FilesFoo {}');
         file_put_contents($this->workingDir.'/bar.php', '<?php class FilesBar {}');
+        file_put_contents($this->workingDir.'/altroot/boo.php', '<?php class FilesBoo {}');
 
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', false, 'TargetDir');
         $this->assertFileEquals(__DIR__.'/Fixtures/autoload_target_dir.php', $this->vendorDir.'/autoload.php');
@@ -648,7 +650,7 @@ EOF;
     {
         $package = new Package('a', '1.0', '1.0');
         $package->setAutoload(array(
-            'psr-0' => array('Main\\Foo' => '', 'Main\\Bar' => ''),
+            'psr-0' => array('Main\\Foo' => '', 'Main\\Bar' => '', 'Main\\Boo' => 'altroot/'),
         ));
         $package->setTargetDir('Main/Foo/');
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -47,12 +47,12 @@ class ComposerAutoloaderInitIncludePath
     public static function autoload($class)
     {
         $dir = dirname(dirname(__DIR__)) . '/';
-        $prefixes = array('Main\\Foo', 'Main\\Bar');
-        foreach ($prefixes as $prefix) {
+        $autoloadPsrZero = array (  'Main\\Foo' => '',  'Main\\Bar' => '',  'Main\\Boo' => 'altroot/',);
+        foreach ($autoloadPsrZero as $prefix => $prefixPath) {
             if (0 !== strpos($class, $prefix)) {
                 continue;
             }
-            $path = $dir . implode('/', array_slice(explode('\\', $class), 2)).'.php';
+            $path = $dir . strtr( substr_replace( $class, $prefixPath, 0, strlen( $prefix ) ), '\\', DIRECTORY_SEPARATOR ) . '.php';
             if (!$path = stream_resolve_include_path($path)) {
                 return false;
             }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -50,12 +50,12 @@ class ComposerAutoloaderInitTargetDir
     public static function autoload($class)
     {
         $dir = dirname(dirname(__DIR__)) . '/';
-        $prefixes = array('Main\\Foo', 'Main\\Bar');
-        foreach ($prefixes as $prefix) {
+        $autoloadPsrZero = array (  'Main\\Foo' => '',  'Main\\Bar' => '',  'Main\\Boo' => 'altroot/',);
+        foreach ($autoloadPsrZero as $prefix => $prefixPath) {
             if (0 !== strpos($class, $prefix)) {
                 continue;
             }
-            $path = $dir . implode('/', array_slice(explode('\\', $class), 2)).'.php';
+            $path = $dir . strtr( substr_replace( $class, $prefixPath, 0, strlen( $prefix ) ), '\\', DIRECTORY_SEPARATOR ) . '.php';
             if (!$path = stream_resolve_include_path($path)) {
                 return false;
             }


### PR DESCRIPTION
Seems like the Target Directory fix for locating a long namespace without nested folders only worked for root.  This extends that feature to any subdirectory.
