### PR TITLE
Installs plugins and dependencies before installation of other packages

### DIFF
--- a/tests/Composer/Test/Fixtures/installer/plugin-in-sub-dependency.test
+++ b/tests/Composer/Test/Fixtures/installer/plugin-in-sub-dependency.test
@@ -1,0 +1,27 @@
+--TEST--
+Installs a plugin package defined in another simple package
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "p/p", "version": "1.0.0", "type": "composer-plugin" }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "p/p": "1.0.0" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    }
+}
+--RUN--
+install
+--EXPECT--
+Installing p/p (1.0.0)
+Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/plugin-invalid-package-name.test
+++ b/tests/Composer/Test/Fixtures/installer/plugin-invalid-package-name.test
@@ -1,0 +1,43 @@
+--TEST--
+Installs a simple plugin package with exact match requirement
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "p/p", "version": "1.0.0", "type": "composer-plugin" }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "p/p": "1.0.0" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0",
+        "b/b": "1.0.0"
+    }
+}
+--RUN--
+install
+--EXPECT-OUTPUT--
+<info>Loading composer repositories with package information</info>
+<info>Installing dependencies (including require-dev)</info>
+<error>Your requirements could not be resolved to an installable set of packages.</error>
+
+  Problem 1
+    - The requested package b/b could not be found in any version, there may be a typo in the package name.
+
+Potential causes:
+ - A typo in the package name
+ - The package is not available in a stable-enough version according to your minimum-stability setting
+   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.
+
+Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
+
+--EXPECT-EXIT-CODE--
+2
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/plugin-restart-always-update-locked-plugin.test
+++ b/tests/Composer/Test/Fixtures/installer/plugin-restart-always-update-locked-plugin.test
@@ -1,0 +1,46 @@
+--TEST--
+Updates a simple plugin package and restarts always the solver after updating of plugin
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "p/p", "version": "1.0.1", "type": "composer-plugin", "extra": { "installer-restart": true } }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "p/p": "1.0.1" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    }
+}
+--INSTALLED--
+[
+    {
+        "name": "p/p", "version": "1.0.0",
+        "source": { "reference": "abc123", "url": "", "type": "git" }
+    }
+]
+--RUN--
+update --verbose
+--EXPECT-OUTPUT--
+<info>Loading composer repositories with package information</info>
+<info>Updating dependencies (including require-dev)</info>
+<info>A new analysis of dependencies is required by:</info>
+  - Plugin <info>p/p</info> (<comment>always</comment>)
+
+<info>Updating dependencies (including require-dev)</info>
+<info>Writing lock file</info>
+<info>Generating autoload files</info>
+
+--EXPECT-EXIT-CODE--
+0
+--EXPECT--
+Updating p/p (1.0.0) to p/p (1.0.1)
+Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/plugin-restart-always-update-locked.test
+++ b/tests/Composer/Test/Fixtures/installer/plugin-restart-always-update-locked.test
@@ -1,0 +1,41 @@
+--TEST--
+Updates a simple plugin package and restarts always the solver after installation of plugin (not restarted because plugin is not updating)
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "p/p", "version": "1.0.0", "type": "composer-plugin", "extra": { "installer-restart": true } }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "p/p": "1.0.0" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    }
+}
+--INSTALLED--
+[
+    {
+        "name": "p/p", "version": "1.0.0",
+        "source": { "reference": "abc123", "url": "", "type": "git" }
+    }
+]
+--RUN--
+update --verbose
+--EXPECT-OUTPUT--
+<info>Loading composer repositories with package information</info>
+<info>Updating dependencies (including require-dev)</info>
+<info>Writing lock file</info>
+<info>Generating autoload files</info>
+
+--EXPECT-EXIT-CODE--
+0
+--EXPECT--
+Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/plugin-restart-always-update.test
+++ b/tests/Composer/Test/Fixtures/installer/plugin-restart-always-update.test
@@ -1,0 +1,39 @@
+--TEST--
+Updates a simple plugin package and restarts always the solver after installation of plugin
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "p/p", "version": "1.0.0", "type": "composer-plugin", "extra": { "installer-restart": true } }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "p/p": "1.0.0" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    }
+}
+--RUN--
+update --verbose
+--EXPECT-OUTPUT--
+<info>Loading composer repositories with package information</info>
+<info>Updating dependencies (including require-dev)</info>
+<info>A new analysis of dependencies is required by:</info>
+  - Plugin <info>p/p</info> (<comment>always</comment>)
+
+<info>Updating dependencies (including require-dev)</info>
+<info>Writing lock file</info>
+<info>Generating autoload files</info>
+
+--EXPECT-EXIT-CODE--
+0
+--EXPECT--
+Installing p/p (1.0.0)
+Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/plugin-restart-always.test
+++ b/tests/Composer/Test/Fixtures/installer/plugin-restart-always.test
@@ -1,0 +1,39 @@
+--TEST--
+Installs a simple plugin package and restarts always the solver after installation of plugin
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "p/p", "version": "1.0.0", "type": "composer-plugin", "extra": { "installer-restart": true } }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "p/p": "1.0.0" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    }
+}
+--RUN--
+install --verbose
+--EXPECT-OUTPUT--
+<info>Loading composer repositories with package information</info>
+<info>Installing dependencies (including require-dev)</info>
+<info>A new analysis of dependencies is required by:</info>
+  - Plugin <info>p/p</info> (<comment>always</comment>)
+
+<info>Installing dependencies (including require-dev)</info>
+<info>Writing lock file</info>
+<info>Generating autoload files</info>
+
+--EXPECT-EXIT-CODE--
+0
+--EXPECT--
+Installing p/p (1.0.0)
+Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/plugin-restart-on-exception-sub-dep.test
+++ b/tests/Composer/Test/Fixtures/installer/plugin-restart-on-exception-sub-dep.test
@@ -1,0 +1,48 @@
+--TEST--
+Installs a simple plugin package and restarts the solver after the exception
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "p/p", "version": "1.0.0", "type": "composer-plugin", "extra": { "installer-restart": "on-exception" } }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "p/p": "1.0.0", "b/b": "1.0.0" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    }
+}
+--RUN--
+install --verbose
+--EXPECT-OUTPUT--
+<info>Loading composer repositories with package information</info>
+<info>Installing dependencies (including require-dev)</info>
+<info>A new analysis of dependencies is required by:</info>
+  - Plugin <info>p/p</info> (<comment>on-exception</comment>)
+
+<info>Installing dependencies (including require-dev)</info>
+<error>Your requirements could not be resolved to an installable set of packages.</error>
+
+  Problem 1
+    - Installation request for a/a 1.0.0 -> satisfiable by a/a[1.0.0].
+    - a/a 1.0.0 requires b/b 1.0.0 -> no matching package found.
+
+Potential causes:
+ - A typo in the package name
+ - The package is not available in a stable-enough version according to your minimum-stability setting
+   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.
+
+Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
+
+--EXPECT-EXIT-CODE--
+2
+--EXPECT--
+Installing p/p (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/plugin-restart-on-exception-valid.test
+++ b/tests/Composer/Test/Fixtures/installer/plugin-restart-on-exception-valid.test
@@ -1,0 +1,35 @@
+--TEST--
+Installs a simple plugin package and restarts the solver after the exception (not restarted because no exception)
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "p/p", "version": "1.0.0", "type": "composer-plugin", "extra": { "installer-restart": "on-exception" } }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "p/p": "1.0.0" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    }
+}
+--RUN--
+install --verbose
+--EXPECT-OUTPUT--
+<info>Loading composer repositories with package information</info>
+<info>Installing dependencies (including require-dev)</info>
+<info>Writing lock file</info>
+<info>Generating autoload files</info>
+
+--EXPECT-EXIT-CODE--
+0
+--EXPECT--
+Installing p/p (1.0.0)
+Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/plugin-restart-on-exception.test
+++ b/tests/Composer/Test/Fixtures/installer/plugin-restart-on-exception.test
@@ -1,0 +1,48 @@
+--TEST--
+Installs a simple plugin package and restarts the solver after the exception
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "p/p", "version": "1.0.0", "type": "composer-plugin", "extra": { "installer-restart": "on-exception" } }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "p/p": "1.0.0" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0",
+        "b/b": "1.0.0"
+    }
+}
+--RUN--
+install --verbose
+--EXPECT-OUTPUT--
+<info>Loading composer repositories with package information</info>
+<info>Installing dependencies (including require-dev)</info>
+<info>A new analysis of dependencies is required by:</info>
+  - Plugin <info>p/p</info> (<comment>on-exception</comment>)
+
+<info>Installing dependencies (including require-dev)</info>
+<error>Your requirements could not be resolved to an installable set of packages.</error>
+
+  Problem 1
+    - The requested package b/b could not be found in any version, there may be a typo in the package name.
+
+Potential causes:
+ - A typo in the package name
+ - The package is not available in a stable-enough version according to your minimum-stability setting
+   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.
+
+Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
+
+--EXPECT-EXIT-CODE--
+2
+--EXPECT--
+Installing p/p (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/plugins-are-installed-first.test
+++ b/tests/Composer/Test/Fixtures/installer/plugins-are-installed-first.test
@@ -25,7 +25,7 @@ Composer installers are installed first if they have no meaningful requirements
 install
 --EXPECT--
 Installing inst (1.0.0)
-Installing inst-with-req (1.0.0)
-Installing pkg (1.0.0)
 Installing pkg2 (1.0.0)
 Installing inst-with-req2 (1.0.0)
+Installing inst-with-req (1.0.0)
+Installing pkg (1.0.0)

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -200,8 +200,12 @@ class InstallerTest extends TestCase
             $composer
         );
 
