### PR TITLE
Add missing require to example composer.json

### DIFF
--- a/doc/articles/custom-installers.md
+++ b/doc/articles/custom-installers.md
@@ -79,6 +79,9 @@ Example:
         },
         "extra": {
             "class": "phpDocumentor\\Composer\\TemplateInstallerPlugin"
+        },
+        "require": {
+            "composer-plugin-api": "1.0.0"
         }
     }
 


### PR DESCRIPTION
The article about custom installers is missing the require for `composer-plugin-api`.
