### PR TITLE
Fixed the json formatting when using JSONC

### DIFF
--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -187,7 +187,7 @@ class JsonFile
             $json = json_encode($data, $options);
 
             //  compact brackets to follow recent php versions
-            if (PHP_VERSION_ID < 50428 || (PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 50512) || (defined('JSON_C_VERSION') && version_compare(php_version('json'), '1.3.6', '<'))) {
+            if (PHP_VERSION_ID < 50428 || (PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 50512) || (defined('JSON_C_VERSION') && version_compare(phpversion('json'), '1.3.6', '<'))) {
                 $json = preg_replace('/\[\s+\]/', '[]', $json);
                 $json = preg_replace('/\{\s+\}/', '{}', $json);
             }


### PR DESCRIPTION
JSONC has not been updated to follow the rules of recent PHP versions until its 1.3.6 release, and it is used on Ubuntu or Debian systems at version 1.3.5. Ubuntu users using the system package were not affected because it ships with 5.5.9 which was already matched by the version check. But dotdeb users can get newer versions (considered as updated by Composer) but still use JSONC.
