### PR TITLE
Add --no-check-all option to composer validate command

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -248,6 +248,10 @@ You should always run the `validate` command before you commit your
 
     $ php composer.phar validate
 
+### Options
+
+* **--no-check-all:** Wether or not composer do a complete validation.
+
 ## status
 
 If you often need to modify the code of your dependencies and they are

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -12,9 +12,11 @@
 
 namespace Composer\Command;
 
+use Composer\Package\Loader\ValidatingArrayLoader;
 use Composer\Util\ConfigValidator;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -34,6 +36,7 @@ class ValidateCommand extends Command
             ->setName('validate')
             ->setDescription('Validates a composer.json')
             ->setDefinition(array(
+                new InputOption('no-check-all', null, InputOption::VALUE_NONE, 'Do not make a complete validation'),
                 new InputArgument('file', InputArgument::OPTIONAL, 'path to composer.json file', './composer.json')
             ))
             ->setHelp(<<<EOT
@@ -65,7 +68,8 @@ EOT
         }
 
         $validator = new ConfigValidator($this->getIO());
-        list($errors, $publishErrors, $warnings) = $validator->validate($file);
+        $checkAll = $input->getOption('no-check-all') ? 0 : ValidatingArrayLoader::CHECK_ALL;
+        list($errors, $publishErrors, $warnings) = $validator->validate($file, $checkAll);
 
         // output errors/warnings
         if (!$errors && !$publishErrors && !$warnings) {

--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -38,10 +38,11 @@ class ConfigValidator
      * Validates the config, and returns the result.
      *
      * @param string $file The path to the file
+     * @param integer $arrayLoaderValidationFlags Flags for ArrayLoader validation
      *
      * @return array a triple containing the errors, publishable errors, and warnings
      */
-    public function validate($file)
+    public function validate($file, $arrayLoaderValidationFlags = ValidatingArrayLoader::CHECK_ALL)
     {
         $errors = array();
         $publishErrors = array();
@@ -119,7 +120,7 @@ class ConfigValidator
         }
 
         try {
-            $loader = new ValidatingArrayLoader(new ArrayLoader(), true, null, ValidatingArrayLoader::CHECK_ALL);
+            $loader = new ValidatingArrayLoader(new ArrayLoader(), true, null, $arrayLoaderValidationFlags);
             if (!isset($manifest['version'])) {
                 $manifest['version'] = '1.0.0';
             }


### PR DESCRIPTION
Example with Packagist project.

Without option:

```
$ composer validate
Reading ./composer.json
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See http://getcomposer.org/doc/04-schema.md for details on the schema
name : is missing and it is required
require.hwi/oauth-bundle : unbound version constraints (dev-master) should be avoided
require.snc/redis-bundle : unbound version constraints (dev-master) should be avoided
require.kriswallsmith/assetic : unbound version constraints (@dev) should be avoided
require.pagerfanta/pagerfanta : unbound version constraints (@dev) should be avoided
```

With option:

```
$ composer validate --no-check-all
Reading ./composer.json
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See http://getcomposer.org/doc/04-schema.md for details on the schema
name : is missing and it is required
```
