### PR TITLE
Prevent fatal error on missing symlink() function in tests

### DIFF
--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -188,6 +188,7 @@ class FilesystemTest extends TestCase
         @mkdir($basepath . "/real", 0777, true);
         touch($basepath . "/real/FILE");
 
+        $this->skipTestIfSymlinkPhpFunctionIsMissing();
         $result = @symlink($basepath . "/real", $symlinked);
 
         if (!$result) {
@@ -216,6 +217,7 @@ class FilesystemTest extends TestCase
         $symlinked              = $basepath . "/linked";
         $symlinkedTrailingSlash = $symlinked . "/";
 
+        $this->skipTestIfSymlinkPhpFunctionIsMissing();
         $result = @symlink($basepath . "/real", $symlinked);
 
         if (!$result) {
@@ -236,5 +238,12 @@ class FilesystemTest extends TestCase
         $this->assertTrue($result);
         $this->assertFalse(file_exists($symlinkedTrailingSlash));
         $this->assertFalse(file_exists($symlinked));
+    }
+
+    private function skipTestIfSymlinkPhpFunctionIsMissing()
+    {
+        if (!function_exists('symlink')) {
+            $this->markTestSkipped('The php symlink() function for symbolic links is not available on this platform');
+        }
     }
 }


### PR DESCRIPTION
The testsuite didn't run through for me because the php symlink() function
was missing.

It is only available on Windows Visa/Server 2008 or higher.

This commit fixes the issue by checking if the method exists, and if not,
marks the test as skipped because of a non-matching precondition.