### PR TITLE
when executing "archive" for a package with multiple versions

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -417,6 +417,12 @@ This command is used to generate a zip/tar archive for a given package in a
 given version. It can also be used to archive your entire project without
 excluded/ignored files.
 
+To archive the latest stable version of a package as a tar-archive:
+
+    $ php composer.phar archive vendor/package
+
+To archive a specific version of a package as a zip-archive:
+
     $ php composer.phar archive vendor/package 2.0.21 --format=zip
 
 ### Options

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -115,7 +115,8 @@ EOT
         $packages = $pool->whatProvides($packageName, $constraint);
 
         if (count($packages) > 1) {
-            $package = $packages[0];
+            // if multiple packages are found, select the last package (latest stable version)
+            $package = array_pop($packages);
             $io->write('<info>Found multiple matches, selected '.$package->getPrettyString().'.</info>');
             $io->write('Alternatives were '.implode(', ', array_map(function ($p) { return $p->getPrettyString(); }, $packages)).'.');
             $io->write('<comment>Please use a more specific constraint to pick a different package.</comment>');


### PR DESCRIPTION
, but without a specific version constraint, package the latest stable version by default, instead of the first version.

Example: `composer archive --format=zip seld/jsonlint`
Before change: packages v1.0.0, after change: packages v1.1.2.
![latest-vesion-as-default-for-archiving](https://cloud.githubusercontent.com/assets/85608/2870706/4260590e-d2d9-11e3-959a-db83c4d44831.jpg)

Updated the CLI docs, to reflect this change.

