### PR TITLE
Bug in RunScriptCommand::execute()

### DIFF
--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -69,7 +69,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $script = $input->getArgument('script');
-        if (!in_array($script, $this->commandEvents) || !in_array($script, $this->scriptEvents)) {
+        if (!in_array($script, $this->commandEvents) && !in_array($script, $this->scriptEvents)) {
             if (defined('Composer\Script\ScriptEvents::'.str_replace('-', '_', strtoupper($script)))) {
                 throw new \InvalidArgumentException(sprintf('Script "%s" cannot be run with this command', $script));
             }


### PR DESCRIPTION
When I try to execute

```
composer run-scripts post-update-cmd
```

it fails with 

```
Script "post-update-cmd" cannot be run with this command
```

This happend because in _RunScriptCommand::execute()_  '&&' should be used instead of '||' when checking for known commands in _commandEvents_ and _scriptEvents_,  
