### PR TITLE
[POC] Show progress when resolving dependencies

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -163,8 +163,11 @@ class Solver
     {
         $this->jobs = $request->getJobs();
 
+        echo " - Setting up installed map\n";
         $this->setupInstalledMap();
+        echo " - Getting rules from rule set generator\n";
         $this->rules = $this->ruleSetGenerator->getRulesFor($this->jobs, $this->installedMap);
+        echo " - Checking for root require problems\n";
         $this->checkForRootRequireProblems();
         $this->decisions = new Decisions($this->pool);
         $this->watchGraph = new RuleWatchGraph;
@@ -173,9 +176,11 @@ class Solver
             $this->watchGraph->insert(new RuleWatchNode($rule));
         }
 
+        echo " - Making assertion rule decisions\n";
         /* make decisions based on job/update assertions */
         $this->makeAssertionRuleDecisions();
 
+        echo " - Running SAT\n";
         $this->runSat(true);
 
         // decide to remove everything that's installed and undecided
@@ -604,7 +609,6 @@ class Solver
         $installedPos = 0;
 
         while (true) {
-
             if (1 === $level) {
                 $conflictRule = $this->propagate($level);
                 if (null !== $conflictRule) {

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -351,6 +351,7 @@ class Installer
         if (!$installFromLock) {
             $repositories = $this->repositoryManager->getRepositories();
             foreach ($repositories as $repository) {
+                $this->io->write(' - Adding repository ' . get_class($repository));
                 $pool->addRepository($repository, $aliases);
             }
         }
@@ -463,6 +464,7 @@ class Installer
         // solve dependencies
         $solver = new Solver($policy, $pool, $installedRepo);
         try {
+            $this->io->write('<info>Solving dependencies</info>');
             $operations = $solver->solve($request);
         } catch (SolverProblemsException $e) {
             $this->io->write('<error>Your requirements could not be resolved to an installable set of packages.</error>');


### PR DESCRIPTION
Hi, this is just an illustrative PR for discussion.

When installing dependencies on large-ish projects I can sometimes be waiting for 10 minutes before composer starts to install packages, and the output of composer doesn't indicate any progress. 

I think it would be beneficial to output messages before time-consuming processes begin. These messages could be at the `-v` level.

I would propose passing either the `OutputInterface` to the `Solver` class, or a logging / profiling service which would access the Output by proxy.

The code in this PR produces:

```
Loading composer repositories with package information
 - Adding repository Composer\Repository\ComposerRepository
 - Adding repository Composer\Repository\ComposerRepository
Installing dependencies (including require-dev)
Solving dependencies
 - Setting up installed map
 - Getting rules from rule set generator
 - Checking for root require problems
 - Making assertion rule decisions
 - Running SAT
Nothing to install or update
 - Setting up installed map
 - Getting rules from rule set generator
 - Checking for root require problems
 - Making assertion rule decisions
 - Running SAT
Writing lock file
Generating autoload files
```

(I don't know why the Solver is called twice and it would be nice to identify the repositories which are being added)
