### PR TITLE
Conform with Symfony Coding Standards

### DIFF
--- a/src/Composer/Console/HtmlOutputFormatter.php
+++ b/src/Composer/Console/HtmlOutputFormatter.php
@@ -83,6 +83,6 @@ class HtmlOutputFormatter extends OutputFormatter
             }
         }
 
-        return $out . '">'.$matches[2].'</span>';
+        return $out.'">'.$matches[2].'</span>';
     }
 }


### PR DESCRIPTION
According to Symfony Coding Standards, a single space must be added around binary operators excluding the concatenation operator.

"Add a single space around binary operators (==, &&, ...), with the exception of the concatenation (.) operator" (http://symfony.com/doc/current/contributing/code/standards.html)