### PR TITLE
Use 'cache-files-ttl' for cache gc, fixes #2441

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -62,7 +62,7 @@ class FileDownloader implements DownloaderInterface
         $this->cache = $cache;
 
         if ($this->cache && !self::$cacheCollected && !mt_rand(0, 50)) {
-            $this->cache->gc($config->get('cache-ttl'), $config->get('cache-files-maxsize'));
+            $this->cache->gc($config->get('cache-files-ttl'), $config->get('cache-files-maxsize'));
         }
         self::$cacheCollected = true;
     }


### PR DESCRIPTION
The configuration option 'cache-ttl' was used instead of 'cache-files-ttl' to determine
whether or not a cache gc should be performed.
- changed 'cache-ttl' to 'cache-files-ttl' to determine if a gc should be performed
