### PR TITLE
Do not use detected width for output formatting if it is not available

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -185,6 +185,11 @@ EOT
                     }
                 }
                 list($width) = $this->getApplication()->getTerminalDimensions();
+                if (null === $width) {
+                    // In case the width is not detected, we're probably running the command
+                    // outside of a real terminal, use space without a limit
+                    $width = INF;
+                }
                 if (defined('PHP_WINDOWS_VERSION_BUILD')) {
                     $width--;
                 }


### PR DESCRIPTION
This fixes this issue : https://github.com/symfony/symfony/issues/8994
