### PR TITLE
Fix for #2613, remove unnecessary backslash before each utf-8 char

### DIFF
--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -231,7 +231,7 @@ class JsonFile
 
                 if ($unescapeUnicode && function_exists('mb_convert_encoding')) {
                     // http://stackoverflow.com/questions/2934563/how-to-decode-unicode-escape-sequences-like-u00ed-to-proper-utf-8-encoded-cha
-                    $buffer = preg_replace_callback('/\\\\u([0-9a-f]{4})/i', function($match) {
+                    $buffer = preg_replace_callback('/(?<!\\\)\\\\u([0-9a-f]{4})/i', function($match) {
                         return mb_convert_encoding(pack('H*', $match[1]), 'UTF-8', 'UCS-2BE');
                     }, $buffer);
                 }

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -198,6 +198,13 @@ class JsonFileTest extends \PHPUnit_Framework_TestCase
         $this->assertJsonFormat('"\\u018c"', $data, 0);
     }
 
+    public function testDoubleEscapedUnicode()
+    {
+        $data = "Zdj\\u0119ciahl\\\\u0119kkjk";
+
+        $this->assertJsonFormat('"Zdj\\\\u0119ciahl\\\\\\\\u0119kkjk"', $data);
+    }
+
     private function expectParseException($text, $json)
     {
         try {


### PR DESCRIPTION
when using  php < 5.4 there was an unnecessary backslash before each utf-8 char.  The problem was that the regexp matched all utf-8 encoded chars (included the ones that where escaped). The new regexp uses the lookbehind feature to check if the backslash isn't prefixed with an other backslash.

This should fix ticket #2613.
