### PR TITLE
Fix the ZipDownloader to catch the exceptions thrown in Symfony process.

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -39,11 +39,17 @@ class ZipDownloader extends ArchiveDownloader
         // try to use unzip on *nix
         if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
             $command = 'unzip '.escapeshellarg($file).' -d '.escapeshellarg($path) . ' && chmod -R u+w ' . escapeshellarg($path);
-            if (0 === $this->process->execute($command, $ignoredOutput)) {
-                return;
-            }
+            try {
+                if (0 === $this->process->execute($command, $ignoredOutput)) {
+                    return;
+                }
 
-            $processError = 'Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput();
+                $processError = 'Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput();
+            }
+            catch(\Exception $e)
+            {
+                $processError = $e->getMessage();
+            }
         }
 
         if (!class_exists('ZipArchive')) {


### PR DESCRIPTION
The problem was introduced in 72d4bea8 and causes composer to not fallback
to ZipArchive when unzip can not be executed (i.e. when proc_open() is
not allowed).
