### PR TITLE
Update 00-intro.md

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -115,7 +115,7 @@ brew update
 brew tap homebrew/homebrew-php
 brew tap homebrew/dupes
 brew tap homebrew/versions
-brew install php55-intl
+brew install php55
 brew install homebrew/php/composer
 ```
 


### PR DESCRIPTION
Via https://github.com/Homebrew/homebrew-php/issues/1112, the homebrew forumla for php55 now includes intl by default and php55-intl is no longer an option.
