### PR TITLE
Remove authentication credentials from git config file

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -37,7 +37,7 @@ class AuthHelper
             $store = $configSource;
         } elseif ($storeAuth === 'prompt') {
             $answer = $this->io->askAndValidate(
-                'Do you want to store credentials for '.$originUrl.' in '.$configSource->getName().' ? [Yn] ',
+                'Do you want to store credentials unencrypted for '.$originUrl.' in '.$configSource->getName().' ? [Yn] ',
                 function ($value) {
                     $input = strtolower(substr(trim($value), 0, 1));
                     if (in_array($input, array('y','n'))) {

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -44,14 +44,6 @@ class Git
             throw new \InvalidArgumentException('The source URL '.$url.' is invalid, ssh URLs should have a port number after ":".'."\n".'Use ssh://git@example.com:22/path or just git@example.com:path if you do not want to provide a password or custom port.');
         }
 
-        if (!$initialClone) {
-            // capture username/password from URL if there is one
-            $this->process->execute('git remote -v', $output, $cwd);
-            if (preg_match('{^(?:composer|origin)\s+https?://(.+):(.+)@([^/]+)}im', $output, $match)) {
-                $this->io->setAuthentication($match[3], urldecode($match[1]), urldecode($match[2]));
-            }
-        }
-
         // public github, autoswitch protocols
         if (preg_match('{^(?:https?|git)://'.self::getGitHubDomainsRegex($this->config).'/(.*)}', $url, $match)) {
             $protocols = $this->config->get('github-protocols');

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Util;
+
+use Composer\Config;
+use Composer\Config\ConfigSourceInterface;
+use Composer\IO\IOInterface;
+use Composer\TestCase;
+use Composer\Util\AuthHelper;
+
+/**
+ * AuthHelper test case
+ */
+class AuthHelperTest extends TestCase
+{
+
+    /**
+     * @param IOInterface $io
+     * @param ConfigSourceInterface $configSource
+     * @return AuthHelper
+     */
+    protected function getHelperMock(IOInterface $io, ConfigSourceInterface $configSource)
+    {
+        $config = new Config();
+        $config->setAuthConfigSource($configSource);
+
+        return new AuthHelper($io, $config);
+    }
+
+    /**
+     * test when helper should store for sure
+     */
+    public function testStoreAuthTrue()
+    {
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io->expects($this->once())->method('getAuthentication')->with()->willReturn('password');
+
+        $authConfigSource = $this->getMock('Composer\Config\ConfigSourceInterface');
+        $authConfigSource->expects($this->never())->method('getName');
+        $authConfigSource->expects($this->once())->method('addConfigSetting')->with('http-basic.example.com', 'password');
+
+        $authHelper = $this->getHelperMock($io, $authConfigSource);
+        $authHelper->storeAuth('example.com', true);
+    }
+
+    /**
+     * test when helper should prompt and the user answers yes
+     */
+    public function testStoreAuthPromptYes()
+    {
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io->expects($this->once())->method('askAndValidate')->with(
+            'Do you want to store credentials unencrypted for example.com in auth.json ? [Yn] ',
+            $this->anything(),
+            false,
+            'y'
+        )->willReturn('y');
+        $io->expects($this->once())->method('getAuthentication')->with()->willReturn('password');
+
+        $authConfigSource = $this->getMock('Composer\Config\ConfigSourceInterface');
+        $authConfigSource->expects($this->once())->method('getName')->with()->willReturn('auth.json');
+        $authConfigSource->expects($this->once())->method('addConfigSetting')->with('http-basic.example.com', 'password');
+
+        $authHelper = $this->getHelperMock($io, $authConfigSource);
+        $authHelper->storeAuth('example.com', 'prompt');
+    }
+
+    /**
+     * test when helper should prompt and the user answers no
+     */
+    public function testStoreAuthPromptNo()
+    {
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io->expects($this->once())->method('askAndValidate')->willReturn('n');
+        $io->expects($this->never())->method('getAuthentication');
+
+        $authConfigSource = $this->getMock('Composer\Config\ConfigSourceInterface');
+        $authConfigSource->expects($this->once())->method('getName')->with()->willReturn('auth.json');
+        $authConfigSource->expects($this->never())->method('addConfigSetting');
+
+        $authHelper = $this->getHelperMock($io, $authConfigSource);
+        $authHelper->storeAuth('example.com', 'prompt');
+    }
+
+    /**
+     * test when helper should not store at all
+     */
+    public function testStoreAuthFalse()
+    {
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io->expects($this->never())->method('getAuthentication')->with()->willReturn('password');
+
+        $authConfigSource = $this->getMock('Composer\Config\ConfigSourceInterface');
+        $authConfigSource->expects($this->never())->method('getName');
+        $authConfigSource->expects($this->never())->method('addConfigSetting');
+
+        $authHelper = $this->getHelperMock($io, $authConfigSource);
+        $authHelper->storeAuth('example.com', false);
+    }
+}

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Util;
+
+use Composer\Config;
+use Composer\TestCase;
+use Composer\Util\Git;
+
+/**
+ * Git test case
+ */
+class GitTest extends TestCase
+{
+    /**
+     * @param null $io
+     * @param null $executor
+     * @param null $config
+     * @param null $filesystem
+     * @return Git
+     */
+    protected function getGitMock($io = null, $executor = null, $config = null, $filesystem = null)
+    {
+        $io = $io ?: $this->getMock('Composer\IO\IOInterface');
+        $executor = $executor ?: $this->getMock('Composer\Util\ProcessExecutor');
+        $filesystem = $filesystem ?: $this->getMock('Composer\Util\Filesystem');
+        if (!$config) {
+            $config = new Config();
+            $config->merge(array(
+                'config' => array(
+                    'store-auths' => false
+                )
+            ));
+        }
+
+        return new Git($io, $config, $executor, $filesystem);
+    }
+
+    /**
+     * test user gets authenticated when auth is stored
+     */
+    public function testPrivateGitRepositoryWithAuthInConfig()
+    {
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io->expects($this->once())->method('hasAuthentication')->willReturn(true);
+        $io->expects($this->once())->method('getAuthentication')->willReturn(array(
+            'username' => 'user',
+            'password' => 'pass'
+        ));
+        $io->expects($this->once())->method('setAuthentication')->with('example.com', 'user', 'pass');
+
+        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process->expects($this->at(0))->method('execute')->with('git fetch https://example.com/composer')->willReturn(1);
+        $process->expects($this->at(1))->method('getErrorOutput')->willReturn('fatal: Authentication failed');
+        $process->expects($this->at(2))->method('execute')->with('git fetch https://user:pass@example.com/composer')->willReturn(0);
+
+        $callback = function ($url) {
+            return 'git fetch ' . $url;
+        };
+
+        $git = $this->getGitMock($io, $process);
+        $git->runCommand($callback, 'https://example.com/composer', '/home', true);
+    }
+
+    /**
+     * test exception when username and password are wrong
+     */
+    public function testPrivateGitRepositoryWrongAuthCredentials()
+    {
+        $this->setExpectedException('RuntimeException');
+
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io->expects($this->once())->method('hasAuthentication')->willReturn(true);
+        $io->expects($this->once())->method('getAuthentication')->willReturn(array(
+            'username' => 'user',
+            'password' => 'pass'
+        ));
+        $io->expects($this->never())->method('setAuthentication');
+
+        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process->expects($this->at(0))->method('execute')->with('git fetch https://example.com/composer')->willReturn(1);
+        $process->expects($this->at(1))->method('getErrorOutput')->willReturn('fatal: Authentication failed');
+        $process->expects($this->at(2))->method('execute')->with('git fetch https://user:pass@example.com/composer')->willReturn(1);
+
+        $callback = function ($url) {
+            return 'git fetch ' . $url;
+        };
+
+        $git = $this->getGitMock($io, $process);
+        $git->runCommand($callback, 'https://example.com/composer', '/home', true);
+    }
+
+    /**
+     * test user gets prompted when auth is not stored
+     */
+    public function testPrivateGitRepositoryWithAuthPrompt()
+    {
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io->expects($this->once())->method('hasAuthentication')->willReturn(false);
+        $io->expects($this->once())->method('isInteractive')->willReturn(true);
+        $io->expects($this->once())->method('ask')->willReturn('user');
+        $io->expects($this->once())->method('askAndHideAnswer')->willReturn('pass');
+        $io->expects($this->once())->method('setAuthentication')->with('example.com', 'user', 'pass');
+
+        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process->expects($this->at(0))->method('execute')->with('git fetch https://example.com/composer')->willReturn(1);
+        $process->expects($this->at(1))->method('getErrorOutput')->willReturn('fatal: Authentication failed');
+        $process->expects($this->at(2))->method('execute')->with('git fetch https://user:pass@example.com/composer')->willReturn(0);
+
+        $callback = function ($url) {
+            return 'git fetch ' . $url;
+        };
+
+        $git = $this->getGitMock($io, $process);
+        $git->runCommand($callback, 'https://example.com/composer', '/home', true);
+    }
+
+    /**
+     * test default username value
+     */
+    public function testPrivateGitRepositoryWithAuthPromptDefaultUsername()
+    {
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io->expects($this->once())->method('hasAuthentication')->willReturn(false);
+        $io->expects($this->once())->method('isInteractive')->willReturn(true);
+        $io->expects($this->once())->method('ask')->with($this->anything(), 'user')->willReturn('user');
+        $io->expects($this->once())->method('askAndHideAnswer')->willReturn('pass');
+        $io->expects($this->once())->method('setAuthentication')->with('example.com', 'user', 'pass');
+
+        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process->expects($this->at(0))->method('execute')->with('git fetch https://user@example.com/composer')->willReturn(1);
+        $process->expects($this->at(1))->method('getErrorOutput')->willReturn('fatal: Authentication failed');
+        $process->expects($this->at(2))->method('execute')->with('git fetch https://user:pass@example.com/composer')->willReturn(0);
+
+        $callback = function ($url) {
+            return 'git fetch ' . $url;
+        };
+
+        $git = $this->getGitMock($io, $process);
+        $git->runCommand($callback, 'https://user@example.com/composer', '/home', true);
+    }
+}


### PR DESCRIPTION
When using private repositories, composer leaves authentication credentials in .git/config. This is undesired behaviour because credentials are potentially leaked. This PR removes credentials after fetching. It contains tests for download and update.
