### PR TITLE
Avoid parser error if composer.json existing but empty

### DIFF
--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -82,6 +82,10 @@ EOT
             return 1;
         }
 
+        if (file_get_contents($file) === '') {
+            file_put_contents($file, "{\n}\n");
+        }
+
         $json = new JsonFile($file);
         $composerDefinition = $json->read();
         $composerBackup = file_get_contents($json->getPath());

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -82,7 +82,7 @@ EOT
             return 1;
         }
 
-        if (file_get_contents($file) === '') {
+        if (filesize($file) === 0) {
             file_put_contents($file, "{\n}\n");
         }
 


### PR DESCRIPTION
Using the require command, if there is a blank composer.json a parser error is thrown:

    [Seld\JsonLint\ParsingException]
    "./composer.json" does not contain valid JSON
    Parse error on line 1:
    ^
    Expected one of: 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '['