### PR TITLE
Added missing $learnedWhy property

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -40,6 +40,7 @@ class Solver
     protected $branches = array();
     protected $problems = array();
     protected $learnedPool = array();
+    protected $learnedWhy = array();
 
     public function __construct(PolicyInterface $policy, Pool $pool, RepositoryInterface $installed)
     {


### PR DESCRIPTION
Missing property triggers ```PHP Notice: Undefined property: Composer\DependencyResolver\Solver::$learnedWhy``` which throws ```ErrorException```