### PR TITLE
Added missing $listeners variable into EventDispatcher

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -44,6 +44,7 @@ class EventDispatcher
     protected $io;
     protected $loader;
     protected $process;
+    protected $listeners;
 
     /**
      * Constructor.


### PR DESCRIPTION
Missing variable triggers ```PHP Notice: Undefined property: Composer\EventDispatcher\EventDispatcher::$listeners``` which throws ```ErrorException```