### PR TITLE
Requiring conflicting, replaced packages

### DIFF
--- a/tests/Composer/Test/Fixtures/installer/replaced-packages-should-not-be-installed-when-installing-from-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/replaced-packages-should-not-be-installed-when-installing-from-lock.test
@@ -1,0 +1,39 @@
+--TEST--
+Requiring a replaced package in a version, that is not provided by the replacing package, should result in a conflict, when installing from lock
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "foo/original", "version": "1.0.0", "replace": {"foo/replaced": "1.0.0"} },
+                { "name": "foo/replaced", "version": "1.0.0" },
+                { "name": "foo/replaced", "version": "2.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "foo/original": "1.0.0",
+        "foo/replaced": "2.0.0"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        { "name": "foo/original", "version": "1.0.0", "replace": {"foo/replaced": "1.0.0"} },
+        { "name": "foo/replaced", "version": "2.0.0" }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--RUN--
+install
+--EXPECT-EXIT-CODE--
+2
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/replaced-packages-should-not-be-installed.test
+++ b/tests/Composer/Test/Fixtures/installer/replaced-packages-should-not-be-installed.test
@@ -1,0 +1,24 @@
+--TEST--
+Requiring a replaced package in a version, that is not provided by the replacing package, should result in a conflict
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "foo/original", "version": "1.0.0", "replace": {"foo/replaced": "1.0.0"} },
+                { "name": "foo/replaced", "version": "1.0.0" },
+                { "name": "foo/replaced", "version": "2.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "foo/original": "1.0.0",
+        "foo/replaced": "2.0.0"
+    }
+}
+--RUN--
+install
+--EXPECT-EXIT-CODE--
+2
+--EXPECT--


### PR DESCRIPTION
If you require a package, that replaces another package in a specific version, an installation from the json file will install a conflicting version of the replaced package alongside the replacing package.
An install attempt from the resulting lock file will then fail as it recognizes the conflict.

This problem became apparent after this PR: https://github.com/composer/composer/pull/3740, as an install request with an existing lock file will now ignore the json completely. Before the patch it seems to have ignored the conflict even when installing from lock.

This PR currently just contains two tests, that reproduce the problem. No fix has been implemented, yet.

As requested by @Seldaek I hereby /cc @naderman for this PR.