### PR TITLE
Concurrent git clone and downloads with React

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ matrix:
 
 before_script:
     - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
-    - composer install
-    - bin/composer install
+    - composer install --ignore-platform-reqs
+    - bin/composer install --ignore-platform-reqs
     - git config --global user.name travis-ci
     - git config --global user.email travis@example.com
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
     "require": {
         "php": ">=5.3.2",
         "justinrainbow/json-schema": "~1.4",
+        "react/stream": "0.4.*",
+        "react/child-process": "0.4.*",
+        "react/promise": "~2.2",
         "seld/jsonlint": "~1.0",
         "symfony/console": "~2.5",
         "symfony/finder": "~2.2",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "justinrainbow/json-schema": "~1.4",
         "react/stream": "0.4.*",
         "react/child-process": "0.4.*",
-        "react/promise": "~2.2",
+        "react/promise": "~1.0",
         "seld/jsonlint": "~1.0",
         "symfony/console": "~2.5",
         "symfony/finder": "~2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,54 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "556ac817fc0b456bddc48918ef09930d",
+    "hash": "ebd6625dd48a11b6d684744a7e286fe2",
     "packages": [
+        {
+            "name": "evenement/evenement",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "f6e843799fd4f4184d54d8fc7b5b3551c9fa803e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/f6e843799fd4f4184d54d8fc7b5b3551c9fa803e",
+                "reference": "f6e843799fd4f4184d54d8fc7b5b3551c9fa803e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Evenement": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch",
+                    "homepage": "http://wiedler.ch/igor/"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "time": "2012-11-02 14:49:47"
+        },
         {
             "name": "justinrainbow/json-schema",
             "version": "1.4.1",
@@ -119,6 +165,182 @@
                 "prompt"
             ],
             "time": "2015-04-30 20:24:49"
+        },
+        {
+            "name": "react/child-process",
+            "version": "v0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/child-process.git",
+                "reference": "8bf211533bcbb2034e00528a47400367570dc3d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/8bf211533bcbb2034e00528a47400367570dc3d7",
+                "reference": "8bf211533bcbb2034e00528a47400367570dc3d7",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "~2.0",
+                "php": ">=5.4.0",
+                "react/event-loop": "0.4.*",
+                "react/stream": "0.4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "React\\ChildProcess\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Library for executing child processes.",
+            "keywords": [
+                "process"
+            ],
+            "time": "2014-02-02 01:11:26"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "18c5297087ca01de85518e2b55078f444144aa1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/18c5297087ca01de85518e2b55078f444144aa1b",
+                "reference": "18c5297087ca01de85518e2b55078f444144aa1b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "suggest": {
+                "ext-event": "~1.0",
+                "ext-libev": "*",
+                "ext-libevent": ">=0.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Event loop abstraction layer that libraries can use for evented I/O.",
+            "keywords": [
+                "event-loop"
+            ],
+            "time": "2014-02-26 17:36:58"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
+                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@googlemail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "time": "2014-12-30 13:32:42"
+        },
+        {
+            "name": "react/stream",
+            "version": "v0.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "acc7a5fec02e0aea674560e1d13c40ed0c8c5465"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/acc7a5fec02e0aea674560e1d13c40ed0c8c5465",
+                "reference": "acc7a5fec02e0aea674560e1d13c40ed0c8c5465",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "~2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "react/event-loop": "0.4.*",
+                "react/promise": "~2.0"
+            },
+            "suggest": {
+                "react/event-loop": "0.4.*",
+                "react/promise": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Basic readable and writable stream interfaces that support piping.",
+            "keywords": [
+                "pipe",
+                "stream"
+            ],
+            "time": "2014-09-10 03:32:31"
         },
         {
             "name": "seld/jsonlint",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ebd6625dd48a11b6d684744a7e286fe2",
+    "hash": "611726e38f4e830e3335be18a19f528b",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -119,54 +119,6 @@
             "time": "2015-03-27 16:41:39"
         },
         {
-            "name": "seld/cli-prompt",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/cli-prompt.git",
-                "reference": "fe114c7a6ac5cb0ce76932ae4017024d9842a49c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/fe114c7a6ac5cb0ce76932ae4017024d9842a49c",
-                "reference": "fe114c7a6ac5cb0ce76932ae4017024d9842a49c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Seld\\CliPrompt\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "Allows you to prompt for user input on the command line, and optionally hide the characters they type",
-            "keywords": [
-                "cli",
-                "console",
-                "hidden",
-                "input",
-                "prompt"
-            ],
-            "time": "2015-04-30 20:24:49"
-        },
-        {
             "name": "react/child-process",
             "version": "v0.4.0",
             "source": {
@@ -252,34 +204,31 @@
         },
         {
             "name": "react/promise",
-            "version": "v2.2.0",
+            "version": "v1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef"
+                "reference": "d6de8cae1dbb4878d909c41cb89aff764504472c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
-                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/d6de8cae1dbb4878d909c41cb89aff764504472c",
+                "reference": "d6de8cae1dbb4878d909c41cb89aff764504472c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=5.3.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
+                "psr-0": {
+                    "React\\Promise": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -288,11 +237,13 @@
             "authors": [
                 {
                     "name": "Jan Sorgalla",
-                    "email": "jsorgalla@googlemail.com"
+                    "email": "jsorgalla@googlemail.com",
+                    "homepage": "http://sorgalla.com",
+                    "role": "maintainer"
                 }
             ],
             "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "time": "2014-12-30 13:32:42"
+            "time": "2013-04-03 14:05:55"
         },
         {
             "name": "react/stream",
@@ -341,6 +292,54 @@
                 "stream"
             ],
             "time": "2014-09-10 03:32:31"
+        },
+        {
+            "name": "seld/cli-prompt",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/cli-prompt.git",
+                "reference": "fe114c7a6ac5cb0ce76932ae4017024d9842a49c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/fe114c7a6ac5cb0ce76932ae4017024d9842a49c",
+                "reference": "fe114c7a6ac5cb0ce76932ae4017024d9842a49c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\CliPrompt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Allows you to prompt for user input on the command line, and optionally hide the characters they type",
+            "keywords": [
+                "cli",
+                "console",
+                "hidden",
+                "input",
+                "prompt"
+            ],
+            "time": "2015-04-30 20:24:49"
         },
         {
             "name": "seld/jsonlint",
@@ -434,17 +433,17 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.6.6",
+            "version": "v2.6.7",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "5b91dc4ed5eb08553f57f6df04c4730a73992667"
+                "reference": "ebc5679854aa24ed7d65062e9e3ab0b18a917272"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/5b91dc4ed5eb08553f57f6df04c4730a73992667",
-                "reference": "5b91dc4ed5eb08553f57f6df04c4730a73992667",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/ebc5679854aa24ed7d65062e9e3ab0b18a917272",
+                "reference": "ebc5679854aa24ed7d65062e9e3ab0b18a917272",
                 "shasum": ""
             },
             "require": {
@@ -478,31 +477,31 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Console Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-30 15:54:10"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02 15:18:45"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.6.6",
+            "version": "v2.6.7",
             "target-dir": "Symfony/Component/Finder",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Finder.git",
-                "reference": "5dbe2e73a580618f5b4880fda93406eed25de251"
+                "reference": "704c64c8b12c8882640d5c0330a8414b1e06dc99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/5dbe2e73a580618f5b4880fda93406eed25de251",
-                "reference": "5dbe2e73a580618f5b4880fda93406eed25de251",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/704c64c8b12c8882640d5c0330a8414b1e06dc99",
+                "reference": "704c64c8b12c8882640d5c0330a8414b1e06dc99",
                 "shasum": ""
             },
             "require": {
@@ -528,31 +527,31 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Finder Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-30 15:54:10"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02 15:18:45"
         },
         {
             "name": "symfony/process",
-            "version": "v2.6.6",
+            "version": "v2.6.7",
             "target-dir": "Symfony/Component/Process",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Process.git",
-                "reference": "a8bebaec1a9dc6cde53e0250e32917579b0be552"
+                "reference": "9f3c4baaf840ed849e1b1f7bfd5ae246e8509562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Process/zipball/a8bebaec1a9dc6cde53e0250e32917579b0be552",
-                "reference": "a8bebaec1a9dc6cde53e0250e32917579b0be552",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/9f3c4baaf840ed849e1b1f7bfd5ae246e8509562",
+                "reference": "9f3c4baaf840ed849e1b1f7bfd5ae246e8509562",
                 "shasum": ""
             },
             "require": {
@@ -578,17 +577,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Process Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-30 15:54:10"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02 15:18:45"
         }
     ],
     "packages-dev": [
@@ -1501,17 +1500,17 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.6.6",
+            "version": "v2.6.7",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "174f009ed36379a801109955fc5a71a49fe62dd4"
+                "reference": "f157ab074e453ecd4c0fa775f721f6e67a99d9e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/174f009ed36379a801109955fc5a71a49fe62dd4",
-                "reference": "174f009ed36379a801109955fc5a71a49fe62dd4",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/f157ab074e453ecd4c0fa775f721f6e67a99d9e2",
+                "reference": "f157ab074e453ecd4c0fa775f721f6e67a99d9e2",
                 "shasum": ""
             },
             "require": {
@@ -1537,17 +1536,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Yaml Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-30 15:54:10"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02 15:18:45"
         }
     ],
     "aliases": [],

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -659,4 +659,9 @@ This env var controls the discard-changes [config option](04-schema.md#config).
 If set to 1, this env var will make composer behave as if you passed the
 `--no-interaction` flag to every command. This can be set on build boxes/CI.
 
+### COMPOSER_PARALLEL_OPERATIONS
+
+On PHP 5.5 and above, composer handles up to 8 concurrent install/update operations.
+This env var allows changing this default value. If set to 1, concurrency is disabled.
+
 &larr; [Libraries](02-libraries.md)  |  [Schema](04-schema.md) &rarr;

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -29,7 +29,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DiagnoseCommand extends Command
 {
-    /** @var RemoteFileSystem */
+    /** @var RemoteFilesystem */
     protected $rfs;
 
     /** @var ProcessExecutor */

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -112,6 +112,8 @@ class Compiler
             ->exclude('Tests')
             ->exclude('tests')
             ->exclude('docs')
+            ->in(__DIR__.'/../../vendor/evenement/')
+            ->in(__DIR__.'/../../vendor/react/')
             ->in(__DIR__.'/../../vendor/symfony/')
             ->in(__DIR__.'/../../vendor/seld/jsonlint/')
             ->in(__DIR__.'/../../vendor/seld/cli-prompt/')

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -45,6 +45,7 @@ class Config
         'github-expose-hostname' => true,
         'store-auths' => 'prompt',
         'platform' => array(),
+        'parallel-operations' => 8,
         // valid keys without defaults (auth config stuff):
         // github-oauth
         // http-basic
@@ -168,6 +169,7 @@ class Config
             case 'cache-files-dir':
             case 'cache-repo-dir':
             case 'cache-vcs-dir':
+            case 'parallel-operations':
                 // convert foo-bar to COMPOSER_FOO_BAR and check if it exists since it overrides the local config
                 $env = 'COMPOSER_' . strtoupper(strtr($key, '-', '_'));
 

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -14,6 +14,9 @@ namespace Composer\Downloader;
 
 use Composer\Package\PackageInterface;
 use Symfony\Component\Finder\Finder;
+use React\EventLoop\LoopInterface;
+use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
 
 /**
  * Base downloader for archives
@@ -27,68 +30,88 @@ abstract class ArchiveDownloader extends FileDownloader
     /**
      * {@inheritDoc}
      */
-    public function download(PackageInterface $package, $path)
+    public function download(PackageInterface $package, $path, LoopInterface $loop = null)
     {
         $temporaryDir = $this->config->get('vendor-dir').'/composer/'.substr(md5(uniqid('', true)), 0, 8);
-        $retries = 3;
-        while ($retries--) {
-            $fileName = parent::download($package, $path);
 
+        $retries = 3;
+        $future = (object) array('deferred' => new Deferred());
+        $future->onDownload = function ($fileName) use ($temporaryDir, $package, $path, $future) {
             if ($this->io->isVerbose()) {
                 $this->io->writeError('    Extracting archive');
             }
 
+            $this->filesystem->ensureDirectoryExists($temporaryDir);
             try {
-                $this->filesystem->ensureDirectoryExists($temporaryDir);
-                try {
-                    $this->extract($fileName, $temporaryDir);
-                } catch (\Exception $e) {
-                    // remove cache if the file was corrupted
-                    parent::clearCache($package, $path);
-                    throw $e;
-                }
-
-                $this->filesystem->unlink($fileName);
-
-                $contentDir = $this->getFolderContent($temporaryDir);
-
-                // only one dir in the archive, extract its contents out of it
-                if (1 === count($contentDir) && is_dir(reset($contentDir))) {
-                    $contentDir = $this->getFolderContent((string) reset($contentDir));
-                }
-
-                // move files back out of the temp dir
-                foreach ($contentDir as $file) {
-                    $file = (string) $file;
-                    $this->filesystem->rename($file, $path . '/' . basename($file));
-                }
-
-                $this->filesystem->removeDirectory($temporaryDir);
-                if ($this->filesystem->isDirEmpty($this->config->get('vendor-dir').'/composer/')) {
-                    $this->filesystem->removeDirectory($this->config->get('vendor-dir').'/composer/');
-                }
-                if ($this->filesystem->isDirEmpty($this->config->get('vendor-dir'))) {
-                    $this->filesystem->removeDirectory($this->config->get('vendor-dir'));
-                }
+                $this->extract($fileName, $temporaryDir);
             } catch (\Exception $e) {
-                // clean up
-                $this->filesystem->removeDirectory($path);
-                $this->filesystem->removeDirectory($temporaryDir);
-
-                // retry downloading if we have an invalid zip file
-                if ($retries && $e instanceof \UnexpectedValueException && class_exists('ZipArchive') && $e->getCode() === \ZipArchive::ER_NOZIP) {
-                    $this->io->writeError('    Invalid zip file, retrying...');
-                    usleep(500000);
-                    continue;
-                }
-
+                // remove cache if the file was corrupted
+                parent::clearCache($package, $path);
                 throw $e;
             }
 
-            break;
-        }
+            $this->filesystem->unlink($fileName);
 
-        $this->io->writeError('');
+            $contentDir = $this->getFolderContent($temporaryDir);
+
+            // only one dir in the archive, extract its contents out of it
+            if (1 === count($contentDir) && is_dir(reset($contentDir))) {
+                $contentDir = $this->getFolderContent((string) reset($contentDir));
+            }
+
+            // move files back out of the temp dir
+            foreach ($contentDir as $file) {
+                $file = (string) $file;
+                $this->filesystem->rename($file, $path . '/' . basename($file));
+            }
+
+            $this->filesystem->removeDirectory($temporaryDir);
+            if ($this->filesystem->isDirEmpty($this->config->get('vendor-dir').'/composer/')) {
+                $this->filesystem->removeDirectory($this->config->get('vendor-dir').'/composer/');
+            }
+            if ($this->filesystem->isDirEmpty($this->config->get('vendor-dir'))) {
+                $this->filesystem->removeDirectory($this->config->get('vendor-dir'));
+            }
+
+            $this->io->writeError('');
+            $future->onDownload = $future->onException = $future->retryLoop = null;
+            $future->deferred->resolve($fileName);
+        };
+        $future->onException = function (\Exception $e) use (&$retries, $path, $temporaryDir, $future) {
+            // clean up
+            $this->filesystem->removeDirectory($path);
+            $this->filesystem->removeDirectory($temporaryDir);
+
+            // retry downloading if we have an invalid zip file
+            if ($retries-- && $e instanceof \UnexpectedValueException && class_exists('ZipArchive') && $e->getCode() === \ZipArchive::ER_NOZIP) {
+                $this->io->writeError('    Invalid zip file, retrying...');
+                usleep(500000);
+                call_user_func($future->retryLoop);
+            } else {
+                $future->onDownload = $future->onException = $future->retryLoop = null;
+                $future->deferred->reject($e);
+            }
+        };
+        $future->retryLoop = function () use ($package, $path, $loop, $future) {
+            try {
+                $promise = parent::download($package, $path, $loop);
+                if ($promise instanceof PromiseInterface) {
+                    $promise->then($future->onDownload)->then(null, $future->onException);
+                } else {
+                    call_user_func($future->onDownload, $promise);
+                }
+            } catch (\Exception $e) {
+                call_user_func($future->onException, $e);
+            }
+        };
+
+        $promise = $future->deferred->promise();
+        if (!$loop) {
+            $promise->done(function ($result) use (&$promise) {$promise = $result;});
+        }
+        call_user_func($future->retryLoop);
+
+        return $promise;
     }
 
     /**

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -15,6 +15,9 @@ namespace Composer\Downloader;
 use Composer\Package\PackageInterface;
 use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
+use React\EventLoop\LoopInterface;
+use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
 
 /**
  * Downloaders manager.
@@ -166,7 +169,7 @@ class DownloadManager
      * @throws \InvalidArgumentException if package have no urls to download from
      * @throws \RuntimeException
      */
-    public function download(PackageInterface $package, $targetDir, $preferSource = null)
+    public function download(PackageInterface $package, $targetDir, $preferSource = null, LoopInterface $loop = null)
     {
         $preferSource = null !== $preferSource ? $preferSource : $this->preferSource;
         $sourceType   = $package->getSourceType();
@@ -190,30 +193,51 @@ class DownloadManager
 
         $this->filesystem->ensureDirectoryExists($targetDir);
 
-        foreach ($sources as $i => $source) {
-            if (isset($e)) {
-                $this->io->writeError('    <warning>Now trying to download from ' . $source . '</warning>');
-            }
-            $package->setInstallationSource($source);
-            try {
-                $downloader = $this->getDownloaderForInstalledPackage($package);
-                if ($downloader) {
-                    $downloader->download($package, $targetDir);
-                }
-                break;
-            } catch (\RuntimeException $e) {
-                if ($i === count($sources) - 1) {
-                    throw $e;
-                }
+        $i = 0;
+        $deferred = new Deferred();
+        $retryLoop = function (\Exception $e = null) use ($sources, $package, $targetDir, $loop, &$i, $deferred, &$retryLoop) {
+            if (!isset($sources[$i])) {
+                $deferred->reject($e);
 
-                $this->io->writeError(
-                    '    <warning>Failed to download '.
-                    $package->getPrettyName().
-                    ' from ' . $source . ': '.
-                    $e->getMessage().'</warning>'
-                );
+                return;
             }
+            $source = $sources[$i++];
+            try {
+                if (isset($e)) {
+                    $this->io->writeError(
+                        '    <warning>Failed to download '.
+                        $package->getPrettyName().
+                        ' from ' . $sources[$i - 1] . ': '.
+                        $e->getMessage().'</warning>'
+                    );
+                    $this->io->writeError('    <warning>Now trying to download from ' . $source . '</warning>');
+                }
+                $package->setInstallationSource($source);
+                $downloader = $this->getDownloaderForInstalledPackage($package);
+                $promise = $downloader ? $downloader->download($package, $targetDir, $loop) : null;
+                if ($promise instanceof PromiseInterface) {
+                    $promise->then(array($deferred, 'resolve'), $retryLoop);
+                } else {
+                    $deferred->resolve($promise);
+                }
+            } catch (\RuntimeException $e) {
+                $retryLoop($e);
+            }
+        };
+
+        $promise = $deferred->promise();
+        if (!$loop) {
+            $promise->done(function ($result) use (&$promise) {$promise = $result;});
         }
+        try {
+            $retryLoop();
+            $retryLoop = null;
+        } catch (\Exception $e) {
+            $retryLoop = null;
+            throw $e;
+        }
+
+        return $promise;
     }
 
     /**
@@ -225,38 +249,41 @@ class DownloadManager
      *
      * @throws \InvalidArgumentException if initial package is not installed
      */
-    public function update(PackageInterface $initial, PackageInterface $target, $targetDir)
+    public function update(PackageInterface $initial, PackageInterface $target, $targetDir, LoopInterface $loop = null)
     {
+        $promise = null;
         $downloader = $this->getDownloaderForInstalledPackage($initial);
-        if (!$downloader) {
-            return;
+        if ($downloader) {
+            $installationSource = $initial->getInstallationSource();
+
+            if ('dist' === $installationSource) {
+                $initialType = $initial->getDistType();
+                $targetType  = $target->getDistType();
+            } else {
+                $initialType = $initial->getSourceType();
+                $targetType  = $target->getSourceType();
+            }
+
+            // upgrading from a dist stable package to a dev package, force source reinstall
+            if ($target->isDev() && 'dist' === $installationSource) {
+                $downloader->remove($initial, $targetDir);
+                $promise = $this->download($target, $targetDir, $loop);
+            } elseif ($initialType === $targetType) {
+                $target->setInstallationSource($installationSource);
+                $promise = $downloader->update($initial, $target, $targetDir, $loop);
+            } else {
+                $downloader->remove($initial, $targetDir);
+                $promise = $this->download($target, $targetDir, 'source' === $installationSource, $loop);
+            }
         }
 
-        $installationSource = $initial->getInstallationSource();
-
-        if ('dist' === $installationSource) {
-            $initialType = $initial->getDistType();
-            $targetType  = $target->getDistType();
-        } else {
-            $initialType = $initial->getSourceType();
-            $targetType  = $target->getSourceType();
+        if (!$promise) {
+            $deferred = new Deferred();
+            $deferred->resolve();
+            $promise = $deferred->promise();
         }
 
-        // upgrading from a dist stable package to a dev package, force source reinstall
-        if ($target->isDev() && 'dist' === $installationSource) {
-            $downloader->remove($initial, $targetDir);
-            $this->download($target, $targetDir);
-
-            return;
-        }
-
-        if ($initialType === $targetType) {
-            $target->setInstallationSource($installationSource);
-            $downloader->update($initial, $target, $targetDir);
-        } else {
-            $downloader->remove($initial, $targetDir);
-            $this->download($target, $targetDir, 'source' === $installationSource);
-        }
+        return $promise;
     }
 
     /**

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -19,6 +19,7 @@ use Composer\Util\ProcessExecutor;
 use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
 use Composer\Config;
+use React\EventLoop\LoopInterface;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -37,7 +38,7 @@ class GitDownloader extends VcsDownloader
     /**
      * {@inheritDoc}
      */
-    public function doDownload(PackageInterface $package, $path, $url)
+    public function doDownload(PackageInterface $package, $path, $url, LoopInterface $loop = null)
     {
         GitUtil::cleanEnv();
         $path = $this->normalizePath($path);
@@ -51,19 +52,20 @@ class GitDownloader extends VcsDownloader
             return sprintf($command, ProcessExecutor::escape($url), ProcessExecutor::escape($path), ProcessExecutor::escape($ref));
         };
 
-        $this->gitUtil->runCommand($commandCallable, $url, $path, true);
-        if ($url !== $package->getSourceUrl()) {
-            $url = $package->getSourceUrl();
-            $this->process->execute(sprintf('git remote set-url origin %s', ProcessExecutor::escape($url)), $output, $path);
-        }
-        $this->setPushUrl($path, $url);
-
-        if ($newRef = $this->updateToCommit($path, $ref, $package->getPrettyVersion(), $package->getReleaseDate())) {
-            if ($package->getDistReference() === $package->getSourceReference()) {
-                $package->setDistReference($newRef);
+        return $this->gitUtil->runCommand($commandCallable, $url, $path, true, $loop)->then(function () use ($url, $package, $path, $ref) {
+            if ($url !== $package->getSourceUrl()) {
+                $url = $package->getSourceUrl();
+                $this->process->execute(sprintf('git remote set-url origin %s', ProcessExecutor::escape($url)), $output, $path);
             }
-            $package->setSourceReference($newRef);
-        }
+            $this->setPushUrl($path, $url);
+
+            if ($newRef = $this->updateToCommit($path, $ref, $package->getPrettyVersion(), $package->getReleaseDate())) {
+                if ($package->getDistReference() === $package->getSourceReference()) {
+                    $package->setDistReference($newRef);
+                }
+                $package->setSourceReference($newRef);
+            }
+        });
     }
 
     /**

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -527,7 +527,8 @@ class Installer
         );
 
         $operations = call_user_func_array('array_merge', $opsGroups);
-        $loop = PHP_VERSION_ID >= 50500 ? React\EventLoop\Factory::create() : null;
+        $parallelOps = $this->config->get('parallel-operations');
+        $loop = $parallelOps > 1 && PHP_VERSION_ID >= 50500 ? React\EventLoop\Factory::create() : null;
         $loopEnableIndex = 2;
 
         foreach ($opsGroups as $i => $ops) {
@@ -585,7 +586,7 @@ class Installer
                     $this->io->writeError('');
                 }
 
-                $this->installationManager->execute($localRepo, $operation, $i >= $loopEnableIndex ? $loop : null);
+                $this->installationManager->execute($localRepo, $operation, $i >= $loopEnableIndex ? $loop : null, $parallelOps);
 
                 // output reasons why the operation was ran, only for install/update operations
                 if ($this->verbose && $this->io->isVeryVerbose() && in_array($operation->getJobType(), array('install', 'update'))) {

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -135,7 +135,7 @@ class InstallationManager
      * @param RepositoryInterface $repo      repository in which to check
      * @param OperationInterface  $operation operation instance
      */
-    public function execute(RepositoryInterface $repo, OperationInterface $operation, $loop = null)
+    public function execute(RepositoryInterface $repo, OperationInterface $operation, $loop = null, $parallelOps = 8)
     {
         $method = $operation->getJobType();
         if ($loop) {
@@ -167,7 +167,7 @@ class InstallationManager
                 };
             }
 
-            if (8 > $loop->composerOperationsCount++) {
+            if ($parallelOps > $loop->composerOperationsCount++) {
                 $loop->futureTick($loop->composerTick);
             }
 

--- a/src/Composer/Installer/PluginInstaller.php
+++ b/src/Composer/Installer/PluginInstaller.php
@@ -26,7 +26,6 @@ use Composer\Package\PackageInterface;
  */
 class PluginInstaller extends LibraryInstaller
 {
-    private $installationManager;
     private static $classCounter = 0;
 
     /**
@@ -34,12 +33,10 @@ class PluginInstaller extends LibraryInstaller
      *
      * @param IOInterface $io
      * @param Composer    $composer
-     * @param string      $type
      */
-    public function __construct(IOInterface $io, Composer $composer, $type = 'library')
+    public function __construct(IOInterface $io, Composer $composer)
     {
         parent::__construct($io, $composer, 'composer-plugin');
-        $this->installationManager = $composer->getInstallationManager();
     }
 
     /**

--- a/src/Composer/Installer/PluginInstaller.php
+++ b/src/Composer/Installer/PluginInstaller.php
@@ -17,6 +17,7 @@ use Composer\Package\Package;
 use Composer\IO\IOInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Package\PackageInterface;
+use React\EventLoop\LoopInterface;
 
 /**
  * Installer for plugin packages
@@ -50,28 +51,30 @@ class PluginInstaller extends LibraryInstaller
     /**
      * {@inheritDoc}
      */
-    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package, LoopInterface $loop = null)
     {
         $extra = $package->getExtra();
         if (empty($extra['class'])) {
             throw new \UnexpectedValueException('Error while installing '.$package->getPrettyName().', composer-plugin packages should have a class defined in their extra key to be usable.');
         }
 
-        parent::install($repo, $package);
-        $this->composer->getPluginManager()->registerPackage($package, true);
+        return parent::install($repo, $package, $loop)->then(function () use ($package) {
+            $this->composer->getPluginManager()->registerPackage($package, true);
+        });
     }
 
     /**
      * {@inheritDoc}
      */
-    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
+    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target, LoopInterface $loop = null)
     {
         $extra = $target->getExtra();
         if (empty($extra['class'])) {
             throw new \UnexpectedValueException('Error while installing '.$target->getPrettyName().', composer-plugin packages should have a class defined in their extra key to be usable.');
         }
 
-        parent::update($repo, $initial, $target);
-        $this->composer->getPluginManager()->registerPackage($target, true);
+        return parent::update($repo, $initial, $target, $loop)->then(function () use ($target) {
+            $this->composer->getPluginManager()->registerPackage($target, true);
+        });
     }
 }

--- a/src/Composer/Installer/ProjectInstaller.php
+++ b/src/Composer/Installer/ProjectInstaller.php
@@ -58,7 +58,7 @@ class ProjectInstaller implements InstallerInterface
     /**
      * {@inheritDoc}
      */
-    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package, $loop = null)
     {
         $installPath = $this->installPath;
         if (file_exists($installPath) && !$this->filesystem->isDirEmpty($installPath)) {
@@ -67,7 +67,7 @@ class ProjectInstaller implements InstallerInterface
         if (!is_dir($installPath)) {
             mkdir($installPath, 0777, true);
         }
-        $this->downloadManager->download($package, $installPath);
+        return $this->downloadManager->download($package, $installPath, $loop);
     }
 
     /**

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -17,6 +17,7 @@ use Composer\Util\Filesystem;
 use Composer\TestCase;
 use Composer\Composer;
 use Composer\Config;
+use React\Promise\Deferred;
 
 class LibraryInstallerTest extends TestCase
 {
@@ -105,6 +106,9 @@ class LibraryInstallerTest extends TestCase
         $library = new LibraryInstaller($this->io, $this->composer);
         $package = $this->createPackageMock();
 
+        $deferred = new Deferred();
+        $deferred->resolve();
+
         $package
             ->expects($this->any())
             ->method('getPrettyName')
@@ -113,7 +117,8 @@ class LibraryInstallerTest extends TestCase
         $this->dm
             ->expects($this->once())
             ->method('download')
-            ->with($package, $this->vendorDir.'/some/package');
+            ->with($package, $this->vendorDir.'/some/package')
+            ->will($this->returnValue($deferred->promise()));
 
         $this->repository
             ->expects($this->once())
@@ -140,6 +145,9 @@ class LibraryInstallerTest extends TestCase
 
         $initial = $this->createPackageMock();
         $target  = $this->createPackageMock();
+
+        $deferred = new Deferred();
+        $deferred->resolve();
 
         $initial
             ->expects($this->once())
@@ -169,7 +177,8 @@ class LibraryInstallerTest extends TestCase
         $this->dm
             ->expects($this->once())
             ->method('update')
-            ->with($initial, $target, $this->vendorDir.'/package1/newtarget');
+            ->with($initial, $target, $this->vendorDir.'/package1/newtarget')
+            ->will($this->returnValue($deferred->promise()));
 
         $this->repository
             ->expects($this->once())

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -17,7 +17,6 @@ use Composer\Util\Filesystem;
 use Composer\TestCase;
 use Composer\Composer;
 use Composer\Config;
-use React\Promise\Deferred;
 
 class LibraryInstallerTest extends TestCase
 {
@@ -106,9 +105,6 @@ class LibraryInstallerTest extends TestCase
         $library = new LibraryInstaller($this->io, $this->composer);
         $package = $this->createPackageMock();
 
-        $deferred = new Deferred();
-        $deferred->resolve();
-
         $package
             ->expects($this->any())
             ->method('getPrettyName')
@@ -117,8 +113,7 @@ class LibraryInstallerTest extends TestCase
         $this->dm
             ->expects($this->once())
             ->method('download')
-            ->with($package, $this->vendorDir.'/some/package')
-            ->will($this->returnValue($deferred->promise()));
+            ->with($package, $this->vendorDir.'/some/package');
 
         $this->repository
             ->expects($this->once())
@@ -145,9 +140,6 @@ class LibraryInstallerTest extends TestCase
 
         $initial = $this->createPackageMock();
         $target  = $this->createPackageMock();
-
-        $deferred = new Deferred();
-        $deferred->resolve();
 
         $initial
             ->expects($this->once())
@@ -177,8 +169,7 @@ class LibraryInstallerTest extends TestCase
         $this->dm
             ->expects($this->once())
             ->method('update')
-            ->with($initial, $target, $this->vendorDir.'/package1/newtarget')
-            ->will($this->returnValue($deferred->promise()));
+            ->with($initial, $target, $this->vendorDir.'/package1/newtarget');
 
         $this->repository
             ->expects($this->once())

--- a/tests/Composer/Test/Mock/InstallationManagerMock.php
+++ b/tests/Composer/Test/Mock/InstallationManagerMock.php
@@ -38,14 +38,14 @@ class InstallationManagerMock extends InstallationManager
         return $repo->hasPackage($package);
     }
 
-    public function install(RepositoryInterface $repo, InstallOperation $operation)
+    public function install(RepositoryInterface $repo, InstallOperation $operation, $loop = null)
     {
         $this->installed[] = $operation->getPackage();
         $this->trace[] = (string) $operation;
         $repo->addPackage(clone $operation->getPackage());
     }
 
-    public function update(RepositoryInterface $repo, UpdateOperation $operation)
+    public function update(RepositoryInterface $repo, UpdateOperation $operation, $loop = null)
     {
         $this->updated[] = array($operation->getInitialPackage(), $operation->getTargetPackage());
         $this->trace[] = (string) $operation;

--- a/tests/Composer/Test/Mock/ProcessExecutorMock.php
+++ b/tests/Composer/Test/Mock/ProcessExecutorMock.php
@@ -12,6 +12,7 @@
 namespace Composer\Test\Mock;
 
 use Composer\Util\ProcessExecutor;
+use React\EventLoop\LoopInterface;
 
 class ProcessExecutorMock extends ProcessExecutor
 {
@@ -22,7 +23,7 @@ class ProcessExecutorMock extends ProcessExecutor
         $this->execute = $execute;
     }
 
-    public function execute($command, &$output = null, $cwd = null)
+    public function execute($command, &$output = null, $cwd = null, LoopInterface $loop = null)
     {
         $execute = $this->execute;
 

--- a/tests/Composer/Test/Mock/ProcessExecutorMock.php
+++ b/tests/Composer/Test/Mock/ProcessExecutorMock.php
@@ -12,7 +12,6 @@
 namespace Composer\Test\Mock;
 
 use Composer\Util\ProcessExecutor;
-use React\EventLoop\LoopInterface;
 
 class ProcessExecutorMock extends ProcessExecutor
 {
@@ -23,10 +22,10 @@ class ProcessExecutorMock extends ProcessExecutor
         $this->execute = $execute;
     }
 
-    public function execute($command, &$output = null, $cwd = null, LoopInterface $loop = null)
+    public function execute($command, &$output = null, $cwd = null, $loop = null)
     {
         $execute = $this->execute;
 
-        return $execute($command, $output, $cwd);
+        return $execute($command, $output, $cwd, $loop);
     }
 }

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -20,7 +20,6 @@ use Composer\Package\Loader\ArrayLoader;
 use Composer\Plugin\PluginManager;
 use Composer\Autoload\AutoloadGenerator;
 use Composer\Util\Filesystem;
-use React\Promise\Deferred;
 
 class PluginInstallerTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,9 +34,6 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $deferred = new Deferred();
-        $deferred->resolve();
-
         $loader = new JsonLoader(new ArrayLoader());
         $this->packages = array();
         $this->directory = sys_get_temp_dir() . '/' . uniqid();
@@ -50,12 +46,6 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $dm = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $dm->expects($this->any())
-            ->method('download')
-            ->will($this->returnValue($deferred->promise()));
-        $dm->expects($this->any())
-            ->method('update')
-            ->will($this->returnValue($deferred->promise()));
 
         $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
 

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -20,6 +20,7 @@ use Composer\Package\Loader\ArrayLoader;
 use Composer\Plugin\PluginManager;
 use Composer\Autoload\AutoloadGenerator;
 use Composer\Util\Filesystem;
+use React\Promise\Deferred;
 
 class PluginInstallerTest extends \PHPUnit_Framework_TestCase
 {
@@ -34,6 +35,9 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $deferred = new Deferred();
+        $deferred->resolve();
+
         $loader = new JsonLoader(new ArrayLoader());
         $this->packages = array();
         $this->directory = sys_get_temp_dir() . '/' . uniqid();
@@ -46,6 +50,12 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $dm = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $dm->expects($this->any())
+            ->method('download')
+            ->will($this->returnValue($deferred->promise()));
+        $dm->expects($this->any())
+            ->method('update')
+            ->will($this->returnValue($deferred->promise()));
 
         $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
 


### PR DESCRIPTION
This adds an optional event loop argument and promises as return values to the GitDownloader.
The Installer takes advantage of it to trigger several `git clone` and manage them concurrently.
No change is made to the behavior of the code when no event loop is used, so that tests still pass.
This could be the first step towards parallel downloads in composer: the other downloaders would need to be updated following the same principle, the GitDownloader also needs to be finished (only public repos can be managed by the loop for now).
The console output also would need to be handled differently.
If someone else likes the approach, help is welcomed for porting the other downloaders to use and return promises! (a PR on this PR anyone?).
PHP 5.3 is not supported by React, but there is no blocker to change that.
