### PR TITLE
Graceful fallback in Filesystem::removeDirectory() to php

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -85,10 +85,14 @@ class Filesystem
 
         $result = $this->getProcess()->execute($cmd, $output) === 0;
 
-        // clear stat cache because external processes aren't tracked by the php stat cache
-        clearstatcache();
+        if ($result) {
+            // clear stat cache because external processes aren't tracked by the php stat cache
+            clearstatcache();
 
-        return $result && !is_dir($directory);
+            return !is_dir($directory);
+        }
+
+        return $this->removeDirectoryPhp($directory);
     }
 
     /**


### PR DESCRIPTION
On a shared system, we have some "Could not completely delete" problems, like this:

```
Loading composer repositories with package information
Updating dependencies (including require-dev)

- Removing menatwork/contao-multicolumnwizard (3.1.0)

  *Internals*
    command: string(80) "rm -rf '/.../vendor/menatwork/contao-multicolumnwizard'"
    return status: bool(false)
    directory still exists: bool(true)
    error output: string(31) "sh: /bin/rm: Permission denied "

[RuntimeException]
Could not completely delete /.../vendor/menatwork/contao-multicolumnwizard, aborting.
```

`Filesystem::removeDirectory()` is the only function in `Filesystem`, that does not do a graceful fallback to php, if the process fails. Now it does :-)
