### PR TITLE
Fixed file_put_contents error in Windows 8

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -531,9 +531,9 @@ class Installer
                 $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $operation);
             }
 
-            if (!$this->dryRun) {
-                $localRepo->write();
-            }
+        }
+        if (!$this->dryRun) {
+            $localRepo->write();
         }
 
         return true;


### PR DESCRIPTION
When 'composer update' tried to deprecate more than one package he raised an error on file_put_contents. I fixed the error avoiding to save many times the file vendor/composer/installed.json
