### PR TITLE
Run processes with predictable LANGUAGE=C

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -56,7 +56,7 @@ class ProcessExecutor
 
         $this->captureOutput = count(func_get_args()) > 1;
         $this->errorOutput = null;
-        $process = new Process($command, $cwd, null, null, static::getTimeout());
+        $process = new Process($command, $cwd, array('LANGUAGE' => 'C') + $_ENV + $_SERVER, null, static::getTimeout());
 
         $callback = is_callable($output) ? $output : array($this, 'outputHandler');
         $process->run($callback);


### PR DESCRIPTION
For some reason, I ran composer with LANGUAGE=fr_FR, and that breaks parsing git's output.