### PR TITLE
Add support to interactive scripts defined in composer.json

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -56,10 +56,12 @@ class ProcessExecutor
 
         $this->captureOutput = count(func_get_args()) > 1;
         $this->errorOutput = null;
-        $process = new Process($command, $cwd, null, null, static::getTimeout());
+        $input = fopen('php://stdin', 'r');
+        $process = new Process($command, $cwd, null, $input, static::getTimeout());
 
         $callback = is_callable($output) ? $output : array($this, 'outputHandler');
         $process->run($callback);
+        fclose($input);
 
         if ($this->captureOutput && !is_callable($output)) {
             $output = $process->getOutput();


### PR DESCRIPTION
This change should allow for interactive scripts defined in composer.json as requested in issue #3299 without breaking non-interactive scripts.

As far as I know, the Process component accepts both a stream or a string as input argument. I see no reason to pass a string, but the stdin is useful. Any reasons not to do it or something I didn't consider?

I've run the test suite and introduces no errors.

Thanks.
