### PR TITLE
Fix cache directory upgrading - do not try to (re)move the active cache dir.

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -118,7 +118,9 @@ class Factory
                             @rename($child, $dir.'/'.basename($child));
                         }
                     }
-                    @rmdir($oldPath);
+                    if ($config->get('cache-dir') != $oldPath) {
+                        @rmdir($oldPath);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a rather cumbersome issue in the moving of legacy cache directories to their new location.

The current behaviour is trying to move the cache directory into a subdirectoy of itself.

This fix adds a check that skips the removal if the directory to remove is the currently configured cache itself (as it would have to get recreated immediately anyway).
