### PR TITLE
Bugfix: Don't show Ambiguous class resolution warning when not ambiguous

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -84,7 +84,7 @@ class ClassMapGenerator
             foreach ($classes as $class) {
                 if (!isset($map[$class])) {
                     $map[$class] = $filePath;
-                } elseif ($io) {
+                } elseif ($io && $map[$class] !== $filePath) {
                     $io->write(
                         '<warning>Warning: Ambiguous class resolution, "'.$class.'"'.
                         ' was found in both "'.$map[$class].'" and "'.$filePath.'", the first will be used.</warning>'

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -134,6 +134,27 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * If one file has a class or interface defined more than once,
+     * an ambiguous reference warning should not be produced
+     */
+    public function testUnambiguousReference()
+    {
+        $this->checkIfFinderIsAvailable();
+
+        $finder = new Finder();
+        $finder->files()->in(__DIR__ . '/Fixtures/Unambiguous');
+
+        $io = $this->getMockBuilder('Composer\IO\ConsoleIO')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $io->expects($this->never())
+            ->method('write');
+
+        ClassMapGenerator::createMap($finder, null, $io);
+    }
+
+    /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Could not scan for classes inside
      */

--- a/tests/Composer/Test/Autoload/Fixtures/Unambiguous/A.php
+++ b/tests/Composer/Test/Autoload/Fixtures/Unambiguous/A.php
@@ -1,0 +1,6 @@
+<?php
+if (PHP_VERSION_ID < 50400) {
+    interface A extends Iterator, ArrayAccess { }
+} else {
+    interface A extends Iterator, ArrayAccess, JsonSerializable { }
+}


### PR DESCRIPTION
if an interface of class is defined multiple times in the same file (see the test fixture for a legitimate example) this should not produce an ambiguous class resolution warning because there is no ambiguity in which file should be loaded.
