### PR TITLE
Add information on how to run scripts manually

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -9,7 +9,7 @@
 A script, in Composer's terms, can either be a PHP callback (defined as a
 static method) or any command-line executable command. Scripts are useful
 for executing a package's custom code or package-specific commands during
-the Composer execution process.r
+the Composer execution process.
 
 **NOTE: Only scripts defined in the root package's `composer.json` are
 executed. If a dependency of the root package specifies its own scripts,


### PR DESCRIPTION
Whenever writing scripts, the first place I look is here, but then I remember it never tells me how to run the script events manually, so I thought this might be useful.
