### PR TITLE
Allow packagist to be disabled via the config command.

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -237,9 +237,19 @@ EOT
         // handle repositories
         if (preg_match('/^repos?(?:itories)?\.(.+)/', $settingKey, $matches)) {
             if ($input->getOption('unset')) {
-                return $this->configSource->removeRepository($matches[1]);
+                // packagist is not written to config and must be overidden with false
+                if ($matches[1] === 'packagist') {
+                    $values = array('false');
+                }
+                else {
+                    return $this->configSource->removeRepository($matches[1]);
+                }
             }
 
+            // special case to allow packagist to be turned off
+            if ($matches[1] === 'packagist' && 1 === count($values) && $values[0] === 'false') {
+                return $this->configSource->addRepository($matches[1], false);
+            }
             if (2 !== count($values)) {
                 throw new \RuntimeException('You must pass the type and a url. Example: php composer.phar config repositories.foo vcs http://bar.com');
             }


### PR DESCRIPTION
Currently there is no equivalent to disable packagist via config as can be done via `composer.json` and documented (https://getcomposer.org/doc/05-repositories.md#disabling-packagist).

    {
        "repositories": [
            {
                "packagist": false
            }
        ]
    }

Currently packagist is displayed like any other repository, but cannot be unset and setting to `false` as done in composer.json is not possible via the command line, but can be done manually and works as expected.

    $ composer config --global --list
    [repositories.packagist.type] composer
    [repositories.packagist.url] https?://packagist.org
    [repositories.packagist.allow_ssl_downgrade] true
    ...

Attempting to unset does not provide an error, but has not effect.

    $ config --global --unset repositories.packagist

This pull request allows for packagist to be disabled using either of the following.

    composer config --global --unset repositories.packagist
    composer config --global repositories.packagist false

Once set everything behaves as expected and `--list` does not display packagist.