### PR TITLE
Reuse current file permissions in selfupdate

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -173,7 +173,7 @@ EOT
     protected function setLocalPhar($localFilename, $newFilename, $backupTarget = null)
     {
         try {
-            @chmod($newFilename, 0777 & ~umask());
+            @chmod($newFilename, fileperms($localFilename));
             if (!ini_get('phar.readonly')) {
                 // test the phar validity
                 $phar = new \Phar($newFilename);


### PR DESCRIPTION
In selfupdate command, reuse original file's permission instead of using `umask`