### PR TITLE
VCS section: add requirements for the branch name

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -234,7 +234,7 @@ project to use the patched version. If the library is on GitHub (this is the
 case most of the time), you can simply fork it there and push your changes to
 your fork. After that you update the project's `composer.json`. All you have
 to do is add your fork as a repository and update the version constraint to
-point to your custom branch. For version constraint naming conventions see
+point to your custom branch. Your custom branch name must be prefixed with `"dev-"`. For version constraint naming conventions see
 [Libraries](02-libraries.md) for more information.
 
 Example assuming you patched monolog to fix a bug in the `bugfix` branch:


### PR DESCRIPTION
If you want to use a custom branch as a requirement in your `composer.json`, that branch must be prefixed with "dev-" or you'll get an error:
```sh
[UnexpectedValueException]
  Could not parse version constraint some-branch: Invalid version string "some-branch".
```

It took me a while to find that info on forums and blogs, so I figured I'd rather update the doc. :grin: 
Let me know.