### PR TITLE
Delegate problem message formatting to a dedicated class

### DIFF
--- a/src/Composer/DependencyResolver/ProblemFormatter.php
+++ b/src/Composer/DependencyResolver/ProblemFormatter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Composer\DependencyResolver;
+
+class ProblemFormatter
+{
+	const COULD_NOT_BE_FOUND_OCCURRENCE = 'could not be found';
+	const NO_MATCHING_PACKAGE_FOUND_OCCURENCE = 'no matching package found';
+
+	const TYPO_ADVICE_LABEL = 'typo';
+	const TYPO_ADVICE_STRING = "Potential causes:\n - A typo in the package name\n - The package is not available in a stable-enough version according to your minimum-stability setting\n   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.\n\nRead <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.";
+
+	protected $advices;
+
+	public function __construct(array $installedMap)
+	{
+		$this->installedMap = $installedMap;
+		$this->advices = array();
+	}
+
+	public function format(Problem $problem, $position)
+	{
+		$prettyString = $problem->getPrettyString($this->installedMap);
+		$this->extractAdvices($prettyString);
+
+		$text = "  Problem ".($position+1).$prettyString."\n";
+
+		$formattedProblem = array("advices" => $this->advices, "text" => $text);
+
+		return $formattedProblem;
+	}
+
+	protected function extractAdvices($prettyString)
+	{
+		 if (strpos($prettyString, self::COULD_NOT_BE_FOUND_OCCURRENCE) || strpos($prettyString, self::NO_MATCHING_PACKAGE_FOUND_OCCURENCE)) {
+		 	$this->advices[self::TYPO_ADVICE_LABEL] = self::TYPO_ADVICE_STRING;
+		 }
+	}
+}

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -190,7 +190,7 @@ class Solver
         }
 
         if ($this->problems) {
-            throw new SolverProblemsException($this->problems, $this->installedMap);
+            throw new SolverProblemsException($this->problems, new ProblemFormatter($this->installedMap));
         }
 
         $transaction = new Transaction($this->policy, $this->pool, $this->installedMap, $this->decisions);

--- a/src/Composer/DependencyResolver/SolverProblemsException.php
+++ b/src/Composer/DependencyResolver/SolverProblemsException.php
@@ -19,11 +19,12 @@ class SolverProblemsException extends \RuntimeException
 {
     protected $problems;
     protected $installedMap;
+    protected $problemFormatter;
 
-    public function __construct(array $problems, array $installedMap)
+    public function __construct(array $problems, ProblemFormatter $problemFormatter)
     {
         $this->problems = $problems;
-        $this->installedMap = $installedMap;
+        $this->problemFormatter = $problemFormatter;
 
         parent::__construct($this->createMessage(), 2);
     }
@@ -31,12 +32,17 @@ class SolverProblemsException extends \RuntimeException
     protected function createMessage()
     {
         $text = "\n";
-        foreach ($this->problems as $i => $problem) {
-            $text .= "  Problem ".($i+1).$problem->getPrettyString($this->installedMap)."\n";
+        $advices = array();
+
+        foreach ($this->problems as $key => $problem) {
+            $formattedProblem = $this->problemFormatter->format($problem, $key);
+
+            $text .= $formattedProblem['text'];
+            $advices = array_merge($advices, $formattedProblem['advices']);
         }
 
-        if (strpos($text, 'could not be found') || strpos($text, 'no matching package found')) {
-            $text .= "\nPotential causes:\n - A typo in the package name\n - The package is not available in a stable-enough version according to your minimum-stability setting\n   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.\n\nRead <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.";
+        foreach ($advices as $advice) {
+            $text .= "\n$advice";
         }
 
         return $text;

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -20,6 +20,7 @@ use Composer\DependencyResolver\SolverProblemsException;
 use Composer\Package\Link;
 use Composer\TestCase;
 use Composer\Package\LinkConstraint\MultiConstraint;
+use Composer\DependencyResolver\ProblemFormatter;
 
 class SolverTest extends TestCase
 {
@@ -705,11 +706,7 @@ class SolverTest extends TestCase
             $msg .= "  Problem 1\n";
             $msg .= "    - Installation request for a -> satisfiable by A[1.0].\n";
             $msg .= "    - A 1.0 requires b >= 2.0 -> no matching package found.\n\n";
-            $msg .= "Potential causes:\n";
-            $msg .= " - A typo in the package name\n";
-            $msg .= " - The package is not available in a stable-enough version according to your minimum-stability setting\n";
-            $msg .= "   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.\n\n";
-            $msg .= "Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.";
+            $msg .= ProblemFormatter::TYPO_ADVICE_STRING;
             $this->assertEquals($msg, $e->getMessage());
         }
     }


### PR DESCRIPTION
Exception was tought to know the installed map, now installed map is a dependency of the problem formatter.
More than one potential failure cause can be noticed now.
Sorry, surely it needs some evolution or refactoring, just a little step over the goal.