### PR TITLE
[create-project] Used no progress value for dependencies

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -145,6 +145,8 @@ EOT
         }
 
         $composer = Factory::create($io, null, $disablePlugins);
+        $composer->getDownloadManager()->setOutputProgress(!$noProgress);
+
         $fs = new Filesystem();
 
         if ($noScripts === false) {


### PR DESCRIPTION
When I use `create-project` with `--no-progress`, the no-progress is used only with root package but not dependencies.

```
$ composer create-project composer/composer --stability=dev --prefer-dist --no-progress
Installing composer/composer (dev-master b8ac790b4f2db1f718e640015636f005401c1c71)
  - Installing composer/composer (dev-master master)
    Downloading

Created project in /var/www/composer
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
  - Installing justinrainbow/json-schema (1.3.7)
    Downloading: 100%

  - Installing seld/jsonlint (1.3.1)
    Downloading: 100%

  - Installing symfony/console (v2.6.4)
    Downloading: 100%
```

This PR fix the problem:

```
$ composer create-project composer/composer --stability=dev --prefer-dist --no-progress
Installing composer/composer (dev-master b8ac790b4f2db1f718e640015636f005401c1c71)
  - Installing composer/composer (dev-master master)
    Downloading

Created project in /var/www/composer
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
  - Installing justinrainbow/json-schema (1.3.7)
    Downloading

  - Installing seld/jsonlint (1.3.1)
    Downloading

  - Installing symfony/console (v2.6.4)
    Downloading
```