### PR TITLE
added svn tags, trunk, branches handling for root packages; minor interface fixes

### DIFF
--- a/src/Composer/Package/CompletePackage.php
+++ b/src/Composer/Package/CompletePackage.php
@@ -45,9 +45,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * Set the repositories
-     *
-     * @param string $repositories
+     * {@inheritDoc}
      */
     public function setRepositories($repositories)
     {

--- a/src/Composer/Package/CompletePackageInterface.php
+++ b/src/Composer/Package/CompletePackageInterface.php
@@ -78,4 +78,11 @@ interface CompletePackageInterface extends PackageInterface
      * @return array
      */
     public function getSupport();
+
+    /**
+     * Set the repositories
+     *
+     * @param string $repositories
+     */
+    public function setRepositories($repositories);
 }

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -116,7 +116,7 @@ class Package extends BasePackage
     public function getTargetDir()
     {
         if (null === $this->targetDir) {
-            return;
+            return '';
         }
 
         return ltrim(preg_replace('{ (?:^|[\\\\/]+) \.\.? (?:[\\\\/]+|$) (?:\.\.? (?:[\\\\/]+|$) )*}x', '/', $this->targetDir), '/');
@@ -171,7 +171,7 @@ class Package extends BasePackage
     }
 
     /**
-     * @param string $alias
+     * {@inheritDoc}
      */
     public function setAlias($alias)
     {
@@ -349,7 +349,7 @@ class Package extends BasePackage
     /**
      * Set the releaseDate
      *
-     * @param DateTime $releaseDate
+     * @param \DateTime $releaseDate
      */
     public function setReleaseDate(\DateTime $releaseDate)
     {

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -308,4 +308,9 @@ interface PackageInterface
      * @return string
      */
     public function getPrettyString();
+
+    /**
+     * @param array $aliases
+     */
+    public function setAliases(array $aliases);
 }

--- a/src/Composer/Package/RootPackage.php
+++ b/src/Composer/Package/RootPackage.php
@@ -24,9 +24,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     protected $references = array();
 
     /**
-     * Set the minimumStability
-     *
-     * @param string $minimumStability
+     * {@inheritDoc}
      */
     public function setMinimumStability($minimumStability)
     {
@@ -42,9 +40,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     }
 
     /**
-     * Set the stabilityFlags
-     *
-     * @param array $stabilityFlags
+     * {@inheritDoc}
      */
     public function setStabilityFlags(array $stabilityFlags)
     {
@@ -60,9 +56,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     }
 
     /**
-     * Set the references
-     *
-     * @param array $references
+     * {@inheritDoc}
      */
     public function setReferences(array $references)
     {

--- a/src/Composer/Package/RootPackageInterface.php
+++ b/src/Composer/Package/RootPackageInterface.php
@@ -43,4 +43,25 @@ interface RootPackageInterface extends CompletePackageInterface
      * @return array
      */
     public function getReferences();
+
+    /**
+     * Set the stabilityFlags
+     *
+     * @param array $stabilityFlags
+     */
+    public function setStabilityFlags(array $stabilityFlags);
+
+    /**
+     * Set the references
+     *
+     * @param array $references
+     */
+    public function setReferences(array $references);
+
+    /**
+     * Set the minimumStability
+     *
+     * @param string $minimumStability
+     */
+    public function setMinimumStability($minimumStability);
 }


### PR DESCRIPTION
Currently there is no handling available for svn based packages.

We have svn repository:

/ProjectA/trunk
/ProjectA/branches/...
/ProjectA/tags/...

/ProjectB/trunk
/ProjectB/branches/...
/ProjectB/tags/...

in ProjectA we want to require: "my-vendor/projectb": "self.version".

now, when we create a branch dev-latest-testing in ProjectA, it should reference the branch /ProjectB/branches/dev-latest-testing, without always have to change the "version" parameter in composer.json for all our branches.

I guess this PR, will add this function.

Your feedback is really appreciated.
