### PR TITLE
fix autoload-dev example for PSR-4

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -534,7 +534,7 @@ Example:
             "psr-4": { "MyLibrary\\": "src/" }
         },
         "autoload-dev": {
-            "psr-4": { "MyLibrary\\Tests": "tests/" }
+            "psr-4": { "MyLibrary\\Tests\\": "tests/" }
         }
     }
 


### PR DESCRIPTION
The example leads to the following error.

```
  [InvalidArgumentException]
  A non-empty PSR-4 prefix must end with a namespace separator.
```
