### PR TITLE
Remove HTTP support from composer. (Solves HTTP-related part of #1074)

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -90,7 +90,7 @@ To edit the global config.json file:
 
 To add a repository:
 
-    <comment>%command.full_name% repositories.foo vcs http://bar.com</comment>
+    <comment>%command.full_name% repositories.foo vcs https://bar.com</comment>
 
 To remove a repository (repo is a short alias for repositories):
 
@@ -412,7 +412,7 @@ EOT
                 }
             }
 
-            throw new \RuntimeException('You must pass the type and a url. Example: php composer.phar config repositories.foo vcs http://bar.com');
+            throw new \RuntimeException('You must pass the type and a url. Example: php composer.phar config repositories.foo vcs https://bar.com');
         }
 
         // handle platform

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -90,7 +90,7 @@ To setup a developer workable version you should create the project using the so
 controlled code by appending the <info>'--prefer-source'</info> flag.
 
 To install a package from another repository than the default one you
-can pass the <info>'--repository-url=http://myrepository.org'</info> flag.
+can pass the <info>'--repository-url=https://myrepository.org'</info> flag.
 
 EOT
             )
@@ -247,10 +247,10 @@ EOT
             } else {
                 $sourceRepo = new FilesystemRepository($json);
             }
-        } elseif (0 === strpos($repositoryUrl, 'http')) {
+        } elseif (0 === strpos($repositoryUrl, 'https')) {
             $sourceRepo = new ComposerRepository(array('url' => $repositoryUrl), $io, $config);
         } else {
-            throw new \InvalidArgumentException("Invalid repository url given. Has to be a .json file or an http url.");
+            throw new \InvalidArgumentException("Invalid repository url given. Has to be a .json file or an https url.");
         }
 
         $parser = new VersionParser();

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -58,7 +58,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $baseUrl = (extension_loaded('openssl') ? 'https' : 'http') . '://' . self::HOMEPAGE;
+        $baseUrl = 'https://' . self::HOMEPAGE;
         $config = Factory::createConfig();
         $remoteFilesystem = new RemoteFilesystem($this->getIO(), $config);
         $cacheDir = $config->get('cache-dir');

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -117,8 +117,8 @@ abstract class ArchiveDownloader extends FileDownloader
             }
         }
 
