### PR TITLE
reduce commit history of git checkout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ before_script:
 
 script:
     - ls -d tests/Composer/Test/* | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/complete.phpunit.xml {};' || exit 1
+
+git:
+  depth: 5


### PR DESCRIPTION
this results in a smaller and faster checkout on travis.

![reduce-composer-checkout-size](https://cloud.githubusercontent.com/assets/85608/2840078/a855863a-d04f-11e3-9ee2-df4d94783b27.jpg)
