### PR TITLE
Simplify the way to assert parse error in json tests

### DIFF
--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -208,12 +208,8 @@ class JsonFileTest extends \PHPUnit_Framework_TestCase
 
     private function expectParseException($text, $json)
     {
-        try {
-            JsonFile::parseJson($json);
-            $this->fail();
-        } catch (ParsingException $e) {
-            $this->assertContains($text, $e->getMessage());
-        }
+        $this->setExpectedException('Seld\JsonLint\ParsingException', $text);
+        JsonFile::parseJson($json);
     }
 
     private function assertJsonFormat($json, $data, $options = null)


### PR DESCRIPTION
The advantage is that we now have a meaningful error message when no parse error is detected instead of having an empty message.

Note that one of the test about parse errors is failing for me locally (no exception thrown), which is how I detected the empty failure message