### PR TITLE
minor fixes in DownloadManager.php

### DIFF
--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -202,7 +202,7 @@ class DownloadManager
                 }
                 break;
             } catch (\RuntimeException $e) {
-                if ($i == count($sources) - 1) {
+                if ($i === count($sources) - 1) {
                     throw $e;
                 }
 


### PR DESCRIPTION
We should use "===" instead of "==" since it's better and faster in this case.
