### PR TITLE
Fix Travis cache issue (~/.composer/cache changes on every build)

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -136,7 +136,7 @@ class Cache
     {
         $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
         if ($this->enabled && file_exists($this->root . $file)) {
-            touch($this->root . $file);
+            touch($this->root . $file, filemtime($this->root . $file), time());
 
             if ($this->io->isDebug()) {
                 $this->io->writeError('Reading '.$this->root . $file.' from cache');


### PR DESCRIPTION
When Composer copies a file from its cache to a vendor directory, it does a `touch` on the cached file which sets both the modification time and access time of the file to the current time. This is to ensure that only the least-recently used files are pruned from the Composer cache when garbage collection runs. However, Composer's cache garbage collection seems to only test the access time of cached files, not the modification time, which means the `touch` doesn't actually need to update the modification time of the cache files when they are read.

Changing the modification time of files causes issues on Travis CI when the _cache_ feature is used on the `$HOME/.composer/cache` directory, as Travis checks the modification times of the files in that directory on every build.

The idea of this PR is to modify the `touch` invokation in Composer so that it only updates the access time of cache files and not the modification time. This should not affect the garbage collection of Composer but should resolve the Travis issue.

Apologies if I have misunderstood anything!