### PR TITLE
Simplified syntax

### DIFF
--- a/src/Composer/Json/JsonValidationException.php
+++ b/src/Composer/Json/JsonValidationException.php
@@ -21,7 +21,7 @@ class JsonValidationException extends Exception
 {
     protected $errors;
 
-    public function __construct($message, $errors = array(), \Exception $previous = null)
+    public function __construct($message, $errors = array(), Exception $previous = null)
     {
         $this->errors = $errors;
         parent::__construct($message, 0, $previous);


### PR DESCRIPTION
The Exception classname has been imported with `use` statement. 