### PR TITLE
Allow Composer to use the Opcache function opcache_is_script_cached. 

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -439,7 +439,11 @@ EOF;
 
 require_once $vendorPathToTargetDirCode . '/autoload_real.php';
 
-return ComposerAutoloaderInit$suffix::getLoader();
+if (defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE == true) {
+    return ComposerAutoloaderInit$suffix::getLoader(true);
+}
+
+return ComposerAutoloaderInit$suffix::getLoader(false);
 
 AUTOLOAD;
     }
@@ -469,14 +473,14 @@ class ComposerAutoloaderInit$suffix
         }
     }
 
-    public static function getLoader()
+    public static function getLoader(\$enableOpcacheOptimize = false)
     {
         if (null !== self::\$loader) {
             return self::\$loader;
         }
 
         spl_autoload_register(array('ComposerAutoloaderInit$suffix', 'loadClassLoader'), true, $prependAutoloader);
-        self::\$loader = \$loader = new \\Composer\\Autoload\\ClassLoader();
+        self::\$loader = \$loader = new \\Composer\\Autoload\\ClassLoader(\$enableOpcacheOptimize);
         spl_autoload_unregister(array('ComposerAutoloaderInit$suffix', 'loadClassLoader'));
 
 

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -439,11 +439,7 @@ EOF;
 
 require_once $vendorPathToTargetDirCode . '/autoload_real.php';
 
-if (defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE == true) {
-    return ComposerAutoloaderInit$suffix::getLoader(true);
-}
-
-return ComposerAutoloaderInit$suffix::getLoader(false);
+return ComposerAutoloaderInit$suffix::getLoader(defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE);
 
 AUTOLOAD;
     }

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -56,8 +56,8 @@ class ClassLoader
 
     private $classMapAuthoritative = false;
 
-    const   SEARCHMODE_OPCACHE = 0;
-    const   SEARCHMODE_FILE = 1;
+    const SEARCHMODE_OPCACHE = 0;
+    const SEARCHMODE_FILE = 1;
     
     public function __construct($enableOpcacheOptimize = false)
     {
@@ -364,7 +364,8 @@ class ClassLoader
         return $file;
     }
 
