### PR TITLE
added non-feature-branches

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -785,8 +785,6 @@ The example will include `/dir/foo/bar/file`, `/foo/bar/baz`, `/file.php`,
 
 Optional.
 
-&larr; [Command-line interface](03-cli.md)  |  [Repositories](05-repositories.md) &rarr;
-
 ### non-feature-branches
 
 A list of regex patterns of branch names that are non-numeric (e.g. "latest" or something), that will NOT be handled as feature branches. This is an array of string.
@@ -815,3 +813,5 @@ Then "composer show -s" will give you "versions : * dev-latest-testing".
 
 
 Optional.
+
+&larr; [Command-line interface](03-cli.md)  |  [Repositories](05-repositories.md) &rarr;

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -799,7 +799,11 @@ To handle non-numeric named branches as versions instead of searching for a pare
 with a valid version or special branch name like master, you can set patterns for branch
 names, that should be handled as dev version branches.
 
+This is really helpful when you have dependencies using "self.version", so that not dev-master,
+but the same branch is installed (in the example: latest-testing).
+
 An example:
+
 If you have a testing branch, that is heavily maintained during a testing phase and is
 deployed to your staging environment, normally "composer show -s" will give you `versions : * dev-master`.
 

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -801,7 +801,7 @@ names, that should be handled as dev version branches.
 
 An example:
 If you have a testing branch, that is heavily maintained during a testing phase and is
-deployed to your staging environment, normally "composer show -s" will give you "versions : * dev-master".
+deployed to your staging environment, normally "composer show -s" will give you `versions : * dev-master`.
 
 If you configure latest-.* as a pattern for non-feature-branches like this:
 
@@ -809,8 +809,7 @@ If you configure latest-.* as a pattern for non-feature-branches like this:
         "non-feature-branches": ["latest-.*"]
     }
 
-Then "composer show -s" will give you "versions : * dev-latest-testing".
-
+Then "composer show -s" will give you `versions : * dev-latest-testing`.
 
 Optional.
 

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -786,3 +786,32 @@ The example will include `/dir/foo/bar/file`, `/foo/bar/baz`, `/file.php`,
 Optional.
 
 &larr; [Command-line interface](03-cli.md)  |  [Repositories](05-repositories.md) &rarr;
+
+### non-feature-branches
+
+A list of regex patterns of branch names that are non-numeric (e.g. "latest" or something), that will NOT be handled as feature branches. This is an array of string.
+
+If you have non-numeric branch names, for example like "latest", "current", "latest-stable"
+or something, that do not look like a version number, then composer handles such branches
+as feature branches. This means it searches for parent branches, that look like a version
+or ends at special branches (like master) and the root package version number becomes the
+version of the parent branch or at least master or something.
+
+To handle non-numeric named branches as versions instead of searching for a parent branch
+with a valid version or special branch name like master, you can set patterns for branch
+names, that should be handled as dev version branches.
+
+An example:
+    If you have a testing branch, that is heavily maintained during a testing phase and is
+    deployed to your staging environment, normally "composer show -s" will give you "versions : * dev-master".
+
+    If you configure latest-.* as a pattern for non-feature-branches like this:
+
+    {
+        "non-feature-branches": ["latest-.*"]
+    }
+
+    Then "composer show -s" will give you "versions : * dev-latest-testing".
+
+
+Optional.

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -802,16 +802,16 @@ with a valid version or special branch name like master, you can set patterns fo
 names, that should be handled as dev version branches.
 
 An example:
-    If you have a testing branch, that is heavily maintained during a testing phase and is
-    deployed to your staging environment, normally "composer show -s" will give you "versions : * dev-master".
+If you have a testing branch, that is heavily maintained during a testing phase and is
+deployed to your staging environment, normally "composer show -s" will give you "versions : * dev-master".
 
-    If you configure latest-.* as a pattern for non-feature-branches like this:
+If you configure latest-.* as a pattern for non-feature-branches like this:
 
     {
         "non-feature-branches": ["latest-.*"]
     }
 
-    Then "composer show -s" will give you "versions : * dev-latest-testing".
+Then "composer show -s" will give you "versions : * dev-latest-testing".
 
 
 Optional.

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -367,6 +367,13 @@
                     "format": "uri"
                 }
             }
