### PR TITLE
Remove extra ? from repositories regex in config command.

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -235,7 +235,7 @@ EOT
         $values = $input->getArgument('setting-value'); // what the user is trying to add/change
 
         // handle repositories
-        if (preg_match('/^repos?(?:itories)?\.(.+)/', $settingKey, $matches)) {
+        if (preg_match('/^repos(?:itories)?\.(.+)/', $settingKey, $matches)) {
             if ($input->getOption('unset')) {
                 return $this->configSource->removeRepository($matches[1]);
             }


### PR DESCRIPTION
This looks like a typo or perhaps the author thought you needed `?` on both sides of optional group? Either way in its current state the regex matches the following. The last one does not look intentional.

```
repositories.foo
repos.foo
repoitories.foo
```

The corrected regex does not match the last entry.
