### PR TITLE
Avoid generating duplicate conflict rules

### DIFF
--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -241,7 +241,7 @@ class RuleSetGenerator
 
                 if (($package instanceof AliasPackage) && $package->getAliasOf() === $provider) {
                     $this->addRule(RuleSet::TYPE_PACKAGE, $rule = $this->createRequireRule($package, array($provider), Rule::RULE_PACKAGE_ALIAS, $package));
-                } elseif (!$this->obsoleteImpossibleForAlias($package, $provider)) {
+                } elseif (!$this->obsoleteImpossibleForAlias($package, $provider) && $package->id <= $provider->id) {
                     $reason = ($package->getName() == $provider->getName()) ? Rule::RULE_PACKAGE_SAME_NAME : Rule::RULE_PACKAGE_IMPLICIT_OBSOLETES;
                     $this->addRule(RuleSet::TYPE_PACKAGE, $rule = $this->createConflictRule($package, $provider, $reason, $package));
                 }


### PR DESCRIPTION
For each version of each package we create a conflict rule with each
other version of itself. These are then added to the rule set and skipped if
duplicate so instead we can just generate them only once to begin with
and avoid unnecessary memory allocation and duplication lookups.

Packagist `composer update --dry-run --profile` before:

```
Memory usage: 164.29MB (peak: 393.37MB), time: 82.9s
```

and after:

```
Memory usage: 163.99MB (peak: 318.46MB), time: 47.14s
```
