### PR TITLE
Add gz compression of zip files

### DIFF
--- a/src/Composer/Package/Archiver/PharArchiver.php
+++ b/src/Composer/Package/Archiver/PharArchiver.php
@@ -41,6 +41,12 @@ class PharArchiver implements ArchiverInterface
             $files = new ArchivableFilesFinder($sources, $excludes);
             $phar->buildFromIterator($files, $sources);
 
+            // Compress zip file if possible (not implemented yet as of HHVM 3.5.0)
+            if ($format === 'zip' && extension_loaded('zlib') && !defined('HHVM_VERSION'))
+            {
+                $phar->compressFiles(\Phar::GZ);
+            }
+
             return $target;
         } catch (\UnexpectedValueException $e) {
             $message = sprintf("Could not create archive '%s' from '%s': %s",


### PR DESCRIPTION
PharData does not compress zip files unless asked for it, so check if zlib is installed and always compress if it is. Reduced files size by order of magnitude if package is mainly php scripts and other text files.

( this was originally part of #3390 )