### PR TITLE
Ignore root requirements in installer when installing from locked state

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -355,6 +355,9 @@ class Installer
         $installFromLock = false;
         if (!$this->update && $this->locker->isLocked()) {
             $installFromLock = true;
+            // we are removing all requirements from the root package so only the lock file is relevant for installation rules
+            $this->package->setRequires(array());
+            $this->package->setDevRequires(array());
             try {
                 $lockedRepository = $this->locker->getLockedRepository($withDevReqs);
             } catch (\RuntimeException $e) {

--- a/tests/Composer/Test/Fixtures/installer/root-requirements-do-not-affect-locked-versions.test
+++ b/tests/Composer/Test/Fixtures/installer/root-requirements-do-not-affect-locked-versions.test
@@ -1,0 +1,41 @@
+--TEST--
+The locked version will not get overwritten by an install
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "foo/bar", "version": "1.0.0" },
+                { "name": "foo/baz", "version": "1.0.0" },
+                { "name": "foo/baz", "version": "2.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "foo/bar": "2.0.0",
+        "foo/baz": "2.0.0"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        { "name": "foo/bar", "version": "1.0.0" },
+        { "name": "foo/baz", "version": "2.0.0" }
+    ],
+    "packages-dev": null,
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false
+}
+--INSTALLED--
+[
+    { "name": "foo/bar", "version": "1.0.0" },
+    { "name": "foo/baz", "version": "1.0.0" }
+]
+--RUN--
+install
+--EXPECT--
+Updating foo/baz (1.0.0) to foo/baz (2.0.0)


### PR DESCRIPTION
Concerning https://github.com/composer/composer/issues/3720

Original PR was https://github.com/composer/composer/pull/3736

After a healthy discussion in the original PR this is my alternative proposal, that is way less intrusive than the original solution.
Now the installer itself removes the requirements from the root package, should it install from a locked state.