### PR TITLE
Fix error handling for incorrect "repositories" array

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -124,7 +124,7 @@ class Config
                 }
 
                 // disable a repository with an anonymous {"name": false} repo
-                if (1 === count($repository) && false === current($repository)) {
+                if (is_array($repository) && 1 === count($repository) && false === current($repository)) {
                     unset($this->repositories[key($repository)]);
                     continue;
                 }

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -97,6 +97,18 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
+        $data['incorrect local config does not cause ErrorException'] = array(
+            array(
+                'packagist' => array('type' => 'composer', 'url' => 'https?://packagist.org', 'allow_ssl_downgrade' => true),
+                'type' => 'vcs',
+                'url' => 'http://example.com',
+            ),
+            array(
+                'type' => 'vcs',
+                'url' => 'http://example.com',
+            ),
+        );
+
         return $data;
     }
 


### PR DESCRIPTION
This is the fix for this issue:
https://github.com/composer/composer/issues/3654

Take a look at the screenshots:

Before fix:
![screenshot from 2015-01-20 13 14 18](https://cloud.githubusercontent.com/assets/1029434/5815559/b2207192-a0a7-11e4-9ada-8799a9984137.png)

After fix:
![screenshot from 2015-01-20 13 14 33](https://cloud.githubusercontent.com/assets/1029434/5815561/b38fd978-a0a7-11e4-9748-e6f89bb8f5a5.png)