### PR TITLE
Require only once `files` (defined in the schema)

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -573,7 +573,7 @@ METHOD_FOOTER;
 
 function composerRequire$suffix(\$file)
 {
-    require \$file;
+    require_once \$file;
 }
 
 FOOTER;

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -51,5 +51,5 @@ class ComposerAutoloaderInitFilesAutoloadOrder
 
 function composerRequireFilesAutoloadOrder($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -51,5 +51,5 @@ class ComposerAutoloaderInitFilesAutoload
 
 function composerRequireFilesAutoload($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -67,5 +67,5 @@ class ComposerAutoloaderInitIncludePath
 
 function composerRequireIncludePath($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -71,5 +71,5 @@ class ComposerAutoloaderInitTargetDir
 
 function composerRequireTargetDir($file)
 {
-    require $file;
+    require_once $file;
 }


### PR DESCRIPTION
Imagine the following scenario:

  * 2 projects: A and B.
  * Both have a `autoload.files` directive in there respective `composer.json` files: A.a and B.b.
  * A.a loads B.b,
  * B loads B.b.

Composer will load files in this order: A.a and B.b. But because A.a already did the load of B.b, when Composer does that, there is an error (“<entity> already exists” for instance).

While, in appareance, it seems a bug that A.a loads B.b, according to the context, it makes sense. For instance, we install dependencies of a project with Composer but we don't use its autoloader. In this case, we need a specific autoloader, the one from A for instance.

From the point of view of A, it is difficult to avoid the load of B.b because Composer did not load it yet.

So this patch does one simple think: It `require_once` the `autoload.files` instead of `require`.