### PR TITLE
Test on HHVM nightly releases. Allow to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ php:
   - 5.6
   - 7.0
   - hhvm
+  - hhvm-nightly
+
+matrix:
+  allow_failures:
+    - php: hhvm-nightly
 
 before_script:
     - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini


### PR DESCRIPTION
Nightly releases could change in unpredictable way.  So they should not fail the whole build.

However we could catch problems and breaking changes on next versions of HHVM early.

I suspect Composer have some problems on HHVM nightly, because of this build: https://travis-ci.org/erusev/parsedown/jobs/53556585#L94