### PR TITLE
added $installer->isDryRun()

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1167,6 +1167,16 @@ class Installer
     }
 
     /**
+     * Checks, if running in verbose mode.
+     *
+     * @return bool
+     */
+    public function isVerbose()
+    {
+        return $this->verbose;
+    }
+
+    /**
      * restrict the update operation to a few packages, all other packages
      * that are already installed will be kept at their current version
      *


### PR DESCRIPTION
added accessor methods for isDryRun() and isVerbose(), because both are protected variables
and i need access to these values without extending the installer.
