### PR TITLE
fix bug in GitHubDriver

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -49,7 +49,7 @@ class GitHubDriver extends VcsDriver
         preg_match('#^(?:(?:https?|git)://([^/]+)/|git@([^:]+):)([^/]+)/(.+?)(?:\.git)?$#', $this->url, $match);
         $this->owner = $match[3];
         $this->repository = $match[4];
-        $this->originUrl = isset($match[1]) ? $match[1] : $match[2];
+        $this->originUrl = !empty($match[1]) ? $match[1] : $match[2];
         $this->cache = new Cache($this->io, $this->config->get('cache-repo-dir').'/'.$this->originUrl.'/'.$this->owner.'/'.$this->repository);
 
         $this->fetchRootIdentifier();
@@ -238,7 +238,7 @@ class GitHubDriver extends VcsDriver
             return false;
         }
 
-        $originUrl = isset($matches[2]) ? $matches[2] : $matches[3];
+        $originUrl = !empty($matches[2]) ? $matches[2] : $matches[3];
         if (!in_array($originUrl, $config->get('github-domains'))) {
             return false;
         }


### PR DESCRIPTION
Since I updated my composer today using self-update, I can't update my vendors.

All my forked github private repos (configured as vcs repositories) give me this error : 

```
Permission denied (publickey).                                                                              
fatal: Could not read from remote repository. 
```

After investigating the issue, I think the problem was introduced in this PR https://github.com/composer/composer/pull/2375.
In the GitHubDriver the `$originUrl` is now set like this : 

``` php
$this->originUrl = isset($match[1]) ? $match[1] : $match[2];
```

The problem is that `preg_match` sets `$match[1]`  to the empty string, not `null`. As a result, `$originUrl` is set to `""` instead of `"github.com"`.

By replacing the previous line by : 

``` php
$this->originUrl = !empty($match[1]) ? $match[1] : $match[2];
```

the `originUrl` is set to `"github.com"` and everything works fine.

I am not at all familiar with Composer's code, so please excuse me if that's not a viable solution.