-        if (!extension_loaded('openssl') && (0 === strpos($url, 'https:') || 0 === strpos($url, 'http://github.com'))) {
-            throw new \RuntimeException('You must enable the openssl extension to download files via https');
+        if (!extension_loaded('openssl')) {
+            throw new \RuntimeException('You must enable the openssl extension to download files.');
         }
 
         return parent::processUrl($package, $url);

--- a/src/Composer/Downloader/PearPackageExtractor.php
+++ b/src/Composer/Downloader/PearPackageExtractor.php
@@ -244,7 +244,7 @@ class PearPackageExtractor
                     $fileSource = $this->combine($source, (string) $child['name']);
                     $fileTarget = $this->combine((string) ($child['baseinstalldir'] ?: $target), (string) $child['name']);
                     $fileTasks = array();
-                    foreach ($child->children('http://pear.php.net/dtd/tasks-1.0') as $taskNode) {
+                    foreach ($child->children('https://pear.php.net/dtd/tasks-1.0') as $taskNode) {
                         if ('replace' == $taskNode->getName()) {
                             $fileTasks[] = array('from' => (string) $taskNode->attributes()->from, 'to' => (string) $taskNode->attributes()->to);
                         }

--- a/src/Composer/Repository/Pear/BaseChannelReader.php
+++ b/src/Composer/Repository/Pear/BaseChannelReader.php
@@ -26,12 +26,12 @@ abstract class BaseChannelReader
     /**
      * PEAR REST Interface namespaces
      */
-    const CHANNEL_NS = 'http://pear.php.net/channel-1.0';
-    const ALL_CATEGORIES_NS = 'http://pear.php.net/dtd/rest.allcategories';
-    const CATEGORY_PACKAGES_INFO_NS = 'http://pear.php.net/dtd/rest.categorypackageinfo';
-    const ALL_PACKAGES_NS = 'http://pear.php.net/dtd/rest.allpackages';
-    const ALL_RELEASES_NS = 'http://pear.php.net/dtd/rest.allreleases';
-    const PACKAGE_INFO_NS = 'http://pear.php.net/dtd/rest.package';
+    const CHANNEL_NS = 'https://pear.php.net/channel-1.0';
+    const ALL_CATEGORIES_NS = 'https://pear.php.net/dtd/rest.allcategories';
+    const CATEGORY_PACKAGES_INFO_NS = 'https://pear.php.net/dtd/rest.categorypackageinfo';
+    const ALL_PACKAGES_NS = 'https://pear.php.net/dtd/rest.allpackages';
+    const ALL_RELEASES_NS = 'https://pear.php.net/dtd/rest.allreleases';
+    const PACKAGE_INFO_NS = 'https://pear.php.net/dtd/rest.package';
 
     /** @var RemoteFilesystem */
     private $rfs;

--- a/src/Composer/Repository/PearRepository.php
+++ b/src/Composer/Repository/PearRepository.php
@@ -47,7 +47,7 @@ class PearRepository extends ArrayRepository
     public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $dispatcher = null, RemoteFilesystem $rfs = null)
     {
         if (!preg_match('{^https?://}', $repoConfig['url'])) {
-            $repoConfig['url'] = 'http://'.$repoConfig['url'];
+            $repoConfig['url'] = 'https://'.$repoConfig['url'];
         }
 
         $urlBits = parse_url($repoConfig['url']);
@@ -108,7 +108,7 @@ class PearRepository extends ArrayRepository
                 // distribution url must be read from /r/{packageName}/{version}.xml::/r/g:text()
                 // but this location is 'de-facto' standard
                 $urlBits = parse_url($this->url);
-                $scheme = (isset($urlBits['scheme']) && 'https' === $urlBits['scheme'] && extension_loaded('openssl')) ? 'https' : 'http';
+                $scheme = 'https';
                 $distUrl = "{$scheme}://{$packageDefinition->getChannelName()}/get/{$packageDefinition->getPackageName()}-{$version}.tgz";
 
                 $requires = array();

--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -77,14 +77,11 @@ abstract class VcsDriver implements VcsDriverInterface
      * Call this only if you know that the server supports both.
      *
      * @return string The correct type of protocol
+     * @deprecated  Should always use a https scheme for retreiving code.
      */
     protected function getScheme()
     {
-        if (extension_loaded('openssl')) {
-            return 'https';
-        }
-
-        return 'http';
+        return 'https';
     }
 
     /**

--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -85,7 +85,7 @@ class ConfigValidator
             $licenseValidator = new SpdxLicense();
             if ('proprietary' !== $manifest['license'] && array() !== $manifest['license'] && !$licenseValidator->validate($manifest['license'])) {
                 $warnings[] = sprintf(
-                    'License %s is not a valid SPDX license identifier, see http://www.spdx.org/licenses/ if you use an open license.'
+                    'License %s is not a valid SPDX license identifier, see https://www.spdx.org/licenses/ if you use an open license.'
                     ."\nIf the software is closed-source, you may use \"proprietary\" as license.",
                     json_encode($manifest['license'])
                 );
@@ -110,7 +110,7 @@ class ConfigValidator
         }
 
         if (!empty($manifest['type']) && $manifest['type'] == 'composer-installer') {
-            $warnings[] = "The package type 'composer-installer' is deprecated. Please distribute your custom installers as plugins from now on. See http://getcomposer.org/doc/articles/plugins.md for plugin documentation.";
+            $warnings[] = "The package type 'composer-installer' is deprecated. Please distribute your custom installers as plugins from now on. See https://getcomposer.org/doc/articles/plugins.md for plugin documentation.";
         }
 
         // check for require-dev overrides

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -146,7 +146,7 @@ class RemoteFilesystem
         $options = $this->getOptionsForUrl($originUrl, $additionalOptions);
 
         if ($this->io->isDebug()) {
-            $this->io->writeError((substr($fileUrl, 0, 4) === 'http' ? 'Downloading ' : 'Reading ') . $fileUrl);
+            $this->io->writeError((substr($fileUrl, 0, 5) === 'https' ? 'Downloading ' : 'Reading ') . $fileUrl);
         }
         if (isset($options['github-token'])) {
             $fileUrl .= (false === strpos($fileUrl, '?') ? '?' : '&') . 'access_token='.$options['github-token'];

--- a/src/Composer/Util/SpdxLicense.php
+++ b/src/Composer/Util/SpdxLicense.php
@@ -60,7 +60,7 @@ class SpdxLicense
         $license = $this->licenses[$identifier];
 
         // add URL for the license text (it's not included in the json)
-        $license[2] = 'http://spdx.org/licenses/' . $identifier . '#licenseText';
+        $license[2] = 'https://spdx.org/licenses/' . $identifier . '#licenseText';
 
         return $license;
     }

--- a/src/Composer/Util/SpdxLicensesUpdater.php
+++ b/src/Composer/Util/SpdxLicensesUpdater.php
@@ -22,7 +22,7 @@ use Composer\Json\JsonFormatter;
  */
 class SpdxLicensesUpdater
 {
-    private $licensesUrl = 'http://www.spdx.org/licenses/';
+    private $licensesUrl = 'https://www.spdx.org/licenses/';
 
     public function update()
     {

--- a/tests/Composer/Test/Downloader/Fixtures/Package_v1.0/package.xml
+++ b/tests/Composer/Test/Downloader/Fixtures/Package_v1.0/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
-<!DOCTYPE package SYSTEM "http://pear.php.net/dtd/package-1.0">
+<!DOCTYPE package SYSTEM "https://pear.php.net/dtd/package-1.0">
 <package version="1.0" packagerversion="1.4.0a4">
     <!-- stripped version of package-->
  <name>PEAR_Frontend_Gtk</name>

--- a/tests/Composer/Test/Downloader/Fixtures/Package_v2.0/package.xml
+++ b/tests/Composer/Test/Downloader/Fixtures/Package_v2.0/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package packagerversion="1.6.0" version="2.0" xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
+<package packagerversion="1.6.0" version="2.0" xmlns="https://pear.php.net/dtd/package-2.0" xmlns:tasks="https://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://pear.php.net/dtd/tasks-1.0 https://pear.php.net/dtd/tasks-1.0.xsd https://pear.php.net/dtd/package-2.0 https://pear.php.net/dtd/package-2.0.xsd">
     <!-- stripped version of package-->
  <name>Net_URL</name>
  <channel>pear.php.net</channel>

--- a/tests/Composer/Test/Downloader/Fixtures/Package_v2.1/package.xml
+++ b/tests/Composer/Test/Downloader/Fixtures/Package_v2.1/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://pear.php.net/dtd/package-2.1" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.1" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.1 http://pear.php.net/dtd/package-2.1.xsd" packagerversion="2.0.0">
+<package xmlns="https://pear.php.net/dtd/package-2.1" xmlns:tasks="https://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.1" xsi:schemaLocation="https://pear.php.net/dtd/tasks-1.0 https://pear.php.net/dtd/tasks-1.0.xsd https://pear.php.net/dtd/package-2.1 https://pear.php.net/dtd/package-2.1.xsd" packagerversion="2.0.0">
     <!-- stripped version of package-->
     <name>Zend_Authentication</name>
     <channel>packages.zendframework.com</channel>

--- a/tests/Composer/Test/Repository/Pear/ChannelReaderTest.php
+++ b/tests/Composer/Test/Repository/Pear/ChannelReaderTest.php
@@ -24,14 +24,14 @@ class ChannelReaderTest extends TestCase
     public function testShouldBuildPackagesFromPearSchema()
     {
         $rfs = new RemoteFilesystemMock(array(
-            'http://pear.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
-            'http://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
-            'http://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),
+            'https://pear.php.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
+            'https://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
+            'https://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),
         ));
 
         $reader = new \Composer\Repository\Pear\ChannelReader($rfs);
 
-        $channelInfo = $reader->read('http://pear.net/');
+        $channelInfo = $reader->read('https://pear.php.net/');
         $packages = $channelInfo->getPackages();
 
         $this->assertCount(3, $packages);
@@ -46,19 +46,19 @@ class ChannelReaderTest extends TestCase
     public function testShouldSelectCorrectReader()
     {
         $rfs = new RemoteFilesystemMock(array(
-            'http://pear.1.0.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.0.xml'),
-            'http://test.loc/rest10/p/packages.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/packages.xml'),
-            'http://test.loc/rest10/p/http_client/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_info.xml'),
-            'http://test.loc/rest10/p/http_request/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_info.xml'),
-            'http://pear.1.1.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
-            'http://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
-            'http://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),
+            'https://pear.1.0.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.0.xml'),
+            'https://test.loc/rest10/p/packages.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/packages.xml'),
+            'https://test.loc/rest10/p/http_client/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_info.xml'),
+            'https://test.loc/rest10/p/http_request/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_info.xml'),
+            'https://pear.1.1.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
+            'https://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
+            'https://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),
         ));
 
         $reader = new \Composer\Repository\Pear\ChannelReader($rfs);
 
