### PR TITLE
bug fix with install / remove source codes

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -178,7 +178,7 @@ class LibraryInstaller implements InstallerInterface
 
     protected function removeCode(PackageInterface $package)
     {
-        $downloadPath = $this->getPackageBasePath($package);
+        $downloadPath = $this->getInstallPath($package);
         $this->downloadManager->remove($package, $downloadPath);
     }
 


### PR DESCRIPTION
Source files aren't installed and removed from the same path. 
- install use getInstallPath() method to install sources and remove use getPackageBasePath one
- problem with targetDir package attribute
