### PR TITLE
ConfigValidator Bugfix: ensure that require-dev exists during override check

### DIFF
--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -108,9 +108,14 @@ class ConfigValidator
             $warnings[] = "The package type 'composer-installer' is deprecated. Please distribute your custom installers as plugins from now on. See http://getcomposer.org/doc/articles/plugins.md for plugin documentation.";
         }
 
-        $requireOverrides = array_intersect_key($manifest['require'], $manifest['require-dev']);
-        if (!empty($requireOverrides)) {
-            $warnings[] = implode(', ', array_keys($requireOverrides)). " is required both in require and require-dev, this can lead to unexpected behavior";
+        // check for require-dev overrides
+        if (isset($manifest['require']) && isset($manifest['require-dev'])) {
+          $requireOverrides = array_intersect_key($manifest['require'], $manifest['require-dev']);
+
+          if (!empty($requireOverrides)) {
+            $plural = (count($requireOverrides) > 1) ? 'are' : 'is';
+            $warnings[] = implode(', ', array_keys($requireOverrides)). " {$plural} required both in require and require-dev, this can lead to unexpected behavior";
+          }
         }
 
         try {


### PR DESCRIPTION
- Ensure that require-dev is present before checking for dependeny overrides.
- A small grammar update for the warning message.

This is to address what @jhampton mentioned: https://github.com/composer/composer/issues/2503#issuecomment-31286820
