### PR TITLE
Clarify log messages when skipping existing bins

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -196,7 +196,7 @@ class LibraryInstaller implements InstallerInterface
         foreach ($binaries as $bin) {
             $binPath = $this->getInstallPath($package).'/'.$bin;
             if (!file_exists($binPath)) {
-                $this->io->write('    <warning>Skipped installation of '.$bin.' for package '.$package->getName().': file not found in package</warning>');
+                $this->io->write('    <warning>Skipped installation of bin '.$bin.' for package '.$package->getName().': file not found in package</warning>');
                 continue;
             }
 
@@ -215,7 +215,7 @@ class LibraryInstaller implements InstallerInterface
                     // is a fresh install of the vendor.
                     @chmod($link, 0777 & ~umask());
                 }
-                $this->io->write('    Skipped installation of '.$bin.' for package '.$package->getName().': name conflicts with an existing file');
+                $this->io->write('    Skipped installation of bin '.$bin.' for package '.$package->getName().': name conflicts with an existing file');
                 continue;
             }
             if (defined('PHP_WINDOWS_VERSION_BUILD')) {
@@ -225,7 +225,7 @@ class LibraryInstaller implements InstallerInterface
                     @chmod($link, 0777 & ~umask());
                     $link .= '.bat';
                     if (file_exists($link)) {
-                        $this->io->write('    Skipped installation of '.$bin.'.bat proxy for package '.$package->getName().': a .bat proxy was already installed');
+                        $this->io->write('    Skipped installation of bin '.$bin.'.bat proxy for package '.$package->getName().': a .bat proxy was already installed');
                     }
                 }
                 if (!file_exists($link)) {


### PR DESCRIPTION
The message is currently really confusing, since it is formatted as a warning and reads:

> Skipped installation of bin phpunit for package phpunit/phpunit: file not found in package

It sounds like the entire package was not installed. This patch clarifies that a little.
