### PR TITLE
Remove incorrect deprecation documentation

### DIFF
--- a/src/Composer/Script/ScriptEvents.php
+++ b/src/Composer/Script/ScriptEvents.php
@@ -74,8 +74,6 @@ class ScriptEvents
      */
     const POST_STATUS_CMD = 'post-status-cmd';
 
-    /** Deprecated constants below */
-
     /**
      * The PRE_AUTOLOAD_DUMP event occurs before the autoload file is generated.
      *


### PR DESCRIPTION
This comment seems to be misplaced, as several of the constants
below it are not explicitly deprecated and do not seem to have
any replacements. Perhaps they should actually be explicitly
deprecated, I cannot rule that out without knowing the code better.
In any case, currently the documentation is only confusing for
people that want to use these constants, so it should be changed
in some manner.

Comment added in 3efed220a6c9fd6e4a13ea806879e124941c9fc7