### PR TITLE
Fix URL sanitisation regexp being too greedy

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -384,7 +384,7 @@ class GitDownloader extends VcsDownloader
 
     protected function sanitizeUrl($message)
     {
-        return preg_replace('{://(.+?):.+?@}', '://$1:***@', $message);
+        return preg_replace('{://([^@]+?):.+?@}', '://$1:***@', $message);
     }
 
     protected function setPushUrl(PackageInterface $package, $path)


### PR DESCRIPTION
Error messages containing URLs without passwords could get incorrectly sanitised.

The following command in the error output:

```
git clone 'ssh://chris@localhost:1234/home/chris/src/composer/.git' '/home/chris/src/composer/testing/vendor/composer/composer' && cd '/home/chris/src/composer/testing/vendor/composer/composer' && git remote add composer 'ssh://chris@localhost:1234/home/chris/src/composer/.git' && git fetch composer
```

Got converted to:

```
git clone 'ssh://chris@localhost:***@localhost:1234/home/chris/src/composer/.git' && git fetch composer
```
