### PR TITLE
[WIP] Extension installer

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -40,6 +40,7 @@ class Config
         'optimize-autoloader' => false,
         'prepend-autoloader' => true,
         'github-domains' => array('github.com'),
+        'ext-options' => array(),
     );
 
     public static $defaultRepositories = array(

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -27,6 +27,7 @@ class Config
         'github-protocols' => array('git', 'https', 'ssh'),
         'vendor-dir' => 'vendor',
         'bin-dir' => '{$vendor-dir}/bin',
+        'ext-dir' => '{$vendor-dir}/ext',
         'cache-dir' => '{$home}/cache',
         'cache-files-dir' => '{$cache-dir}/files',
         'cache-repo-dir' => '{$cache-dir}/repo',
@@ -135,6 +136,7 @@ class Config
         switch ($key) {
             case 'vendor-dir':
             case 'bin-dir':
+            case 'ext-dir':
             case 'process-timeout':
             case 'cache-dir':
             case 'cache-files-dir':

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -419,6 +419,7 @@ class Factory
         $im->addInstaller(new Installer\PearInstaller($io, $composer, 'pear-library'));
         $im->addInstaller(new Installer\PluginInstaller($io, $composer));
         $im->addInstaller(new Installer\MetapackageInstaller($io));
+        $im->addInstaller(new Installer\ExtensionInstaller($io, $composer));
     }
 
     /**

--- a/src/Composer/Installer/ExtensionInstaller.php
+++ b/src/Composer/Installer/ExtensionInstaller.php
@@ -12,10 +12,12 @@
 
 namespace Composer\Installer;
 
+use Composer\Composer;
 use Composer\IO\IOInterface;
-use Composer\Downloader\DownloadManager;
-use Composer\Repository\WritableRepositoryInterface;
+use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Package\PackageInterface;
+use Composer\Util\Filesystem;
+use Symfony\Component\Process\Process;
 
 /**
  * PHP Extension Installer.
@@ -25,6 +27,7 @@ use Composer\Package\PackageInterface;
 class ExtensionInstaller extends LibraryInstaller
 {
     protected $extDir;
+    protected $extOptions;
 
     /**
      * {@inheritDoc}
@@ -34,14 +37,15 @@ class ExtensionInstaller extends LibraryInstaller
         parent::__construct($io, $composer, 'extension', $filesystem);
 
         $this->extDir = rtrim($composer->getConfig()->get('ext-dir'), '/');
+        $this->extOptions = $composer->getConfig()->get('ext-options');
     }
 
     /**
      * {@inheritDoc}
      */
-    public function install(PackageInterface $package)
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
-        parent::install($package);
+        parent::install($repo, $package);
 
         $this->compileExtension($package);
     }
@@ -49,38 +53,77 @@ class ExtensionInstaller extends LibraryInstaller
     /**
      * {@inheritDoc}
      */
-    public function update(PackageInterface $initial, PackageInterface $target)
+    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
     {
-        parent::update($initial, $target);
+        parent::update($repo, $initial, $target);
 
-        $this->cleanExtension($package);
-        $this->compileExtension($package);
+        $this->cleanExtension($target);
+        $this->compileExtension($target);
     }
 
