### PR TITLE
Readme: 00-intro - use __DIR__

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -179,7 +179,7 @@ downloads. To use it, just add the following line to your code's bootstrap
 process:
 
 ```php
-require 'vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 ```
 
 Woah! Now start using monolog! To keep learning more about Composer, keep


### PR DESCRIPTION
It is best practice to use `__DIR__` constant. Also it's used in `autoload.php` itself.