### PR TITLE
generateUnixyProxyCode() properly supporting Cygwin & Git Bash

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -303,13 +303,29 @@ class LibraryInstaller implements InstallerInterface
     protected function generateUnixyProxyCode($bin, $link)
     {
         $binPath = $this->filesystem->findShortestPath($link, $bin);
+        $binDir = escapeshellarg(dirname($binPath));
+        $binFile = basename($binPath);
 
-        return "#!/usr/bin/env sh\n".
-            'SRC_DIR="`pwd`"'."\n".
-            'cd "`dirname "$0"`"'."\n".
-            'cd '.escapeshellarg(dirname($binPath))."\n".
-            'BIN_TARGET="`pwd`/'.basename($binPath)."\"\n".
-            'cd "$SRC_DIR"'."\n".
-            '"$BIN_TARGET" "$@"'."\n";
+        $proxyCode = <<<PROXY
+#!/bin/sh
+
+dir=$(d=$(dirname "$0"); cd "\$d"; cd $binDir && pwd)
+
+# see if we are running in cygwin by checking for cygpath program
+if command -v 'cygpath' >/dev/null 2>&1; then
+	# cygwin paths start with /cygdrive/ which will break windows PHP,
+	# so we need to translate the dir path to windows format. However
+	# we could be using cygwin PHP which does not require this, so we
+	# test if the path to PHP starts with /cygdrive/ rather than /usr/bin.
+	if [[ $(which php) == /cygdrive/* ]]; then
+		dir=$(cygpath -m \$dir);
+	fi
+fi
+
+dir=$(echo \$dir | sed 's/ /\ /g')
+"\${dir}/$binFile" "$@"
+PROXY;
+
+        return $proxyCode;
     }
 }

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -307,7 +307,7 @@ class LibraryInstaller implements InstallerInterface
         $binFile = basename($binPath);
 
         $proxyCode = <<<PROXY
-#!/bin/sh
+#!/usr/bin/env sh
 
 dir=$(d=$(dirname "$0"); cd "\$d"; cd $binDir && pwd)
 

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -311,12 +311,12 @@ class LibraryInstaller implements InstallerInterface
 
 dir=$(d=$(dirname "$0"); cd "\$d"; cd $binDir && pwd)
 
-# see if we are running in cygwin by checking for cygpath program
+# See if we are running in Cygwin by checking for cygpath program
 if command -v 'cygpath' >/dev/null 2>&1; then
-	# cygwin paths start with /cygdrive/ which will break windows PHP,
+	# Cygwin paths start with /cygdrive/ which will break windows PHP,
 	# so we need to translate the dir path to windows format. However
 	# we could be using cygwin PHP which does not require this, so we
-	# test if the path to PHP starts with /cygdrive/ rather than /usr/bin.
+	# test if the path to PHP starts with /cygdrive/ rather than /usr/bin
 	if [[ $(which php) == /cygdrive/* ]]; then
 		dir=$(cygpath -m \$dir);
 	fi


### PR DESCRIPTION
Based on Composer's proxy: https://github.com/composer/windows-setup/blob/master/src/shims/composer

Previous `generateUnixyProxyCode()`'s version was generating unixy-proxy file which was causing problems:

```
$ phpunit
Could not open input file: /cygdrive/c/Users/<user>/AppData/Roaming/Composer/vendor/phpunit/phpunit/phpunit
```