### PR TITLE
Fix error on check exclude from download composer.json

### DIFF
--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -144,10 +144,12 @@ class ArchiveManager
             $this->downloadManager->download($package, $sourcePath);
 
             // Check exclude from downloaded composer.json
-            $jsonFile = new JsonFile($sourcePath.'/composer.json');
-            $jsonData = $jsonFile->read();
-            if (!empty($jsonData['archive']['exclude'])) {
-                $package->setArchiveExcludes($jsonData['archive']['exclude']);
+            if (file_exists($composerJsonPath = $sourcePath.'/composer.json')) {
+                $jsonFile = new JsonFile($composerJsonPath);
+                $jsonData = $jsonFile->read();
+                if (!empty($jsonData['archive']['exclude'])) {
+                    $package->setArchiveExcludes($jsonData['archive']['exclude']);
+                }
             }
         }
 


### PR DESCRIPTION
@lcf reports an error on check exclude from downloaded `composer.json` (https://github.com/composer/composer/commit/ca7cb68dd5739b0405b3de5f4854cda44d9660e3).
