### PR TITLE
Fix coding standards

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -110,7 +110,7 @@ EOF;
             }
             $exportedPrefix = var_export($namespace, true);
             $namespacesFile .= "    $exportedPrefix => ";
-            $namespacesFile .= "array(".implode(', ', $exportedPaths)."),\n";
+            $namespacesFile .= 'array('.implode(', ', $exportedPaths)."),\n";
         }
         $namespacesFile .= ");\n";
 
@@ -122,7 +122,7 @@ EOF;
             }
             $exportedPrefix = var_export($namespace, true);
             $psr4File .= "    $exportedPrefix => ";
-            $psr4File .= "array(".implode(', ', $exportedPaths)."),\n";
+            $psr4File .= 'array('.implode(', ', $exportedPaths)."),\n";
         }
         $psr4File .= ");\n";
 
@@ -295,11 +295,12 @@ EOF;
     }
 
     /**
-     * Compiles an ordered list of namespace => path mappings
+     * Compiles an ordered list of namespace => path mappings.
      *
-     * @param  array            $packageMap  array of array(package, installDir-relative-to-composer.json)
-     * @param  PackageInterface $mainPackage root package instance
-     * @return array            array('psr-0' => array('Ns\\Foo' => array('installDir')))
+     * @param array            $packageMap  array of array(package, installDir-relative-to-composer.json)
+     * @param PackageInterface $mainPackage root package instance
+     *
+     * @return array array('psr-0' => array('Ns\\Foo' => array('installDir')))
      */
     public function parseAutoloads(array $packageMap, PackageInterface $mainPackage)
     {
@@ -320,9 +321,10 @@ EOF;
     }
 
     /**
-     * Registers an autoloader based on an autoload map returned by parseAutoloads
+     * Registers an autoloader based on an autoload map returned by parseAutoloads.
      *
-     * @param  array       $autoloads see parseAutoloads return value
+     * @param array $autoloads see parseAutoloads return value
+     *
      * @return ClassLoader
      */
     public function createLoader(array $autoloads)
@@ -367,7 +369,7 @@ EOF;
 
         $includePathsCode = '';
         foreach ($includePaths as $path) {
-            $includePathsCode .= "    " . $this->getPathCode($filesystem, $basePath, $vendorPath, $path) . ",\n";
+            $includePathsCode .= '    ' . $this->getPathCode($filesystem, $basePath, $vendorPath, $path) . ",\n";
         }
 
         return <<<EOF
@@ -422,7 +424,7 @@ EOF;
             $baseDir = '$vendorDir';
 
             if ($path !== false) {
-                $baseDir .= " . ";
+                $baseDir .= ' . ';
             }
         } else {
             $path = $filesystem->normalizePath($filesystem->findShortestPath($basePath, $path, true));
@@ -436,7 +438,7 @@ EOF;
             $baseDir = "'phar://' . " . $baseDir;
         }
 
-        return $baseDir . (($path !== false) ? var_export($path, true) : "");
+        return $baseDir . (($path !== false) ? var_export($path, true) : '');
     }
 
     protected function getAutoloadFile($vendorPathToTargetDirCode, $suffix)
@@ -637,11 +639,12 @@ FOOTER;
     }
 
     /**
-     * Sorts packages by dependency weight
+     * Sorts packages by dependency weight.
      *
      * Packages of equal weight retain the original order
      *
-     * @param  array $packageMap
+     * @param array $packageMap
+     *
      * @return array
      */
     protected function sortPackageMap(array $packageMap)

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -13,7 +13,7 @@
 namespace Composer\Autoload;
 
 /**
- * ClassLoader implements a PSR-0 class loader
+ * ClassLoader implements a PSR-0 class loader.
  *
  * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
  *
@@ -171,7 +171,7 @@ class ClassLoader
             // Register directories for a new namespace.
             $length = strlen($prefix);
             if ('\\' !== $prefix[$length - 1]) {
-                throw new \InvalidArgumentException("A non-empty PSR-4 prefix must end with a namespace separator.");
+                throw new \InvalidArgumentException('A non-empty PSR-4 prefix must end with a namespace separator.');
             }
             $this->prefixLengthsPsr4[$prefix[0]][$prefix] = $length;
             $this->prefixDirsPsr4[$prefix] = (array) $paths;
@@ -222,7 +222,7 @@ class ClassLoader
         } else {
             $length = strlen($prefix);
             if ('\\' !== $prefix[$length - 1]) {
-                throw new \InvalidArgumentException("A non-empty PSR-4 prefix must end with a namespace separator.");
+                throw new \InvalidArgumentException('A non-empty PSR-4 prefix must end with a namespace separator.');
             }
             $this->prefixLengthsPsr4[$prefix[0]][$prefix] = $length;
             $this->prefixDirsPsr4[$prefix] = (array) $paths;
@@ -292,7 +292,8 @@ class ClassLoader
     /**
      * Loads the given class or interface.
      *
-     * @param  string    $class The name of the class
+     * @param string $class The name of the class
+     *
      * @return bool|null True if loaded, null otherwise
      */
     public function loadClass($class)

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -17,7 +17,7 @@ use Symfony\Component\Finder\Finder;
 use Composer\IO\IOInterface;
 
 /**
- * ClassMapGenerator
+ * ClassMapGenerator.
  *
  * @author Gyula Sallai <salla016@gmail.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -25,7 +25,7 @@ use Composer\IO\IOInterface;
 class ClassMapGenerator
 {
     /**
-     * Generate a class map file
+     * Generate a class map file.
      *
      * @param \Traversable $dirs Directories or a single path to search in
      * @param string       $file The name of the class map file
@@ -42,7 +42,7 @@ class ClassMapGenerator
     }
 
     /**
-     * Iterate over all files in the given directory searching for classes
+     * Iterate over all files in the given directory searching for classes.
      *
      * @param \Iterator|string $path      The path to search in or an iterator
      * @param string           $whitelist Regex that matches against the file path
@@ -104,11 +104,13 @@ class ClassMapGenerator
     }
 
     /**
-     * Extract the classes in the given file
+     * Extract the classes in the given file.
      *
-     * @param  string            $path The file to check
+     * @param string $path The file to check
+     *
      * @throws \RuntimeException
-     * @return array             The found classes
+     *
+     * @return array The found classes
      */
     private static function findClasses($path)
     {
@@ -173,7 +175,7 @@ class ClassMapGenerator
                 if ($name[0] === ':') {
                     // This is an XHP class, https://github.com/facebook/xhp
                     $name = 'xhp'.substr(str_replace(array('-', ':'), array('_', '__'), $name), 1);
-                } else if ($matches['type'][$i] === 'enum') {
+                } elseif ($matches['type'][$i] === 'enum') {
                     // In Hack, something like:
                     //   enum Foo: int { HERP = '123'; }
                     // The regex above captures the colon, which isn't part of

--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -17,7 +17,7 @@ use Composer\Util\Filesystem;
 use Symfony\Component\Finder\Finder;
 
 /**
- * Reads/writes to a filesystem cache
+ * Reads/writes to a filesystem cache.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
@@ -111,7 +111,7 @@ class Cache
     }
 
     /**
-     * Copy a file into the cache
+     * Copy a file into the cache.
      */
     public function copyFrom($file, $source)
     {
@@ -130,7 +130,7 @@ class Cache
     }
 
     /**
-     * Copy a file out of the cache
+     * Copy a file out of the cache.
      */
     public function copyTo($file, $target)
     {

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -20,7 +20,6 @@ use Composer\Script\ScriptEvents;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Composer\Package\Version\VersionParser;
-
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -83,7 +82,7 @@ EOT
     protected function archive(IOInterface $io, $packageName = null, $version = null, $format = 'tar', $dest = '.')
     {
         $config = Factory::createConfig();
-        $factory = new Factory;
+        $factory = new Factory();
         $downloadManager = $factory->createDownloadManager($io, $config);
         $archiveManager = $factory->createArchiveManager($config, $downloadManager);
 

--- a/src/Composer/Command/Command.php
+++ b/src/Composer/Command/Command.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 
 /**
- * Base class for Composer commands
+ * Base class for Composer commands.
  *
  * @author Ryan Weaver <ryan@knplabs.com>
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
@@ -39,9 +39,11 @@ abstract class Command extends BaseCommand
     private $io;
 
     /**
-     * @param  bool              $required
-     * @param  bool              $disablePlugins
+     * @param bool $required
+     * @param bool $disablePlugins
+     *
      * @throws \RuntimeException
+     *
      * @return Composer
      */
     public function getComposer($required = true, $disablePlugins = false)
@@ -71,7 +73,7 @@ abstract class Command extends BaseCommand
     }
 
     /**
-     * Removes the cached composer instance
+     * Removes the cached composer instance.
      */
     public function resetComposer()
     {

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -154,12 +154,12 @@ EOT
         // initialize the global file if it's not there
         if ($input->getOption('global') && !$this->configFile->exists()) {
             touch($this->configFile->getPath());
-            $this->configFile->write(array('config' => new \ArrayObject));
+            $this->configFile->write(array('config' => new \ArrayObject()));
             @chmod($this->configFile->getPath(), 0600);
         }
         if ($input->getOption('global') && !$this->authConfigFile->exists()) {
             touch($this->authConfigFile->getPath());
-            $this->authConfigFile->write(array('http-basic' => new \ArrayObject, 'github-oauth' => new \ArrayObject));
+            $this->authConfigFile->write(array('http-basic' => new \ArrayObject(), 'github-oauth' => new \ArrayObject()));
             @chmod($this->authConfigFile->getPath(), 0600);
         }
 
@@ -273,7 +273,7 @@ EOT
             'use-include-path' => array($booleanValidator, $booleanNormalizer),
             'preferred-install' => array(
                 function ($val) { return in_array($val, array('auto', 'source', 'dist'), true); },
-                function ($val) { return $val; }
+                function ($val) { return $val; },
             ),
             'store-auths' => array(
                 function ($val) { return in_array($val, array('true', 'false', 'prompt'), true); },
@@ -283,7 +283,7 @@ EOT
                     }
 
                     return $val !== 'false' && (bool) $val;
-                }
+                },
             ),
             'notify-on-install' => array($booleanValidator, $booleanNormalizer),
             'vendor-dir' => array('is_string', function ($val) { return $val; }),
@@ -296,7 +296,7 @@ EOT
             'cache-files-ttl' => array('is_numeric', 'intval'),
             'cache-files-maxsize' => array(
                 function ($val) { return preg_match('/^\s*([0-9.]+)\s*(?:([kmg])(?:i?b)?)?\s*$/i', $val) > 0; },
-                function ($val) { return $val; }
+                function ($val) { return $val; },
             ),
             'discard-changes' => array(
                 function ($val) { return in_array($val, array('stash', 'true', 'false', '1', '0'), true); },
@@ -306,7 +306,7 @@ EOT
                     }
 
                     return $val !== 'false' && (bool) $val;
-                }
+                },
             ),
             'autoloader-suffix' => array('is_string', function ($val) { return $val === 'null' ? null : $val; }),
             'optimize-autoloader' => array($booleanValidator, $booleanNormalizer),
@@ -331,7 +331,7 @@ EOT
                 },
                 function ($vals) {
                     return $vals;
-                }
+                },
             ),
             'github-domains' => array(
                 function ($vals) {
@@ -343,7 +343,7 @@ EOT
                 },
                 function ($vals) {
                     return $vals;
-                }
+                },
             ),
         );
 
