### PR TITLE
Use PHP to call the proxyed binary target

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -311,6 +311,6 @@ class LibraryInstaller implements InstallerInterface
             'cd '.ProcessExecutor::escape(dirname($binPath))."\n".
             'BIN_TARGET="`pwd`/'.basename($binPath)."\"\n".
             'cd "$SRC_DIR"'."\n".
-            '"$BIN_TARGET" "$@"'."\n";
+            '/usr/bin/env php "$BIN_TARGET" "$@"'."\n";
     }
 }


### PR DESCRIPTION
When Composer is not able to create a symlink to the binary, it creates a proxy shell script, but if the filesystem does not support symlinks it may also not support the executable bit, so the proxy script will try to execute a non executable file and the user, which was probably having to execute it this way:

```
sh vendor/bin/phpspec
```

Will receive this error message:

```
vendor/bin/phpspec: 7: vendor/bin/phpspec: /var/www/ci-app/vendor/phpspec/phpspec/bin/phpspec: Permission denied
```

Happens to me with all files in vendor/bin, because I use a Linux box as a server but the www folder is a mounted cifs share, to a Windows SSD drive, so I'm currently editing them and adding _php_ before "$BIN_TARGET" "$@":

```
#!/usr/bin/env sh
SRC_DIR="`pwd`"
...
php "$BIN_TARGET" "$@"
```

The implementation does not take in consideration the fact that the binary may not be a PHP script, it's unlikely but still possible.
