### PR TITLE
Added deprecated warning for the dev option

### DIFF
--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -74,6 +74,10 @@ EOT
             $input->setOption('no-plugins', true);
         }
 
+        if ($input->getOption('dev')) {
+            $output->writeln('<warning>You are using the deprecated option "dev". Dev packages are installed by default now.</warning>');
+        }
+
         $composer = $this->getComposer(true, $input->getOption('no-plugins'));
         $composer->getDownloadManager()->setOutputProgress(!$input->getOption('no-progress'));
         $io = $this->getIO();

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -76,6 +76,10 @@ EOT
             $input->setOption('no-plugins', true);
         }
 
+        if ($input->getOption('dev')) {
+            $output->writeln('<warning>You are using the deprecated option "dev". Dev packages are installed by default now.</warning>');
+        }
+
         $composer = $this->getComposer(true, $input->getOption('no-plugins'));
         $composer->getDownloadManager()->setOutputProgress(!$input->getOption('no-progress'));
         $io = $this->getIO();


### PR DESCRIPTION
The option isn't used for a long time already, but there was no warning about the usage of it. This could lead to confusion, as people could be thinking that no-dev is the default.