### PR TITLE
[travis-ci] Remove hhvm-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,9 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: hhvm-nightly
 
 before_script:
     - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini


### PR DESCRIPTION
HHVM Nightly is not supported by the current OS used by Travis-CI