### PR TITLE
Update 00-intro.md

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -115,7 +115,7 @@ brew update
 brew tap homebrew/homebrew-php
 brew tap homebrew/dupes
 brew tap homebrew/versions
-brew install php55-intl
+brew install php55
 brew install homebrew/php/composer
 ```
 


### PR DESCRIPTION
php55-intl is no longer available as a formula.

See this commit: 
https://github.com/Homebrew/homebrew-php/commit/911d13a8ab240e73318a2321be95e16a13dce38d

It is now included in abstract-php formula which is extended by all the default php installations. (eg. php53 / php56 )
