### PR TITLE
Use 'cache-files-ttl' for cache gc, fixes #2441

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -23,6 +23,7 @@ use Symfony\Component\Finder\Finder;
  */
 class Cache
 {
+    private static $cacheCollected = false;
     private $io;
     private $root;
     private $enabled = true;
@@ -126,6 +127,11 @@ class Cache
         return false;
     }
 
+    public function gcIsNecessary()
+    {
+       return (!self::$cacheCollected && !mt_rand(0, 50));
+    }
+
     public function remove($file)
     {
         $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
@@ -156,6 +162,8 @@ class Cache
                 $iterator->next();
             }
         }
+
+        self::$cacheCollected = true;
 
         return true;
     }

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -34,7 +34,6 @@ use Composer\Util\RemoteFilesystem;
  */
 class FileDownloader implements DownloaderInterface
 {
-    private static $cacheCollected = false;
     protected $io;
     protected $config;
     protected $rfs;
@@ -61,10 +60,10 @@ class FileDownloader implements DownloaderInterface
         $this->filesystem = $filesystem ?: new Filesystem();
         $this->cache = $cache;
 
-        if ($this->cache && !self::$cacheCollected && !mt_rand(0, 50)) {
-            $this->cache->gc($config->get('cache-ttl'), $config->get('cache-files-maxsize'));
+
+        if ($this->cache && $this->cache->gcIsNecessary()) {
+            $this->cache->gc($config->get('cache-files-ttl'), $config->get('cache-files-maxsize'));
         }
-        self::$cacheCollected = true;
     }
 
     /**


### PR DESCRIPTION
The configuration option 'cache-ttl' was used instead of 'cache-files-ttl' to determine
whether or not a cache gc should be performed.
- changed 'cache-ttl' to 'cache-files-ttl' to determine if a gc should be performed
- refactored FileDownloader to allow for easier testing
- added test to ensure that the gc is called with the proper config option
