### PR TITLE
Git Checkout Branch / File Differentiation

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -215,7 +215,7 @@ class GitDownloader extends VcsDownloader
      */
     protected function updateToCommit($path, $reference, $branch, $date)
     {
-        $template = 'git checkout %s && git reset --hard %1$s';
+        $template = 'git checkout %s -- && git reset --hard %1$s';
         $branch = preg_replace('{(?:^dev-|(?:\.x)?-dev$)}i', '', $branch);
 
         $branches = null;
@@ -242,7 +242,7 @@ class GitDownloader extends VcsDownloader
                 $branch = 'v' . $branch;
             }
 
-            $command = sprintf('git checkout %s', ProcessExecutor::escape($branch));
+            $command = sprintf('git checkout %s --', ProcessExecutor::escape($branch));
             $fallbackCommand = sprintf('git checkout -B %s %s', ProcessExecutor::escape($branch), ProcessExecutor::escape('composer/'.$branch));
             if (0 === $this->process->execute($command, $output, $path)
                 || 0 === $this->process->execute($fallbackCommand, $output, $path)

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -74,7 +74,7 @@ class GitDownloaderTest extends \PHPUnit_Framework_TestCase
 
         $processExecutor->expects($this->at(2))
             ->method('execute')
-            ->with($this->equalTo($this->winCompat("git checkout 'master'")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
+            ->with($this->equalTo($this->winCompat("git checkout 'master' --")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
             ->will($this->returnValue(0));
 
         $processExecutor->expects($this->at(3))
@@ -134,7 +134,7 @@ class GitDownloaderTest extends \PHPUnit_Framework_TestCase
 
         $processExecutor->expects($this->at(6))
             ->method('execute')
-            ->with($this->equalTo($this->winCompat("git checkout 'ref' && git reset --hard 'ref'")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
+            ->with($this->equalTo($this->winCompat("git checkout 'ref' -- && git reset --hard 'ref'")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
             ->will($this->returnValue(0));
 
         $downloader = $this->getDownloaderMock(null, new Config(), $processExecutor);
@@ -266,7 +266,7 @@ class GitDownloaderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(0));
         $processExecutor->expects($this->at(4))
             ->method('execute')
-            ->with($this->equalTo($this->winCompat("git checkout 'ref' && git reset --hard 'ref'")), $this->equalTo(null), $this->equalTo($this->winCompat($tmpDir)))
+            ->with($this->equalTo($this->winCompat("git checkout 'ref' -- && git reset --hard 'ref'")), $this->equalTo(null), $this->equalTo($this->winCompat($tmpDir)))
             ->will($this->returnValue(0));
 
         $downloader = $this->getDownloaderMock(null, new Config(), $processExecutor);


### PR DESCRIPTION
This fixes a minor inaccuracy issue when creating git checkout commands
for branches.

The git checkout command used within `GitDownloader::updateToCommit()`
does  not use the "`--`" sequence to separate branch from file parameters.

This leads to an inaccuary as git tries as well the branch name as file
name. If the non-existent branch is actually the name of a file, the file
is checked out. If the non-existent branch is not the name of a file, an
error message is given:

> error: pathspec 'non-existent-branch' did not match any file(s) known to
git.

Both cases are not expected for the program flow in
`GitDownloader::updateToCommit()`.

The only thing that is expected is a non-existent branch to fail to
checkout - but with a different error message:

> // reference was not found (prints "fatal: reference is not a tree:
 $ref")

This can be easily fixed by adding the missing separator when constructing
the command which is applied with this commit.