### PR TITLE
Package not found exception - more explicit

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -599,7 +599,7 @@ EOT
 
         if (!$package) {
             throw new \InvalidArgumentException(sprintf(
-                'Could not find package %s at any version for your minimum-stability (%s). Check the package spelling or your minimum-stability',
+                'Could not find package "%s" at any version for your minimum-stability (%s). Check the package spelling or your minimum-stability',
                 $name,
                 $this->getMinimumStability($input)
             ));


### PR DESCRIPTION
Now you can get report like this: `Could not find package at all at any version.`

Already fixed here: https://github.com/composer/composer/blob/e0ce559838e0cd7a01404b4b85d2a2768d0ec1e9/src/Composer/Command/DependsCommand.php#L68

This should be more readable, [see issue on SO](http://stackoverflow.com/a/30346004/1348344).


If this gets accepted, can send PR to all other `package %s` reports.