+        },
+        "non-feature-branches": {
+            "type": ["array"],
+            "description": "A set of string or regex patterns for non-numeric branch names that will not be handles as feature branches.",
+            "items": {
+                "type": "string"
+            }
         }
     }
 }

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -272,7 +272,18 @@ class RootPackageLoader extends ArrayLoader
         ) {
             $branch = preg_replace('{^dev-}', '', $version);
             $length = PHP_INT_MAX;
+
+            $nonFeatureBranches = '';
+            if(!empty($config['non-feature-branches'])) {
+                $nonFeatureBranches = implode('|', $config['non-feature-branches']);
+            }
+
             foreach ($branches as $candidate) {
+                // return directly, if branch is configured to be non-feature branch
+                if($candidate === $branch && preg_match('{^(' . $nonFeatureBranches . ')$}', $candidate)) {
+                    return $version;
+                }
+
                 // do not compare against other feature branches
                 if ($candidate === $branch || !preg_match('{^(master|trunk|default|develop|\d+\..+)$}', $candidate, $match)) {
                     continue;

--- a/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
@@ -153,4 +153,80 @@ class RootPackageLoaderTest extends \PHPUnit_Framework_TestCase
             'qux/quux' => BasePackage::STABILITY_RC,
         ), $package->getStabilityFlags());
     }
+
+    public function testFeatureBranchPrettyVersion()
+    {
+        if (!function_exists('proc_open')) {
+            $this->markTestSkipped('proc_open() is not available');
+        }
+
+        $manager = $this->getMockBuilder('\\Composer\\Repository\\RepositoryManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $self = $this;
+
+        /* Can do away with this mock object when https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81 is fixed */
+        $processExecutor = new ProcessExecutorMock(function($command, &$output = null, $cwd = null) use ($self) {
+            if (0 === strpos($command, 'git rev-list')) {
+                $output = "";
+                return 0;
+            }
+
+            if ('git branch --no-color --no-abbrev -v' !== $command) {
+                return 1; //0;
+            }
+
+            $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+
+            $output = "* latest-production 38137d2f6c70e775e137b2d8a7a7d3eaebf7c7e5 Commit message\n  master 4f6ed96b0bc363d2aa4404c3412de1c011f67c66 Commit message\n";
+
+            return 0;
+        });
+
+        $config = new Config;
+        $config->merge(array('repositories' => array('packagist' => false)));
+        $loader = new RootPackageLoader($manager, $config, null, $processExecutor);
+        $package = $loader->load(array('require' => array('foo/bar' => 'self.version')));
+
+        $this->assertEquals("dev-master", $package->getPrettyVersion());
+    }
+
+    public function testNonFeatureBranchPrettyVersion()
+    {
+        if (!function_exists('proc_open')) {
+            $this->markTestSkipped('proc_open() is not available');
+        }
+
+        $manager = $this->getMockBuilder('\\Composer\\Repository\\RepositoryManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $self = $this;
+
+        /* Can do away with this mock object when https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81 is fixed */
+        $processExecutor = new ProcessExecutorMock(function($command, &$output = null, $cwd = null) use ($self) {
+            if (0 === strpos($command, 'git rev-list')) {
+                $output = "";
+                return 0;
+            }
+
+            if ('git branch --no-color --no-abbrev -v' !== $command) {
+                return 1; //0;
+            }
+
+            $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+
+            $output = "* latest-production 38137d2f6c70e775e137b2d8a7a7d3eaebf7c7e5 Commit message\n  master 4f6ed96b0bc363d2aa4404c3412de1c011f67c66 Commit message\n";
+
+            return 0;
+        });
+
+        $config = new Config;
+        $config->merge(array('repositories' => array('packagist' => false)));
+        $loader = new RootPackageLoader($manager, $config, null, $processExecutor);
+        $package = $loader->load(array('require' => array('foo/bar' => 'self.version'), "non-feature-branches" => array("latest-.*")));
+
+        $this->assertEquals("dev-latest-production", $package->getPrettyVersion());
+    }
 }


### PR DESCRIPTION
Hello!

We had a problem on handling our release and testing branches with composer correctly, when using "self.version" on dependencies, when the release branch has a non-numeric / non-version name, like "latest" or "latest-testing" or "latest-production".

If the root package branch name does not look like a version number, then composer handles the branch as feature branch, which means, it checks all ancestors until it finds a parent branch or tag that looks like a version number or at least ends on master/develop/trunk.

This is a problem if during a testing or release phase you are working with (and also releasing) branches that are named "latest-testing" "current-release" or whatever, when you have dependencies defined with self.version. Since latest-testing is a branch created from master some time ago, self.version actually becomes "master". then latest-testing from our application depends on master of its self.version dependencies, instead of also depend on latest-testing branch from these dependencies.

I added a configuration, where you can specify, what patterns should not be handled like feature branches.
in your composer.json, you can now add something like:
```
"non-feature-branches": ["latest-.*", "release-.*"]
```

all branches matching given patterns will not be handled as feature branches, but as normal "dev" branches, so "latest-testing" becomes version "dev-latest-testing", "latest-production" is version "dev-latest-production".
Then self.version will reference the correct branches of these dependencies, that make use of self.version.

What do you think?

Best regards,
René.

