### PR TITLE
Only show instead of open the repository or homepage URL

### DIFF
--- a/src/Composer/Command/HomeCommand.php
+++ b/src/Composer/Command/HomeCommand.php
@@ -84,7 +84,7 @@ EOT
             }
 
             if ($input->getOption('show')) {
-                $output->writeln(sprintf('<comment>%s: </comment><info>%s</info>', $input->getOption('homepage') ? 'Homepage URL' : 'Repository URL', $url).' </info>');
+                $output->writeln(sprintf('<info>%s</info>', $url));
             } else {
                 $this->openBrowser($url);
             }

--- a/src/Composer/Command/HomeCommand.php
+++ b/src/Composer/Command/HomeCommand.php
@@ -40,12 +40,14 @@ class HomeCommand extends Command
             ->setDefinition(array(
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Package(s) to browse to.'),
                 new InputOption('homepage', 'H', InputOption::VALUE_NONE, 'Open the homepage instead of the repository URL.'),
+                new InputOption('show', 's', InputOption::VALUE_NONE, 'Only show the homepage or repository URL.'),
             ))
             ->setHelp(<<<EOT
-The home command opens a package's repository URL or
+The home command opens or shows a package's repository URL or
 homepage in your default browser.
 
 To open the homepage by default, use -H or --homepage.
+To show instead of open the repository or homepage URL, use -s or --show.
 EOT
             );
     }
@@ -81,7 +83,11 @@ EOT
                 continue;
             }
 
-            $this->openBrowser($url);
+            if ($input->getOption('show')) {
+                $output->writeln(sprintf('<comment>%s: </comment><info>%s</info>', $input->getOption('homepage') ? 'Homepage URL' : 'Repository URL', $url).' </info>');
+            } else {
+                $this->openBrowser($url);
+            }
         }
 
         return $return;


### PR DESCRIPTION
Small but useful option to show instead of launching the repository or homepage URL.

use:  with -s or --show option
$composer home monolog/monolog -Hs
Homepage URL: http://github.com/Seldaek/monolog

$composer home monolog/monolog --show  (or -s)
Repository URL: http://github.com/Seldaek/monolog