### PR TITLE
Docs: Added Note about tags vs. version constraint

### DIFF
--- a/doc/02-libraries.md
+++ b/doc/02-libraries.md
@@ -82,6 +82,10 @@ Here are a few examples of valid tag names:
     v2.0.0-alpha
     v2.0.4-p1
 
+> **Note:** Even if your tag is prefixed with `v`, a [version constraint](01-basic-usage.md#package-versions)
+> in a `require` statement has to be specified without prefix
+> (e.g. tag `v1.0.0` will result in version `1.0.0`). 
+
 ### Branches
 
 For every branch, a package development version will be created. If the branch


### PR DESCRIPTION
I made this mistake myself a few days ago, so I think it will be useful to note that here.

https://github.com/yiisoft/yii2/commit/85a15424bd1d84525bd05ddc19ff157f5cb0e829
https://github.com/yiisoft/yii2/commit/594fd2daed88ad939acf727467e8a4f4d3511f95
