### PR TITLE
Add support for archive compression (gz/bz2)

### DIFF
--- a/src/Composer/Package/Archiver/PharArchiver.php
+++ b/src/Composer/Package/Archiver/PharArchiver.php
@@ -24,22 +24,49 @@ class PharArchiver implements ArchiverInterface
         'tar' => \Phar::TAR,
     );
 
+    protected static $tarCompressionFormats = array(
+        'tar.gz' => \Phar::GZ,
+        'tar.bz2' => \Phar::BZ2,
+    );
+
     /**
      * {@inheritdoc}
      */
     public function archive($sources, $target, $format, array $excludes = array())
     {
         $sources = realpath($sources);
+        $tarCompressionFormat = false;
+        $archiveFile = $target;
 
-        // Phar would otherwise load the file which we don't want
-        if (file_exists($target)) {
-            unlink($target);
+        // Support compressed tar.[gz|bz2] files by first generating tar and then compressing it.
+        if (isset(static::$tarCompressionFormats[$format]))
+        {
+            $tarCompressionFormat = $format;
+            $format = 'tar';
+            $archiveFile = substr($target, 0, - strlen($tarCompressionFormat)) . $format;
+        }
+
+        // Phar archive would otherwise load the file which we don't want
+        if (file_exists($archiveFile)) {
+            unlink($archiveFile);
         }
 
         try {
-            $phar = new \PharData($target, null, null, static::$formats[$format]);
+            $phar = new \PharData($archiveFile, null, null, static::$formats[$format]);
             $files = new ArchivableFilesFinder($sources, $excludes);
             $phar->buildFromIterator($files, $sources);
+
+            // Generate compressed tar file and unlink temporary archive
+            if ($tarCompressionFormat)
+            {
+                $phar->compress(static::$tarCompressionFormats[$tarCompressionFormat], $tarCompressionFormat);
+                unlink($archiveFile);
+            }
+            // if zip attempt to compress the file if possible with gz
+            else if ($format === 'zip' && extension_loaded('zlib'))
+            {
+                $phar->compressFiles(\Phar::GZ);
+            }
 
             return $target;
         } catch (\UnexpectedValueException $e) {
@@ -58,6 +85,6 @@ class PharArchiver implements ArchiverInterface
      */
     public function supports($format, $sourceType)
     {
-        return isset(static::$formats[$format]);
+        return isset(static::$formats[$format]) || isset(static::$tarCompressionFormats[$format]);
     }
 }


### PR DESCRIPTION
Adds support for file extensions tar.gz and tar.bz2 where these
implies use of compression as supported by `PharData` natively.

Compression support is not added to zip file as Phar doc explicitly
says it is not supported on file level, and compression would then
have to be exposed differently as it uses same file name.

File size was in my limited testing reduced to 1/8th, but this depends
on content of course.

Todo (if approach is ok):
- [ ] update tests