### PR TITLE
Add the ability to show and confirm changes before doing them.

### DIFF
--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -47,6 +47,7 @@ class UpdateCommand extends Command
                 new InputOption('with-dependencies', null, InputOption::VALUE_NONE, 'Add also all dependencies of whitelisted packages to the whitelist.'),
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump.'),
+                new InputOption('confirm', 'c', InputOption::VALUE_NONE, 'Prompt to confirm changes.'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore platform requirements (php & ext- packages).'),
                 new InputOption('prefer-stable', null, InputOption::VALUE_NONE, 'Prefer stable versions of dependencies.'),
                 new InputOption('prefer-lowest', null, InputOption::VALUE_NONE, 'Prefer lowest versions of dependencies.'),
@@ -119,6 +120,7 @@ EOT
         $install
             ->setDryRun($input->getOption('dry-run'))
             ->setVerbose($input->getOption('verbose'))
+            ->setConfirm($input->getOption('confirm'))
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
             ->setDevMode(!$input->getOption('no-dev'))

--- a/src/Composer/DependencyResolver/Operation/InstallOperation.php
+++ b/src/Composer/DependencyResolver/Operation/InstallOperation.php
@@ -61,6 +61,14 @@ class InstallOperation extends SolverOperation
      */
     public function __toString()
     {
-        return 'Installing '.$this->package->getPrettyName().' ('.$this->formatVersion($this->package).')';
+        return 'Installing '.$this->getChangeAsString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getChangeAsString()
+    {
+        return $this->package->getPrettyName().' ('.$this->formatVersion($this->package).')';
     }
 }

--- a/src/Composer/DependencyResolver/Operation/InstallOperation.php
+++ b/src/Composer/DependencyResolver/Operation/InstallOperation.php
@@ -21,6 +21,11 @@ use Composer\Package\PackageInterface;
  */
 class InstallOperation extends SolverOperation
 {
+    /**
+     * The operation type.
+     */
+    const TYPE = 'install';
+
     protected $package;
 
     /**
@@ -47,13 +52,11 @@ class InstallOperation extends SolverOperation
     }
 
     /**
-     * Returns job type.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getJobType()
     {
-        return 'install';
+        return self::TYPE;
     }
 
     /**

--- a/src/Composer/DependencyResolver/Operation/MarkAliasInstalledOperation.php
+++ b/src/Composer/DependencyResolver/Operation/MarkAliasInstalledOperation.php
@@ -63,4 +63,12 @@ class MarkAliasInstalledOperation extends SolverOperation
     {
         return 'Marking '.$this->package->getPrettyName().' ('.$this->formatVersion($this->package).') as installed, alias of '.$this->package->getAliasOf()->getPrettyName().' ('.$this->formatVersion($this->package->getAliasOf()).')';
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getChangeAsString()
+    {
+        return 'Marking '.$this->package->getPrettyName().' ('.$this->formatVersion($this->package).') as installed - alias of '.$this->package->getAliasOf()->getPrettyName().' ('.$this->formatVersion($this->package->getAliasOf()).')';
+    }
 }

--- a/src/Composer/DependencyResolver/Operation/MarkAliasInstalledOperation.php
+++ b/src/Composer/DependencyResolver/Operation/MarkAliasInstalledOperation.php
@@ -21,6 +21,11 @@ use Composer\Package\AliasPackage;
  */
 class MarkAliasInstalledOperation extends SolverOperation
 {
+    /**
+     * The operation type.
+     */
+    const TYPE = 'markAliasInstalled';
+
     protected $package;
 
     /**
@@ -47,13 +52,11 @@ class MarkAliasInstalledOperation extends SolverOperation
     }
 
     /**
-     * Returns job type.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getJobType()
     {
-        return 'markAliasInstalled';
+        return self::TYPE;
     }
 
     /**

--- a/src/Composer/DependencyResolver/Operation/MarkAliasUninstalledOperation.php
+++ b/src/Composer/DependencyResolver/Operation/MarkAliasUninstalledOperation.php
@@ -21,6 +21,11 @@ use Composer\Package\AliasPackage;
  */
 class MarkAliasUninstalledOperation extends SolverOperation
 {
+    /**
+     * The operation type.
+     */
+    const TYPE = 'markAliasUninstalled';
+
     protected $package;
 
     /**
@@ -47,13 +52,11 @@ class MarkAliasUninstalledOperation extends SolverOperation
     }
 
     /**
-     * Returns job type.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getJobType()
     {
-        return 'markAliasUninstalled';
+        return self::TYPE;
     }
 
     /**

--- a/src/Composer/DependencyResolver/Operation/MarkAliasUninstalledOperation.php
+++ b/src/Composer/DependencyResolver/Operation/MarkAliasUninstalledOperation.php
@@ -63,4 +63,12 @@ class MarkAliasUninstalledOperation extends SolverOperation
     {
         return 'Marking '.$this->package->getPrettyName().' ('.$this->formatVersion($this->package).') as uninstalled, alias of '.$this->package->getAliasOf()->getPrettyName().' ('.$this->formatVersion($this->package->getAliasOf()).')';
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getChangeAsString()
+    {
+        return 'Marking '.$this->package->getPrettyName().' ('.$this->formatVersion($this->package).') as uninstalled - alias of '.$this->package->getAliasOf()->getPrettyName().' ('.$this->formatVersion($this->package->getAliasOf()).')';
+    }
 }

--- a/src/Composer/DependencyResolver/Operation/OperationCollection.php
+++ b/src/Composer/DependencyResolver/Operation/OperationCollection.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\DependencyResolver\Operation;
+
+use Composer\Repository\PlatformRepository;
+
+/**
+ * Collection class for the different operation types
+ *
+ * @author Chad Sikorra <chad.sikorra@gmail.com>
+ */
+class OperationCollection implements \IteratorAggregate
+{
+    /**
+     * @var array The operations sorted by type
+     */
+    private $operations = array(
+        'install' => array(),
+        'update' => array(),
+        'uninstall' => array(),
+        'plugin' => array(),
+        'markAliasInstalled' => array(),
+        'markAliasUninstalled' => array(),
+    );
+
+    /**
+     * @return array
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->sortOperationsToArray());
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->sortOperationsToArray();
+    }
+    /**
+     * Add an operation to the collection.
+     *
+     * @param OperationInterface $operation
+     * @throws \InvalidArgumentException if the operation type is not known.
+     */
+    public function add(OperationInterface $operation)
+    {
+
+        if ($operation instanceof InstallOperation || $operation instanceof UpdateOperation) {
+            if ($this->operationNeedsToMoveUp($operation)) {
+                $this->operations['plugin'][] = $operation;
+            }
+            elseif ($operation instanceof InstallOperation) {
+                $this->operations['install'][] = $operation;
+            }
+            else {
+                $this->operations['update'][] = $operation;
+            }
+        }
+        elseif ($operation instanceof UninstallOperation) {
+            $this->operations['uninstall'][] = $operation;
+        }
+        elseif ($operation instanceof MarkAliasInstalledOperation) {
+            $this->operations['markAliasInstalled'][] = $operation;
+        }
+        elseif ($operation instanceof MarkAliasUninstalledOperation) {
+            $this->operations['markAliasUninstalled'][] = $operation;
+        }
+        else {
+            throw new \InvalidArgumentException('Unknown operation type.');
+        }
+    }
+
+    /**
+     * Workaround: if your packages depend on plugins, we must be sure
+     * that those are installed / updated first; else it would lead to packages
+     * being installed multiple times in different folders, when running Composer
+     * twice.
+     *
+     * While this does not fix the root-causes of https://github.com/composer/composer/issues/1147,
+     * it at least fixes the symptoms and makes usage of composer possible (again)
+     * in such scenarios.
+     *
+     * @param OperationInterface $operation
+     * @return bool
+     */
+    private function operationNeedsToMoveUp(OperationInterface $operation)
+    {
+        $package = $operation->getPackage();
+
+        if (!($package->getType() === 'composer-plugin' || $package->getType() === 'composer-installer')) {
+            return false;
+        }
+
+        $requires = array_keys($package->getRequires());
+
+        foreach ($requires as $index => $req) {
+            if ($req === 'composer-plugin-api' || preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $req)) {
+                unset($requires[$index]);
+            }
+        }
+
+        // if there are no other requirements, the plugin should move to the top of the list
+        return !count($requires);
+    }
+
+    /**
+     * Sorts operations in the order they should be processed. Removals of packages should be executed before
+     * installations in case two packages resolve to the same path (due to custom installers). Additionally,
+     * plugin update/install operations should occur before other updates/installs.
+     *
+     * @return array A sorted array of operation objects
+     */
+    private function sortOperationsToArray()
+    {
+        return array_merge(
+            $this->operations['uninstall'],
+            $this->operations['plugin'],
+            $this->operations['markAliasUninstalled'],
+            $this->operations['install'],
+            $this->operations['markAliasInstalled'],
+            $this->operations['update']
+        );
+    }
+}

--- a/src/Composer/DependencyResolver/Operation/OperationInterface.php
+++ b/src/Composer/DependencyResolver/Operation/OperationInterface.php
@@ -39,4 +39,11 @@ interface OperationInterface
      * @return string
      */
     public function __toString();
+
+    /**
+     * Serializes the operation in a human readable format for confirmation prior to any changes
+     *
+     * @return string
+     */
+    public function getChangeAsString();
 }

--- a/src/Composer/DependencyResolver/Operation/UninstallOperation.php
+++ b/src/Composer/DependencyResolver/Operation/UninstallOperation.php
@@ -61,6 +61,14 @@ class UninstallOperation extends SolverOperation
      */
     public function __toString()
     {
-        return 'Uninstalling '.$this->package->getPrettyName().' ('.$this->formatVersion($this->package).')';
+        return 'Uninstalling '.$this->getChangeAsString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getChangeAsString()
+    {
+        return $this->package->getPrettyName().' ('.$this->formatVersion($this->package).')';
     }
 }

--- a/src/Composer/DependencyResolver/Operation/UninstallOperation.php
+++ b/src/Composer/DependencyResolver/Operation/UninstallOperation.php
@@ -21,6 +21,11 @@ use Composer\Package\PackageInterface;
  */
 class UninstallOperation extends SolverOperation
 {
+    /**
+     * The operation type.
+     */
+    const TYPE = 'uninstall';
+
     protected $package;
 
     /**
@@ -47,13 +52,11 @@ class UninstallOperation extends SolverOperation
     }
 
     /**
-     * Returns job type.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getJobType()
     {
-        return 'uninstall';
+        return self::TYPE;
     }
 
     /**

--- a/src/Composer/DependencyResolver/Operation/UpdateOperation.php
+++ b/src/Composer/DependencyResolver/Operation/UpdateOperation.php
@@ -74,7 +74,15 @@ class UpdateOperation extends SolverOperation
      */
     public function __toString()
     {
-        return 'Updating '.$this->initialPackage->getPrettyName().' ('.$this->formatVersion($this->initialPackage).') to '.
+        return 'Updating '.$this->getChangeAsString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getChangeAsString()
+    {
+        return $this->initialPackage->getPrettyName().' ('.$this->formatVersion($this->initialPackage).') to '.
             $this->targetPackage->getPrettyName(). ' ('.$this->formatVersion($this->targetPackage).')';
     }
 }

--- a/src/Composer/DependencyResolver/Operation/UpdateOperation.php
+++ b/src/Composer/DependencyResolver/Operation/UpdateOperation.php
@@ -21,6 +21,11 @@ use Composer\Package\PackageInterface;
  */
 class UpdateOperation extends SolverOperation
 {
+    /**
+     * The operation type.
+     */
+    const TYPE = 'update';
+
     protected $initialPackage;
     protected $targetPackage;
 
@@ -60,13 +65,11 @@ class UpdateOperation extends SolverOperation
     }
 
     /**
-     * Returns job type.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getJobType()
     {
-        return 'update';
+        return self::TYPE;
     }
 
     /**

--- a/src/Composer/DependencyResolver/Transaction.php
+++ b/src/Composer/DependencyResolver/Transaction.php
@@ -31,7 +31,7 @@ class Transaction
         $this->pool = $pool;
         $this->installedMap = $installedMap;
         $this->decisions = $decisions;
-        $this->transaction = array();
+        $this->transaction = new Operation\OperationCollection();
     }
 
     public function getOperations()
@@ -212,12 +212,12 @@ class Transaction
             return $this->markAliasInstalled($package, $reason);
         }
 
-        $this->transaction[] = new Operation\InstallOperation($package, $reason);
+        $this->transaction->add(new Operation\InstallOperation($package, $reason));
     }
 
     protected function update($from, $to, $reason)
     {
-        $this->transaction[] = new Operation\UpdateOperation($from, $to, $reason);
+        $this->transaction->add(new Operation\UpdateOperation($from, $to, $reason));
     }
 
     protected function uninstall($package, $reason)
@@ -226,16 +226,16 @@ class Transaction
             return $this->markAliasUninstalled($package, $reason);
         }
 
-        $this->transaction[] = new Operation\UninstallOperation($package, $reason);
+        $this->transaction->add(new Operation\UninstallOperation($package, $reason));
     }
 
     protected function markAliasInstalled($package, $reason)
     {
-        $this->transaction[] = new Operation\MarkAliasInstalledOperation($package, $reason);
+        $this->transaction->add(new Operation\MarkAliasInstalledOperation($package, $reason));
     }
 
     protected function markAliasUninstalled($package, $reason)
     {
-        $this->transaction[] = new Operation\MarkAliasUninstalledOperation($package, $reason);
+        $this->transaction->add(new Operation\MarkAliasUninstalledOperation($package, $reason));
     }
 }

--- a/tests/Composer/Test/DependencyResolver/Operation/OperationCollectionTest.php
+++ b/tests/Composer/Test/DependencyResolver/Operation/OperationCollectionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\DependencyResolver\Operation;
+
+use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\MarkAliasInstalledOperation;
+use Composer\DependencyResolver\Operation\MarkAliasUninstalledOperation;
+use Composer\DependencyResolver\Operation\OperationCollection;
+use Composer\DependencyResolver\Operation\UninstallOperation;
+use Composer\DependencyResolver\Operation\UpdateOperation;
+use Composer\Package\AliasPackage;
+use Composer\TestCase;
+
+class OperationCollectionTest extends TestCase
+{
+    protected function addPackagesToCollection(OperationCollection $collection)
+    {
+        $package = $this->getMock('Composer\Package\PackageInterface');
+        $expects = array (
+            'getName' => 'foo',
+            'getRequires' => array(),
+            'getDevRequires' => array(),
+            'getConflicts' => array(),
+            'getProvides' => array(),
+            'getReplaces' => array(),
+        );
+        foreach ($expects as $method => $returns) {
+            $package->expects($this->any())
+                ->method($method)
+                ->willReturn($returns);
+        }
+        $alias = new AliasPackage($package,'1.0','1.0');
+        $plugin = $this->getMock('Composer\Package\PackageInterface');
+        $plugin->expects($this->any())
+            ->method('getType')
+            ->willReturn('composer-plugin');
+        $plugin->expects($this->any())
+            ->method('getRequires')
+            ->willReturn(array());
+
+        $collection->add(new UpdateOperation($package, $package));
+        $collection->add(new InstallOperation($package));
+        $collection->add(new UninstallOperation($package));
+        $collection->add(new MarkAliasInstalledOperation($alias));
+        $collection->add(new MarkAliasUninstalledOperation($alias));
+        $collection->add(new InstallOperation($plugin));
+    }
+
+    public function testAddOperations()
+    {
+        $collection = new OperationCollection();
+        $this->assertTrue($collection->isEmpty());
+
+        $this->addPackagesToCollection($collection);
+
+        $this->assertFalse($collection->isEmpty());
+        $this->assertCount(6, $collection->toArray());
+        $this->assertCount(1, $collection->getInstalls());
+        $this->assertCount(1, $collection->getUpdates());
+        $this->assertCount(1, $collection->getUninstalls());
+        $this->assertCount(1, $collection->getMarkAliasInstalled());
+        $this->assertCount(1, $collection->getMarkAliasUninstalled());
+        $this->assertCount(1, $collection->getPlugins());
+    }
+
+    public function testOperationSorting()
+    {
+        $collection = new OperationCollection();
+        $this->addPackagesToCollection($collection);
+        $operations = $collection->toArray();
+
+        $this->assertInstanceOf('Composer\DependencyResolver\Operation\UninstallOperation', reset($operations));
+        $this->assertTrue(next($operations)->getPackage()->getType() == 'composer-plugin');
+        $this->assertInstanceOf('Composer\DependencyResolver\Operation\MarkAliasUninstalledOperation', next($operations));
+        $this->assertInstanceOf('Composer\DependencyResolver\Operation\InstallOperation', next($operations));
+        $this->assertInstanceOf('Composer\DependencyResolver\Operation\MarkAliasInstalledOperation', next($operations));
+        $this->assertInstanceOf('Composer\DependencyResolver\Operation\UpdateOperation', next($operations));
+    }
+
+    public function testIsIterable()
+    {
+        $collection = new OperationCollection();
+        $this->assertInstanceOf('\IteratorAggregate', $collection);
+    }
+}

--- a/tests/Composer/Test/DependencyResolver/Operation/OperationCollectionTest.php
+++ b/tests/Composer/Test/DependencyResolver/Operation/OperationCollectionTest.php
@@ -81,10 +81,10 @@ class OperationCollectionTest extends TestCase
 
         $this->assertInstanceOf('Composer\DependencyResolver\Operation\UninstallOperation', reset($operations));
         $this->assertTrue(next($operations)->getPackage()->getType() == 'composer-plugin');
-        $this->assertInstanceOf('Composer\DependencyResolver\Operation\MarkAliasUninstalledOperation', next($operations));
+        $this->assertInstanceOf('Composer\DependencyResolver\Operation\UpdateOperation', next($operations));
         $this->assertInstanceOf('Composer\DependencyResolver\Operation\InstallOperation', next($operations));
         $this->assertInstanceOf('Composer\DependencyResolver\Operation\MarkAliasInstalledOperation', next($operations));
-        $this->assertInstanceOf('Composer\DependencyResolver\Operation\UpdateOperation', next($operations));
+        $this->assertInstanceOf('Composer\DependencyResolver\Operation\MarkAliasUninstalledOperation', next($operations));
     }
 
     public function testIsIterable()

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -344,13 +344,13 @@ class SolverTest extends TestCase
 
         $this->checkSolverResult(array(
             array(
+                'job' => 'remove',
+                'package' => $packageB,
+            ),
+            array(
                 'job' => 'update',
                 'from' => $packageA,
                 'to' => $newPackageA,
-            ),
-            array(
-                'job' => 'remove',
-                'package' => $packageB,
             ),
         ));
     }
@@ -375,10 +375,10 @@ class SolverTest extends TestCase
         $this->request->remove('D');
 
         $this->checkSolverResult(array(
+            array('job' => 'remove',  'package' => $packageD),
             array('job' => 'update',  'from' => $oldPackageC, 'to' => $packageC),
             array('job' => 'install', 'package' => $packageB),
             array('job' => 'install', 'package' => $packageA),
-            array('job' => 'remove',  'package' => $packageD),
         ));
     }
 


### PR DESCRIPTION
This adds the ability to do a `--confirm` on an update and be shown what the changes will be and confirm them. I implemented this because I like to see what will happen prior to everything happening. I also implemented a collection class around the different operation type classes, as I thought this made things easier to understand  as I implemented this and extracted some of the code from the Installer class. Something I wasn't too sure about: Is the order I'm returnining the operation types in  `sortOperationsToArray` in the OperationCollection class correct?
