### PR TITLE
fixes #2242: Set write permissions on unzipped package contents

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -38,7 +38,7 @@ class ZipDownloader extends ArchiveDownloader
 
         // try to use unzip on *nix
         if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $command = 'unzip '.escapeshellarg($file).' -d '.escapeshellarg($path);
+            $command = 'unzip '.escapeshellarg($file).' -d '.escapeshellarg($path) . ' && chmod -R u+w ' . escapeshellarg($path);
             if (0 === $this->process->execute($command, $ignoredOutput)) {
                 return;
             }


### PR DESCRIPTION
This fix adds a `chmod` call to `ZipDownloader` when unzipping an archive, to address an issue where the archive contents were zipped without write permissions, causing composer to fail when trying to unlink the cached contents.
