### PR TITLE
Autoloader mod to deal with projects that have a "target-dir"

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -217,14 +217,25 @@ class ClassLoader
         }
 
         $classPath .= strtr($className, '_', DIRECTORY_SEPARATOR) . '.php';
+        $rootPath = dirname(dirname(__DIR__));
 
         $first = $class[0];
-        if (isset($this->prefixes[$first])) {
+        if (isset( $this->prefixes[$first] )) {
             foreach ($this->prefixes[$first] as $prefix => $dirs) {
                 if (0 === strpos($class, $prefix)) {
                     foreach ($dirs as $dir) {
                         if (file_exists($dir . DIRECTORY_SEPARATOR . $classPath)) {
                             return $dir . DIRECTORY_SEPARATOR . $classPath;
+                        }
+                            //	If target-dir used, need to check local project
+                        $dir = rtrim($dir, DIRECTORY_SEPARATOR);
+
+                        if ($dir == $rootPath) {
+                            $targetClassPath =
+                                str_replace(str_replace('\\', DIRECTORY_SEPARATOR, $prefix), null, $classPath);
+                            if (file_exists($dir . DIRECTORY_SEPARATOR . $targetClassPath)) {
+                                return $dir . DIRECTORY_SEPARATOR . $targetClassPath;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In writing our library unit tests, we discovered that the autoloader does not properly look in the right place for projects that contain a "target-dir" configuration option.

Because the autoloader has no knowledge of composer or the configuration, it the target-dir is assumed to be the namespace. This portion is removed from the directory before the file_exists() check.

I've tested this fix and it works perfectly for this application.  I know you know there is trouble with the "target-dir", but this is a decent fix until the new PSR is out and code is compliant.
