### PR TITLE
Prevent APC causing random fatal errors [fixes #264]

### DIFF
--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -212,6 +212,16 @@ class Compiler
  * the license that is located at the bottom of this file.
  */
 
+// Avoid APC causing random fatal errors per https://github.com/composer/composer/issues/264
+if (extension_loaded('apc') && ini_get('apc.enable_cli') && ini_get('apc.cache_by_default')) {
+    if (version_compare(phpversion('apc'), '3.0.12', '>=')) {
+        ini_set('apc.cache_by_default', 0);
+    } else {
+        fwrite(STDERR, 'Warning: APC <= 3.0.12 may cause fatal errors when running composer commands.'.PHP_EOL);
+        fwrite(STDERR, 'Update APC, or set apc.enable_cli or apc.cache_by_default to 0 in your php.ini.'.PHP_EOL);
+    }
+}
+
 Phar::mapPhar('composer.phar');
 
 EOF;


### PR DESCRIPTION
Update the phar stub to prevent APC attempting to run the composer classes through the opcode cache on supported APC versions to avoid the random fatal "duplicate class" errors at runtime as reported in #264.

Prior to APC version 3.0.12 this was a PHP_INI_SYSTEM directive, so it outputs a warning instead.

I realise that there are existing recommended workarounds, either setting `apc.enable_cli = 0` (problematic if the user cache is required in CLI eg for functional/unit tests) or `apc.cache_by_default = 0` (requires global configuration and is hassle in environments when CLI and web configuration is otherwise the same).

I also realise that the fact APC is slowly on the way out, and the fact it can only be done with logic in the phar stub, means there are reasons not to accept this fix.

However, I do think it's worth doing - APC is still far from dead and the fatal error is not immediately obvious and happens semi-randomly with different classes. It's therefore hard to debug the first time you see it, and takes time to work out what's going on and update configuration to fix.

It would save a lot of head scratching and frustration if composer handled this internally where possible.
