### PR TITLE
AuthHelper Exception Fix on Store Credentials

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -45,7 +45,7 @@ class AuthHelper
                     }
                     throw new \RuntimeException('Please answer (y)es or (n)o');
                 },
-                false,
+                null,
                 'y'
             );
 


### PR DESCRIPTION
This fixes the issue described in https://github.com/composer/composer/issues/3987 which causes an exception to always be thrown when asked if you want to store your authentication credentials.