### PR TITLE
Make parseJson safer

### DIFF
--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -253,6 +253,9 @@ class JsonFile
      */
     public static function parseJson($json, $file = null)
     {
+        if (null === $json) {
+            return;
+        }
         $data = json_decode($json, true);
         if (null === $data && JSON_ERROR_NONE !== json_last_error()) {
             self::validateSyntax($json, $file);


### PR DESCRIPTION
Null is given to parseJson() when there is some problem with getContents().
With PHP < 7 the json_last_error would return JSON_ERROR_NONE but with PHP > 7 it will return JSON_ERROR_SYNTAX and this is causing the tests to fail because they enter the validateSyntax() which will return an exception because of the null.

I'm not sure if this is the best solution for the failing test but I think it makes the parseJson safer at least.

Related:
PHP issue: https://bugs.php.net/bug.php?id=69187
Upgrading PHP info https://github.com/php/php-src/commit/9d037d574cc359405c7a818c2235644633705999
