### PR TITLE
Install plugin dependencies before plugin installation

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -622,17 +622,13 @@ class Installer
      */
     private function movePluginsToFront(array $operations)
     {
-        $installerOps = array();
-        foreach ($operations as $idx => $op) {
-            if ($op instanceof InstallOperation) {
-                $package = $op->getPackage();
-            } elseif ($op instanceof UpdateOperation) {
-                $package = $op->getTargetPackage();
-            } else {
+        $pluginDependencies = array();
+        foreach ($operations as $op) {
+            if (null === $package = $this->getOperationPackage($op)) {
                 continue;
             }
 
-            if ($package->getType() === 'composer-plugin' || $package->getType() === 'composer-installer') {
+            if ($this->isPlugin($package)) {
                 // ignore requirements to platform or composer-plugin-api
                 $requires = array_keys($package->getRequires());
                 foreach ($requires as $index => $req) {
@@ -640,11 +636,21 @@ class Installer
                         unset($requires[$index]);
                     }
                 }
-                // if there are no other requirements, move the plugin to the top of the op list
-                if (!count($requires)) {
-                    $installerOps[] = $op;
-                    unset($operations[$idx]);
-                }
+                $pluginDependencies = array_merge($pluginDependencies, $requires);
+            }
+        }
+        $pluginDependencies = array_unique($pluginDependencies);
+
+        $installerOps = array();
+        foreach ($operations as $idx => $op) {
+            if (null === $package = $this->getOperationPackage($op)) {
+                continue;
+            }
+
+            if ($this->isPlugin($package)
+                || in_array($package->getName(), $pluginDependencies)) {
+                $installerOps[] = $op;
+                unset($operations[$idx]);
             }
         }
 
@@ -669,6 +675,36 @@ class Installer
         }
 
         return array_merge($uninstOps, $operations);
+    }
+
+    /**
+     * Get the package of operation
+     *
+     * @param OperationInterface $operation
+     *
+     * @return PackageInterface|null
+     */
+    private function getOperationPackage(OperationInterface $operation)
+    {
+        if ($operation instanceof InstallOperation) {
+            return $operation->getPackage();
+        } elseif ($operation instanceof UpdateOperation) {
+            return $operation->getTargetPackage();
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if package is a plugin
+     *
+     * @param  PackageInterface $package
+     * @return bool
+     */
+    private function isPlugin(PackageInterface $package)
+    {
+        return $package->getType() === 'composer-plugin'
+            || $package->getType() === 'composer-installer';
     }
 
     private function createPool($withDevReqs)

--- a/tests/Composer/Test/Fixtures/installer/plugins-are-installed-first.test
+++ b/tests/Composer/Test/Fixtures/installer/plugins-are-installed-first.test
@@ -25,7 +25,7 @@ Composer installers are installed first if they have no meaningful requirements
 install
 --EXPECT--
 Installing inst (1.0.0)
-Installing inst-with-req (1.0.0)
-Installing pkg (1.0.0)
 Installing pkg2 (1.0.0)
 Installing inst-with-req2 (1.0.0)
+Installing inst-with-req (1.0.0)
+Installing pkg (1.0.0)


### PR DESCRIPTION
| Q             | A
| ------------- | -------------------------------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2972
| License       | MIT

> **Note:** This PR is an extraction of the bug fix of 'order of installation of plugin dependencies' fixed by the PR #3082

Fixes a "strange" behavior of the order of installation of plugins and their dependencies.

The plugin dependencies must be installed before the plugin, then the plugin must be installed, and then the rest of depedencies can be installed.

Test example:

```json
{
    "repositories": [
        {
            "type": "package",
            "package": [
                { "name": "pkg", "version": "1.0.0" },
                { "name": "pkg2", "version": "1.0.0" },
                { "name": "inst", "version": "1.0.0", "type": "composer-plugin" },
                { "name": "inst-with-req", "version": "1.0.0", "type": "composer-plugin", "require": { "php": ">=5", "ext-json": "*", "composer-plugin-api": "*" } },
                { "name": "inst-with-req2", "version": "1.0.0", "type": "composer-plugin", "require": { "pkg2": "*" } }
            ]
        }
    ],
    "require": {
        "pkg": "1.0.0",
        "inst": "1.0.0",
        "inst-with-req2": "1.0.0",
        "inst-with-req": "1.0.0"
    }
}
```

The order should be:

```
Installing inst (1.0.0)
Installing pkg2 (1.0.0)
Installing inst-with-req2 (1.0.0)
Installing inst-with-req (1.0.0)
Installing pkg (1.0.0)
```

and not (actually):

```
Installing inst (1.0.0)
Installing inst-with-req (1.0.0)
Installing pkg (1.0.0)
Installing pkg2 (1.0.0)
Installing inst-with-req2 (1.0.0)
```