### PR TITLE
Report Travis CI build success early

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ php:
   - hhvm-nightly
 
 matrix:
+  fast_finish: true
   allow_failures:
     - php: hhvm-nightly
 


### PR DESCRIPTION
This will report the build has succceeded even if allowed to fail jobs are still running.

See https://github.com/composer/composer/pull/3828.

Docs: http://docs.travis-ci.com/user/build-configuration/#Fast-finishing

Props to @fonsecas72.