### PR TITLE
Prevent Git from converting any LFs to CRLFs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-tests/Composer/Test/Fixtures/installer/*.test   eol=lf
+*   -text


### PR DESCRIPTION
Allowing Git to convert LFs to CRLFs breaks dozens of the tests.  This change tells Git not to modify line endings (similar to setting ```core.autocrlf``` to ```false```).  See https://github.com/composer/composer/pull/4049#issuecomment-106314053 for more details.