### PR TITLE
If installer sets prefer to false, the manager should too. Fixes #2359

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -171,12 +171,8 @@ class Installer
         unset($devRepo, $package);
         // end BC
 
-        if ($this->preferSource) {
-            $this->downloadManager->setPreferSource(true);
-        }
-        if ($this->preferDist) {
-            $this->downloadManager->setPreferDist(true);
-        }
+        $this->downloadManager->setPreferSource($this->preferSource);
+        $this->downloadManager->setPreferDist($this->preferDist);
 
         // clone root package to have one in the installed repo that does not require anything
         // we don't want it to be uninstallable, but its requirements should not conflict


### PR DESCRIPTION
Hi,

The installer should force the prefer options of the download manager, even if it false.

Otherwise, if we have preferred-install = source in config, and prefer-dist option given to Install Command, this happens : 
- The install command instanciates composer, uses config and set downloadManager->preferSource = true
- Then install command reads CLI options, and set installer->preferSource = false, installer->preferDist = true which is fine
- When install->run() is executed, the downloadManager->preferSource (actually true due to config) is not overriden, because we override it only if the value is true.

The result : We have both downloadManager->preferSource = true and downloadManager->preferDist = true, and preferSource takes priority.

Fixes #2359 
