### PR TITLE
Added installation using npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ Global installation of Composer (manual)
 
 Follow instructions [in the documentation](https://getcomposer.org/doc/00-intro.md#globally)
 
+
+Installation as a Node Module (requires npm)
+--------------------------------------------
+
+Download composer using npm
+
+````shell
+#global
+npm install -g getcomposer
+
+#local
+npm install getcomposer
+````
+
+
 Updating Composer
 -----------------
 


### PR DESCRIPTION
## Node module
[getcomposer](https://github.com/jadjoubran/getcomposer)

## Why?
Being able to install composer from `npm` makes it easier for people/organizations already using `npm` to install composer.