@@ -440,7 +440,7 @@ EOT
     }
 
     /**
-     * Display the contents of the file in a pretty formatted way
+     * Display the contents of the file in a pretty formatted way.
      *
      * @param array           $contents
      * @param array           $rawContents

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -239,7 +239,7 @@ EOT
     {
         if (null === $repositoryUrl) {
             $sourceRepo = new CompositeRepository(Factory::createDefaultRepositories($io, $config));
-        } elseif ("json" === pathinfo($repositoryUrl, PATHINFO_EXTENSION) && file_exists($repositoryUrl)) {
+        } elseif ('json' === pathinfo($repositoryUrl, PATHINFO_EXTENSION) && file_exists($repositoryUrl)) {
             $json = new JsonFile($repositoryUrl, new RemoteFilesystem($io, $config));
             $data = $json->read();
             if (!empty($data['packages']) || !empty($data['includes']) || !empty($data['provider-includes'])) {
@@ -250,7 +250,7 @@ EOT
         } elseif (0 === strpos($repositoryUrl, 'http')) {
             $sourceRepo = new ComposerRepository(array('url' => $repositoryUrl), $io, $config);
         } else {
-            throw new \InvalidArgumentException("Invalid repository url given. Has to be a .json file or an http url.");
+            throw new \InvalidArgumentException('Invalid repository url given. Has to be a .json file or an http url.');
         }
 
         $parser = new VersionParser();
@@ -286,7 +286,7 @@ EOT
         }
 
         if (null === $directory) {
-            $parts = explode("/", $name, 2);
+            $parts = explode('/', $name, 2);
             $directory = getcwd() . DIRECTORY_SEPARATOR . array_pop($parts);
         }
 
@@ -335,11 +335,12 @@ EOT
     }
 
     /**
-     * Updated preferSource or preferDist based on the preferredInstall config option
+     * Updated preferSource or preferDist based on the preferredInstall config option.
+     *
      * @param Config         $config
      * @param InputInterface $input
-     * @param boolean        $preferSource
-     * @param boolean        $preferDist
+     * @param bool           $preferSource
+     * @param bool           $preferDist
      */
     protected function updatePreferredOptions(Config $config, InputInterface $input, &$preferSource, &$preferDist)
     {

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -261,7 +261,7 @@ EOT
             $url = $domain === 'github.com' ? 'https://api.'.$domain.'/user/repos' : 'https://'.$domain.'/api/v3/user/repos';
 
             return $this->rfs->getContents($domain, $url, false, array(
-                'retry-auth-failure' => false
+                'retry-auth-failure' => false,
             )) ? true : 'Unexpected error';
         } catch (\Exception $e) {
             if ($e instanceof TransportException && $e->getCode() === 401) {
@@ -275,7 +275,9 @@ EOT
     /**
      * @param string $domain
      * @param string $token
+     *
      * @return array
+     *
      * @throws TransportException
      */
     private function getGithubRateLimit($domain, $token = null)
@@ -422,41 +424,41 @@ EOT
             foreach ($errors as $error => $current) {
                 switch ($error) {
                     case 'json':
-                        $text = PHP_EOL."The json extension is missing.".PHP_EOL;
-                        $text .= "Install it or recompile php without --disable-json";
+                        $text = PHP_EOL.'The json extension is missing.'.PHP_EOL;
+                        $text .= 'Install it or recompile php without --disable-json';
                         break;
 
                     case 'phar':
-                        $text = PHP_EOL."The phar extension is missing.".PHP_EOL;
-                        $text .= "Install it or recompile php without --disable-phar";
+                        $text = PHP_EOL.'The phar extension is missing.'.PHP_EOL;
+                        $text .= 'Install it or recompile php without --disable-phar';
                         break;
 
                     case 'filter':
-                        $text = PHP_EOL."The filter extension is missing.".PHP_EOL;
-                        $text .= "Install it or recompile php without --disable-filter";
+                        $text = PHP_EOL.'The filter extension is missing.'.PHP_EOL;
+                        $text .= 'Install it or recompile php without --disable-filter';
                         break;
 
                     case 'hash':
-                        $text = PHP_EOL."The hash extension is missing.".PHP_EOL;
-                        $text .= "Install it or recompile php without --disable-hash";
+                        $text = PHP_EOL.'The hash extension is missing.'.PHP_EOL;
+                        $text .= 'Install it or recompile php without --disable-hash';
                         break;
 
                     case 'ctype':
-                        $text = PHP_EOL."The ctype extension is missing.".PHP_EOL;
-                        $text .= "Install it or recompile php without --disable-ctype";
+                        $text = PHP_EOL.'The ctype extension is missing.'.PHP_EOL;
+                        $text .= 'Install it or recompile php without --disable-ctype';
                         break;
 
                     case 'unicode':
-                        $text = PHP_EOL."The detect_unicode setting must be disabled.".PHP_EOL;
-                        $text .= "Add the following to the end of your `php.ini`:".PHP_EOL;
-                        $text .= "    detect_unicode = Off";
+                        $text = PHP_EOL.'The detect_unicode setting must be disabled.'.PHP_EOL;
+                        $text .= 'Add the following to the end of your `php.ini`:'.PHP_EOL;
+                        $text .= '    detect_unicode = Off';
                         $displayIniMessage = true;
                         break;
 
                     case 'suhosin':
-                        $text = PHP_EOL."The suhosin.executor.include.whitelist setting is incorrect.".PHP_EOL;
-                        $text .= "Add the following to the end of your `php.ini` or suhosin.ini (Example path [for Debian]: /etc/php5/cli/conf.d/suhosin.ini):".PHP_EOL;
-                        $text .= "    suhosin.executor.include.whitelist = phar ".$current;
+                        $text = PHP_EOL.'The suhosin.executor.include.whitelist setting is incorrect.'.PHP_EOL;
+                        $text .= 'Add the following to the end of your `php.ini` or suhosin.ini (Example path [for Debian]: /etc/php5/cli/conf.d/suhosin.ini):'.PHP_EOL;
+                        $text .= '    suhosin.executor.include.whitelist = phar '.$current;
                         $displayIniMessage = true;
                         break;
 
@@ -465,22 +467,22 @@ EOT
                         break;
 
                     case 'allow_url_fopen':
-                        $text = PHP_EOL."The allow_url_fopen setting is incorrect.".PHP_EOL;
-                        $text .= "Add the following to the end of your `php.ini`:".PHP_EOL;
-                        $text .= "    allow_url_fopen = On";
+                        $text = PHP_EOL.'The allow_url_fopen setting is incorrect.'.PHP_EOL;
+                        $text .= 'Add the following to the end of your `php.ini`:'.PHP_EOL;
+                        $text .= '    allow_url_fopen = On';
                         $displayIniMessage = true;
                         break;
 
                     case 'ioncube':
                         $text = PHP_EOL."Your ionCube Loader extension ($current) is incompatible with Phar files.".PHP_EOL;
-                        $text .= "Upgrade to ionCube 4.0.9 or higher or remove this line (path may be different) from your `php.ini` to disable it:".PHP_EOL;
-                        $text .= "    zend_extension = /usr/lib/php5/20090626+lfs/ioncube_loader_lin_5.3.so";
+                        $text .= 'Upgrade to ionCube 4.0.9 or higher or remove this line (path may be different) from your `php.ini` to disable it:'.PHP_EOL;
+                        $text .= '    zend_extension = /usr/lib/php5/20090626+lfs/ioncube_loader_lin_5.3.so';
                         $displayIniMessage = true;
                         break;
 
                     case 'openssl':
-                        $text = PHP_EOL."The openssl extension is missing, which means that secure HTTPS transfers are impossible.".PHP_EOL;
-                        $text .= "If possible you should enable it or recompile php with --with-openssl";
+                        $text = PHP_EOL.'The openssl extension is missing, which means that secure HTTPS transfers are impossible.'.PHP_EOL;
+                        $text .= 'If possible you should enable it or recompile php with --with-openssl';
                         break;
                 }
                 $out($text, 'error');
@@ -493,37 +495,37 @@ EOT
             foreach ($warnings as $warning => $current) {
                 switch ($warning) {
                     case 'apc_cli':
-                        $text  = "The apc.enable_cli setting is incorrect.".PHP_EOL;
-                        $text .= "Add the following to the end of your `php.ini`:".PHP_EOL;
-                        $text .= "  apc.enable_cli = Off";
+                        $text  = 'The apc.enable_cli setting is incorrect.'.PHP_EOL;
+                        $text .= 'Add the following to the end of your `php.ini`:'.PHP_EOL;
+                        $text .= '  apc.enable_cli = Off';
                         $displayIniMessage = true;
                         break;
 
                     case 'sigchild':
-                        $text  = "PHP was compiled with --enable-sigchild which can cause issues on some platforms.".PHP_EOL;
-                        $text .= "Recompile it without this flag if possible, see also:".PHP_EOL;
-                        $text .= "  https://bugs.php.net/bug.php?id=22999";
+                        $text  = 'PHP was compiled with --enable-sigchild which can cause issues on some platforms.'.PHP_EOL;
+                        $text .= 'Recompile it without this flag if possible, see also:'.PHP_EOL;
+                        $text .= '  https://bugs.php.net/bug.php?id=22999';
                         break;
 
                     case 'curlwrappers':
-                        $text  = "PHP was compiled with --with-curlwrappers which will cause issues with HTTP authentication and GitHub.".PHP_EOL;
-                        $text .= " Recompile it without this flag if possible";
+                        $text  = 'PHP was compiled with --with-curlwrappers which will cause issues with HTTP authentication and GitHub.'.PHP_EOL;
+                        $text .= ' Recompile it without this flag if possible';
                         break;
 
                     case 'php':
                         $text  = "Your PHP ({$current}) is quite old, upgrading to PHP 5.3.4 or higher is recommended.".PHP_EOL;
-                        $text .= " Composer works with 5.3.2+ for most people, but there might be edge case issues.";
+                        $text .= ' Composer works with 5.3.2+ for most people, but there might be edge case issues.';
                         break;
 
                     case 'xdebug_loaded':
-                        $text  = "The xdebug extension is loaded, this can slow down Composer a little.".PHP_EOL;
-                        $text .= " Disabling it when using Composer is recommended.";
+                        $text  = 'The xdebug extension is loaded, this can slow down Composer a little.'.PHP_EOL;
+                        $text .= ' Disabling it when using Composer is recommended.';
                         break;
 
                     case 'xdebug_profile':
-                        $text  = "The xdebug.profiler_enabled setting is enabled, this can slow down Composer a lot.".PHP_EOL;
-                        $text .= "Add the following to the end of your `php.ini` to disable it:".PHP_EOL;
-                        $text .= "  xdebug.profiler_enabled = 0";
+                        $text  = 'The xdebug.profiler_enabled setting is enabled, this can slow down Composer a lot.'.PHP_EOL;
+                        $text .= 'Add the following to the end of your `php.ini` to disable it:'.PHP_EOL;
+                        $text .= '  xdebug.profiler_enabled = 0';
                         $displayIniMessage = true;
                         break;
                 }

--- a/src/Composer/Command/Helper/DialogHelper.php
+++ b/src/Composer/Command/Helper/DialogHelper.php
@@ -17,7 +17,9 @@ use Symfony\Component\Console\Helper\DialogHelper as BaseDialogHelper;
 class DialogHelper extends BaseDialogHelper
 {
     /**
-     * Build text for asking a question. For example:
+     * Build text for asking a question.
+     *
+     * For example:
      *
      *  "Do you want to continue [yes]:"
      *

--- a/src/Composer/Command/HomeCommand.php
+++ b/src/Composer/Command/HomeCommand.php
@@ -100,10 +100,11 @@ EOT
     }
 
     /**
-     * finds a package by name
+     * finds a package by name.
      *
-     * @param  RepositoryInterface      $repos
-     * @param  string                   $name
+     * @param RepositoryInterface $repos
+     * @param string              $name
+     *
      * @return CompletePackageInterface
      */
     protected function getPackage(RepositoryInterface $repos, $name)
@@ -125,7 +126,7 @@ EOT
     }
 
     /**
-     * opens a url in your system default browser
+     * opens a url in your system default browser.
      *
      * @param string $url
      */
@@ -150,7 +151,7 @@ EOT
     }
 
     /**
-     * Initializes repositories
+     * Initializes repositories.
      *
      * Returns an array of repos in order they should be checked in
      *
@@ -163,7 +164,7 @@ EOT
         if ($composer) {
             return array(
                 $composer->getRepositoryManager()->getLocalRepository(),
-                new CompositeRepository($composer->getRepositoryManager()->getRepositories())
+                new CompositeRepository($composer->getRepositoryManager()->getRepositories()),
             );
         }
 

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -44,7 +44,7 @@ class InitCommand extends Command
             if ($this->isValidEmail($match['email'])) {
                 return array(
                     'name'  => trim($match['name']),
-                    'email' => $match['email']
+                    'email' => $match['email'],
                 );
             }
         }
@@ -100,15 +100,15 @@ EOT
             unset($options['stability']);
         }
 
-        $options['require'] = isset($options['require']) ? $this->formatRequirements($options['require']) : new \stdClass;
+        $options['require'] = isset($options['require']) ? $this->formatRequirements($options['require']) : new \stdClass();
         if (array() === $options['require']) {
-            $options['require'] = new \stdClass;
+            $options['require'] = new \stdClass();
         }
 
         if (isset($options['require-dev'])) {
             $options['require-dev'] = $this->formatRequirements($options['require-dev']);
             if (array() === $options['require-dev']) {
-                $options['require-dev'] = new \stdClass;
+                $options['require-dev'] = new \stdClass();
             }
         }
 
@@ -120,7 +120,7 @@ EOT
             $this->getIO()->writeError(array(
                 '',
                 $json,
-                ''
+                '',
             ));
             if (!$dialog->askConfirmation($output, $dialog->getQuestion('Do you confirm generation', 'yes', '?'), true)) {
                 $this->getIO()->writeError('<error>Command aborted</error>');
@@ -157,7 +157,7 @@ EOT
         $this->getIO()->writeError(array(
             '',
             $formatter->formatBlock('Welcome to the Composer config generator', 'bg=blue;fg=white', true),
-            ''
+            '',
         ));
 
         // namespace
@@ -167,7 +167,7 @@ EOT
             '',
         ));
 
-        $cwd = realpath(".");
+        $cwd = realpath('.');
 
         if (!$name = $input->getOption('name')) {
             $name = basename($cwd);
@@ -269,7 +269,7 @@ EOT
         $this->getIO()->writeError(array(
             '',
             'Define your dependencies.',
-            ''
+            '',
         ));
 
         $requirements = array();
@@ -293,7 +293,7 @@ EOT
     {
         if (!$this->repos) {
             $this->repos = new CompositeRepository(array_merge(
-                array(new PlatformRepository),
+                array(new PlatformRepository()),
                 Factory::createDefaultRepositories($this->getIO())
             ));
         }
@@ -349,7 +349,7 @@ EOT
                     $this->getIO()->writeError(array(
                         '',
                         sprintf('Found <info>%s</info> packages matching <info>%s</info>', count($matches), $package),
-                        ''
+                        '',
                     ));
 
                     $this->getIO()->writeError($choices);
@@ -506,7 +506,7 @@ EOT
 
     protected function addVendorIgnore($ignoreFile, $vendor = '/vendor/')
     {
-        $contents = "";
+        $contents = '';
         if (file_exists($ignoreFile)) {
             $contents = file_get_contents($ignoreFile);
 
@@ -564,9 +564,11 @@ EOT
      *
      * This returns a version with the ~ operator prefixed when possible.
      *
-     * @param  InputInterface            $input
-     * @param  string                    $name
+     * @param InputInterface $input
+     * @param string         $name
+     *
      * @return string
+     *
      * @throws \InvalidArgumentException
      */
     private function findBestVersionForPackage(InputInterface $input, $name)

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -19,7 +19,6 @@ use Composer\Plugin\PluginEvents;
 use Composer\Package\PackageInterface;
 use Composer\Repository\RepositoryInterface;
 use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Helper\TableStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -57,7 +56,7 @@ EOT
         $root = $composer->getPackage();
         $repo = $composer->getRepositoryManager()->getLocalRepository();
 
-        $versionParser = new VersionParser;
+        $versionParser = new VersionParser();
 
         if ($input->getOption('no-dev')) {
             $packages = $this->filterRequiredPackages($repo, $root);
@@ -112,7 +111,7 @@ EOT
     }
 
     /**
-     * Find package requires and child requires
+     * Find package requires and child requires.
      *
      * @param RepositoryInterface $repo
      * @param PackageInterface    $package
@@ -139,10 +138,11 @@ EOT
     }
 
     /**
-     * Adds packages to the package list
+     * Adds packages to the package list.
      *
-     * @param  array $packages the list of packages to add
-     * @param  array $bucket   the list to add packages to
+     * @param array $packages the list of packages to add
+     * @param array $bucket   the list to add packages to
+     *
      * @return array
      */
     public function appendPackages(array $packages, array $bucket)

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -90,7 +90,7 @@ EOT
         $repos = $composer->getRepositoryManager()->getRepositories();
 
         $this->repos = new CompositeRepository(array_merge(
-            array(new PlatformRepository),
+            array(new PlatformRepository()),
             $repos
         ));
 

--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -55,7 +55,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         // init repos
-        $platformRepo = new PlatformRepository;
+        $platformRepo = new PlatformRepository();
         if ($composer = $this->getComposer(false)) {
             $localRepo = $composer->getRepositoryManager()->getLocalRepository();
             $installedRepo = new CompositeRepository(array($localRepo, $platformRepo));

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -104,7 +104,7 @@ EOT
             self::OLD_INSTALL_EXT
         );
 
-        $this->getIO()->writeError(sprintf("Updating to version <info>%s</info>.", $updateVersion));
+        $this->getIO()->writeError(sprintf('Updating to version <info>%s</info>.', $updateVersion));
         $remoteFilename = $baseUrl . (preg_match('{^[0-9a-f]{40}$}', $updateVersion) ? '/composer.phar' : "/download/{$updateVersion}/composer.phar");
         $remoteFilesystem->copy(self::HOMEPAGE, $remoteFilename, $tempFilename, !$input->getOption('no-progress'));
         if (!file_exists($tempFilename)) {
@@ -117,7 +117,7 @@ EOT
         if ($input->getOption('clean-backups')) {
             $finder = $this->getOldInstallationFinder($rollbackDir);
 
-            $fs = new Filesystem;
+            $fs = new Filesystem();
             foreach ($finder as $file) {
                 $file = (string) $file;
                 $this->getIO()->writeError('<info>Removing: '.$file.'</info>');
@@ -160,7 +160,7 @@ EOT
         }
 
         $oldFile = $rollbackDir . "/{$rollbackVersion}" . self::OLD_INSTALL_EXT;
-        $this->getIO()->writeError(sprintf("Rolling back to version <info>%s</info>.", $rollbackVersion));
+        $this->getIO()->writeError(sprintf('Rolling back to version <info>%s</info>.', $rollbackVersion));
         if ($err = $this->setLocalPhar($localFilename, $oldFile)) {
             $this->getIO()->writeError('<error>The backup file was corrupted ('.$err->getMessage().') and has been removed.</error>');
 

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -65,10 +65,10 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->versionParser = new VersionParser;
+        $this->versionParser = new VersionParser();
 
         // init repos
-        $platformRepo = new PlatformRepository;
+        $platformRepo = new PlatformRepository();
 
         $composer = $this->getComposer(false);
         if ($input->getOption('self')) {
@@ -233,13 +233,15 @@ EOT
     }
 
     /**
-     * finds a package by name and version if provided
+     * finds a package by name and version if provided.
      *
-     * @param  RepositoryInterface       $installedRepo
-     * @param  RepositoryInterface       $repos
-     * @param  string                    $name
-     * @param  string                    $version
-     * @return array                     array(CompletePackageInterface, array of versions)
+     * @param RepositoryInterface $installedRepo
+     * @param RepositoryInterface $repos
+     * @param string              $name
+     * @param string              $version
+     *
+     * @return array array(CompletePackageInterface, array of versions)
+     *
      * @throws \InvalidArgumentException
      */
     protected function getPackage(RepositoryInterface $installedRepo, RepositoryInterface $repos, $name, $version = null)
@@ -282,13 +284,13 @@ EOT
     }
 
     /**
-     * prints package meta data
+     * prints package meta data.
      */
     protected function printMeta(CompletePackageInterface $package, array $versions, RepositoryInterface $installedRepo)
     {
         $this->getIO()->write('<info>name</info>     : ' . $package->getPrettyName());
         $this->getIO()->write('<info>descrip.</info> : ' . $package->getDescription());
-        $this->getIO()->write('<info>keywords</info> : ' . join(', ', $package->getKeywords() ?: array()));
+        $this->getIO()->write('<info>keywords</info> : ' . implode(', ', $package->getKeywords() ?: array()));
         $this->printVersions($package, $versions, $installedRepo);
         $this->getIO()->write('<info>type</info>     : ' . $package->getType());
         $this->printLicenses($package);
@@ -338,7 +340,7 @@ EOT
     }
 
     /**
-     * prints all available versions of this package and highlights the installed one if any
+     * prints all available versions of this package and highlights the installed one if any.
      */
     protected function printVersions(CompletePackageInterface $package, array $versions, RepositoryInterface $installedRepo)
     {
@@ -360,7 +362,7 @@ EOT
     }
 
     /**
-     * print link objects
+     * print link objects.
      *
      * @param CompletePackageInterface $package
      * @param string                   $linkType
@@ -370,7 +372,7 @@ EOT
     {
         $title = $title ?: $linkType;
         if ($links = $package->{'get'.ucfirst($linkType)}()) {
-            $this->getIO()->write("\n<info>" . $title . "</info>");
+            $this->getIO()->write("\n<info>" . $title . '</info>');
 
             foreach ($links as $link) {
                 $this->getIO()->write($link->getTarget() . ' <comment>' . $link->getPrettyConstraint() . '</comment>');
@@ -379,21 +381,21 @@ EOT
     }
 
     /**
-     * Prints the licenses of a package with metadata
+     * Prints the licenses of a package with metadata.
      *
      * @param CompletePackageInterface $package
      */
     protected function printLicenses(CompletePackageInterface $package)
     {
-        $spdxLicense = new SpdxLicense;
+        $spdxLicense = new SpdxLicense();
 
         $licenses = $package->getLicense();
 
-        foreach($licenses as $licenseId) {
+        foreach ($licenses as $licenseId) {
             $license = $spdxLicense->getLicenseByIdentifier($licenseId); // keys: 0 fullname, 1 osi, 2 url
 
             // is license OSI approved?
-            if($license[1] === true) {
+            if ($license[1] === true) {
                 $out = sprintf('%s (%s) (OSI approved) %s', $license[0], $licenseId, $license[2]);
             } else {
                 $out = sprintf('%s (%s) %s', $license[0], $licenseId, $license[2]);

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * ValidateCommand
+ * ValidateCommand.
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -28,7 +28,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ValidateCommand extends Command
 {
     /**
-     * configure
+     * configure.
      */
     protected function configure()
     {
@@ -38,7 +38,7 @@ class ValidateCommand extends Command
             ->setDefinition(array(
                 new InputOption('no-check-all', null, InputOption::VALUE_NONE, 'Do not make a complete validation'),
                 new InputOption('no-check-publish', null, InputOption::VALUE_NONE, 'Do not check for publish errors'),
-                new InputArgument('file', InputArgument::OPTIONAL, 'path to composer.json file', './composer.json')
+                new InputArgument('file', InputArgument::OPTIONAL, 'path to composer.json file', './composer.json'),
             ))
             ->setHelp(<<<EOT
 The validate command validates a given composer.json

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -17,7 +17,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 
 /**
- * The Compiler class compiles composer into a phar
+ * The Compiler class compiles composer into a phar.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -29,10 +29,11 @@ class Compiler
     private $versionDate;
 
     /**
-     * Compiles composer into a single phar file
+     * Compiles composer into a single phar file.
      *
      * @throws \RuntimeException
-     * @param  string            $pharFile The full path to the file to create
+     *
+     * @param string $pharFile The full path to the file to create
      */
     public function compile($pharFile = 'composer.phar')
     {
@@ -169,7 +170,8 @@ class Compiler
     /**
      * Removes whitespace from a PHP source string while preserving line numbers.
      *
-     * @param  string $source A PHP string
+     * @param string $source A PHP string
+     *
      * @return string The PHP string with the whitespace removed
      */
     private function stripWhitespace($source)

--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -78,8 +78,7 @@ class Composer
     private $autoloadGenerator;
 
     /**
-     * @param  Package\RootPackageInterface $package
-     * @return void
+     * @param Package\RootPackageInterface $package
      */
     public function setPackage(RootPackageInterface $package)
     {

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -54,7 +54,7 @@ class Config
             'type' => 'composer',
             'url' => 'https?://packagist.org',
             'allow_ssl_downgrade' => true,
-        )
+        ),
     );
 
     private $config;
@@ -65,7 +65,7 @@ class Config
     private $useEnvironment;
 
     /**
-     * @param boolean $useEnvironment Use COMPOSER_ environment variables to replace config settings
+     * @param bool $useEnvironment Use COMPOSER_ environment variables to replace config settings
      */
     public function __construct($useEnvironment = true, $baseDir = null)
     {
@@ -97,7 +97,7 @@ class Config
     }
 
     /**
-     * Merges new config values with the existing ones (overriding)
+     * Merges new config values with the existing ones (overriding).
      *
      * @param array $config
      */
@@ -150,11 +150,13 @@ class Config
     }
 
     /**
-     * Returns a setting
+     * Returns a setting.
      *
-     * @param  string            $key
-     * @param  int               $flags Options (see class constants)
+     * @param string $key
+     * @param int    $flags Options (see class constants)
+     *
      * @throws \RuntimeException
+     *
      * @return mixed
      */
     public function get($key, $flags = 0)
@@ -275,9 +277,10 @@ class Config
     }
 
     /**
-     * Checks whether a setting exists
+     * Checks whether a setting exists.
      *
-     * @param  string $key
+     * @param string $key
+     *
      * @return bool
      */
     public function has($key)
@@ -286,10 +289,11 @@ class Config
     }
 
     /**
-     * Replaces {$refs} inside a config string
+     * Replaces {$refs} inside a config string.
      *
-     * @param  string $value a config string that can contain {$refs-to-other-config}
-     * @param  int    $flags Options (see class constants)
+     * @param string $value a config string that can contain {$refs-to-other-config}
+     * @param int    $flags Options (see class constants)
+     *
      * @return string
      */
     private function process($value, $flags)
@@ -306,11 +310,12 @@ class Config
     }
 
     /**
-     * Turns relative paths in absolute paths without realpath()
+     * Turns relative paths in absolute paths without realpath().
      *
      * Since the dirs might not exist yet we can not call realpath or it will fail.
      *
-     * @param  string $path
+     * @param string $path
+     *
      * @return string
      */
     private function realpath($path)
@@ -323,13 +328,14 @@ class Config
     }
 
     /**
-     * Reads the value of a Composer environment variable
+     * Reads the value of a Composer environment variable.
      *
      * This should be used to read COMPOSER_ environment variables
      * that overload config values.
      *
-     * @param  string         $var
-     * @return string|boolean
+     * @param string $var
+     *
+     * @return string|bool
      */
     private function getComposerEnv($var)
     {

--- a/src/Composer/Config/ConfigSourceInterface.php
+++ b/src/Composer/Config/ConfigSourceInterface.php
@@ -13,7 +13,7 @@
 namespace Composer\Config;
 
 /**
- * Configuration Source Interface
+ * Configuration Source Interface.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Beau Simensen <beau@dflydev.com>
@@ -21,7 +21,7 @@ namespace Composer\Config;
 interface ConfigSourceInterface
 {
     /**
-     * Add a repository
+     * Add a repository.
      *
      * @param string $name   Name
      * @param array  $config Configuration
@@ -29,14 +29,14 @@ interface ConfigSourceInterface
     public function addRepository($name, $config);
 
     /**
-     * Remove a repository
+     * Remove a repository.
      *
      * @param string $name
      */
     public function removeRepository($name);
 
     /**
-     * Add a config setting
+     * Add a config setting.
      *
      * @param string $name  Name
      * @param string $value Value
@@ -44,14 +44,14 @@ interface ConfigSourceInterface
     public function addConfigSetting($name, $value);
 
     /**
-     * Remove a config setting
+     * Remove a config setting.
      *
      * @param string $name
      */
     public function removeConfigSetting($name);
 
     /**
-     * Add a package link
+     * Add a package link.
      *
      * @param string $type  Type (require, require-dev, provide, suggest, replace, conflict)
      * @param string $name  Name
@@ -60,7 +60,7 @@ interface ConfigSourceInterface
     public function addLink($type, $name, $value);
 
     /**
-     * Remove a package link
+     * Remove a package link.
      *
      * @param string $type Type (require, require-dev, provide, suggest, replace, conflict)
      * @param string $name Name
@@ -68,7 +68,7 @@ interface ConfigSourceInterface
     public function removeLink($type, $name);
 
     /**
-     * Gives a user-friendly name to this source (file path or so)
+     * Gives a user-friendly name to this source (file path or so).
      *
      * @return string
      */

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -16,7 +16,7 @@ use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
 
 /**
- * JSON Configuration Source
+ * JSON Configuration Source.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Beau Simensen <beau@dflydev.com>
@@ -34,7 +34,7 @@ class JsonConfigSource implements ConfigSourceInterface
     private $authConfig;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param JsonFile $file
      * @param bool     $authConfig
@@ -180,8 +180,9 @@ class JsonConfigSource implements ConfigSourceInterface
     /**
      * Prepend a reference to an element to the beginning of an array.
      *
-     * @param  array $array
-     * @param  mixed $value
+     * @param array $array
+     * @param mixed $value
+     *
      * @return array
      */
     private function arrayUnshiftRef(&$array, &$value)

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -29,7 +29,7 @@ use Composer\Json\JsonValidationException;
 use Composer\Util\ErrorHandler;
 
 /**
- * The console application that handles the commands
+ * The console application that handles the commands.
  *
  * @author Ryan Weaver <ryan@knplabs.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -158,8 +158,10 @@ class Application extends BaseApplication
     }
 
     /**
-     * @param  InputInterface    $input
+     * @param InputInterface $input
+     *
      * @return string
+     *
      * @throws \RuntimeException
      */
     private function getNewWorkingDir(InputInterface $input)
@@ -211,9 +213,11 @@ class Application extends BaseApplication
     }
 
     /**
-     * @param  bool                    $required
-     * @param  bool                    $disablePlugins
+     * @param bool $required
+     * @param bool $disablePlugins
+     *
      * @throws JsonValidationException
+     *
      * @return \Composer\Composer
      */
     public function getComposer($required = true, $disablePlugins = false)
@@ -237,7 +241,7 @@ class Application extends BaseApplication
     }
 
     /**
-     * Removes the cached composer instance
+     * Removes the cached composer instance.
      */
     public function resetComposer()
     {
@@ -258,7 +262,7 @@ class Application extends BaseApplication
     }
 
     /**
-     * Initializes all the composer commands
+     * Initializes all the composer commands.
      */
     protected function getDefaultCommands()
     {

--- a/src/Composer/Console/HtmlOutputFormatter.php
+++ b/src/Composer/Console/HtmlOutputFormatter.php
@@ -27,7 +27,7 @@ class HtmlOutputFormatter extends OutputFormatter
         34 => 'blue',
         35 => 'magenta',
         36 => 'cyan',
-        37 => 'white'
+        37 => 'white',
     );
     private static $availableBackgroundColors = array(
         40 => 'black',
@@ -37,7 +37,7 @@ class HtmlOutputFormatter extends OutputFormatter
         44 => 'blue',
         45 => 'magenta',
         46 => 'cyan',
-        47 => 'white'
+        47 => 'white',
     );
     private static $availableOptions = array(
         1 => 'bold',

--- a/src/Composer/DependencyResolver/DebugSolver.php
+++ b/src/Composer/DependencyResolver/DebugSolver.php
@@ -39,7 +39,7 @@ class DebugSolver extends Solver
     {
         echo "DecisionQueue: \n";
         foreach ($this->decisionQueue as $i => $literal) {
-            echo '    ' . $this->pool->literalToString($literal) . ' ' . $this->decisionQueueWhy[$i]." level ".$this->decisionMap[abs($literal)]."\n";
+            echo '    ' . $this->pool->literalToString($literal) . ' ' . $this->decisionQueueWhy[$i].' level '.$this->decisionMap[abs($literal)]."\n";
         }
         echo "\n";
     }
@@ -57,17 +57,17 @@ class DebugSolver extends Solver
                 echo $indent.$watch;
 
                 if ($watch) {
-                    echo ' [id='.$watch->getId().',watch1='.$this->literalFromId($watch->watch1).',watch2='.$this->literalFromId($watch->watch2)."]";
+                    echo ' [id='.$watch->getId().',watch1='.$this->literalFromId($watch->watch1).',watch2='.$this->literalFromId($watch->watch2).']';
                 }
 
                 echo "\n";
 
                 if ($watch && ($watch->next1 == $watch || $watch->next2 == $watch)) {
                     if ($watch->next1 == $watch) {
-                        echo $indent."    1 *RECURSION*";
+                        echo $indent.'    1 *RECURSION*';
                     }
                     if ($watch->next2 == $watch) {
-                        echo $indent."    2 *RECURSION*";
+                        echo $indent.'    2 *RECURSION*';
                     }
                 } elseif ($watch && ($watch->next1 || $watch->next2)) {
                     $indent = str_replace(array('1', '2'), ' ', $indent);

--- a/src/Composer/DependencyResolver/Decisions.php
+++ b/src/Composer/DependencyResolver/Decisions.php
@@ -13,7 +13,7 @@
 namespace Composer\DependencyResolver;
 
 /**
- * Stores decisions on installing, removing or keeping packages
+ * Stores decisions on installing, removing or keeping packages.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */
@@ -186,7 +186,7 @@ class Decisions implements \Iterator, \Countable
             $literalString = $this->pool->literalToString($literal);
             $package = $this->pool->literalToPackage($literal);
             throw new SolverBugException(
-                "Trying to decide $literalString on level $level, even though $package was previously decided as ".(int) $previousDecision."."
+                "Trying to decide $literalString on level $level, even though $package was previously decided as ".(int) $previousDecision.'.'
             );
         }
 

--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -177,8 +177,9 @@ class DefaultPolicy implements PolicyInterface
      * Replace constraints are ignored. This method should only be used for
      * prioritisation, not for actual constraint verification.
      *
-     * @param  PackageInterface $source
-     * @param  PackageInterface $target
+     * @param PackageInterface $source
+     * @param PackageInterface $target
+     *
      * @return bool
      */
     protected function replaces(PackageInterface $source, PackageInterface $target)
@@ -219,7 +220,7 @@ class DefaultPolicy implements PolicyInterface
     }
 
     /**
-     * Assumes that installed packages come first and then all highest priority packages
+     * Assumes that installed packages come first and then all highest priority packages.
      */
     protected function pruneToHighestPriorityOrInstalled(Pool $pool, array $installedMap, array $literals)
     {
@@ -250,7 +251,7 @@ class DefaultPolicy implements PolicyInterface
     }
 
     /**
-     * Assumes that locally aliased (in root package requires) packages take priority over branch-alias ones
+     * Assumes that locally aliased (in root package requires) packages take priority over branch-alias ones.
      *
      * If no package is a local alias, nothing happens
      */

--- a/src/Composer/DependencyResolver/Operation/OperationInterface.php
+++ b/src/Composer/DependencyResolver/Operation/OperationInterface.php
@@ -34,7 +34,7 @@ interface OperationInterface
     public function getReason();
 
     /**
-     * Serializes the operation in a human readable format
+     * Serializes the operation in a human readable format.
      *
      * @return string
      */

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -55,7 +55,7 @@ class Pool
 
     public function __construct($minimumStability = 'stable', array $stabilityFlags = array(), array $filterRequires = array())
     {
-        $this->versionParser = new VersionParser;
+        $this->versionParser = new VersionParser();
         $this->acceptableStabilities = array();
         foreach (BasePackage::$stabilities as $stability => $value) {
             if ($value <= BasePackage::$stabilities[$minimumStability]) {
@@ -78,7 +78,7 @@ class Pool
     }
 
     /**
-     * Adds a repository and its packages to this package pool
+     * Adds a repository and its packages to this package pool.
      *
      * @param RepositoryInterface $repo        A package repository
      * @param array               $rootAliases
@@ -143,32 +143,34 @@ class Pool
         $priority = array_search($repo, $this->repositories, true);
 
         if (false === $priority) {
-            throw new \RuntimeException("Could not determine repository priority. The repository was not registered in the pool.");
+            throw new \RuntimeException('Could not determine repository priority. The repository was not registered in the pool.');
         }
 
         return -$priority;
     }
 
     /**
-    * Retrieves the package object for a given package id.
-    *
-    * @param int $id
-    * @return PackageInterface
-    */
+     * Retrieves the package object for a given package id.
+     *
+     * @param int $id
+     *
+     * @return PackageInterface
+     */
     public function packageById($id)
     {
         return $this->packages[$id - 1];
     }
 
     /**
-     * Searches all packages providing the given package name and match the constraint
+     * Searches all packages providing the given package name and match the constraint.
      *
-     * @param  string                  $name          The package name to be searched for
-     * @param  LinkConstraintInterface $constraint    A constraint that all returned
-     *                                                packages must match or null to return all
-     * @param  bool                    $mustMatchName Whether the name of returned packages
-     *                                                must match the given name
-     * @return PackageInterface[]      A set of packages
+     * @param string                  $name          The package name to be searched for
+     * @param LinkConstraintInterface $constraint    A constraint that all returned
+     *                                               packages must match or null to return all
+     * @param bool                    $mustMatchName Whether the name of returned packages
+     *                                               must match the given name
+     *
+     * @return PackageInterface[] A set of packages
      */
     public function whatProvides($name, LinkConstraintInterface $constraint = null, $mustMatchName = false)
     {
@@ -307,12 +309,13 @@ class Pool
 
     /**
      * Checks if the package matches the given constraint directly or through
-     * provided or replaced packages
+     * provided or replaced packages.
      *
-     * @param  array|PackageInterface  $candidate
-     * @param  string                  $name       Name of the package to be matched
-     * @param  LinkConstraintInterface $constraint The constraint to verify
-     * @return int                     One of the MATCH* constants of this class or 0 if there is no match
+     * @param array|PackageInterface  $candidate
+     * @param string                  $name       Name of the package to be matched
+     * @param LinkConstraintInterface $constraint The constraint to verify
+     *
+     * @return int One of the MATCH* constants of this class or 0 if there is no match
      */
     private function match($candidate, $name, LinkConstraintInterface $constraint = null)
     {
@@ -324,7 +327,7 @@ class Pool
         if (!$isDev && !$isAlias && isset($this->filterRequires[$name])) {
             $requireFilter = $this->filterRequires[$name];
         } else {
-            $requireFilter = new EmptyConstraint;
+            $requireFilter = new EmptyConstraint();
         }
 
         if ($candidateName === $name) {

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -13,20 +13,22 @@
 namespace Composer\DependencyResolver;
 
 /**
- * Represents a problem detected while solving dependencies
+ * Represents a problem detected while solving dependencies.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */
 class Problem
 {
     /**
-     * A map containing the id of each rule part of this problem as a key
+     * A map containing the id of each rule part of this problem as a key.
+     *
      * @var array
      */
     protected $reasonSeen;
 
     /**
-     * A set of reasons for the problem, each is a rule or a job and a rule
+     * A set of reasons for the problem, each is a rule or a job and a rule.
+     *
      * @var array
      */
     protected $reasons = array();
@@ -41,7 +43,7 @@ class Problem
     }
 
     /**
-     * Add a rule as a reason
+     * Add a rule as a reason.
      *
      * @param Rule $rule A rule which is a reason for this problem
      */
@@ -54,7 +56,7 @@ class Problem
     }
 
     /**
-     * Retrieve all reasons for this problem
+     * Retrieve all reasons for this problem.
      *
      * @return array The problem's reasons
      */
@@ -64,9 +66,10 @@ class Problem
     }
 
     /**
-     * A human readable textual representation of the problem's reasons
+     * A human readable textual representation of the problem's reasons.
      *
-     * @param  array  $installedMap A map of all installed packages
+     * @param array $installedMap A map of all installed packages
+     *
      * @return string
      */
     public function getPrettyString(array $installedMap = array())
@@ -152,7 +155,7 @@ class Problem
     }
 
     /**
-     * Store a reason descriptor but ignore duplicates
+     * Store a reason descriptor but ignore duplicates.
      *
      * @param string $id     A canonical identifier for the reason
      * @param string $reason The reason descriptor
@@ -171,9 +174,10 @@ class Problem
     }
 
     /**
-     * Turns a job into a human readable description
+     * Turns a job into a human readable description.
      *
-     * @param  array  $job
+     * @param array $job
+     *
      * @return string
      */
     protected function jobToText($job)
@@ -216,9 +220,10 @@ class Problem
     }
 
     /**
-     * Turns a constraint into text usable in a sentence describing a job
+     * Turns a constraint into text usable in a sentence describing a job.
      *
-     * @param  \Composer\Package\LinkConstraint\LinkConstraintInterface $constraint
+     * @param \Composer\Package\LinkConstraint\LinkConstraintInterface $constraint
+     *
      * @return string
      */
     protected function constraintToText($constraint)

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -44,7 +44,7 @@ class Request
     }
 
     /**
-     * Mark an existing package as being installed and having to remain installed
+     * Mark an existing package as being installed and having to remain installed.
      *
      * These jobs will not be tempered with by the solver
      */
@@ -61,7 +61,7 @@ class Request
             'cmd' => $cmd,
             'packageName' => $packageName,
             'constraint' => $constraint,
-            'fixed' => $fixed
+            'fixed' => $fixed,
         );
     }
 

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -31,6 +31,7 @@ class Rule
 
     /**
      * READ-ONLY: The literals this rule consists of.
+     *
      * @var array
      */
     public $literals;
@@ -105,11 +106,12 @@ class Rule
     }
 
     /**
-     * Checks if this rule is equal to another one
+     * Checks if this rule is equal to another one.
      *
      * Ignores whether either of the rules is disabled.
      *
-     * @param  Rule $rule The rule to check against
+     * @param Rule $rule The rule to check against
+     *
      * @return bool Whether the rules are equal
      */
     public function equals(Rule $rule)
@@ -277,7 +279,7 @@ class Rule
     }
 
     /**
-     * Formats a rule as a string of the format (Literal1|Literal2|...)
+     * Formats a rule as a string of the format (Literal1|Literal2|...).
      *
      * @return string
      */

--- a/src/Composer/DependencyResolver/RuleSet.php
+++ b/src/Composer/DependencyResolver/RuleSet.php
@@ -23,7 +23,7 @@ class RuleSet implements \IteratorAggregate, \Countable
     const TYPE_LEARNED = 4;
 
     /**
-     * READ-ONLY: Lookup table for rule id to rule object
+     * READ-ONLY: Lookup table for rule id to rule object.
      *
      * @var Rule[]
      */
@@ -154,7 +154,7 @@ class RuleSet implements \IteratorAggregate, \Countable
     {
         $string = "\n";
         foreach ($this->rules as $type => $rules) {
-            $string .= str_pad(self::$types[$type], 8, ' ') . ": ";
+            $string .= str_pad(self::$types[$type], 8, ' ') . ': ';
             foreach ($rules as $rule) {
                 $string .= ($pool ? $rule->getPrettyString($pool) : $rule)."\n";
             }

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -36,18 +36,19 @@ class RuleSetGenerator
     }
 
     /**
-     * Creates a new rule for the requirements of a package
+     * Creates a new rule for the requirements of a package.
      *
      * This rule is of the form (-A|B|C), where B and C are the providers of
      * one requirement of the package A.
      *
-     * @param  PackageInterface $package    The package with a requirement
-     * @param  array            $providers  The providers of the requirement
-     * @param  int              $reason     A RULE_* constant describing the
-     *                                      reason for generating this rule
-     * @param  mixed            $reasonData Any data, e.g. the requirement name,
-     *                                      that goes with the reason
-     * @return Rule             The generated rule or null if tautological
+     * @param PackageInterface $package    The package with a requirement
+     * @param array            $providers  The providers of the requirement
+     * @param int              $reason     A RULE_* constant describing the
+     *                                     reason for generating this rule
+     * @param mixed            $reasonData Any data, e.g. the requirement name,
+     *                                     that goes with the reason
+     *
+     * @return Rule The generated rule or null if tautological
      */
     protected function createRequireRule(PackageInterface $package, array $providers, $reason, $reasonData = null)
     {
@@ -65,16 +66,17 @@ class RuleSetGenerator
     }
 
     /**
-     * Creates a rule to install at least one of a set of packages
+     * Creates a rule to install at least one of a set of packages.
      *
      * The rule is (A|B|C) with A, B and C different packages. If the given
      * set of packages is empty an impossible rule is generated.
      *
-     * @param  array $packages The set of packages to choose from
-     * @param  int   $reason   A RULE_* constant describing the reason for
-     *                         generating this rule
-     * @param  array $job      The job this rule was created from
-     * @return Rule  The generated rule
+     * @param array $packages The set of packages to choose from
+     * @param int   $reason   A RULE_* constant describing the reason for
+     *                        generating this rule
+     * @param array $job      The job this rule was created from
+     *
+     * @return Rule The generated rule
      */
     protected function createInstallOneOfRule(array $packages, $reason, $job)
     {
@@ -87,15 +89,16 @@ class RuleSetGenerator
     }
 
     /**
-     * Creates a rule to remove a package
+     * Creates a rule to remove a package.
      *
      * The rule for a package A is (-A).
      *
-     * @param  PackageInterface $package The package to be removed
-     * @param  int              $reason  A RULE_* constant describing the
-     *                                   reason for generating this rule
-     * @param  array            $job     The job this rule was created from
-     * @return Rule             The generated rule
+     * @param PackageInterface $package The package to be removed
+     * @param int              $reason  A RULE_* constant describing the
+     *                                  reason for generating this rule
+     * @param array            $job     The job this rule was created from
+     *
+     * @return Rule The generated rule
      */
     protected function createRemoveRule(PackageInterface $package, $reason, $job)
     {
@@ -103,18 +106,19 @@ class RuleSetGenerator
     }
 
     /**
-     * Creates a rule for two conflicting packages
+     * Creates a rule for two conflicting packages.
      *
      * The rule for conflicting packages A and B is (-A|-B). A is called the issuer
      * and B the provider.
      *
-     * @param  PackageInterface $issuer     The package declaring the conflict
-     * @param  PackageInterface $provider   The package causing the conflict
-     * @param  int              $reason     A RULE_* constant describing the
-     *                                      reason for generating this rule
-     * @param  mixed            $reasonData Any data, e.g. the package name, that
-     *                                      goes with the reason
-     * @return Rule             The generated rule
+     * @param PackageInterface $issuer     The package declaring the conflict
+     * @param PackageInterface $provider   The package causing the conflict
+     * @param int              $reason     A RULE_* constant describing the
+     *                                     reason for generating this rule
+     * @param mixed            $reasonData Any data, e.g. the package name, that
+     *                                     goes with the reason
+     *
+     * @return Rule The generated rule
      */
     protected function createConflictRule(PackageInterface $issuer, PackageInterface $provider, $reason, $reasonData = null)
     {
@@ -127,7 +131,7 @@ class RuleSetGenerator
     }
 
     /**
-     * Adds a rule unless it duplicates an existing one of any type
+     * Adds a rule unless it duplicates an existing one of any type.
      *
      * To be able to directly pass in the result of one of the rule creation
      * methods null is allowed which will not insert a rule.
@@ -146,7 +150,7 @@ class RuleSetGenerator
 
     protected function whitelistFromPackage(PackageInterface $package)
     {
-        $workQueue = new \SplQueue;
+        $workQueue = new \SplQueue();
         $workQueue->enqueue($package);
 
         while (!$workQueue->isEmpty()) {
@@ -181,7 +185,7 @@ class RuleSetGenerator
 
     protected function addRulesForPackage(PackageInterface $package, $ignorePlatformReqs)
     {
-        $workQueue = new \SplQueue;
+        $workQueue = new \SplQueue();
         $workQueue->enqueue($package);
 
         while (!$workQueue->isEmpty()) {
@@ -314,7 +318,7 @@ class RuleSetGenerator
     public function getRulesFor($jobs, $installedMap, $ignorePlatformReqs = false)
     {
         $this->jobs = $jobs;
-        $this->rules = new RuleSet;
+        $this->rules = new RuleSet();
         $this->installedMap = $installedMap;
 
         $this->whitelistedMap = array();

--- a/src/Composer/DependencyResolver/RuleWatchChain.php
+++ b/src/Composer/DependencyResolver/RuleWatchChain.php
@@ -13,7 +13,7 @@
 namespace Composer\DependencyResolver;
 
 /**
- * An extension of SplDoublyLinkedList with seek and removal of current element
+ * An extension of SplDoublyLinkedList with seek and removal of current element.
  *
  * SplDoublyLinkedList only allows deleting a particular offset and has no
  * method to set the internal iterator to a particular offset.
@@ -25,7 +25,7 @@ class RuleWatchChain extends \SplDoublyLinkedList
     protected $offset = 0;
 
     /**
-     * Moves the internal iterator to the specified offset
+     * Moves the internal iterator to the specified offset.
      *
      * @param int $offset The offset to seek to.
      */
@@ -36,7 +36,7 @@ class RuleWatchChain extends \SplDoublyLinkedList
     }
 
     /**
-     * Removes the current element from the list
+     * Removes the current element from the list.
      *
      * As SplDoublyLinkedList only allows deleting a particular offset and
      * incorrectly sets the internal iterator if you delete the current value

--- a/src/Composer/DependencyResolver/RuleWatchGraph.php
+++ b/src/Composer/DependencyResolver/RuleWatchGraph.php
@@ -13,7 +13,7 @@
 namespace Composer\DependencyResolver;
 
 /**
- * The RuleWatchGraph efficiently propagates decisions to other rules
+ * The RuleWatchGraph efficiently propagates decisions to other rules.
  *
  * All rules generated for solving a SAT problem should be inserted into the
  * graph. When a decision on a literal is made, the graph can be used to
@@ -27,7 +27,7 @@ class RuleWatchGraph
     protected $watchChains = array();
 
     /**
-     * Inserts a rule node into the appropriate chains within the graph
+     * Inserts a rule node into the appropriate chains within the graph.
      *
      * The node is prepended to the watch chains for each of the two literals it
      * watches.
@@ -46,7 +46,7 @@ class RuleWatchGraph
 
         foreach (array($node->watch1, $node->watch2) as $literal) {
             if (!isset($this->watchChains[$literal])) {
-                $this->watchChains[$literal] = new RuleWatchChain;
+                $this->watchChains[$literal] = new RuleWatchChain();
             }
 
             $this->watchChains[$literal]->unshift($node);
@@ -54,7 +54,7 @@ class RuleWatchGraph
     }
 
     /**
-     * Propagates a decision on a literal to all rules watching the literal
+     * Propagates a decision on a literal to all rules watching the literal.
      *
      * If a decision, e.g. +A has been made, then all rules containing -A, e.g.
      * (-A|+B|+C) now need to satisfy at least one of the other literals, so
@@ -69,11 +69,12 @@ class RuleWatchGraph
      * above example the rule was (-A|+B), then A turning true means that
      * B must now be decided true as well.
      *
-     * @param  int       $decidedLiteral The literal which was decided (A in our example)
-     * @param  int       $level          The level at which the decision took place and at which
-     *                                   all resulting decisions should be made.
-     * @param  Decisions $decisions      Used to check previous decisions and to
-     *                                   register decisions resulting from propagation
+     * @param int       $decidedLiteral The literal which was decided (A in our example)
+     * @param int       $level          The level at which the decision took place and at which
+     *                                  all resulting decisions should be made.
+     * @param Decisions $decisions      Used to check previous decisions and to
+     *                                  register decisions resulting from propagation
+     *
      * @return Rule|null If a conflict is found the conflicting rule is returned
      */
     public function propagateLiteral($decidedLiteral, $level, $decisions)
@@ -123,7 +124,7 @@ class RuleWatchGraph
     }
 
     /**
-     * Moves a rule node from one watch chain to another
+     * Moves a rule node from one watch chain to another.
      *
      * The rule node's watched literals are updated accordingly.
      *
@@ -134,7 +135,7 @@ class RuleWatchGraph
     protected function moveWatch($fromLiteral, $toLiteral, $node)
     {
         if (!isset($this->watchChains[$toLiteral])) {
-            $this->watchChains[$toLiteral] = new RuleWatchChain;
+            $this->watchChains[$toLiteral] = new RuleWatchChain();
         }
 
         $node->moveWatch($fromLiteral, $toLiteral);

--- a/src/Composer/DependencyResolver/RuleWatchNode.php
+++ b/src/Composer/DependencyResolver/RuleWatchNode.php
@@ -13,7 +13,7 @@
 namespace Composer\DependencyResolver;
 
 /**
- * Wrapper around a Rule which keeps track of the two literals it watches
+ * Wrapper around a Rule which keeps track of the two literals it watches.
  *
  * Used by RuleWatchGraph to store rules in two RuleWatchChains.
  *
@@ -42,7 +42,7 @@ class RuleWatchNode
     }
 
     /**
-     * Places the second watch on the rule's literal, decided at the highest level
+     * Places the second watch on the rule's literal, decided at the highest level.
      *
      * Useful for learned rules where the literal for the highest rule is most
      * likely to quickly lead to further decisions.
@@ -71,7 +71,7 @@ class RuleWatchNode
     }
 
     /**
-     * Returns the rule this node wraps
+     * Returns the rule this node wraps.
      *
      * @return Rule
      */
@@ -81,9 +81,10 @@ class RuleWatchNode
     }
 
     /**
-     * Given one watched literal, this method returns the other watched literal
+     * Given one watched literal, this method returns the other watched literal.
      *
      * @param int The watched literal that should not be returned
+     *
      * @return int A literal
      */
     public function getOtherWatch($literal)
