### PR TITLE
Adding ssh protocol support to "github-protocols".

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -294,8 +294,8 @@ EOT
                     }
 
                     foreach ($vals as $val) {
-                        if (!in_array($val, array('git', 'https'))) {
-                            return 'valid protocols include: git, https';
+                        if (!in_array($val, array('git', 'https', 'ssh'))) {
+                            return 'valid protocols include: git, https, ssh';
                         }
                     }
 

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -24,7 +24,7 @@ class Config
         'use-include-path' => false,
         'preferred-install' => 'auto',
         'notify-on-install' => true,
-        'github-protocols' => array('git', 'https'),
+        'github-protocols' => array('git', 'https', 'ssh'),
         'vendor-dir' => 'vendor',
         'bin-dir' => '{$vendor-dir}/bin',
         'cache-dir' => '{$home}/cache',
@@ -206,7 +206,7 @@ class Config
 
             case 'github-protocols':
                 if (reset($this->config['github-protocols']) === 'http') {
-                    throw new \RuntimeException('The http protocol for github is not available anymore, update your config\'s github-protocols to use "https" or "git"');
+                    throw new \RuntimeException('The http protocol for github is not available anymore, update your config\'s github-protocols to use "https" or "git" or "ssh"');
                 }
 
                 return $this->config[$key];

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -312,14 +312,19 @@ class GitDownloader extends VcsDownloader
         }
 
         // public github, autoswitch protocols
-        if (preg_match('{^(?:https?|git)(://'.$this->getGitHubDomainsRegex().'/.*)}', $url, $match)) {
+        if (preg_match('{^(?:https?|git)://'.$this->getGitHubDomainsRegex().'/(.*)}', $url, $match)) {
             $protocols = $this->config->get('github-protocols');
             if (!is_array($protocols)) {
                 throw new \RuntimeException('Config value "github-protocols" must be an array, got '.gettype($protocols));
             }
             $messages = array();
             foreach ($protocols as $protocol) {
-                $url = $protocol . $match[1];
+                if ('ssh' === $protocol) {
+                    $url = "git@" . $match[1] . ":" . $match[2];
+                } else {
+                    $url = $protocol ."://" . $match[1] . "/" . $match[2];
+                }
+
                 if (0 === $this->process->execute(call_user_func($commandCallable, $url), $ignoredOutput, $cwd)) {
                     return;
                 }


### PR DESCRIPTION
Adding SSH support for "GitHub". This fixes a few issues I've ran into and provides another method to try when everything else fails.  (https fails because of auth in "git clone", and git being disabled in "github" configuration)

This is based on:
- https://help.github.com/articles/generating-ssh-keys
- http://git-scm.com/book/ch4-1.html#The-SSH-Protocol
