### PR TITLE
Optimization of VersionConstraint

### DIFF
--- a/src/Composer/Package/LinkConstraint/VersionConstraint.php
+++ b/src/Composer/Package/LinkConstraint/VersionConstraint.php
@@ -60,19 +60,20 @@ class VersionConstraint extends SpecificConstraint
         return version_compare($a, $b, $operator);
     }
 
+    /**
+     * @param  VersionConstraint $provider
+     * @param  bool              $compareBranches
+     * @return bool
+     */
     public function matchSpecific(VersionConstraint $provider, $compareBranches = false)
     {
         static $c = array();
         if (isset($c[$this->operator][$this->version][$provider->operator][$provider->version][$compareBranches])) {
-            //if ($c[$this->operator][$this->version][$provider->operator][$provider->version][$compareBranches] !=
-            //    $this->_matchSpecific($provider, $compareBranches)) {
-            //    throw new \Exception('Broken cache');
-            //}
             return $c[$this->operator][$this->version][$provider->operator][$provider->version][$compareBranches];
         }
 
         return $c[$this->operator][$this->version][$provider->operator][$provider->version][$compareBranches] =
-            $this->_matchSpecific($provider, $compareBranches);
+            $this->doMatchSpecific($provider, $compareBranches);
     }
 
     /**
@@ -80,7 +81,7 @@ class VersionConstraint extends SpecificConstraint
      * @param  bool              $compareBranches
      * @return bool
      */
-    public function _matchSpecific(VersionConstraint $provider, $compareBranches = false)
+    private function doMatchSpecific(VersionConstraint $provider, $compareBranches = false)
     {
         $noEqualOp = str_replace('=', '', $this->operator);
         $providerNoEqualOp = str_replace('=', '', $provider->operator);


### PR DESCRIPTION
I've added a no-braner cache to the `VersionConstraint::matchSpecific()` and this made `composer update` work 10% faster.

``` bash
# in the composer's own git repository:
wicked@wnote:~/Programming/composer-ak$ git checkout cache-version-constraint 
# ...
# then a few warmup runs and then:
wicked@wnote:~/Programming/composer-ak$ time bin/composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Nothing to install or update
Generating autoload files

real    0m13.365s
user    0m12.456s
sys 0m0.264s
wicked@wnote:~/Programming/composer-ak$ git checkout master
# ...
# then a few warmup runs and then:
wicked@wnote:~/Programming/composer-ak$ time bin/composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Nothing to install or update
Generating autoload files

real    0m14.784s
user    0m13.836s
sys 0m0.288s
```

I see the following pros and cons:
- pros:
  - real speedup of the whole `composer update`
  - simple realization, almost like regular function memoization, minimal code change
  - 97% hit ratio - so it seems the right place for the cache
- cons:
  - it's not covered by any tests explicitly - still not sure I've done it right
  - it can cause some tests interference if it doesn't work properly

You can ensure it works correctly by uncommenting the commented lines.
