### PR TITLE
Add 'info' alias for 'show' command

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -41,6 +41,7 @@ class ShowCommand extends Command
     {
         $this
             ->setName('show')
+            ->setAliases(array('info'))
             ->setDescription('Show information about packages')
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect'),


### PR DESCRIPTION
Working with RedHat/CentOS systems I can't count the times I typed `composer info <package>` instead of `composer show <package>` since the equivalent `yum` command is `info`. So I open this PR to add an alias. I suppose I'm not the only one doing this mistake regularly and I think it improves the user experience.