### PR TITLE
changes size of the line default value

### DIFF
--- a/src/Composer/IO/IOInterface.php
+++ b/src/Composer/IO/IOInterface.php
@@ -71,7 +71,7 @@ interface IOInterface
      * @param bool         $newline  Whether to add a newline or not
      * @param integer      $size     The size of line
      */
-    public function overwrite($messages, $newline = true, $size = 80);
+    public function overwrite($messages, $newline = true, $size = null);
 
     /**
      * Asks a question to the user.


### PR DESCRIPTION
Implementation of IOInterface in ConsoleIO was inconsistent having default value as null rather than 80. Changing value in ConsoleIO implementation fails one test, so i decided to change it in IOInterface.
