### PR TITLE
Mark "extra" as root only in docs

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -832,7 +832,7 @@ through the use of scripts.
 
 See [Scripts](articles/scripts.md) for events details and examples.
 
-### extra
+### extra <span>(root-only)</span>
 
 Arbitrary extra data for consumption by `scripts`.
 


### PR DESCRIPTION
I was so glad that "extra" wasn't set as root-only so that I could have other packages merge stuff in the root-package. 
Then I read this guy: https://tobymackenzie.wordpress.com/2014/07/11/composer-scripts-and-extra-from-non-root-package/

Dammit!