### PR TITLE
Add fallback for findPackage(s) for repo without provider

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -103,6 +103,9 @@ class ComposerRepository extends ArrayRepository implements StreamableRepository
      */
     public function findPackage($name, $version)
     {
+        if (!$this->hasProviders()) {
+            return parent::findPackage($name, $version);
+        }
         // normalize version & name
         $versionParser = new VersionParser();
         $version = $versionParser->normalize($version);
@@ -125,6 +128,9 @@ class ComposerRepository extends ArrayRepository implements StreamableRepository
      */
     public function findPackages($name, $version = null)
     {
+        if (!$this->hasProviders()) {
+            return parent::findPackages($name, $version);
+        }
         // normalize name
         $name = strtolower($name);
 


### PR DESCRIPTION
This was introduced in a4d43ee8605e8c48d8a8b277720dea9f92119d82, but is missing the fallback for a repository without providers.
