### PR TITLE
Add --no-scripts argument for dump-autoload command

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -40,6 +40,8 @@ class AutoloadGenerator
 
     private $devMode = false;
 
+    private $scriptMode = false;
+
     public function __construct(EventDispatcher $eventDispatcher, IOInterface $io = null)
     {
         $this->eventDispatcher = $eventDispatcher;
@@ -51,9 +53,14 @@ class AutoloadGenerator
         $this->devMode = (boolean) $devMode;
     }
 
+    public function setRunScripts($scriptMode = true)
+    {
+        $this->scriptMode = (boolean) $scriptMode;
+    }
+
     public function dump(Config $config, InstalledRepositoryInterface $localRepo, PackageInterface $mainPackage, InstallationManager $installationManager, $targetDir, $scanPsr0Packages = false, $suffix = '')
     {
-        $this->eventDispatcher->dispatchScript(ScriptEvents::PRE_AUTOLOAD_DUMP, $this->devMode);
+        $this->scriptMode && $this->eventDispatcher->dispatchScript(ScriptEvents::PRE_AUTOLOAD_DUMP, $this->devMode);
 
         $filesystem = new Filesystem();
         $filesystem->ensureDirectoryExists($config->get('vendor-dir'));
@@ -235,7 +242,7 @@ EOF;
         fclose($targetLoader);
         unset($sourceLoader, $targetLoader);
 
-        $this->eventDispatcher->dispatchScript(ScriptEvents::POST_AUTOLOAD_DUMP, $this->devMode);
+        $this->scriptMode && $this->eventDispatcher->dispatchScript(ScriptEvents::POST_AUTOLOAD_DUMP, $this->devMode);
     }
 
     public function buildPackageMap(InstallationManager $installationManager, PackageInterface $mainPackage, array $packages)

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -30,6 +30,7 @@ class DumpAutoloadCommand extends Command
             ->setAliases(array('dumpautoload'))
             ->setDescription('Dumps the autoloader')
             ->setDefinition(array(
+                new InputOption('no-scripts', null, InputOption::VALUE_NONE, 'Skips the execution of all scripts defined in composer.json file.'),
                 new InputOption('optimize', 'o', InputOption::VALUE_NONE, 'Optimizes PSR0 and PSR4 packages to be loaded with classmaps too, good for production.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables autoload-dev rules.'),
             ))
@@ -62,6 +63,7 @@ EOT
 
         $generator = $composer->getAutoloadGenerator();
         $generator->setDevMode(!$input->getOption('no-dev'));
+        $generator->setRunScripts(!$input->getOption('no-scripts'));
         $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
     }
 }

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -814,6 +814,7 @@ EOF;
             ->method('getCanonicalPackages')
             ->will($this->returnValue(array()));
 
+        $this->generator->setRunScripts(true);
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', true, '_8');
     }
 


### PR DESCRIPTION
Script is executed, if post-autoload-dump specified and ````composer install --no-scripts```` is executed.

````
"scripts": {
    "post-autoload-dump": "echo 1"
},
````

This PR do not execute scripts.