### PR TITLE
Add argument to update lock without installing

### DIFF
--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -39,6 +39,7 @@ class UpdateCommand extends Command
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Enables installation of require-dev packages (enabled by default, only present for BC).'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables installation of require-dev packages.'),
                 new InputOption('lock', null, InputOption::VALUE_NONE, 'Only updates the lock file hash to suppress warning about the lock file being out of date.'),
+                new InputOption('no-install', null, InputOption::VALUE_NONE, 'Update the lock file, but do not install packages.'),
                 new InputOption('no-plugins', null, InputOption::VALUE_NONE, 'Disables all plugins.'),
                 new InputOption('no-custom-installers', null, InputOption::VALUE_NONE, 'DEPRECATED: Use no-plugins instead.'),
                 new InputOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation'),
@@ -126,6 +127,7 @@ EOT
             ->setRunScripts(!$input->getOption('no-scripts'))
             ->setOptimizeAutoloader($optimize)
             ->setUpdate(true)
+            ->setInstall(!$input->getOption('no-install'))
             ->setUpdateWhitelist($input->getOption('lock') ? array('lock') : $input->getArgument('packages'))
             ->setWhitelistDependencies($input->getOption('with-dependencies'))
             ->setIgnorePlatformRequirements($input->getOption('ignore-platform-reqs'))

