### PR TITLE
Added a failing test for #2626

### DIFF
--- a/tests/Composer/Test/Fixtures/installer/replace-alias.test
+++ b/tests/Composer/Test/Fixtures/installer/replace-alias.test
@@ -1,0 +1,24 @@
+--TEST--
+Ensure a replacer package deals with branch aliases
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "dev-master", "replace": {"c/c": "self.version" }, "extra": { "branch-alias": {"dev-master": "1.0.x-dev"} } },
+                { "name": "b/b", "version": "1.0.0", "require": {"c/c": "1.*"} },
+                { "name": "c/c", "version": "dev-master", "extra": { "branch-alias": {"dev-master": "1.0.x-dev"} } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "dev-master",
+        "b/b": "1.*"
+    }
+}
+--RUN--
+install
+--EXPECT--
+Installing a/a (dev-master)
+Installing b/b (1.0.0)


### PR DESCRIPTION
Here is a test reproducing the issue reported in #2626

Note that requiring `1.0.*` for `a/a` (i.e. the alias package) will work fine for the replacement.

I'm quite sure this is caused by the optimization done in https://github.com/composer/composer/pull/2326 : the alias package is not added to the providing packages for `c/c:1.0.*` (maybe not even to the pool)
