### PR TITLE
Fixes #3946

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -96,11 +96,17 @@ class ProcessExecutor
         echo $buffer;
     }
 
+    /**
+     * @return int
+     */
     public static function getTimeout()
     {
         return getenv('COMPOSER_PROCESS_TIMEOUT') ?: static::$timeout;
     }
 
+    /**
+     * @param int $timeout
+     */
     public static function setTimeout($timeout)
     {
         static::$timeout = $timeout;
@@ -113,7 +119,6 @@ class ProcessExecutor
      *
      * @return string The escaped argument
      */
-
     public static function escape($argument)
     {
         return ProcessUtils::escapeArgument($argument);

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -98,7 +98,7 @@ class ProcessExecutor
 
     public static function getTimeout()
     {
-        return static::$timeout;
+        return getenv('COMPOSER_PROCESS_TIMEOUT') ?: static::$timeout;
     }
 
     public static function setTimeout($timeout)


### PR DESCRIPTION
Use COMPOSER_PROCESS_TIMEOUT if available.

Strangely enough, this **documented** environment variable is not actually implemented in the source code at the time of writing this PR (or I'm just really bad at using `grep`).