### PR TITLE
[gh-2658] Add support for "doc_dir" to PEAR compatibilty layer.

### DIFF
--- a/src/Composer/Installer/PearInstaller.php
+++ b/src/Composer/Installer/PearInstaller.php
@@ -67,12 +67,13 @@ class PearInstaller extends LibraryInstaller
             'php_dir' => $installPath,
             'bin_dir' => $installPath . '/bin',
             'data_dir' => $installPath . '/data',
+            'doc_dir' => $installPath . '/doc',
             'version' => $package->getPrettyVersion(),
         );
 
         $packageArchive = $this->getInstallPath($package).'/'.pathinfo($package->getDistUrl(), PATHINFO_BASENAME);
         $pearExtractor = new PearPackageExtractor($packageArchive);
-        $pearExtractor->extractTo($this->getInstallPath($package), array('php' => '/', 'script' => '/bin', 'data' => '/data'), $vars);
+        $pearExtractor->extractTo($this->getInstallPath($package), array('php' => '/', 'script' => '/bin', 'data' => '/data', 'doc' => '/doc'), $vars);
 
         if ($this->io->isVerbose()) {
             $this->io->write('    Cleaning up');


### PR DESCRIPTION
Composer's PEAR legacy support silently ignored any "doc" role items,
which break certain packages, notably pman.

I have also upgraded the baseinstalldir support to be more conforming to
the spec. According to http://pear.php.net/manual/en/guide.users.concepts.filerole.php
only php,script,www honor baseinstalldir; all other roles should ignore it.
