### PR TITLE
Updated validator

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -328,6 +328,7 @@ EOT
             return $result;
         }
 
+        $versionParser = new VersionParser();
         while (null !== $package = $dialog->ask($output, $prompt)) {
             $matches = $this->findPackages($package);
 
@@ -353,22 +354,32 @@ EOT
                     $output->writeln($choices);
                     $output->writeln('');
 
-                    $validator = function ($selection) use ($matches) {
+                    $validator = function ($selection) use ($matches, $versionParser) {
                         if ('' === $selection) {
                             return false;
                         }
 
-                        if (!is_numeric($selection) && preg_match('{^\s*(\S+)\s+(\S.*)\s*$}', $selection, $matches)) {
-                            return $matches[1].' '.$matches[2];
+                        if (is_numeric($selection) && isset($matches[(int) $selection])) {
+                            $package = $matches[(int) $selection];
+
+                            return $package['name'];
                         }
 
-                        if (!isset($matches[(int) $selection])) {
-                            throw new \Exception('Not a valid selection');
+                        if (preg_match('{^\s*(?P<name>[\S/]+)(?:\s+(?P<version>\S+))?\s*$}', $selection, $packageMatches)) {
+                            if (isset($packageMatches['version'])) {
+                                // parsing `acme/example ~2.3`
+
+                                // validate version constraint
+                                $versionParser->parseConstraints($packageMatches['version']);
+
+                                return $packageMatches['name'].' '.$packageMatches['version'];
+                            }
+
+                            // parsing `acme/example`
+                            return $packageMatches['name'];
                         }
 
-                        $package = $matches[(int) $selection];
-
-                        return $package['name'];
+                        throw new \Exception('Not a valid selection');
                     };
 
                     $package = $dialog->askAndValidate($output, $dialog->getQuestion('Enter package # to add, or the complete package name if it is not listed', false, ':'), $validator, 3);


### PR DESCRIPTION
It's really strange to say that `zendframework zend-eventmanager` is a full package name, since Composer always uses `zendframework/zend-eventmanager`.