@@ -96,7 +97,7 @@ class RuleWatchNode
     }
 
     /**
-     * Moves a watch from one literal to another
+     * Moves a watch from one literal to another.
      *
      * @param int $from The previously watched literal
      * @param int $to   The literal to be watched now

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -172,7 +172,7 @@ class Solver
         $this->rules = $this->ruleSetGenerator->getRulesFor($this->jobs, $this->installedMap, $ignorePlatformReqs);
         $this->checkForRootRequireProblems($ignorePlatformReqs);
         $this->decisions = new Decisions($this->pool);
-        $this->watchGraph = new RuleWatchGraph;
+        $this->watchGraph = new RuleWatchGraph();
 
         foreach ($this->rules as $rule) {
             $this->watchGraph->insert(new RuleWatchNode($rule));
@@ -212,7 +212,8 @@ class Solver
      * Evaluates each term affected by the decision (linked through watches)
      * If we find unit rules we make new decisions based on them
      *
-     * @param  integer   $level
+     * @param int $level
+     *
      * @return Rule|null A rule on conflict, otherwise null.
      */
     protected function propagate($level)
@@ -300,7 +301,7 @@ class Solver
 
             if ($newLevel <= 0 || $newLevel >= $level) {
                 throw new SolverBugException(
-                    "Trying to revert to invalid level ".(int) $newLevel." from level ".(int) $level."."
+                    'Trying to revert to invalid level '.(int) $newLevel.' from level '.(int) $level.'.'
                 );
             } elseif (!$newRule) {
                 throw new SolverBugException(

--- a/src/Composer/DependencyResolver/SolverProblemsException.php
+++ b/src/Composer/DependencyResolver/SolverProblemsException.php
@@ -32,7 +32,7 @@ class SolverProblemsException extends \RuntimeException
     {
         $text = "\n";
         foreach ($this->problems as $i => $problem) {
-            $text .= "  Problem ".($i+1).$problem->getPrettyString($this->installedMap)."\n";
+            $text .= '  Problem '.($i+1).$problem->getPrettyString($this->installedMap)."\n";
         }
 
         if (strpos($text, 'could not be found') || strpos($text, 'no matching package found')) {

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -16,7 +16,7 @@ use Composer\Package\PackageInterface;
 use Symfony\Component\Finder\Finder;
 
 /**
- * Base downloader for archives
+ * Base downloader for archives.
  *
  * @author Kirill chEbba Chebunin <iam@chebba.org>
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -125,7 +125,7 @@ abstract class ArchiveDownloader extends FileDownloader
     }
 
     /**
-     * Extract file to directory
+     * Extract file to directory.
      *
      * @param string $file Extracted file
      * @param string $path Directory
@@ -135,9 +135,10 @@ abstract class ArchiveDownloader extends FileDownloader
     abstract protected function extract($file, $path);
 
     /**
-     * Returns the folder content, excluding dotfiles
+     * Returns the folder content, excluding dotfiles.
      *
-     * @param  string         $dir Directory
+     * @param string $dir Directory
+     *
      * @return \SplFileInfo[]
      */
     private function getFolderContent($dir)

--- a/src/Composer/Downloader/ChangeReportInterface.php
+++ b/src/Composer/Downloader/ChangeReportInterface.php
@@ -22,11 +22,12 @@ use Composer\Package\PackageInterface;
 interface ChangeReportInterface
 {
     /**
-     * Checks for changes to the local copy
+     * Checks for changes to the local copy.
      *
-     * @param  PackageInterface $package package instance
-     * @param  string           $path    package directory
-     * @return string|null      changes or null
+     * @param PackageInterface $package package instance
+     * @param string           $path    package directory
+     *
+     * @return string|null changes or null
      */
     public function getLocalChanges(PackageInterface $package, $path);
 }

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -46,7 +46,8 @@ class DownloadManager
     /**
      * Makes downloader prefer source installation over the dist.
      *
-     * @param  bool            $preferSource prefer downloading from source
+     * @param bool $preferSource prefer downloading from source
+     *
      * @return DownloadManager
      */
     public function setPreferSource($preferSource)
@@ -59,7 +60,8 @@ class DownloadManager
     /**
      * Makes downloader prefer dist installation over the source.
      *
-     * @param  bool            $preferDist prefer downloading from dist
+     * @param bool $preferDist prefer downloading from dist
+     *
      * @return DownloadManager
      */
     public function setPreferDist($preferDist)
@@ -71,9 +73,10 @@ class DownloadManager
 
     /**
      * Sets whether to output download progress information for all registered
-     * downloaders
+     * downloaders.
      *
-     * @param  bool            $outputProgress
+     * @param bool $outputProgress
+     *
      * @return DownloadManager
      */
     public function setOutputProgress($outputProgress)
@@ -88,8 +91,9 @@ class DownloadManager
     /**
      * Sets installer downloader for a specific installation type.
      *
-     * @param  string              $type       installation type
-     * @param  DownloaderInterface $downloader downloader instance
+     * @param string              $type       installation type
+     * @param DownloaderInterface $downloader downloader instance
+     *
      * @return DownloadManager
      */
     public function setDownloader($type, DownloaderInterface $downloader)
@@ -103,7 +107,8 @@ class DownloadManager
     /**
      * Returns downloader for a specific installation type.
      *
-     * @param  string              $type installation type
+     * @param string $type installation type
+     *
      * @return DownloaderInterface
      *
      * @throws \InvalidArgumentException if downloader for provided type is not registered
@@ -121,7 +126,8 @@ class DownloadManager
     /**
      * Returns downloader for already installed package.
      *
-     * @param  PackageInterface         $package package instance
+     * @param PackageInterface $package package instance
+     *
      * @return DownloaderInterface|null
      *
      * @throws \InvalidArgumentException if package has no installation source specified

--- a/src/Composer/Downloader/DownloaderInterface.php
+++ b/src/Composer/Downloader/DownloaderInterface.php
@@ -55,9 +55,10 @@ interface DownloaderInterface
     public function remove(PackageInterface $package, $path);
 
     /**
-     * Sets whether to output download progress information or not
+     * Sets whether to output download progress information or not.
      *
-     * @param  bool                $outputProgress
+     * @param bool $outputProgress
+     *
      * @return DownloaderInterface
      */
     public function setOutputProgress($outputProgress);

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -24,7 +24,7 @@ use Composer\Util\Filesystem;
 use Composer\Util\RemoteFilesystem;
 
 /**
- * Base downloader for files
+ * Base downloader for files.
  *
  * @author Kirill chEbba Chebunin <iam@chebba.org>
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -81,7 +81,7 @@ class FileDownloader implements DownloaderInterface
             throw new \InvalidArgumentException('The given package is missing url information');
         }
 
-        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . VersionParser::formatVersion($package) . "</comment>)");
+        $this->io->writeError('  - Installing <info>' . $package->getName() . '</info> (<comment>' . VersionParser::formatVersion($package) . '</comment>)');
 
         $urls = $package->getDistUrls();
         while ($url = array_shift($urls)) {
@@ -138,7 +138,7 @@ class FileDownloader implements DownloaderInterface
                         break;
                     } catch (TransportException $e) {
                         // if we got an http response with a proper code, then requesting again will probably not help, abort
-                        if ((0 !== $e->getCode() && !in_array($e->getCode(),array(500, 502, 503, 504))) || !$retries) {
+                        if ((0 !== $e->getCode() && !in_array($e->getCode(), array(500, 502, 503, 504))) || !$retries) {
                             throw $e;
                         }
                         if ($this->io->isVerbose()) {
@@ -205,18 +205,19 @@ class FileDownloader implements DownloaderInterface
      */
     public function remove(PackageInterface $package, $path)
     {
-        $this->io->writeError("  - Removing <info>" . $package->getName() . "</info> (<comment>" . VersionParser::formatVersion($package) . "</comment>)");
+        $this->io->writeError('  - Removing <info>' . $package->getName() . '</info> (<comment>' . VersionParser::formatVersion($package) . '</comment>)');
         if (!$this->filesystem->removeDirectory($path)) {
             throw new \RuntimeException('Could not completely delete '.$path.', aborting.');
         }
     }
 
     /**
-     * Gets file name for specific package
+     * Gets file name for specific package.
      *
-     * @param  PackageInterface $package package instance
-     * @param  string           $path    download path
-     * @return string           file name
+     * @param PackageInterface $package package instance
+     * @param string           $path    download path
+     *
+     * @return string file name
      */
     protected function getFileName(PackageInterface $package, $path)
     {
@@ -224,11 +225,12 @@ class FileDownloader implements DownloaderInterface
     }
 
     /**
-     * Process the download url
+     * Process the download url.
      *
-     * @param  PackageInterface $package package the url is coming from
-     * @param  string           $url     download url
-     * @return string           url
+     * @param PackageInterface $package package the url is coming from
+     * @param string           $url     download url
+     *
+     * @return string url
      *
      * @throws \RuntimeException If any problem with the url
      */

--- a/src/Composer/Downloader/FilesystemException.php
+++ b/src/Composer/Downloader/FilesystemException.php
@@ -13,7 +13,7 @@
 namespace Composer\Downloader;
 
 /**
- * Exception thrown when issues exist on local filesystem
+ * Exception thrown when issues exist on local filesystem.
  *
  * @author Javier Spagnoletti <jspagnoletti@javierspagnoletti.com.ar>
  */

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -45,7 +45,7 @@ class GitDownloader extends VcsDownloader
         $ref = $package->getSourceReference();
         $flag = defined('PHP_WINDOWS_VERSION_MAJOR') ? '/D ' : '';
         $command = 'git clone --no-checkout %s %s && cd '.$flag.'%2$s && git remote add composer %1$s && git fetch composer';
-        $this->io->writeError("    Cloning ".$ref);
+        $this->io->writeError('    Cloning '.$ref);
 
         $commandCallable = function ($url) use ($ref, $path, $command) {
             return sprintf($command, ProcessExecutor::escape($url), ProcessExecutor::escape($path), ProcessExecutor::escape($ref));
@@ -78,11 +78,11 @@ class GitDownloader extends VcsDownloader
         }
 
         $ref = $target->getSourceReference();
-        $this->io->writeError("    Checking out ".$ref);
+        $this->io->writeError('    Checking out '.$ref);
         $command = 'git remote set-url composer %s && git fetch composer && git fetch --tags composer';
 
         $commandCallable = function ($url) use ($command) {
-            return sprintf($command, ProcessExecutor::escape ($url));
+            return sprintf($command, ProcessExecutor::escape($url));
         };
 
         $this->gitUtil->runCommand($commandCallable, $url, $path);
@@ -203,12 +203,13 @@ class GitDownloader extends VcsDownloader
     }
 
     /**
-     * Updates the given path to the given commit ref
+     * Updates the given path to the given commit ref.
      *
-     * @param  string      $path
-     * @param  string      $reference
-     * @param  string      $branch
-     * @param  \DateTime   $date
+     * @param string    $path
+     * @param string    $reference
+     * @param string    $branch
+     * @param \DateTime $date
+     *
      * @return null|string if a string is returned, it is the commit reference that was checked out if the original could not be found
      *
      * @throws \RuntimeException
@@ -298,6 +299,7 @@ class GitDownloader extends VcsDownloader
 
     /**
      * @param $path
+     *
      * @throws \RuntimeException
      */
     protected function discardChanges($path)
@@ -310,6 +312,7 @@ class GitDownloader extends VcsDownloader
 
     /**
      * @param $path
+     *
      * @throws \RuntimeException
      */
     protected function stashChanges($path)

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -27,7 +27,7 @@ class HgDownloader extends VcsDownloader
     {
         $url = ProcessExecutor::escape($url);
         $ref = ProcessExecutor::escape($package->getSourceReference());
-        $this->io->writeError("    Cloning ".$package->getSourceReference());
+        $this->io->writeError('    Cloning '.$package->getSourceReference());
         $command = sprintf('hg clone %s %s', $url, ProcessExecutor::escape($path));
         if (0 !== $this->process->execute($command, $ignoredOutput)) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
@@ -45,7 +45,7 @@ class HgDownloader extends VcsDownloader
     {
         $url = ProcessExecutor::escape($url);
         $ref = ProcessExecutor::escape($target->getSourceReference());
-        $this->io->writeError("    Updating to ".$target->getSourceReference());
+        $this->io->writeError('    Updating to '.$target->getSourceReference());
 
         if (!is_dir($path.'/.hg')) {
             throw new \RuntimeException('The .hg directory is missing from '.$path.', see http://getcomposer.org/commit-deps for more information');

--- a/src/Composer/Downloader/PearPackageExtractor.php
+++ b/src/Composer/Downloader/PearPackageExtractor.php
@@ -41,14 +41,14 @@ class PearPackageExtractor
     }
 
     /**
-     * Installs PEAR source files according to package.xml definitions and removes extracted files
+     * Installs PEAR source files according to package.xml definitions and removes extracted files.
      *
-     * @param  string                    $target target install location. all source installation would be performed relative to target path.
-     * @param  array                     $roles  types of files to install. default role for PEAR source files are 'php'.
-     * @param  array                     $vars   used for replacement tasks
+     * @param string $target target install location. all source installation would be performed relative to target path.
+     * @param array  $roles  types of files to install. default role for PEAR source files are 'php'.
+     * @param array  $vars   used for replacement tasks
+     *
      * @throws \RuntimeException
      * @throws \UnexpectedValueException
-     *
      */
     public function extractTo($target, array $roles = array('php' => '/', 'script' => '/bin'), $vars = array())
     {
@@ -71,7 +71,7 @@ class PearPackageExtractor
     }
 
     /**
-     * Perform copy actions on files
+     * Perform copy actions on files.
      *
      * @param array $files array of copy actions ('from', 'to') with relative paths
      * @param $source string path to source dir.
@@ -127,11 +127,13 @@ class PearPackageExtractor
     /**
      * Builds list of copy and list of remove actions that would transform extracted PEAR tarball into installed package.
      *
-     * @param  string            $source string path to extracted files
-     * @param  array             $roles  array [role => roleRoot] relative root for files having that role
-     * @param  array             $vars   list of values can be used for replacement tasks
-     * @return array             array of 'source' => 'target', where source is location of file in the tarball (relative to source
-     *                                  path, and target is destination of file (also relative to $source path)
+     * @param string $source string path to extracted files
+     * @param array  $roles  array [role => roleRoot] relative root for files having that role
+     * @param array  $vars   list of values can be used for replacement tasks
+     *
+     * @return array array of 'source' => 'target', where source is location of file in the tarball (relative to source
+     *               path, and target is destination of file (also relative to $source path)
+     *
      * @throws \RuntimeException
      */
     private function buildCopyActions($source, array $roles, $vars)

--- a/src/Composer/Downloader/PerforceDownloader.php
+++ b/src/Composer/Downloader/PerforceDownloader.php
@@ -43,7 +43,7 @@ class PerforceDownloader extends VcsDownloader
 
     private function getLabelFromSourceReference($ref)
     {
-        $pos = strpos($ref,'@');
+        $pos = strpos($ref, '@');
         if (false !== $pos) {
             return substr($ref, $pos + 1);
         }

--- a/src/Composer/Downloader/PharDownloader.php
+++ b/src/Composer/Downloader/PharDownloader.php
@@ -13,7 +13,7 @@
 namespace Composer\Downloader;
 
 /**
- * Downloader for phar files
+ * Downloader for phar files.
  *
  * @author Kirill chEbba Chebunin <iam@chebba.org>
  */

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -29,8 +29,8 @@ class SvnDownloader extends VcsDownloader
         SvnUtil::cleanEnv();
         $ref = $package->getSourceReference();
 
-        $this->io->writeError("    Checking out ".$package->getSourceReference());
-        $this->execute($url, "svn co", sprintf("%s/%s", $url, $ref), null, $path);
+        $this->io->writeError('    Checking out '.$package->getSourceReference());
+        $this->execute($url, 'svn co', sprintf('%s/%s', $url, $ref), null, $path);
     }
 
     /**
@@ -45,15 +45,15 @@ class SvnDownloader extends VcsDownloader
             throw new \RuntimeException('The .svn directory is missing from '.$path.', see http://getcomposer.org/commit-deps for more information');
         }
 
-        $flags = "";
+        $flags = '';
         if (0 === $this->process->execute('svn --version', $output)) {
             if (preg_match('{(\d+(?:\.\d+)+)}', $output, $match) && version_compare($match[1], '1.7.0', '>=')) {
                 $flags .= ' --ignore-ancestry';
             }
         }
 
-        $this->io->writeError("    Checking out " . $ref);
-        $this->execute($url, "svn switch" . $flags, sprintf("%s/%s", $url, $ref), $path);
+        $this->io->writeError('    Checking out ' . $ref);
+        $this->execute($url, 'svn switch' . $flags, sprintf('%s/%s', $url, $ref), $path);
     }
 
     /**
@@ -74,12 +74,14 @@ class SvnDownloader extends VcsDownloader
      * Execute an SVN command and try to fix up the process with credentials
      * if necessary.
      *
-     * @param  string            $baseUrl Base URL of the repository
-     * @param  string            $command SVN command to run
-     * @param  string            $url     SVN url
-     * @param  string            $cwd     Working directory
-     * @param  string            $path    Target for a checkout
+     * @param string $baseUrl Base URL of the repository
+     * @param string $command SVN command to run
+     * @param string $url     SVN url
+     * @param string $cwd     Working directory
+     * @param string $path    Target for a checkout
+     *
      * @throws \RuntimeException
+     *
      * @return string
      */
     protected function execute($baseUrl, $command, $url, $cwd = null, $path = null)
@@ -151,7 +153,7 @@ class SvnDownloader extends VcsDownloader
      */
     protected function getCommitLogs($fromReference, $toReference, $path)
     {
-        if (preg_match('{.*@(\d+)$}', $fromReference) && preg_match('{.*@(\d+)$}', $toReference) ) {
+        if (preg_match('{.*@(\d+)$}', $fromReference) && preg_match('{.*@(\d+)$}', $toReference)) {
             // strip paths from references and only keep the actual revision
             $fromRevision = preg_replace('{.*@(\d+)$}', '$1', $fromReference);
             $toRevision = preg_replace('{.*@(\d+)$}', '$1', $toReference);

--- a/src/Composer/Downloader/TarDownloader.php
+++ b/src/Composer/Downloader/TarDownloader.php
@@ -13,7 +13,7 @@
 namespace Composer\Downloader;
 
 /**
- * Downloader for tar files: tar, tar.gz or tar.bz2
+ * Downloader for tar files: tar, tar.gz or tar.bz2.
  *
  * @author Kirill chEbba Chebunin <iam@chebba.org>
  */

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -34,7 +34,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
         $this->io = $io;
         $this->config = $config;
         $this->process = $process ?: new ProcessExecutor($io);
-        $this->filesystem = $fs ?: new Filesystem;
+        $this->filesystem = $fs ?: new Filesystem();
     }
 
     /**
@@ -54,7 +54,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
             throw new \InvalidArgumentException('Package '.$package->getPrettyName().' is missing reference information');
         }
 
-        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . VersionParser::formatVersion($package) . "</comment>)");
+        $this->io->writeError('  - Installing <info>' . $package->getName() . '</info> (<comment>' . VersionParser::formatVersion($package) . '</comment>)');
         $this->filesystem->emptyDirectory($path);
 
         $urls = $package->getSourceUrls();
@@ -104,7 +104,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
             $to = VersionParser::formatVersion($target);
         }
 
-        $this->io->writeError("  - Updating <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>)");
+        $this->io->writeError('  - Updating <info>' . $name . '</info> (<comment>' . $from . '</comment> => <comment>' . $to . '</comment>)');
 
         $this->cleanChanges($initial, $path, true);
         $urls = $target->getSourceUrls();
@@ -159,7 +159,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
      */
     public function remove(PackageInterface $package, $path)
     {
-        $this->io->writeError("  - Removing <info>" . $package->getName() . "</info> (<comment>" . $package->getPrettyVersion() . "</comment>)");
+        $this->io->writeError('  - Removing <info>' . $package->getName() . '</info> (<comment>' . $package->getPrettyVersion() . '</comment>)');
         $this->cleanChanges($package, $path, false);
         if (!$this->filesystem->removeDirectory($path)) {
             throw new \RuntimeException('Could not completely delete '.$path.', aborting.');
@@ -176,12 +176,13 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     }
 
     /**
-     * Prompt the user to check if changes should be stashed/removed or the operation aborted
+     * Prompt the user to check if changes should be stashed/removed or the operation aborted.
      *
-     * @param  PackageInterface  $package
-     * @param  string            $path
-     * @param  bool              $update  if true (update) the changes can be stashed and reapplied after an update,
-     *                                    if false (remove) the changes should be assumed to be lost if the operation is not aborted
+     * @param PackageInterface $package
+     * @param string           $path
+     * @param bool             $update  if true (update) the changes can be stashed and reapplied after an update,
+     *                                  if false (remove) the changes should be assumed to be lost if the operation is not aborted
+     *
      * @throws \RuntimeException in case the operation must be aborted
      */
     protected function cleanChanges(PackageInterface $package, $path, $update)
@@ -193,9 +194,10 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     }
 
     /**
-     * Guarantee that no changes have been made to the local copy
+     * Guarantee that no changes have been made to the local copy.
      *
-     * @param  string            $path
+     * @param string $path
+     *
      * @throws \RuntimeException in case the operation must be aborted or the patch does not apply cleanly
      */
     protected function reapplyChanges($path)
@@ -222,11 +224,12 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     abstract protected function doUpdate(PackageInterface $initial, PackageInterface $target, $path, $url);
 
     /**
-     * Fetches the commit logs between two commits
+     * Fetches the commit logs between two commits.
      *
-     * @param  string $fromReference the source reference
-     * @param  string $toReference   the target reference
-     * @param  string $path          the package path
+     * @param string $fromReference the source reference
+     * @param string $toReference   the target reference
+     * @param string $path          the package path
+     *
      * @return string
      */
     abstract protected function getCommitLogs($fromReference, $toReference, $path);

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -77,7 +77,7 @@ class ZipDownloader extends ArchiveDownloader
         }
 
         if (true !== $zipArchive->extractTo($path)) {
-            throw new \RuntimeException("There was an error extracting the ZIP file. Corrupt file?");
+            throw new \RuntimeException('There was an error extracting the ZIP file. Corrupt file?');
         }
 
         $zipArchive->close();
@@ -86,8 +86,9 @@ class ZipDownloader extends ArchiveDownloader
     /**
      * Give a meaningful error message to the user.
      *
-     * @param  int    $retval
-     * @param  string $file
+     * @param int    $retval
+     * @param string $file
+     *
      * @return string
      */
     protected function getErrorMessage($retval, $file)
@@ -98,9 +99,9 @@ class ZipDownloader extends ArchiveDownloader
             case ZipArchive::ER_INCONS:
                 return sprintf("Zip archive '%s' is inconsistent.", $file);
             case ZipArchive::ER_INVAL:
-                return sprintf("Invalid argument (%s)", $file);
+                return sprintf('Invalid argument (%s)', $file);
             case ZipArchive::ER_MEMORY:
-                return sprintf("Malloc failure (%s)", $file);
+                return sprintf('Malloc failure (%s)', $file);
             case ZipArchive::ER_NOENT:
                 return sprintf("No such zip file: '%s'", $file);
             case ZipArchive::ER_NOZIP:
@@ -108,9 +109,9 @@ class ZipDownloader extends ArchiveDownloader
             case ZipArchive::ER_OPEN:
                 return sprintf("Can't open zip file: %s", $file);
             case ZipArchive::ER_READ:
-                return sprintf("Zip read error (%s)", $file);
+                return sprintf('Zip read error (%s)', $file);
             case ZipArchive::ER_SEEK:
-                return sprintf("Zip seek error (%s)", $file);
+                return sprintf('Zip seek error (%s)', $file);
             default:
                 return sprintf("'%s' is not a valid zip archive, got error code: %s", $file, $retval);
         }

--- a/src/Composer/EventDispatcher/Event.php
+++ b/src/Composer/EventDispatcher/Event.php
@@ -13,7 +13,7 @@
 namespace Composer\EventDispatcher;
 
 /**
- * The base event class
+ * The base event class.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */
@@ -35,7 +35,7 @@ class Event
     protected $flags;
 
     /**
-     * @var boolean Whether the event should not be passed to more listeners
+     * @var bool Whether the event should not be passed to more listeners
      */
     private $propagationStopped = false;
 
@@ -84,9 +84,9 @@ class Event
     }
 
     /**
-     * Checks if stopPropagation has been called
+     * Checks if stopPropagation has been called.
      *
-     * @return boolean Whether propagation has been stopped
+     * @return bool Whether propagation has been stopped
      */
     public function isPropagationStopped()
     {
@@ -94,7 +94,7 @@ class Event
     }
 
     /**
-     * Prevents the event from being passed to further listeners
+     * Prevents the event from being passed to further listeners.
      */
     public function stopPropagation()
     {

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -60,12 +60,13 @@ class EventDispatcher
     }
 
     /**
-     * Dispatch an event
+     * Dispatch an event.
      *
-     * @param  string $eventName An event name
-     * @param  Event  $event
-     * @return int    return code of the executed script if any, for php scripts a false return
-     *                          value is changed to 1, anything else to 0
+     * @param string $eventName An event name
+     * @param Event  $event
+     *
+     * @return int return code of the executed script if any, for php scripts a false return
+     *             value is changed to 1, anything else to 0
      */
     public function dispatch($eventName, Event $event = null)
     {
@@ -79,12 +80,13 @@ class EventDispatcher
     /**
      * Dispatch a script event.
      *
-     * @param  string $eventName      The constant in ScriptEvents
-     * @param  bool   $devMode
-     * @param  array  $additionalArgs Arguments passed by the user
-     * @param  array  $flags          Optional flags to pass data not as argument
-     * @return int    return code of the executed script if any, for php scripts a false return
-     *                               value is changed to 1, anything else to 0
+     * @param string $eventName      The constant in ScriptEvents
+     * @param bool   $devMode
+     * @param array  $additionalArgs Arguments passed by the user
+     * @param array  $flags          Optional flags to pass data not as argument
+     *
+     * @return int return code of the executed script if any, for php scripts a false return
+     *             value is changed to 1, anything else to 0
      */
     public function dispatchScript($eventName, $devMode = false, $additionalArgs = array(), $flags = array())
     {
@@ -133,10 +135,12 @@ class EventDispatcher
     /**
      * Triggers the listeners of an event.
      *
-     * @param  Event             $event          The event object to pass to the event handlers/listeners.
-     * @param  string            $additionalArgs
-     * @return int               return code of the executed script if any, for php scripts a false return
-     *                                          value is changed to 1, anything else to 0
+     * @param Event  $event          The event object to pass to the event handlers/listeners.
+     * @param string $additionalArgs
+     *
+     * @return int return code of the executed script if any, for php scripts a false return
+     *             value is changed to 1, anything else to 0
+     *
      * @throws \RuntimeException
      * @throws \Exception
      */
@@ -165,12 +169,12 @@ class EventDispatcher
                 try {
                     $return = false === $this->executeEventPhpScript($className, $methodName, $event) ? 1 : 0;
                 } catch (\Exception $e) {
-                    $message = "Script %s handling the %s event terminated with an exception";
+                    $message = 'Script %s handling the %s event terminated with an exception';
                     $this->io->writeError('<error>'.sprintf($message, $callable, $event->getName()).'</error>');
                     throw $e;
                 }
             } else {
-                $args = implode(' ', array_map(array('Composer\Util\ProcessExecutor','escape'), $event->getArguments()));
+                $args = implode(' ', array_map(array('Composer\Util\ProcessExecutor', 'escape'), $event->getArguments()));
                 if (0 !== ($exitCode = $this->process->execute($callable . ($args === '' ? '' : ' '.$args)))) {
                     $this->io->writeError(sprintf('<error>Script %s handling the %s event returned with an error</error>', $callable, $event->getName()));
 
@@ -201,6 +205,7 @@ class EventDispatcher
     /**
      * @param mixed $target
      * @param Event $event
+     *
      * @return Event|CommandEvent
      */
     protected function checkListenerExpectedEvent($target, Event $event)
@@ -243,11 +248,11 @@ class EventDispatcher
     }
 
     /**
-     * Add a listener for a particular event
+     * Add a listener for a particular event.
      *
      * @param string   $eventName The event name - typically a constant
      * @param Callable $listener  A callable expecting an event argument
-     * @param integer  $priority  A higher value represents a higher priority
+     * @param int      $priority  A higher value represents a higher priority
      */
     protected function addListener($eventName, $listener, $priority = 0)
     {
@@ -255,7 +260,7 @@ class EventDispatcher
     }
 
     /**
-     * Adds object methods as listeners for the events in getSubscribedEvents
+     * Adds object methods as listeners for the events in getSubscribedEvents.
      *
      * @see EventSubscriberInterface
      *
@@ -277,9 +282,10 @@ class EventDispatcher
     }
 
     /**
-     * Retrieves all listeners for a given event
+     * Retrieves all listeners for a given event.
      *
-     * @param  Event $event
+     * @param Event $event
+     *
      * @return array All listeners: callables and scripts
      */
     protected function getListeners(Event $event)
@@ -298,10 +304,11 @@ class EventDispatcher
     }
 
     /**
-     * Checks if an event has listeners registered
+     * Checks if an event has listeners registered.
      *
-     * @param  Event   $event
-     * @return boolean
+     * @param Event $event
+     *
+     * @return bool
      */
     public function hasEventListeners(Event $event)
     {
@@ -311,9 +318,10 @@ class EventDispatcher
     }
 
     /**
-     * Finds all listeners defined as scripts in the package
+     * Finds all listeners defined as scripts in the package.
      *
-     * @param  Event $event Event object
+     * @param Event $event Event object
+     *
      * @return array Listeners
      */
     protected function getScriptListeners(Event $event)
@@ -340,10 +348,11 @@ class EventDispatcher
     }
 
     /**
-     * Checks if string given references a class path and method
+     * Checks if string given references a class path and method.
      *
-     * @param  string  $callable
-     * @return boolean
+     * @param string $callable
+     *
+     * @return bool
      */
     protected function isPhpScript($callable)
     {

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -37,6 +37,7 @@ class Factory
 {
     /**
      * @return string
+     *
      * @throws \RuntimeException
      */
     protected static function getHomeDir()
@@ -84,7 +85,8 @@ class Factory
     }
 
     /**
-     * @param  IOInterface|null $io
+     * @param IOInterface|null $io
+     *
      * @return Config
      */
     public static function createConfig(IOInterface $io = null, $cwd = null)
@@ -159,7 +161,7 @@ class Factory
             if (!$io) {
                 throw new \InvalidArgumentException('This function requires either an IOInterface or a RepositoryManager');
             }
-            $factory = new static;
+            $factory = new static();
             $rm = $factory->createRepositoryManager($io, $config);
         }
 
@@ -184,15 +186,17 @@ class Factory
     }
 
     /**
-     * Creates a Composer instance
+     * Creates a Composer instance.
      *
-     * @param  IOInterface               $io             IO instance
-     * @param  array|string|null         $localConfig    either a configuration array or a filename to read from, if null it will
-     *                                                   read from the default filename
-     * @param  bool                      $disablePlugins Whether plugins should not be loaded
-     * @param  bool                      $fullLoad       Whether to initialize everything or only main project stuff (used when loading the global composer)
+     * @param IOInterface       $io             IO instance
+     * @param array|string|null $localConfig    either a configuration array or a filename to read from, if null it will
+     *                                          read from the default filename
+     * @param bool              $disablePlugins Whether plugins should not be loaded
+     * @param bool              $fullLoad       Whether to initialize everything or only main project stuff (used when loading the global composer)
+     *
      * @throws \InvalidArgumentException
      * @throws \UnexpectedValueException
+     *
      * @return Composer
      */
     public function createComposer(IOInterface $io, $localConfig = null, $disablePlugins = false, $cwd = null, $fullLoad = true)
@@ -266,7 +270,7 @@ class Factory
         $this->addLocalRepository($rm, $vendorDir);
 
         // load package
-        $parser = new VersionParser;
+        $parser = new VersionParser();
         $loader  = new Package\Loader\RootPackageLoader($rm, $config, $parser, new ProcessExecutor($io));
         $package = $loader->load($localConfig);
         $composer->setPackage($package);
@@ -306,7 +310,7 @@ class Factory
 
         // init locker if possible
         if ($fullLoad && isset($composerFile)) {
-            $lockFile = "json" === pathinfo($composerFile, PATHINFO_EXTENSION)
+            $lockFile = 'json' === pathinfo($composerFile, PATHINFO_EXTENSION)
                 ? substr($composerFile, 0, -4).'lock'
                 : $composerFile . '.lock';
             $locker = new Package\Locker($io, new JsonFile($lockFile, new RemoteFilesystem($io, $config)), $rm, $im, md5_file($composerFile));
@@ -317,9 +321,10 @@ class Factory
     }
 
     /**
-     * @param  IOInterface                  $io
-     * @param  Config                       $config
-     * @param  EventDispatcher              $eventDispatcher
+     * @param IOInterface     $io
+     * @param Config          $config
+     * @param EventDispatcher $eventDispatcher
+     *
      * @return Repository\RepositoryManager
      */
     protected function createRepositoryManager(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null)
@@ -348,7 +353,8 @@ class Factory
     }
 
     /**
-     * @param  Config        $config
+     * @param Config $config
+     *
      * @return Composer|null
      */
     protected function createGlobalComposer(IOInterface $io, Config $config, $disablePlugins)
@@ -370,9 +376,10 @@ class Factory
     }
 
     /**
-     * @param  IO\IOInterface             $io
-     * @param  Config                     $config
-     * @param  EventDispatcher            $eventDispatcher
+     * @param IO\IOInterface  $io
+     * @param Config          $config
+     * @param EventDispatcher $eventDispatcher
+     *
      * @return Downloader\DownloadManager
      */
     public function createDownloadManager(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null)
@@ -425,15 +432,16 @@ class Factory
         }
 
         $am = new Archiver\ArchiveManager($dm);
