### PR TITLE
Some improvements and clarifications to the instructions/examples.

### DIFF
--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -43,32 +43,38 @@ depends on.
 ```json
 {
     "require": {
-        "monolog/monolog": "1.0.*"
+        "myvendor/mypackage": "1.0.*"
     }
 }
 ```
 
-As you can see, `require` takes an object that maps **package names** (e.g. `monolog/monolog`)
-to **package versions** (e.g. `1.0.*`).
+Each item in the `require` key maps **package names** (e.g. `myvendor/mypackage`)
+to **package versions** (e.g. `1.0.*`).  
+
+> **Note:** You can check the syntax of your `composer.json` file by using 
+> the `composer validate` command.
 
 ### Package Names
 
 The package name consists of a vendor name and the project's name. Often these
-will be identical - the vendor name just exists to prevent naming clashes. It allows
-two different people to create a library named `json`, which would then just be
-named `igorw/json` and `seldaek/json`.
-
-Here we are requiring `monolog/monolog`, so the vendor name is the same as the
-project's name. For projects with a unique name this is recommended. It also
-allows adding more related projects under the same namespace later on. If you
-are maintaining a library, this would make it really easy to split it up into
-smaller decoupled parts.
+will be identical.  The vendor name exists to prevent naming clashes. For example, 
+use of the vendor name  allows two different people to both create a library named `json`, 
+which might be named `igorw/json` and `seldaek/json`.
 
 ### Package Versions
 
-In the previous example we were requiring version `1.0.*` of monolog. This
-means any version in the `1.0` development branch. It would match `1.0.0`,
-`1.0.2` or `1.0.20`.
+Let's look at this example:
+
+```json
+{
+    "require": {
+        "monolog/monolog": "1.0.*"
+    }
+}
+```
+In this example we were requiring version `1.0.*` of monolog. The star 
+would match any version in the `1.0` development branch including version `1.0.0`,
+`1.0.2`, or `1.0.20`.
 
 Version constraints can be specified in a few different ways.
 
@@ -105,10 +111,17 @@ packages instead of doing per dependency you can also use the
 ## Installing Dependencies
 
 To fetch the defined dependencies into your local project, just run the
-`install` command of `composer.phar`.
+`install` command of `composer.phar` from the directory containing your `composer.json` file.
 
 ```sh
 php composer.phar install
+```
+
+You often see the following syntax used in documentation -- you can use this syntax if you have
+installed composer globally:
+
+```sh
+composer install
 ```
 
 This will find the latest version of `monolog/monolog` that matches the
@@ -117,8 +130,8 @@ It's a convention to put third party code into a directory named `vendor`.
 In case of monolog it will put it into `vendor/monolog/monolog`.
 
 > **Tip:** If you are using git for your project, you probably want to add
-> `vendor` into your `.gitignore`. You really don't want to add all of that
-> code to your repository.
+> the `vendor/` directory into your `.gitignore`.  You don't need to version
+> control the dependencies in your project's repository.
 
 Another thing that the `install` command does is it adds a `composer.lock`
 file into your project root.

--- a/doc/articles/custom-installers.md
+++ b/doc/articles/custom-installers.md
@@ -69,6 +69,7 @@ requirements:
 2. the [extra][2] attribute must contain an element `class` defining the
    class name of the plugin (including namespace). If a package contains
    multiple plugins this can be array of class names.
+3. the [require][6] attribute must reference the `composer-plugin-api`
 
 Example:
 
@@ -130,10 +131,11 @@ recognized by packages that will use this installer in the `supports()` method.
 > the format: `vendor-type`_. For example: `phpdocumentor-template`.
 
 The InstallerInterface class defines the following methods (please see the
-source for the exact signature):
+source for the exact signatures):
 
-* **supports()**, here you test whether the passed [type][1] matches the name
-  that you declared for this installer (see the example).
+* **supports()**, here you test whether the passed [type][1] matches the package type(s)
+  that this installer will operate on (see the example).  Note that only packages being required will 
+  be evaluated; the root package's type is not evaluated.
 * **isInstalled()**, determines whether a supported package is installed or not.
 * **install()**, here you can determine the actions that need to be executed
   upon installation.
@@ -144,6 +146,8 @@ source for the exact signature):
 * **getInstallPath()**, this method should return the location where the
   package is to be installed, _relative from the location of composer.json._
 
+Note that some methods accept different class instances as inputs, so you can omit or add the necessary `use` statements accordingly.
+
 Example:
 
 ```php
@@ -153,6 +157,7 @@ namespace phpDocumentor\Composer;
 
 use Composer\Package\PackageInterface;
 use Composer\Installer\LibraryInstaller;
+use Composer\Repository\InstalledRepositoryInterface;
 
 class TemplateInstaller extends LibraryInstaller
 {
@@ -196,3 +201,4 @@ different installation path.
 [3]: https://github.com/composer/composer/blob/master/src/Composer/Plugin/PluginInterface.php
 [4]: https://github.com/composer/composer/blob/master/src/Composer/Installer/InstallerInterface.php
 [5]: https://github.com/composer/composer/blob/master/src/Composer/Installer/LibraryInstaller.php
+[6]: ../04-schema.md#require


### PR DESCRIPTION
I tried to clean up some of the flow of the basic usage and I tried to add some clarifications to the confusing process of adding custom installers.  The two key points there that were previously omitted were that 1. the custom installer does not operate on the root package, and 2. the composer-plugin-api must be required.

In basic usage, I removed the paragraph that attempted to explain why vendor names and package names are often the same.  Sorry, but I have no idea what you're talking about and I've been reading that blurb and using composer for over a year.  E.g. this bit: "For projects with a unique name" -- what does that mean?  Doesn't *every* project have a unique name?   If you want to elaborate on the use case, then please come up with a valid explanation and example.  For now I've removed that because I think it helps your readers from sinking into confusion.