### PR TITLE
allow a date-based version format of Year-DayOfYear-ArbitraryDigits

### DIFF
--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -119,7 +119,7 @@ class VersionParser
                 .(!empty($matches[3]) ? $matches[3] : '.0')
                 .(!empty($matches[4]) ? $matches[4] : '.0');
             $index = 5;
-        } elseif (preg_match('{^v?(\d{4}(?:[.:-]?\d{2}){1,6}(?:[.:-]?\d{1,3})?)'.self::$modifierRegex.'$}i', $version, $matches)) { // match date-based versioning
+        } elseif (preg_match('{^v?(\d{4}(?:[.:-]?\d{2}){1,6}(?:[.:-]?\d.*)?)'.self::$modifierRegex.'$}i', $version, $matches)) { // match date-based versioning
             $version = preg_replace('{\D}', '-', $matches[1]);
             $index = 2;
         }

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -107,6 +107,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             'parses arbitrary2' => array('DEV-FOOBAR',          'dev-FOOBAR'),
             'parses arbitrary3' => array('dev-feature/foo',     'dev-feature/foo'),
             'ignores aliases'   => array('dev-master as 1.0.0', '9999999-dev'),
+            'parses dates y-z'  => array('v2014.001.123456789', '2014-001-123456789'),
         );
     }
 


### PR DESCRIPTION
(yyyy.zzz.digits)

The versioning I'm trying to accomplish is specifically:
- major = year (v2014)
- minor = incrementer (001 - 999), but it can also work as DayOfYear (000 - 365)
- patch = arbitrary digits... my use case is a ticket#

This patch accomplishes my use case without breaking any existing tests.
