### PR TITLE
added support for file:// url to repository

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -63,7 +63,7 @@ class ComposerRepository extends ArrayRepository implements StreamableRepository
         }
 
         $urlBits = parse_url($repoConfig['url']);
-        if (empty($urlBits['scheme']) || empty($urlBits['host'])) {
+        if ($urlBits === false || empty($urlBits['scheme'])) {
             throw new \UnexpectedValueException('Invalid url given for Composer repository: '.$repoConfig['url']);
         }
 


### PR DESCRIPTION
file:// is valid url even if it does not define a host.

allows to define a repo like this (local directory generated with composer/satis):

``` json
{
    "repositories": [ { "type": "composer", "url": "file:///home/cebe/dev/xeno-core/core/repo" } ],
    "require": {
        ...
    }
}
```
