### PR TITLE
Load auth information before root package gets installed

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -133,6 +133,9 @@ EOT
     {
         $oldCwd = getcwd();
 
+        // we need to manually load the configuration to pass the auth credentials to the io interface!
+        $io->loadConfiguration($config);
+
         if ($packageName !== null) {
             $installedFromVcs = $this->installRootPackage($io, $config, $packageName, $directory, $packageVersion, $stability, $preferSource, $preferDist, $installDevPackages, $repositoryUrl, $disablePlugins, $noScripts, $keepVcs, $noProgress);
         } else {


### PR DESCRIPTION
When trying to create a new project with an installer residing in a local satis repo (protected with http basic auth) the user will be asked to provide the credentials even if the credentials are stored in the auth.json file. This PR changes this behavior to load the credentials before the first request to satis is done.
