### PR TITLE
Documentation fixes for composer-plugin type

### DIFF
--- a/doc/articles/custom-installers.md
+++ b/doc/articles/custom-installers.md
@@ -145,7 +145,7 @@ Example:
         /**
          * {@inheritDoc}
          */
-        public function getInstallPath(PackageInterface $package)
+        public function getPackageBasePath(PackageInterface $package)
         {
             $prefix = substr($package->getPrettyName(), 0, 23);
             if ('phpdocumentor/template-' !== $prefix) {


### PR DESCRIPTION
As documented in https://github.com/composer/composer/blob/master/doc/articles/custom-installers.md#composerjson:

> the type attribute must be composer-plugin.

In addition use getPackageBasePath instead of getInstallPath, as LibraryInstaller uses getPackageBasePath for uninstall: https://github.com/composer/composer/blob/master/src/Composer/Installer/LibraryInstaller.php#L126
