### PR TITLE
wrap call_user_func_array in a wrapper method which optimizes calls with at max 9 args.

### DIFF
--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Config;
 
+use Composer\Util\UserFunc;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
 
@@ -113,13 +114,13 @@ class JsonConfigSource implements ConfigSourceInterface
         $newFile = !$this->file->exists();
 
         // try to update cleanly
-        if (call_user_func_array(array($manipulator, $method), $args)) {
+        if (UserFunc::withArray(array($manipulator, $method), $args)) {
             file_put_contents($this->file->getPath(), $manipulator->getContents());
         } else {
             // on failed clean update, call the fallback and rewrite the whole file
             $config = $this->file->read();
             array_unshift($args, $config);
-            call_user_func_array($fallback, $args);
+            UserFunc::withArray($fallback, $args);
             $this->file->write($config);
         }
 

--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -16,6 +16,7 @@ use Composer\Package\PackageInterface;
 use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
 use Composer\Package\LinkConstraint\VersionConstraint;
+use Composer\Util\UserFunc;
 
 /**
  * @author Nils Adermann <naderman@naderman.de>
@@ -79,7 +80,7 @@ class DefaultPolicy implements PolicyInterface
             $literals = $this->pruneRemoteAliases($pool, $literals);
         }
 
-        $selected = call_user_func_array('array_merge', $packages);
+        $selected = UserFunc::withArray('array_merge', $packages);
 
         // now sort the result across all packages to respect replaces across packages
         usort($selected, function ($a, $b) use ($policy, $pool, $installedMap, $requiredPackage) {

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -12,6 +12,8 @@
 
 namespace Composer\DependencyResolver;
 
+use Composer\Util\UserFunc;
+
 /**
  * Represents a problem detected while solving dependencies
  *
@@ -71,7 +73,7 @@ class Problem
      */
     public function getPrettyString(array $installedMap = array())
     {
-        $reasons = call_user_func_array('array_merge', array_reverse($this->reasons));
+        $reasons = UserFunc::withArray('array_merge', array_reverse($this->reasons));
 
         if (count($reasons) === 1) {
             reset($reasons);

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -19,6 +19,7 @@ use Composer\Script;
 use Composer\Script\CommandEvent;
 use Composer\Script\PackageEvent;
 use Composer\Util\ProcessExecutor;
+use Composer\Util\UserFunc;
 
 /**
  * The Event Dispatcher.
@@ -217,7 +218,7 @@ class EventDispatcher
         $listeners = $this->listeners;
         $listeners[$event->getName()][0] = array_merge($listeners[$event->getName()][0], $scriptListeners);
 
-        return call_user_func_array('array_merge', $listeners[$event->getName()]);
+        return UserFunc::withArray('array_merge', $listeners[$event->getName()]);
     }
 
     /**

--- a/src/Composer/Repository/CompositeRepository.php
+++ b/src/Composer/Repository/CompositeRepository.php
@@ -13,6 +13,7 @@
 namespace Composer\Repository;
 
 use Composer\Package\PackageInterface;
+use Composer\Util\UserFunc;
 
 /**
  * Composite repository.
@@ -91,7 +92,7 @@ class CompositeRepository implements RepositoryInterface
             $packages[] = $repository->findPackages($name, $version);
         }
 
-        return $packages ? call_user_func_array('array_merge', $packages) : array();
+        return $packages ? UserFunc::withArray('array_merge', $packages) : array();
     }
 
     /**
@@ -105,7 +106,7 @@ class CompositeRepository implements RepositoryInterface
             $matches[] = $repository->search($query, $mode);
         }
 
-        return $matches ? call_user_func_array('array_merge', $matches) : array();
+        return $matches ? UserFunc::withArray('array_merge', $matches) : array();
     }
 
     /**
@@ -133,7 +134,7 @@ class CompositeRepository implements RepositoryInterface
             $packages[] = $repository->getPackages();
         }
 
-        return $packages ? call_user_func_array('array_merge', $packages) : array();
+        return $packages ? UserFunc::withArray('array_merge', $packages) : array();
     }
 
     /**

--- a/src/Composer/Util/UserFunc.php
+++ b/src/Composer/Util/UserFunc.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Util;
+
+class UserFunc
+{
+    public static function withArray($func, $args) {
+        $numArgs = count($args);
+        
+        if ($numArgs >= 1 && $numArgs <= 9) {
+            // make a 0-indexed array out of params.
+            // its not documented behaviour for call_user_func_array 
+            // but Composer relies on it in e.g. DefaultPolicy
+            $args0 = array();
+            foreach($args as $val) {
+                $args0[] = $val;
+            }
+        }
+        if (is_array($func)) {
+            list ($objOrClass, $method) = $func;
+            
+            if (is_object($objOrClass)) {
+                switch ($numArgs) {
+                    case 0: return $objOrClass->$method();
+                    case 1: return $objOrClass->$method($args0[0]);
+                    case 2: return $objOrClass->$method($args0[0], $args0[1]);
+                    case 3: return $objOrClass->$method($args0[0], $args0[1], $args0[2]);
+                    case 4: return $objOrClass->$method($args0[0], $args0[1], $args0[2], $args0[3]);
+                    case 5: return $objOrClass->$method($args0[0], $args0[1], $args0[2], $args0[3], $args0[4]);
+                    case 6: return $objOrClass->$method($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5]);
+                    case 7: return $objOrClass->$method($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5], $args0[6]);
+                    case 8: return $objOrClass->$method($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5], $args0[6], $args0[7]);
+                    case 9: return $objOrClass->$method($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5], $args0[6], $args0[7], $args0[8]);
+                }
+            } else {
+                switch ($numArgs) {
+                    case 0: return $objOrClass::$method();
+                    case 1: return $objOrClass::$method($args0[0]);
+                    case 2: return $objOrClass::$method($args0[0], $args0[1]);
+                    case 3: return $objOrClass::$method($args0[0], $args0[1], $args0[2]);
+                    case 4: return $objOrClass::$method($args0[0], $args0[1], $args0[2], $args0[3]);
+                    case 5: return $objOrClass::$method($args0[0], $args0[1], $args0[2], $args0[3], $args0[4]);
+                    case 6: return $objOrClass::$method($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5]);
+                    case 7: return $objOrClass::$method($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5], $args0[6]);
+                    case 8: return $objOrClass::$method($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5], $args0[6], $args0[7]);
+                    case 9: return $objOrClass::$method($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5], $args0[6], $args0[7], $args0[8]);
+                }
+            }            
+        }
+                
+        switch ($numArgs) {
+            case 0: return $func();
+            case 1: return $func($args0[0]);
+            case 2: return $func($args0[0], $args0[1]);
+            case 3: return $func($args0[0], $args0[1], $args0[2]);
+            case 4: return $func($args0[0], $args0[1], $args0[2], $args0[3]);
+            case 5: return $func($args0[0], $args0[1], $args0[2], $args0[3], $args0[4]);
+            case 6: return $func($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5]);
+            case 7: return $func($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5], $args0[6]);
+            case 8: return $func($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5], $args0[6], $args0[7]);
+            case 9: return $func($args0[0], $args0[1], $args0[2], $args0[3], $args0[4], $args0[5], $args0[6], $args0[7], $args0[8]);
+        }
+        
+        // call_user_func_array is faster when more arguments are in the game
+        return call_user_func_array($func, $args);
+    }
+}


### PR DESCRIPTION
on my machine this make things faster.

with the patch

```
php bin/composer update --profile --dry-run
Memory usage: 31.88MB (peak: 57.62MB), time: 7.24s
```

without the patch

```
composer update --profile --dry-run
Memory usage: 31.88MB (peak: 56.62MB), time: 8.13s
```

measured it ~20 times and its roughly 1sec faster including the patch (though peak memory rised 1MB).
I intentionally did not make changes in files which are used by a app at runtime (classloader). Idea was to speedup things for a dev while update/install.

In case you like it we could also add unit-tests.
