### PR TITLE
Blacklisting gh-pages fix

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -231,7 +231,9 @@ class GitHubDriver extends VcsDriver
                 $branchData = JsonFile::parseJson($this->getContents($resource), $resource);
                 foreach ($branchData as $branch) {
                     $name = substr($branch['ref'], 11);
-                    $this->branches[$name] = $branch['object']['sha'];
+                    if ($name != 'gh-pages') {
+                        $this->branches[$name] = $branch['object']['sha'];
+                    }
                 }
 
                 $resource = $this->getNextPage();

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -162,6 +162,29 @@ class GitHubDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($sha, $source['reference']);
     }
 
+    public function testIgnoreGHPages()
+    {
+        $repoUrl = 'http://github.com/composer/installers';
+        $repoApiUrl = 'https://api.github.com/repos/composer/installers';
+        $sha = 'SOMESHA';
+
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io->expects($this->any())
+            ->method('isInteractive')
+            ->will($this->returnValue(true));
+
+        $repoConfig = array(
+            'url' => $repoUrl,
+        );
+        $repoUrl = 'https://github.com/composer/installers.git';
+
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, null);
+        $gitHubDriver->initialize();
+
+        $branches = $gitHubDriver->getBranches();
+        $this->assertArrayNotHasKey('gh-pages', $branches);
+    }
+
     public function testPublicRepository2()
     {
         $repoUrl = 'http://github.com/composer/packagist';


### PR DESCRIPTION
Ignore the 'gh-pages' branch as per #3073. Modified the github driver to... not add 'gh-pages' to getBranches(). Added a test case with a repo that has a 'gh-pages' branch.
