### PR TITLE
Fixed svn update command

### DIFF
--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -121,7 +121,7 @@ class Svn
         }
 
         $errorOutput = $this->process->getErrorOutput();
-        $fullOutput = join("\n", array($output, $errorOutput));
+        $fullOutput = implode("\n", array($output, $errorOutput));
 
         // the error is not auth-related
         if (false === stripos($fullOutput, 'Could not authenticate to server:')

--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -120,16 +120,18 @@ class Svn
             return $output;
         }
 
+        $errorOutput = $this->process->getErrorOutput();
         if (empty($output)) {
-            $output = $this->process->getErrorOutput();
+            $output = $errorOutput;
         }
+        $fullOutput = "$output\n$errorOutput";
 
         // the error is not auth-related
-        if (false === stripos($output, 'Could not authenticate to server:')
-            && false === stripos($output, 'authorization failed')
-            && false === stripos($output, 'svn: E170001:')
-            && false === stripos($output, 'svn: E215004:')) {
-            throw new \RuntimeException($output);
+        if (false === stripos($fullOutput, 'Could not authenticate to server:')
+            && false === stripos($fullOutput, 'authorization failed')
+            && false === stripos($fullOutput, 'svn: E170001:')
+            && false === stripos($fullOutput, 'svn: E215004:')) {
+            throw new \RuntimeException($fullOutput);
         }
 
         if (!$this->hasAuth()) {

--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -121,10 +121,7 @@ class Svn
         }
 
         $errorOutput = $this->process->getErrorOutput();
-        if (empty($output)) {
-            $output = $errorOutput;
-        }
-        $fullOutput = "$output\n$errorOutput";
+        $fullOutput = join("\n", array($output, $errorOutput));
 
         // the error is not auth-related
         if (false === stripos($fullOutput, 'Could not authenticate to server:')
@@ -145,7 +142,7 @@ class Svn
         }
 
         throw new \RuntimeException(
-            'wrong credentials provided ('.$output.')'
+            'wrong credentials provided ('.$fullOutput.')'
         );
     }
 


### PR DESCRIPTION
=> Fails before attempting to use authentication provided in auth.json because the svn command outputs to STDOUT *and* STDERR, which breaks the condition that checks for an authentication issue before throwing a RuntimeException.