-        $am->addArchiver(new Archiver\PharArchiver);
+        $am->addArchiver(new Archiver\PharArchiver());
 
         return $am;
     }
 
     /**
-     * @param  IOInterface          $io
-     * @param  Composer             $composer
-     * @param  Composer             $globalComposer
+     * @param IOInterface $io
+     * @param Composer    $composer
+     * @param Composer    $globalComposer
+     *
      * @return Plugin\PluginManager
      */
     protected function createPluginManager(IOInterface $io, Composer $composer, Composer $globalComposer = null)
@@ -476,10 +484,11 @@ class Factory
     }
 
     /**
-     * @param  IOInterface $io             IO instance
-     * @param  mixed       $config         either a configuration array or a filename to read from, if null it will read from
-     *                                     the default filename
-     * @param  bool        $disablePlugins Whether plugins should not be loaded
+     * @param IOInterface $io             IO instance
+     * @param mixed       $config         either a configuration array or a filename to read from, if null it will read from
+     *                                    the default filename
+     * @param bool        $disablePlugins Whether plugins should not be loaded
+     *
      * @return Composer
      */
     public static function create(IOInterface $io, $config = null, $disablePlugins = false)

--- a/src/Composer/IO/BufferIO.php
+++ b/src/Composer/IO/BufferIO.php
@@ -23,8 +23,8 @@ use Symfony\Component\Console\Helper\HelperSet;
 class BufferIO extends ConsoleIO
 {
     /**
-     * @param string $input
-     * @param int $verbosity
+     * @param string                   $input
+     * @param int                      $verbosity
      * @param OutputFormatterInterface $formatter
      */
     public function __construct(

--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -110,8 +110,8 @@ class ConsoleIO extends BaseIO
 
     /**
      * @param array $messages
-     * @param boolean $newline
-     * @param boolean $stderr
+     * @param bool  $newline
+     * @param bool  $stderr
      */
     private function doWrite($messages, $newline, $stderr)
     {
@@ -125,12 +125,13 @@ class ConsoleIO extends BaseIO
 
         if (true === $stderr && $this->output instanceof ConsoleOutputInterface) {
             $this->output->getErrorOutput()->write($messages, $newline);
-            $this->lastMessageErr = join($newline ? "\n" : '', (array) $messages);
+            $this->lastMessageErr = implode($newline ? "\n" : '', (array) $messages);
+
             return;
         }
 
         $this->output->write($messages, $newline);
-        $this->lastMessage = join($newline ? "\n" : '', (array) $messages);
+        $this->lastMessage = implode($newline ? "\n" : '', (array) $messages);
     }
 
     /**
@@ -151,9 +152,9 @@ class ConsoleIO extends BaseIO
 
     /**
      * @param array $messages
-     * @param boolean $newline
-     * @param integer $size
-     * @param boolean $stderr
+     * @param bool  $newline
+     * @param int   $size
+     * @param bool  $stderr
      */
     private function doOverwrite($messages, $newline, $size, $stderr)
     {
@@ -164,7 +165,7 @@ class ConsoleIO extends BaseIO
         }
 
         // messages can be an array, let's convert it to string anyway
-        $messages = join($newline ? "\n" : '', (array) $messages);
+        $messages = implode($newline ? "\n" : '', (array) $messages);
 
         // since overwrite is supposed to overwrite last message...
         if (!isset($size)) {

--- a/src/Composer/IO/IOInterface.php
+++ b/src/Composer/IO/IOInterface.php
@@ -77,7 +77,7 @@ interface IOInterface
      *
      * @param string|array $messages The message as an array of lines or a single string
      * @param bool         $newline  Whether to add a newline or not
-     * @param integer      $size     The size of line
+     * @param int          $size     The size of line
      */
     public function overwrite($messages, $newline = true, $size = null);
 
@@ -86,7 +86,7 @@ interface IOInterface
      *
      * @param string|array $messages The message as an array of lines or a single string
      * @param bool         $newline  Whether to add a newline or not
-     * @param integer      $size     The size of line
+     * @param int          $size     The size of line
      */
     public function overwriteError($messages, $newline = true, $size = null);
 
@@ -123,7 +123,7 @@ interface IOInterface
      *
      * @param string|array $question  The question to ask
      * @param callback     $validator A PHP callback
-     * @param bool|integer $attempts  Max number of times to ask before giving up (false by default, which means infinite)
+     * @param bool|int     $attempts  Max number of times to ask before giving up (false by default, which means infinite)
      * @param string       $default   The default answer if none is given by the user
      *
      * @return mixed
@@ -153,7 +153,7 @@ interface IOInterface
      *
      * @param string $repositoryName The unique name of repository
      *
-     * @return boolean
+     * @return bool
      */
     public function hasAuthentication($repositoryName);
 
@@ -176,7 +176,7 @@ interface IOInterface
     public function setAuthentication($repositoryName, $username, $password = null);
 
     /**
-     * Loads authentications from a config instance
+     * Loads authentications from a config instance.
      *
      * @param Config $config
      */

--- a/src/Composer/IO/NullIO.php
+++ b/src/Composer/IO/NullIO.php
@@ -13,7 +13,7 @@
 namespace Composer\IO;
 
 /**
- * IOInterface that is not interactive and never writes the output
+ * IOInterface that is not interactive and never writes the output.
  *
  * @author Christophe Coevoet <stof@notk.org>
  */

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -111,7 +111,7 @@ class Installer
     protected $preferStable = false;
     protected $preferLowest = false;
     /**
-     * Array of package names/globs flagged for update
+     * Array of package names/globs flagged for update.
      *
      * @var array|null
      */
@@ -129,7 +129,7 @@ class Installer
     protected $additionalInstalledRepository;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param IOInterface          $io
      * @param Config               $config
@@ -155,7 +155,7 @@ class Installer
     }
 
     /**
-     * Run installation (or update)
+     * Run installation (or update).
      *
      * @return int 0 on success or a positive error code on failure
      *
@@ -169,7 +169,7 @@ class Installer
         if ($this->dryRun) {
             $this->verbose = true;
             $this->runScripts = false;
-            $this->installationManager->addInstaller(new NoopInstaller);
+            $this->installationManager->addInstaller(new NoopInstaller());
             $this->mockLocalRepositories($this->repositoryManager);
         }
 
@@ -259,7 +259,7 @@ class Installer
 
             $this->io->writeError(
                 sprintf(
-                    "<error>Package %s is abandoned, you should avoid using it. %s.</error>",
+                    '<error>Package %s is abandoned, you should avoid using it. %s.</error>',
                     $package->getPrettyName(),
                     $replacement
                 )
@@ -617,7 +617,8 @@ class Installer
      * it at least fixes the symptoms and makes usage of composer possible (again)
      * in such scenarios.
      *
-     * @param  OperationInterface[] $operations
+     * @param OperationInterface[] $operations
+     *
      * @return OperationInterface[] reordered operation list
      */
     private function movePluginsToFront(array $operations)
@@ -653,9 +654,10 @@ class Installer
 
     /**
      * Removals of packages should be executed before installations in
-     * case two packages resolve to the same path (due to custom installers)
+     * case two packages resolve to the same path (due to custom installers).
      *
-     * @param  OperationInterface[] $operations
+     * @param OperationInterface[] $operations
+     *
      * @return OperationInterface[] reordered operation list
      */
     private function moveUninstallsToFront(array $operations)
@@ -881,7 +883,7 @@ class Installer
         foreach ($aliases as $alias) {
             $normalizedAliases[$alias['package']][$alias['version']] = array(
                 'alias' => $alias['alias'],
-                'alias_normalized' => $alias['alias_normalized']
+                'alias_normalized' => $alias['alias_normalized'],
             );
         }
 
@@ -919,16 +921,17 @@ class Installer
     }
 
     /**
-     * Build a regexp from a package name, expanding * globs as required
+     * Build a regexp from a package name, expanding * globs as required.
      *
-     * @param  string $whiteListedPattern
+     * @param string $whiteListedPattern
+     *
      * @return string
      */
     private function packageNameToRegexp($whiteListedPattern)
     {
         $cleanedWhiteListedPattern = str_replace('\\*', '.*', preg_quote($whiteListedPattern));
 
-        return "{^" . $cleanedWhiteListedPattern . "$}i";
+        return '{^' . $cleanedWhiteListedPattern . '$}i';
     }
 
     private function extractPlatformRequirements($links)
@@ -951,7 +954,7 @@ class Installer
      * update whitelist themselves.
      *
      * @param RepositoryInterface $localRepo
-     * @param boolean             $devMode
+     * @param bool                $devMode
      * @param array               $rootRequires    An array of links to packages in require of the root package
      * @param array               $rootDevRequires An array of links to packages in require-dev of the root package
      */
@@ -975,7 +978,7 @@ class Installer
             $skipPackages[$require->getTarget()] = true;
         }
 
-        $pool = new Pool;
+        $pool = new Pool();
         $pool->addRepository($localRepo);
 
         $seen = array();
@@ -983,7 +986,7 @@ class Installer
         $rootRequiredPackageNames = array_keys($rootRequires);
 
         foreach ($this->updateWhitelist as $packageName => $void) {
-            $packageQueue = new \SplQueue;
+            $packageQueue = new \SplQueue();
 
             $depPackages = $pool->whatProvides($packageName);
 
@@ -1038,7 +1041,7 @@ class Installer
     }
 
     /**
-     * Replace local repositories with InstalledArrayRepository instances
+     * Replace local repositories with InstalledArrayRepository instances.
      *
      * This is to prevent any accidental modification of the existing repos on disk
      *
@@ -1062,10 +1065,11 @@ class Installer
     }
 
     /**
-     * Create Installer
+     * Create Installer.
      *
-     * @param  IOInterface $io
-     * @param  Composer    $composer
+     * @param IOInterface $io
+     * @param Composer    $composer
+     *
      * @return Installer
      */
     public static function create(IOInterface $io, Composer $composer)
@@ -1091,9 +1095,10 @@ class Installer
     }
 
     /**
-     * Whether to run in drymode or not
+     * Whether to run in drymode or not.
      *
-     * @param  boolean   $dryRun
+     * @param bool $dryRun
+     *
      * @return Installer
      */
     public function setDryRun($dryRun = true)
@@ -1114,9 +1119,10 @@ class Installer
     }
 
     /**
-     * prefer source installation
+     * prefer source installation.
      *
-     * @param  boolean   $preferSource
+     * @param bool $preferSource
+     *
      * @return Installer
      */
     public function setPreferSource($preferSource = true)
@@ -1127,9 +1133,10 @@ class Installer
     }
 
     /**
-     * prefer dist installation
+     * prefer dist installation.
      *
-     * @param  boolean   $preferDist
+     * @param bool $preferDist
+     *
      * @return Installer
      */
     public function setPreferDist($preferDist = true)
@@ -1140,9 +1147,10 @@ class Installer
     }
 
     /**
-     * Whether or not generated autoloader are optimized
+     * Whether or not generated autoloader are optimized.
      *
-     * @param  bool      $optimizeAutoloader
+     * @param bool $optimizeAutoloader
+     *
      * @return Installer
      */
     public function setOptimizeAutoloader($optimizeAutoloader = false)
@@ -1153,9 +1161,10 @@ class Installer
     }
 
     /**
-     * update packages
+     * update packages.
      *
-     * @param  boolean   $update
+     * @param bool $update
+     *
      * @return Installer
      */
     public function setUpdate($update = true)
@@ -1166,9 +1175,10 @@ class Installer
     }
 
     /**
-     * enables dev packages
+     * enables dev packages.
      *
-     * @param  boolean   $devMode
+     * @param bool $devMode
+     *
      * @return Installer
      */
     public function setDevMode($devMode = true)
@@ -1179,9 +1189,10 @@ class Installer
     }
 
     /**
-     * set whether to run autoloader or not
+     * set whether to run autoloader or not.
      *
-     * @param boolean $dumpAutoloader
+     * @param bool $dumpAutoloader
+     *
      * @return Installer
      */
     public function setDumpAutoloader($dumpAutoloader = true)
@@ -1192,9 +1203,10 @@ class Installer
     }
 
     /**
-     * set whether to run scripts or not
+     * set whether to run scripts or not.
      *
-     * @param  boolean   $runScripts
+     * @param bool $runScripts
+     *
      * @return Installer
      */
     public function setRunScripts($runScripts = true)
@@ -1205,9 +1217,10 @@ class Installer
     }
 
     /**
-     * set the config instance
+     * set the config instance.
      *
-     * @param  Config    $config
+     * @param Config $config
+     *
      * @return Installer
      */
     public function setConfig(Config $config)
@@ -1218,9 +1231,10 @@ class Installer
     }
 
     /**
-     * run in verbose mode
+     * run in verbose mode.
      *
-     * @param  boolean   $verbose
+     * @param bool $verbose
+     *
      * @return Installer
      */
     public function setVerbose($verbose = true)
@@ -1241,9 +1255,10 @@ class Installer
     }
 
     /**
-     * set ignore Platform Package requirements
+     * set ignore Platform Package requirements.
      *
-     * @param  boolean   $ignorePlatformReqs
+     * @param bool $ignorePlatformReqs
+     *
      * @return Installer
      */
     public function setIgnorePlatformRequirements($ignorePlatformReqs = false)
