### PR TITLE
WIP - Allow plugins to register commands

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -289,7 +289,11 @@ class Factory
         $this->createDefaultInstallers($im, $composer, $io);
 
         if ($fullLoad) {
-            $globalComposer = $this->createGlobalComposer($io, $config, $disablePlugins);
+            $globalComposer = null;
+            if (realpath($config->get('home')) !== $cwd) {
+                $globalComposer = $this->createGlobalComposer($io, $config, $disablePlugins);
+            }
+
             $pm = $this->createPluginManager($io, $composer, $globalComposer);
             $composer->setPluginManager($pm);
 
@@ -351,15 +355,11 @@ class Factory
      * @param  Config        $config
      * @return Composer|null
      */
-    protected function createGlobalComposer(IOInterface $io, Config $config, $disablePlugins)
+    protected function createGlobalComposer(IOInterface $io, Config $config, $disablePlugins, $fullLoad = false)
     {
-        if (realpath($config->get('home')) === getcwd()) {
-            return;
-        }
-
         $composer = null;
         try {
-            $composer = self::createComposer($io, $config->get('home') . '/composer.json', $disablePlugins, $config->get('home'), false);
+            $composer = self::createComposer($io, $config->get('home') . '/composer.json', $disablePlugins, $config->get('home'), $fullLoad);
         } catch (\Exception $e) {
             if ($io->isDebug()) {
                 $io->writeError('Failed to initialize global composer: '.$e->getMessage());
@@ -487,5 +487,17 @@ class Factory
         $factory = new static();
 
         return $factory->createComposer($io, $config, $disablePlugins);
+    }
+
+    /**
+     * @param  IOInterface $io             IO instance
+     * @param  bool        $disablePlugins Whether plugins should not be loaded
+     * @return Composer
+     */
+    public static function createGlobal(IOInterface $io, $disablePlugins = false)
+    {
+        $factory = new static();
+
+        return $factory->createGlobalComposer($io, static::createConfig($io), $disablePlugins, true);
     }
 }

--- a/src/Composer/Plugin/CommandsProviderInterface.php
+++ b/src/Composer/Plugin/CommandsProviderInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Plugin;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+
+/**
+ * Commands Provider Interface
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+interface CommandsProviderInterface
+{
+
+    /**
+     * Retreives list of commands
+     *
+     * @return array
+     */
+    public function getCommands();
+}

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v5/Installer/Plugin.php
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v5/Installer/Plugin.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Installer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+use Composer\Plugin\CommandsProviderInterface;
+
+class Plugin implements PluginInterface, CommandsProviderInterface
+{
+    public $version = 'installer-v5';
+
+    public function activate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function getCommands()
+    {
+        return null;
+    }
+}

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v5/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v5/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "plugin-v5",
+    "version": "5.0.0",
+    "type": "composer-plugin",
+    "autoload": { "psr-0": { "Installer": "" } },
+    "extra": {
+        "class": [
+            "Installer\\Plugin"
+        ]
+    },
+    "require": {
+        "composer-plugin-api": "1.0.0"
+    }
+}

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -37,7 +37,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $loader = new JsonLoader(new ArrayLoader());
         $this->packages = array();
         $this->directory = sys_get_temp_dir() . '/' . uniqid();
-        for ($i = 1; $i <= 4; $i++) {
+        for ($i = 1; $i <= 5; $i++) {
             $filename = '/Fixtures/plugin-v'.$i.'/composer.json';
             mkdir(dirname($this->directory . $filename), 0777, true);
             $this->packages[] = $loader->load(__DIR__ . $filename);


### PR DESCRIPTION
This PR will move plugins to a next level by exposing the application to the plugins (and also loads the plugins BEFORE the application starts).

It might be a start to solve few tickets like #3312 or https://twitter.com/lsmith/status/526053583834603520
ping @lsmith77

It should also fixes #1234, #2761

Sample of use
```
composer global require FriendsOfPHP/security-advisories
cd my/project
composer security-check
```

Want to simply test  it see a sample plugin (https://github.com/jeremy-derusse/composer-plugin)
```
composer global require jderuse/plugin
composer demo:greet
```

Todo
* [x] Add tests
* [x] Refactor the "plugins warmup" thing
* [ ] Avoid fatal errors when loading the plugin in an old instance of composer
* [ ] Add documentation about plugin creation
