### PR TITLE
Keep-Alive by curl (boost downloading speed)

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -303,6 +303,7 @@ EOT
             'classmap-authoritative' => array($booleanValidator, $booleanNormalizer),
             'prepend-autoloader' => array($booleanValidator, $booleanNormalizer),
             'github-expose-hostname' => array($booleanValidator, $booleanNormalizer),
+            'enable-curl-transfer' => array($booleanValidator, $booleanNormalizer),
         );
         $multiConfigValues = array(
             'github-protocols' => array(

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -44,6 +44,7 @@ class Config
         'github-domains' => array('github.com'),
         'github-expose-hostname' => true,
         'store-auths' => 'prompt',
+        'enable-curl-transfer' => true,
         // valid keys without defaults (auth config stuff):
         // github-oauth
         // http-basic

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -242,6 +242,20 @@ class Factory
         $vendorDir = $config->get('vendor-dir');
         $binDir = $config->get('bin-dir');
 
+        // initialize curl-transfer
+        if (extension_loaded('curl') && $config->get('enable-curl-transfer') && !defined(__NAMESPACE__ . '\\CURL_ENABLED')) {
+            $wrappers = stream_get_wrappers();
+            if (in_array('http', $wrappers)) {
+                stream_wrapper_unregister('http');
+            }
+            if (in_array('https', $wrappers)) {
+                stream_wrapper_unregister('https');
+            }
+            stream_wrapper_register('http', 'Composer\\Util\\CurlStream');
+            stream_wrapper_register('https', 'Composer\\Util\\CurlStream');
+            define(__NAMESPACE__ . '\\CURL_ENABLED', true);
+        }
+
         // initialize composer
         $composer = new Composer();
         $composer->setConfig($config);

--- a/src/Composer/Util/CurlStream.php
+++ b/src/Composer/Util/CurlStream.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Util;
+
+/**
+ * http/https streamWrapper by ext-curl
+ * @author Hiraku Nakano <hiraku@tojiru.net>
+ * @see http://php.net/manual/en/class.streamwrapper.php
+ */
+class CurlStream
+{
+    /** @type resource $context */
+    public $context;
+
+    /** @type resource<url>[] $cache */
+    private static $cache = array();
+
+    /** @type resource<curl> $ch */
+    private $ch;
+
+    /** @type int $p */
+    private $p = 0;
+
+    /** @type string[] $header */
+    private static $header = array();
+
+    /** @type string $body */
+    private $body;
+
+    /** @type int $length */
+    private $length;
+
+    static function getLastHeaders()
+    {
+        return self::$header;
+    }
+
+    static function clearLastHeaders()
+    {
+        self::$header = array();
+    }
+
+    function stream_close()
+    {
+        // do nothing
+    }
+
+    /**
+     * @return bool
+     */
+    function stream_eof()
+    {
+        return $this->p > $this->length;
+    }
+
+    /**
+     * @param string $path
+     * @param string $mode
+     * @param int $options
+     * @param string &$opend_path
+     * @return bool
+     */
+    function stream_open($path, $mode, $options, &$opened_path)
+    {
+        $parsed = parse_url($path);
+        $origin = "$parsed[scheme]://";
+        if (isset($parsed['user'])) {
+            $origin .= $parsed['user'];
+            if (isset($parsed['pass'])) {
+                $origin .= ":$parsed[pass]";
+            }
+            $origin .= '@';
+        }
+        $origin .= $parsed['host'];
+        if (isset($parsed['port'])) {
+            $origin .= ":$parsed[port]";
+        }
+
+        if (isset(self::$cache[$origin])) {
+            $ch = self::$cache[$origin];
+        } else {
+            $ch = self::$cache[$origin] = curl_init();
+            curl_setopt_array($ch, array(
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_ENCODING => 'gzip',
+                CURLOPT_HEADER => true,
+                CURLOPT_FOLLOWLOCATION => true,
+                CURLOPT_MAXREDIRS => 20,
+            ));
+        }
+        curl_setopt($ch, CURLOPT_URL, $path);
+
+        $params = stream_context_get_params($this->context);
+        $context = $params['options'];
+        if (isset($context['http']['method']) && $context['http']['method'] === 'POST') {
+            curl_setopt($ch, CURLOPT_POST, true);
+        } else {
+            curl_setopt($ch, CURLOPT_HTTPGET, true);
+        }
+        if (isset($context['http']['header'])) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $context['http']['header']);
+        }
+        if (isset($context['http']['content'])) {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $context['http']['content']);
+        }
+
+        if (isset($params['notification'])) {
+            $callbackGet = $params['notification'];
+            curl_setopt($ch, CURLOPT_NOPROGRESS, false);
+            curl_setopt($ch, CURLOPT_PROGRESSFUNCTION,
+                function($ch, $downbytesMax, $downbytes, $upbytesMax, $upbytes)
+                use($callbackGet)
+                {
+                    static $bytesMaxSended = false;
+                    if ($downbytes) {
+                        $code = $bytesMaxSended ?
+                            STREAM_NOTIFY_PROGRESS :
+                            STREAM_NOTIFY_FILE_SIZE_IS;
+                        call_user_func(
+                            $callbackGet,
+                            $code, //notificationCode
+                            STREAM_NOTIFY_SEVERIRY_INFO, //severity
+                            '', //message
+                            0, //messageCode
+                            $downbytes, //bytesTransferred
+                            $downbytesMax //bytesMax
+                        );
+                    }
+                    return 0;
+                }
+            );
+        } else {
+            curl_setopt($ch, CURLOPT_NOPROGRESS, true);
+        }
+
+        $result = curl_exec($ch);
+        $errno = curl_errno($ch);
+        if (CURLE_OK !== $errno) {
+            throw new RuntimeException(curl_error($ch), $errno);
+        }
+
+        $info = curl_getinfo($ch);
+        $header = substr($result, 0, $info['header_size']);
+        self::$header = explode("\r\n", rtrim($header));
+        $this->body = substr($result, $info['header_size']);
+        $this->length = strlen($this->body);
+
+        $this->ch = $ch;
+        return true;
+    }
+
+    /**
+     * @param int $count
+     * @return string
+     */
+    function stream_read($count)
+    {
+        $p = $this->p;
+        $this->p += $count;
+        return substr($this->body, $p, $count);
+    }
+
+    /**
+     * @return array
+     */
+    function stream_stat()
+    {
+        return array();
+    }
+}
+

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -172,6 +172,10 @@ class RemoteFilesystem
         });
         try {
             $result = file_get_contents($fileUrl, false, $ctx);
+            if (defined('Composer\CURL_ENABLED')) {
+                $http_response_header = CurlStream::getLastHeaders();
+                CurlStream::clearLastHeaders();
+            }
         } catch (\Exception $e) {
             if ($e instanceof TransportException && !empty($http_response_header[0])) {
                 $e->setHeaders($http_response_header);
@@ -202,7 +206,7 @@ class RemoteFilesystem
         }
 
         // decode gzip
-        if ($result && extension_loaded('zlib') && substr($fileUrl, 0, 4) === 'http') {
+        if ($result && !defined('Composer\CURL_ENABLED') && extension_loaded('zlib') && substr($fileUrl, 0, 4) === 'http') {
             $decode = false;
             foreach ($http_response_header as $header) {
                 if (preg_match('{^content-encoding: *gzip *$}i', $header)) {


### PR DESCRIPTION
Hello. I came from Japan.

packagist.org (Belgium) is far from Japan. Round Trip Time is so long, it takes very long to `composer install`, I am frustrated.

So, I wrote a patch reusing TCP connection (Keep-Alive) by ext-curl. Download time can be shortened. In particular, in countries where it is from packagist.org farther (Japan such as ), the effect will be higher.

Before coding this patch, I read Pull Requests and Issues. It seems difficult to keep compatibility with past ideas. I tried to implement the curl RemoteFileSystem by emulating the default "http"/"https" streamWrapper.

Finally, since I send pull request first time to this repo, please let me know if my manners is wrong. 

relates:
- #704
- #3282 
- #3636
- #2696 more better ? it looks stopped.