### PR TITLE
Fix PSR-4 autoload classmap generator

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -168,7 +168,7 @@ EOF;
                         $whitelist = sprintf(
                             '{%s/%s.+(?<!(?<!/)Test\.php)$}',
                             preg_quote($dir),
-                            ($psrType === 'psr-4' || strpos($namespace, '_') === false) ? preg_quote(strtr($namespace, '\\', '/')) : ''
+                            ($psrType === 'psr-0' && strpos($namespace, '_') === false) ? preg_quote(strtr($namespace, '\\', '/')) : ''
                         );
                         foreach (ClassMapGenerator::createMap($dir, $whitelist) as $class => $path) {
                             if ('' === $namespace || 0 === strpos($class, $namespace)) {

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -111,17 +111,19 @@ class AutoloadGeneratorTest extends TestCase
             ->will($this->returnValue(array()));
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/composer');
-        $this->fs->ensureDirectoryExists($this->workingDir.'/src');
+        $this->fs->ensureDirectoryExists($this->workingDir.'/src/Lala');
         $this->fs->ensureDirectoryExists($this->workingDir.'/lib');
+        file_put_contents($this->workingDir.'/src/Lala/ClassMapMain.php', '<?php namespace Lala; class ClassMapMain {}');
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/src-fruit');
         $this->fs->ensureDirectoryExists($this->workingDir.'/src-cake');
         $this->fs->ensureDirectoryExists($this->workingDir.'/lib-cake');
+        file_put_contents($this->workingDir.'/src-cake/ClassMapBar.php', '<?php namespace Acme\Cake; class ClassMapBar {}');
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/composersrc');
         file_put_contents($this->workingDir.'/composersrc/foo.php', '<?php class ClassMapFoo {}');
 
-        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', false, '_1');
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', true, '_1');
 
         // Assert that autoload_namespaces.php was correctly generated.
         $this->assertAutoloadFiles('main', $this->vendorDir.'/composer');

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_classmap.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_classmap.php
@@ -6,5 +6,7 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
+    'Acme\\Cake\\ClassMapBar' => $baseDir . '/src-cake/ClassMapBar.php',
     'ClassMapFoo' => $baseDir . '/composersrc/foo.php',
+    'Lala\\ClassMapMain' => $baseDir . '/src/Lala/ClassMapMain.php',
 );


### PR DESCRIPTION
`autoload_classmap.php` file does not contain PSR-4 classes when we use `--optimize` option.

Fix #2625 and replace #2655.
