### PR TITLE
On Json tests failures show more test failure details

### DIFF
--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -209,8 +209,8 @@ class JsonFileTest extends \PHPUnit_Framework_TestCase
     private function expectParseException($text, $json)
     {
         try {
-            JsonFile::parseJson($json);
-            $this->fail();
+            $result = JsonFile::parseJson($json);
+            $this->fail(sprintf("Parsing should have failed but didn't.\nExpected:\n\"%s\"\nFor:\n\"%s\"\nGot:\n\"%s\"", $text, $json, var_export($result, true)));
         } catch (ParsingException $e) {
             $this->assertContains($text, $e->getMessage());
         }


### PR DESCRIPTION
Hi all,

It seems there is a little problem with Json parsing (testing).
The JsonFileTest.php (https://github.com/composer/composer/blob/master/tests/Composer/Test/Json/JsonFileTest.php#L60) keeps failing for my setup.

A little test script for some background info:

```php
<?php
require_once __DIR__ . '/vendor/autoload.php';

$json = '{
\'foo\': "bar"
}';

$data = json_decode($json, true);
var_dump($data);
var_dump(json_last_error());

$a = extension_loaded('json');
var_dump($a);

$a = phpversion('json');
var_dump($a);

// made "public" for testing
\Composer\Json\JsonFile::validateSyntax($json);
```

Result

```
array(1) {
  'foo' =>
  string(3) "bar"
}
int(0)
bool(true)
string(5) "1.3.2"
PHP Fatal error:  Uncaught exception 'Seld\JsonLint\ParsingException' with message '"" does not contain valid JSON
Parse error on line 1:
{'foo': "bar"}
^
Invalid string, it appears you used single quotes instead of double quotes' in /home/possum/work/composer/src/Composer/Json/JsonFile.php:289
Stack trace:
#0 /home/possum/work/composer/test.php(18): Composer\Json\JsonFile::validateSyntax('{?'foo': "bar"?...')
#1 {main}
  thrown in /home/possum/work/composer/src/Composer/Json/JsonFile.php on line 289
```

I seems the PECL json package @ 1.3.2 for Ubuntu allows the Json input while it shouldn't. Something the `JsonParser` can detect. 
Maybe we can add the json package to `composer.json` to require / restrict the version of the package?
(on second thoughts, maybe I should report the issue to package builders...)