### PR TITLE
Enhancement: Sort packages by importance, then alphabetically

### DIFF
--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -332,6 +332,34 @@ class JsonManipulatorTest extends \PHPUnit_Framework_TestCase
 }
 '
             ),
+            array(
+                '{
+    "require": {
+        "foo": "baz",
+        "ext-mcrypt": "*",
+        "ext-gd": "*",
+        "lib-foo": "*",
+        "hhvm": "*",
+        "php": ">=5.5"
+    }
+}',
+                'require',
+                'igorw/retry',
+                '*',
+                true,
+                '{
+    "require": {
+        "php": ">=5.5",
+        "hhvm": "*",
+        "ext-gd": "*",
+        "ext-mcrypt": "*",
+        "lib-foo": "*",
+        "foo": "baz",
+        "igorw/retry": "*"
+    }
+}
+',
+            ),
         );
     }
 


### PR DESCRIPTION
This PR

* [x] sorts packages by importance (platform packages first, then PHP dependencies) and alphabetically

Follows #3549.

:bulb: Not sure if anyone but me uses that feature, but it would be a lot nicer if packages were sorted by importance (platform packages first), then followed by PHP dependencies, both sorted alphabetically.

See https://getcomposer.org/doc/02-libraries.md#platform-packages.
> 
* `php` represents the PHP version of the user, allowing you to apply constraints, e.g. `>=5.4.0`. To require a 64bit version of php, you can require the php-64bit package.
>* `hhvm` represents the version of the HHVM runtime (aka HipHop Virtual Machine) and allows you to apply a constraint, e.g., `>=2.3.3`.
> * `ext-<name>` allows you to require PHP extensions (includes core extensions). Versioning can be quite inconsistent here, so it's often a good idea to just set the constraint to *. An example of an extension package name is `ext-gd`.
>* `lib-<name>` allows constraints to be made on versions of libraries used by PHP. The following are available: curl, iconv, icu, libxml, openssl, pcre, uuid, xsl.