### PR TITLE
Fixed handling of Metapackages in DownloadManager.

### DIFF
--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -179,7 +179,9 @@ class DownloadManager
         $this->filesystem->ensureDirectoryExists($targetDir);
 
         $downloader = $this->getDownloaderForInstalledPackage($package);
-        $downloader->download($package, $targetDir);
+        if($downloader) {
+            $downloader->download($package, $targetDir);
+        }
     }
 
     /**
@@ -194,6 +196,11 @@ class DownloadManager
     public function update(PackageInterface $initial, PackageInterface $target, $targetDir)
     {
         $downloader = $this->getDownloaderForInstalledPackage($initial);
+        if(!$downloader) {
+
+            return;
+        }
+
         $installationSource = $initial->getInstallationSource();
 
         if ('dist' === $installationSource) {
@@ -230,6 +237,8 @@ class DownloadManager
     public function remove(PackageInterface $package, $targetDir)
     {
         $downloader = $this->getDownloaderForInstalledPackage($package);
-        $downloader->remove($package, $targetDir);
+        if($downloader) {
+            $downloader->remove($package, $targetDir);
+        }
     }
 }


### PR DESCRIPTION
The "getDownloaderForInstalledPackage" returns null for "metapackage" and the download(), update() and remove() methods did not handle this correctly.
