### PR TITLE
Add archive configuration

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -810,6 +810,11 @@ The following options are supported:
   updates when in non-interactive mode. `true` will always discard changes in
   vendors, while `"stash"` will try to stash and reapply. Use this for CI
   servers or deploy scripts if you tend to have modified vendors.
+* **archive-format:** Defaults to `tar`. Composer allows you to add a default
+  archive format when the workflow needs to create a dedicated archiving format.
+* **archive-dir:** Defaults to `.`. Composer allows you to add a default
+  archive directory when the workflow needs to create a dedicated archiving format.
+  Or for easier development between modules.
 
 Example:
 

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -216,6 +216,14 @@
                 "github-expose-hostname": {
                     "type": "boolean",
                     "description": "Defaults to true. If set to false, the OAuth tokens created to access the github API will have a date instead of the machine hostname."
+                },
+                "archive-format": {
+                    "type": "string",
+                    "description": "The default archiving format when not provided on cli, defaults to \"tar\"."
+                },
+                "archive-dir": {
+                    "type": "string",
+                    "description": "The default archive path when not provided on cli, defaults to \".\"."
                 }
             }
         },

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -46,6 +46,8 @@ class Config
         'github-expose-hostname' => true,
         'store-auths' => 'prompt',
         'platform' => array(),
+        'archive-format' => 'tar',
+        'archive-dir' => '.',
         // valid keys without defaults (auth config stuff):
         // github-oauth
         // http-basic


### PR DESCRIPTION
Add some configuration values to be able to customize the archive command behaviour in `$COMPOSER_HOME/.composer/config.json`

Thus a content of 
```json
{
    "repositories": [
        {
            "type": "artifact",
            "url": "/var/lib/composer/artifacts"
        }
    ],
    "config": {
        "archive-format":"zip",
        "archive-dir":"/var/lib/composer/artifacts",
    }
}
```
would make  `composer archive` to build by default `zip` archives to be built into `/var/lib/composer/artifacts`
but `composer archive --dir=. --format=tar` would build archives locally in `tar` format