### PR TITLE
Bugfix for #3874

### DIFF
--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -250,6 +250,14 @@ class DownloadManager
             return;
         }
 
+        // Totally different repositories mean it is not safe to update-in-place
+        if($initial->getSourceUrl() !== $target->getSourceUrl()){
+            $this->io->writeError('    <warning>Repository URL changed, re-downloading.</warning>');
+            $downloader->remove($initial, $targetDir);
+            $this->download($target, $targetDir);
+            return;
+        }
+
         if ($initialType === $targetType) {
             $target->setInstallationSource($installationSource);
             $downloader->update($initial, $target, $targetDir);

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -250,14 +250,6 @@ class DownloadManager
             return;
         }
 
-        // Totally different repositories mean it is not safe to update-in-place
-        if($initial->getSourceUrl() !== $target->getSourceUrl()){
-            $this->io->writeError('    <warning>Repository URL changed, re-downloading.</warning>');
-            $downloader->remove($initial, $targetDir);
-            $this->download($target, $targetDir);
-            return;
-        }
-
         if ($initialType === $targetType) {
             $target->setInstallationSource($installationSource);
             $downloader->update($initial, $target, $targetDir);

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -79,7 +79,7 @@ class GitDownloader extends VcsDownloader
 
         $ref = $target->getSourceReference();
         $this->io->writeError("    Checking out ".$ref);
-        $command = 'git remote set-url composer %s && git fetch composer && git fetch --tags composer';
+        $command = 'git remote set-url composer %1$s && git fetch composer && git fetch --tags composer && git remote set-url origin %1$s';
 
         $commandCallable = function ($url) use ($command) {
             return sprintf($command, ProcessExecutor::escape ($url));

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -79,13 +79,27 @@ class GitDownloader extends VcsDownloader
 
         $ref = $target->getSourceReference();
         $this->io->writeError("    Checking out ".$ref);
-        $command = 'git remote set-url composer %1$s && git fetch composer && git fetch --tags composer && git remote set-url origin %1$s';
+        $command = 'git remote set-url composer %s && git fetch composer && git fetch --tags composer';
 
         $commandCallable = function ($url) use ($command) {
             return sprintf($command, ProcessExecutor::escape ($url));
         };
 
         $this->gitUtil->runCommand($commandCallable, $url, $path);
+
+        if($initial->getSourceUrl() !== $target->getSourceUrl()){
+            /*
+             * If this were a fresh download, then git-clone would automatically
+             * set the origin for us. Since it isn't, we need to update it
+             * ourselves to match the new repository.
+             */
+            $command2 = 'git remote set-url origin %s';
+            $commandCallable2 = function ($url) use ($command2) {
+                return sprintf($command2, ProcessExecutor::escape ($url));
+            };
+            $this->gitUtil->runCommand($commandCallable2, $url, $path);
+        }
+
         if ($newRef =  $this->updateToCommit($path, $ref, $target->getPrettyVersion(), $target->getReleaseDate())) {
             if ($target->getDistReference() === $target->getSourceReference()) {
                 $target->setDistReference($newRef);

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -32,6 +32,7 @@ use Composer\IO\IOInterface;
 use Composer\Json\JsonFile;
 use Composer\Package\AliasPackage;
 use Composer\Package\CompletePackage;
+use Composer\Package\CompletePackageInterface;
 use Composer\Package\Link;
 use Composer\Package\LinkConstraint\VersionConstraint;
 use Composer\Package\Locker;
@@ -762,7 +763,7 @@ class Installer
         return $request;
     }
 
-    private function processDevPackages($localRepo, $pool, $policy, $repositories, $lockedRepository, $installFromLock, $task, array $operations = null)
+    private function processDevPackages(RepositoryInterface $localRepo, Pool $pool, $policy, $repositories, $lockedRepository, $installFromLock, $task, array $operations = null)
     {
         if ($task === 'force-updates' && null === $operations) {
             throw new \InvalidArgumentException('Missing operations argument');
@@ -846,6 +847,7 @@ class Installer
                         if ($task === 'force-updates' && $newPackage && (
                             (($newPackage->getSourceReference() && $newPackage->getSourceReference() !== $package->getSourceReference())
                                 || ($newPackage->getDistReference() && $newPackage->getDistReference() !== $package->getDistReference())
+                                || ($newPackage->getSourceUrl() && $newPackage->getSourceUrl() !== $package->getSourceUrl())
                             )
                         )) {
                             $operations[] = new UpdateOperation($package, $newPackage);


### PR DESCRIPTION
This attempts to fix issues #3874 and #3703.

In summary, these changes will:

1. When updating a git-repository within the vendor folder, always update the "origin" remote. (As opposed to only during the initial cloning, which git does automatically.)
2. Consider a git-repository in the vendor folder in need of updating whenever the source repo-URL changes. (Without this change, it will not notice if the revision-hash is the same.)