-        $reader->read('http://pear.1.0.net/');
-        $reader->read('http://pear.1.1.net/');
+        $reader->read('https://pear.1.0.net/');
+        $reader->read('https://pear.1.1.net/');
     }
 
     public function testShouldCreatePackages()
@@ -122,7 +122,7 @@ class ChannelReaderTest extends TestCase
         $expectedPackage->setDistType('file');
         $expectedPackage->setDescription('description');
         $expectedPackage->setLicense(array('license'));
-        $expectedPackage->setDistUrl("http://test.loc/get/sample-1.0.0.1.tgz");
+        $expectedPackage->setDistUrl("https://test.loc/get/sample-1.0.0.1.tgz");
         $expectedPackage->setAutoload(array('classmap' => array('')));
         $expectedPackage->setIncludePaths(array('/'));
         $expectedPackage->setRequires(array(

--- a/tests/Composer/Test/Repository/Pear/ChannelRest10ReaderTest.php
+++ b/tests/Composer/Test/Repository/Pear/ChannelRest10ReaderTest.php
@@ -20,19 +20,19 @@ class ChannelRest10ReaderTest extends TestCase
     public function testShouldBuildPackagesFromPearSchema()
     {
         $rfs = new RemoteFilesystemMock(array(
-            'http://test.loc/rest10/p/packages.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/packages.xml'),
-            'http://test.loc/rest10/p/http_client/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_info.xml'),
-            'http://test.loc/rest10/r/http_client/allreleases.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_allreleases.xml'),
-            'http://test.loc/rest10/r/http_client/deps.1.2.1.txt' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_deps.1.2.1.txt'),
-            'http://test.loc/rest10/p/http_request/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_info.xml'),
-            'http://test.loc/rest10/r/http_request/allreleases.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_allreleases.xml'),
-            'http://test.loc/rest10/r/http_request/deps.1.4.0.txt' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_deps.1.4.0.txt'),
+            'https://test.loc/rest10/p/packages.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/packages.xml'),
+            'https://test.loc/rest10/p/http_client/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_info.xml'),
+            'https://test.loc/rest10/r/http_client/allreleases.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_allreleases.xml'),
+            'https://test.loc/rest10/r/http_client/deps.1.2.1.txt' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_deps.1.2.1.txt'),
+            'https://test.loc/rest10/p/http_request/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_info.xml'),
+            'https://test.loc/rest10/r/http_request/allreleases.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_allreleases.xml'),
+            'https://test.loc/rest10/r/http_request/deps.1.4.0.txt' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_deps.1.4.0.txt'),
         ));
 
         $reader = new \Composer\Repository\Pear\ChannelRest10Reader($rfs);
 
         /** @var $packages \Composer\Package\PackageInterface[] */
