### PR TITLE
Feature: --self-update --rollback

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -91,8 +91,6 @@ EOT
             $rollbackVersion = $this->getLastVersion($rollbackDir);
             if (!$rollbackVersion) {
                 throw new FilesystemException('Composer rollback failed: no installation to roll back to in "'.$rollbackDir.'"');
-
-                return 1;
             }
         }
 


### PR DESCRIPTION
Hopefully resolves https://github.com/composer/composer/issues/2371

Given that `${VERSION}` is the version of the running instance of composer:
- `composer self-update` saves a copy of the running `composer.phar` into `$config->get('home')/${VERSION}-old.phar`.
- `composer self-update --rollback` or `composer self-update -r` takes the **last** `$config->get('home') /${OTHER_VERSION}-old.phar` and replaces the running `composer.phar` with that file. This is done via `filemtime()`
- `composer self-update --clean-rollbacks` removes all `$config->get('home')/*-old.phar` files before saving the current `composer.phar` into `$config->get('home')/${VERSION}-old.phar`.
