### PR TITLE
Load only explicitly named package data

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -276,6 +276,7 @@ EOT
 
         $pool = new Pool($stability);
         $pool->addRepository($sourceRepo);
+        $pool->loadRecursively(array($name));
 
         // find the latest version if there are multiple
         $versionSelector = new VersionSelector($pool);

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -99,7 +99,6 @@ class Pool
             if ($repo instanceof ComposerRepository && $repo->hasProviders()) {
                 $this->providerRepos[] = $repo;
                 $repo->setRootAliases($rootAliases);
-                $repo->resetPackageIds();
             } else {
                 foreach ($repo->getPackages() as $package) {
                     $this->loadPackage($package, $rootAliases, $exempt);
@@ -222,26 +221,13 @@ class Pool
     private function computeWhatProvides($name, $constraint, $mustMatchName = false)
     {
         $candidates = array();
-/*
-        foreach ($this->providerRepos as $repo) {
-            foreach ($repo->whatProvides($this, $name) as $candidate) {
-                $candidates[] = $candidate;
-                if ($candidate->id < 1) {
-                    $candidate->setId($this->id++);
-                    $this->packages[$this->id - 2] = $candidate;
-                }
-            }
-        }*/
 
         if ($mustMatchName) {
-            $candidates = array_filter($candidates, function ($candidate) use ($name) {
-                return $candidate->getName() == $name;
-            });
             if (isset($this->packageByExactName[$name])) {
-                $candidates = array_merge($candidates, $this->packageByExactName[$name]);
+                $candidates = $this->packageByExactName[$name];
             }
         } elseif (isset($this->packageByName[$name])) {
-            $candidates = array_merge($candidates, $this->packageByName[$name]);
+            $candidates = $this->packageByName[$name];
         }
 
         $matches = $provideMatches = array();

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -167,7 +167,7 @@ class Pool
         return $this->packages[$id - 1];
     }
 
-    public function loadRecursively(array $packageNames, $loadDev)
+    public function loadRecursively(array $packageNames)
     {
         $loadedMap = array();
         do {
@@ -177,7 +177,6 @@ class Pool
             foreach ($this->providerRepos as $repo) {
                 $packages = $repo->loadRecursively(
                     $packageNames,
-                    $loadDev,
                     array($this, 'isPackageAcceptable')
                 );
 

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -160,6 +160,13 @@ class Pool
         return $this->packages[$id - 1];
     }
 
+    public function ensureLoaded($constrainedNames)
+    {
+        foreach ($this->providerRepos as $repo) {
+            $repo->ensureLoaded($this, $constrainedNames);
+        }
+    }
+
     /**
      * Searches all packages providing the given package name and match the constraint
      *

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -169,6 +169,21 @@ class Solver
         $this->jobs = $request->getJobs();
 
         $this->setupInstalledMap();
+
+        $constrainedNames = array();
+        foreach ($this->jobs as $job) {
+            switch ($job['cmd']) {
+                case 'install':
+                    $constrainedNames[] = array(
+                        'name' => $job['packageName'],
+                        'constraint' => $job['constraint'],
+                    );
+                    break;
+            }
+        }
+
+        $this->pool->ensureLoaded($constrainedNames);
+
         $this->rules = $this->ruleSetGenerator->getRulesFor($this->jobs, $this->installedMap, $ignorePlatformReqs);
         $this->checkForRootRequireProblems($ignorePlatformReqs);
         $this->decisions = new Decisions($this->pool);

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -174,12 +174,12 @@ class Solver
         foreach ($this->jobs as $job) {
             switch ($job['cmd']) {
                 case 'install':
-                    $packageNames[] = $job['packageName'];
+                    $packageNames[$job['packageName']] = true;
                     break;
             }
         }
 
-        $this->pool->loadRecursively($packageNames, true);
+        $this->pool->loadRecursively(array_keys($packageNames), true);
 
         $this->rules = $this->ruleSetGenerator->getRulesFor($this->jobs, $this->installedMap, $ignorePlatformReqs);
         $this->checkForRootRequireProblems($ignorePlatformReqs);

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -170,19 +170,16 @@ class Solver
 
         $this->setupInstalledMap();
 
-        $constrainedNames = array();
+        $packageNames = array();
         foreach ($this->jobs as $job) {
             switch ($job['cmd']) {
                 case 'install':
-                    $constrainedNames[] = array(
-                        'name' => $job['packageName'],
-                        'constraint' => $job['constraint'],
-                    );
+                    $packageNames[] = $job['packageName'];
                     break;
             }
         }
 
-        $this->pool->ensureLoaded($constrainedNames);
+        $this->pool->loadRecursively($packageNames, true);
 
         $this->rules = $this->ruleSetGenerator->getRulesFor($this->jobs, $this->installedMap, $ignorePlatformReqs);
         $this->checkForRootRequireProblems($ignorePlatformReqs);

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -179,7 +179,7 @@ class Solver
             }
         }
 
-        $this->pool->loadRecursively(array_keys($packageNames), true);
+        $this->pool->loadRecursively(array_keys($packageNames));
 
         $this->rules = $this->ruleSetGenerator->getRulesFor($this->jobs, $this->installedMap, $ignorePlatformReqs);
         $this->checkForRootRequireProblems($ignorePlatformReqs);

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -128,7 +128,7 @@ class ComposerRepository extends ArrayRepository
     }
 
     protected function loadName($pool, $name)
-    {echo "Loading $name\n";
+    {
         // skip platform packages
         if (preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $name) || '__root__' === $name) {
             return array();

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -100,7 +100,7 @@ class ComposerRepository extends ArrayRepository
         return $this->rootAliases;
     }
 
-    public function loadRecursively(array $packageNames, $loadDev, $acceptableCallback)
+    public function loadRecursively(array $packageNames, $acceptableCallback)
     {
         $workQueue = new \SplQueue;
 
@@ -123,9 +123,6 @@ class ComposerRepository extends ArrayRepository
             foreach ($packages as $package) {
                 $loadedPackages[] = $package;
                 $requires = $package->getRequires();
-                if ($loadDev) {
-                    $requires = array_merge($requires, $package->getDevRequires());
-                }
                 foreach ($requires as $link) {
                     $workQueue->enqueue($link->getTarget());
                 }

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -180,21 +180,11 @@ class ComposerRepository extends ArrayRepository
                 }
 
                 // avoid loading the same objects twice
-                if (isset($this->providersByUid[$version['uid']])) {die("wtf?");
-                    // skip if already assigned
-                    if (!isset($this->providers[$name][$version['uid']])) {
-                        // expand alias in two packages
-                        if ($this->providersByUid[$version['uid']] instanceof AliasPackage) {
-                            $this->providers[$name][$version['uid']] = $this->providersByUid[$version['uid']]->getAliasOf();
-                            $this->providers[$name][$version['uid'].'-alias'] = $this->providersByUid[$version['uid']];
-                        } else {
-                            $this->providers[$name][$version['uid']] = $this->providersByUid[$version['uid']];
-                        }
-                        // check for root aliases
-                        if (isset($this->providersByUid[$version['uid'].'-root'])) {
-                            $this->providers[$name][$version['uid'].'-root'] = $this->providersByUid[$version['uid'].'-root'];
-                        }
-                    }
+                if (isset($this->providersByUid[$version['uid']])) {
+                    /**
+                     * @todo verify and remove
+                     */
+                    throw new \RuntimeException("Should not happen anymore");
                 } else {
                     if (!$pool->isPackageAcceptable(strtolower($version['name']), VersionParser::parseStability($version['version']))) {
                         continue;
@@ -415,108 +405,11 @@ class ComposerRepository extends ArrayRepository
         if (preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $name) || '__root__' === $name || 'composer-plugin-api' === $name) {
             return array();
         }
-        var_dump($name);
-        debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        die("should not reach\n");
 
-        if (null === $this->providerListing) {
-            $this->loadProviderListings($this->loadRootServerFile());
-        }
-
-        if ($this->lazyProvidersUrl && !isset($this->providerListing[$name])) {
-            $hash = null;
-            $url = str_replace('%package%', $name, $this->lazyProvidersUrl);
-            $cacheKey = false;
-        } elseif ($this->providersUrl) {
-            // package does not exist in this repo
-            if (!isset($this->providerListing[$name])) {
-                return array();
-            }
-
-            $hash = $this->providerListing[$name]['sha256'];
-            $url = str_replace(array('%package%', '%hash%'), array($name, $hash), $this->providersUrl);
-            $cacheKey = 'provider-'.strtr($name, '/', '$').'.json';
-        } else {
-            // BC handling for old providers-includes
-            $url = 'p/'.$name.'.json';
-
-            // package does not exist in this repo
-            if (!isset($this->providerListing[$url])) {
-                return array();
-            }
-            $hash = $this->providerListing[$url]['sha256'];
-            $cacheKey = null;
-        }
-
-        if ($cacheKey && $this->cache->sha256($cacheKey) === $hash) {
-            $packages = json_decode($this->cache->read($cacheKey), true);
-        } else {
-            $packages = $this->fetchFile($url, $cacheKey, $hash);
-        }
-
-        $this->providers[$name] = array();
-        foreach ($packages['packages'] as $versions) {
-            foreach ($versions as $version) {
-                // avoid loading the same objects twice
-                if (isset($this->providersByUid[$version['uid']])) {
-                    // skip if already assigned
-                    if (!isset($this->providers[$name][$version['uid']])) {
-                        // expand alias in two packages
-                        if ($this->providersByUid[$version['uid']] instanceof AliasPackage) {
-                            $this->providers[$name][$version['uid']] = $this->providersByUid[$version['uid']]->getAliasOf();
-                            $this->providers[$name][$version['uid'].'-alias'] = $this->providersByUid[$version['uid']];
-                        } else {
-                            $this->providers[$name][$version['uid']] = $this->providersByUid[$version['uid']];
-                        }
-                        // check for root aliases
-                        if (isset($this->providersByUid[$version['uid'].'-root'])) {
-                            $this->providers[$name][$version['uid'].'-root'] = $this->providersByUid[$version['uid'].'-root'];
-                        }
-                    }
-                } else {
-                    if (!$pool->isPackageAcceptable(strtolower($version['name']), VersionParser::parseStability($version['version']))) {
-                        continue;
-                    }
-
-                    // load acceptable packages in the providers
-                    $package = $this->createPackage($version, 'Composer\Package\Package');
-                    $package->setRepository($this);
-
-                    if ($package instanceof AliasPackage) {
-                        $aliased = $package->getAliasOf();
-                        $aliased->setRepository($this);
-
-                        $this->providers[$name][$version['uid']] = $aliased;
-                        $this->providers[$name][$version['uid'].'-alias'] = $package;
-
-                        // override provider with its alias so it can be expanded in the if block above
-                        $this->providersByUid[$version['uid']] = $package;
-                    } else {
-                        $this->providers[$name][$version['uid']] = $package;
-                        $this->providersByUid[$version['uid']] = $package;
-                    }
-
-                    // handle root package aliases
-                    unset($rootAliasData);
-
-                    if (isset($this->rootAliases[$package->getName()][$package->getVersion()])) {
-                        $rootAliasData = $this->rootAliases[$package->getName()][$package->getVersion()];
-                    } elseif ($package instanceof AliasPackage && isset($this->rootAliases[$package->getName()][$package->getAliasOf()->getVersion()])) {
-                        $rootAliasData = $this->rootAliases[$package->getName()][$package->getAliasOf()->getVersion()];
-                    }
-
-                    if (isset($rootAliasData)) {
-                        $alias = $this->createAliasPackage($package, $rootAliasData['alias_normalized'], $rootAliasData['alias']);
-                        $alias->setRepository($this);
-
-                        $this->providers[$name][$version['uid'].'-root'] = $alias;
-                        $this->providersByUid[$version['uid'].'-root'] = $alias;
-                    }
-                }
-            }
-        }
-
-        return $this->providers[$name];
+        /**
+         * @todo verify this is no longer possible and change code to remove this
+         */
+        throw new \RuntimeException("Could not find package that should have been loaded.");
     }
 
     /**

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -181,7 +181,9 @@ class ComposerRepository extends ArrayRepository
                     continue;
                 }
 
-                if ($acceptableCallback && !$acceptableCallback(strtolower($version['name']), VersionParser::parseStability($version['version']))) {
+                if ($acceptableCallback && !call_user_func(
+                    $acceptableCallback, strtolower($version['name']), VersionParser::parseStability($version['version'])
+                )) {
                     continue;
                 }
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -336,12 +336,12 @@ class ComposerRepository extends ArrayRepository
         }
 
         $loadedPackages = array();
-        foreach ($packages['packages'] as $versions) {
-            foreach ($versions as $version) {
-                if ($exactMatch && $version['name'] !== $name) {
-                    continue;
-                }
+        foreach ($packages['packages'] as $packageName => $versions) {
+            if ($exactMatch && $packageName !== $name) {
+                continue;
+            }
 
+            foreach ($versions as $version) {
                 if ($acceptableCallback && !call_user_func(
                     $acceptableCallback, strtolower($version['name']), VersionParser::parseStability($version['version'])
                 )) {

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -96,6 +96,161 @@ class ComposerRepository extends ArrayRepository
         $this->rootAliases = $rootAliases;
     }
 
+    public function ensureLoaded($pool, array $constrainedNames)
+    {
+        $workQueue = new \SplQueue;
+
+        foreach ($constrainedNames as $packageSpec) {
+            $workQueue->enqueue($packageSpec);
+        }
+
+        $loadedMap = array();
+
+        while (!$workQueue->isEmpty()) {
+            $packageSpec = $workQueue->dequeue();
+            if (isset($this->loadedMap[$packageSpec['name']])) {
+                continue;
+            }
+
+            $this->loadedMap[$packageSpec['name']] = true;
+
+            $packages = $this->loadName($pool, $packageSpec['name']);
+
+            foreach ($packages as $package) {
+                foreach ($package->getRequires() as $link) {
+                    $workQueue->enqueue(array(
+                        'name' => $link->getTarget(),
+                        'constraint' => $link->getConstraint()
+                    ));
+                }
+            }
+        }
+    }
+
+    protected function loadName($pool, $name)
+    {echo "Loading $name\n";
+        // skip platform packages
+        if (preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $name) || '__root__' === $name) {
+            return array();
+        }
+
+        if (null === $this->providerListing) {
+            $this->loadProviderListings($this->loadRootServerFile());
+        }
+
+        if ($this->lazyProvidersUrl && !isset($this->providerListing[$name])) {
+            $hash = null;
+            $url = str_replace('%package%', $name, $this->lazyProvidersUrl);
+            $cacheKey = false;
+        } elseif ($this->providersUrl) {
+            // package does not exist in this repo
+            if (!isset($this->providerListing[$name])) {
+                $this->providers[$name] = array();
+                return array();
+            }
+
+            $hash = $this->providerListing[$name]['sha256'];
+            $url = str_replace(array('%package%', '%hash%'), array($name, $hash), $this->providersUrl);
+            $cacheKey = 'provider-'.strtr($name, '/', '$').'.json';
+        } else {
+            // BC handling for old providers-includes
+            $url = 'p/'.$name.'.json';
+
+            // package does not exist in this repo
+            if (!isset($this->providerListing[$url])) {
+                $this->providers[$name] = array();
+                return array();
+            }
+            $hash = $this->providerListing[$url]['sha256'];
+            $cacheKey = null;
+        }
+
+        if ($cacheKey && $this->cache->sha256($cacheKey) === $hash) {
+            $packages = json_decode($this->cache->read($cacheKey), true);
+        } else {
+            $packages = $this->fetchFile($url, $cacheKey, $hash);
+        }
+
+        $this->providers[$name] = array();
+        $loadedPackages = array();
+        foreach ($packages['packages'] as $versions) {
+            foreach ($versions as $version) {
+                if ($version['name'] !== $name) {
+                    continue;
+                }
+
+                // avoid loading the same objects twice
+                if (isset($this->providersByUid[$version['uid']])) {die("wtf?");
+                    // skip if already assigned
+                    if (!isset($this->providers[$name][$version['uid']])) {
+                        // expand alias in two packages
+                        if ($this->providersByUid[$version['uid']] instanceof AliasPackage) {
+                            $this->providers[$name][$version['uid']] = $this->providersByUid[$version['uid']]->getAliasOf();
+                            $this->providers[$name][$version['uid'].'-alias'] = $this->providersByUid[$version['uid']];
+                        } else {
+                            $this->providers[$name][$version['uid']] = $this->providersByUid[$version['uid']];
+                        }
+                        // check for root aliases
+                        if (isset($this->providersByUid[$version['uid'].'-root'])) {
+                            $this->providers[$name][$version['uid'].'-root'] = $this->providersByUid[$version['uid'].'-root'];
+                        }
+                    }
+                } else {
+                    if (!$pool->isPackageAcceptable(strtolower($version['name']), VersionParser::parseStability($version['version']))) {
+                        continue;
+                    }
+
+                    // load acceptable packages in the providers
+                    $package = $this->createPackage($version, 'Composer\Package\Package');
+                    $package->setRepository($this);
+
+                    $loadedPackages[] = $package;
+
+                    if ($package instanceof AliasPackage) {
+                        $aliased = $package->getAliasOf();
+                        $aliased->setRepository($this);
+
+                        $loadedPackages[] = $aliased;
+
+                        foreach ($aliased->getNames() as $providedName) {
+                            $this->providers[$providedName][$version['uid']] = $aliased;
+                            $this->providers[$providedName][$version['uid'].'-alias'] = $package;
+                        }
+
+                        // override provider with its alias so it can be expanded in the if block above
+                        $this->providersByUid[$version['uid']] = $package;
+                    } else {
+                        foreach ($package->getNames() as $providedName) {
+                            $this->providers[$providedName][$version['uid']] = $package;
+                        }
+                        $this->providersByUid[$version['uid']] = $package;
+                    }
+
+                    // handle root package aliases
+                    unset($rootAliasData);
+
+                    if (isset($this->rootAliases[$package->getName()][$package->getVersion()])) {
+                        $rootAliasData = $this->rootAliases[$package->getName()][$package->getVersion()];
+                    } elseif ($package instanceof AliasPackage && isset($this->rootAliases[$package->getName()][$package->getAliasOf()->getVersion()])) {
+                        $rootAliasData = $this->rootAliases[$package->getName()][$package->getAliasOf()->getVersion()];
+                    }
+
+                    if (isset($rootAliasData)) {
+                        $alias = $this->createAliasPackage($package, $rootAliasData['alias_normalized'], $rootAliasData['alias']);
+                        $alias->setRepository($this);
+
+                        $loadedPackages[] = $alias;
+
+                        $this->providers[$name][$version['uid'].'-root'] = $alias;
+                        $this->providersByUid[$version['uid'].'-root'] = $alias;
+                    }
+                }
+            }
+        }
+
+        return $loadedPackages;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -257,9 +412,12 @@ class ComposerRepository extends ArrayRepository
         }
 
         // skip platform packages
-        if (preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $name) || '__root__' === $name) {
+        if (preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $name) || '__root__' === $name || 'composer-plugin-api' === $name) {
             return array();
         }
+        var_dump($name);
+        debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        die("should not reach\n");
 
         if (null === $this->providerListing) {
             $this->loadProviderListings($this->loadRootServerFile());

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -100,6 +100,14 @@ class ComposerRepository extends ArrayRepository
         return $this->rootAliases;
     }
 
+    /**
+     * Load all packages with given names and dependencies
+     *
+     * @param array $packageNames
+     * @param callable|null $acceptableCallback Callback to filter packages
+     *
+     * @return array The loaded package objects
+     */
     public function loadRecursively(array $packageNames, $acceptableCallback)
     {
         $workQueue = new \SplQueue;
@@ -258,11 +266,29 @@ class ComposerRepository extends ArrayRepository
         return $providers;
     }
 
+    protected function configurePackageTransportOptions(PackageInterface $package)
+    {
+        foreach ($package->getDistUrls() as $url) {
+            if (strpos($url, $this->baseUrl) === 0) {
+                $package->setTransportOptions($this->options);
+
+                return;
+            }
+        }
+    }
+
+    public function hasProviders()
+    {
+        $this->loadRootServerFile();
+
+        return $this->hasProviders;
+    }
+
     /**
      * Loads package data for a given package name or provider name
      *
      * @param string $name
-     * @param callable $acceptableCallback A callback to check if a package should be loaded
+     * @param callable|null $acceptableCallback A callback to check if a package should be loaded
      * @param bool $exactMatch Whether packages only providing the name should be ignored
      *
      * @return array All packages that were loaded
@@ -335,25 +361,6 @@ class ComposerRepository extends ArrayRepository
         }
 
         return $loadedPackages;
-    }
-
-
-    protected function configurePackageTransportOptions(PackageInterface $package)
-    {
-        foreach ($package->getDistUrls() as $url) {
-            if (strpos($url, $this->baseUrl) === 0) {
-                $package->setTransportOptions($this->options);
-
-                return;
-            }
-        }
-    }
-
-    public function hasProviders()
-    {
-        $this->loadRootServerFile();
-
-        return $this->hasProviders;
     }
 
     /**

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -96,8 +96,8 @@ class ComposerRepositoryTest extends TestCase
         );
     }
 
-    public function testWhatProvides()
-    {/*
+    public function testLoadRecursively()
+    {
         $repo = $this->getMockBuilder('Composer\Repository\ComposerRepository')
             ->disableOriginalConstructor()
             ->setMethods(array('fetchFile'))
@@ -144,25 +144,19 @@ class ComposerRepositoryTest extends TestCase
                 )
             )));
 
-        $pool = $this->getMock('Composer\DependencyResolver\Pool');
-        $pool->expects($this->any())
-            ->method('isPackageAcceptable')
-            ->will($this->returnValue(true));
-
         $versionParser = new VersionParser();
-        $repo->setRootAliases(array(
-            'a' => array(
-                $versionParser->normalize('0.6') => array('alias' => 'dev-feature', 'alias_normalized' => $versionParser->normalize('dev-feature')),
-                $versionParser->normalize('1.1.x-dev') => array('alias' => '1.0', 'alias_normalized' => $versionParser->normalize('1.0')),
-            ),
-        ));
 
-        $packages = $repo->whatProvides($pool, 'a');
+        $that = $this;
+        $packages = $repo->loadRecursively(array('a'), true, function ($name, $stability) use ($that) {
+            $this->assertEquals('a', $name);
+            return true;
+        });
 
-        $this->assertCount(7, $packages);
-        $this->assertEquals(array('1', '1-alias', '2', '2-alias', '2-root', '3', '3-root'), array_keys($packages));
-        $this->assertInstanceOf('Composer\Package\AliasPackage', $packages['2-root']);
-        $this->assertSame($packages['2'], $packages['2-root']->getAliasOf());
-        $this->assertSame($packages['2'], $packages['2-alias']->getAliasOf());*/
+        $this->assertCount(5, $packages);
+        $this->assertEquals(array('1.0.x-dev', 'dev-master', '1.1.x-dev', 'dev-develop', '0.6'), array_map(function ($p) {
+            return $p->getPrettyVersion();
+        }, $packages));
+        $this->assertInstanceOf('Composer\Package\AliasPackage', $packages[2]);
+        $this->assertSame($packages[3], $packages[2]->getAliasOf());
     }
 }

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -148,7 +148,7 @@ class ComposerRepositoryTest extends TestCase
 
         $that = $this;
         $packages = $repo->loadRecursively(array('a'), function ($name, $stability) use ($that) {
-            $this->assertEquals('a', $name);
+            $that->assertEquals('a', $name);
             return true;
         });
 

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -124,23 +124,25 @@ class ComposerRepositoryTest extends TestCase
             ->method('fetchFile')
             ->will($this->returnValue(array(
                 'packages' => array(
-                    array(array(
-                        'uid' => 1,
-                        'name' => 'a',
-                        'version' => 'dev-master',
-                        'extra' => array('branch-alias' => array('dev-master' => '1.0.x-dev')),
-                    )),
-                    array(array(
-                        'uid' => 2,
-                        'name' => 'a',
-                        'version' => 'dev-develop',
-                        'extra' => array('branch-alias' => array('dev-develop' => '1.1.x-dev')),
-                    )),
-                    array(array(
-                        'uid' => 3,
-                        'name' => 'a',
-                        'version' => '0.6',
-                    )),
+                    'a' => array(
+                        'dev-master' => array(
+                            'uid' => 1,
+                            'name' => 'a',
+                            'version' => 'dev-master',
+                            'extra' => array('branch-alias' => array('dev-master' => '1.0.x-dev')),
+                        ),
+                        'dev-develop' => array(
+                            'uid' => 2,
+                            'name' => 'a',
+                            'version' => 'dev-develop',
+                            'extra' => array('branch-alias' => array('dev-develop' => '1.1.x-dev')),
+                        ),
+                        '0.6' => array(
+                            'uid' => 3,
+                            'name' => 'a',
+                            'version' => '0.6',
+                        ),
+                    ),
                 )
             )));
 

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -147,7 +147,7 @@ class ComposerRepositoryTest extends TestCase
         $versionParser = new VersionParser();
 
         $that = $this;
-        $packages = $repo->loadRecursively(array('a'), true, function ($name, $stability) use ($that) {
+        $packages = $repo->loadRecursively(array('a'), function ($name, $stability) use ($that) {
             $this->assertEquals('a', $name);
             return true;
         });

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -97,7 +97,7 @@ class ComposerRepositoryTest extends TestCase
     }
 
     public function testWhatProvides()
-    {
+    {/*
         $repo = $this->getMockBuilder('Composer\Repository\ComposerRepository')
             ->disableOriginalConstructor()
             ->setMethods(array('fetchFile'))
@@ -163,6 +163,6 @@ class ComposerRepositoryTest extends TestCase
         $this->assertEquals(array('1', '1-alias', '2', '2-alias', '2-root', '3', '3-root'), array_keys($packages));
         $this->assertInstanceOf('Composer\Package\AliasPackage', $packages['2-root']);
         $this->assertSame($packages['2'], $packages['2-root']->getAliasOf());
-        $this->assertSame($packages['2'], $packages['2-alias']->getAliasOf());
+        $this->assertSame($packages['2'], $packages['2-alias']->getAliasOf());*/
     }
 }


### PR DESCRIPTION
This will significantly reduce the amount of loaded metadata for the solver. This should improve network time as well as solver complexity.