### PR TITLE
List all available downloader types in exception message

### DIFF
--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -109,7 +109,7 @@ class DownloadManager
     {
         $type = strtolower($type);
         if (!isset($this->downloaders[$type])) {
-            throw new \InvalidArgumentException('Unknown downloader type: '.$type);
+            throw new \InvalidArgumentException(sprintf('Unknown downloader type: %s. Available types: %s.', $type, implode(', ', array_keys($this->downloaders))));
         }
 
         return $this->downloaders[$type];


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

This small change can help developers to replace unsupported downloader type with one of available types.
