### PR TITLE
[alias] RootAliasPackage manages the requirements correctly

### DIFF
--- a/src/Composer/Package/RootAliasPackage.php
+++ b/src/Composer/Package/RootAliasPackage.php
@@ -63,18 +63,24 @@ class RootAliasPackage extends AliasPackage implements RootPackageInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @param array $require
+     * @return mixed
      */
     public function setRequires(array $require)
     {
+        $this->requires = $this->replaceSelfVersionDependencies($require, 'requires');
+
         return $this->aliasOf->setRequires($require);
     }
 
     /**
-     * {@inheritDoc}
+     * @param array $devRequire
+     * @return mixed
      */
     public function setDevRequires(array $devRequire)
     {
+        $this->devRequires = $this->replaceSelfVersionDependencies($devRequire, 'devRequires');
+
         return $this->aliasOf->setDevRequires($devRequire);
     }
 


### PR DESCRIPTION
The data integrity of requirements in RootAliasPackage is broken. 

Let's assume, we have an `aliased` package:

```json
{
    "name": "my/package",
    "description": "My best package",
    "require": {
        "php": ">=5.3.3",
        "symfony/symfony": "2.3.6"
    },
    "extra": {
        "branch-alias": {
            "dev-master": "0.1-dev"
        }
    }
}
```

If we want to dynamically install a new package

```php
use Composer\Factory;
use Composer\IO\BufferIO;
use Composer\Installer;

$newPackage = array('my/new-package' => '1.0');
$io = new BufferIO;

$composer = Factory::create($io);
$composer->getRootPackage()->setRequires(array_merge(
  $composer->getRootPackage()->getRequires(),
  $newPackage
));

$installer = Installer::create($io, $composer);
$installer
    ->setDryRun(false)
    ->setVerbose(true)
    ->setPreferSource(false)
    ->setPreferDist(true)
    ->setDevMode(false)
    ->setRunScripts(true)
    ->setUpdate(true)
    ->setUpdateWhitelist(array('my/new-package'))
    ->setOptimizeAutoloader(true)
    ->run()
;
```
we get an unexpected result. Composer will install nothing. The issue is that `Installer` uses `RootPackage` to compute the difference between already installed and new packages. But in the case of  `aliased` package, installer deals with a `RootAliasPackage`. RootAliasPackage package is able to set new requirements for original RootPackage, but this changes won't affect itself (an immutable property). So Installer works with outdated set of requirements.

This PR fixes the issue described above.

I didn't add the tests cuz couldn't find a test which should be edited. But all other passed successfully

![2013-12-10 12 54 17](https://f.cloud.github.com/assets/365720/1713381/7473e9ae-6189-11e3-853a-418a4023f740.png)
