### PR TITLE
New command to install a global composer

### DIFF
--- a/src/Composer/Command/AddGlobalCmdCommand.php
+++ b/src/Composer/Command/AddGlobalCmdCommand.php
@@ -123,6 +123,8 @@ EOT
             if (!$installMode) {
                 $output->writeln('Success! Run <info>composer</info> to use the global executable.');
             }
+
+            return 0;
         } else {
             if (!$installMode) {
                 $output->writeln('<error>Global executable command failed</error>');

--- a/src/Composer/Command/AddGlobalCmdCommand.php
+++ b/src/Composer/Command/AddGlobalCmdCommand.php
@@ -176,7 +176,7 @@ EOT
     {
         // if we're already executable, no need to change permissions
         if (is_executable($targetPath)) {
-            return;
+            return true;
         }
 
         $process = new Process(sprintf('sudo chmod +x %s', $targetPath));

--- a/src/Composer/Command/AddGlobalCmdCommand.php
+++ b/src/Composer/Command/AddGlobalCmdCommand.php
@@ -91,7 +91,7 @@ EOT
             return 1;
         }
 
-        $output->writeln(sprintf('Composer successfully copied to <info>%s</info>', $targetPath));
+        $output->writeln(sprintf('Composer copied to <info>%s</info>', $targetPath));
 
         if ($isWindows) {
             // create a .bat file for Windows that executes composer

--- a/src/Composer/Command/AddGlobalCmdCommand.php
+++ b/src/Composer/Command/AddGlobalCmdCommand.php
@@ -76,7 +76,7 @@ EOT
         }
 
         // try to copy the composer file
-        $targetPath = $targetDir.'/composer';
+        $targetPath = $targetDir.DIRECTORY_SEPARATOR.'composer';
         if ($isWindows) {
             // windows will have a composer.phar AND a composer.bat that will call it
             $targetPath .= '.phar';
@@ -95,7 +95,7 @@ EOT
 
         if ($isWindows) {
             // create a .bat file for Windows that executes composer
-            $batPath = $targetDir.'/composer.bat';
+            $batPath = $targetDir.DIRECTORY_SEPARATOR.'composer.bat';
             if (!$this->createWindowsBatFile($batPath)) {
                 if (!$installMode) {
                     $output->writeln(sprintf('<error>Failed copying Windows bat file into %s</error>', $targetDir));

--- a/src/Composer/Command/AddGlobalCmdCommand.php
+++ b/src/Composer/Command/AddGlobalCmdCommand.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class AddGlobalCmdCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('add-global-cmd')
+            ->setDescription('Creates a global system "composer" command')
+            ->addOption('install-mode', null, InputOption::VALUE_NONE, 'Used when installing Composer - different input/output')
+            ->setHelp(<<<EOT
+<info>php composer.phar add-global-cmd</info>
+EOT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // only run on Linux!
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $output->writeln('This command cannot be run on Windows. Use the Windows installer.');
+
+            return;
+        }
+
+        $installMode = $input->getOption('install-mode');
+
+        // if we're being called by the installer, ask for confirmation first
+        if ($installMode) {
+            /** @var \Symfony\Component\Console\Helper\DialogHelper $dialogHelper */
+            $dialogHelper = $this->getHelper('dialog');
+
+            if (!$dialogHelper->askConfirmation(
+                $output,
+                "Do you want to install a global executable?\nThis will let you type <info>composer</info> anywhere to use it (requires root access). [Y/n] "
+            )) {
+                return;
+            }
+        } else {
+            // give normal user's a notice that the you might be asked for your sudo password
+            $output->writeln('<comment>This will attempt to create a global composer executable, which requires root access.</comment>');
+        }
+
+        // try to find a target bin directory
+        $targetDir = $this->findTargetBinDir();
+        if (!$targetDir) {
+            // hide the output if we're being called by the installer
+            if (!$installMode) {
+                $output->writeln('<error>Could not determine a valid bin directory</error>');
+            }
+
+            return;
+        }
+
+        $sourcePhar = \Phar::running(false);
+        if (!$sourcePhar) {
+            $output->writeln('<error>This command can only be run from a PHAR file</error>');
+
+            return;
+        }
+
+        // try to copy the composer file
+        $targetPath = $targetDir.'/composer';
+        if (!$this->copyComposerExec($sourcePhar, $targetPath)) {
+            if (!$installMode) {
+                $output->writeln(sprintf('<error>Failed copying composer into %s</error>', $targetDir));
+                $this->printErrorMessage($output);
+            }
+
+            return;
+        }
+
+        // set the executable permissions
+        if (!$this->setExecutablePermissions($targetPath)) {
+            if (!$installMode) {
+                $output->writeln(sprintf('<error>Failed giving %s executable permissions</error>', $targetDir));
+                $this->printErrorMessage($output);
+            }
+
+            return;
+        }
+
+        $output->writeln(sprintf('Composer successfully copied to <info>%s</info>', $targetPath));
+
+        // check to see if we now have a composer command or not (PATH problem?)
+        if ($this->doesComposerGlobalExist()) {
+            if (!$installMode) {
+                $output->writeln('Success! Run <info>composer</info> to use the global executable.');
+            }
+        } else {
+            if (!$installMode) {
+                $output->writeln('<error>Global executable command failed</error>');
+                $this->printErrorMessage($output);
+            }
+        }
+    }
+
+    /**
+     * Can the user type "composer" as a global command already?
+     *
+     * @return bool
+     */
+    protected function doesComposerGlobalExist()
+    {
+        $process = new Process('which composer');
+        $process->run();
+
+        // if there is no exectuable, the output is empty
+        return (bool) $process->getOutput();
+    }
+
+    /**
+     * Returns the path to the directory where the PHP binary exists
+     *
+     * @return bool|string
+     */
+    protected function findTargetBinDir()
+    {
+        $phpExecutableFinder = new PhpExecutableFinder();
+        $phpBinPath = $phpExecutableFinder->find();
+        if (!$phpBinPath) {
+            return false;
+        }
+
+        return dirname($phpBinPath);
+    }
+
+    /**
+     * Actually copies this composer executable into the target directory
+     *
+     * @param string $sourcePhar
+     * @param string $targetPath
+     * @return bool
+     */
+    protected function copyComposerExec($sourcePhar, $targetPath)
+    {
+        // this might not be a phar. In that case, we can't copy it
+        if (!$sourcePhar) {
+            return false;
+        }
+
+        $process = new Process(sprintf('sudo cp %s %s', $sourcePhar, $targetPath));
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+
+    /**
+     * Tries to make the composer file executable
+     *
+     * @param string $targetPath
+     * @return bool
+     */
+    protected function setExecutablePermissions($targetPath)
+    {
+        $process = new Process(sprintf('sudo chmod +x %s', $targetPath));
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+
+    protected function printErrorMessage(OutputInterface $output)
+    {
+        $output->writeln('If you want a global composer command, manually copy <info>composer.phar</info> into a bin directory and rename it to composer');
+    }
+}

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -246,6 +246,7 @@ class Application extends BaseApplication
         $commands[] = new Command\ClearCacheCommand();
         $commands[] = new Command\RemoveCommand();
         $commands[] = new Command\HomeCommand();
+        $commands[] = new Command\AddGlobalCmdCommand();
 
         if ('phar:' === substr(__FILE__, 0, 5)) {
             $commands[] = new Command\SelfUpdateCommand();


### PR DESCRIPTION
Hi guys!

See #3125. This introduces a new command - `add-global-cmd` - which attempts to move the PHAR file that's currently being executed into the bin directory where the php executable lives. The plan is to then (in a different PR, on the proper repository) modify the `https://getcomposer.org/installer` script to call this command on the brand new `composer.phar` file it just downloaded.

With this, the original `composer.phar` file remains in-tact, meaning that people can easily use "local" composer.phar installs just like before.

To summarize, after this is merged and the `installer` script is modified (not done here), the flow would be:

1. Run `curl -sS https://getcomposer.org/installer | php` (probably with a new option, like `--global` that triggers this new behavior, to protect BC)

2. The `composer.phar` file is downloaded into the current directory, like always

3. This new command asks the user if they want a global `composer` command also installed

4. If yes, the `composer.phar` file is copied into a global path. This requires sudo - so most users will be asked for their password

5. After finishing, the installer script will summarize what happened and how to run composer (e.g. "Run `composer` or `php composer.phar` to use Composer").

Two questions are:

A) Do we see any issues or improvements with this "flow"?

B) Do we see any technical/security issues, especially with running sudo and trying to figure out *where* to place the `composer` executable.

Thanks!