### PR TITLE
Free up memory before disabling gc.

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -160,6 +160,7 @@ class Installer
      */
     public function run()
     {
+        gc_collect_cycles();
         gc_disable();
 
         if ($this->dryRun) {


### PR DESCRIPTION
It is recommended to call gc_collect_cycles(); before disabling garbage collection.
