### PR TITLE
Reordered Factory:createComposer function to init plugins before loading...

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -250,22 +250,10 @@ class Factory
 
         // initialize repository manager
         $rm = $this->createRepositoryManager($io, $config, $dispatcher);
+        $composer->setRepositoryManager($rm);
 
         // load local repository
         $this->addLocalRepository($rm, $vendorDir);
-
-        // load package
-        $parser = new VersionParser;
-        $loader  = new Package\Loader\RootPackageLoader($rm, $config, $parser, new ProcessExecutor($io));
-        $package = $loader->load($localConfig);
-
-        // initialize installation manager
-        $im = $this->createInstallationManager();
-
-        // Composer composition
-        $composer->setPackage($package);
-        $composer->setRepositoryManager($rm);
-        $composer->setInstallationManager($im);
 
         // initialize download manager
         $dm = $this->createDownloadManager($io, $config, $dispatcher);
@@ -277,9 +265,6 @@ class Factory
         $generator = new AutoloadGenerator($dispatcher, $io);
         $composer->setAutoloadGenerator($generator);
 
-        // add installers to the manager
-        $this->createDefaultInstallers($im, $composer, $io);
-
         $globalRepository = $this->createGlobalRepository($config, $vendorDir);
         $pm = $this->createPluginManager($composer, $io, $globalRepository);
         $composer->setPluginManager($pm);
@@ -288,6 +273,21 @@ class Factory
             $pm->loadInstalledPlugins();
         }
 
+        // load package
+        $parser = new VersionParser;
+        $loader  = new Package\Loader\RootPackageLoader($rm, $config, $parser, new ProcessExecutor($io));
+        $package = $loader->load($localConfig);
+
+        // initialize installation manager
+        $im = $this->createInstallationManager();
+
+        // Composer composition
+        $composer->setPackage($package);
+        $composer->setInstallationManager($im);
+        
+        // add installers to the manager
+        $this->createDefaultInstallers($im, $composer, $io);
+        
         // purge packages if they have been deleted on the filesystem
         $this->purgePackages($rm, $im);
 


### PR DESCRIPTION
... composer.json file

I was developing plugin with custom repository class and stuck in the corner with this because plugins are inited after composer.json is readed and custom type repository is not registered and composer crash with exception that type is not registered. I have played a little with this code to make it work. I have tested a little bit by myself and it works but I am not 100% sure it not damaged anything. Maybe someone with better understanding in composer core could make some changes or guide how to implement custom repository type