### PR TITLE
Silence symlink() error

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -239,7 +239,7 @@ class LibraryInstaller implements InstallerInterface
                     // when using it in smbfs mounted folder
                     $relativeBin = $this->filesystem->findShortestPath($link, $binPath);
                     chdir(dirname($link));
-                    if (false === symlink($relativeBin, $link)) {
+                    if (false === @symlink($relativeBin, $link)) {
                         throw new \ErrorException();
                     }
                 } catch (\ErrorException $e) {


### PR DESCRIPTION
If not silenced it gives "symlink(): Operation not supported" on my ubuntu system with mounted cifs share.