### PR TITLE
Only print suggestions in dev mode

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -223,16 +223,18 @@ class Installer
         }
         $this->installationManager->notifyInstalls();
 
-        // output suggestions
-        foreach ($this->suggestedPackages as $suggestion) {
-            $target = $suggestion['target'];
-            foreach ($installedRepo->getPackages() as $package) {
-                if (in_array($target, $package->getNames())) {
-                    continue 2;
+        // output suggestions if we're in dev mode
+        if (!$this->devMode) {
+            foreach ($this->suggestedPackages as $suggestion) {
+                $target = $suggestion['target'];
+                foreach ($installedRepo->getPackages() as $package) {
+                    if (in_array($target, $package->getNames())) {
+                        continue 2;
+                    }
                 }
-            }
 
-            $this->io->write($suggestion['source'].' suggests installing '.$suggestion['target'].' ('.$suggestion['reason'].')');
+                $this->io->write($suggestion['source'].' suggests installing '.$suggestion['target'].' ('.$suggestion['reason'].')');
+            }
         }
 
         if (!$this->dryRun) {


### PR DESCRIPTION
There is no need to clutter the screen/logs/whatever with suggestions in production installs. If someone didn't care about them in dev mode, they certainly won't in production :)

(as discussed with @naderman)
