### PR TITLE
Skip external symlinks when creating PHAR archive

### DIFF
--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -52,6 +52,10 @@ class ArchivableFilesFinder extends \FilterIterator
         $this->finder = new Finder\Finder();
 
         $filter = function (\SplFileInfo $file) use ($sources, $filters, $fs) {
+            if ($file->isLink() && strpos($file->getLinkTarget(), $sources) !== 0) {
+                return false;
+            }
+
             $relativePath = preg_replace(
                 '#^'.preg_quote($sources, '#').'#',
                 '',


### PR DESCRIPTION
I encountered a few repositories with (broken) external symlinks. These symlinks were not important for regular package usage (mostly tests data), but they break the PHAR archiver.

This patch skips any external link when creating the PHAR archive.