@@ -1255,9 +1270,10 @@ class Installer
 
     /**
      * restrict the update operation to a few packages, all other packages
-     * that are already installed will be kept at their current version
+     * that are already installed will be kept at their current version.
      *
-     * @param  array     $packages
+     * @param array $packages
+     *
      * @return Installer
      */
     public function setUpdateWhitelist(array $packages)
@@ -1270,7 +1286,8 @@ class Installer
     /**
      * Should dependencies of whitelisted packages be updated recursively?
      *
-     * @param  boolean   $updateDependencies
+     * @param bool $updateDependencies
+     *
      * @return Installer
      */
     public function setWhitelistDependencies($updateDependencies = true)
@@ -1283,7 +1300,8 @@ class Installer
     /**
      * Should packages be prefered in a stable version when updating?
      *
-     * @param  boolean   $preferStable
+     * @param bool $preferStable
+     *
      * @return Installer
      */
     public function setPreferStable($preferStable = true)
@@ -1296,7 +1314,8 @@ class Installer
     /**
      * Should packages be prefered in a lowest version when updating?
      *
-     * @param  boolean   $preferLowest
+     * @param bool $preferLowest
+     *
      * @return Installer
      */
     public function setPreferLowest($preferLowest = true)

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -43,7 +43,7 @@ class InstallationManager
     }
 
     /**
-     * Adds installer
+     * Adds installer.
      *
      * @param InstallerInterface $installer installer instance
      */
@@ -54,7 +54,7 @@ class InstallationManager
     }
 
     /**
-     * Removes installer
+     * Removes installer.
      *
      * @param InstallerInterface $installer installer instance
      */
@@ -219,10 +219,11 @@ class InstallationManager
     }
 
     /**
-     * Returns the installation path of a package
+     * Returns the installation path of a package.
      *
-     * @param  PackageInterface $package
-     * @return string           path
+     * @param PackageInterface $package
+     *
+     * @return string path
      */
     public function getInstallPath(PackageInterface $package)
     {
@@ -243,13 +244,13 @@ class InstallationManager
                         'version' => $package->getPrettyVersion(),
                         'version_normalized' => $package->getVersion(),
                     );
-                    $opts = array('http' =>
-                        array(
+                    $opts = array(
+                        'http' => array(
                             'method'  => 'POST',
                             'header'  => array('Content-type: application/x-www-form-urlencoded'),
                             'content' => http_build_query($params, '', '&'),
                             'timeout' => 3,
-                        )
+                        ),
                     );
 
                     $context = StreamContextFactory::getContext($url, $opts);
@@ -267,13 +268,13 @@ class InstallationManager
                 );
             }
 
-            $opts = array('http' =>
-                array(
+            $opts = array(
+                'http' => array(
                     'method'  => 'POST',
                     'header'  => array('Content-Type: application/json'),
                     'content' => json_encode($postData),
                     'timeout' => 6,
-                )
+                ),
             );
 
             $context = StreamContextFactory::getContext($repoUrl, $opts);

--- a/src/Composer/Installer/InstallerInterface.php
+++ b/src/Composer/Installer/InstallerInterface.php
@@ -24,9 +24,10 @@ use Composer\Repository\InstalledRepositoryInterface;
 interface InstallerInterface
 {
     /**
-     * Decides if the installer supports the given type
+     * Decides if the installer supports the given type.
      *
-     * @param  string $packageType
+     * @param string $packageType
+     *
      * @return bool
      */
     public function supports($packageType);
@@ -69,10 +70,11 @@ interface InstallerInterface
     public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package);
 
     /**
-     * Returns the installation path of a package
+     * Returns the installation path of a package.
      *
-     * @param  PackageInterface $package
-     * @return string           path
+     * @param PackageInterface $package
+     *
+     * @return string path
      */
     public function getInstallPath(PackageInterface $package);
 }

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -297,7 +297,7 @@ class LibraryInstaller implements InstallerInterface
         }
 
         return "@ECHO OFF\r\n".
-            "SET BIN_TARGET=%~dp0/".trim(ProcessExecutor::escape($binPath), '"')."\r\n".
+            'SET BIN_TARGET=%~dp0/'.trim(ProcessExecutor::escape($binPath), '"')."\r\n".
             "{$caller} \"%BIN_TARGET%\" %*\r\n";
     }
 

--- a/src/Composer/Installer/NoopInstaller.php
+++ b/src/Composer/Installer/NoopInstaller.php
@@ -16,7 +16,7 @@ use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Package\PackageInterface;
 
 /**
- * Does not install anything but marks packages installed in the repo
+ * Does not install anything but marks packages installed in the repo.
  *
  * Useful for dry runs
  *

--- a/src/Composer/Installer/PearInstaller.php
+++ b/src/Composer/Installer/PearInstaller.php
@@ -125,7 +125,7 @@ class PearInstaller extends LibraryInstaller
                     "pushd .\r\n".
                     "cd %~dp0\r\n".
                     "set PHP_PROXY=%CD%\\composer-php.bat\r\n".
-                    "cd ".ProcessExecutor::escape(dirname($binPath))."\r\n".
+                    'cd '.ProcessExecutor::escape(dirname($binPath))."\r\n".
                     "set BIN_TARGET=%CD%\\".basename($binPath)."\r\n".
                     "popd\r\n".
                     "%PHP_PROXY% \"%BIN_TARGET%\" %*\r\n";
@@ -135,7 +135,7 @@ class PearInstaller extends LibraryInstaller
         return "@echo off\r\n".
             "pushd .\r\n".
             "cd %~dp0\r\n".
-            "cd ".ProcessExecutor::escape(dirname($binPath))."\r\n".
+            'cd '.ProcessExecutor::escape(dirname($binPath))."\r\n".
             "set BIN_TARGET=%CD%\\".basename($binPath)."\r\n".
             "popd\r\n".
             $caller." \"%BIN_TARGET%\" %*\r\n";

--- a/src/Composer/Installer/PluginInstaller.php
+++ b/src/Composer/Installer/PluginInstaller.php
@@ -13,13 +13,12 @@
 namespace Composer\Installer;
 
 use Composer\Composer;
-use Composer\Package\Package;
 use Composer\IO\IOInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Package\PackageInterface;
 
 /**
- * Installer for plugin packages
+ * Installer for plugin packages.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Nils Adermann <naderman@naderman.de>

--- a/src/Composer/Installer/ProjectInstaller.php
+++ b/src/Composer/Installer/ProjectInstaller.php
@@ -33,13 +33,14 @@ class ProjectInstaller implements InstallerInterface
     {
         $this->installPath = rtrim(strtr($installPath, '\\', '/'), '/').'/';
         $this->downloadManager = $dm;
-        $this->filesystem = new Filesystem;
+        $this->filesystem = new Filesystem();
     }
 
     /**
-     * Decides if the installer supports the given type
+     * Decides if the installer supports the given type.
      *
-     * @param  string $packageType
+     * @param string $packageType
+     *
      * @return bool
      */
     public function supports($packageType)
@@ -75,7 +76,7 @@ class ProjectInstaller implements InstallerInterface
      */
     public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
     {
-        throw new \InvalidArgumentException("not supported");
+        throw new \InvalidArgumentException('not supported');
     }
 
     /**
@@ -83,14 +84,15 @@ class ProjectInstaller implements InstallerInterface
      */
     public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
-        throw new \InvalidArgumentException("not supported");
+        throw new \InvalidArgumentException('not supported');
     }
 
     /**
-     * Returns the installation path of a package
+     * Returns the installation path of a package.
      *
-     * @param  PackageInterface $package
-     * @return string           path
+     * @param PackageInterface $package
+     *
+     * @return string path
      */
     public function getInstallPath(PackageInterface $package)
     {

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -39,8 +39,9 @@ class JsonFile
     /**
      * Initializes json file reader/parser.
      *
-     * @param  string                    $path path to a lockfile
-     * @param  RemoteFilesystem          $rfs  required for loading http/https json files
+     * @param string           $path path to a lockfile
+     * @param RemoteFilesystem $rfs  required for loading http/https json files
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct($path, RemoteFilesystem $rfs = null)
@@ -75,6 +76,7 @@ class JsonFile
      * Reads json file.
      *
      * @throws \RuntimeException
+     *
      * @return mixed
      */
     public function read()
@@ -97,8 +99,9 @@ class JsonFile
     /**
      * Writes json file.
      *
-     * @param  array                     $hash    writes hash into json file
-     * @param  int                       $options json_encode options (defaults to JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+     * @param array $hash    writes hash into json file
+     * @param int   $options json_encode options (defaults to JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+     *
      * @throws \UnexpectedValueException
      */
     public function write(array $hash, $options = 448)
@@ -134,10 +137,12 @@ class JsonFile
     }
 
     /**
-     * Validates the schema of the current json file according to composer-schema.json rules
+     * Validates the schema of the current json file according to composer-schema.json rules.
      *
-     * @param  int                     $schema a JsonFile::*_SCHEMA constant
-     * @return bool                    true on success
+     * @param int $schema a JsonFile::*_SCHEMA constant
+     *
+     * @return bool true on success
+     *
      * @throws JsonValidationException
      */
     public function validateSchema($schema = self::STRICT_SCHEMA)
@@ -174,10 +179,11 @@ class JsonFile
     }
 
     /**
-     * Encodes an array into (optionally pretty-printed) JSON
+     * Encodes an array into (optionally pretty-printed) JSON.
      *
-     * @param  mixed  $data    Data to encode into a formatted JSON string
-     * @param  int    $options json_encode options (defaults to JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+     * @param mixed $data    Data to encode into a formatted JSON string
+     * @param int   $options json_encode options (defaults to JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+     *
      * @return string Encoded json
      */
     public static function encode($data, $options = 448)
@@ -216,9 +222,10 @@ class JsonFile
     }
 
     /**
-     * Throws an exception according to a given code with a customized message
+     * Throws an exception according to a given code with a customized message.
      *
      * @param int $code return code of json_last_error function
+     *
      * @throws \RuntimeException
      */
     private static function throwEncodeError($code)
@@ -265,11 +272,13 @@ class JsonFile
     }
 
     /**
-     * Validates the syntax of a JSON string
+     * Validates the syntax of a JSON string.
      *
-     * @param  string                    $json
-     * @param  string                    $file
-     * @return bool                      true on success
+     * @param string $json
+     * @param string $file
+     *
+     * @return bool true on success
+     *
      * @throws \UnexpectedValueException
      * @throws JsonValidationException
      * @throws ParsingException

--- a/src/Composer/Json/JsonFormatter.php
+++ b/src/Composer/Json/JsonFormatter.php
@@ -15,7 +15,7 @@ namespace Composer\Json;
 /**
  * Formats json strings used for php < 5.4 because the json_encode doesn't
  * supports the flags JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE
- * in these versions
+ * in these versions.
  *
  * @author Konstantin Kudryashiv <ever.zet@gmail.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -23,16 +23,16 @@ namespace Composer\Json;
 class JsonFormatter
 {
     /**
-     *
      * This code is based on the function found at:
-     *  http://recursive-design.com/blog/2008/03/11/format-json-with-php/
+     *  http://recursive-design.com/blog/2008/03/11/format-json-with-php/.
      *
      * Originally licensed under MIT by Dave Perrett <mail@recursive-design.com>
      *
      *
-     * @param  string $json
-     * @param  bool   $unescapeUnicode Un escape unicode
-     * @param  bool   $unescapeSlashes Un escape slashes
+     * @param string $json
+     * @param bool   $unescapeUnicode Un escape unicode
+     * @param bool   $unescapeSlashes Un escape slashes
+     *
      * @return string
      */
     public static function format($json, $unescapeUnicode, $unescapeSlashes)

--- a/src/Composer/Package/AliasPackage.php
+++ b/src/Composer/Package/AliasPackage.php
@@ -35,7 +35,7 @@ class AliasPackage extends BasePackage implements CompletePackageInterface
     protected $suggests;
 
     /**
-     * All descendants' constructors should call this parent constructor
+     * All descendants' constructors should call this parent constructor.
      *
      * @param PackageInterface $aliasOf       The package this package is an alias of
      * @param string           $version       The version the alias must report
@@ -155,7 +155,7 @@ class AliasPackage extends BasePackage implements CompletePackageInterface
     }
 
     /**
-     * Stores whether this is an alias created by an aliasing in the requirements of the root package or not
+     * Stores whether this is an alias created by an aliasing in the requirements of the root package or not.
      *
      * Use by the policy for sorting manually aliased packages first, see #576
      *
@@ -170,6 +170,7 @@ class AliasPackage extends BasePackage implements CompletePackageInterface
 
     /**
      * @see setRootPackageAlias
+     *
      * @return bool
      */
     public function isRootPackageAlias()

--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -13,11 +13,10 @@
 namespace Composer\Package\Archiver;
 
 use Composer\Util\Filesystem;
-
 use Symfony\Component\Finder;
 
 /**
- * A Symfony Finder wrapper which locates files that should go into archives
+ * A Symfony Finder wrapper which locates files that should go into archives.
  *
  * Handles .gitignore, .gitattributes and .hgignore files as well as composer's
  * own exclude rules from composer.json
@@ -32,7 +31,7 @@ class ArchivableFilesFinder extends \FilterIterator
     protected $finder;
 
     /**
-     * Initializes the internal Symfony Finder with appropriate filters
+     * Initializes the internal Symfony Finder with appropriate filters.
      *
      * @param string $sources  Path to source files to be archived
      * @param array  $excludes Composer's own exclude rules from composer.json

--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -50,7 +50,7 @@ class ArchiveManager
     }
 
     /**
-     * Set whether existing archives should be overwritten
+     * Set whether existing archives should be overwritten.
      *
      * @param bool $overwriteFiles New setting
      *
@@ -94,12 +94,14 @@ class ArchiveManager
     /**
      * Create an archive of the specified package.
      *
-     * @param  PackageInterface          $package   The package to archive
-     * @param  string                    $format    The format of the archive (zip, tar, ...)
-     * @param  string                    $targetDir The diretory where to build the archive
+     * @param PackageInterface $package   The package to archive
+     * @param string           $format    The format of the archive (zip, tar, ...)
+     * @param string           $targetDir The diretory where to build the archive
+     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
-     * @return string                    The path of the created archive
+     *
+     * @return string The path of the created archive
      */
     public function archive(PackageInterface $package, $format, $targetDir)
     {

--- a/src/Composer/Package/Archiver/ArchiverInterface.php
+++ b/src/Composer/Package/Archiver/ArchiverInterface.php
@@ -37,7 +37,7 @@ interface ArchiverInterface
      * @param string $format     The archive format
      * @param string $sourceType The source type (git, svn, hg, etc.)
      *
-     * @return boolean true if the format is supported by the archiver
+     * @return bool true if the format is supported by the archiver
      */
     public function supports($format, $sourceType);
 }

--- a/src/Composer/Package/Archiver/BaseExcludeFilter.php
+++ b/src/Composer/Package/Archiver/BaseExcludeFilter.php
@@ -39,7 +39,7 @@ abstract class BaseExcludeFilter
     }
 
     /**
-     * Checks the given path against all exclude patterns in this filter
+     * Checks the given path against all exclude patterns in this filter.
      *
      * Negated patterns overwrite exclude decisions of previous filters.
      *
@@ -68,7 +68,7 @@ abstract class BaseExcludeFilter
     }
 
     /**
-     * Processes a file containing exclude rules of different formats per line
+     * Processes a file containing exclude rules of different formats per line.
      *
      * @param array    $lines      A set of lines to be parsed
      * @param callback $lineParser The parser to be used on each line
@@ -97,7 +97,7 @@ abstract class BaseExcludeFilter
     }
 
     /**
-     * Generates a set of exclude patterns for filter() from gitignore rules
+     * Generates a set of exclude patterns for filter() from gitignore rules.
      *
      * @param array $rules A list of exclude rules in gitignore syntax
      *
@@ -114,7 +114,7 @@ abstract class BaseExcludeFilter
     }
 
     /**
-     * Generates an exclude pattern for filter() from a gitignore rule
+     * Generates an exclude pattern for filter() from a gitignore rule.
      *
      * @param string $rule An exclude rule in gitignore syntax
      *

--- a/src/Composer/Package/Archiver/ComposerExcludeFilter.php
+++ b/src/Composer/Package/Archiver/ComposerExcludeFilter.php
@@ -13,7 +13,7 @@
 namespace Composer\Package\Archiver;
 
 /**
- * An exclude filter which processes composer's own exclude rules
+ * An exclude filter which processes composer's own exclude rules.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */

--- a/src/Composer/Package/Archiver/GitExcludeFilter.php
+++ b/src/Composer/Package/Archiver/GitExcludeFilter.php
@@ -13,7 +13,7 @@
 namespace Composer\Package\Archiver;
 
 /**
- * An exclude filter that processes gitignore and gitattributes
+ * An exclude filter that processes gitignore and gitattributes.
  *
  * It respects export-ignore git attributes
  *
@@ -22,7 +22,7 @@ namespace Composer\Package\Archiver;
 class GitExcludeFilter extends BaseExcludeFilter
 {
     /**
-     * Parses .gitignore and .gitattributes files if they exist
+     * Parses .gitignore and .gitattributes files if they exist.
      *
      * @param string $sourcePath
      */
@@ -47,7 +47,7 @@ class GitExcludeFilter extends BaseExcludeFilter
     }
 
     /**
-     * Callback line parser which process gitignore lines
+     * Callback line parser which process gitignore lines.
      *
      * @param string $line A line from .gitignore
      *
@@ -59,7 +59,7 @@ class GitExcludeFilter extends BaseExcludeFilter
     }
 
     /**
-     * Callback parser which finds export-ignore rules in git attribute lines
+     * Callback parser which finds export-ignore rules in git attribute lines.
      *
      * @param string $line A line from .gitattributes
      *

--- a/src/Composer/Package/Archiver/HgExcludeFilter.php
+++ b/src/Composer/Package/Archiver/HgExcludeFilter.php
@@ -15,7 +15,7 @@ namespace Composer\Package\Archiver;
 use Symfony\Component\Finder;
 
 /**
- * An exclude filter that processes hgignore files
+ * An exclude filter that processes hgignore files.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */
@@ -25,13 +25,14 @@ class HgExcludeFilter extends BaseExcludeFilter
     const HG_IGNORE_GLOB = 2;
 
     /**
-     * Either HG_IGNORE_REGEX or HG_IGNORE_GLOB
-     * @var integer
+     * Either HG_IGNORE_REGEX or HG_IGNORE_GLOB.
+     *
+     * @var int
      */
     protected $patternMode;
 
     /**
-     * Parses .hgignore file if it exist
+     * Parses .hgignore file if it exist.
      *
      * @param string $sourcePath
      */
@@ -50,7 +51,7 @@ class HgExcludeFilter extends BaseExcludeFilter
     }
 
     /**
-     * Callback line parser which process hgignore lines
+     * Callback line parser which process hgignore lines.
      *
      * @param string $line A line from .hgignore
      *
@@ -76,7 +77,7 @@ class HgExcludeFilter extends BaseExcludeFilter
     }
 
     /**
-     * Generates an exclude pattern for filter() from a hg glob expression
+     * Generates an exclude pattern for filter() from a hg glob expression.
      *
      * @param string $line A line from .hgignore in glob mode
      *
@@ -91,7 +92,7 @@ class HgExcludeFilter extends BaseExcludeFilter
     }
 
     /**
-     * Generates an exclude pattern for filter() from a hg regexp expression
+     * Generates an exclude pattern for filter() from a hg regexp expression.
      *
      * @param string $line A line from .hgignore in regexp mode
      *

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -16,7 +16,7 @@ use Composer\Repository\RepositoryInterface;
 use Composer\Repository\PlatformRepository;
 
 /**
- * Base class for packages providing name storage and default match implementation
+ * Base class for packages providing name storage and default match implementation.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */
@@ -45,7 +45,8 @@ abstract class BasePackage implements PackageInterface
     );
 
     /**
-     * READ-ONLY: The package id, public for fast access in dependency solver
+     * READ-ONLY: The package id, public for fast access in dependency solver.
+     *
      * @var int
      */
     public $id;
@@ -57,7 +58,7 @@ abstract class BasePackage implements PackageInterface
     protected $transportOptions;
 
     /**
-     * All descendants' constructors should call this parent constructor
+     * All descendants' constructors should call this parent constructor.
      *
      * @param string $name The package's name
      */
@@ -149,7 +150,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Configures the list of options to download package dist files
+     * Configures the list of options to download package dist files.
      *
      * @param array $options
      */
@@ -159,9 +160,9 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * checks if this package is a platform package
+     * checks if this package is a platform package.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPlatform()
     {
@@ -192,7 +193,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Converts the package into a readable and unique string
+     * Converts the package into a readable and unique string.
      *
      * @return string
      */

--- a/src/Composer/Package/CompletePackage.php
+++ b/src/Composer/Package/CompletePackage.php
@@ -13,7 +13,7 @@
 namespace Composer\Package;
 
 /**
- * Package containing additional metadata that is not used by the solver
+ * Package containing additional metadata that is not used by the solver.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */
@@ -46,7 +46,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * Set the repositories
+     * Set the repositories.
      *
      * @param array $repositories
      */
@@ -64,7 +64,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * Set the license
+     * Set the license.
      *
      * @param array $license
      */
@@ -82,7 +82,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * Set the keywords
+     * Set the keywords.
      *
      * @param array $keywords
      */
@@ -100,7 +100,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * Set the authors
+     * Set the authors.
      *
      * @param array $authors
      */
@@ -118,7 +118,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * Set the description
+     * Set the description.
      *
      * @param string $description
      */
@@ -136,7 +136,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * Set the homepage
+     * Set the homepage.
      *
      * @param string $homepage
      */
@@ -154,7 +154,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * Set the support information
+     * Set the support information.
      *
      * @param array $support
      */
@@ -172,7 +172,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isAbandoned()
     {
@@ -180,7 +180,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * @param boolean|string $abandoned
+     * @param bool|string $abandoned
      */
     public function setAbandoned($abandoned)
     {
@@ -188,7 +188,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     }
 
     /**
-     * If the package is abandoned and has a suggested replacement, this method returns it
+     * If the package is abandoned and has a suggested replacement, this method returns it.
      *
      * @return string|null
      */

--- a/src/Composer/Package/CompletePackageInterface.php
+++ b/src/Composer/Package/CompletePackageInterface.php
@@ -13,21 +13,21 @@
 namespace Composer\Package;
 
 /**
- * Defines package metadata that is not necessarily needed for solving and installing packages
+ * Defines package metadata that is not necessarily needed for solving and installing packages.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */
 interface CompletePackageInterface extends PackageInterface
 {
     /**
-     * Returns the scripts of this package
+     * Returns the scripts of this package.
      *
      * @return array array('script name' => array('listeners'))
      */
     public function getScripts();
 
     /**
-     * Returns an array of repositories
+     * Returns an array of repositories.
      *
      * {"<type>": {<config key/values>}}
      *
@@ -36,35 +36,35 @@ interface CompletePackageInterface extends PackageInterface
     public function getRepositories();
 
     /**
-     * Returns the package license, e.g. MIT, BSD, GPL
+     * Returns the package license, e.g. MIT, BSD, GPL.
      *
      * @return array The package licenses
      */
     public function getLicense();
 
     /**
-     * Returns an array of keywords relating to the package
+     * Returns an array of keywords relating to the package.
      *
      * @return array
      */
     public function getKeywords();
 
     /**
-     * Returns the package description
+     * Returns the package description.
      *
      * @return string
      */
     public function getDescription();
 
     /**
-     * Returns the package homepage
+     * Returns the package homepage.
      *
      * @return string
      */
     public function getHomepage();
 
     /**
-     * Returns an array of authors of the package
+     * Returns an array of authors of the package.
      *
      * Each item can contain name/homepage/email keys
      *
@@ -73,21 +73,21 @@ interface CompletePackageInterface extends PackageInterface
     public function getAuthors();
 
     /**
-     * Returns the support information
+     * Returns the support information.
      *
      * @return array
      */
     public function getSupport();
 
     /**
-     * Returns if the package is abandoned or not
+     * Returns if the package is abandoned or not.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAbandoned();
 
     /**
-     * If the package is abandoned and has a suggested replacement, this method returns it
+     * If the package is abandoned and has a suggested replacement, this method returns it.
      *
      * @return string
      */

--- a/src/Composer/Package/Link.php
+++ b/src/Composer/Package/Link.php
@@ -15,7 +15,7 @@ namespace Composer\Package;
 use Composer\Package\LinkConstraint\LinkConstraintInterface;
 
 /**
- * Represents a link between two packages, represented by their names
+ * Represents a link between two packages, represented by their names.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */

--- a/src/Composer/Package/LinkConstraint/EmptyConstraint.php
+++ b/src/Composer/Package/LinkConstraint/EmptyConstraint.php
@@ -13,7 +13,7 @@
 namespace Composer\Package\LinkConstraint;
 
 /**
- * Defines an absence of constraints
+ * Defines an absence of constraints.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */

--- a/src/Composer/Package/LinkConstraint/MultiConstraint.php
+++ b/src/Composer/Package/LinkConstraint/MultiConstraint.php
@@ -13,7 +13,7 @@
 namespace Composer\Package\LinkConstraint;
 
 /**
- * Defines a conjunctive or disjunctive set of constraints on the target of a package link
+ * Defines a conjunctive or disjunctive set of constraints on the target of a package link.
  *
  * @author Nils Adermann <naderman@naderman.de>
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -25,7 +25,7 @@ class MultiConstraint implements LinkConstraintInterface
     protected $conjunctive;
 
     /**
-     * Sets operator and version to compare a package with
+     * Sets operator and version to compare a package with.
      *
      * @param array $constraints A set of constraints
      * @param bool  $conjunctive Whether the constraints should be treated as conjunctive or disjunctive

--- a/src/Composer/Package/LinkConstraint/SpecificConstraint.php
+++ b/src/Composer/Package/LinkConstraint/SpecificConstraint.php
@@ -13,7 +13,7 @@
 namespace Composer\Package\LinkConstraint;
 
 /**
- * Provides a common basis for specific package link constraints
+ * Provides a common basis for specific package link constraints.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */

--- a/src/Composer/Package/LinkConstraint/VersionConstraint.php
+++ b/src/Composer/Package/LinkConstraint/VersionConstraint.php
@@ -13,7 +13,7 @@
 namespace Composer\Package\LinkConstraint;
 
 /**
- * Constrains a package link based on package version
+ * Constrains a package link based on package version.
  *
  * Version numbers must be compatible with version_compare
  *
@@ -25,7 +25,7 @@ class VersionConstraint extends SpecificConstraint
     private $version;
 
     /**
-     * Sets operator and version to compare a package with
+     * Sets operator and version to compare a package with.
      *
      * @param string $operator A comparison operator
      * @param string $version  A version to compare to
@@ -61,8 +61,9 @@ class VersionConstraint extends SpecificConstraint
     }
 
     /**
-     * @param  VersionConstraint $provider
-     * @param  bool              $compareBranches
+     * @param VersionConstraint $provider
+     * @param bool              $compareBranches
+     *
      * @return bool
      */
     public function matchSpecific(VersionConstraint $provider, $compareBranches = false)
@@ -77,8 +78,9 @@ class VersionConstraint extends SpecificConstraint
     }
 
     /**
-     * @param  VersionConstraint $provider
-     * @param  bool              $compareBranches
+     * @param VersionConstraint $provider
+     * @param bool              $compareBranches
+     *
      * @return bool
      */
     private function doMatchSpecific(VersionConstraint $provider, $compareBranches = false)

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -30,7 +30,7 @@ class ArrayLoader implements LoaderInterface
     public function __construct(VersionParser $parser = null, $loadOptions = false)
     {
         if (!$parser) {
-            $parser = new VersionParser;
+            $parser = new VersionParser();
         }
         $this->versionParser = $parser;
         $this->loadOptions = $loadOptions;
@@ -217,9 +217,10 @@ class ArrayLoader implements LoaderInterface
     }
 
     /**
-     * Retrieves a branch alias (dev-master => 1.0.x-dev for example) if it exists
+     * Retrieves a branch alias (dev-master => 1.0.x-dev for example) if it exists.
      *
-     * @param  array       $config the entire package config
+     * @param array $config the entire package config
+     *
      * @return string|null normalized version of the branch alias or null if there is none
      */
     public function getBranchAlias(array $config)

--- a/src/Composer/Package/Loader/JsonLoader.php
+++ b/src/Composer/Package/Loader/JsonLoader.php
@@ -27,7 +27,8 @@ class JsonLoader
     }
 
     /**
-     * @param  string|JsonFile                    $json A filename, json string or JsonFile instance to load the package from
+     * @param string|JsonFile $json A filename, json string or JsonFile instance to load the package from
+     *
      * @return \Composer\Package\PackageInterface
      */
     public function load($json)

--- a/src/Composer/Package/Loader/LoaderInterface.php
+++ b/src/Composer/Package/Loader/LoaderInterface.php
@@ -13,17 +13,18 @@
 namespace Composer\Package\Loader;
 
 /**
- * Defines a loader that takes an array to create package instances
+ * Defines a loader that takes an array to create package instances.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 interface LoaderInterface
 {
     /**
-     * Converts a package from an array to a real instance
+     * Converts a package from an array to a real instance.
      *
-     * @param  array                              $package Package config
-     * @param  string                             $class   Package class to use
+     * @param array  $package Package config
+     * @param string $class   Package class to use
+     *
      * @return \Composer\Package\PackageInterface
      */
     public function load(array $package, $class = 'Composer\Package\CompletePackage');

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -25,7 +25,7 @@ use Composer\Util\Git as GitUtil;
 use Composer\Util\Svn as SvnUtil;
 
 /**
- * ArrayLoader built for the sole purpose of loading the root package
+ * ArrayLoader built for the sole purpose of loading the root package.
  *
  * Sets additional defaults and loads repositories
  *

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -77,7 +77,7 @@ class Locker
     }
 
     /**
-     * Checks whether the lock file is still up to date with the current hash
+     * Checks whether the lock file is still up to date with the current hash.
      *
      * @return bool
      */
@@ -91,8 +91,10 @@ class Locker
     /**
      * Searches and returns an array of locked packages, retrieved from registered repositories.
      *
-     * @param  bool                                     $withDevReqs true to retrieve the locked dev packages
+     * @param bool $withDevReqs true to retrieve the locked dev packages
+     *
      * @throws \RuntimeException
+     *
      * @return \Composer\Repository\RepositoryInterface
      */
     public function getLockedRepository($withDevReqs = false)
@@ -125,9 +127,10 @@ class Locker
     }
 
     /**
-     * Returns the platform requirements stored in the lock file
+     * Returns the platform requirements stored in the lock file.
      *
-     * @param  bool                     $withDevReqs if true, the platform requirements from the require-dev block are also returned
+     * @param bool $withDevReqs if true, the platform requirements from the require-dev block are also returned
+     *
      * @return \Composer\Package\Link[]
      */
     public function getPlatformRequirements($withDevReqs = false)
