### PR TITLE
Ignore composer.json if installing from lock file

### DIFF
--- a/src/Composer/Command/Command.php
+++ b/src/Composer/Command/Command.php
@@ -44,13 +44,13 @@ abstract class Command extends BaseCommand
      * @throws \RuntimeException
      * @return Composer
      */
-    public function getComposer($required = true, $disablePlugins = false)
+    public function getComposer($required = true, $disablePlugins = false, $ignoreRootReqsIfLockIsPresent = false)
     {
         if (null === $this->composer) {
             $application = $this->getApplication();
             if ($application instanceof Application) {
                 /* @var $application    Application */
-                $this->composer = $application->getComposer($required, $disablePlugins);
+                $this->composer = $application->getComposer($required, $disablePlugins, $ignoreRootReqsIfLockIsPresent);
             } elseif ($required) {
                 throw new \RuntimeException(
                     'Could not create a Composer\Composer instance, you must inject '.

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -79,7 +79,7 @@ EOT
             $output->writeln('<warning>You are using the deprecated option "dev". Dev packages are installed by default now.</warning>');
         }
 
-        $composer = $this->getComposer(true, $input->getOption('no-plugins'));
+        $composer = $this->getComposer(true, $input->getOption('no-plugins'), true);
         $composer->getDownloadManager()->setOutputProgress(!$input->getOption('no-progress'));
         $io = $this->getIO();
 

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -211,11 +211,11 @@ class Application extends BaseApplication
      * @throws JsonValidationException
      * @return \Composer\Composer
      */
-    public function getComposer($required = true, $disablePlugins = false)
+    public function getComposer($required = true, $disablePlugins = false, $ignoreRootReqsIfLockIsPresent = false)
     {
         if (null === $this->composer) {
             try {
-                $this->composer = Factory::create($this->io, null, $disablePlugins);
+                $this->composer = Factory::create($this->io, null, $disablePlugins, $ignoreRootReqsIfLockIsPresent);
             } catch (\InvalidArgumentException $e) {
                 if ($required) {
                     $this->io->write($e->getMessage());

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -222,7 +222,7 @@ class Factory
             $localConfig = $file->read();
         }
 
-        if($ignoreRootReqsIfLockIsPresent && isset($composerFile) && file_exists($this->getLockFilename($composerFile))){
+        if ($ignoreRootReqsIfLockIsPresent && isset($composerFile) && file_exists($this->getLockFilename($composerFile))) {
             // ignore all requirements from the original composer.json file in case we are installing from a lock file.
             $localConfig["require"] = array();
             $localConfig["require-dev"] = array();
@@ -498,9 +498,8 @@ class Factory
      */
     protected function getLockFilename($composerFile)
     {
-        $lockFile = "json" === pathinfo($composerFile, PATHINFO_EXTENSION)
+        return "json" === pathinfo($composerFile, PATHINFO_EXTENSION)
             ? substr($composerFile, 0, -4) . 'lock'
             : $composerFile . '.lock';
-        return $lockFile;
     }
 }

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -244,6 +244,7 @@ class Factory
                 $config->setAuthConfigSource(new JsonConfigSource($localAuthFile, true));
             }
         }
+
         $vendorDir = $config->get('vendor-dir');
         $binDir = $config->get('bin-dir');
 
@@ -362,7 +363,7 @@ class Factory
 
         $composer = null;
         try {
-            $composer = self::createComposer($io, $config->get('home') . '/composer.json', $disablePlugins, $config->get('home'), false, false);
+            $composer = self::createComposer($io, $config->get('home') . '/composer.json', $disablePlugins, $config->get('home'), false);
         } catch (\Exception $e) {
             if ($io->isDebug()) {
                 $io->write('Failed to initialize global composer: '.$e->getMessage());
@@ -496,7 +497,7 @@ class Factory
      * @param $composerFile
      * @return string
      */
-    protected function getLockFilename($composerFile)
+    private function getLockFilename($composerFile)
     {
         return "json" === pathinfo($composerFile, PATHINFO_EXTENSION)
             ? substr($composerFile, 0, -4) . 'lock'

--- a/tests/Composer/Test/Fixtures/installer/install-from-lock-keeps-locked-version.test
+++ b/tests/Composer/Test/Fixtures/installer/install-from-lock-keeps-locked-version.test
@@ -1,0 +1,41 @@
+--TEST--
+The locked version will not get overwritten by an install
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "foo/bar", "version": "1.0.0" },
+                { "name": "foo/baz", "version": "1.0.0" },
+                { "name": "foo/baz", "version": "2.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "foo/bar": "2.0.0",
+        "foo/baz": "2.0.0"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        { "name": "foo/bar", "version": "1.0.0" },
+        { "name": "foo/baz", "version": "2.0.0" }
+    ],
+    "packages-dev": null,
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false
+}
+--INSTALLED--
+[
+    { "name": "foo/bar", "version": "1.0.0" },
+    { "name": "foo/baz", "version": "1.0.0" }
+]
+--RUN--
+install
+--EXPECT--
+Installing foo/baz (2.0.0)


### PR DESCRIPTION
This is my proposal to this issue: https://github.com/composer/composer/issues/3720

I've added a flag to the composer factory which allows to ignore all requirements from composer.json, should a lock file be present. This flag will be set by the installer to avoid evaluating the composer.json file and complaining about not met requirements if it just should install from the lock file. The warning, that the json file is not in sync with the lock file will still be shown.