### PR TITLE
Use caret operator for 0.x releases when guessing versions, fixes #3518

### DIFF
--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -109,13 +109,8 @@ class VersionSelector
         if (count($semanticVersionParts) == 4 && preg_match('{^0\D?}', $semanticVersionParts[3])) {
             // remove the last parts (i.e. the patch version number and any extra)
             if ($semanticVersionParts[0] === '0') {
-                if ($semanticVersionParts[1] === '0') {
-                    $semanticVersionParts[3] = '*';
-                } else {
-                    $semanticVersionParts[2] = '*';
-                    unset($semanticVersionParts[3]);
-                }
-                $op = '';
+                unset($semanticVersionParts[3]);
+                $op = '^';
             } else {
                 unset($semanticVersionParts[2], $semanticVersionParts[3]);
             }
@@ -130,7 +125,7 @@ class VersionSelector
         }
 
         // 2.1 -> ~2.1
-        return $op.$version;
+        return $op . $version;
     }
 
     private function getParser()

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -326,6 +326,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             array('^1.2.3',        new VersionConstraint('>=', '1.2.3.0-dev'), new VersionConstraint('<', '2.0.0.0-dev')),
             array('^0.2.3',        new VersionConstraint('>=', '0.2.3.0-dev'), new VersionConstraint('<', '0.3.0.0-dev')),
             array('^0.2',          new VersionConstraint('>=', '0.2.0.0-dev'), new VersionConstraint('<', '0.3.0.0-dev')),
+            array('^0.2.0',        new VersionConstraint('>=', '0.2.0.0-dev'), new VersionConstraint('<', '0.3.0.0-dev')),
             array('^0.0.3',        new VersionConstraint('>=', '0.0.3.0-dev'), new VersionConstraint('<', '0.0.4.0-dev')),
             array('^0.0.3-alpha',  new VersionConstraint('>=', '0.0.3.0-alpha'), new VersionConstraint('<', '0.0.4.0-dev')),
             array('^0.0.3-dev',    new VersionConstraint('>=', '0.0.3.0-dev'), new VersionConstraint('<', '0.0.4.0-dev')),

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -98,13 +98,13 @@ class VersionSelectorTest extends \PHPUnit_Framework_TestCase
             array('v1.2.1', false, 'stable', '~1.2'),
             array('3.1.2-pl2', false, 'stable', '~3.1'),
             array('3.1.2-patch', false, 'stable', '~3.1'),
-            array('0.1.0', false, 'stable', '0.1.*'),
-            array('0.1.3', false, 'stable', '0.1.*'),
-            array('0.0.3', false, 'stable', '0.0.3.*'),
-            array('0.0.3-alpha', false, 'alpha', '0.0.3.*@alpha'),
             array('2.0-beta.1', false, 'beta', '~2.0@beta'),
             array('3.1.2-alpha5', false, 'alpha', '~3.1@alpha'),
             array('3.0-RC2', false, 'RC', '~3.0@RC'),
+            array('0.1.0', false, 'stable', '^0.1.0'),
+            array('0.1.3', false, 'stable', '^0.1.3'),
+            array('0.0.3', false, 'stable', '^0.0.3'),
+            array('0.0.3-alpha', false, 'alpha', '^0.0.3@alpha'),
             // date-based versions are not touched at all
             array('v20121020', false, 'stable', 'v20121020'),
             array('v20121020.2', false, 'stable', 'v20121020.2'),
@@ -115,6 +115,8 @@ class VersionSelectorTest extends \PHPUnit_Framework_TestCase
             array('dev-master', true, 'dev', '~2.1@dev', '2.1.x-dev'),
             array('dev-master', true, 'dev', '~2.1@dev', '2.1.3.x-dev'),
             array('dev-master', true, 'dev', '~2.0@dev', '2.x-dev'),
+            array('dev-master', true, 'dev', '^0.3.0@dev', '0.3.x-dev'),
+            array('dev-master', true, 'dev', '^0.0.3@dev', '0.0.3.x-dev'),
         );
     }
 


### PR DESCRIPTION
Should not be merged until the ^ op is in a release IMO.