### PR TITLE
Adding missing closing <info> tag when re-applying stashed changes

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -191,7 +191,7 @@ class GitDownloader extends VcsDownloader
         $path = $this->normalizePath($path);
         if ($this->hasStashedChanges) {
             $this->hasStashedChanges = false;
-            $this->io->write('    <info>Re-applying stashed changes');
+            $this->io->write('    <info>Re-applying stashed changes</info>');
             if (0 !== $this->process->execute('git stash pop', $output, $path)) {
                 throw new \RuntimeException("Failed to apply stashed changes:\n\n".$this->process->getErrorOutput());
             }


### PR DESCRIPTION
When a conflict occurs when updating, if telling composer to stash changes then re-apply, all the console text following the "Re-applying stashed changes" message comes out green.

This PR fixes this by closing the `info` tag when printing the "Re-applying stashed changes" message.
