### PR TITLE
Fix for #1966, use the preferred-install from the rootPackage

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -147,8 +147,6 @@ EOT
             $composer->getEventDispatcher()->dispatchCommandEvent(ScriptEvents::POST_ROOT_PACKAGE_INSTALL, $installDevPackages);
         }
 
-        // Update preferSource / preferDist with preferred-install from the root package if both vars still
-        // have their default initial value (false)
         $rootPackageConfig = $composer->getConfig();
         $this->updatePreferredOptions($rootPackageConfig, $input, $preferSource, $preferDist);
 


### PR DESCRIPTION
use the preferred-install from the rootPackage config to install the dependencies.