-        $packages = $reader->read('http://test.loc/rest10');
+        $packages = $reader->read('https://test.loc/rest10');
 
         $this->assertCount(2, $packages);
         $this->assertEquals('HTTP_Client', $packages[0]->getPackageName());

--- a/tests/Composer/Test/Repository/Pear/ChannelRest11ReaderTest.php
+++ b/tests/Composer/Test/Repository/Pear/ChannelRest11ReaderTest.php
@@ -20,15 +20,15 @@ class ChannelRest11ReaderTest extends TestCase
     public function testShouldBuildPackagesFromPearSchema()
     {
         $rfs = new RemoteFilesystemMock(array(
-            'http://pear.1.1.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
-            'http://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
-            'http://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),
+            'https://pear.1.1.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
+            'https://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
+            'https://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),
         ));
 
         $reader = new \Composer\Repository\Pear\ChannelRest11Reader($rfs);
 
         /** @var $packages \Composer\Package\PackageInterface[] */
-        $packages = $reader->read('http://test.loc/rest11');
+        $packages = $reader->read('https://test.loc/rest11');
 
         $this->assertCount(3, $packages);
         $this->assertEquals('HTTP_Client', $packages[0]->getPackageName());

--- a/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.0/http_client_allreleases.xml
+++ b/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.0/http_client_allreleases.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<a xmlns="http://pear.php.net/dtd/rest.allreleases" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://pear.php.net/dtd/rest.allreleases http://pear.php.net/dtd/rest.allreleases.xsd">
+<a xmlns="https://pear.php.net/dtd/rest.allreleases" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="https://pear.php.net/dtd/rest.allreleases https://pear.php.net/dtd/rest.allreleases.xsd">
     <p>HTTP_Client</p>
     <c>pear.net</c>
     <r>

--- a/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.0/http_client_info.xml
+++ b/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.0/http_client_info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p xmlns="http://pear.php.net/dtd/rest.package" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://pear.php.net/dtd/rest.package http://pear.php.net/dtd/rest.package.xsd">
+<p xmlns="https://pear.php.net/dtd/rest.package" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="https://pear.php.net/dtd/rest.package https://pear.php.net/dtd/rest.package.xsd">
     <n>HTTP_Client</n>
     <c>pear.net</c>
     <ca xlink:href="/rest/c/Default">Default</ca>

--- a/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.0/http_request_allreleases.xml
+++ b/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.0/http_request_allreleases.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<a xmlns="http://pear.php.net/dtd/rest.allreleases" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://pear.php.net/dtd/rest.allreleases http://pear.php.net/dtd/rest.allreleases.xsd">
+<a xmlns="https://pear.php.net/dtd/rest.allreleases" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="https://pear.php.net/dtd/rest.allreleases https://pear.php.net/dtd/rest.allreleases.xsd">
     <p>HTTP_Request</p>
     <c>pear.net</c>
     <r>

--- a/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.0/http_request_info.xml
+++ b/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.0/http_request_info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p xmlns="http://pear.php.net/dtd/rest.package" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://pear.php.net/dtd/rest.package http://pear.php.net/dtd/rest.package.xsd">
+<p xmlns="https://pear.php.net/dtd/rest.package" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="https://pear.php.net/dtd/rest.package https://pear.php.net/dtd/rest.package.xsd">
     <n>HTTP_Request</n>
     <c>pear.net</c>
     <ca xlink:href="/rest/c/Default">Default</ca>

--- a/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.0/packages.xml
+++ b/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.0/packages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<a xmlns="http://pear.php.net/dtd/rest.allpackages" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://pear.php.net/dtd/rest.allpackages http://pear.php.net/dtd/rest.allpackages.xsd">
+<a xmlns="https://pear.php.net/dtd/rest.allpackages" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="https://pear.php.net/dtd/rest.allpackages https://pear.php.net/dtd/rest.allpackages.xsd">
     <c>pear.net</c>
     <p>HTTP_Client</p>
     <p>HTTP_Request</p>

--- a/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.1/categories.xml
+++ b/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.1/categories.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<a xmlns="http://pear.php.net/dtd/rest.allcategories" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://pear.php.net/dtd/rest.allcategories http://pear.php.net/dtd/rest.allcategories.xsd">
+<a xmlns="https://pear.php.net/dtd/rest.allcategories" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="https://pear.php.net/dtd/rest.allcategories https://pear.php.net/dtd/rest.allcategories.xsd">
     <ch>pear.net</ch>
     <c xlink:href="/rest/c/Default/info.xml">Default</c>
 </a>

--- a/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.1/packagesinfo.xml
+++ b/tests/Composer/Test/Repository/Pear/Fixtures/Rest1.1/packagesinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<f xmlns="http://pear.php.net/dtd/rest.categorypackageinfo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://pear.php.net/dtd/rest.categorypackageinfo http://pear.php.net/dtd/rest.categorypackageinfo.xsd">
+<f xmlns="https://pear.php.net/dtd/rest.categorypackageinfo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="https://pear.php.net/dtd/rest.categorypackageinfo https://pear.php.net/dtd/rest.categorypackageinfo.xsd">
     <pi>
         <p>
             <n>HTTP_Client</n>

--- a/tests/Composer/Test/Repository/Pear/Fixtures/channel.1.0.xml
+++ b/tests/Composer/Test/Repository/Pear/Fixtures/channel.1.0.xml
@@ -1,11 +1,11 @@
-<channel xmlns="http://pear.php.net/channel-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" xsi:schemaLocation="http://pear.php.net/channel-1.0 http://pear.php.net/dtd/channel-1.0.xsd">
+<channel xmlns="https://pear.php.net/channel-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" xsi:schemaLocation="https://pear.php.net/channel-1.0 https://pear.php.net/dtd/channel-1.0.xsd">
     <name>pear.net</name>
     <summary>Test PEAR channel</summary>
     <suggestedalias>test_alias</suggestedalias>
     <servers>
         <primary>
             <rest>
-                <baseurl type="REST1.0">http://test.loc/rest10/</baseurl>
+                <baseurl type="REST1.0">https://test.loc/rest10/</baseurl>
             </rest>
         </primary>
     </servers>

--- a/tests/Composer/Test/Repository/Pear/Fixtures/channel.1.1.xml
+++ b/tests/Composer/Test/Repository/Pear/Fixtures/channel.1.1.xml
@@ -1,11 +1,11 @@
-<channel xmlns="http://pear.php.net/channel-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" xsi:schemaLocation="http://pear.php.net/channel-1.0 http://pear.php.net/dtd/channel-1.0.xsd">
+<channel xmlns="https://pear.php.net/channel-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" xsi:schemaLocation="https://pear.php.net/channel-1.0 https://pear.php.net/dtd/channel-1.0.xsd">
     <name>pear.net</name>
     <summary>Test PEAR channel</summary>
     <suggestedalias>test_alias</suggestedalias>
     <servers>
         <primary>
             <rest>
-                <baseurl type="REST1.1">http://test.loc/rest11/</baseurl>
+                <baseurl type="REST1.1">https://test.loc/rest11/</baseurl>
             </rest>
         </primary>
     </servers>


### PR DESCRIPTION
This PR resolves the http portion of issue https://github.com/composer/composer/issues/1074 (Remote Code Execution via MITM) by disabling plain http schemes entirely. It creates a hard dependency on openssl and a valid certificate bundle. 

This is likely BC-breaking for those using insecure http urls to install code or those operating without https support installed into PHP. This is an acceptable BC break given the security/privacy implications. 

This PR has seen limited testing so is submitted for discussion only at this time.