### PR TITLE
added new command for changing property settings

### DIFF
--- a/src/Composer/Command/Helper/FilesystemHelper.php
+++ b/src/Composer/Command/Helper/FilesystemHelper.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Command\Helper;
+
+use Composer\Util\Filesystem;
+use Symfony\Component\Console\Helper\Helper;
+
+class FilesystemHelper extends Helper
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    public function ensureFileExists($file, $content = '')
+    {
+        return $this->filesystem->ensureFileExists($file, $content);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'filesystem';
+    }
+}

--- a/src/Composer/Command/PropertySetCommand.php
+++ b/src/Composer/Command/PropertySetCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Command;
+
+use Composer\Command\Helper\FileHelper;
+use Composer\Json\JsonManipulator;
+use Composer\Plugin\CommandEvent;
+use Composer\Plugin\PluginEvents;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Composer\Factory;
+use Composer\Installer;
+use Composer\Json\JsonFile;
+
+/**
+ * @author Frank Stelzer <dev@frankstelzer.de>
+ */
+class PropertySetCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('property-set')
+            ->setDescription('Sets or overwrites a property')
+            ->setDefinition(
+                array(
+                    new InputArgument('name', InputArgument::REQUIRED, 'The property name, e.g. name, description, minimum-stability'),
+                    new InputArgument('value', InputArgument::REQUIRED, 'The property value, e.g. foo, "foo bar"'),
+                )
+            )
+            ->setHelp(<<<EOT
+The property-set command sets or overwrites a property with assigned value.
+
+Note that your composer.json is immediately modified. On failure the original file content will be restored.
+
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // do some file checks
+        $file = Factory::getComposerFile();
+
+        try {
+            $this->getHelperSet()->get('filesystem')->ensureFileExists($file, "{\n}\n");
+        } catch (\RuntimeException $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return 1;
+        }
+
+        // fire event before real command logic is executed
+        $composer = $this->getComposer();
+
+        $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'property-set', $input, $output);
+        $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
+
+        // start modifying the file
+        $json = new JsonFile($file);
+        $composer = $json->read();
+        $composerBackup = file_get_contents($json->getPath());
+
+        // only simple properties could be set currently
+        $whitelist = array('name', 'description', 'homepage', 'minimum-stability', 'license');
+
+        // validate name argument, abort with error on failure
+        $name = $input->getArgument('name');
+        if (!in_array($name, $whitelist)) {
+            $output->writeln(
+                '<error>property "' . $name . '" is not supported (allowed: ' .
+                implode(', ', array_keys($whitelist)) .
+                ')</error>'
+            );
+
+            return 1;
+        }
+
+        // go really sure that we are overwriting strings only
+        if (array_key_exists($name, $composer) && is_array($composer[$name])) {
+            $output->writeln(
+                '<error>array/object detected in property "' . $name . '", overwriting not allowed.</error>'
+            );
+
+            return 1;
+        }
+
+        $this->updateFile($json, $name, $input->getArgument('value'));
+
+        // validate generated json, rollback on failure
+        try {
+            $jsonValidate = new JsonFile($file);
+            $jsonValidate->read();
+        } catch (\RuntimeException $e) {
+            $output->writeln("\n" . '<error>Update failed, reverting ' . $file . ' to its original content.</error>');
+            file_put_contents($json->getPath(), $composerBackup);
+
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private function updateFile(JsonFile $json, $key, $value)
+    {
+        $contents = file_get_contents($json->getPath());
+
+        $manipulator = new JsonManipulator($contents);
+        $manipulator->addMainKey($key, $value);
+
+        file_put_contents($json->getPath(), $manipulator->getContents());
+
+        return true;
+    }
+}

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -12,6 +12,8 @@
 
 namespace Composer\Console;
 
+use Composer\Command\Helper\FilesystemHelper;
+use Composer\Util\Filesystem;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -227,6 +229,7 @@ class Application extends BaseApplication
         $commands[] = new Command\RunScriptCommand();
         $commands[] = new Command\LicensesCommand();
         $commands[] = new Command\GlobalCommand();
