### PR TITLE
Add the P character to the regex pattern

### DIFF
--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -178,7 +178,7 @@ class VersionParser
      */
     public function parseNumericAliasPrefix($branch)
     {
-        if (preg_match('/^(?<version>(\d+\\.)*\d+)(?:\.x)?-dev$/i', $branch, $matches)) {
+        if (preg_match('/^(?P<version>(\d+\\.)*\d+)(?:\.x)?-dev$/i', $branch, $matches)) {
             return $matches['version'].".";
         }
 


### PR DESCRIPTION
According to http://php.net/manual/en/function.preg-match.php and some other sources named groups should contain a 'P' character after the '?'

Without this, I receive the following error when running an update:

[ErrorException]                                                                
  preg_match(): Compilation failed: unrecognized character after (?< at offset 4  
                                                                                  
Exception trace:
 () at phar:///directory/composer.phar/src/Composer/Package/Version/VersionParser.php:181