### PR TITLE
Fixed brew install formulae name

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -115,7 +115,7 @@ brew update
 brew tap homebrew/homebrew-php
 brew tap homebrew/dupes
 brew tap homebrew/versions
-brew install php55-intl
+brew install php55
 brew install homebrew/php/composer
 ```
 


### PR DESCRIPTION
The `php55-intl` formulae has been removed.

http://braumeister.org/repos/josegonzalez/homebrew-php/formula/php55-intl
