### PR TITLE
Updated Satis install command in docs.

### DIFF
--- a/doc/articles/handling-private-packages-with-satis.md
+++ b/doc/articles/handling-private-packages-with-satis.md
@@ -9,7 +9,7 @@ lightweight, static file-based version of packagist and can be used to host the
 metadata of your company's private packages, or your own. It basically acts as
 a micro-packagist. You can get it from
 [GitHub](http://github.com/composer/satis) or install via CLI:
-`composer.phar create-project composer/satis --stability=dev`.
+`php composer.phar create-project composer/satis --stability=dev --keep-vcs`.
 
 ## Setup
 


### PR DESCRIPTION
It now uses the same command (or parameters to be correct) as the [readme file](https://github.com/composer/satis/blob/master/README.md#usage).
