### PR TITLE
Show VCS state when displaying local changes in StatusCommand.

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -140,7 +140,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
         }
 
-        return trim($output);
+        return trim($output) ?: null;
     }
 
     /**

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -66,7 +66,7 @@ class HgDownloader extends VcsDownloader
     /**
      * {@inheritDoc}
      */
-    public function getLocalChanges(PackageInterface $package, $path)
+    protected function getWorkingTreeState(PackageInterface $package, $path)
     {
         if (!is_dir($path.'/.hg')) {
             return null;

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -80,6 +80,23 @@ class HgDownloader extends VcsDownloader
     /**
      * {@inheritDoc}
      */
+    protected function getCurrentReference(PackageInterface $package, $path)
+    {
+        if (!is_dir($path.'/.hg')) {
+            return;
+        }
+
+        $command = sprintf('hg parent --template %s', escapeshellarg('{node}'));
+        if (0 !== $this->process->execute($command, $output, $path)) {
+            throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
+        }
+
+        return trim($output) ?: null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     protected function getCommitLogs($fromReference, $toReference, $path)
     {
         $command = sprintf('hg log -r %s:%s --style compact', $fromReference, $toReference);

--- a/src/Composer/Downloader/PerforceDownloader.php
+++ b/src/Composer/Downloader/PerforceDownloader.php
@@ -84,7 +84,7 @@ class PerforceDownloader extends VcsDownloader
     /**
      * {@inheritDoc}
      */
-    public function getLocalChanges(PackageInterface $package, $path)
+    protected function getWorkingTreeState(PackageInterface $package, $path)
     {
         $this->io->writeError('Perforce driver does not check for local changes before overriding', true);
 

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -111,7 +111,7 @@ class SvnDownloader extends VcsDownloader
      */
     protected function cleanChanges(PackageInterface $package, $path, $update)
     {
-        if (!$changes = $this->getLocalChanges($package, $path)) {
+        if (!$changes = $this->getWorkingTreeState($package, $path)) {
             return;
         }
 

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -70,7 +70,7 @@ class SvnDownloader extends VcsDownloader
     /**
      * {@inheritDoc}
      */
-    public function getLocalChanges(PackageInterface $package, $path)
+    protected function getWorkingTreeState(PackageInterface $package, $path)
     {
         if (!$this->hasMetadataRepository($path)) {
             return null;

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -82,6 +82,22 @@ class SvnDownloader extends VcsDownloader
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function getCurrentReference(PackageInterface $package, $path)
+    {
+        if (!$this->hasMetadataRepository($path)) {
+            return;
+        }
+
+        if (0 !== $this->process->execute('svnversion', $output, $path)) {
+            throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
+        }
+
+        return trim($output) ?: null;
+    }
+
+    /**
      * Execute an SVN command and try to fix up the process with credentials
      * if necessary.
      *

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -194,6 +194,16 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getLocalChanges(PackageInterface $package, $path)
+    {
+        $output = $this->getVersionDifference($package, $path)."\n".$this->getWorkingTreeState($package, $path);
+        
+        return trim($output) ?: null;
+    }
+    
+    /**
      * Prompt the user to check if changes should be stashed/removed or the operation aborted
      *
      * @param  PackageInterface  $package
@@ -205,9 +215,33 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     protected function cleanChanges(PackageInterface $package, $path, $update)
     {
         // the default implementation just fails if there are any changes, override in child classes to provide stash-ability
-        if (null !== $this->getLocalChanges($package, $path)) {
+        if (null !== $this->getWorkingTreeState($package, $path)) {
             throw new \RuntimeException('Source directory ' . $path . ' has uncommitted changes.');
         }
+    }
+
+    /**
+     * Checks for changes to the local copy
+     *
+     * @param  PackageInterface $package package instance
+     * @param  string           $path    package directory
+     * @return string|null      changes or null
+     */
+    abstract protected function getWorkingTreeState(PackageInterface $package, $path);
+
+    /**
+     * Compare the package version to the local version
+     *
+     * @param  PackageInterface $package package instance
+     * @param  string           $path    package directory
+     * @return string|null     current reference or null if equal or cannot be determined
+     */
+    protected function getVersionDifference(PackageInterface $package, $path)
+    {
+        $driver = ltrim(substr(get_class($this), strlen(__NAMESPACE__), -10), '\\');
+        $this->io->writeError(sprintf('<info>%s driver does not check for version changes before overriding</info>', $driver), true);
+
+        return;
     }
 
     /**


### PR DESCRIPTION
This adds the concept of current ref vs expected ref to the `VcsDownloader` to address #1968. I've only implemented support in the Git driver so far.