### PR TITLE
Add flag/option to skip autoload generation

### DIFF
--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -42,6 +42,7 @@ class InstallCommand extends Command
                 new InputOption('no-custom-installers', null, InputOption::VALUE_NONE, 'DEPRECATED: Use no-plugins instead.'),
                 new InputOption('no-scripts', null, InputOption::VALUE_NONE, 'Skips the execution of all scripts defined in composer.json file.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
+                new InputOption('no-dump-autoload', null, InputOption::VALUE_NONE, 'Skips the generation of autoload files.'),
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump')
             ))
@@ -100,6 +101,7 @@ EOT
             ->setPreferDist($preferDist)
             ->setDevMode(!$input->getOption('no-dev'))
             ->setRunScripts(!$input->getOption('no-scripts'))
+            ->setDumpAutoloader(!$input->getOption('no-dump-autoload'))
             ->setOptimizeAutoloader($input->getOption('optimize-autoloader'))
         ;
 

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -99,6 +99,7 @@ class Installer
 
     protected $preferSource = false;
     protected $preferDist = false;
+    protected $dumpAutoloader = true;
     protected $optimizeAutoloader = false;
     protected $devMode = false;
     protected $dryRun = false;
@@ -279,8 +280,10 @@ class Installer
             }
 
             // write autoloader
-            $this->io->write('<info>Generating autoload files</info>');
-            $this->autoloadGenerator->dump($this->config, $localRepo, $this->package, $this->installationManager, 'composer', $this->optimizeAutoloader);
+            if ($this->dumpAutoloader) {
+                $this->io->write('<info>Generating autoload files</info>');
+                $this->autoloadGenerator->dump($this->config, $localRepo, $this->package, $this->installationManager, 'composer', $this->optimizeAutoloader);
+            }
 
             if ($this->runScripts) {
                 // dispatch post event
@@ -959,6 +962,19 @@ class Installer
     public function setPreferDist($preferDist = true)
     {
         $this->preferDist = (boolean) $preferDist;
+
+        return $this;
+    }
+
+    /**
+     * Whether or not to generate the autoload files
+     *
+     * @param  bool      $dumpAutoloader
+     * @return Installer
+     */
+    public function setDumpAutoloader($dumpAutoloader = true)
+    {
+        $this->dumpAutoloader = (boolean) $dumpAutoloader;
 
         return $this;
     }


### PR DESCRIPTION
I'd like to suggest to add a flag/switch to skip autoload code generation during the "install". When using this switch, one would have to "dump-autoload" later on, of course.

Reason:

I am using composer in a multistage build process. At the time "install" is run, not all directories to be included in the autoload scanning process have been generated or are available (some of them are the result of code generation tools that will be run later on).

Would you accept a patch for that?
