### PR TITLE
Prefer globally installed packages in PluginManager autoload

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -198,11 +198,11 @@ class PluginManager
         $classes = is_array($extra['class']) ? $extra['class'] : array($extra['class']);
 
         $pool = new Pool('dev');
-        $localRepo = $this->composer->getRepositoryManager()->getLocalRepository();
-        $pool->addRepository($localRepo);
         if ($this->globalRepository) {
             $pool->addRepository($this->globalRepository);
         }
+        $localRepo = $this->composer->getRepositoryManager()->getLocalRepository();
+        $pool->addRepository($localRepo);
 
         $autoloadPackages = array($package->getName() => $package);
         $autoloadPackages = $this->collectDependencies($pool, $autoloadPackages, $package);


### PR DESCRIPTION
When a package is installed globally and in the current project, PluginManager's autoload is built with the current project version which will break if you're going to update that package:

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Removing aws/aws-sdk-php (2.4.11)
  - Installing aws/aws-sdk-php (2.6.12)
    Downloading: connection...PHP Fatal error:  Class 'Aws\S3\S3Client' not found in /srv/home/a_samson/.composer/vendor/naderman/composer-aws/src/Naderman/Composer/AWS/AwsClient.php on line 161

Fatal error: Class 'Aws\S3\S3Client' not found in /srv/home/a_samson/.composer/vendor/naderman/composer-aws/src/Naderman/Composer/AWS/AwsClient.php on line 161
```

This PR makes the globally installed version preferred.