-    private function findFileWithExtension($class, $ext) {
+    private function findFileWithExtension($class, $ext)
+    {
         foreach ($this->searchModes as $searchMode) {
 
             // PSR-4 lookup

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -378,7 +378,7 @@ class ClassLoader
                         foreach ($this->prefixDirsPsr4[$prefix] as $dir) {
                             $file = $dir.DIRECTORY_SEPARATOR.substr($logicalPathPsr4, $length);
                             if ($searchMode == self::SEARCHMODE_OPCACHE) {
-                                if (opcache_is_script_cached($file) == true) {
+                                if (opcache_is_script_cached($file)) {
                                     return $file;
                                 }
                             }
@@ -396,7 +396,7 @@ class ClassLoader
             foreach ($this->fallbackDirsPsr4 as $dir) {
                 $file = $dir.DIRECTORY_SEPARATOR.$logicalPathPsr4;
                 if ($searchMode == self::SEARCHMODE_OPCACHE) {
-                    if (opcache_is_script_cached($file) == true) {
+                    if (opcache_is_script_cached($file)) {
                         return $file;
                     }
                 }
@@ -424,7 +424,7 @@ class ClassLoader
                         foreach ($dirs as $dir) {
                             $file = $dir.DIRECTORY_SEPARATOR.$logicalPathPsr0;
                             if ($searchMode == self::SEARCHMODE_OPCACHE) {
-                                if (opcache_is_script_cached($file) == true) {
+                                if (opcache_is_script_cached($file)) {
                                     return $file;
                                 }
                             }
@@ -442,7 +442,7 @@ class ClassLoader
             foreach ($this->fallbackDirsPsr0 as $dir) {
                 $file = $dir.DIRECTORY_SEPARATOR.$logicalPathPsr0;
                 if ($searchMode == self::SEARCHMODE_OPCACHE) {
-                    if (opcache_is_script_cached($file) == true) {
+                    if (opcache_is_script_cached($file)) {
                         return $file;
                     }
                 }

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -377,12 +377,12 @@ class ClassLoader
                     if (0 === strpos($class, $prefix)) {
                         foreach ($this->prefixDirsPsr4[$prefix] as $dir) {
                             $file = $dir.DIRECTORY_SEPARATOR.substr($logicalPathPsr4, $length);
-                            if ($searchMode == self::SEARCHMODE_OPCACHE) {
+                            if ($searchMode === self::SEARCHMODE_OPCACHE) {
                                 if (opcache_is_script_cached($file)) {
                                     return $file;
                                 }
                             }
-                            else if ($searchMode == self::SEARCHMODE_FILE) {
+                            else if ($searchMode === self::SEARCHMODE_FILE) {
                                 if (file_exists($file)) {
                                     return $file;
                                 }
@@ -395,12 +395,12 @@ class ClassLoader
             // PSR-4 fallback dirs
             foreach ($this->fallbackDirsPsr4 as $dir) {
                 $file = $dir.DIRECTORY_SEPARATOR.$logicalPathPsr4;
-                if ($searchMode == self::SEARCHMODE_OPCACHE) {
+                if ($searchMode === self::SEARCHMODE_OPCACHE) {
                     if (opcache_is_script_cached($file)) {
                         return $file;
                     }
                 }
-                else if ($searchMode == self::SEARCHMODE_FILE) {
+                else if ($searchMode === self::SEARCHMODE_FILE) {
                     if (file_exists($file)) {
                         return $file;
                     }
@@ -423,12 +423,12 @@ class ClassLoader
                     if (0 === strpos($class, $prefix)) {
                         foreach ($dirs as $dir) {
                             $file = $dir.DIRECTORY_SEPARATOR.$logicalPathPsr0;
-                            if ($searchMode == self::SEARCHMODE_OPCACHE) {
+                            if ($searchMode === self::SEARCHMODE_OPCACHE) {
                                 if (opcache_is_script_cached($file)) {
                                     return $file;
                                 }
                             }
-                            else if ($searchMode == self::SEARCHMODE_FILE) {
+                            else if ($searchMode === self::SEARCHMODE_FILE) {
                                 if (file_exists($file)) {
                                     return $file;
                                 }
@@ -441,12 +441,12 @@ class ClassLoader
             // PSR-0 fallback dirs
             foreach ($this->fallbackDirsPsr0 as $dir) {
                 $file = $dir.DIRECTORY_SEPARATOR.$logicalPathPsr0;
-                if ($searchMode == self::SEARCHMODE_OPCACHE) {
+                if ($searchMode === self::SEARCHMODE_OPCACHE) {
                     if (opcache_is_script_cached($file)) {
                         return $file;
                     }
                 }
-                else if ($searchMode == self::SEARCHMODE_FILE) {
+                else if ($searchMode === self::SEARCHMODE_FILE) {
                     if (file_exists($file)) {
                         return $file;
                     }

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -56,6 +56,29 @@ class ClassLoader
 
     private $classMapAuthoritative = false;
 
+    const   SEARCHMODE_OPCACHE = 0;
+    const   SEARCHMODE_FILE = 1;
+    
+    public function __construct($enableOpcacheOptimize = false)
+    {
+        $this->searchModes = array(
+            self::SEARCHMODE_FILE
+        );
+
+        if ($enableOpcacheOptimize == false) {
+            return;
+        }
+        if (function_exists('opcache_is_script_cached') == false) {
+            //todo - should a warning be generated?
+            return;
+        }
+
+        $this->searchModes = array(
+            self::SEARCHMODE_OPCACHE,
+            self::SEARCHMODE_FILE,
+        );
+    }
+
     public function getPrefixes()
     {
         if (!empty($this->prefixesPsr0)) {
@@ -341,63 +364,98 @@ class ClassLoader
         return $file;
     }
 
-    private function findFileWithExtension($class, $ext)
-    {
-        // PSR-4 lookup
-        $logicalPathPsr4 = strtr($class, '\\', DIRECTORY_SEPARATOR) . $ext;
+    private function findFileWithExtension($class, $ext) {
+        foreach ($this->searchModes as $searchMode) {
 
-        $first = $class[0];
-        if (isset($this->prefixLengthsPsr4[$first])) {
-            foreach ($this->prefixLengthsPsr4[$first] as $prefix => $length) {
-                if (0 === strpos($class, $prefix)) {
-                    foreach ($this->prefixDirsPsr4[$prefix] as $dir) {
-                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
-                            return $file;
+            // PSR-4 lookup
+            $logicalPathPsr4 = strtr($class, '\\', DIRECTORY_SEPARATOR).$ext;
+
+            $first = $class[0];
+            if (isset($this->prefixLengthsPsr4[$first])) {
+                foreach ($this->prefixLengthsPsr4[$first] as $prefix => $length) {
+                    if (0 === strpos($class, $prefix)) {
+                        foreach ($this->prefixDirsPsr4[$prefix] as $dir) {
+                            $file = $dir.DIRECTORY_SEPARATOR.substr($logicalPathPsr4, $length);
+                            if ($searchMode == self::SEARCHMODE_OPCACHE) {
+                                if (opcache_is_script_cached($file) == true) {
+                                    return $file;
+                                }
+                            }
+                            else if ($searchMode == self::SEARCHMODE_FILE) {
+                                if (file_exists($file)) {
+                                    return $file;
+                                }
+                            }
                         }
                     }
                 }
             }
-        }
 
-        // PSR-4 fallback dirs
-        foreach ($this->fallbackDirsPsr4 as $dir) {
-            if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr4)) {
-                return $file;
+            // PSR-4 fallback dirs
+            foreach ($this->fallbackDirsPsr4 as $dir) {
+                $file = $dir.DIRECTORY_SEPARATOR.$logicalPathPsr4;
+                if ($searchMode == self::SEARCHMODE_OPCACHE) {
+                    if (opcache_is_script_cached($file) == true) {
+                        return $file;
+                    }
+                }
+                else if ($searchMode == self::SEARCHMODE_FILE) {
+                    if (file_exists($file)) {
+                        return $file;
+                    }
+                }
             }
-        }
 
-        // PSR-0 lookup
-        if (false !== $pos = strrpos($class, '\\')) {
-            // namespaced class name
-            $logicalPathPsr0 = substr($logicalPathPsr4, 0, $pos + 1)
-                . strtr(substr($logicalPathPsr4, $pos + 1), '_', DIRECTORY_SEPARATOR);
-        } else {
-            // PEAR-like class name
-            $logicalPathPsr0 = strtr($class, '_', DIRECTORY_SEPARATOR) . $ext;
-        }
+            // PSR-0 lookup
+            if (false !== $pos = strrpos($class, '\\')) {
+                // namespaced class name
+                $logicalPathPsr0 = substr($logicalPathPsr4, 0, $pos + 1)
+                    .strtr(substr($logicalPathPsr4, $pos + 1), '_', DIRECTORY_SEPARATOR);
+            }
+            else {
+                // PEAR-like class name
+                $logicalPathPsr0 = strtr($class, '_', DIRECTORY_SEPARATOR).$ext;
+            }
 
-        if (isset($this->prefixesPsr0[$first])) {
-            foreach ($this->prefixesPsr0[$first] as $prefix => $dirs) {
-                if (0 === strpos($class, $prefix)) {
-                    foreach ($dirs as $dir) {
-                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
-                            return $file;
+            if (isset($this->prefixesPsr0[$first])) {
+                foreach ($this->prefixesPsr0[$first] as $prefix => $dirs) {
+                    if (0 === strpos($class, $prefix)) {
+                        foreach ($dirs as $dir) {
+                            $file = $dir.DIRECTORY_SEPARATOR.$logicalPathPsr0;
+                            if ($searchMode == self::SEARCHMODE_OPCACHE) {
+                                if (opcache_is_script_cached($file) == true) {
+                                    return $file;
+                                }
+                            }
+                            else if ($searchMode == self::SEARCHMODE_FILE) {
+                                if (file_exists($file)) {
+                                    return $file;
+                                }
+                            }
                         }
                     }
                 }
             }
-        }
 
-        // PSR-0 fallback dirs
-        foreach ($this->fallbackDirsPsr0 as $dir) {
-            if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
+            // PSR-0 fallback dirs
+            foreach ($this->fallbackDirsPsr0 as $dir) {
+                $file = $dir.DIRECTORY_SEPARATOR.$logicalPathPsr0;
+                if ($searchMode == self::SEARCHMODE_OPCACHE) {
+                    if (opcache_is_script_cached($file) == true) {
+                        return $file;
+                    }
+                }
+                else if ($searchMode == self::SEARCHMODE_FILE) {
+                    if (file_exists($file)) {
+                        return $file;
+                    }
+                }
+            }
+
+            // PSR-0 include paths.
+            if ($this->useIncludePath && $file = stream_resolve_include_path($logicalPathPsr0)) {
                 return $file;
             }
-        }
-
-        // PSR-0 include paths.
-        if ($this->useIncludePath && $file = stream_resolve_include_path($logicalPathPsr0)) {
-            return $file;
         }
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_functions.php
@@ -4,4 +4,8 @@
 
 require_once __DIR__ . '/composer' . '/autoload_real.php';
 
-return ComposerAutoloaderInitFilesAutoload::getLoader();
+if (defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE == true) {
+    return ComposerAutoloaderInitFilesAutoload::getLoader(true);
+}
+
+return ComposerAutoloaderInitFilesAutoload::getLoader(false);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_functions.php
@@ -4,8 +4,4 @@
 
 require_once __DIR__ . '/composer' . '/autoload_real.php';
 
-if (defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE == true) {
-    return ComposerAutoloaderInitFilesAutoload::getLoader(true);
-}
-
-return ComposerAutoloaderInitFilesAutoload::getLoader(false);
+return ComposerAutoloaderInitFilesAutoload::getLoader(defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_functions_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_functions_by_dependency.php
@@ -4,4 +4,8 @@
 
 require_once __DIR__ . '/composer' . '/autoload_real.php';
 
-return ComposerAutoloaderInitFilesAutoloadOrder::getLoader();
+if (defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE == true) {
+    return ComposerAutoloaderInitFilesAutoloadOrder::getLoader(true);
+}
+
+return ComposerAutoloaderInitFilesAutoloadOrder::getLoader(false);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_functions_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_functions_by_dependency.php
@@ -4,8 +4,4 @@
 
 require_once __DIR__ . '/composer' . '/autoload_real.php';
 
-if (defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE == true) {
-    return ComposerAutoloaderInitFilesAutoloadOrder::getLoader(true);
-}
-
-return ComposerAutoloaderInitFilesAutoloadOrder::getLoader(false);
+return ComposerAutoloaderInitFilesAutoloadOrder::getLoader(defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -13,14 +13,14 @@ class ComposerAutoloaderInitFilesAutoloadOrder
         }
     }
 
-    public static function getLoader()
+    public static function getLoader($enableOpcacheOptimize = false)
     {
         if (null !== self::$loader) {
             return self::$loader;
         }
 
         spl_autoload_register(array('ComposerAutoloaderInitFilesAutoloadOrder', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        self::$loader = $loader = new \Composer\Autoload\ClassLoader($enableOpcacheOptimize);
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoloadOrder', 'loadClassLoader'));
 
         $map = require __DIR__ . '/autoload_namespaces.php';

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -13,14 +13,14 @@ class ComposerAutoloaderInitFilesAutoload
         }
     }
 
-    public static function getLoader()
+    public static function getLoader($enableOpcacheOptimize = false)
     {
         if (null !== self::$loader) {
             return self::$loader;
         }
 
         spl_autoload_register(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        self::$loader = $loader = new \Composer\Autoload\ClassLoader($enableOpcacheOptimize);
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
         $map = require __DIR__ . '/autoload_namespaces.php';

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -13,14 +13,14 @@ class ComposerAutoloaderInitIncludePath
         }
     }
 
-    public static function getLoader()
+    public static function getLoader($enableOpcacheOptimize = false)
     {
         if (null !== self::$loader) {
             return self::$loader;
         }
 
         spl_autoload_register(array('ComposerAutoloaderInitIncludePath', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        self::$loader = $loader = new \Composer\Autoload\ClassLoader($enableOpcacheOptimize);
         spl_autoload_unregister(array('ComposerAutoloaderInitIncludePath', 'loadClassLoader'));
 
         $map = require __DIR__ . '/autoload_namespaces.php';

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -13,14 +13,14 @@ class ComposerAutoloaderInitTargetDir
         }
     }
 
-    public static function getLoader()
+    public static function getLoader($enableOpcacheOptimize = false)
     {
         if (null !== self::$loader) {
             return self::$loader;
         }
 
         spl_autoload_register(array('ComposerAutoloaderInitTargetDir', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        self::$loader = $loader = new \Composer\Autoload\ClassLoader($enableOpcacheOptimize);
         spl_autoload_unregister(array('ComposerAutoloaderInitTargetDir', 'loadClassLoader'));
 
         $map = require __DIR__ . '/autoload_namespaces.php';

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_target_dir.php
@@ -4,8 +4,4 @@
 
 require_once __DIR__ . '/composer' . '/autoload_real.php';
 
-if (defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE == true) {
-    return ComposerAutoloaderInitTargetDir::getLoader(true);
-}
-
-return ComposerAutoloaderInitTargetDir::getLoader(false);
+return ComposerAutoloaderInitTargetDir::getLoader(defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_target_dir.php
@@ -4,4 +4,8 @@
 
 require_once __DIR__ . '/composer' . '/autoload_real.php';
 
-return ComposerAutoloaderInitTargetDir::getLoader();
+if (defined('COMPOSER_OPCACHE_OPTIMIZE') && COMPOSER_OPCACHE_OPTIMIZE == true) {
+    return ComposerAutoloaderInitTargetDir::getLoader(true);
+}
+
+return ComposerAutoloaderInitTargetDir::getLoader(false);


### PR DESCRIPTION
This eliminates almost all file-system access once the cache is warmed. In the case where the file for the class is in the first directory that the Composer autoloader looks this eliminates one stat call which is usually cached by PHP, which is only a tiny benefit.

The real benefit comes when a class is not in the first directory that Composer looks in. In that case there will be file stat calls which will fail and so are not cached by PHP, which results in an actual filesystem hit for each one.

I can make a benchmark if you really want - but the difference is so huge I'm not sure one is actually needed.

btw this change almost certainly removes any benefit from using the dumped/optimized classmap. OpCache has all the information available to it, and C code is far better at searching for strings than PHP code is. That eliminates the relatively large amount of memory used by PHP to load a large array.

## Questions remaining

1) This stuff isn't unit testable. It would be possible to make an integration test that mocks the functions `opcache_is_script_cached` and `file_exists`, but want to hear if that's the way you want it tested before doing do.

2) How should it be turned off/on? Enabling the OpCache optimisation is done by setting a define currently:

```
define('COMPOSER_OPCACHE_OPTIMIZE', true);

require(__DIR__.'/../vendor/autoload.php');
```

I've left it like that for now as it makes testing the performance easier. I can't see any reason why it shouldn't be enabled by default....but there might be. 

btw [opcache_is_script_cached](http://php.net/manual/en/function.opcache-is-script-cached.php) is available since PHP 5.6





