### PR TITLE
Fix Cache::gc() when COMPOSER_CACHE_DIR=/dev/null

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -144,28 +144,33 @@ class Cache
 
     public function gc($ttl, $maxSize)
     {
-        $expire = new \DateTime();
-        $expire->modify('-'.$ttl.' seconds');
+        if ($this->enabled)
+        {
+            $expire = new \DateTime();
+            $expire->modify('-'.$ttl.' seconds');
 
-        $finder = $this->getFinder()->date('until '.$expire->format('Y-m-d H:i:s'));
-        foreach ($finder as $file) {
-            unlink($file->getRealPath());
-        }
-
-        $totalSize = $this->filesystem->size($this->root);
-        if ($totalSize > $maxSize) {
-            $iterator = $this->getFinder()->sortByAccessedTime()->getIterator();
-            while ($totalSize > $maxSize && $iterator->valid()) {
-                $filepath = $iterator->current()->getRealPath();
-                $totalSize -= $this->filesystem->size($filepath);
-                unlink($filepath);
-                $iterator->next();
+            $finder = $this->getFinder()->date('until '.$expire->format('Y-m-d H:i:s'));
+            foreach ($finder as $file) {
+                unlink($file->getRealPath());
             }
+
+            $totalSize = $this->filesystem->size($this->root);
+            if ($totalSize > $maxSize) {
+                $iterator = $this->getFinder()->sortByAccessedTime()->getIterator();
+                while ($totalSize > $maxSize && $iterator->valid()) {
+                    $filepath = $iterator->current()->getRealPath();
+                    $totalSize -= $this->filesystem->size($filepath);
+                    unlink($filepath);
+                    $iterator->next();
+                }
+            }
+
+            self::$cacheCollected = true;
+
+            return true;
         }
 
-        self::$cacheCollected = true;
-
-        return true;
+        return false;
     }
 
     public function sha1($file)


### PR DESCRIPTION
If we set COMPOSER_CACHE_DIR=/dev/null, and the garbage collector
is triggered, we end up with the following error :

The "/dev/null/" directory does not exist.

This is because the Cache::gc() function does not check for Cache::enabled
and instanciates a Finder unconditionnaly.

Fix this by adding a check on Cache::enabled.
