### PR TITLE
fix bug in GitDriver::supports for remote repo

### DIFF
--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -242,7 +242,7 @@ class GitDriver extends VcsDriver
         }
 
         $process = new ProcessExecutor($io);
-        if($process->execute('git ls-remote --heads ' . ProcessExecutor::escape($url)) === 0) {
+        if($process->execute('git ls-remote --heads ' . ProcessExecutor::escape($url), $output) === 0) {
             return true;
         }
 


### PR DESCRIPTION
for some reason it does not work (in packagist) without the $output param. I don't get any error message here, maybe someone has an idea, why?

Anyway, need this ;)