### PR TITLE
Added branch-alias to version output when no tags present

### DIFF
--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -12,6 +12,7 @@
 
 namespace Composer;
 
+use Composer\Json\JsonFile;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 
@@ -43,6 +44,14 @@ class Compiler
             throw new \RuntimeException('Can\'t run git log. You must ensure to run compile from composer git repository clone and that git binary is available.');
         }
         $this->version = trim($process->getOutput());
+
+        $localConfig = __DIR__.'/../../composer.json';
+        $file = new JsonFile($localConfig);
+        $localConfig = $file->read();
+
+        if (isset($localConfig['extra']['branch-alias']['dev-master'])) {
+            $this->version = sprintf('%s (%s)', $localConfig['extra']['branch-alias']['dev-master'], $this->version);
+        }
 
         $process = new Process('git log -n1 --pretty=%ci HEAD', __DIR__);
         if ($process->run() != 0) {


### PR DESCRIPTION
Added branch-alias for dev-master to `--version|-V` output when current version is actually a revision (a non release/git tag).
Example:

Before:

```
$ composer --version
Composer version 73e9db5d9952d52a46ecbc20a269a8c5f9c5b011 2014-10-07 15:03:19
```

After:

```
$ composer --version
Composer version 1.0-dev (73e9db5d9952d52a46ecbc20a269a8c5f9c5b011) 2014-10-07 15:03:19
```

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Doc PR | none |
