### PR TITLE
Skip aliases packages when looking for plugins.

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -18,6 +18,7 @@ use Composer\IO\IOInterface;
 use Composer\Package\Package;
 use Composer\Package\Version\VersionParser;
 use Composer\Repository\RepositoryInterface;
+use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;
 use Composer\Package\Link;
 use Composer\Package\LinkConstraint\VersionConstraint;
@@ -95,6 +96,9 @@ class PluginManager
     protected function loadRepository(RepositoryInterface $repo)
     {
         foreach ($repo->getPackages() as $package) {
+            if ($package instanceof AliasPackage) {
+                continue;
+            }
             if ('composer-plugin' === $package->getType()) {
                 $requiresComposer = null;
                 foreach ($package->getRequires() as $link) {


### PR DESCRIPTION
I was running into a case where my dev plugin was being fired twice. It took awhile to track down but it looks to be because the plugin was being created for both the package and the alias package. This patch seems to fix it in my case but I'm not sure if there might be reasons not to do this.
