### PR TITLE
Improved the handling of trunkPath

### DIFF
--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -193,7 +193,7 @@ class SvnDriver extends VcsDriver
         if (null === $this->branches) {
             $this->branches = array();
 
-            if(false === $this->trunkPath) {
+            if (false === $this->trunkPath) {
                 $trunkParent = $this->baseUrl . '/';
             } else {
                 $trunkParent = $this->baseUrl . '/' . $this->trunkPath;


### PR DESCRIPTION
In this composer/satis#88 Satis-issue, there was a fix for subversion repositories that don't have a `root/trunk`, `root/tags` & `root/branches` structure, but a rather deep one.

For testing purposes, I have created two repositories at Google Code:

[Basic SVN Structure](https://code.google.com/p/composer-project-with-basic-svn-structure/source/browse/)
[Deep SVN Structure](https://code.google.com/p/composer-project-with-deep-svn-structure/source/browse/)

This PR has three changes:
- set `$trunkParent` to `$this->baseUrl` only if `$this->trunkPath` equals `false`. In other cases, concatenate `$this->baseUrl` and `$this->trunkPath` 
- Instead of checking `$output` for the `$this->trunkPath`, check for the existence of `composer.json`. In case of the former it would not work if `$this->trunkPath` was more than one directory deep, because the output of `svn ls` would only show the first directory-name and never the whole path.
- The identifier for the trunk is not equal to `$this->trunkPath`, but always `trunk`, which results in a `devel-trunk` branch. In the old situation, a deeper `trunkPath` would result in a `devel-long-deep-nested-path-trunk` branch.