+        $self = $this;
         $application = new Application;
-        $application->get('install')->setCode(function ($input, $output) use ($installer) {
+        $application->get('install')->setCode(function ($input, $output) use ($installer, $io, $self) {
+            $io->expects($self->any())
+                ->method('isVerbose')
+                ->will($self->returnValue($input->getOption('verbose')));
             $installer
                 ->setDevMode(!$input->getOption('no-dev'))
                 ->setDryRun($input->getOption('dry-run'))
@@ -210,7 +214,10 @@ class InstallerTest extends TestCase
             return $installer->run();
         });
 
-        $application->get('update')->setCode(function ($input, $output) use ($installer) {
+        $application->get('update')->setCode(function ($input, $output) use ($installer, $io, $self) {
+            $io->expects($self->any())
+                ->method('isVerbose')
+                ->will($self->returnValue($input->getOption('verbose')));
             $installer
                 ->setDevMode(!$input->getOption('no-dev'))
                 ->setUpdate(true)


### PR DESCRIPTION
| Q             | A
| ------------- | -------------------------------
| Bug fix?      | yes (installation plugin order)
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2972, #2879, #2878, #1121, #3078
| License       | MIT

This feature allows installing plugins and their dependencies before restarting the installation of other packages in the project. It allows the plugins to be added directly in the project and must not be installed in global.

With this feature it is for example possible to create a plugin adding automatically  the repositories, without that Composer throws an error when the first installation.

It does not change the original behavior of the install, but at the same time, fixes a "strange" behavior of the order of the installation of plugins and their dependencies.

The dependencies plugins must be installed before the plugin, then the plugin must be installed, and then the rest of depedencies can be installed.

Test example:

```json
{
    "repositories": [
        {
            "type": "package",
            "package": [
                { "name": "pkg", "version": "1.0.0" },
                { "name": "pkg2", "version": "1.0.0" },
                { "name": "inst", "version": "1.0.0", "type": "composer-plugin" },
                { "name": "inst2", "version": "1.0.0", "type": "composer-plugin", "require": { "pkg2": "*" } }
            ]
        }
    ],
    "require": {
        "pkg": "1.0.0",
        "inst": "1.0.0",
        "inst2": "1.0.0"
    }
}
```

The order should be:

```
Installing inst (1.0.0)
Installing pkg2 (1.0.0)
Installing inst2 (1.0.0)
Installing pkg (1.0.0)
```

and not (actually):

```
Installing inst (1.0.0)
Installing pkg (1.0.0)
Installing pkg2 (1.0.0)
Installing inst2 (1.0.0)
```