### PR TITLE
Fix space encoding in password for git auth

### DIFF
--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -88,7 +88,7 @@ class GitDriver extends VcsDriver
                             );
                         }
 
-                        $url = $match[1].urlencode($auth['username']).':'.urlencode($auth['password']).'@'.$match[2].$match[3];
+                        $url = $match[1].rawurlencode($auth['username']).':'.rawurlencode($auth['password']).'@'.$match[2].$match[3];
 
                         $command = sprintf('git clone --mirror %s %s', escapeshellarg($url), escapeshellarg($this->repoDir));
 


### PR DESCRIPTION
Related to #2826
If password contains space character, `urlencode()` replaces it with '+' sign, but as of RFC 3986 it should be '%20'. This PR fixes it and uses `rawurlencode()` instead.
