### PR TITLE
Retry on some 5xx errors

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -120,7 +120,7 @@ class FileDownloader implements DownloaderInterface
                             break;
                         } catch (TransportException $e) {
                             // if we got an http response with a proper code, then requesting again will probably not help, abort
-                            if ((0 !== $e->getCode() && 500 !== $e->getCode()) || !$retries) {
+                            if ((0 !== $e->getCode() && !in_array($e->getCode(),array(500, 502, 503, 504))) || !$retries) {
                                 throw $e;
                             }
                             if ($this->io->isVerbose()) {


### PR DESCRIPTION
`composer install` gives me some intermittent 502 errors on github. Composer already does some retries. I think, on 502, 503 and 504, we should retry.
