### PR TITLE
Fix homebrew instructions

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -95,9 +95,12 @@ Then, just run `composer` in order to run Composer instead of `php composer.phar
 
 Composer is part of the homebrew-php project.
 
-    brew update
-    brew install composer
-
+    $ brew update
+    $ brew tap josegonzalez/homebrew-php
+    $ brew tap homebrew/versions
+    $ brew install php55-intl
+    $ brew install josegonzalez/php/composer
+ 
 ## Installation - Windows
 
 ### Using the Installer


### PR DESCRIPTION
1. `brew install composer` now works; apparently there is no need to use a separate brew tap.
2. The Markdown triple-backtick thing that was being used doesn't seem to be showing up correctly on getcomposer.org; see https://getcomposer.org/doc/00-intro.md#globally-on-osx-via-homebrew-
