### PR TITLE
Use justinrainbow/json-schema 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "justinrainbow/json-schema": "~1.3",
+        "justinrainbow/json-schema": "~1.4",
         "seld/jsonlint": "~1.0",
         "symfony/console": "~2.5",
         "symfony/finder": "~2.2",


### PR DESCRIPTION
justinrainbow/json-schema version 1.4.0 has been tagged (https://github.com/justinrainbow/json-schema/releases/tag/1.4.0), which fixes naming conflicts with Scalar Type Hints in (what will be) PHP 7.