### PR TITLE
Prioritize repository over package versions in the default policy

### DIFF
--- a/doc/dev/DefaultPolicy.md
+++ b/doc/dev/DefaultPolicy.md
@@ -12,6 +12,13 @@ resulting order in which the solver will try to install them.
 
 The rules are to be applied in the order of these descriptions.
 
+### Repository priorities
+
+Packages Repo1.Av1, Repo2.Av1
+
+* priority(Repo1) >= priority(Repo2) => (Repo1.Av1, Repo2.Av1)
+* priority(Repo1) <  priority(Repo2) => (Repo2.Av1, Repo1.Av1)
+
 ### Package versions
 
 Packages: Av1, Av2, Av3
@@ -21,13 +28,6 @@ Packages: Av1, Av2, Av3
 Request: install A
 
 * (Av3)
-
-### Repository priorities
-
-Packages Repo1.Av1, Repo2.Av1
-
-* priority(Repo1) >= priority(Repo2) => (Repo1.Av1, Repo2.Av1)
-* priority(Repo1) <  priority(Repo2) => (Repo2.Av1, Repo1.Av1)
 
 ### Virtual Packages (provides)
 

--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -82,9 +82,9 @@ class DefaultPolicy implements PolicyInterface
         }
 
         foreach ($packages as &$literals) {
-            $literals = $this->pruneToBestVersion($pool, $literals);
-
             $literals = $this->pruneToHighestPriorityOrInstalled($pool, $installedMap, $literals);
+
+            $literals = $this->pruneToBestVersion($pool, $literals);
 
             $literals = $this->pruneRemoteAliases($pool, $literals);
         }

--- a/tests/Composer/Test/Fixtures/installer/install-prefers-repos-over-package-versions.test
+++ b/tests/Composer/Test/Fixtures/installer/install-prefers-repos-over-package-versions.test
@@ -1,0 +1,30 @@
+--TEST--
+Install prefers higher priority repositories over higher priority package versions
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0" }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.1.0" },
+                { "name": "b/b", "version": "1.1.0" },
+                { "name": "b/b", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "*",
+        "b/b": "*"
+    }
+}
+--RUN--
+install
+--EXPECT--
+Installing a/a (1.0.0)
+Installing b/b (1.1.0)


### PR DESCRIPTION
In practice it is quite rare to have a package in multiple repos unless you intend to install your own fork of it, so I don't think this breaks any real use case, and it would improve security by preventing hijacks from packagist using a higher version of a private package.

@naderman I'd be happy to get your feedback in case you think of something I missed, otherwise I'll go ahead and merge.

Fixes #3509