### PR TITLE
Add Vagrant (and provisioning) file for consistent testing environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@
 /nbproject
 phpunit.xml
 .vagrant
-Vagrantfile
 .idea
 .php_cs.cache

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  # Define which vagrant box to use.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Configure the VM as necessary so that the tests can pass.
+  config.vm.provision :shell, :path => "vagrant-provision.sh"
+end

--- a/vagrant-provision.sh
+++ b/vagrant-provision.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+# Make sure apt-git has a current list of repos.
+sudo apt-get update
+
+# Install any required packages.
+sudo apt-get install -y php5 git
+
+# Install Composer's dependencies.
+cd /vagrant/
+curl -sS https://getcomposer.org/installer | php
+php composer.phar install
+
+
+# Update the php.ini file as necessary: #
+
+# Make sure phar.readonly is off.
+sudo sed -i".bak" "s/^\;phar.readonly.*$/phar.readonly = Off/g" /etc/php5/cli/php.ini
+
+# Make sure a timezone is set.
+sudo sed -i "s/^\;date\.timezone.*$/date\.timezone = \"America\\/Chicago\" /g" /etc/php5/cli/php.ini


### PR DESCRIPTION
Trying to get set up to simply run all of the tests (in a way where they all pass, as they do on Travis-CI) is proving rather difficult.  Setting up a Ubuntu VM (via Vagrant), tweaking some settings in php.ini, and making sure I cloned the repo with Git's core.autocrlf setting to false has gotten me most of the way there.  (Oddly enough, the only remaining failing test is that json_decode is accepting single quotes for some strange reason).

This commit provides my (mostly) working Vagrantfile and vagrant provisioning script to enable others to get (at least nearly) up and running more quickly than I did.

Since my setup isn't fully working, I won't be surprised if this pull request is rejected or requires me to make some more changes before it's accepted.  It seemed better, though, to offer this pull request now (rather than waiting for it to get behind master) in case it does seem valuable to others as-is.

I also don't know why Vagrantfile was being ignored previously, so there may be a very good reason to continue to ignore it rather than including it now (as I've done).