### PR TITLE
Switch to the docker-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: php
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+addons:
+  apt_packages:
+    - parallel
+
 php:
   - 5.3.3
   - 5.3
@@ -10,10 +20,9 @@ php:
   - hhvm
 
 before_script:
-    - sudo apt-get install parallel
     - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
-    - composer install --prefer-source
-    - bin/composer install --prefer-source
+    - composer install
+    - bin/composer install
     - git config --global user.name travis-ci
     - git config --global user.email travis@example.com
 


### PR DESCRIPTION
The docker-based infrastructure is faster and allows to use the build cache, which can make things even faster by caching deps downloads between builds for dists.

Given that the only usage of sudo is about installing an APT package and this package is in the whitelist for the travis addon (because I requested adding it a while ago), the build is compatible with this infrastructure.