-    protected function initializeDirs()
+    protected function initializeExtDir()
     {
-        parent::initializeDirs();
-
         $this->filesystem->ensureDirectoryExists($this->extDir);
         $this->extDir = realpath($this->extDir);
     }
 
     private function compileExtension(PackageInterface $package)
     {
-        $path = $this->getInstallPath($package);
-        $command = sprintf('cd %s; phpize && ./configure && make', escapeshellarg($path));
-        passthru($command);
+        $this->initializeExtDir();
 
-        $modulesDir = $this->getInstallPath($package).'/modules';
-        foreach (new \FilesystemIterator($modulesDir) as $file) {
-            copy($file, $this->extDir.'/'.$file->getBasename());
+        $flags = isset($this->extOptions[$package->getName()]) ? $this->extOptions[$package->getName()] : '';
+        $path = $this->getInstallPath($package);
+
+        if (defined('HHVM_VERSION')) {
+            $command = sprintf('hphpize && cmake %s . && make', escapeshellarg($flags));
+        } else {
+            $command = sprintf('phpize && ./configure %s && make && make install', escapeshellarg($flags));
         }
+
+        $process = new Process($command, $path);
+        $io = $this->io;
+        $status = $process->run(function ($stream, $data) use ($io) {
+            $io->write($data, false);
+        });
+
+        if (0 !== $status) {
+            throw new \RuntimeException("Could not compile extension ".$package->getName());
+        }
+
+        $extensions = [];
+
+        if (defined('HHVM_VERSION')) {
+            foreach (new \FilesystemIterator($this->getInstallPath($package)) as $file) {
+                if ($file->getExtension() == 'so') {
+                    $extensions[] = $file->getBasename();
+                    copy($file, $this->extDir.'/'.$file->getBasename());
+                }
+            }
+        } else {
+            $modulesDir = $this->getInstallPath($package).'/modules';
+            foreach (new \FilesystemIterator($modulesDir) as $file) {
+                if ($file->getExtension() == 'so') {
+                    $extensions[] = $file->getBasename();
+                }
+                copy($file, $this->extDir.'/'.$file->getBasename());
+            }
+        }
+
+        $content = implode('', array_map(function ($extension) {
+            return 'extension='.$extension."\n";
+        }, $extensions));
+
+        file_put_contents($this->extDir.'/extensions.ini', $content);
     }
 
     private function cleanExtension(PackageInterface $package)
     {
+        $this->initializeExtDir();
+
         $path = $this->getInstallPath($package);
-        $command = sprintf('cd %s; make clean', escapeshellarg($path));
-        passthru($command);
+        $command = 'make clean';
+
+        $process = new Process($command, $path);
+        $process->run();
     }
 }

--- a/src/Composer/Installer/ExtensionInstaller.php
+++ b/src/Composer/Installer/ExtensionInstaller.php
@@ -90,7 +90,7 @@ class ExtensionInstaller extends LibraryInstaller
             throw new \RuntimeException("Could not compile extension ".$package->getName());
         }
 
-        $extensions = [];
+        $extensions = array();
 
         if (defined('HHVM_VERSION')) {
             foreach (new \FilesystemIterator($this->getInstallPath($package)) as $file) {

--- a/src/Composer/Installer/ExtensionInstaller.php
+++ b/src/Composer/Installer/ExtensionInstaller.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Installer;
+
+use Composer\IO\IOInterface;
+use Composer\Downloader\DownloadManager;
+use Composer\Repository\WritableRepositoryInterface;
+use Composer\Package\PackageInterface;
+
+/**
+ * PHP Extension Installer.
+ *
+ * @author Igor Wiedler <igor@wiedler.ch>
+ */
+class ExtensionInstaller extends LibraryInstaller
+{
+    protected $extDir;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(IOInterface $io, Composer $composer, Filesystem $filesystem = null)
+    {
+        parent::__construct($io, $composer, 'extension', $filesystem);
+
+        $this->extDir = rtrim($composer->getConfig()->get('ext-dir'), '/');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function install(PackageInterface $package)
+    {
+        parent::install($package);
+
+        $this->compileExtension($package);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function update(PackageInterface $initial, PackageInterface $target)
+    {
+        parent::update($initial, $target);
+
+        $this->cleanExtension($package);
+        $this->compileExtension($package);
+    }
+
+    protected function initializeDirs()
+    {
+        parent::initializeDirs();
+
+        $this->filesystem->ensureDirectoryExists($this->extDir);
+        $this->extDir = realpath($this->extDir);
+    }
+
+    private function compileExtension(PackageInterface $package)
+    {
+        $path = $this->getInstallPath($package);
+        $command = sprintf('cd %s; phpize && ./configure && make', escapeshellarg($path));
+        passthru($command);
+
+        $modulesDir = $this->getInstallPath($package).'/modules';
+        foreach (new \FilesystemIterator($modulesDir) as $file) {
+            copy($file, $this->extDir.'/'.$file->getBasename());
+        }
+    }
+
+    private function cleanExtension(PackageInterface $package)
+    {
+        $path = $this->getInstallPath($package);
+        $command = sprintf('cd %s; make clean', escapeshellarg($path));
+        passthru($command);
+    }
+}


### PR DESCRIPTION
Supports PHP & HHVM.

Todo:
- [ ] Need to come up with a solution for ext-\* packages actually being installable now, so extensions can be compiled automatically to satisfy dependencies on extensions.
- [ ] Documentation
- [ ] Use a different downloader to download binary builds from github releases for windows (or pecl for PHP)
- [ ] Output information on configuring the server to include extension.so

Replaces the earlier PR #498
