### PR TITLE
fixed: dead symlink breaks gc

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -151,14 +151,14 @@ class Cache
 
             $finder = $this->getFinder()->date('until '.$expire->format('Y-m-d H:i:s'));
             foreach ($finder as $file) {
-                unlink($file->getRealPath());
+                unlink($file->getPathname());
             }
 
             $totalSize = $this->filesystem->size($this->root);
             if ($totalSize > $maxSize) {
                 $iterator = $this->getFinder()->sortByAccessedTime()->getIterator();
                 while ($totalSize > $maxSize && $iterator->valid()) {
-                    $filepath = $iterator->current()->getRealPath();
+                    $filepath = $iterator->current()->getPathname();
                     $totalSize -= $this->filesystem->size($filepath);
                     unlink($filepath);
                     $iterator->next();


### PR DESCRIPTION
Hi,

i changed the file-deletion in Composers GC function from realpath to pathname.

Why? When the garbage collection finds a dead symlink, realpath tries to resolve the symlink. Because it's impossible to resolve the symlink, realpath returns false and unlink gets called with "false" instead of a path. Satis (in this case) aborts with an ErrorException.

Changing to pathname deletes the symlink itself, not the dereferenced file. I don't know if this is a problem, but i dont think so. If the symlinks target is within the cache-root, it should be found anyways (one occurrence for the symlink itself and one for the symlinks target but i don't know for sure if the finder component works that way).

If the symlink targets is outside of the cache-dir (i don't know if that's even possible, but it shouldn't) it shouldn't handled by the garbage collection in the first way because it isn't inside the cache directory.

Actually, dead symlinks is a thing. See composer/satis#126
