### PR TITLE
Fixing DYLD_LIBRARY_PATH env variable in Svn ultility helper

### DIFF
--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -72,7 +72,7 @@ class Svn
     public static function cleanEnv()
     {
         // clean up env for OSX, see https://github.com/composer/composer/issues/2146#issuecomment-35478940
-        putenv("DYLD_LIBRARY_PATH");
+        putenv("DYLD_LIBRARY_PATH=''");
     }
 
     /**


### PR DESCRIPTION
This fixes the `DYLD_LIBRARY_PATH` env variable that OSX relies on when using SVN. Fix was originally suggested here: https://github.com/composer/composer/issues/2146#issuecomment-35478940 but it looks like the implementation of the fix was incomplete.