@@ -231,7 +234,7 @@ class Locker
         $lock = array(
             '_readme' => array('This file locks the dependencies of your project to a known state',
                                'Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file',
-                               'This file is @gener'.'ated automatically'),
+                               'This file is @gener'.'ated automatically', ),
             'hash' => $this->hash,
             'packages' => null,
             'packages-dev' => null,
@@ -333,8 +336,9 @@ class Locker
     /**
      * Returns the packages's datetime for its source reference.
      *
-     * @param  PackageInterface $package The package to scan.
-     * @return string|null      The formatted datetime or null if none was found.
+     * @param PackageInterface $package The package to scan.
+     *
+     * @return string|null The formatted datetime or null if none was found.
      */
     private function getPackageTime(PackageInterface $package)
     {

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -16,7 +16,7 @@ use Composer\Package\Version\VersionParser;
 use Composer\Util\ComposerMirror;
 
 /**
- * Core package definitions that are needed to resolve dependencies and install packages
+ * Core package definitions that are needed to resolve dependencies and install packages.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */
@@ -349,7 +349,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Set the releaseDate
+     * Set the releaseDate.
      *
      * @param \DateTime $releaseDate
      */
@@ -367,7 +367,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Set the required packages
+     * Set the required packages.
      *
      * @param array $requires A set of package links
      */
@@ -385,7 +385,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Set the conflicting packages
+     * Set the conflicting packages.
      *
      * @param array $conflicts A set of package links
      */
@@ -403,7 +403,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Set the provided virtual packages
+     * Set the provided virtual packages.
      *
      * @param array $provides A set of package links
      */
@@ -421,7 +421,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Set the packages this one replaces
+     * Set the packages this one replaces.
      *
      * @param array $replaces A set of package links
      */
@@ -439,7 +439,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Set the recommended packages
+     * Set the recommended packages.
      *
      * @param array $devRequires A set of package links
      */
@@ -457,7 +457,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Set the suggested packages
+     * Set the suggested packages.
      *
      * @param array $suggests A set of package names/comments
      */
@@ -475,7 +475,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Set the autoload mapping
+     * Set the autoload mapping.
      *
      * @param array $autoload Mapping of autoloading rules
      */
@@ -493,7 +493,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Set the dev autoload mapping
+     * Set the dev autoload mapping.
      *
      * @param array $devAutoload Mapping of dev autoloading rules
      */
@@ -529,7 +529,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Sets the notification URL
+     * Sets the notification URL.
      *
      * @param string $notificationUrl
      */
@@ -547,7 +547,7 @@ class Package extends BasePackage
     }
 
     /**
-     * Sets a list of patterns to be excluded from archives
+     * Sets a list of patterns to be excluded from archives.
      *
      * @param array $excludes
      */

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -15,28 +15,28 @@ namespace Composer\Package;
 use Composer\Repository\RepositoryInterface;
 
 /**
- * Defines the essential information a package has that is used during solving/installation
+ * Defines the essential information a package has that is used during solving/installation.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 interface PackageInterface
 {
     /**
-     * Returns the package's name without version info, thus not a unique identifier
+     * Returns the package's name without version info, thus not a unique identifier.
      *
      * @return string package name
      */
     public function getName();
 
     /**
-     * Returns the package's pretty (i.e. with proper case) name
+     * Returns the package's pretty (i.e. with proper case) name.
      *
      * @return string package name
      */
     public function getPrettyName();
 
     /**
-     * Returns a set of names that could refer to this package
+     * Returns a set of names that could refer to this package.
      *
      * No version or release type information should be included in any of the
      * names. Provided or replaced package names need to be returned as well.
@@ -53,35 +53,35 @@ interface PackageInterface
     public function setId($id);
 
     /**
-     * Retrieves the package's id set through setId
+     * Retrieves the package's id set through setId.
      *
      * @return int The previously set package id
      */
     public function getId();
 
     /**
-     * Returns whether the package is a development virtual package or a concrete one
+     * Returns whether the package is a development virtual package or a concrete one.
      *
      * @return bool
      */
     public function isDev();
 
     /**
-     * Returns the package type, e.g. library
+     * Returns the package type, e.g. library.
      *
      * @return string The package type
      */
     public function getType();
 
     /**
-     * Returns the package targetDir property
+     * Returns the package targetDir property.
      *
      * @return string The package targetDir
      */
     public function getTargetDir();
 
     /**
-     * Returns the package extra data
+     * Returns the package extra data.
      *
      * @return array The package extra data
      */
@@ -102,105 +102,105 @@ interface PackageInterface
     public function getInstallationSource();
 
     /**
-     * Returns the repository type of this package, e.g. git, svn
+     * Returns the repository type of this package, e.g. git, svn.
      *
      * @return string The repository type
      */
     public function getSourceType();
 
     /**
-     * Returns the repository url of this package, e.g. git://github.com/naderman/composer.git
+     * Returns the repository url of this package, e.g. git://github.com/naderman/composer.git.
      *
      * @return string The repository url
      */
     public function getSourceUrl();
 
     /**
-     * Returns the repository urls of this package including mirrors, e.g. git://github.com/naderman/composer.git
+     * Returns the repository urls of this package including mirrors, e.g. git://github.com/naderman/composer.git.
      *
      * @return array
      */
     public function getSourceUrls();
 
     /**
-     * Returns the repository reference of this package, e.g. master, 1.0.0 or a commit hash for git
+     * Returns the repository reference of this package, e.g. master, 1.0.0 or a commit hash for git.
      *
      * @return string The repository reference
      */
     public function getSourceReference();
 
     /**
-     * Returns the source mirrors of this package
+     * Returns the source mirrors of this package.
      *
      * @return array|null
      */
     public function getSourceMirrors();
 
     /**
-     * Returns the type of the distribution archive of this version, e.g. zip, tarball
+     * Returns the type of the distribution archive of this version, e.g. zip, tarball.
      *
      * @return string The repository type
      */
     public function getDistType();
 
     /**
-     * Returns the url of the distribution archive of this version
+     * Returns the url of the distribution archive of this version.
      *
      * @return string
      */
     public function getDistUrl();
 
     /**
-     * Returns the urls of the distribution archive of this version, including mirrors
+     * Returns the urls of the distribution archive of this version, including mirrors.
      *
      * @return array
      */
     public function getDistUrls();
 
     /**
-     * Returns the reference of the distribution archive of this version, e.g. master, 1.0.0 or a commit hash for git
+     * Returns the reference of the distribution archive of this version, e.g. master, 1.0.0 or a commit hash for git.
      *
      * @return string
      */
     public function getDistReference();
 
     /**
-     * Returns the sha1 checksum for the distribution archive of this version
+     * Returns the sha1 checksum for the distribution archive of this version.
      *
      * @return string
      */
     public function getDistSha1Checksum();
 
     /**
-     * Returns the dist mirrors of this package
+     * Returns the dist mirrors of this package.
      *
      * @return array|null
      */
     public function getDistMirrors();
 
     /**
-     * Returns the version of this package
+     * Returns the version of this package.
      *
      * @return string version
      */
     public function getVersion();
 
     /**
-     * Returns the pretty (i.e. non-normalized) version string of this package
+     * Returns the pretty (i.e. non-normalized) version string of this package.
      *
      * @return string version
      */
     public function getPrettyVersion();
 
     /**
-     * Returns the release date of the package
+     * Returns the release date of the package.
      *
      * @return \DateTime
      */
     public function getReleaseDate();
 
     /**
-     * Returns the stability of this package: one of (dev, alpha, beta, RC, stable)
+     * Returns the stability of this package: one of (dev, alpha, beta, RC, stable).
      *
      * @return string
      */
@@ -208,7 +208,7 @@ interface PackageInterface
 
     /**
      * Returns a set of links to packages which need to be installed before
-     * this package can be installed
+     * this package can be installed.
      *
      * @return array An array of package links defining required packages
      */
@@ -216,7 +216,7 @@ interface PackageInterface
 
     /**
      * Returns a set of links to packages which must not be installed at the
-     * same time as this package
+     * same time as this package.
      *
      * @return array An array of package links defining conflicting packages
      */
@@ -224,7 +224,7 @@ interface PackageInterface
 
     /**
      * Returns a set of links to virtual packages that are provided through
-     * this package
+     * this package.
      *
      * @return array An array of package links defining provided packages
      */
@@ -232,7 +232,7 @@ interface PackageInterface
 
     /**
      * Returns a set of links to packages which can alternatively be
-     * satisfied by installing this package
+     * satisfied by installing this package.
      *
      * @return array An array of package links defining replaced packages
      */
@@ -255,7 +255,7 @@ interface PackageInterface
     public function getSuggests();
 
     /**
-     * Returns an associative array of autoloading rules
+     * Returns an associative array of autoloading rules.
      *
      * {"<type>": {"<namespace": "<directory>"}}
      *
@@ -267,7 +267,7 @@ interface PackageInterface
     public function getAutoload();
 
     /**
-     * Returns an associative array of dev autoloading rules
+     * Returns an associative array of dev autoloading rules.
      *
      * {"<type>": {"<namespace": "<directory>"}}
      *
@@ -287,21 +287,21 @@ interface PackageInterface
     public function getIncludePaths();
 
     /**
-     * Stores a reference to the repository that owns the package
+     * Stores a reference to the repository that owns the package.
      *
      * @param RepositoryInterface $repository
      */
     public function setRepository(RepositoryInterface $repository);
 
     /**
-     * Returns a reference to the repository that owns the package
+     * Returns a reference to the repository that owns the package.
      *
      * @return RepositoryInterface
      */
     public function getRepository();
 
     /**
-     * Returns the package binaries
+     * Returns the package binaries.
      *
      * @return array
      */
@@ -315,35 +315,35 @@ interface PackageInterface
     public function getUniqueName();
 
     /**
-     * Returns the package notification url
+     * Returns the package notification url.
      *
      * @return string
      */
     public function getNotificationUrl();
 
     /**
-     * Converts the package into a readable and unique string
+     * Converts the package into a readable and unique string.
      *
      * @return string
      */
     public function __toString();
 
     /**
-     * Converts the package into a pretty readable string
+     * Converts the package into a pretty readable string.
      *
      * @return string
      */
     public function getPrettyString();
 
     /**
-     * Returns a list of patterns to exclude from package archives
+     * Returns a list of patterns to exclude from package archives.
      *
      * @return array
      */
     public function getArchiveExcludes();
 
     /**
-     * Returns a list of options to download package dist files
+     * Returns a list of options to download package dist files.
      *
      * @return array
      */

--- a/src/Composer/Package/RootPackage.php
+++ b/src/Composer/Package/RootPackage.php
@@ -13,7 +13,7 @@
 namespace Composer\Package;
 
 /**
- * The root package represents the project's composer.json and contains additional metadata
+ * The root package represents the project's composer.json and contains additional metadata.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
@@ -26,7 +26,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     protected $aliases = array();
 
     /**
-     * Set the minimumStability
+     * Set the minimumStability.
      *
      * @param string $minimumStability
      */
@@ -44,7 +44,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     }
 
     /**
-     * Set the stabilityFlags
+     * Set the stabilityFlags.
      *
      * @param array $stabilityFlags
      */
@@ -62,7 +62,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     }
 
     /**
-     * Set the preferStable
+     * Set the preferStable.
      *
      * @param bool $preferStable
      */
@@ -80,7 +80,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     }
 
     /**
-     * Set the references
+     * Set the references.
      *
      * @param array $references
      */
@@ -98,7 +98,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     }
 
     /**
-     * Set the aliases
+     * Set the aliases.
      *
      * @param array $aliases
      */

--- a/src/Composer/Package/RootPackageInterface.php
+++ b/src/Composer/Package/RootPackageInterface.php
@@ -13,28 +13,28 @@
 namespace Composer\Package;
 
 /**
- * Defines additional fields that are only needed for the root package
+ * Defines additional fields that are only needed for the root package.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 interface RootPackageInterface extends CompletePackageInterface
 {
     /**
-     * Returns a set of package names and their aliases
+     * Returns a set of package names and their aliases.
      *
      * @return array
      */
     public function getAliases();
 
     /**
-     * Returns the minimum stability of the package
+     * Returns the minimum stability of the package.
      *
      * @return string
      */
     public function getMinimumStability();
 
     /**
-     * Returns the stability flags to apply to dependencies
+     * Returns the stability flags to apply to dependencies.
      *
      * array('foo/bar' => 'dev')
      *
@@ -43,7 +43,7 @@ interface RootPackageInterface extends CompletePackageInterface
     public function getStabilityFlags();
 
     /**
-     * Returns a set of package names and source references that must be enforced on them
+     * Returns a set of package names and source references that must be enforced on them.
      *
      * array('foo/bar' => 'abcd1234')
      *
@@ -52,21 +52,21 @@ interface RootPackageInterface extends CompletePackageInterface
     public function getReferences();
 
     /**
-     * Returns true if the root package prefers picking stable packages over unstable ones
+     * Returns true if the root package prefers picking stable packages over unstable ones.
      *
      * @return bool
      */
     public function getPreferStable();
 
     /**
-     * Set the required packages
+     * Set the required packages.
      *
      * @param array $requires A set of package links
      */
     public function setRequires(array $requires);
 
     /**
-     * Set the recommended packages
+     * Set the recommended packages.
      *
      * @param array $devRequires A set of package links
      */

--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -20,7 +20,7 @@ use Composer\Package\LinkConstraint\MultiConstraint;
 use Composer\Package\LinkConstraint\VersionConstraint;
 
 /**
- * Version parser
+ * Version parser.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
@@ -29,9 +29,10 @@ class VersionParser
     private static $modifierRegex = '[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)(?:[.-]?(\d+))?)?([.-]?dev)?';
 
     /**
-     * Returns the stability of a version
+     * Returns the stability of a version.
      *
-     * @param  string $version
+     * @param string $version
+     *
      * @return string
      */
     public static function parseStability($version)
@@ -84,11 +85,13 @@ class VersionParser
     }
 
     /**
-     * Normalizes a version string to be able to perform comparisons on it
+     * Normalizes a version string to be able to perform comparisons on it.
      *
-     * @param  string                    $version
-     * @param  string                    $fullVersion optional complete version string to give more context
+     * @param string $version
+     * @param string $fullVersion optional complete version string to give more context
+     *
      * @throws \UnexpectedValueException
+     *
      * @return string
      */
     public function normalize($version, $fullVersion = null)
@@ -171,24 +174,26 @@ class VersionParser
 
     /**
      * Extract numeric prefix from alias, if it is in numeric format, suitable for
-     * version comparison
+     * version comparison.
      *
      * @param string $branch Branch name (e.g. 2.1.x-dev)
+     *
      * @return string|false Numeric prefix if present (e.g. 2.1.) or false
      */
     public function parseNumericAliasPrefix($branch)
     {
         if (preg_match('/^(?P<version>(\d+\\.)*\d+)(?:\.x)?-dev$/i', $branch, $matches)) {
-            return $matches['version'].".";
+            return $matches['version'].'.';
         }
 
         return false;
     }
 
     /**
-     * Normalizes a branch name to be able to perform comparisons on it
+     * Normalizes a branch name to be able to perform comparisons on it.
      *
-     * @param  string $name
+     * @param string $name
+     *
      * @return string
      */
     public function normalizeBranch($name)
@@ -212,10 +217,11 @@ class VersionParser
     }
 
     /**
-     * @param  string $source        source package name
-     * @param  string $sourceVersion source package version (pretty version ideally)
-     * @param  string $description   link description (e.g. requires, replaces, ..)
-     * @param  array  $links         array of package name => constraint mappings
+     * @param string $source        source package name
+     * @param string $sourceVersion source package version (pretty version ideally)
+     * @param string $description   link description (e.g. requires, replaces, ..)
+     * @param array  $links         array of package name => constraint mappings
+     *
      * @return Link[]
      */
     public function parseLinks($source, $sourceVersion, $description, $links)
@@ -234,9 +240,10 @@ class VersionParser
     }
 
     /**
-     * Parses as constraint string into LinkConstraint objects
+     * Parses as constraint string into LinkConstraint objects.
      *
-     * @param  string                                                   $constraints
+     * @param string $constraints
+     *
      * @return \Composer\Package\LinkConstraint\LinkConstraintInterface
      */
     public function parseConstraints($constraints)
@@ -294,7 +301,7 @@ class VersionParser
         }
 
         if (preg_match('{^[xX*](\.[xX*])*$}i', $constraint)) {
-            return array(new EmptyConstraint);
+            return array(new EmptyConstraint());
         }
 
         $versionRegex = '(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.(\d+))?'.self::$modifierRegex;
@@ -334,7 +341,7 @@ class VersionParser
             }
 
             if (!$stabilitySuffix) {
-                $stabilitySuffix = "-dev";
+                $stabilitySuffix = '-dev';
             }
             $lowVersion = $this->manipulateVersionString($matches, $position, 0) . $stabilitySuffix;
             $lowerBound = new VersionConstraint('>=', $lowVersion);
@@ -347,7 +354,7 @@ class VersionParser
 
             return array(
                 $lowerBound,
-                $upperBound
+                $upperBound,
             );
         }
 
@@ -378,7 +385,7 @@ class VersionParser
 
             return array(
                 $lowerBound,
-                $upperBound
+                $upperBound,
             );
         }
 
@@ -392,10 +399,10 @@ class VersionParser
                 $position = 1;
             }
 
-            $lowVersion = $this->manipulateVersionString($matches, $position) . "-dev";
-            $highVersion = $this->manipulateVersionString($matches, $position, 1) . "-dev";
+            $lowVersion = $this->manipulateVersionString($matches, $position) . '-dev';
+            $highVersion = $this->manipulateVersionString($matches, $position, 1) . '-dev';
 
-            if ($lowVersion === "0.0.0.0-dev") {
+            if ($lowVersion === '0.0.0.0-dev') {
                 return array(new VersionConstraint('<', $highVersion));
             }
 
@@ -427,7 +434,7 @@ class VersionParser
 
             return array(
                 $lowerBound,
-                $upperBound
+                $upperBound,
             );
         }
 
@@ -462,10 +469,11 @@ class VersionParser
      *
      * Support function for {@link parseConstraint()}
      *
-     * @param  array  $matches   Array with version parts in array indexes 1,2,3,4
-     * @param  int    $position  1,2,3,4 - which segment of the version to decrement
-     * @param  int    $increment
-     * @param  string $pad       The string to pad version parts after $position
+     * @param array  $matches   Array with version parts in array indexes 1,2,3,4
+     * @param int    $position  1,2,3,4 - which segment of the version to decrement
+     * @param int    $increment
+     * @param string $pad       The string to pad version parts after $position
+     *
      * @return string The new version
      */
     private function manipulateVersionString($matches, $position, $increment = 0, $pad = '0')
@@ -511,9 +519,10 @@ class VersionParser
     }
 
     /**
-     * Parses a name/version pairs and returns an array of pairs + the
+     * Parses a name/version pairs and returns an array of pairs + the.
      *
-     * @param  array   $pairs a set of package/version pairs separated by ":", "=" or " "
+     * @param array $pairs a set of package/version pairs separated by ":", "=" or " "
+     *
      * @return array[] array of arrays containing a name and (if provided) a version
      */
     public function parseNameVersionPairs(array $pairs)
@@ -529,7 +538,7 @@ class VersionParser
             }
 
             if (strpos($pair, ' ')) {
-                list($name, $version) = explode(" ", $pair, 2);
+                list($name, $version) = explode(' ', $pair, 2);
                 $result[] = array('name' => $name, 'version' => $version);
             } else {
                 $result[] = array('name' => $pair);

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -18,7 +18,7 @@ use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\Dumper\ArrayDumper;
 
 /**
- * Selects the best possible version for a package
+ * Selects the best possible version for a package.
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
  */
@@ -37,8 +37,9 @@ class VersionSelector
      * Given a package name and optional version, returns the latest PackageInterface
      * that matches.
      *
-     * @param  string                $packageName
-     * @param  string                $targetPackageVersion
+     * @param string $packageName
+     * @param string $targetPackageVersion
+     *
      * @return PackageInterface|bool
      */
     public function findBestCandidate($packageName, $targetPackageVersion = null)
@@ -73,7 +74,8 @@ class VersionSelector
      *  * dev-master    -> ~2.1@dev      (dev version with alias)
      *  * dev-master    -> dev-master    (dev versions are untouched)
      *
-     * @param  PackageInterface $package
+     * @param PackageInterface $package
+     *
      * @return string
      */
     public function findRecommendedRequireVersion(PackageInterface $package)

--- a/src/Composer/Plugin/CommandEvent.php
+++ b/src/Composer/Plugin/CommandEvent.php
@@ -57,7 +57,7 @@ class CommandEvent extends Event
     }
 
     /**
-     * Returns the command input interface
+     * Returns the command input interface.
      *
      * @return InputInterface
      */
@@ -67,7 +67,7 @@ class CommandEvent extends Event
     }
 
     /**
-     * Retrieves the command output interface
+     * Retrieves the command output interface.
      *
      * @return OutputInterface
      */
@@ -77,7 +77,7 @@ class CommandEvent extends Event
     }
 
     /**
-     * Retrieves the name of the command being run
+     * Retrieves the name of the command being run.
      *
      * @return string
      */

--- a/src/Composer/Plugin/PluginEvents.php
+++ b/src/Composer/Plugin/PluginEvents.php
@@ -20,7 +20,7 @@ namespace Composer\Plugin;
 class PluginEvents
 {
     /**
-     * The COMMAND event occurs as a command begins
+     * The COMMAND event occurs as a command begins.
      *
      * The event listener method receives a
      * Composer\Plugin\CommandEvent instance.
@@ -30,7 +30,7 @@ class PluginEvents
     const COMMAND = 'command';
 
     /**
-     * The PRE_FILE_DOWNLOAD event occurs before downloading a file
+     * The PRE_FILE_DOWNLOAD event occurs before downloading a file.
      *
      * The event listener method receives a
      * Composer\Plugin\PreFileDownloadEvent instance.

--- a/src/Composer/Plugin/PluginInterface.php
+++ b/src/Composer/Plugin/PluginInterface.php
@@ -16,21 +16,21 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 
 /**
- * Plugin interface
+ * Plugin interface.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */
 interface PluginInterface
 {
     /**
-     * Version number of the fake composer-plugin-api package
+     * Version number of the fake composer-plugin-api package.
      *
      * @var string
      */
     const PLUGIN_API_VERSION = '1.0.0';
 
     /**
-     * Apply plugin modifications to composer
+     * Apply plugin modifications to composer.
      *
      * @param Composer    $composer
      * @param IOInterface $io

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -25,7 +25,7 @@ use Composer\Package\LinkConstraint\VersionConstraint;
 use Composer\DependencyResolver\Pool;
 
 /**
- * Plugin manager
+ * Plugin manager.
  *
  * @author Nils Adermann <naderman@naderman.de>
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -43,11 +43,11 @@ class PluginManager
     private static $classCounter = 0;
 
     /**
-     * Initializes plugin manager
+     * Initializes plugin manager.
      *
-     * @param IOInterface         $io
-     * @param Composer            $composer
-     * @param Composer            $globalComposer
+     * @param IOInterface $io
+     * @param Composer    $composer
+     * @param Composer    $globalComposer
      */
     public function __construct(IOInterface $io, Composer $composer, Composer $globalComposer = null)
     {
@@ -58,7 +58,7 @@ class PluginManager
     }
 
     /**
-     * Loads all plugins from currently installed plugin packages
+     * Loads all plugins from currently installed plugin packages.
      */
     public function loadInstalledPlugins()
     {
@@ -73,7 +73,7 @@ class PluginManager
     }
 
     /**
-     * Adds a plugin, activates it and registers it with the event dispatcher
+     * Adds a plugin, activates it and registers it with the event dispatcher.
      *
      * @param PluginInterface $plugin plugin instance
      */
@@ -91,7 +91,7 @@ class PluginManager
     }
 
     /**
-     * Gets all currently active plugin instances
+     * Gets all currently active plugin instances.
      *
      * @return array plugins
      */
@@ -101,7 +101,7 @@ class PluginManager
     }
 
     /**
-     * Load all plugins and installers from a repository
+     * Load all plugins and installers from a repository.
      *
      * Note that plugins in the specified repository that rely on events that
      * have fired prior to loading will be missed. This means you likely want to
@@ -126,11 +126,11 @@ class PluginManager
                 }
 
                 if (!$requiresComposer) {
-                    throw new \RuntimeException("Plugin ".$package->getName()." is missing a require statement for a version of the composer-plugin-api package.");
+                    throw new \RuntimeException('Plugin '.$package->getName().' is missing a require statement for a version of the composer-plugin-api package.');
                 }
 
                 if (!$requiresComposer->matches(new VersionConstraint('==', $this->versionParser->normalize(PluginInterface::PLUGIN_API_VERSION)))) {
-                    $this->io->writeError("<warning>The plugin ".$package->getName()." requires a version of composer-plugin-api that does not match your composer installation. You may need to run composer update with the '--no-plugins' option.</warning>");
+                    $this->io->writeError('<warning>The plugin '.$package->getName()." requires a version of composer-plugin-api that does not match your composer installation. You may need to run composer update with the '--no-plugins' option.</warning>");
                 }
 
                 $this->registerPackage($package);
@@ -143,7 +143,7 @@ class PluginManager
     }
 
     /**
-     * Recursively generates a map of package names to packages for all deps
+     * Recursively generates a map of package names to packages for all deps.
      *
      * @param Pool             $pool      Package pool of installed packages
      * @param array            $collected Current state of the map for recursion
@@ -170,7 +170,7 @@ class PluginManager
     }
 
     /**
-     * Resolves a package link to a package in the installed pool
+     * Resolves a package link to a package in the installed pool.
      *
      * Since dependencies are already installed this should always find one.
      *

--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -47,7 +47,7 @@ class PreFileDownloadEvent extends Event
     }
 
     /**
-     * Returns the remote filesystem
+     * Returns the remote filesystem.
      *
      * @return RemoteFilesystem
      */
