### PR TITLE
Readme: update coding standard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ merged. This is to ensure proper review of all the code.
 Fork the project, create a feature branch, and send us a pull request.
 
 To ensure a consistent code base, you should make sure the code follows
-the [Coding Standards](http://symfony.com/doc/2.0/contributing/code/standards.html)
+the [Coding Standards](http://symfony.com/doc/current/contributing/code/standards.html)
 which we borrowed from Symfony.
 
 If you would like to help take a look at the [list of issues](http://github.com/composer/composer/issues).


### PR DESCRIPTION
Maybe it's on purpose, but current link leads to documentation, where deprecated note.
