### PR TITLE
Fix missing validation on default value for author input

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -228,10 +228,7 @@ EOT
             $output,
             $dialog->getQuestion('Author', $author),
             function ($value) use ($self, $author) {
-                if (null === $value) {
-                    return $author;
-                }
-
+                $value = $value ?: $author;
                 $author = $self->parseAuthorString($value);
 
                 return sprintf('%s <%s>', $author['name'], $author['email']);


### PR DESCRIPTION
The default author value on the composer init command is not validated against `parseAuthorString` method and thus not being re-prompted, finally throwing an InvalidArgumentException when it tries to generate the composer.json file.

The changes forces the validation of both the entered author string or the default value.

Tried to add a few tests to validate this but couldn't get too further on that idea. If it's needed I'll give a second try.
