### PR TITLE
Add a setup() method to generated autoloaders.

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -487,7 +487,13 @@ class ComposerAutoloaderInit$suffix
         spl_autoload_register(array('ComposerAutoloaderInit$suffix', 'loadClassLoader'), true, $prependAutoloader);
         self::\$loader = \$loader = new \\Composer\\Autoload\\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInit$suffix', 'loadClassLoader'));
+        self::setup(\$loader);
 
+        return \$loader;
+    }
+
+    public static function setup(\$loader)
+    {
 
 HEADER;
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -22,7 +22,13 @@ class ComposerAutoloaderInitFilesAutoloadOrder
         spl_autoload_register(array('ComposerAutoloaderInitFilesAutoloadOrder', 'loadClassLoader'), true, true);
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoloadOrder', 'loadClassLoader'));
+        self::setup($loader);
 
+        return $loader;
+    }
+
+    public static function setup($loader)
+    {
         $map = require __DIR__ . '/autoload_namespaces.php';
         foreach ($map as $namespace => $path) {
             $loader->set($namespace, $path);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -22,7 +22,13 @@ class ComposerAutoloaderInitFilesAutoload
         spl_autoload_register(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'), true, true);
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
+        self::setup($loader);
 
+        return $loader;
+    }
+
+    public static function setup($loader)
+    {
         $map = require __DIR__ . '/autoload_namespaces.php';
         foreach ($map as $namespace => $path) {
             $loader->set($namespace, $path);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -22,7 +22,13 @@ class ComposerAutoloaderInitIncludePath
         spl_autoload_register(array('ComposerAutoloaderInitIncludePath', 'loadClassLoader'), true, true);
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitIncludePath', 'loadClassLoader'));
+        self::setup($loader);
 
+        return $loader;
+    }
+
+    public static function setup($loader)
+    {
         $map = require __DIR__ . '/autoload_namespaces.php';
         foreach ($map as $namespace => $path) {
             $loader->set($namespace, $path);

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -22,7 +22,13 @@ class ComposerAutoloaderInitTargetDir
         spl_autoload_register(array('ComposerAutoloaderInitTargetDir', 'loadClassLoader'), true, true);
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitTargetDir', 'loadClassLoader'));
+        self::setup($loader);
 
+        return $loader;
+    }
+
+    public static function setup($loader)
+    {
         $map = require __DIR__ . '/autoload_namespaces.php';
         foreach ($map as $namespace => $path) {
             $loader->set($namespace, $path);


### PR DESCRIPTION
I've run into a static caching issue when using Composer with Drupal 7 projects.

[Composer Manager](https://www.drupal.org/project/composer_manager) handles composer.json management and updating vendors. After Drupal modules are enabled or composer libraries are updated, other code can respond to those events.

The issue arises when:

1. You enable a new module with something like `drush pm-enable <modulename>`.
1. During the drush bootstrap, we pull in composer's autoloader.
1. Composer manager will update composer.json and update dependencies on disk.
1. The new module tries to use new libraries it's required, but can't because the autoloader is already registered. The old `autoload_classmap.php` and so on are being used.
1. We can't force a rescan due to the static cache of $loader in `ComposerAutoloaderInitComposerManager::getLoader()`.

Rather than adding a reset flag, I've pulled out a new setup() function so other code can call getLoader() followed by setup().

Tests pass and code coverage stats are the same.