### PR TITLE
Replaced <error> with <warning> for abandoned package messages

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -302,7 +302,7 @@ EOT
                 : null;
 
             $this->getIO()->writeError(
-                sprintf('<error>Attention: This package is abandoned and no longer maintained.%s</error>', $replacement)
+                sprintf('<warning>Attention: This package is abandoned and no longer maintained.%s</warning>', $replacement)
             );
         }
 

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -264,7 +264,7 @@ class Installer
 
             $this->io->writeError(
                 sprintf(
-                    "<error>Package %s is abandoned, you should avoid using it. %s.</error>",
+                    "<warning>Package %s is abandoned, you should avoid using it. %s.</warning>",
                     $package->getPrettyName(),
                     $replacement
                 )

--- a/tests/Composer/Test/Fixtures/installer/abandoned-listed.test
+++ b/tests/Composer/Test/Fixtures/installer/abandoned-listed.test
@@ -26,8 +26,8 @@ install
 --EXPECT-OUTPUT--
 <info>Loading composer repositories with package information</info>
 <info>Installing dependencies (including require-dev)</info>
-<error>Package a/a is abandoned, you should avoid using it. No replacement was suggested.</error>
-<error>Package c/c is abandoned, you should avoid using it. Use b/b instead.</error>
+<warning>Package a/a is abandoned, you should avoid using it. No replacement was suggested.</warning>
+<warning>Package c/c is abandoned, you should avoid using it. Use b/b instead.</warning>
 <info>Writing lock file</info>
 <info>Generating autoload files</info>
 


### PR DESCRIPTION
Currently the abandoned package messages use `<error>` which displays a red message. [This](https://github.com/reactphp/http/issues/24) [seems](https://github.com/ratchetphp/Ratchet/issues/309) [to](https://github.com/ratchetphp/Ratchet/issues/285) [lead](https://github.com/ratchetphp/Ratchet/pull/287) [to](https://github.com/ratchetphp/Ratchet/issues/305) some confusion by users thinking the the message is an error not an warning. Therefore I'm proposing by this PR to use `<warning>` displaying a yellow message instead.

#### Visual differences 
Using an abandoned package:
![](http://i.imgur.com/hK5TeNp.png)

Showing a package's using `composer show vendor/package`:
![](http://i.imgur.com/3S3taYu.png)