### PR TITLE
Suppress exceptions for deprecation notices, and simply output them to console instead

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -79,6 +79,7 @@ class Application extends BaseApplication
             $styles = Factory::createAdditionalStyles();
             $formatter = new OutputFormatter(null, $styles);
             $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, null, $formatter);
+            ErrorHandler::setOutput($output);
         }
 
         return parent::run($input, $output);

--- a/tests/Composer/Test/Util/ErrorHandlerTest.php
+++ b/tests/Composer/Test/Util/ErrorHandlerTest.php
@@ -54,4 +54,16 @@ class ErrorHandlerTest extends TestCase
 
         @trigger_error('test', E_USER_NOTICE);
     }
+
+    /**
+     * Test ErrorHandler ignored deprecation notices
+     */
+    public function testErrorHandlerIgnoresDeprecationNotices()
+    {
+        ErrorHandler::register();
+
+        ob_start();
+        trigger_error('A user deprecation notice', E_USER_DEPRECATED);
+        ob_end_clean();
+    }
 }


### PR DESCRIPTION
Hi,

We're running composer in a test environment with minimum-stability set to dev and seeing failures since Symfony started adding deprecation messages a day or so ago. Composer currently handles these deprecation messages as errors and throws an ErrorException, causing the composer run to fail.

This patch causes E_DEPRECATED and E_USER_DEPRECATED (which Symfony is using) to simply output to standard out, or if console is initialised as a "<warning>text</warning>" message, and to not end the composer run with a failure.

Let me know if you believe a different approach is necessary - but I think deprecation notices are likely able to be ignored in dev stability. It might make moving forward from the deprecation notices easier too as it will output them all at once. It should be easy to extend this patch too to have an option to hide deprecation messages, even by default, if it's felt necessary.

Thanks,

Jason