### PR TITLE
[Docs] [Typo] Correct a misused article in the docs

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -103,7 +103,7 @@ It may include any of the other fields specified in the [schema](04-schema.md).
 
 #### notify-batch
 
-The `notify-batch` field allows you to specify an URL that will be called
+The `notify-batch` field allows you to specify a URL that will be called
 every time a user installs a package. The URL can be either an absolute path
 (that will use the same domain as the repository) or a fully qualified URL.
 


### PR DESCRIPTION
I'm not a native English speaker, but I think that we must use _a_ (and not _an_) in front of a _u_ when it is pronounced _you_ (like in _user_).

Source: https://www.englishclub.com/pronunciation/a-an.htm