### PR TITLE
Format the possible version formats as a table

### DIFF
--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -64,12 +64,12 @@ means any version in the `1.0` development branch. It would match `1.0.0`,
 
 Version constraints can be specified in a few different ways.
 
-Name           | Example               | Description
--------------- | --------------------- | -----------
-Exact version  | `1.0.2`               | You can specify the exact version of a package.
-Range          | `>=1.0` `>=1.0,<2.0`  | By using comparison operators you can specify ranges of valid versions. Valid operators are `>`, `>=`, `<`, `<=`, `!=`. You can define multiple ranges, separated by a comma, which will be treated as a **logical AND**.
-Wildcard       | `1.0.*`               | You can specify a pattern with a `*` wildcard. `1.0.*` is the equivalent of `>=1.0,<1.1`.
-Tilde Operator | `~1.2`                | Very useful for projects that follow semantic versioning. `~1.2` is equivalent to `>=1.2,<2.0`. For more details, read the next section below.
+Name           | Example                                   | Description
+-------------- | ---------------------                     | -----------
+Exact version  | `1.0.2`                                   | You can specify the exact version of a package.
+Range          | `>=1.0` `>=1.0,<2.0` `>=1.0,<1.1 | >=1.2` | By using comparison operators you can specify ranges of valid versions. Valid operators are `>`, `>=`, `<`, `<=`, `!=`. <br />You can define multiple ranges, separated by a comma, which will be treated as a **logical AND**. A pipe symbol `|` will be treated as a **logical OR**. <br />AND has higher precedence than OR.
+Wildcard       | `1.0.*`                                   | You can specify a pattern with a `*` wildcard. `1.0.*` is the equivalent of `>=1.0,<1.1`.
+Tilde Operator | `~1.2`                                    | Very useful for projects that follow semantic versioning. `~1.2` is equivalent to `>=1.2,<2.0`. For more details, read the next section below.
 
 ### Next Significant Release (Tilde Operator)
 


### PR DESCRIPTION
**Note I:** This syntax is supported by MarkdownExtra, which both getcomposer
and github are using.

**Note II:** This patch currently breaks the PDF, because pandoc does not like
non-standard markdown tables. Ideas for fixing this appreciated.

**Note III:** The idea for this patch came up a few weeks ago on IRC. We
agreed back then that a table would be a good idea.

**Note IV:** This patch creates a stability section which opens the door for
finally documenting how stability works in the composer docs.

---

With [this patch](https://github.com/composer/getcomposer.org/pull/53) applied to getcomposer, the result looks as follows:

![screen shot 2013-10-02 at 1 12 07 am](https://f.cloud.github.com/assets/88061/1250119/fa67eee2-2aee-11e3-88c3-073acc13c21e.png)
