### PR TITLE
Added a tree view of required packages

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -299,6 +299,7 @@ php composer.phar show monolog/monolog 1.0.2
 * **--installed (-i):** List the packages that are installed.
 * **--platform (-p):** List only platform packages (php & extensions).
 * **--self (-s):** List the root package info.
+* **--tree (-t):** List the dependencies as a tree.
 
 ## browse / home
 


### PR DESCRIPTION
I've added a new option for the `show` command.

```bash
$ composer show -t
```
will display something like:
```
justinrainbow/json-schema    1.1.0
└── php >= 5.3.0.0
phpunit/php-code-coverage    1.2.13 Library that provides collection, processing, and rendering functionality for PHP code coverage information.
├── php >= 5.3.3.0
├── phpunit/php-file-iterator >= 1.3.0.0
├── phpunit/php-text-template >= 1.1.1.0
└── phpunit/php-token-stream >= 1.1.3.0
phpunit/php-file-iterator    1.3.4  FilterIterator implementation that filters files based on a list of suffixes.
└── php >= 5.3.3.0
phpunit/php-text-template    1.1.4  Simple template engine.
└── php >= 5.3.3.0
phpunit/php-timer            1.0.5  Utility class for timing
└── php >= 5.3.3.0
phpunit/php-token-stream     1.2.1  Wrapper around PHP's tokenizer extension.
├── ext-tokenizer []
└── php >= 5.3.3.0
phpunit/phpunit              3.7.28 The PHP Unit Testing framework.
├── ext-dom []
├── ext-pcre []
├── ext-reflection []
├── ext-spl []
├── php >= 5.3.3.0
├── phpunit/php-code-coverage [>= 1.2.1.0-dev, < 1.3.0.0-dev]
├── phpunit/php-file-iterator >= 1.3.1.0
├── phpunit/php-text-template >= 1.1.1.0
├── phpunit/php-timer >= 1.0.4.0
├── phpunit/phpunit-mock-objects [>= 1.2.0.0-dev, < 1.3.0.0-dev]
└── symfony/yaml [>= 2.0.0.0-dev, < 3.0.0.0-dev]
phpunit/phpunit-mock-objects 1.2.3  Mock Object library for PHPUnit
├── php >= 5.3.3.0
└── phpunit/php-text-template >= 1.1.1.0
seld/jsonlint                1.1.2  JSON Linter
└── php >= 5.3.0.0
symfony/console              v2.4.1 Symfony Console Component
└── php >= 5.3.3.0
symfony/finder               v2.4.1 Symfony Finder Component
└── php >= 5.3.3.0
symfony/process              v2.4.1 Symfony Process Component
└── php >= 5.3.3.0
symfony/yaml                 v2.4.1 Symfony Yaml Component
└── php >= 5.3.3.0
```