### PR TITLE
Skip JSON downloads when no dependencies exist in composer.json

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -496,10 +496,10 @@ class Installer
         // force dev packages to have the latest links if we update or install from a (potentially new) lock
         $this->processDevPackages($localRepo, $pool, $policy, $repositories, $lockedRepository, $installFromLock, 'force-links');
 
+        $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $pool, $installedRepo, $request);
         $operations = array();
         if ($this->package->hasDependencies()) {
             // solve dependencies
-            $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $pool, $installedRepo, $request);
             $solver = new Solver($policy, $pool, $installedRepo);
             try {
                 $operations = $solver->solve($request, $this->ignorePlatformReqs);

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -496,17 +496,20 @@ class Installer
         // force dev packages to have the latest links if we update or install from a (potentially new) lock
         $this->processDevPackages($localRepo, $pool, $policy, $repositories, $lockedRepository, $installFromLock, 'force-links');
 
-        // solve dependencies
-        $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $pool, $installedRepo, $request);
-        $solver = new Solver($policy, $pool, $installedRepo);
-        try {
-            $operations = $solver->solve($request, $this->ignorePlatformReqs);
-            $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, $this->devMode, $policy, $pool, $installedRepo, $request, $operations);
-        } catch (SolverProblemsException $e) {
-            $this->io->writeError('<error>Your requirements could not be resolved to an installable set of packages.</error>');
-            $this->io->writeError($e->getMessage());
+        $operations = array();
+        if ($this->package->hasDependencies()) {
+            // solve dependencies
+            $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $pool, $installedRepo, $request);
+            $solver = new Solver($policy, $pool, $installedRepo);
+            try {
+                $operations = $solver->solve($request, $this->ignorePlatformReqs);
+                $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, $this->devMode, $policy, $pool, $installedRepo, $request, $operations);
+            } catch (SolverProblemsException $e) {
+                $this->io->writeError('<error>Your requirements could not be resolved to an installable set of packages.</error>');
+                $this->io->writeError($e->getMessage());
 
-            return max(1, $e->getCode());
+                return max(1, $e->getCode());
+            }
         }
 
         // force dev packages to be updated if we update or install from a (potentially new) lock

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -384,7 +384,7 @@ class Installer
             $pool->addRepository($lockedRepository, $aliases);
         }
 
-        if (!$installFromLock) {
+        if (!$installFromLock && $this->package->hasDependencies()) {
             $repositories = $this->repositoryManager->getRepositories();
             foreach ($repositories as $repository) {
                 $pool->addRepository($repository, $aliases);

--- a/src/Composer/Package/RootAliasPackage.php
+++ b/src/Composer/Package/RootAliasPackage.php
@@ -78,6 +78,11 @@ class RootAliasPackage extends AliasPackage implements RootPackageInterface
         return $this->aliasOf->setDevRequires($devRequire);
     }
 
+    public function hasDependencies()
+    {
+        return $this->aliasOf->hasDependencies();
+    }
+
     public function __clone()
     {
         parent::__clone();

--- a/src/Composer/Package/RootPackage.php
+++ b/src/Composer/Package/RootPackage.php
@@ -120,6 +120,6 @@ class RootPackage extends CompletePackage implements RootPackageInterface
      */
     public function hasDependencies()
     {
-        return (!empty($this->getRequires()) || !empty($this->getDevRequires()));
+        return (count($this->getRequires()) > 0 || count($this->getDevRequires()) > 0);
     }
 }

--- a/src/Composer/Package/RootPackage.php
+++ b/src/Composer/Package/RootPackage.php
@@ -114,4 +114,12 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     {
         return $this->aliases;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasDependencies()
+    {
+        return (!empty($this->getRequires()) || !empty($this->getDevRequires()));
+    }
 }

--- a/src/Composer/Package/RootPackageInterface.php
+++ b/src/Composer/Package/RootPackageInterface.php
@@ -71,4 +71,11 @@ interface RootPackageInterface extends CompletePackageInterface
      * @param array $devRequires A set of package links
      */
     public function setDevRequires(array $devRequires);
+
+    /**
+     * Does the package have any dependencies?
+     *
+     * @return bool
+     */
+    public function hasDependencies();
 }


### PR DESCRIPTION
When composer.json lists zero dependencies, the many JSON files are still downloaded from packagist on each install (since no lockfile will exist).  This patch avoids those downloads in this scenario.

This proves to be a timesaver in apps where composer's sole job is to generate an autoloader (thus, no dependencies are listed).