### PR TITLE
Allow to select virtual packages in init command

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -333,8 +333,7 @@ EOT
         }
 
         while (null !== $package = $dialog->ask($output, $prompt)) {
-            $matches = $this->findPackages($package);
-
+            $matches = array_values($this->findPackages($package));
             if (count($matches)) {
                 $output->writeln(array(
                     '',


### PR DESCRIPTION
It seems matches returns virtual packages with their keys the same as their name. This means you can't actually select them when prompted:

![](http://ss.jhf.tw/gX5eC2XVzV.png)

![](http://ss.jhf.tw/pArAVN4w16.png)

It's a simple fix by using `array_values` on the return of `findPackages`

Let me know if i've overlooked something, I also looked where to add a test but couldn't really see any existing tests for the command internals.
