### PR TITLE
Fix for #3791

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -643,7 +643,9 @@ class Installer
         $packagesUninstallOperations = array();
 
         foreach ($packagesIndex as $packageName => $packageData) {
-            if ($packageData['package']->getType() === 'composer-plugin') {
+            if ($packageData['package']->getType() === 'composer-plugin'
+                || $packageData['package']->getType() === 'composer-installer'
+            ) {
                 $pluginRelatedPackagesNames = $this->getAllRequires($packageData['package'], $packagesIndex);
                 $pluginOperations = array();
                 foreach ($pluginRelatedPackagesNames as $packageName) {

--- a/tests/Composer/Test/Fixtures/installer/plugins-are-installed-first.test
+++ b/tests/Composer/Test/Fixtures/installer/plugins-are-installed-first.test
@@ -1,5 +1,5 @@
 --TEST--
-Composer installers are installed first if they have no meaningful requirements
+Composer installers and plugins are installed first if they have requirements then requirements installed before
 --COMPOSER--
 {
     "repositories": [
@@ -25,7 +25,7 @@ Composer installers are installed first if they have no meaningful requirements
 install
 --EXPECT--
 Installing inst (1.0.0)
-Installing inst-with-req (1.0.0)
-Installing pkg (1.0.0)
 Installing pkg2 (1.0.0)
 Installing inst-with-req2 (1.0.0)
+Installing inst-with-req (1.0.0)
+Installing pkg (1.0.0)


### PR DESCRIPTION
This coed change does fix issue with operations order for plugins.
After that fix will be introduced following order:
1. uninstall packages
2. uninstall plugins and plugin's dependencies
3. install plugin's dependencies and plugin
4. install packages
