### PR TITLE
Escape env value before passing it to system call

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -132,7 +132,7 @@ EOT
     {
         // Open file in editor
         if ($input->getOption('editor')) {
-            $editor = getenv('EDITOR');
+            $editor = escapeshellcmd(getenv('EDITOR'));
             if (!$editor) {
                 if (defined('PHP_WINDOWS_VERSION_BUILD')) {
                     $editor = 'notepad';


### PR DESCRIPTION
You can possible inject shell commands into composer config command.

```
EDITOR="ls;gedit" composer config -e
```