--- a/tests/Composer/Test/Fixtures/installer/update-all-no-install.test
+++ b/tests/Composer/Test/Fixtures/installer/update-all-no-install.test
@@ -1,0 +1,57 @@
+--TEST--
+Updates lockfile for updateable packages
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0" },
+                { "name": "a/a", "version": "1.0.1" },
+                { "name": "a/a", "version": "1.1.0" },
+
+                { "name": "a/b", "version": "1.0.0" },
+                { "name": "a/b", "version": "1.0.1" },
+                { "name": "a/b", "version": "2.0.0" },
+
+                { "name": "a/c", "version": "1.0.0" },
+                { "name": "a/c", "version": "2.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.*",
+        "a/c": "1.*"
+    },
+    "require-dev": {
+        "a/b": "*"
+    }
+}
+--INSTALLED--
+[
+    { "name": "a/a", "version": "1.0.0" },
+    { "name": "a/c", "version": "1.0.0" },
+    { "name": "a/b", "version": "1.0.0" }
+]
+--RUN--
+update --no-install
+--EXPECT--
+Updating a/a (1.0.0) to a/a (1.0.1)
+Updating a/b (1.0.0) to a/b (2.0.0)
+--EXPECT-LOCK--
+{
+    "packages": [
+        { "name": "a/a", "version": "1.0.1", "type": "library" },
+        { "name": "a/c", "version": "1.0.0", "type": "library" }
+    ],
+    "packages-dev": [
+        { "name": "a/b", "version": "2.0.0", "type": "library" }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/tests/Composer/Test/Fixtures/installer/update-whitelist-no-install.test
+++ b/tests/Composer/Test/Fixtures/installer/update-whitelist-no-install.test
@@ -1,0 +1,39 @@
+--TEST--
+Update lockfile with a package whitelist only updates those packages listed as command arguments
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "fixed", "version": "1.1.0" },
+                { "name": "fixed", "version": "1.0.0" },
+                { "name": "whitelisted", "version": "1.1.0", "require": { "dependency": "1.*" } },
+                { "name": "whitelisted", "version": "1.0.0", "require": { "dependency": "1.*" } },
+                { "name": "dependency", "version": "1.1.0" },
+                { "name": "dependency", "version": "1.0.0" },
+                { "name": "unrelated", "version": "1.1.0", "require": { "unrelated-dependency": "1.*" }  },
+                { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" }  },
+                { "name": "unrelated-dependency", "version": "1.1.0" },
+                { "name": "unrelated-dependency", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "fixed": "1.*",
+        "whitelisted": "1.*",
+        "unrelated": "1.*"
+    }
+}
+--INSTALLED--
+[
+    { "name": "fixed", "version": "1.0.0" },
+    { "name": "whitelisted", "version": "1.0.0", "require": { "dependency": "1.*" } },
+    { "name": "dependency", "version": "1.0.0" },
+    { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" } },
+    { "name": "unrelated-dependency", "version": "1.0.0" }
+]
+--RUN--
+update whitelisted --no-install
+--EXPECT--
+Updating whitelisted (1.0.0) to whitelisted (1.1.0)

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -220,6 +220,7 @@ class InstallerTest extends TestCase
                 ->setWhitelistDependencies($input->getOption('with-dependencies'))
                 ->setPreferStable($input->getOption('prefer-stable'))
                 ->setPreferLowest($input->getOption('prefer-lowest'))
+                ->setInstall(!$input->getOption('no-install'))
                 ->setIgnorePlatformRequirements($input->getOption('ignore-platform-reqs'));
 
             return $installer->run();


### PR DESCRIPTION
The documentation for update --lock states:
`Only updates the lock file hash to suppress warning about the lock file being out of date.`

From this I understand that we are performing a `composer update`, which would normally update the dependency tree, update the lock file, and install the dependencies into the vendor directory; but without actually installing the dependencies.

However, if I update my composer.json from one fixed version to another, then call `composer update --lock`, I get a confusing message which suggests that the lock file is being updated based on the data in the composer.json *and* the data currently in composer.lock.

### Steps to reproduce:

    # Clone my sample repo and install the dependencies:
    git clone https://github.com/andrewnicols/composer-mtc-issue.git
    git checkout master
    composer install

    # Bump the version of the dependency, to 1.28.0, or checkout the branch I created for you:
    git checkout versionUpdated

    # Update the lock file:
    composer update --lock

### Expected Result
The lock file is updated without installing the dependencies into the vendor directory.

### Actual Result
Some confusing mismash of composer.lock + composer.json:

    Loading composer repositories with package information
    Updating dependencies (including require-dev)
    Your requirements could not be resolved to an installable set of packages.

      Problem 1
        - The requested package moodlehq/behat-extension == 1.28.6.0 could not be found.
      Problem 2
        - Installation request for moodlehq/behat-extension 1.28.8 -> satisfiable by moodlehq/behat-extension[v1.28.8].
        - Conclusion: remove guzzle/common v3.9.2
        - moodlehq/behat-extension v1.28.8 requires guzzlehttp/guzzle ~3.1 -> satisfiable by guzzlehttp/guzzle[v3.1.0, v3.1.1, v3.1.2, v3.2.0, v3.3.0, v3.3.1, v3.4.0, v3.4.1, v3.4.2, v3.4.3, v3.5.0, v3.6.0, v3.7.0, v3.7.1, v3.7.2, v3.7.3, v3.7.4, v3.8.0, v3.8.1].
        - don't install guzzlehttp/guzzle v3.1.0|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.1.1|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.1.2|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.2.0|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.3.0|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.3.1|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.4.0|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.4.1|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.4.2|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.4.3|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.5.0|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.6.0|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.7.0|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.7.1|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.7.2|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.7.3|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.7.4|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.8.0|don't install guzzle/common v3.9.2
        - don't install guzzlehttp/guzzle v3.8.1|don't install guzzle/common v3.9.2
        - Installation request for guzzle/common == 3.9.2.0 -> satisfiable by guzzle/common[v3.9.2].

    Potential causes:
    - A typo in the package name
    - The package is not available in a stable-enough version according to your minimum-stability setting
      see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

    Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.


### Usecase
We wish to add a CI server task which runs composer update --lock to ensure that the lock file is up-to-date with the composer.json and will warn accordingly if someone attempts to push a change to one without a change to the other.
We do not necessarily need to install the dependencies for this task.

### Summary
This could simply be an issue in the documentation - e.g. that --lock does not actually do as we expect, or it could be doing completely the wrong thing.