### PR TITLE
fixed class map generator when using a heredoc with spaces

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -119,7 +119,7 @@ class ClassMapGenerator
         }
 
         // strip heredocs/nowdocs
-        $contents = preg_replace('{<<<\'?(\w+)\'?(?:\r\n|\n|\r)(?:.*?)(?:\r\n|\n|\r)\\1(?=\r\n|\n|\r|;)}s', 'null', $contents);
+        $contents = preg_replace('{<<<\s*(\'?)(\w+)\\1(?:\r\n|\n|\r)(?:.*?)(?:\r\n|\n|\r)\\2(?=\r\n|\n|\r|;)}s', 'null', $contents);
         // strip strings
         $contents = preg_replace('{"[^"\\\\]*(\\\\.[^"\\\\]*)*"|\'[^\'\\\\]*(\\\\.[^\'\\\\]*)*\'}s', 'null', $contents);
         // strip leading non-php code if needed

--- a/tests/Composer/Test/Autoload/Fixtures/classmap/StripNoise.php
+++ b/tests/Composer/Test/Autoload/Fixtures/classmap/StripNoise.php
@@ -15,12 +15,30 @@ class Fail2
 
 }
 A
-. <<<'TEST'
+. <<<  AB
 class Fail3
 {
 
 }
-TEST;
+AB
+. <<<'TEST'
+class Fail4
+{
+
+}
+TEST
+. <<< 'ANOTHER'
+class Fail5
+{
+
+}
+ANOTHER
+. <<<	'ONEMORE'
+class Fail6
+{
+
+}
+ONEMORE;
     }
 
     public function test2()


### PR DESCRIPTION
Heredocs and nowdocs accepts spaces between `<<<` and the doc name. This PR fixes that to avoid wrong `Ambiguous class resolution` warnings.
