### PR TITLE
Use get home from Config instead of factory

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -113,7 +113,7 @@ class Factory
         $config->merge(array('config' => array('home' => $home, 'cache-dir' => $cacheDir)));
 
         // load global config
-        $file = new JsonFile($home.'/config.json');
+        $file = new JsonFile($config->get('home').'/config.json');
         if ($file->exists()) {
             if ($io && $io->isDebug()) {
                 $io->writeError('Loading config file ' . $file->getPath());


### PR DESCRIPTION
If I understood this correctly, we have no guarantee that the COMPOSER_HOME will not end with ```/``` or ```\``` so we should rely on the Config instead.