### PR TITLE
If install path is checked using getInstalledPath, then the removal of c...

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -163,7 +163,7 @@ class LibraryInstaller implements InstallerInterface
 
     protected function removeCode(PackageInterface $package)
     {
-        $downloadPath = $this->getPackageBasePath($package);
+        $downloadPath = $this->getInstallPath($package);
         $this->downloadManager->remove($package, $downloadPath);
     }
 


### PR DESCRIPTION
...ode should also check the same path, and not a different one. This is with reference to issue https://github.com/auraphp/installer-system/issues/2
