### PR TITLE
Updated ClassLoader.php to enable multiple namespaces with safe

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -182,7 +182,7 @@ class ClassLoader
     public function loadClass($class)
     {
         if ($file = $this->findFile($class)) {
-            include $file;
+            include_once $file;
 
             return true;
         }


### PR DESCRIPTION
I've changed from "include" to "include_once" to enable Composer to support multiple namespaces at once.
