### PR TITLE
Use default description and license from CLI args

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -208,7 +208,8 @@ EOT
         $description = $input->getOption('description') ?: false;
         $description = $dialog->ask(
             $output,
-            $dialog->getQuestion('Description', $description)
+            $dialog->getQuestion('Description', $description),
+            $description
         );
         $input->setOption('description', $description);
 
@@ -258,7 +259,8 @@ EOT
         $license = $input->getOption('license') ?: false;
         $license = $dialog->ask(
             $output,
-            $dialog->getQuestion('License', $license)
+            $dialog->getQuestion('License', $license),
+            $license
         );
         $input->setOption('license', $license);
 


### PR DESCRIPTION
When running `composer init` with `--description` and `--license` arguments on the command line they are later suggested as defaults during the interactive flow.

However when you press Enter (to use the default suggesstion) Composer does not use it, but instead skip them entirely from the `composer.json` generation.

This change provides a default argument not only to `DialogHelper::getQuestion()`, but also to `DialogHelper::ask()`.
