### PR TITLE
suggest available package versions in interactive mode

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -233,7 +233,7 @@ EOT
      * @return array                     array(CompletePackageInterface, array of versions)
      * @throws \InvalidArgumentException
      */
-    protected function getPackage(RepositoryInterface $installedRepo, RepositoryInterface $repos, $name, $version = null)
+    public function getPackage(RepositoryInterface $installedRepo, RepositoryInterface $repos, $name, $version = null)
     {
         $name = strtolower($name);
         $constraint = null;


### PR DESCRIPTION
**motivation:** I generally know the package I want, but don't remember the version. Opening a new terminal session and running `composer show -a repo/package` is too much of a hassle.

**changes:** `composer init` (and consequently `composer require`) shows available versions of picked package if it is not specified explicitly.

**remarks:** since the version finder is hardcoded in `show` command, I just changed it to public. This is rather messy and it should be refactored prior to merging this patch with master. This pull request should serve for a discussion regarding the WIP.

*Original vs patched version*:
![original version and patched version](https://f.cloud.github.com/assets/192200/1712641/43eb4bde-6179-11e3-9af6-8f587dc87e60.png)
