### PR TITLE
don't require the error message have the first line of HTTP output in it

### DIFF
--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -157,7 +157,6 @@ class RemoteFilesystemTest extends \PHPUnit_Framework_TestCase
         } catch (\Exception $e) {
             $this->assertInstanceOf('Composer\Downloader\TransportException', $e);
             $this->assertEquals(404, $e->getCode());
-            $this->assertContains('404 Not Found', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
HHVM doesn't match PHP on error message. The message we give is:

```
The "http://user:pass@www.example.com/something" file could not be downloaded: Failed to open http://user:pass@www.example.com/something ()
```

which seems reasonable. The test is already asserting it is 404 the line above.
