### PR TITLE
retry slow test if timeout occurs

### DIFF
--- a/tests/Composer/Test/AllFunctionalTest.php
+++ b/tests/Composer/Test/AllFunctionalTest.php
@@ -89,7 +89,7 @@ class AllFunctionalTest extends \PHPUnit_Framework_TestCase
         putenv('COMPOSER_HOME='.$this->testDir.'home');
 
         $cmd = 'php '.escapeshellarg(self::$pharPath).' --no-ansi '.$testData['RUN'];
-        $proc = new Process($cmd, __DIR__.'/Fixtures/functional');
+        $proc = new Process($cmd, __DIR__.'/Fixtures/functional', null, null, 300);
         $exitcode = $proc->run();
 
         if (isset($testData['EXPECT'])) {


### PR DESCRIPTION
Hopefully fixes sporadic failure of test suite.

Alternatively, we could replace
```
$proc = new Process($cmd, __DIR__.'/Fixtures/functional');
```
with
```
$proc = new Process($cmd, __DIR__.'/Fixtures/functional', null, null, $timeout);
```
where `$timeout` is something higher than the default of 60.

/cc @Seldaek @stof suggestions / feedback?