### PR TITLE
Allow the autoloader suffix to be configurable

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -177,7 +177,7 @@
                     "description": "The default style of handling dirty updates, defaults to false and can be any of true, false or \"stash\"."
                 },
                 "autoloader-suffix": {
-                    "type": ["string", "boolean"],
+                    "type": "string",
                     "description": "Optional string to be used as a suffix to the autoloader generator. When null a random one will be generated."
                 },
                 "prepend-autoloader": {

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -169,7 +169,7 @@ EOF;
         $classmapFile .= ");\n";
 
         if (!$suffix) {
-            $suffix = $config->get('autoloader-suffix') ? $config->get('autoloader-suffix') : md5(uniqid('', true));
+            $suffix = $config->get('autoloader-suffix') ?: md5(uniqid('', true));
         }
 
         file_put_contents($targetDir.'/autoload_namespaces.php', $namespacesFile);

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -35,7 +35,7 @@ class Config
         'cache-files-ttl' => null, // fallback to cache-ttl
         'cache-files-maxsize' => '300MiB',
         'discard-changes' => false,
-        'autoload-suffix' => false,
+        'autoload-suffix' => null,
         'prepend-autoloader' => true,
         'github-domains' => array('github.com'),
     );


### PR DESCRIPTION
This change would allow for the ComposerAutoloaderInit class name to be configurable.  This is useful for some projects where deployment may not be atomic and the class name change could cause problems.  It would also prevent the file from appearing as changed when no changes have actually occurred, which can be helpful in a variety of deployment scenarios.

Seems like this would also resolve issue #1413
