### PR TITLE
PHP version checks tweaking

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -112,7 +112,7 @@ class ClassMapGenerator
      */
     private static function findClasses($path)
     {
-        $extraTypes = version_compare(PHP_VERSION, '5.4', '<') ? '' : '|trait';
+        $extraTypes = PHP_VERSION_ID < 50400 ? '' : '|trait';
         if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>=')) {
             $extraTypes .= '|enum';
         }

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -377,11 +377,11 @@ EOT
             $errors['ioncube'] = ioncube_loader_version();
         }
 
-        if (version_compare(PHP_VERSION, '5.3.2', '<')) {
+        if (PHP_VERSION_ID < 50302) {
             $errors['php'] = PHP_VERSION;
         }
 
-        if (!isset($errors['php']) && version_compare(PHP_VERSION, '5.3.4', '<')) {
+        if (!isset($errors['php']) && PHP_VERSION_ID < 50304) {
             $warnings['php'] = PHP_VERSION;
         }
 

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -548,7 +548,7 @@ EOT
         }
 
         // php <5.3.3 has a very broken email validator, so bypass checks
-        if (version_compare(PHP_VERSION, '5.3.3', '<')) {
+        if (PHP_VERSION_ID < 50303) {
             return true;
         }
 

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -90,7 +90,7 @@ class Application extends BaseApplication
     {
         $this->io = new ConsoleIO($input, $output, $this->getHelperSet());
 
-        if (version_compare(PHP_VERSION, '5.3.2', '<')) {
+        if (PHP_VERSION_ID < 50302) {
             $this->getIO()->writeError('<warning>Composer only officially supports PHP 5.3.2 and above, you will most likely encounter problems with your PHP '.PHP_VERSION.', upgrading is strongly recommended.</warning>');
         }
 

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -182,7 +182,7 @@ class JsonFile
      */
     public static function encode($data, $options = 448)
     {
-        if (version_compare(PHP_VERSION, '5.4', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $json = json_encode($data, $options);
             if (false === $json) {
                 self::throwEncodeError(json_last_error());

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -214,7 +214,7 @@ class RemoteFilesystem
             }
 
             if ($decode) {
-                if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+                if (PHP_VERSION_ID >= 50400) {
                     $result = zlib_decode($result);
                 } else {
                     // work around issue with gzuncompress & co that do not work with all gzip checksums

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -96,7 +96,7 @@ final class StreamContextFactory
             // add SNI opts for https URLs
             if ('https' === parse_url($url, PHP_URL_SCHEME)) {
                 $options['ssl']['SNI_enabled'] = true;
-                if (version_compare(PHP_VERSION, '5.6.0', '<')) {
+                if (PHP_VERSION_ID < 50600) {
                     $options['ssl']['SNI_server_name'] = parse_url($url, PHP_URL_HOST);
                 }
             }

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -64,7 +64,7 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
             array(__DIR__.'/Fixtures/template', array()),
         );
 
-        if (version_compare(PHP_VERSION, '5.4', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $data[] = array(__DIR__.'/Fixtures/php5.4', array(
                 'TFoo' => __DIR__.'/Fixtures/php5.4/traits.php',
                 'CFoo' => __DIR__.'/Fixtures/php5.4/traits.php',

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -150,7 +150,7 @@ class JsonFileTest extends \PHPUnit_Framework_TestCase
 
     public function testUnicode()
     {
-        if (!function_exists('mb_convert_encoding') && version_compare(PHP_VERSION, '5.4', '<')) {
+        if (!function_exists('mb_convert_encoding') && PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Test requires the mbstring extension');
         }
 
@@ -164,7 +164,7 @@ class JsonFileTest extends \PHPUnit_Framework_TestCase
 
     public function testOnlyUnicode()
     {
-        if (!function_exists('mb_convert_encoding') && version_compare(PHP_VERSION, '5.4', '<')) {
+        if (!function_exists('mb_convert_encoding') && PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Test requires the mbstring extension');
         }
 

--- a/tests/Composer/Test/Util/StreamContextFactoryTest.php
+++ b/tests/Composer/Test/Util/StreamContextFactoryTest.php
@@ -146,7 +146,7 @@ class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
                 'SNI_server_name' => 'example.org'
             )
         );
-        if (version_compare(PHP_VERSION, '5.6.0', '>=')) {
+        if (PHP_VERSION_ID >= 50600) {
             unset($expected['ssl']['SNI_server_name']);
         }
         $this->assertEquals($expected, $options);
@@ -176,7 +176,7 @@ class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
                 'SNI_server_name' => 'example.org'
             )
         );
-        if (version_compare(PHP_VERSION, '5.6.0', '>=')) {
+        if (PHP_VERSION_ID >= 50600) {
             unset($expected['ssl']['SNI_server_name']);
         }
         $this->assertEquals($expected, $options);


### PR DESCRIPTION
`PHP_VERSION_ID` is available since PHP 5.2.7 and already used in Composer. This will speeds up PHP version checking. With `Composer requires PHP 5.3.2+ to run.` this should be safe to do.