### PR TITLE
change preProcess from private to public

### DIFF
--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -265,7 +265,7 @@ class VcsRepository extends ArrayRepository
         }
     }
 
-    private function preProcess(VcsDriverInterface $driver, array $data, $identifier)
+    protected function preProcess(VcsDriverInterface $driver, array $data, $identifier)
     {
         // keep the name of the main identifier for all packages
         $data['name'] = $this->packageName ?: $data['name'];


### PR DESCRIPTION
I need to override the preProcess method from a child class.

The use case is related to package renaming in a private satis repository. I understand the implication for packagist (and other public repository) but keeping the root packageName cause problem when you need to rename a package.

I will override override the name assignation with this

``` PHP

// use the main identifier if name is not present
$data['name'] = !isset($data['name']) ? $this->packageName : $data['name'];

```
