### PR TITLE
Escape delimiter characters in BaseExcludeFilter.

### DIFF
--- a/src/Composer/Package/Archiver/BaseExcludeFilter.php
+++ b/src/Composer/Package/Archiver/BaseExcludeFilter.php
@@ -140,8 +140,9 @@ abstract class BaseExcludeFilter
             $pattern .= '/';
         }
 
-        // remove delimiters as well as caret (^) and dollar sign ($) from the regex
-        $pattern .= substr(Finder\Glob::toRegex($rule), 2, -2) . '(?=$|/)';
+        // remove delimiters as well as caret (^) and dollar sign ($) from the regex,
+        // escape new regexp delimiter characters (#)
+        $pattern .= str_replace('#', '\\#', substr(Finder\Glob::toRegex($rule), 2, -2)) . '(?=$|/)';
 
         return array($pattern . '#', $negate, false);
     }

--- a/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
+++ b/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
@@ -31,6 +31,7 @@ class GitExcludeFilterTest extends \PHPUnit_Framework_TestCase
         return array(
             array('app/config/parameters.yml', array('#(?=[^\.])app/(?=[^\.])config/(?=[^\.])parameters\.yml(?=$|/)#', false, false)),
             array('!app/config/parameters.yml', array('#(?=[^\.])app/(?=[^\.])config/(?=[^\.])parameters\.yml(?=$|/)#', true, false)),
+            array('\\#*\\#', array('#/(?=[^\.])\#[^/]*\#(?=$|/)#', false, false)),
         );
     }
 }


### PR DESCRIPTION
When parsing .gitignore files, it's possible that the rule will contain a '#' character (eg. https://github.com/yiisoft/yii/blob/master/.gitignore#L37). As it's the same as the delimiter character, this will cause the built regexp to be invalid. To fix this issue, the '#' characters should be properly escaped.

I've found this issue when trying to setup Satis with the Yii package, which resulted in:

    [ErrorException]                    
        preg_match(): Unknown modifier '['