### PR TITLE
read and discard zero chars to initialise STDIN

### DIFF
--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -177,7 +177,7 @@ class ConsoleIO extends BaseIO
             // use bash if it's present
             if ($finder->find('bash') && $finder->find('stty')) {
                 $this->write($question, false);
-                $value = rtrim(shell_exec('bash -c "stty -echo; read -r mypassword; stty echo; echo $mypassword"'));
+                $value = rtrim(shell_exec('bash -c "stty -echo; read -n0 discard; read -r mypassword; stty echo; echo $mypassword"'));
                 $this->write('');
 
                 return $value;


### PR DESCRIPTION
Resolves issue in cygwin on windows 8.1 where password field is skipped. See later comments of issue #2831.
