### PR TITLE
Check for VCS reference difference in command 'status'

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -106,7 +106,20 @@ class GitDownloader extends VcsDownloader
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
         }
 
-        return trim($output) ?: null;
+        if (trim($output)) {
+            return trim($output);
+        }
+
+        $path = $this->normalizePath($path);
+        if (0 !== $this->process->execute('git rev-parse --verify HEAD', $refOutput, $path)) {
+            throw new \RuntimeException("Could not determine reference\n\n:".$this->process->getErrorOutput());
+        }
+
+        if (!trim($refOutput)) {
+            return null;
+        }
+
+        return trim($refOutput) !== $package->getSourceReference() ? 'Reference differs' : null;
     }
 
     /**

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -110,16 +110,32 @@ class GitDownloader extends VcsDownloader
             return trim($output);
         }
 
-        $path = $this->normalizePath($path);
         if (0 !== $this->process->execute('git rev-parse --verify HEAD', $refOutput, $path)) {
             throw new \RuntimeException("Could not determine reference\n\n:".$this->process->getErrorOutput());
         }
 
-        if (!trim($refOutput)) {
+        $reference = trim($refOutput);
+        if (!$reference) {
             return null;
         }
 
-        return trim($refOutput) !== $package->getSourceReference() ? 'Reference differs' : null;
+        if ($reference === $package->getSourceReference()) {
+            return null;
+        }
+
+        // perform tag resolving
+        $tagReferenceCommand = sprintf('git rev-parse --verify %s^{commit}', escapeshellarg($package->getSourceReference()));
+        if (0 !== $this->process->execute($tagReferenceCommand, $refTagOutput, $path)) {
+            throw new \RuntimeException("Could not determine tag reference\n\n:".$this->process->getErrorOutput());
+        }
+
+        $tagReference = trim($refTagOutput);
+
+        if (!$tagReference) {
+            return null;
+        }
+
+        return $tagReference !== $reference ? 'Reference differs' : null;
     }
 
     /**

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -71,7 +71,7 @@ class HgDownloader extends VcsDownloader
             return trim($output);
         }
 
-        $this->process->execute('hg parent --template \'{node}\'', $refOutput, realpath($path));
+        $this->process->execute('hg parent --template ' . escapeshellarg('{node}'), $refOutput, realpath($path));
 
         if (!trim($refOutput)) {
             return null;

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -67,7 +67,17 @@ class HgDownloader extends VcsDownloader
 
         $this->process->execute('hg st', $output, realpath($path));
 
-        return trim($output) ?: null;
+        if (trim($output)) {
+            return trim($output);
+        }
+
+        $this->process->execute('hg parent --template \'{node}\'', $refOutput, realpath($path));
+
+        if (!trim($refOutput)) {
+            return null;
+        }
+
+        return trim($refOutput) !== $package->getSourceReference() ? 'Reference differs' : null;
     }
 
     /**

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -67,7 +67,19 @@ class SvnDownloader extends VcsDownloader
 
         $this->process->execute('svn status --ignore-externals', $output, $path);
 
-        return preg_match('{^ *[^X ] +}m', $output) ? $output : null;
+        if (preg_match('{^ *[^X ] +}m', $output)) {
+            return $output;
+        }
+
+        $this->process->execute('svnversion', $refOutput, $path);
+
+        $sourceRef = substr($package->getSourceReference(), strrpos($package->getSourceReference(), '@') + 1);
+
+        if (!trim($refOutput)) {
+            return null;
+        }
+
+        return trim($refOutput) !== $sourceRef ? 'Reference differs' : null;
     }
 
     /**

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -239,17 +239,21 @@ class GitDownloaderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(0));
         $processExecutor->expects($this->at(1))
             ->method('execute')
-            ->with($this->equalTo($this->winCompat("git remote -v")))
+            ->with($this->equalTo($this->winCompat("git rev-parse --verify HEAD")))
             ->will($this->returnValue(0));
         $processExecutor->expects($this->at(2))
             ->method('execute')
-            ->with($this->equalTo($expectedGitUpdateCommand))
+            ->with($this->equalTo($this->winCompat("git remote -v")))
             ->will($this->returnValue(0));
         $processExecutor->expects($this->at(3))
             ->method('execute')
-            ->with($this->equalTo('git branch -r'))
+            ->with($this->equalTo($expectedGitUpdateCommand))
             ->will($this->returnValue(0));
         $processExecutor->expects($this->at(4))
+            ->method('execute')
+            ->with($this->equalTo('git branch -r'))
+            ->will($this->returnValue(0));
+        $processExecutor->expects($this->at(5))
             ->method('execute')
             ->with($this->equalTo($this->winCompat("git checkout 'ref' && git reset --hard 'ref'")), $this->equalTo(null), $this->equalTo($this->winCompat($tmpDir)))
             ->will($this->returnValue(0));
@@ -282,9 +286,13 @@ class GitDownloaderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(0));
         $processExecutor->expects($this->at(1))
             ->method('execute')
-            ->with($this->equalTo($this->winCompat("git remote -v")))
+            ->with($this->equalTo($this->winCompat("git rev-parse --verify HEAD")))
             ->will($this->returnValue(0));
         $processExecutor->expects($this->at(2))
+            ->method('execute')
+            ->with($this->equalTo($this->winCompat("git remote -v")))
+            ->will($this->returnValue(0));
+        $processExecutor->expects($this->at(3))
             ->method('execute')
             ->with($this->equalTo($expectedGitUpdateCommand))
             ->will($this->returnValue(1));

--- a/tests/Composer/Test/Downloader/HgDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/HgDownloaderTest.php
@@ -102,8 +102,13 @@ class HgDownloaderTest extends \PHPUnit_Framework_TestCase
             ->method('execute')
             ->with($this->equalTo($expectedHgCommand))
             ->will($this->returnValue(0));
-        $expectedHgCommand = $this->getCmd("hg pull 'https://github.com/l3l0/composer' && hg up 'ref'");
+        $expectedHgCommand = $this->getCmd("hg parent --template '{node}'");
         $processExecutor->expects($this->at(1))
+            ->method('execute')
+            ->with($this->equalTo($expectedHgCommand))
+            ->will($this->returnValue(0));
+        $expectedHgCommand = $this->getCmd("hg pull 'https://github.com/l3l0/composer' && hg up 'ref'");
+        $processExecutor->expects($this->at(2))
             ->method('execute')
             ->with($this->equalTo($expectedHgCommand))
             ->will($this->returnValue(0));


### PR DESCRIPTION
Composer status detects only uncommited changes for VCS packages. This patch
adds informations about different reference versions.
If a package has no uncommited changes, but differs from the
revision defined in composer.lock, a change message is triggered.

This commit is related to #1968

Missing pieces:
* Perforce support
* It might be better to add a separate abstract function to VcsDownloader for this check (reuse)
* Test case for new behavior