### PR TITLE
Remember that a class does exist

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -337,6 +337,7 @@ class ClassLoader
             // Remember that this class does not exist.
             return $this->classMap[$class] = false;
         }
+        
         return $this->classMap[$class] = $file;
     }
 

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -337,8 +337,7 @@ class ClassLoader
             // Remember that this class does not exist.
             return $this->classMap[$class] = false;
         }
-
-        return $file;
+        return $this->classMap[$class] = $file;
     }
 
     private function findFileWithExtension($class, $ext)

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -337,7 +337,7 @@ class ClassLoader
             // Remember that this class does not exist.
             return $this->classMap[$class] = false;
         }
-        
+
         return $this->classMap[$class] = $file;
     }
 


### PR DESCRIPTION
If a class is already loaded and we call
<pre>
$composer_loader->findFile($class)
</pre>
the composer will redo the full search for the class.

We can now remember that the class exist which improves performances.