### PR TITLE
force symfony/console 2.3.* on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=5.3.2",
         "justinrainbow/json-schema": "~1.3",
         "seld/jsonlint": "~1.0",
-        "symfony/console": "~2.3",
+        "symfony/console": "2.3.*",
         "symfony/finder": "~2.2",
         "symfony/process": "~2.1"
     },


### PR DESCRIPTION
For some reason, `composer` was installing `symfony/console` version 2.7 in my project. 

I've changed my project's `composer.json` to use `"symfony/console": "2.3.*"` and now it's installing the correct version.