@@ -57,7 +57,7 @@ class PreFileDownloadEvent extends Event
     }
 
     /**
-     * Sets the remote filesystem
+     * Sets the remote filesystem.
      *
      * @param RemoteFilesystem $rfs
      */
@@ -67,7 +67,7 @@ class PreFileDownloadEvent extends Event
     }
 
     /**
-     * Retrieves the processed URL this remote filesystem will be used for
+     * Retrieves the processed URL this remote filesystem will be used for.
      *
      * @return string
      */

--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -18,7 +18,7 @@ use Composer\Package\CompletePackageInterface;
 use Composer\Package\Version\VersionParser;
 
 /**
- * A repository implementation that simply stores packages in an array
+ * A repository implementation that simply stores packages in an array.
  *
  * @author Nils Adermann <naderman@naderman.de>
  */
@@ -118,7 +118,7 @@ class ArrayRepository implements RepositoryInterface
     }
 
     /**
-     * Adds a new package to the repository
+     * Adds a new package to the repository.
      *
      * @param PackageInterface $package
      */
@@ -174,7 +174,7 @@ class ArrayRepository implements RepositoryInterface
     }
 
     /**
-     * Returns the number of packages in this repository
+     * Returns the number of packages in this repository.
      *
      * @return int Number of packages
      */

--- a/src/Composer/Repository/ArtifactRepository.php
+++ b/src/Composer/Repository/ArtifactRepository.php
@@ -77,8 +77,9 @@ class ArtifactRepository extends ArrayRepository
     /**
      * Find a file by name, returning the one that has the shortest path.
      *
-     * @param  \ZipArchive $zip
+     * @param \ZipArchive $zip
      * @param $filename
+     *
      * @return bool|int
      */
     private function locateFile(\ZipArchive $zip, $filename)
@@ -140,7 +141,7 @@ class ArtifactRepository extends ArrayRepository
         $package['dist'] = array(
             'type' => 'zip',
             'url' => $file->getPathname(),
-            'shasum' => sha1_file($file->getRealPath())
+            'shasum' => sha1_file($file->getRealPath()),
         );
 
         $package = $this->loader->load($package);

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -376,7 +376,7 @@ class ComposerRepository extends ArrayRepository
     }
 
     /**
-     * Adds a new package to the repository
+     * Adds a new package to the repository.
      *
      * @param PackageInterface $package
      */
@@ -487,7 +487,7 @@ class ComposerRepository extends ArrayRepository
             $includes = $data['provider-includes'];
             foreach ($includes as $include => $metadata) {
                 $url = $this->baseUrl . '/' . str_replace('%hash%', $metadata['sha256'], $include);
-                $cacheKey = str_replace(array('%hash%','$'), '', $include);
+                $cacheKey = str_replace(array('%hash%', '$'), '', $include);
                 if ($this->cache->sha256($cacheKey) === $metadata['sha256']) {
                     $includedData = json_decode($this->cache->read($cacheKey), true);
                 } else {

--- a/src/Composer/Repository/CompositeRepository.php
+++ b/src/Composer/Repository/CompositeRepository.php
@@ -22,13 +22,15 @@ use Composer\Package\PackageInterface;
 class CompositeRepository implements RepositoryInterface
 {
     /**
-     * List of repositories
+     * List of repositories.
+     *
      * @var array
      */
     private $repositories;
 
     /**
-     * Constructor
+     * Constructor.
+     *
      * @param array $repositories
      */
     public function __construct(array $repositories)
@@ -40,7 +42,7 @@ class CompositeRepository implements RepositoryInterface
     }
 
     /**
-     * Returns all the wrapped repositories
+     * Returns all the wrapped repositories.
      *
      * @return array
      */
@@ -163,6 +165,7 @@ class CompositeRepository implements RepositoryInterface
 
     /**
      * Add a repository.
+     *
      * @param RepositoryInterface $repository
      */
     public function addRepository(RepositoryInterface $repository)

--- a/src/Composer/Repository/InvalidRepositoryException.php
+++ b/src/Composer/Repository/InvalidRepositoryException.php
@@ -13,7 +13,7 @@
 namespace Composer\Repository;
 
 /**
- * Exception thrown when a package repository is utterly broken
+ * Exception thrown when a package repository is utterly broken.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */

--- a/src/Composer/Repository/PackageRepository.php
+++ b/src/Composer/Repository/PackageRepository.php
@@ -46,7 +46,7 @@ class PackageRepository extends ArrayRepository
     {
         parent::initialize();
 
-        $loader = new ValidatingArrayLoader(new ArrayLoader, false);
+        $loader = new ValidatingArrayLoader(new ArrayLoader(), false);
         foreach ($this->config as $package) {
             try {
                 $package = $loader->load($package);

--- a/src/Composer/Repository/Pear/BaseChannelReader.php
+++ b/src/Composer/Repository/Pear/BaseChannelReader.php
@@ -24,7 +24,7 @@ use Composer\Util\RemoteFilesystem;
 abstract class BaseChannelReader
 {
     /**
-     * PEAR REST Interface namespaces
+     * PEAR REST Interface namespaces.
      */
     const CHANNEL_NS = 'http://pear.php.net/channel-1.0';
     const ALL_CATEGORIES_NS = 'http://pear.php.net/dtd/rest.allcategories';
@@ -46,7 +46,9 @@ abstract class BaseChannelReader
      *
      * @param $origin string server
      * @param $path   string relative path to content
+     *
      * @throws \UnexpectedValueException
+     *
      * @return \SimpleXMLElement
      */
     protected function requestContent($origin, $path)
@@ -61,17 +63,19 @@ abstract class BaseChannelReader
     }
 
     /**
-     * Read xml content from remote filesystem
+     * Read xml content from remote filesystem.
      *
      * @param $origin string server
      * @param $path   string relative path to content
+     *
      * @throws \UnexpectedValueException
+     *
      * @return \SimpleXMLElement
      */
     protected function requestXml($origin, $path)
     {
         // http://components.ez.no/p/packages.xml is malformed. to read it we must ignore parsing errors.
-        $xml = simplexml_load_string($this->requestContent($origin, $path), "SimpleXMLElement", LIBXML_NOERROR);
+        $xml = simplexml_load_string($this->requestContent($origin, $path), 'SimpleXMLElement', LIBXML_NOERROR);
 
         if (false == $xml) {
             $url = rtrim($origin, '/') . '/' . ltrim($path, '/');

--- a/src/Composer/Repository/Pear/ChannelInfo.php
+++ b/src/Composer/Repository/Pear/ChannelInfo.php
@@ -13,7 +13,7 @@
 namespace Composer\Repository\Pear;
 
 /**
- * PEAR channel info
+ * PEAR channel info.
  *
  * @author Alexey Prilipko <palex@farpost.com>
  */
@@ -36,7 +36,7 @@ class ChannelInfo
     }
 
     /**
-     * Name of the channel
+     * Name of the channel.
      *
      * @return string
      */
@@ -46,7 +46,7 @@ class ChannelInfo
     }
 
     /**
-     * Alias of the channel
+     * Alias of the channel.
      *
      * @return string
      */
@@ -56,7 +56,7 @@ class ChannelInfo
     }
 
     /**
-     * List of channel packages
+     * List of channel packages.
      *
      * @return PackageInfo[]
      */

--- a/src/Composer/Repository/Pear/ChannelReader.php
+++ b/src/Composer/Repository/Pear/ChannelReader.php
@@ -42,15 +42,17 @@ class ChannelReader extends BaseChannelReader
     }
 
     /**
-     * Reads PEAR channel through REST interface and builds list of packages
+     * Reads PEAR channel through REST interface and builds list of packages.
      *
      * @param $url string PEAR Channel url
+     *
      * @throws \UnexpectedValueException
+     *
      * @return ChannelInfo
      */
     public function read($url)
     {
-        $xml = $this->requestXml($url, "/channel.xml");
+        $xml = $this->requestXml($url, '/channel.xml');
 
         $channelName = (string) $xml->name;
         $channelSummary = (string) $xml->summary;
@@ -69,10 +71,11 @@ class ChannelReader extends BaseChannelReader
     }
 
     /**
-     * Reads channel supported REST interfaces and selects one of them
+     * Reads channel supported REST interfaces and selects one of them.
      *
      * @param $channelXml \SimpleXMLElement
      * @param $supportedVersions string[] supported PEAR REST protocols
+     *
      * @return array|null hash with selected version and baseUrl
      */
     private function selectRestVersion($channelXml, $supportedVersions)

--- a/src/Composer/Repository/Pear/ChannelRest10Reader.php
+++ b/src/Composer/Repository/Pear/ChannelRest10Reader.php
@@ -15,7 +15,7 @@ namespace Composer\Repository\Pear;
 use Composer\Downloader\TransportException;
 
 /**
- * Read PEAR packages using REST 1.0 interface
+ * Read PEAR packages using REST 1.0 interface.
  *
  * At version 1.0 package descriptions read from:
  *  {baseUrl}/p/packages.xml
@@ -37,7 +37,7 @@ class ChannelRest10Reader extends BaseChannelReader
     }
 
     /**
-     * Reads package descriptions using PEAR Rest 1.0 interface
+     * Reads package descriptions using PEAR Rest 1.0 interface.
      *
      * @param $baseUrl  string base Url interface
      *
@@ -50,9 +50,10 @@ class ChannelRest10Reader extends BaseChannelReader
 
     /**
      * Read list of packages from
-     *  {baseUrl}/p/packages.xml
+     *  {baseUrl}/p/packages.xml.
      *
      * @param $baseUrl string
+     *
      * @return PackageInfo[]
      */
     private function readPackages($baseUrl)
@@ -73,10 +74,11 @@ class ChannelRest10Reader extends BaseChannelReader
 
     /**
      * Read package info from
-     *  {baseUrl}/p/{package}/info.xml
+     *  {baseUrl}/p/{package}/info.xml.
      *
      * @param $baseUrl      string
      * @param $packageName  string
+     *
      * @return PackageInfo
      */
     private function readPackage($baseUrl, $packageName)
@@ -103,12 +105,14 @@ class ChannelRest10Reader extends BaseChannelReader
 
     /**
      * Read package releases from
-     *  {baseUrl}/p/{package}/allreleases.xml
+     *  {baseUrl}/p/{package}/allreleases.xml.
      *
      * @param $baseUrl      string
      * @param $packageName  string
+     *
      * @throws \Composer\Downloader\TransportException|\Exception
-     * @return ReleaseInfo[]                                      hash array with keys as version numbers
+     *
+     * @return ReleaseInfo[] hash array with keys as version numbers
      */
     private function readPackageReleases($baseUrl, $packageName)
     {
@@ -144,11 +148,12 @@ class ChannelRest10Reader extends BaseChannelReader
 
     /**
      * Read package dependencies from
-     *  {baseUrl}/p/{package}/deps.{version}.txt
+     *  {baseUrl}/p/{package}/deps.{version}.txt.
      *
      * @param $baseUrl      string
      * @param $packageName  string
      * @param $version      string
+     *
      * @return DependencyInfo[]
      */
     private function readPackageReleaseDependencies($baseUrl, $packageName, $version)

--- a/src/Composer/Repository/Pear/ChannelRest11Reader.php
+++ b/src/Composer/Repository/Pear/ChannelRest11Reader.php
@@ -13,7 +13,7 @@
 namespace Composer\Repository\Pear;
 
 /**
- * Read PEAR packages using REST 1.1 interface
+ * Read PEAR packages using REST 1.1 interface.
  *
  * At version 1.1 package descriptions read from:
  *  {baseUrl}/c/categories.xml
@@ -33,7 +33,7 @@ class ChannelRest11Reader extends BaseChannelReader
     }
 
     /**
-     * Reads package descriptions using PEAR Rest 1.1 interface
+     * Reads package descriptions using PEAR Rest 1.1 interface.
      *
      * @param $baseUrl  string base Url interface
      *
@@ -46,16 +46,17 @@ class ChannelRest11Reader extends BaseChannelReader
 
     /**
      * Read list of channel categories from
-     *  {baseUrl}/c/categories.xml
+     *  {baseUrl}/c/categories.xml.
      *
      * @param $baseUrl string
+     *
      * @return PackageInfo[]
      */
     private function readChannelPackages($baseUrl)
     {
         $result = array();
 
-        $xml = $this->requestXml($baseUrl, "/c/categories.xml");
+        $xml = $this->requestXml($baseUrl, '/c/categories.xml');
         $xml->registerXPathNamespace('ns', self::ALL_CATEGORIES_NS);
         foreach ($xml->xpath('ns:c') as $node) {
             $categoryName = (string) $node;
@@ -68,10 +69,11 @@ class ChannelRest11Reader extends BaseChannelReader
 
     /**
      * Read packages from
-     *  {baseUrl}/c/{category}/packagesinfo.xml
+     *  {baseUrl}/c/{category}/packagesinfo.xml.
      *
      * @param $baseUrl      string
      * @param $categoryName string
+     *
      * @return PackageInfo[]
      */
     private function readCategoryPackages($baseUrl, $categoryName)
@@ -93,6 +95,7 @@ class ChannelRest11Reader extends BaseChannelReader
      * Parses package node.
      *
      * @param $packageInfo  \SimpleXMLElement   xml element describing package
+     *
      * @return PackageInfo
      */
     private function parsePackage($packageInfo)

--- a/src/Composer/Repository/Pear/DependencyConstraint.php
+++ b/src/Composer/Repository/Pear/DependencyConstraint.php
@@ -13,7 +13,7 @@
 namespace Composer\Repository\Pear;
 
 /**
- * PEAR package release dependency info
+ * PEAR package release dependency info.
  *
  * @author Alexey Prilipko <palex@farpost.com>
  */

--- a/src/Composer/Repository/Pear/DependencyInfo.php
+++ b/src/Composer/Repository/Pear/DependencyInfo.php
@@ -13,7 +13,7 @@
 namespace Composer\Repository\Pear;
 
 /**
- * PEAR package release dependency info
+ * PEAR package release dependency info.
  *
  * @author Alexey Prilipko <palex@farpost.com>
  */

--- a/src/Composer/Repository/Pear/PackageDependencyParser.php
+++ b/src/Composer/Repository/Pear/PackageDependencyParser.php
@@ -13,7 +13,7 @@
 namespace Composer\Repository\Pear;
 
 /**
- * Read PEAR packages using REST 1.0 interface
+ * Read PEAR packages using REST 1.0 interface.
  *
  * @author Alexey Prilipko <palex@farpost.com>
  */
@@ -23,6 +23,7 @@ class PackageDependencyParser
      * Builds dependency information. It detects used package.xml format.
      *
      * @param $depArray array
+     *
      * @return DependencyInfo
      */
     public function buildDependencyInfo($depArray)
@@ -38,7 +39,7 @@ class PackageDependencyParser
     }
 
     /**
-     * Builds dependency information from package.xml 1.0 format
+     * Builds dependency information from package.xml 1.0 format.
      *
      * http://pear.php.net/manual/en/guide.developers.package2.dependencies.php
      *
@@ -47,6 +48,7 @@ class PackageDependencyParser
      *   channel="channelName" name="extName|packageName" }
      *
      * @param $depArray array Dependency data in package.xml 1.0 format
+     *
      * @return DependencyConstraint[]
      */
     private function buildDependency10Info($depArray)
@@ -113,9 +115,10 @@ class PackageDependencyParser
     }
 
     /**
-     * Builds dependency information from package.xml 2.0 format
+     * Builds dependency information from package.xml 2.0 format.
      *
      * @param $depArray array Dependency data in package.xml 1.0 format
+     *
      * @return DependencyInfo
      */
     private function buildDependency20Info($depArray)
@@ -185,10 +188,11 @@ class PackageDependencyParser
     }
 
     /**
-     * Builds dependency constraint of 'extension' type
+     * Builds dependency constraint of 'extension' type.
      *
      * @param $depItem array dependency constraint or array of dependency constraints
      * @param $depType string target type of building constraint.
+     *
      * @return DependencyConstraint[]
      */
     private function buildDepExtensionConstraints($depItem, $depType)
@@ -215,10 +219,11 @@ class PackageDependencyParser
     }
 
     /**
-     * Builds dependency constraint of 'package' type
+     * Builds dependency constraint of 'package' type.
      *
      * @param $depItem array dependency constraint or array of dependency constraints
      * @param $depType string target type of building constraint.
+     *
      * @return DependencyConstraint[]
      */
     private function buildDepPackageConstraints($depItem, $depType)
@@ -248,9 +253,10 @@ class PackageDependencyParser
     }
 
     /**
-     * Parses version constraint
+     * Parses version constraint.
      *
-     * @param  array  $data array containing several 'min', 'max', 'has', 'exclude' and other keys.
+     * @param array $data array containing several 'min', 'max', 'has', 'exclude' and other keys.
+     *
      * @return string
      */
     private function parse20VersionConstraint(array $data)
@@ -282,9 +288,10 @@ class PackageDependencyParser
     }
 
     /**
-     * Softened version parser
+     * Softened version parser.
      *
      * @param $version
+     *
      * @return null|string
      */
     private function parseVersion($version)
@@ -302,9 +309,10 @@ class PackageDependencyParser
     }
 
     /**
-     * Test if array is associative or hash type
+     * Test if array is associative or hash type.
      *
-     * @param  array $array
+     * @param array $array
+     *
      * @return bool
      */
     private function isHash(array $array)

--- a/src/Composer/Repository/Pear/PackageInfo.php
+++ b/src/Composer/Repository/Pear/PackageInfo.php
@@ -13,7 +13,7 @@
 namespace Composer\Repository\Pear;
 
 /**
- * PEAR Package info
+ * PEAR Package info.
  *
  * @author Alexey Prilipko <palex@farpost.com>
  */

--- a/src/Composer/Repository/Pear/ReleaseInfo.php
+++ b/src/Composer/Repository/Pear/ReleaseInfo.php
@@ -13,7 +13,7 @@
 namespace Composer\Repository\Pear;
 
 /**
- * PEAR package release info
+ * PEAR package release info.
  *
  * @author Alexey Prilipko <palex@farpost.com>
  */

--- a/src/Composer/Repository/PearRepository.php
+++ b/src/Composer/Repository/PearRepository.php
@@ -85,8 +85,9 @@ class PearRepository extends ArrayRepository
     /**
      * Builds CompletePackages from PEAR package definition data.
      *
-     * @param  ChannelInfo     $channelInfo
-     * @param  VersionParser   $versionParser
+     * @param ChannelInfo   $channelInfo
+     * @param VersionParser $versionParser
+     *
      * @return CompletePackage
      */
     private function buildComposerPackages(ChannelInfo $channelInfo, VersionParser $versionParser)
@@ -179,7 +180,7 @@ class PearRepository extends ArrayRepository
     private function buildComposerPackageName($channelName, $packageName)
     {
         if ('php' === $channelName) {
-            return "php";
+            return 'php';
         }
         if ('ext' === $channelName) {
             return "ext-{$packageName}";

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -63,10 +63,11 @@ interface RepositoryInterface extends \Countable
     public function getPackages();
 
     /**
-     * Searches the repository for packages containing the query
+     * Searches the repository for packages containing the query.
      *
-     * @param  string  $query search query
-     * @param  int     $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only
+     * @param string $query search query
+     * @param int    $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only
+     *
      * @return array[] an array of array('name' => '...', 'description' => '...')
      */
     public function search($query, $mode = 0);

--- a/src/Composer/Repository/RepositoryManager.php
+++ b/src/Composer/Repository/RepositoryManager.php
@@ -76,7 +76,7 @@ class RepositoryManager
     }
 
     /**
-     * Adds repository
+     * Adds repository.
      *
      * @param RepositoryInterface $repository repository instance
      */
@@ -88,9 +88,11 @@ class RepositoryManager
     /**
      * Returns a new repository for a specific installation type.
      *
-     * @param  string                    $type   repository type
-     * @param  array                     $config repository configuration
+     * @param string $type   repository type
+     * @param array  $config repository configuration
+     *
      * @return RepositoryInterface
+     *
      * @throws \InvalidArgumentException if repository for provided type is not registered
      */
     public function createRepository($type, $config)
@@ -149,6 +151,7 @@ class RepositoryManager
      * Returns all local repositories for the project.
      *
      * @deprecated getLocalDevRepository is gone, so this is useless now, just use getLocalRepository instead
+     *
      * @return array[WritableRepositoryInterface]
      */
     public function getLocalRepositories()

--- a/src/Composer/Repository/RepositorySecurityException.php
+++ b/src/Composer/Repository/RepositorySecurityException.php
@@ -13,7 +13,7 @@
 namespace Composer\Repository;
 
 /**
- * Thrown when a security problem, like a broken or missing signature
+ * Thrown when a security problem, like a broken or missing signature.
  *
  * @author Eric Daspet <edaspet@survol.fr>
  */

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -35,7 +35,7 @@ class GitHubDriver extends VcsDriver
     protected $isPrivate = false;
 
     /**
-     * Git Driver
+     * Git Driver.
      *
      * @var GitDriver
      */
@@ -276,7 +276,7 @@ class GitHubDriver extends VcsDriver
     }
 
     /**
-     * Generate an SSH URL
+     * Generate an SSH URL.
      *
      * @return string
      */
@@ -393,7 +393,7 @@ class GitHubDriver extends VcsDriver
     }
 
     /**
-     * Fetch root identifier from GitHub
+     * Fetch root identifier from GitHub.
      *
      * @throws TransportException
      */

--- a/src/Composer/Repository/Vcs/PerforceDriver.php
+++ b/src/Composer/Repository/Vcs/PerforceDriver.php
@@ -119,7 +119,7 @@ class PerforceDriver extends VcsDriver
             'type'      => 'perforce',
             'url'       => $this->repoConfig['url'],
             'reference' => $identifier,
-            'p4user'    => $this->perforce->getUser()
+            'p4user'    => $this->perforce->getUser(),
         );
 
         return $source;

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -305,9 +305,11 @@ class SvnDriver extends VcsDriver
      * Execute an SVN command and try to fix up the process with credentials
      * if necessary.
      *
-     * @param  string            $command The svn command to run.
-     * @param  string            $url     The SVN URL.
+     * @param string $command The svn command to run.
+     * @param string $url     The SVN URL.
+     *
      * @throws \RuntimeException
+     *
      * @return string
      */
     protected function execute($command, $url)
@@ -331,7 +333,7 @@ class SvnDriver extends VcsDriver
     }
 
     /**
-     * Build the identifier respecting "package-path" config option
+     * Build the identifier respecting "package-path" config option.
      *
      * @param string $baseDir  The path to trunk/branch/tag
      * @param int    $revision The revision mark to add to identifier

--- a/src/Composer/Repository/Vcs/VcsDriverInterface.php
+++ b/src/Composer/Repository/Vcs/VcsDriverInterface.php
@@ -21,53 +21,56 @@ use Composer\IO\IOInterface;
 interface VcsDriverInterface
 {
     /**
-     * Initializes the driver (git clone, svn checkout, fetch info etc)
+     * Initializes the driver (git clone, svn checkout, fetch info etc).
      */
     public function initialize();
 
     /**
-     * Return the composer.json file information
+     * Return the composer.json file information.
      *
-     * @param  string $identifier Any identifier to a specific branch/tag/commit
-     * @return array  containing all infos from the composer.json file
+     * @param string $identifier Any identifier to a specific branch/tag/commit
+     *
+     * @return array containing all infos from the composer.json file
      */
     public function getComposerInformation($identifier);
 
     /**
-     * Return the root identifier (trunk, master, default/tip ..)
+     * Return the root identifier (trunk, master, default/tip ..).
      *
      * @return string Identifier
      */
     public function getRootIdentifier();
 
     /**
-     * Return list of branches in the repository
+     * Return list of branches in the repository.
      *
      * @return array Branch names as keys, identifiers as values
      */
     public function getBranches();
 
     /**
-     * Return list of tags in the repository
+     * Return list of tags in the repository.
      *
      * @return array Tag names as keys, identifiers as values
      */
     public function getTags();
 
     /**
-     * @param  string $identifier Any identifier to a specific branch/tag/commit
-     * @return array  With type, url reference and shasum keys.
+     * @param string $identifier Any identifier to a specific branch/tag/commit
+     *
+     * @return array With type, url reference and shasum keys.
      */
     public function getDist($identifier);
 
     /**
-     * @param  string $identifier Any identifier to a specific branch/tag/commit
-     * @return array  With type, url and reference keys.
+     * @param string $identifier Any identifier to a specific branch/tag/commit
+     *
+     * @return array With type, url and reference keys.
      */
     public function getSource($identifier);
 
     /**
-     * Return the URL of the repository
+     * Return the URL of the repository.
      *
      * @return string
      */
@@ -77,24 +80,25 @@ interface VcsDriverInterface
      * Return true if the repository has a composer file for a given identifier,
      * false otherwise.
      *
-     * @param  string  $identifier Any identifier to a specific branch/tag/commit
-     * @return boolean Whether the repository has a composer file for a given identifier.
+     * @param string $identifier Any identifier to a specific branch/tag/commit
+     *
+     * @return bool Whether the repository has a composer file for a given identifier.
      */
     public function hasComposerFile($identifier);
 
     /**
-     * Performs any cleanup necessary as the driver is not longer needed
-     *
+     * Performs any cleanup necessary as the driver is not longer needed.
      */
     public function cleanup();
 
     /**
-     * Checks if this driver can handle a given url
+     * Checks if this driver can handle a given url.
      *
-     * @param  IOInterface $io     IO instance
-     * @param  Config      $config current $config
-     * @param  string      $url    URL to validate/check
-     * @param  bool        $deep   unless true, only shallow checks (url matching typically) should be done
+     * @param IOInterface $io     IO instance
+     * @param Config      $config current $config
+     * @param string      $url    URL to validate/check
+     * @param bool        $deep   unless true, only shallow checks (url matching typically) should be done
+     *
      * @return bool
      */
     public static function supports(IOInterface $io, Config $config, $url, $deep = false);

--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -115,7 +115,7 @@ class VcsRepository extends ArrayRepository
             throw new \InvalidArgumentException('No driver found to handle VCS repository '.$this->url);
         }
 
-        $this->versionParser = new VersionParser;
+        $this->versionParser = new VersionParser();
         if (!$this->loader) {
             $this->loader = new ArrayLoader($this->versionParser);
         }

--- a/src/Composer/Repository/WritableRepositoryInterface.php
+++ b/src/Composer/Repository/WritableRepositoryInterface.php
@@ -41,14 +41,14 @@ interface WritableRepositoryInterface extends RepositoryInterface
     public function removePackage(PackageInterface $package);
 
     /**
-     * Get unique packages, with aliases resolved and removed
+     * Get unique packages, with aliases resolved and removed.
      *
      * @return PackageInterface[]
      */
     public function getCanonicalPackages();
 
     /**
-     * Forces a reload of all packages
+     * Forces a reload of all packages.
      */
     public function reload();
 }

--- a/src/Composer/Script/Event.php
+++ b/src/Composer/Script/Event.php
@@ -17,7 +17,7 @@ use Composer\IO\IOInterface;
 use Composer\EventDispatcher\Event as BaseEvent;
 
 /**
- * The script event class
+ * The script event class.
  *
  * @author François Pluchino <francois.pluchino@opendisplay.com>
  * @author Nils Adermann <naderman@naderman.de>
@@ -35,7 +35,7 @@ class Event extends BaseEvent
     private $io;
 
     /**
-     * @var boolean Dev mode flag
+     * @var bool Dev mode flag
      */
     private $devMode;
 
