### PR TITLE
Remember prefer-stable setting in composer.lock

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -277,7 +277,8 @@ class Installer
                     $platformDevReqs,
                     $aliases,
                     $this->package->getMinimumStability(),
-                    $this->package->getStabilityFlags()
+                    $this->package->getStabilityFlags(),
+                    $this->package->getPreferStable()
                 );
                 if ($updatedLock) {
                     $this->io->write('<info>Writing lock file</info>');
@@ -647,7 +648,7 @@ class Installer
 
     private function createPolicy()
     {
-        return new DefaultPolicy($this->package->getPreferStable());
+        return new DefaultPolicy((!$this->update && $this->locker->isLocked()) ? $this->locker->getPreferStable() : $this->package->getPreferStable());
     }
 
     private function createRequest(Pool $pool, RootPackageInterface $rootPackage, PlatformRepository $platformRepo)

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -173,6 +173,13 @@ class Locker
         return isset($lockData['stability-flags']) ? $lockData['stability-flags'] : array();
     }
 
+    public function getPreferStable()
+    {
+        $lockData = $this->getLockData();
+
+        return isset($lockData['prefer-stable']) ? $lockData['prefer-stable'] : false;
+    }
+
     public function getAliases()
     {
         $lockData = $this->getLockData();
@@ -206,7 +213,7 @@ class Locker
      *
      * @return bool
      */
-    public function setLockData(array $packages, $devPackages, array $platformReqs, $platformDevReqs, array $aliases, $minimumStability, array $stabilityFlags)
+    public function setLockData(array $packages, $devPackages, array $platformReqs, $platformDevReqs, array $aliases, $minimumStability, array $stabilityFlags, $preferStable)
     {
         $lock = array(
             '_readme' => array('This file locks the dependencies of your project to a known state',
@@ -218,6 +225,7 @@ class Locker
             'aliases' => array(),
             'minimum-stability' => $minimumStability,
             'stability-flags' => $stabilityFlags,
+            'prefer-stable' => $preferStable,
         );
 
         foreach ($aliases as $package => $versions) {

--- a/tests/Composer/Test/Fixtures/installer/install-dev-using-dist.test
+++ b/tests/Composer/Test/Fixtures/installer/install-dev-using-dist.test
@@ -47,6 +47,7 @@ install --prefer-dist
     "stability-flags": {
         "a/a": 20
     },
+    "prefer-stable": false,
     "platform": [],
     "platform-dev": []
 }

--- a/tests/Composer/Test/Fixtures/installer/install-from-empty-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/install-from-empty-lock.test
@@ -24,7 +24,8 @@ Requirements from the composer file are not installed if the lock file is presen
     "packages-dev": null,
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": []
+    "stability-flags": [],
+    "prefer-stable": false
 }
 --RUN--
 install

--- a/tests/Composer/Test/Fixtures/installer/install-missing-alias-from-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/install-missing-alias-from-lock.test
@@ -32,7 +32,8 @@ Installing an old alias that doesn't exist anymore from a lock is possible
     "packages-dev": null,
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": []
+    "stability-flags": [],
+    "prefer-stable": false
 }
 --RUN--
 install

--- a/tests/Composer/Test/Fixtures/installer/partial-update-downgrades-non-whitelisted-unstable.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-downgrades-non-whitelisted-unstable.test
@@ -35,6 +35,7 @@ Partial update from lock file should apply lock file and downgrade unstable pack
     "stability-flags": {
         "b/unstable": 15
     },
+    "prefer-stable": false,
     "platform": [],
     "platform-dev": []
 }
@@ -57,6 +58,7 @@ update c/uptodate
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
+    "prefer-stable": false,
     "platform": [],
     "platform-dev": []
 }

--- a/tests/Composer/Test/Fixtures/installer/partial-update-from-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-from-lock.test
@@ -35,6 +35,7 @@ Partial update from lock file should update everything to the state of the lock,
     "stability-flags": {
         "b/unstable": 15
     },
+    "prefer-stable": false,
     "platform": [],
     "platform-dev": []
 }
@@ -57,6 +58,7 @@ update b/unstable
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
+    "prefer-stable": false,
     "platform": [],
     "platform-dev": []
 }

--- a/tests/Composer/Test/Fixtures/installer/partial-update-without-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-without-lock.test
@@ -42,6 +42,7 @@ update b/unstable
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
+    "prefer-stable": false,
     "platform": [],
     "platform-dev": []
 }

--- a/tests/Composer/Test/Fixtures/installer/update-alias-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/update-alias-lock.test
@@ -38,7 +38,8 @@ Update aliased package does not mess up the lock file
     "packages-dev": null,
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": []
+    "stability-flags": [],
+    "prefer-stable": false
 }
 --INSTALLED--
 [
@@ -64,6 +65,7 @@ update
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": [],
+    "prefer-stable": false,
     "platform": [],
     "platform-dev": []
 }

--- a/tests/Composer/Test/Fixtures/installer/update-whitelist-reads-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/update-whitelist-reads-lock.test
@@ -31,7 +31,8 @@ Limited update takes rules from lock if available, and not from the installed re
     "packages-dev": null,
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": []
+    "stability-flags": [],
+    "prefer-stable": false
 }
 --INSTALLED--
 [

--- a/tests/Composer/Test/Fixtures/installer/updating-dev-from-lock-removes-old-deps.test
+++ b/tests/Composer/Test/Fixtures/installer/updating-dev-from-lock-removes-old-deps.test
@@ -19,7 +19,8 @@ Installing locked dev packages should remove old dependencies
     "packages-dev": null,
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": []
+    "stability-flags": [],
+    "prefer-stable": false
 }
 --INSTALLED--
 [

--- a/tests/Composer/Test/Fixtures/installer/updating-dev-updates-url-and-reference.test
+++ b/tests/Composer/Test/Fixtures/installer/updating-dev-updates-url-and-reference.test
@@ -31,7 +31,8 @@ Updating a dev package for new reference updates the url and reference
     "packages-dev": null,
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {"a/a":20}
+    "stability-flags": {"a/a":20},
+    "prefer-stable": false
 }
 --INSTALLED--
 [
@@ -57,6 +58,7 @@ update
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {"a/a":20},
+    "prefer-stable": false,
     "platform": [],
     "platform-dev": []
 }

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -134,9 +134,10 @@ class LockerTest extends \PHPUnit_Framework_TestCase
                 'stability-flags' => array(),
                 'platform' => array(),
                 'platform-dev' => array(),
+                'prefer-stable' => false,
             ));
 
-        $locker->setLockData(array($package1, $package2), array(), array(), array(), array(), 'dev', array());
+        $locker->setLockData(array($package1, $package2), array(), array(), array(), array(), 'dev', array(), false);
     }
 
     public function testLockBadPackages()
@@ -155,7 +156,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('LogicException');
 
-        $locker->setLockData(array($package1), array(), array(), array(), array(), 'dev', array());
+        $locker->setLockData(array($package1), array(), array(), array(), array(), 'dev', array(), false);
     }
 
     public function testIsFresh()


### PR DESCRIPTION
Stability flags and `minimum-stability` are written to `composer.lock` at the moment, but for some reason, `prefer-stable` is not.

Fix "attached" :)
