### PR TITLE
Removing dist reference info from Artifact Repository

### DIFF
--- a/src/Composer/Repository/ArtifactRepository.php
+++ b/src/Composer/Repository/ArtifactRepository.php
@@ -139,7 +139,6 @@ class ArtifactRepository extends ArrayRepository
         $package['dist'] = array(
             'type' => 'zip',
             'url' => $file->getRealPath(),
-            'reference' => $file->getBasename(),
             'shasum' => sha1_file($file->getRealPath())
         );
 


### PR DESCRIPTION
The getComposerInformation method adds dist information to package. This includes reference, which holds the name of the zip file. For e.g. "MyPackage-1.2.zip". 

Now, when using satis for hosting these packages, it uses the same code for archiving composer packages implemented at https://github.com/composer/composer/blob/master/src/Composer/Package/Archiver/ArchiveManager.php

In the implementation, getPackageFilename() adds the distReference info to the file name, which makes the zip file created at the end to be weird. Like "jay-logger-1.2-MyPackage-1.2.zip.tar". I am not sure if there is any other use of dist reference in Artifact Repository, but this would stop causing that issue.
