### PR TITLE
Ignore platform packages

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -39,6 +39,7 @@ class Config
         'optimize-autoloader' => false,
         'prepend-autoloader' => true,
         'github-domains' => array('github.com'),
+        'platform' => array(),
     );
 
     public static $defaultRepositories = array(

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -196,7 +196,7 @@ class Installer
 
         // create installed repo, this contains all local packages + platform packages (php & extensions)
         $localRepo = $this->repositoryManager->getLocalRepository();
-        $platformRepo = new PlatformRepository();
+        $platformRepo = new PlatformRepository($this->config->get('platform'));
         $repos = array(
             $localRepo,
             new InstalledArrayRepository(array($installedRootPackage)),

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -196,7 +196,9 @@ class Installer
 
         // create installed repo, this contains all local packages + platform packages (php & extensions)
         $localRepo = $this->repositoryManager->getLocalRepository();
-        $platformRepo = new PlatformRepository($this->config->get('platform'));
+        $platformOverride = $this->config->get('platform');
+        $platformOverride = is_array($platformOverride) ? $platformOverride : array();
+        $platformRepo = new PlatformRepository($platformOverride);
         $repos = array(
             $localRepo,
             new InstalledArrayRepository(array($installedRootPackage)),

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -49,7 +49,7 @@ class PlatformRepository extends ArrayRepository
                 parent::addPackage($package);
             }
             else {
-                throw new \UnexpectedValueException('Invalid platform package "'.$name);
+                throw new \InvalidArgumentException('Invalid platform package '.$name);
             }
         }
 

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -41,10 +41,16 @@ class PlatformRepository extends ArrayRepository
         // Add each of the override versions as options.
         // Later we might even replace the extensions instead.
         foreach( $this->overrides as $name => $prettyVersion ) {
-            $version = $versionParser->normalize($prettyVersion);
-            $package = new CompletePackage($name, $version, $prettyVersion);
-            $package->setDescription("Overridden virtual platform package $name.");
-            parent::addPackage($package);
+            // Check that it's a platform package.
+            if( preg_match(self::PLATFORM_PACKAGE_REGEX, $name) ) {
+                $version = $versionParser->normalize($prettyVersion);
+                $package = new CompletePackage($name, $version, $prettyVersion);
+                $package->setDescription("Overridden virtual platform package $name.");
+                parent::addPackage($package);
+            }
+            else {
+                throw new \UnexpectedValueException('Invalid platform package "'.$name);
+            }
         }
 
 


### PR DESCRIPTION
Here's my attempt at #1522.

If a package is present in the 'platform'  config option, that package will override whatever PlatformRepository finds.
The "1.0.0" value is a version and not a constraint, so you can't do `"ext-pdo":"*"`. I don't know if that's a good idea though.

```
"config":{
  "platform": {
    "ext-pdo": "1.0.0"
  }
}
```

It also assumes that only a single version of each platform package will be found.
Finally, no tests in there. I wouldn't know where to start...
I have tested it locally though with success.