### PR TITLE
Fix link to Composer\Installer\InstallerInterface.

### DIFF
--- a/doc/articles/custom-installers.md
+++ b/doc/articles/custom-installers.md
@@ -51,7 +51,7 @@ An example composer.json of such a template package would be:
 ## Creating an Installer
 
 A Custom Installer is defined as a class that implements the
-[`Composer\Installer\InstallerInterface`][3] and is usually distributed in a
+[`Composer\Installer\InstallerInterface`][4] and is usually distributed in a
 Composer Plugin.
 
 A basic Installer Plugin would thus compose of three files:


### PR DESCRIPTION
The link was pointing to Composer\Plugin\PluginInterface since
commit 98e5eab. Fix the link by updating the reference from
`[3]` to `[4]`.