### PR TITLE
"artifact" type repo creates absolute paths in .lock file

### DIFF
--- a/src/Composer/Repository/ArtifactRepository.php
+++ b/src/Composer/Repository/ArtifactRepository.php
@@ -96,7 +96,7 @@ class ArtifactRepository extends ArrayRepository
         $package = JsonFile::parseJson($json, $composerFile);
         $package['dist'] = array(
             'type' => 'zip',
-            'url' => $file->getRealPath(),
+            'url' => $file->getPathname(),
             'reference' => $file->getBasename(),
             'shasum' => sha1_file($file->getRealPath())
         );

--- a/tests/Composer/Test/Repository/ArtifactRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ArtifactRepositoryTest.php
@@ -16,6 +16,7 @@ use Composer\TestCase;
 use Composer\IO\NullIO;
 use Composer\Config;
 use Composer\Package\BasePackage;
+use Composer\Util\Filesystem;
 
 class ArtifactRepositoryTest extends TestCase
 {
@@ -40,4 +41,27 @@ class ArtifactRepositoryTest extends TestCase
 
         $this->assertSame($expectedPackages, $foundPackages);
     }
+
+    public function testAbsoluteRepoUrlCreatesAbsoluteUrlPackages()
+    {
+        $absolutePath = __DIR__ . '/Fixtures/artifacts';
+        $coordinates = array('type' => 'artifact', 'url' => $absolutePath);
+        $repo = new ArtifactRepository($coordinates, new NullIO(), new Config());
+
+        foreach ($repo->getPackages() as $package) {
+            $this->assertTrue(strpos($package->getDistUrl(), $absolutePath) === 0);
+        }
+    }
+
+    public function testRelativeRepoUrlCreatesRelativeUrlPackages()
+    {
+        $relativePath = 'tests/Composer/Test/Repository/Fixtures/artifacts';
+        $coordinates = array('type' => 'artifact', 'url' => $relativePath);
+        $repo = new ArtifactRepository($coordinates, new NullIO(), new Config());
+
+        foreach ($repo->getPackages() as $package) {
+            $this->assertTrue(strpos($package->getDistUrl(), $relativePath) === 0);
+        }
+    }
+
 }


### PR DESCRIPTION
The "artifact" type repository can take a relative path to a directory containing .zip files.

However, the .lock file will contain absolute paths to the installed package .zip files. Obviously that's a problem when someone else tries to install from this lock file with a checkout in another location.
