### PR TITLE
Update to fix issue with multiple perforce repositories

### DIFF
--- a/src/Composer/Downloader/PerforceDownloader.php
+++ b/src/Composer/Downloader/PerforceDownloader.php
@@ -45,6 +45,7 @@ class PerforceDownloader extends VcsDownloader
     private function initPerforce($package, $path, $ref)
     {
         if ($this->perforce) {
+            $this->perforce->initializePath($path);
             return;
         }
 

--- a/src/Composer/Util/Perforce.php
+++ b/src/Composer/Util/Perforce.php
@@ -38,9 +38,7 @@ class Perforce
     {
         $this->windowsFlag = $isWindows;
         $this->p4Port = $port;
-        $this->path = $path;
-        $fs = new Filesystem();
-        $fs->ensureDirectoryExists($path);
+        $this->initializePath($path);
         $this->process = $process;
         $this->initialize($repoConfig);
     }
@@ -129,6 +127,13 @@ class Perforce
     protected function getPath()
     {
         return $this->path;
+    }
+
+    public function initializePath($path)
+    {
+        $this->path = $path;
+        $fs = new Filesystem();
+        $fs->ensureDirectoryExists($path);
     }
 
     protected function getPort()


### PR DESCRIPTION
was previously re-using the path from the first initialization of the downloader.  Now it initializes it with the new path.
