### PR TITLE
fixed failing test Config->testVarReplacement() on windows, referencing ...

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -159,7 +159,8 @@ class Config
                 $env = 'COMPOSER_' . strtoupper(strtr($key, '-', '_'));
 
                 $val = rtrim($this->process(getenv($env) ?: $this->config[$key]), '/\\');
-                $val = preg_replace('#^(\$HOME|~)(/|$)#', rtrim(getenv('HOME') ?: getenv('USERPROFILE'), '/\\') . '/', $val);
+                $home = rtrim(getenv('HOME') ?: getenv('USERPROFILE'), '/\\') . DIRECTORY_SEPARATOR;
+                $val = preg_replace('#^(\$HOME|~)(/|$)#', $home, $val);
 
                 return $val;
 

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -115,10 +115,10 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config->merge(array('config' => array('a' => 'b', 'c' => '{$a}')));
         $config->merge(array('config' => array('bin-dir' => '$HOME', 'cache-dir' => '~/foo/')));
 
-        $home = rtrim(getenv('HOME'), '\\/');
+        $home = rtrim(getenv('HOME') ?: getenv('USERPROFILE'), '/\\');
         $this->assertEquals('b', $config->get('c'));
-        $this->assertEquals($home.'/', $config->get('bin-dir'));
-        $this->assertEquals($home.'/foo', $config->get('cache-dir'));
+        $this->assertEquals($home . DIRECTORY_SEPARATOR, $config->get('bin-dir'));
+        $this->assertEquals($home . DIRECTORY_SEPARATOR . 'foo', $config->get('cache-dir'));
     }
 
     public function testOverrideGithubProtocols()


### PR DESCRIPTION
...https://github.com/composer/composer/commit/449f8165ef64829dc34be836235ceb74d9227dd7 and issue #3060

1) Composer\Test\ConfigTest::testVarReplacement
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'/'
+'C:\Users\koch/'