@@ -45,7 +45,7 @@ class Event extends BaseEvent
      * @param string      $name     The event name
      * @param Composer    $composer The composer object
      * @param IOInterface $io       The IOInterface object
-     * @param boolean     $devMode  Whether or not we are in dev mode
+     * @param bool        $devMode  Whether or not we are in dev mode
      * @param array       $args     Arguments passed by the user
      * @param array       $flags    Optional flags to pass data not as argument
      */
@@ -78,9 +78,9 @@ class Event extends BaseEvent
     }
 
     /**
-     * Return the dev mode flag
+     * Return the dev mode flag.
      *
-     * @return boolean
+     * @return bool
      */
     public function isDevMode()
     {

--- a/src/Composer/Script/ScriptEvents.php
+++ b/src/Composer/Script/ScriptEvents.php
@@ -105,7 +105,7 @@ class ScriptEvents
 
     /**
      * The POST_CREATE_PROJECT event occurs after the create-project command has been executed.
-     * Note: Event occurs after POST_INSTALL_CMD
+     * Note: Event occurs after POST_INSTALL_CMD.
      *
      * The event listener method receives a Composer\Script\PackageEvent instance.
      *
@@ -137,6 +137,7 @@ class ScriptEvents
      * The event listener method receives a Composer\Script\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::PRE_PACKAGE_INSTALL instead.
+     *
      * @var string
      */
     const PRE_PACKAGE_INSTALL = 'pre-package-install';
@@ -147,6 +148,7 @@ class ScriptEvents
      * The event listener method receives a Composer\Script\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::POST_PACKAGE_INSTALL instead.
+     *
      * @var string
      */
     const POST_PACKAGE_INSTALL = 'post-package-install';
@@ -157,6 +159,7 @@ class ScriptEvents
      * The event listener method receives a Composer\Script\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::PRE_PACKAGE_UPDATE instead.
+     *
      * @var string
      */
     const PRE_PACKAGE_UPDATE = 'pre-package-update';
@@ -167,6 +170,7 @@ class ScriptEvents
      * The event listener method receives a Composer\Script\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::POST_PACKAGE_UPDATE instead.
+     *
      * @var string
      */
     const POST_PACKAGE_UPDATE = 'post-package-update';
@@ -177,6 +181,7 @@ class ScriptEvents
      * The event listener method receives a Composer\Script\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::PRE_PACKAGE_UNINSTALL instead.
+     *
      * @var string
      */
     const PRE_PACKAGE_UNINSTALL = 'pre-package-uninstall';
@@ -187,6 +192,7 @@ class ScriptEvents
      * The event listener method receives a Composer\Script\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::POST_PACKAGE_UNINSTALL instead.
+     *
      * @var string
      */
     const POST_PACKAGE_UNINSTALL = 'post-package-uninstall';

--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -40,7 +40,7 @@ class AuthHelper
                 'Do you want to store credentials for '.$originUrl.' in '.$configSource->getName().' ? [Yn] ',
                 function ($value) {
                     $input = strtolower(substr(trim($value), 0, 1));
-                    if (in_array($input, array('y','n'))) {
+                    if (in_array($input, array('y', 'n'))) {
                         return $input;
                     }
                     throw new \RuntimeException('Please answer (y)es or (n)o');

--- a/src/Composer/Util/ComposerMirror.php
+++ b/src/Composer/Util/ComposerMirror.php
@@ -13,7 +13,7 @@
 namespace Composer\Util;
 
 /**
- * Composer mirror utilities
+ * Composer mirror utilities.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */

--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -37,8 +37,8 @@ class ConfigValidator
     /**
      * Validates the config, and returns the result.
      *
-     * @param string  $file                       The path to the file
-     * @param integer $arrayLoaderValidationFlags Flags for ArrayLoader validation
+     * @param string $file                       The path to the file
+     * @param int    $arrayLoaderValidationFlags Flags for ArrayLoader validation
      *
      * @return array a triple containing the errors, publishable errors, and warnings
      */

--- a/src/Composer/Util/ErrorHandler.php
+++ b/src/Composer/Util/ErrorHandler.php
@@ -13,14 +13,14 @@
 namespace Composer\Util;
 
 /**
- * Convert PHP errors into exceptions
+ * Convert PHP errors into exceptions.
  *
  * @author Artem Lopata <biozshock@gmail.com>
  */
 class ErrorHandler
 {
     /**
-     * Error handler
+     * Error handler.
      *
      * @param int    $level   Level of the error raised
      * @param string $message Error message
@@ -28,6 +28,7 @@ class ErrorHandler
      * @param int    $line    Line number the error was raised at
      *
      * @static
+     *
      * @throws \ErrorException
      */
     public static function handle($level, $message, $file, $line)
@@ -46,7 +47,7 @@ class ErrorHandler
     }
 
     /**
-     * Register error handler
+     * Register error handler.
      *
      * @static
      */

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -43,9 +43,10 @@ class Filesystem
     }
 
     /**
-     * Checks if a directory is empty
+     * Checks if a directory is empty.
      *
-     * @param  string $dir
+     * @param string $dir
+     *
      * @return bool
      */
     public function isDirEmpty($dir)
@@ -83,12 +84,13 @@ class Filesystem
     }
 
     /**
-     * Recursively remove a directory
+     * Recursively remove a directory.
      *
      * Uses the process component if proc_open is enabled on the PHP
      * installation.
      *
-     * @param  string $directory
+     * @param string $directory
+     *
      * @return bool
      *
      * @throws \RuntimeException
@@ -136,7 +138,8 @@ class Filesystem
      * before directories, creating a single non-recursive loop
      * to delete files/directories in the correct order.
      *
-     * @param  string $directory
+     * @param string $directory
+     *
      * @return bool
      */
     public function removeDirectoryPhp($directory)
@@ -172,9 +175,10 @@ class Filesystem
     }
 
     /**
-     * Attempts to unlink a file and in case of failure retries after 350ms on windows
+     * Attempts to unlink a file and in case of failure retries after 350ms on windows.
      *
-     * @param  string $path
+     * @param string $path
+     *
      * @return bool
      *
      * @throws \RuntimeException
@@ -198,9 +202,10 @@ class Filesystem
     }
 
     /**
-     * Attempts to rmdir a file and in case of failure retries after 350ms on windows
+     * Attempts to rmdir a file and in case of failure retries after 350ms on windows.
      *
-     * @param  string $path
+     * @param string $path
+     *
      * @return bool
      *
      * @throws \RuntimeException
@@ -298,12 +303,14 @@ class Filesystem
     }
 
     /**
-     * Returns the shortest path from $from to $to
+     * Returns the shortest path from $from to $to.
      *
-     * @param  string                    $from
-     * @param  string                    $to
-     * @param  bool                      $directories if true, the source/target are considered to be directories
+     * @param string $from
+     * @param string $to
+     * @param bool   $directories if true, the source/target are considered to be directories
+     *
      * @throws \InvalidArgumentException
+     *
      * @return string
      */
     public function findShortestPath($from, $to, $directories = false)
@@ -340,12 +347,14 @@ class Filesystem
     }
 
     /**
-     * Returns PHP code that, when executed in $from, will return the path to $to
+     * Returns PHP code that, when executed in $from, will return the path to $to.
      *
-     * @param  string                    $from
-     * @param  string                    $to
-     * @param  bool                      $directories if true, the source/target are considered to be directories
+     * @param string $from
+     * @param string $to
+     * @param bool   $directories if true, the source/target are considered to be directories
+     *
      * @throws \InvalidArgumentException
+     *
      * @return string
      */
     public function findShortestPathCode($from, $to, $directories = false)
@@ -382,9 +391,10 @@ class Filesystem
     }
 
     /**
-     * Checks if the given path is absolute
+     * Checks if the given path is absolute.
      *
-     * @param  string $path
+     * @param string $path
+     *
      * @return bool
      */
     public function isAbsolutePath($path)
@@ -396,8 +406,10 @@ class Filesystem
      * Returns size of a file or directory specified by path. If a directory is
      * given, it's size will be computed recursively.
      *
-     * @param  string            $path Path to the file or directory
+     * @param string $path Path to the file or directory
+     *
      * @throws \RuntimeException
+     *
      * @return int
      */
     public function size($path)
@@ -416,7 +428,8 @@ class Filesystem
      * Normalize a path. This replaces backslashes with slashes, removes ending
      * slash and collapses redundant separators and up-level references.
      *
-     * @param  string $path Path to the file or directory
+     * @param string $path Path to the file or directory
+     *
      * @return string
      */
     public function normalizePath($path)
@@ -451,9 +464,10 @@ class Filesystem
     }
 
     /**
-     * Return if the given path is local
+     * Return if the given path is local.
      *
-     * @param  string $path
+     * @param string $path
+     *
      * @return bool
      */
     public static function isLocalPath($path)
@@ -487,11 +501,11 @@ class Filesystem
 
     protected function getProcess()
     {
-        return new ProcessExecutor;
+        return new ProcessExecutor();
     }
 
     /**
-     * delete symbolic link implementation (commonly known as "unlink()")
+     * delete symbolic link implementation (commonly known as "unlink()").
      *
      * symbolic links on windows which link to directories need rmdir instead of unlink
      *
@@ -532,7 +546,7 @@ class Filesystem
     }
 
     /**
-     * resolve pathname to symbolic link of a directory
+     * resolve pathname to symbolic link of a directory.
      *
      * @param string $pathname directory path to resolve
      *

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -62,9 +62,9 @@ class Git
             $messages = array();
             foreach ($protocols as $protocol) {
                 if ('ssh' === $protocol) {
-                    $url = "git@" . $match[1] . ":" . $match[2];
+                    $url = 'git@' . $match[1] . ':' . $match[2];
                 } else {
-                    $url = $protocol ."://" . $match[1] . "/" . $match[2];
+                    $url = $protocol .'://' . $match[1] . '/' . $match[2];
                 }
 
                 if (0 === $this->process->execute(call_user_func($commandCallable, $url), $ignoredOutput, $cwd)) {
@@ -105,7 +105,7 @@ class Git
                         return;
                     }
                 }
-            } elseif ( // private non-github repo that failed to authenticate
+            } elseif (// private non-github repo that failed to authenticate
                 $this->isAuthenticationFailure($url, $match)
             ) {
                 if (strpos($match[2], '@')) {
@@ -119,7 +119,7 @@ class Git
                     $defaultUsername = null;
                     if (isset($authParts) && $authParts) {
                         if (false !== strpos($authParts, ':')) {
-                            list($defaultUsername,) = explode(':', $authParts, 2);
+                            list($defaultUsername) = explode(':', $authParts, 2);
                         } else {
                             $defaultUsername = $authParts;
                         }
@@ -154,7 +154,8 @@ class Git
         }
     }
 
-    private function isAuthenticationFailure ($url, &$match) {
+    private function isAuthenticationFailure($url, &$match)
+    {
         if (!preg_match('{(https?://)([^/]+)(.*)$}i', $url, $match)) {
             return false;
         }
@@ -197,7 +198,7 @@ class Git
         }
 
         // clean up env for OSX, see https://github.com/composer/composer/issues/2146#issuecomment-35478940
-        putenv("DYLD_LIBRARY_PATH");
+        putenv('DYLD_LIBRARY_PATH');
         unset($_SERVER['DYLD_LIBRARY_PATH']);
     }
 

--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -39,15 +39,16 @@ class GitHub
     {
         $this->io = $io;
         $this->config = $config;
-        $this->process = $process ?: new ProcessExecutor;
+        $this->process = $process ?: new ProcessExecutor();
         $this->remoteFilesystem = $remoteFilesystem ?: new RemoteFilesystem($io, $config);
     }
 
     /**
-     * Attempts to authorize a GitHub domain via OAuth
+     * Attempts to authorize a GitHub domain via OAuth.
      *
-     * @param  string $originUrl The host this GitHub instance is located at
-     * @return bool   true on success
+     * @param string $originUrl The host this GitHub instance is located at
+     *
+     * @return bool true on success
      */
     public function authorizeOAuth($originUrl)
     {
@@ -66,13 +67,15 @@ class GitHub
     }
 
     /**
-     * Authorizes a GitHub domain interactively via OAuth
+     * Authorizes a GitHub domain interactively via OAuth.
      *
-     * @param  string                        $originUrl The host this GitHub instance is located at
-     * @param  string                        $message   The reason this authorization is required
+     * @param string $originUrl The host this GitHub instance is located at
+     * @param string $message   The reason this authorization is required
+     *
      * @throws \RuntimeException
      * @throws TransportException|\Exception
-     * @return bool                          true on success
+     *
+     * @return bool true on success
      */
     public function authorizeOAuthInteractively($originUrl, $message = null)
     {
@@ -127,7 +130,7 @@ class GitHub
             return true;
         }
 
-        throw new \RuntimeException("Invalid GitHub credentials 5 times in a row, aborting.");
+        throw new \RuntimeException('Invalid GitHub credentials 5 times in a row, aborting.');
     }
 
     private function createToken($originUrl, $otp = null)
@@ -163,7 +166,7 @@ class GitHub
                     'note' => $note,
                     'note_url' => 'https://getcomposer.org/',
                 )),
-            )
+            ),
         ));
 
         $this->io->writeError('Token successfully created');

--- a/src/Composer/Util/NoProxyPattern.php
+++ b/src/Composer/Util/NoProxyPattern.php
@@ -107,14 +107,14 @@ class NoProxyPattern
     }
 
     /**
-     * Check an IP address against a CIDR
+     * Check an IP address against a CIDR.
      *
      * http://framework.zend.com/svn/framework/extras/incubator/library/ZendX/Whois/Adapter/Cidr.php
      *
      * @param string $cidr IPv4 block in CIDR notation
      * @param string $ip   IPv4 address
      *
-     * @return boolean
+     * @return bool
      */
     private static function inCIDRBlock($cidr, $ip)
     {

--- a/src/Composer/Util/Perforce.php
+++ b/src/Composer/Util/Perforce.php
@@ -102,7 +102,7 @@ class Perforce
 
     public function generateUniquePerforceClientName()
     {
-        return gethostname() . "_" . time();
+        return gethostname() . '_' . time();
     }
 
     public function cleanupClientSpec()
@@ -119,7 +119,7 @@ class Perforce
 
     protected function executeCommand($command)
     {
-        $this->commandResult = "";
+        $this->commandResult = '';
         $exit_code = $this->process->execute($command, $this->commandResult);
 
         return $exit_code;
@@ -297,7 +297,7 @@ class Perforce
                 }
                 throw new \Exception('p4 command not found in path: ' . $errorOutput);
             }
-            throw new \Exception('Invalid user name: ' . $this->getUser() );
+            throw new \Exception('Invalid user name: ' . $this->getUser());
         }
 
         return true;
@@ -305,7 +305,7 @@ class Perforce
 
     public function connectClient()
     {
-        $p4CreateClientCommand = $this->generateP4Command('client -i < ' . str_replace( " ", "\\ ", $this->getP4ClientSpec() ));
+        $p4CreateClientCommand = $this->generateP4Command('client -i < ' . str_replace(' ', "\\ ", $this->getP4ClientSpec()));
         $this->executeCommand($p4CreateClientCommand);
     }
 
@@ -390,7 +390,7 @@ class Perforce
                 $exitCode = $this->executeCommand($command);
                 $result = trim($this->commandResult);
                 if ($exitCode) {
-                    throw new \Exception("Error logging in:" . $this->process->getErrorOutput());
+                    throw new \Exception('Error logging in:' . $this->process->getErrorOutput());
                 }
             }
         }
@@ -446,7 +446,7 @@ class Perforce
             }
         }
 
-        return "";
+        return '';
     }
 
     public function getBranches()

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -33,13 +33,14 @@ class ProcessExecutor
     }
 
     /**
-     * runs a process on the commandline
+     * runs a process on the commandline.
      *
-     * @param  string $command the command to execute
-     * @param  mixed  $output  the output will be written into this var if passed by ref
-     *                         if a callable is passed it will be used as output handler
-     * @param  string $cwd     the working directory
-     * @return int    statuscode
+     * @param string $command the command to execute
+     * @param mixed  $output  the output will be written into this var if passed by ref
+     *                        if a callable is passed it will be used as output handler
+     * @param string $cwd     the working directory
+     *
+     * @return int statuscode
      */
     public function execute($command, &$output = null, $cwd = null)
     {
@@ -78,7 +79,7 @@ class ProcessExecutor
     }
 
     /**
-     * Get any error output from the last command
+     * Get any error output from the last command.
      *
      * @return string
      */
@@ -113,7 +114,6 @@ class ProcessExecutor
      *
      * @return string The escaped argument
      */
-
     public static function escape($argument)
     {
         return ProcessUtils::escapeArgument($argument);

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -55,11 +55,11 @@ class RemoteFilesystem
     /**
      * Copy the remote file in local.
      *
-     * @param string  $originUrl The origin URL
-     * @param string  $fileUrl   The file URL
-     * @param string  $fileName  the local filename
-     * @param boolean $progress  Display the progression
-     * @param array   $options   Additional context options
+     * @param string $originUrl The origin URL
+     * @param string $fileUrl   The file URL
+     * @param string $fileName  the local filename
+     * @param bool   $progress  Display the progression
+     * @param array  $options   Additional context options
      *
      * @return bool true
      */
@@ -71,10 +71,10 @@ class RemoteFilesystem
     /**
      * Get the content.
      *
-     * @param string  $originUrl The origin URL
-     * @param string  $fileUrl   The file URL
-     * @param boolean $progress  Display the progression
-     * @param array   $options   Additional context options
+     * @param string $originUrl The origin URL
+     * @param string $fileUrl   The file URL
+     * @param bool   $progress  Display the progression
+     * @param array  $options   Additional context options
      *
      * @return bool|string The content
      */
@@ -84,7 +84,7 @@ class RemoteFilesystem
     }
 
     /**
-     * Retrieve the options set in the constructor
+     * Retrieve the options set in the constructor.
      *
      * @return array Options
      */
@@ -94,7 +94,7 @@ class RemoteFilesystem
     }
 
     /**
-     * Returns the headers of the last request
+     * Returns the headers of the last request.
      *
      * @return array
      */
@@ -106,11 +106,11 @@ class RemoteFilesystem
     /**
      * Get file content or copy action.
      *
-     * @param string  $originUrl         The origin URL
-     * @param string  $fileUrl           The file URL
-     * @param array   $additionalOptions context options
-     * @param string  $fileName          the local filename
-     * @param boolean $progress          Display the progression
+     * @param string $originUrl         The origin URL
+     * @param string $fileUrl           The file URL
+     * @param array  $additionalOptions context options
+     * @param string $fileName          the local filename
+     * @param bool   $progress          Display the progression
      *
      * @throws TransportException|\Exception
      * @throws TransportException            When the file could not be downloaded
@@ -158,7 +158,7 @@ class RemoteFilesystem
         $ctx = StreamContextFactory::getContext($fileUrl, $options, array('notification' => array($this, 'callbackGet')));
 
         if ($this->progress) {
-            $this->io->writeError("    Downloading: <comment>Connecting...</comment>", false);
+            $this->io->writeError('    Downloading: <comment>Connecting...</comment>', false);
         }
 
         $errorMessage = '';
@@ -228,7 +228,7 @@ class RemoteFilesystem
         }
 
         if ($this->progress && !$this->retry) {
-            $this->io->overwriteError("    Downloading: <comment>100%</comment>");
+            $this->io->overwriteError('    Downloading: <comment>100%</comment>');
         }
 
         // handle copy command if download was successful
@@ -282,12 +282,13 @@ class RemoteFilesystem
     /**
      * Get notification action.
      *
-     * @param  integer            $notificationCode The notification code
-     * @param  integer            $severity         The severity level
-     * @param  string             $message          The message
-     * @param  integer            $messageCode      The message code
-     * @param  integer            $bytesTransferred The loaded size
-     * @param  integer            $bytesMax         The total size
+     * @param int    $notificationCode The notification code
+     * @param int    $severity         The severity level
+     * @param string $message          The message
+     * @param int    $messageCode      The message code
+     * @param int    $bytesTransferred The loaded size
+     * @param int    $bytesMax         The total size
+     *
      * @throws TransportException
      */
     protected function callbackGet($notificationCode, $severity, $message, $messageCode, $bytesTransferred, $bytesMax)
@@ -397,7 +398,7 @@ class RemoteFilesystem
                 php_uname('s'),
                 php_uname('r'),
                 $phpVersion
-            )
+            ),
         );
 
         if (extension_loaded('zlib')) {

--- a/src/Composer/Util/SpdxLicense.php
+++ b/src/Composer/Util/SpdxLicense.php
@@ -34,7 +34,7 @@ class SpdxLicense
 
     private function loadLicenses()
     {
-        if(is_array($this->licenses)) {
+        if (is_array($this->licenses)) {
             return $this->licenses;
         }
 
@@ -71,7 +71,7 @@ class SpdxLicense
     public function getIdentifierByName($name)
     {
         foreach ($this->licenses as $identifier => $licenseData) {
-            if($licenseData[0] === $name) { // key 0 = fullname
+            if ($licenseData[0] === $name) { // key 0 = fullname
                 return $identifier;
             }
         }
@@ -89,7 +89,7 @@ class SpdxLicense
 
     /**
      * Check, if the identifier for a license is valid.
-     * 
+     *
      * @param string $identifier
      *
      * @return bool
@@ -105,6 +105,7 @@ class SpdxLicense
      * @param array|string $license
      *
      * @return bool
+     *
      * @throws \InvalidArgumentException
      */
     public function validate($license)
@@ -130,6 +131,7 @@ class SpdxLicense
      * @param string $license
      *
      * @return bool
+     *
      * @throws \RuntimeException
      */
     private function isValidLicenseString($license)

--- a/src/Composer/Util/SpdxLicensesUpdater.php
+++ b/src/Composer/Util/SpdxLicensesUpdater.php
@@ -35,21 +35,21 @@ class SpdxLicensesUpdater
     {
         $licenses = array();
 
-        $dom = new \DOMDocument;
+        $dom = new \DOMDocument();
         $dom->loadHTMLFile($this->licensesUrl);
 
         $xPath = new \DOMXPath($dom);
         $trs = $xPath->query('//table//tbody//tr');
 
         // iterate over each row in the table
-        foreach($trs as $tr) {
+        foreach ($trs as $tr) {
             $tds = $tr->getElementsByTagName('td'); // get the columns in this row
 
-            if($tds->length < 4) {
+            if ($tds->length < 4) {
                 throw new \Exception('Obtaining the license table failed. Wrong table format. Found less than 4 cells in a row.');
             }
 
-            if(trim($tds->item(3)->nodeValue) == 'License Text') {
+            if (trim($tds->item(3)->nodeValue) == 'License Text') {
                 $fullname    = trim($tds->item(0)->nodeValue);
                 $identifier  = trim($tds->item(1)->nodeValue);
                 $osiApproved = ((isset($tds->item(2)->nodeValue) && $tds->item(2)->nodeValue === 'Y')) ? true : false;

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -13,7 +13,7 @@
 namespace Composer\Util;
 
 /**
- * Allows the creation of a basic context supporting http proxy
+ * Allows the creation of a basic context supporting http proxy.
  *
  * @author Jordan Alliot <jordan.alliot@gmail.com>
  * @author Markus Tacker <m@coderbyheart.de>
@@ -21,12 +21,14 @@ namespace Composer\Util;
 final class StreamContextFactory
 {
     /**
-     * Creates a context supporting HTTP proxies
+     * Creates a context supporting HTTP proxies.
      *
-     * @param  string            $url            URL the context is to be used for
-     * @param  array             $defaultOptions Options to merge with the default
-     * @param  array             $defaultParams  Parameters to specify on the context
-     * @return resource          Default context
+     * @param string $url            URL the context is to be used for
+     * @param array  $defaultOptions Options to merge with the default
+     * @param array  $defaultParams  Parameters to specify on the context
+     *
+     * @return resource Default context
+     *
      * @throws \RuntimeException if https proxy required and OpenSSL uninstalled
      */
     public static function getContext($url, array $defaultOptions = array(), array $defaultParams = array())
@@ -61,11 +63,11 @@ final class StreamContextFactory
             $proxyURL .= isset($proxy['host']) ? $proxy['host'] : '';
 
             if (isset($proxy['port'])) {
-                $proxyURL .= ":" . $proxy['port'];
+                $proxyURL .= ':' . $proxy['port'];
             } elseif ('http://' == substr($proxyURL, 0, 7)) {
-                $proxyURL .= ":80";
+                $proxyURL .= ':80';
             } elseif ('https://' == substr($proxyURL, 0, 8)) {
-                $proxyURL .= ":443";
+                $proxyURL .= ':443';
             }
 
             // http(s):// is not supported in proxy
@@ -132,12 +134,14 @@ final class StreamContextFactory
 
     /**
      * A bug in PHP prevents the headers from correctly being sent when a content-type header is present and
-     * NOT at the end of the array
+     * NOT at the end of the array.
      *
      * This method fixes the array by moving the content-type header to the end
      *
      * @link https://bugs.php.net/bug.php?id=61548
+     *
      * @param $header
+     *
      * @return array
      */
     private static function fixHttpHeaderField($header)

--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -54,7 +54,7 @@ class Svn
     protected $process;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $qtyAuthTries = 0;
 
@@ -74,13 +74,13 @@ class Svn
         $this->url = $url;
         $this->io  = $io;
         $this->config = $config;
-        $this->process = $process ?: new ProcessExecutor;
+        $this->process = $process ?: new ProcessExecutor();
     }
 
     public static function cleanEnv()
     {
         // clean up env for OSX, see https://github.com/composer/composer/issues/2146#issuecomment-35478940
-        putenv("DYLD_LIBRARY_PATH");
+        putenv('DYLD_LIBRARY_PATH');
         unset($_SERVER['DYLD_LIBRARY_PATH']);
     }
 
@@ -148,7 +148,7 @@ class Svn
     }
 
     /**
-     * @param boolean $cacheCredentials
+     * @param bool $cacheCredentials
      */
     public function setCacheCredentials($cacheCredentials)
     {
@@ -159,6 +159,7 @@ class Svn
      * Repositories requests credentials, let's put them in.
      *
      * @return \Composer\Util\Svn
+     *
      * @throws \RuntimeException
      */
     protected function doAuthDance()
@@ -173,10 +174,10 @@ class Svn
         $this->io->writeError("The Subversion server ({$this->url}) requested credentials:");
 
         $this->hasAuth = true;
-        $this->credentials['username'] = $this->io->ask("Username: ");
-        $this->credentials['password'] = $this->io->askAndHideAnswer("Password: ");
+        $this->credentials['username'] = $this->io->ask('Username: ');
+        $this->credentials['password'] = $this->io->askAndHideAnswer('Password: ');
 
-        $this->cacheCredentials = $this->io->askConfirmation("Should Subversion cache these credentials? (yes/no) ", true);
+        $this->cacheCredentials = $this->io->askConfirmation('Should Subversion cache these credentials? (yes/no) ', true);
 
         return $this;
     }
@@ -231,12 +232,13 @@ class Svn
      * Get the password for the svn command. Can be empty.
      *
      * @return string
+     *
      * @throws \LogicException
      */
     protected function getPassword()
     {
         if ($this->credentials === null) {
-            throw new \LogicException("No svn auth detected.");
+            throw new \LogicException('No svn auth detected.');
         }
 
         return isset($this->credentials['password']) ? $this->credentials['password'] : '';
@@ -246,12 +248,13 @@ class Svn
      * Get the username for the svn command.
      *
      * @return string
+     *
      * @throws \LogicException
      */
     protected function getUsername()
     {
         if ($this->credentials === null) {
-            throw new \LogicException("No svn auth detected.");
+            throw new \LogicException('No svn auth detected.');
         }
 
         return $this->credentials['username'];
@@ -310,7 +313,7 @@ class Svn
     }
 
     /**
-     * Create the auth params from the url
+     * Create the auth params from the url.
      *
      * @return bool
      */


### PR DESCRIPTION
This is the result of applying PHP-CS-Fixer at the Symfony level, except the ``concat_without_space`` and ``empty_return`` fixers (because the code currently does not apply these rules) and with the ``concat_with_space`` one (because the code follows this rule). 