### PR TITLE
Check exclude from downloaded composer.json

### DIFF
--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -16,6 +16,7 @@ use Composer\Downloader\DownloadManager;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackage;
 use Composer\Util\Filesystem;
+use Composer\Json\JsonFile;
 
 /**
  * @author Matthieu Moquet <matthieu@moquet.net>
@@ -141,6 +142,13 @@ class ArchiveManager
 
             // Download sources
             $this->downloadManager->download($package, $sourcePath);
+
+            // Check exclude from downloaded composer.json
+            $jsonFile = new JsonFile($sourcePath.'/composer.json');
+            $jsonData = $jsonFile->read();
+            if (!empty($jsonData['archive']['exclude'])) {
+                $package->setArchiveExcludes($jsonData['archive']['exclude']);
+            }
         }
 
         // Create the archive

--- a/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
@@ -79,13 +79,13 @@ class ArchiveManagerTest extends ArchiverTest
             throw new \RuntimeException('Could not init: '.$this->process->getErrorOutput());
         }
 
-        $result = file_put_contents('b', 'a');
+        $result = file_put_contents('composer.json', '{"name":"faker/faker", "description": "description", "license": "MIT"}');
         if (false === $result) {
             chdir($currentWorkDir);
             throw new \RuntimeException('Could not save file.');
         }
 
-        $result = $this->process->execute('git add b && git commit -m "commit b" -q', $output, $this->testDir);
+        $result = $this->process->execute('git add composer.json && git commit -m "commit composer.json" -q', $output, $this->testDir);
         if ($result > 0) {
             chdir($currentWorkDir);
             throw new \RuntimeException('Could not commit: '.$this->process->getErrorOutput());


### PR DESCRIPTION
Hi !

I met a problem when archiving a repo from packagist.

https://github.com/liip/LiipImagineBundle has a [composer archive property](http://getcomposer.org/doc/04-schema.md#archive) which excludes a directory from the archive. But it seems it does not work because packagist doesn't give this property.

Thanks to @adriensamson for your help ;)
