### PR TITLE
Add support for using classmap to autoload Hack enums

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -112,10 +112,9 @@ class ClassMapGenerator
      */
     private static function findClasses($path)
     {
-        $traits = version_compare(PHP_VERSION, '5.4', '<') ? '' : '|trait';
-        $enums = '';
+        $extraTypes = version_compare(PHP_VERSION, '5.4', '<') ? '' : '|trait';
         if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>=')) {
-            $enums = '|enum';
+            $extraTypes .= '|enum';
         }
 
         try {
@@ -133,7 +132,7 @@ class ClassMapGenerator
         }
 
         // return early if there is no chance of matching anything in this file
-        if (!preg_match('{\b(?:class|interface'.$traits.$enums.')\s}i', $contents)) {
+        if (!preg_match('{\b(?:class|interface'.$extraTypes.')\s}i', $contents)) {
             return array();
         }
 
@@ -158,7 +157,7 @@ class ClassMapGenerator
 
         preg_match_all('{
             (?:
-                 \b(?<![\$:>])(?P<type>class|interface'.$traits.$enums.') \s+ (?P<name>[a-zA-Z_\x7f-\xff:][a-zA-Z0-9_\x7f-\xff:\-]*)
+                 \b(?<![\$:>])(?P<type>class|interface'.$extraTypes.') \s+ (?P<name>[a-zA-Z_\x7f-\xff:][a-zA-Z0-9_\x7f-\xff:\-]*)
                | \b(?<![\$:>])(?P<ns>namespace) (?P<nsname>\s+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\s*\\\\\s*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*)? \s*[\{;]
             )
         }ix', $contents, $matches);

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -114,7 +114,7 @@ class ClassMapGenerator
     {
         $traits = version_compare(PHP_VERSION, '5.4', '<') ? '' : '|trait';
         $enums = '';
-        if (defined('HPHP_VERSION') && version_compare(HPHP_VERSION, '3.3', '>=')) {
+        if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>=')) {
             $enums = '|enum';
         }
 

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -74,7 +74,7 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
                 'Foo\\CBar' => __DIR__.'/Fixtures/php5.4/traits.php',
             ));
         }
-        if (defined('HPHP_VERSION') && version_compare(HPHP_VERSION, '3.3', '>=')) {
+        if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>=')) {
             $data[] = array(__DIR__.'/Fixtures/hhvm3.3', array(
                 'FooEnum' => __DIR__.'/Fixtures/hhvm3.3/HackEnum.php',
                 'Foo\BarEnum' => __DIR__.'/Fixtures/hhvm3.3/NamespacedHackEnum.php',

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -78,6 +78,7 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
             $data[] = array(__DIR__.'/Fixtures/hhvm3.3', array(
                 'FooEnum' => __DIR__.'/Fixtures/hhvm3.3/HackEnum.php',
                 'Foo\BarEnum' => __DIR__.'/Fixtures/hhvm3.3/NamespacedHackEnum.php',
+                'GenericsClass' => __DIR__.'/Fixtures/hhvm3.3/Generics.php',
             ));
         }
 

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -74,6 +74,12 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
                 'Foo\\CBar' => __DIR__.'/Fixtures/php5.4/traits.php',
             ));
         }
+        if (defined('HPHP_VERSION') && version_compare(HPHP_VERSION, '3.3', '>=')) {
+            $data[] = array(__DIR__.'/Fixtures/hhvm3.3', array(
+                'FooEnum' => __DIR__.'/Fixtures/hhvm3.3/HackEnum.php',
+                'Foo\BarEnum' => __DIR__.'/Fixtures/hhvm3.3/NamespacedHackEnum.php',
+            ));
+        }
 
         return $data;
     }

--- a/tests/Composer/Test/Autoload/Fixtures/hhvm3.3/Generics.php
+++ b/tests/Composer/Test/Autoload/Fixtures/hhvm3.3/Generics.php
@@ -1,0 +1,4 @@
+<?hh
+
+class GenericsClass<Tk, Tv> {
+}

--- a/tests/Composer/Test/Autoload/Fixtures/hhvm3.3/HackEnum.php
+++ b/tests/Composer/Test/Autoload/Fixtures/hhvm3.3/HackEnum.php
@@ -1,0 +1,6 @@
+<?hh
+
+enum FooEnum: int {
+  HERP = 1;
+  DERP = 2;
+}

--- a/tests/Composer/Test/Autoload/Fixtures/hhvm3.3/NamespacedHackEnum.php
+++ b/tests/Composer/Test/Autoload/Fixtures/hhvm3.3/NamespacedHackEnum.php
@@ -1,0 +1,7 @@
+<?hh
+
+namespace Foo;
+
+enum BarEnum: string {
+  HERP = 'DERP';
+}


### PR DESCRIPTION
fixes composer/composer#3823

Ran tests with both PHP5.5.9-1ubuntu4.5 and HHVM 3.6. Test fails on HHVM only
if I back out the ClassMapGenerator.php change.