### PR TITLE
Check whether scope isolated function `includeFile` is already defined

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -377,7 +377,10 @@ class ClassLoader
  *
  * Prevents access to $this/self from included files.
  */
-function includeFile($file)
-{
-    include $file;
-}
+ if(!function_exists('includeFile')) {
+    function includeFile($file)
+    {
+        include $file;
+    }
+ }
+


### PR DESCRIPTION
This simple check enables integration of several projects that use Composer as their autoload manager by checking whether a global method `includeFile` exists or not, thus avoiding potential PHP fatal error. If one includes files of a project that already used Composer to manage dependencies (or autoloading), a clash is inevitable when it comes to defining the `includeFile` method - thus raising a PHP fatal error. This small patch checks whether the method is already defined.