### PR TITLE
Allow numeric author name

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -40,7 +40,7 @@ class InitCommand extends Command
 
     public function parseAuthorString($author)
     {
-        if (preg_match('/^(?P<name>[- \.,\p{L}\'’]+) <(?P<email>.+?)>$/u', $author, $match)) {
+        if (preg_match('/^(?P<name>[- \.,\p{L}\p{N}\'’]+) <(?P<email>.+?)>$/u', $author, $match)) {
             if ($this->isValidEmail($match['email'])) {
                 return array(
                     'name'  => trim($match['name']),

--- a/tests/Composer/Test/Command/InitCommandTest.php
+++ b/tests/Composer/Test/Command/InitCommandTest.php
@@ -33,6 +33,14 @@ class InitCommandTest extends TestCase
         $this->assertEquals('matti@example.com', $author['email']);
     }
 
+    public function testParseNumericAuthorString()
+    {
+        $command = new InitCommand;
+        $author = $command->parseAuthorString('h4x0r <h4x@example.com>');
+        $this->assertEquals('h4x0r', $author['name']);
+        $this->assertEquals('h4x@example.com', $author['email']);
+    }
+
     public function testParseEmptyAuthorString()
     {
         $command = new InitCommand;


### PR DESCRIPTION
Could also change it to just accept whatever. Do we really want to enforce strict rules regarding valid author names?

Closes #3948