### PR TITLE
Update homebrew installation steps

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -114,6 +114,7 @@ Composer is part of the homebrew-php project.
 brew update
 brew tap homebrew/dupes
 brew tap homebrew/php
+brew install php55
 brew install composer
 ```
 


### PR DESCRIPTION
The current instructions for installing Composer via Homebrew are incomplete. After following the instructions, I received the following message:

> $ brew install composer
> ==> Installing composer from homebrew/homebrew-php
> composer: Missing PHP53, PHP54, PHP55 or PHP56 from homebrew-php. Please install one of them before continuing
> Error: An unsatisfied requirement failed this build.

To solve this, I ran `brew install php55`. Once that completed, I re-ran `brew install composer` and composer installed successfully.
