### PR TITLE
Allow local package dependency that is not under VCS

### DIFF
--- a/src/Composer/Downloader/FolderDownloader.php
+++ b/src/Composer/Downloader/FolderDownloader.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Downloader;
+
+use Composer\Package\PackageInterface;
+use Composer\Package\Version\VersionParser;
+
+/**
+ * Downloader for folders
+ *
+ * @author Johann Reinke <johann.reinke@gmail.com>
+ */
+class FolderDownloader extends FileDownloader
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function download(PackageInterface $package, $path)
+    {
+        if (is_dir($path)) {
+            rmdir($path);
+        }
+        if (false === symlink($package->getDistUrl(), $path)) {
+            throw new \ErrorException();
+        }
+        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . VersionParser::formatVersion($package) . "</comment>)");
+        $this->io->writeError('');
+    }
+}

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -334,6 +334,7 @@ class Factory
         $rm->setRepositoryClass('perforce', 'Composer\Repository\VcsRepository');
         $rm->setRepositoryClass('hg', 'Composer\Repository\VcsRepository');
         $rm->setRepositoryClass('artifact', 'Composer\Repository\ArtifactRepository');
+        $rm->setRepositoryClass('folder', 'Composer\Repository\FolderRepository');
 
         return $rm;
     }
@@ -406,6 +407,7 @@ class Factory
         $dm->setDownloader('gzip', new Downloader\GzipDownloader($io, $config, $eventDispatcher, $cache));
         $dm->setDownloader('phar', new Downloader\PharDownloader($io, $config, $eventDispatcher, $cache));
         $dm->setDownloader('file', new Downloader\FileDownloader($io, $config, $eventDispatcher, $cache));
+        $dm->setDownloader('folder', new Downloader\FolderDownloader($io, $config, $eventDispatcher, $cache));
 
         return $dm;
     }

--- a/src/Composer/Repository/FolderRepository.php
+++ b/src/Composer/Repository/FolderRepository.php
@@ -25,7 +25,7 @@ use Composer\Package\Loader\ArrayLoader;
  * @code
  * "require": {
  *     "<vendor>/<local-package>": "*"
- * }
+ * },
  * "repositories": [
  *     {
  *         "type": "folder",

--- a/src/Composer/Repository/FolderRepository.php
+++ b/src/Composer/Repository/FolderRepository.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Repository;
+
+use Composer\Json\JsonFile;
+use Composer\Package\Loader\ArrayLoader;
+
+/**
+ * This repository allows installing local packages that are not under any VCS.
+ * Just add paths in repositories so the local package can be found.
+ * The local packages will be added as symlinks, it means that any modification
+ * made in local packages will be automatically applied to other packages depending on it.
+ * Both relative and absolute paths are handled.
+ *
+ * @code
+ * "require": {
+ *     "<vendor>/<local-package>": "*"
+ * }
+ * "repositories": [
+ *     {
+ *         "type": "folder",
+ *         "url": "../../relative/path/to/package/"
+ *     },
+ *     {
+ *         "type": "folder",
+ *         "url": "/absolute/path/to/package/"
+ *     }
+ * ]
+ * @endcode
+ *
+ * @author Johann Reinke <johann.reinke@gmail.com>
+ */
+class FolderRepository extends ArrayRepository
+{
+    protected $path;
+
+    protected $loader;
+
+    /**
+     * Initializes folder repository.
+     *
+     * @param array $config package definition
+     */
+    public function __construct(array $config)
+    {
+        if (!isset($config['url'])) {
+            throw new \RuntimeException('You must specify a path for the folder repository');
+        }
+        $this->path = realpath(rtrim($config['url'], '/')) . '/';
+        $this->loader = new ArrayLoader();
+    }
+
+    /**
+     * Initializes repository (reads folders).
+     */
+    protected function initialize()
+    {
+        parent::initialize();
+
+        $file = $this->path . 'composer.json';
+        if (is_file($file) && is_readable($file)) {
+            $json = file_get_contents($file);
+            $package = JsonFile::parseJson($json, $file);
+            $package['dist'] = array(
+                'type' => 'folder',
+                'url' => $this->path,
+            );
+            if (!isset($package['version'])) {
+                $package['version'] = 'dev-master';
+            }
+            $package = $this->loader->load($package);
+            $this->addPackage($package);
+        }
+    }
+}


### PR DESCRIPTION
Several issues/requests were reported for such a feature: #1299, #2171, #3254, #3658.

This PR adds a repository that allows installing local packages that are not under VCS.
Just add paths in repositories so the local packages can be found.
The local packages will be added as symlinks, it means that any modification
made in local packages will be automatically applied to other packages depending on it.
Both relative and absolute paths are handled.
```json
"require": {
    "<vendor>/<local-package>": "*"
},
"repositories": [
    {
        "type": "folder",
        "url": "../../relative/path/to/package/"
    },
    {
        "type": "folder",
        "url": "/absolute/path/to/package/"
    }
]
```