### PR TITLE
[bugfix] Fixed undefined var in DiagnoseCommand::execute().

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -118,7 +118,7 @@ EOT
                 }
             } catch (\Exception $e) {
                 if ($e instanceof TransportException && $e->getCode() === 401) {
-                    $this->outputResult('<comment>The oauth token for '.$domain.' seems invalid, run "composer config --global --unset github-oauth.'.$domain.'" to remove it</comment>');
+                    $this->outputResult('<comment>The oauth token for github.com seems invalid, run "composer config --global --unset github-oauth.github.com" to remove it</comment>');
                 } else {
                     $this->outputResult($e);
                 }


### PR DESCRIPTION
 Fixed undefined var ```$domain``` in DiagnoseCommand::execute().
I introduced [this bug](https://github.com/phansys/composer/commit/5b2a7e6bad10bd2f0622973c03e907647a92b0bc#diff-834340f065067888bcc9eccd566b600eR121) in #3929. My apologies.