### PR TITLE
Add support for overriding the archive filename

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -540,6 +540,7 @@ php composer.phar archive vendor/package 2.0.21 --format=zip
 * **--format (-f):** Format of the resulting archive: tar or zip (default:
   "tar")
 * **--dir:** Write the archive to this directory (default: ".")
+* **--filename:** Overwrites the default archive filename (the file extension is unaffected)
 
 ## help
 

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -43,13 +43,14 @@ class ArchiveCommand extends Command
                 new InputArgument('version', InputArgument::OPTIONAL, 'A version constraint to find the package to archive'),
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the resulting archive: tar or zip', 'tar'),
                 new InputOption('dir', false, InputOption::VALUE_REQUIRED, 'Write the archive to this directory', '.'),
+                new InputOption('filename', false, InputOption::VALUE_OPTIONAL, 'Override the default archive filename'),
             ))
             ->setHelp(<<<EOT
 The <info>archive</info> command creates an archive of the specified format
 containing the files and directories of the Composer project or the specified
 package in the specified version and writes it to the specified directory.
 
-<info>php composer.phar archive [--format=zip] [--dir=/foo] [package [version]]</info>
+<info>php composer.phar archive [--filename=my-package] [--format=zip] [--dir=/foo] [package [version]]</info>
 
 EOT
             )
@@ -70,7 +71,8 @@ EOT
             $input->getArgument('package'),
             $input->getArgument('version'),
             $input->getOption('format'),
-            $input->getOption('dir')
+            $input->getOption('dir'),
+            $input->getOption('filename')
         );
 
         if (0 === $returnCode && $composer) {
@@ -80,7 +82,7 @@ EOT
         return $returnCode;
     }
 
-    protected function archive(IOInterface $io, $packageName = null, $version = null, $format = 'tar', $dest = '.')
+    protected function archive(IOInterface $io, $packageName = null, $version = null, $format = 'tar', $dest = '.', $filename = null)
     {
         $config = Factory::createConfig();
         $factory = new Factory;
@@ -98,7 +100,7 @@ EOT
         }
 
         $io->writeError('<info>Creating the archive.</info>');
-        $archiveManager->archive($package, $format, $dest);
+        $archiveManager->archive($package, $format, $dest, $filename);
 
         return 0;
     }

--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -96,12 +96,13 @@ class ArchiveManager
      *
      * @param  PackageInterface          $package   The package to archive
      * @param  string                    $format    The format of the archive (zip, tar, ...)
-     * @param  string                    $targetDir The diretory where to build the archive
+     * @param  string                    $targetDir The directory where to build the archive
+     * @param  string                    $filename  Overrides the archive's default filename
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      * @return string                    The path of the created archive
      */
-    public function archive(PackageInterface $package, $format, $targetDir)
+    public function archive(PackageInterface $package, $format, $targetDir, $filename = null)
     {
         if (empty($format)) {
             throw new \InvalidArgumentException('Format must be specified');
@@ -123,6 +124,9 @@ class ArchiveManager
 
         $filesystem = new Filesystem();
         $packageName = $this->getPackageFilename($package);
+        if ($filename) {
+            $packageName = $filename;
+        }
 
         // Archive filename
         $filesystem->ensureDirectoryExists($targetDir);

--- a/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
@@ -55,6 +55,23 @@ class ArchiveManagerTest extends ArchiverTest
         unlink($target);
     }
 
+    public function testArchiveFilename()
+    {
+        $this->setupGitRepo();
+
+        $package = $this->setupPackage();
+
+        $this->manager->archive($package, 'tar', $this->targetDir, 'override');
+
+        $target = $this->targetDir.'/override.tar';
+        $this->assertFileExists($target);
+
+        $tmppath = sys_get_temp_dir().'/composer_archiver/'.$this->manager->getPackageFilename($package);
+        $this->assertFileNotExists($tmppath);
+
+        unlink($target);
+    }
+
     protected function getTargetName(PackageInterface $package, $format)
     {
         $packageName = $this->manager->getPackageFilename($package);


### PR DESCRIPTION
Instead of running a shell command to rename the archive I want to be able to specify a option to do it straight away.

`composer archive --format=zip --filename=my-package` would create a archive `my-package.zip`