### PR TITLE
Add blank line to output for FileDownloader.

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -101,6 +101,8 @@ class FileDownloader implements DownloaderInterface
                 }
             }
         }
+        
+        $this->io->write('');
     }
 
     protected function doDownload(PackageInterface $package, $path, $url)


### PR DESCRIPTION
The VcsDownloader outputs a blank line between each dependency:

https://github.com/composer/composer/blob/745dcbce3317f7119575c39cef2cb601f9c5ffcf/src/Composer/Downloader/VcsDownloader.php#L80

This write makes output consistent.
