### PR TITLE
Bugfix for #3356 (workaround)

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -88,8 +88,14 @@ EOT
             return 1;
         }
 
-        if (Composer::VERSION === $updateVersion) {
-            $output->writeln('<info>You are already using composer version '.$updateVersion.'.</info>');
+        // Workaround for issue #3356
+        $composerVersion = Composer::VERSION;
+        if (preg_match('{^.*([0-9a-f]{40})\)?$}', $composerVersion, $matches) && isset($matches[1])) {
+            $composerVersion = $matches[1];
+        }
+
+        if ($composerVersion === $updateVersion) {
+            $output->writeln('<info>You are already using composer version '.Composer::VERSION.'.</info>');
 
             return 0;
         }
@@ -99,7 +105,7 @@ EOT
             '%s/%s-%s%s',
             $rollbackDir,
             strtr(Composer::RELEASE_DATE, ' :', '_-'),
-            preg_replace('{^([0-9a-f]{7})[0-9a-f]{33}$}', '$1', Composer::VERSION),
+            preg_replace('{^([0-9a-f]{7})[0-9a-f]{33}$}', '$1', $composerVersion),
             self::OLD_INSTALL_EXT
         );
 


### PR DESCRIPTION
`http://getcomposer.org/version` is still returning commit reference (only git signature), and this
URI is used to compare the local version against latest:

Example:

```
$ curl http://getcomposer.org/version
c33c5196b19c77ea89b05a81c573d88543d3a93d
```

while `Composer::VERSION` now is `1.0-dev (c33c5196b19c77ea89b05a81c573d88543d3a93d)`.

@Seldaek, how can I see the controller logic for `/version` endpoint in http://getcomposer.org? Maybe it's a minor change.
I hope your opinion. 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #3356 |
| Doc PR | none |