+        $commands[] = new Command\PropertySetCommand();
 
         if ('phar:' === substr(__FILE__, 0, 5)) {
             $commands[] = new Command\SelfUpdateCommand();
@@ -263,6 +266,7 @@ class Application extends BaseApplication
         $helperSet = parent::getDefaultHelperSet();
 
         $helperSet->set(new DialogHelper());
+        $helperSet->set(new FilesystemHelper(new Filesystem()));
 
         return $helperSet;
     }

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -130,6 +130,30 @@ class Filesystem
     }
 
     /**
+     * Checks if a given file exists and if it is writable.
+     * When the file does not exist, it will be created with assigned content.
+     *
+     * @param string $file absolute file path
+     *
+     * @throws \RuntimeException if the file is not readable or writable
+     */
+    public function ensureFileExists($file, $content = '')
+    {
+        if (is_dir($file)) {
+            throw new \RuntimeException($file . ' is a directory not a file.');
+        }
+        if (!file_exists($file) && !file_put_contents($file, $content)) {
+            throw new \RuntimeException($file . ' could not be created.');
+        }
+        if (!is_readable($file)) {
+            throw new \RuntimeException($file . ' is not readable.');
+        }
+        if (!is_writable($file)) {
+            throw new \RuntimeException($file . ' is not writable.');
+        }
+    }
+
+    /**
      * Copy then delete is a non-atomic version of {@link rename}.
      *
      * Some systems can't rename and also don't have proc_open,

--- a/tests/Composer/Resources/property/composer_test.json
+++ b/tests/Composer/Resources/property/composer_test.json
@@ -1,0 +1,9 @@
+{
+    "name": "composer/composer-test",
+
+    "description": "Dependency Manager",
+    "keywords": ["package", "dependency", "autoload"],
+    "homepage": "http://getcomposer.org/",
+    "type": "library",
+    "license": "MIT"
+}

--- a/tests/Composer/Resources/property/composer_test_changed_homepage.json
+++ b/tests/Composer/Resources/property/composer_test_changed_homepage.json
@@ -1,0 +1,9 @@
+{
+    "name": "composer/composer-test",
+
+    "description": "Dependency Manager",
+    "keywords": ["package", "dependency", "autoload"],
+    "homepage": "http://foo.bar.baz",
+    "type": "library",
+    "license": "MIT"
+}

--- a/tests/Composer/Resources/property/composer_test_changed_license.json
+++ b/tests/Composer/Resources/property/composer_test_changed_license.json
@@ -1,0 +1,9 @@
+{
+    "name": "composer/composer-test",
+
+    "description": "Dependency Manager",
+    "keywords": ["package", "dependency", "autoload"],
+    "homepage": "http://getcomposer.org/",
+    "type": "library",
+    "license": "FOO"
+}

--- a/tests/Composer/Resources/property/composer_test_changed_name.json
+++ b/tests/Composer/Resources/property/composer_test_changed_name.json
@@ -1,0 +1,9 @@
+{
+    "name": "foo/bar",
+
+    "description": "Dependency Manager",
+    "keywords": ["package", "dependency", "autoload"],
+    "homepage": "http://getcomposer.org/",
+    "type": "library",
+    "license": "MIT"
+}

--- a/tests/Composer/Resources/property/composer_test_changed_stability.json
+++ b/tests/Composer/Resources/property/composer_test_changed_stability.json
@@ -1,0 +1,10 @@
+{
+    "name": "composer/composer-test",
+
+    "description": "Dependency Manager",
+    "keywords": ["package", "dependency", "autoload"],
+    "homepage": "http://getcomposer.org/",
+    "type": "library",
+    "license": "MIT",
+    "minimum-stability": "beta"
+}

--- a/tests/Composer/Test/Command/Helper/FilesystemHelperTest.php
+++ b/tests/Composer/Test/Command/Helper/FilesystemHelperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Command\Helper;
+
+use Composer\Command\Helper\FilesystemHelper;
+
+class FilesystemHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEnsureFileExists()
+    {
+        $file = 'foo';
+        $content = 'bar';
+
+        $filesystem = $this->getMockBuilder('\Composer\Util\Filesystem')
+            ->disableOriginalConstructor()
+            ->setMethods(array('ensureFileExists'))
+            ->getMock();
+
+        $filesystem->expects($this->once())
+            ->method('ensureFileExists')
+            ->with($file, $content);
+
+        $filesystemHelper = new FilesystemHelper($filesystem);
+        $filesystemHelper->ensureFileExists($file, $content);
+    }
+}

--- a/tests/Composer/Test/Command/PropertySetCommandTest.php
+++ b/tests/Composer/Test/Command/PropertySetCommandTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Command;
+
+use Composer\Command\PropertySetCommand;
+
+class PropertySetCommandTest extends \PHPUnit_Framework_TestCase
+{
+    private $composerEnv = './composer_test.json';
+    private $origEnv;
+    private $testFile;
+    private $rootDir;
+    private $resourcesDir;
+
+    protected function setUp()
+    {
+        // getenv is internally used to customize composer.json file location
+        // using it here to not modify the original file
+        $this->origEnv = getenv('COMPOSER');
+        putenv('COMPOSER=' . $this->composerEnv);
+
+        $this->resourcesDir = __DIR__ . '/../../Resources/property';
+        $this->rootDir = __DIR__ . '/../../../..';
+
+        $this->testFile = $this->rootDir . DIRECTORY_SEPARATOR . '/composer_test.json';
+
+        file_put_contents(
+            $this->testFile,
+            $this->readResourcesFile('composer_test.json')
+        );
+    }
+
+    protected function tearDown()
+    {
+        // reset custom env var to not produce any side effects
+        putenv('COMPOSER=' . $this->origEnv);
+
+        if (file_exists($this->testFile)) {
+            unlink($this->testFile);
+        }
+    }
+
+    /**
+     * Exception is catched within command and error is added to output
+     *
+     * @group exception
+     */
+    public function testFileException()
+    {
+        $filesystemHelper = $this->getFilesystemHelper();
+
+        $filesystemHelper->expects($this->once())
+            ->method('ensureFileExists')
+            ->with($this->composerEnv)
+            ->will(
+                $this->returnCallback(
+                    function () {
+                        throw new \RuntimeException('foo exception');
+                    }
+                )
+            );
+
+        $input = $this->getInput();
+
+        $output = $this->getOutput();
+
+        $output->expects($this->once())
+            ->method('writeln')
+            ->with('<error>foo exception</error>');
+
+
+        $command = new PropertySetCommand();
+        $command->setHelperSet($this->getHelperSet($filesystemHelper));
+        $command->run($input, $output);
+    }
+
+    public function testAbortsWithInvalidProperty()
+    {
+        $filesystemHelper = $this->getFilesystemHelper();
+
+        $filesystemHelper->expects($this->once())
+            ->method('ensureFileExists')
+            ->with($this->composerEnv);
+
+        $input = $this->getInput();
+
+        // input calls done in parent Command class
+        // 0: $input->bind()
+        // 1: $input->isInteractive()
+        // 2: $input->validate()
+        // -> "at" index call starts by 3 in child Command classes
+        $input->expects($this->at(3))
+            ->method('getArgument')
+            ->with('name')
+            ->will($this->returnValue('invalid'));
+
+        $output = $this->getOutput();
+
+        $output->expects($this->once())
+            ->method('writeln')
+            ->with(
+                $this->callback(
+                    function ($e) {
+                        return (bool)preg_match("/<error>property \"invalid\" is not supported/", $e);
+                    }
+                )
+            );
+
+        $command = new PropertySetCommand();
+        $command->setHelperSet($this->getHelperSet($filesystemHelper));
+        $command->setComposer($this->getComposer());
+        $command->run($input, $output);
+    }
+
+    /**
+     * @dataProvider provideFiles
+     */
+    public function testSetWithWhitelistedProperty($name, $value, $checkFile)
+    {
+        $filesystemHelper = $this->getFilesystemHelper();
+
+        $filesystemHelper->expects($this->once())
+            ->method('ensureFileExists')
+            ->with($this->composerEnv);
+
+        $input = $this->getInput();
+
+        // input calls done in parent Command class
+        // 0: $input->bind()
+        // 1: $input->isInteractive()
+        // 2: $input->validate()
+        // -> "at" index call starts by 3 in child Command classes
+        $input->expects($this->at(3))
+            ->method('getArgument')
+            ->with('name')
+            ->will($this->returnValue($name));
+
+        $input->expects($this->at(4))
+            ->method('getArgument')
+            ->with('value')
+            ->will($this->returnValue($value));
+
+        $output = $this->getOutput();
+
+        $command = new PropertySetCommand();
+        $command->setHelperSet($this->getHelperSet($filesystemHelper));
+        $command->setComposer($this->getComposer());
+        $command->run($input, $output);
+
+        $this->assertEquals($this->readResourcesFile($checkFile), $this->readTestFile());
+    }
+
+    public static function provideFiles()
+    {
+        return array(
+            array('name', 'foo/bar', 'composer_test_changed_name.json'),
+            array('homepage', 'http://foo.bar.baz', 'composer_test_changed_homepage.json'),
+            array('license', 'FOO', 'composer_test_changed_license.json'),
+            array('minimum-stability', 'beta', 'composer_test_changed_stability.json'),
+        );
+    }
+
+    protected function getFilesystemHelper()
+    {
+        return $this->getMockBuilder('\Composer\Command\Helper\FilesystemHelper')
+            ->disableOriginalConstructor()
+            ->setMethods(array('ensureFileExists'))
+            ->getMock();
+    }
+
+    protected function getHelperSet($filesystemHelper)
+    {
+        $helperSet = $this->getMockBuilder('\Symfony\Component\Console\Helper\HelperSet')
+            ->disableOriginalConstructor()
+            ->setMethods(array('get'))
+            ->getMock();
+
+        $helperSet->expects($this->atLeastOnce())
+            ->method('get')
+            ->with('filesystem')
+            ->will($this->returnValue($filesystemHelper));
+
+        return $helperSet;
+    }
+
+    protected function getInput()
+    {
+        return $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+            ->getMockForAbstractClass();
+    }
+
+    protected function getOutput()
+    {
+        return $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+            ->getMockForAbstractClass();
+    }
+
+    protected function getComposer()
+    {
+        $eventDispatcher = $this->getMockBuilder('\Composer\EventDispatcher\EventDispatcher')
+            ->disableOriginalConstructor()
+            ->setMethods(array('dispatch'))
+            ->getMock();
+
+        $composer = $this->getMockBuilder('\Composer\Composer')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getEventDispatcher'))
+            ->getMock();
+
+        $composer->expects($this->atLeastOnce())
+            ->method('getEventDispatcher')
+            ->will($this->returnValue($eventDispatcher));
+
+        return $composer;
+    }
+
+    protected function readResourcesFile($file)
+    {
+        return file_get_contents($this->resourcesDir . DIRECTORY_SEPARATOR . $file);
+    }
+
+    protected function readTestFile()
+    {
+        return file_get_contents($this->testFile);
+    }
+}

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -17,6 +17,22 @@ use Composer\TestCase;
 
 class FilesystemTest extends TestCase
 {
+    private $rootDir;
+    private $testFile;
+
+    protected function setUp()
+    {
+        $this->rootDir = realpath(__DIR__ . '/../../../..');
+        $this->testFile = $this->rootDir . DIRECTORY_SEPARATOR . 'test.json';
+    }
+
+    protected function tearDown()
+    {
+        if (file_exists($this->testFile)) {
+            unlink($this->testFile);
+        }
+    }
+
     /**
      * @dataProvider providePathCouplesAsCode
      */
@@ -175,5 +191,29 @@ class FilesystemTest extends TestCase
             array('c:../b', 'c:.\\..\\a\\..\\b'),
             array('phar://c:../Foo', 'phar://c:../Foo'),
         );
+    }
+
+    public function testEnsureFileExistsCreatesFileWhenNotExisting()
+    {
+        $fs = new Filesystem();
+        $fs->ensureFileExists($this->testFile, 'foobar');
+
+        $this->assertEquals('foobar', file_get_contents($this->testFile));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage is not writable
+     */
+    public function testEnsureFileExistsThrowsExceptionWhenFileNotWritable()
+    {
+        // ouch ... somebody any idea how this could be better tested?
+        touch($this->testFile);
+        chmod($this->testFile, 0400);
+
+        $fs = new Filesystem();
+        $fs->ensureFileExists($this->testFile);
+
+        chmod($this->testFile, 0600);
     }
 }


### PR DESCRIPTION
As of #1411 I have added a new Command for changing simple properties like
- name
- description
- homepage
- minimum-stability (**not** stability)
- license

Example calls:
```
composer property-set name "foo/bar"
composer property-set minimum-stability "beta"
```

Things to discuss:
- I re-used some logic from `RequireCommand` and moved it to `Command\Helper\FileHelper`: Should be `RequireCommand` adapted accordingly?
- I tried to test several tests for this new command. Currently not many test cases for commands are existing and so I want to go sure if the used workflow is OK for you

