### PR TITLE
drop ^A

### DIFF
--- a/doc/articles/aliases.md
+++ b/doc/articles/aliases.md
@@ -65,7 +65,7 @@ local project.
 
 You are using `symfony/monolog-bundle` which requires `monolog/monolog` version
 `1.*`. So you need your `dev-bugfix` to match that constraint.
-
+
 Just add this to your project's root `composer.json`:
 
     {


### PR DESCRIPTION
added probably mistakenly in e34dae4d42a2bbe2ed9eb581f371ae3b00b8c4e2
