### PR TITLE
Add support of 'select' from option list in ConsoleIO and NullIO

### DIFF
--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -237,4 +237,12 @@ class ConsoleIO extends BaseIO
         // not able to hide the answer, proceed with normal question handling
         return $this->ask($question);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function select($question, $choices, $default = null, $attempts = false, $errorMessage = 'Value "%s" is invalid', $multiselect = false)
+    {
+        return $this->helperSet->get('dialog')->select($this->output, $question, $choices, $default, $attempts, $errorMessage, $multiselect);
+    }
 }

--- a/src/Composer/IO/IOInterface.php
+++ b/src/Composer/IO/IOInterface.php
@@ -125,6 +125,22 @@ interface IOInterface
     public function askAndHideAnswer($question);
 
     /**
+     * Asks the user to select a value.
+     *
+     * @param string|array $question     The question to ask
+     * @param array        $choices      List of choices to pick from
+     * @param bool|string  $default      The default answer if the user enters nothing
+     * @param bool|int     $attempts Max number of times to ask before giving up (false by default, which means infinite)
+     * @param string       $errorMessage Message which will be shown if invalid value from choice list would be picked
+     * @param bool         $multiselect  Select more than one value separated by comma
+     *
+     * @return int|string|array The selected value or values (the key of the choices array)
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function select($question, $choices, $default = null, $attempts = false, $errorMessage = 'Value "%s" is invalid', $multiselect = false);
+
+    /**
      * Get all authentication information entered.
      *
      * @return array The map of authentication data

--- a/src/Composer/IO/NullIO.php
+++ b/src/Composer/IO/NullIO.php
@@ -104,4 +104,12 @@ class NullIO extends BaseIO
     {
         return null;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function select($question, $choices, $default = null, $attempts = false, $errorMessage = 'Value "%s" is invalid', $multiselect = false)
+    {
+        return $default;
+    }
 }

--- a/tests/Composer/Test/IO/ConsoleIOTest.php
+++ b/tests/Composer/Test/IO/ConsoleIOTest.php
@@ -149,6 +149,31 @@ class ConsoleIOTest extends TestCase
         $consoleIO->askAndValidate('Why?', 'validator', 10, 'default');
     }
 
+    public function testSelect()
+    {
+        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
+        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $dialogMock = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
+        $helperMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+
+        $dialogMock->expects($this->once())
+            ->method('select')
+            ->with($this->isInstanceOf('Symfony\Component\Console\Output\OutputInterface'),
+                $this->equalTo('Select item'),
+                $this->equalTo(array("item1", "item2")),
+                $this->equalTo(null),
+                $this->equalTo(false),
+                $this->equalTo("Error message"),
+                $this->equalTo(true));
+        $helperMock->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('dialog'))
+            ->will($this->returnValue($dialogMock));
+
+        $consoleIO = new ConsoleIO($inputMock, $outputMock, $helperMock);
+        $consoleIO->select('Select item', array("item1", "item2"), null, false, "Error message", true);
+    }
+
     public function testSetAndgetAuthentication()
     {
         $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');

--- a/tests/Composer/Test/IO/NullIOTest.php
+++ b/tests/Composer/Test/IO/NullIOTest.php
@@ -67,4 +67,11 @@ class NullIOTest extends TestCase
 
         $this->assertEquals('foo', $io->askAndValidate('question', 'validator', false, 'foo'));
     }
+
+    public function testSelect()
+    {
+        $io = new NullIO();
+
+        $this->assertEquals('1', $io->select('question', array('item1', 'item2'), '1', 2, 'foo', true));
+    }
 }


### PR DESCRIPTION
Sometimes it is useful in scripts (script handlers, plugins) to have ability to choose values from list of predefined options during console interactions. This pull request makes it possible due to support of 'select' method in IOInterface