### PR TITLE
remove unused method argument

### DIFF
--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -83,7 +83,7 @@ EOT
                         implode(', ', $package->getLicense()) ?: 'none',
                     ));
                 }
-                $table->render($output);
+                $table->render();
                 break;
 
             case 'json':


### PR DESCRIPTION
Unlike the `TableHelper`, the `render()` method of the `Table` class
does not make use of an `$output` argument. The actual `OutputInterface`
to send the table to is passed in the constructor instead.