### PR TITLE
PSR-4 classes were always whitelisted from optimized classmaps.

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -166,9 +166,8 @@ EOF;
                             continue;
                         }
                         $whitelist = sprintf(
-                            '{%s/%s.+(?<!(?<!/)Test\.php)$}',
-                            preg_quote($dir),
-                            ($psrType === 'psr-4' || strpos($namespace, '_') === false) ? preg_quote(strtr($namespace, '\\', '/')) : ''
+                            '{%s/.+(?<!(?<!/)Test\.php)$}',
+                            preg_quote($dir)
                         );
                         foreach (ClassMapGenerator::createMap($dir, $whitelist) as $class => $path) {
                             if ('' === $namespace || 0 === strpos($class, $namespace)) {


### PR DESCRIPTION
Right now the namespace was still prefixed to the folders corresponding with that prefix. Removing this restriction allows PSR-4 classes to be included in the optimised class maps.
