### PR TITLE
Added missing information about --keep-vcs in create-project.

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -466,7 +466,7 @@ By default the command checks for the packages on packagist.org.
   terminals or scripts which don't handle backspace characters.
 * **--keep-vcs:** Skip the deletion of the VCS metadata for the created
   project. This is mostly useful if you run the command in non-interactive
-  mode.
+  mode. (only works together with: -s dev|--stability=dev|dev-master)
 * **--ignore-platform-reqs:** ignore `php`, `hhvm`, `lib-*` and `ext-*`
   requirements and force the installation even if the local machine does not
   fulfill these.


### PR DESCRIPTION
Hi,
i found a bit confusing that --keep-vcs only works under dev, and it silently-doest-nothing under stable versions.

This PR attempts to notice the users about this behavior.

btw, why it doesnt keep the vcs files for stable versions? i cant understand this limitation.
Thank you for your time,