### PR TITLE
Move VersionParser::formatVersion() to BasePackage::getFullPrettyVersion()

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -298,7 +298,7 @@ EOT
             });
         }
 
-        $io->writeError('<info>Installing ' . $package->getName() . ' (' . VersionParser::formatVersion($package, false) . ')</info>');
+        $io->writeError('<info>Installing ' . $package->getName() . ' (' . $package->getFullPrettyVersion(false) . ')</info>');
 
         if ($disablePlugins) {
             $io->writeError('<info>Plugins have been disabled.</info>');

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -13,7 +13,6 @@
 namespace Composer\Command;
 
 use Composer\Json\JsonFile;
-use Composer\Package\Version\VersionParser;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Composer\Package\PackageInterface;
@@ -56,8 +55,6 @@ EOT
         $root = $composer->getPackage();
         $repo = $composer->getRepositoryManager()->getLocalRepository();
 
-        $versionParser = new VersionParser;
-
         if ($input->getOption('no-dev')) {
             $packages = $this->filterRequiredPackages($repo, $root);
         } else {
@@ -69,7 +66,7 @@ EOT
         switch ($format = $input->getOption('format')) {
             case 'text':
                 $this->getIO()->write('Name: <comment>'.$root->getPrettyName().'</comment>');
-                $this->getIO()->write('Version: <comment>'.$versionParser->formatVersion($root).'</comment>');
+                $this->getIO()->write('Version: <comment>'.$root->getFullPrettyVersion().'</comment>');
                 $this->getIO()->write('Licenses: <comment>'.(implode(', ', $root->getLicense()) ?: 'none').'</comment>');
                 $this->getIO()->write('Dependencies:');
                 $this->getIO()->write('');
@@ -82,7 +79,7 @@ EOT
                 foreach ($packages as $package) {
                     $table->addRow(array(
                         $package->getPrettyName(),
-                        $versionParser->formatVersion($package),
+                        $package->getFullPrettyVersion(),
                         implode(', ', $package->getLicense()) ?: 'none',
                     ));
                 }
@@ -92,14 +89,14 @@ EOT
             case 'json':
                 foreach ($packages as $package) {
                     $dependencies[$package->getPrettyName()] = array(
-                        'version' => $versionParser->formatVersion($package),
+                        'version' => $package->getFullPrettyVersion(),
                         'license' => $package->getLicense(),
                     );
                 }
 
                 $this->getIO()->write(JsonFile::encode(array(
                     'name'         => $root->getPrettyName(),
-                    'version'      => $versionParser->formatVersion($root),
+                    'version'      => $root->getFullPrettyVersion(),
                     'license'      => $root->getLicense(),
                     'dependencies' => $dependencies,
                 )));

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -181,7 +181,7 @@ EOT
                 foreach ($packages[$type] as $package) {
                     if (is_object($package)) {
                         $nameLength = max($nameLength, strlen($package->getPrettyName()));
-                        $versionLength = max($versionLength, strlen($this->versionParser->formatVersion($package)));
+                        $versionLength = max($versionLength, strlen($package->getFullPrettyVersion()));
                     } else {
                         $nameLength = max($nameLength, $package);
                     }
@@ -209,7 +209,7 @@ EOT
                         $output->write($indent . str_pad($package->getPrettyName(), $nameLength, ' '), false);
 
                         if ($writeVersion) {
-                            $output->write(' ' . str_pad($this->versionParser->formatVersion($package), $versionLength, ' '), false);
+                            $output->write(' ' . str_pad($package->getFullPrettyVersion(), $versionLength, ' '), false);
                         }
 
                         if ($writeDescription) {

--- a/src/Composer/DependencyResolver/Operation/SolverOperation.php
+++ b/src/Composer/DependencyResolver/Operation/SolverOperation.php
@@ -12,7 +12,6 @@
 
 namespace Composer\DependencyResolver\Operation;
 
-use Composer\Package\Version\VersionParser;
 use Composer\Package\PackageInterface;
 
 /**
@@ -46,6 +45,6 @@ abstract class SolverOperation implements OperationInterface
 
     protected function formatVersion(PackageInterface $package)
     {
-        return VersionParser::formatVersion($package);
+        return $package->getFullPrettyVersion();
     }
 }

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -16,7 +16,6 @@ use Composer\Config;
 use Composer\Cache;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
-use Composer\Package\Version\VersionParser;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PreFileDownloadEvent;
 use Composer\EventDispatcher\EventDispatcher;
@@ -81,7 +80,7 @@ class FileDownloader implements DownloaderInterface
             throw new \InvalidArgumentException('The given package is missing url information');
         }
 
-        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . VersionParser::formatVersion($package) . "</comment>)");
+        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . $package->getFullPrettyVersion() . "</comment>)");
 
         $urls = $package->getDistUrls();
         while ($url = array_shift($urls)) {
@@ -205,7 +204,7 @@ class FileDownloader implements DownloaderInterface
      */
     public function remove(PackageInterface $package, $path)
     {
-        $this->io->writeError("  - Removing <info>" . $package->getName() . "</info> (<comment>" . VersionParser::formatVersion($package) . "</comment>)");
+        $this->io->writeError("  - Removing <info>" . $package->getName() . "</info> (<comment>" . $package->getFullPrettyVersion() . "</comment>)");
         if (!$this->filesystem->removeDirectory($path)) {
             throw new \RuntimeException('Could not completely delete '.$path.', aborting.');
         }

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -14,7 +14,6 @@ namespace Composer\Downloader;
 
 use Composer\Config;
 use Composer\Package\PackageInterface;
-use Composer\Package\Version\VersionParser;
 use Composer\Util\ProcessExecutor;
 use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
@@ -54,7 +53,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
             throw new \InvalidArgumentException('Package '.$package->getPrettyName().' is missing reference information');
         }
 
-        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . VersionParser::formatVersion($package) . "</comment>)");
+        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . $package->getFullPrettyVersion() . "</comment>)");
         $this->filesystem->emptyDirectory($path);
 
         $urls = $package->getSourceUrls();
@@ -100,8 +99,8 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
             }
             $name .= ' '.$initial->getPrettyVersion();
         } else {
-            $from = VersionParser::formatVersion($initial);
-            $to = VersionParser::formatVersion($target);
+            $from = $initial->getFullPrettyVersion();
+            $to = $target->getFullPrettyVersion();
         }
 
         $this->io->writeError("  - Updating <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>)");

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -206,6 +206,23 @@ abstract class BasePackage implements PackageInterface
         return $this->getPrettyName().' '.$this->getPrettyVersion();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function getFullPrettyVersion($truncate = true)
+    {
+        if (!$this->isDev() || !in_array($this->getSourceType(), array('hg', 'git'))) {
+            return $this->getPrettyVersion();
+        }
+
+        // if source reference is a sha1 hash -- truncate
+        if ($truncate && strlen($this->getSourceReference()) === 40) {
+            return $this->getPrettyVersion() . ' ' . substr($this->getSourceReference(), 0, 7);
+        }
+
+        return $this->getPrettyVersion() . ' ' . $this->getSourceReference();
+    }
+
     public function __clone()
     {
         $this->repository = null;

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -193,6 +193,16 @@ interface PackageInterface
     public function getPrettyVersion();
 
     /**
+     * Returns the pretty version string plus a git or hg commit hash of this package
+     *
+     * @see getPrettyVersion
+     *
+     * @param bool $truncate If the source reference is a sha1 hash, truncate it
+     * @return string version
+     */
+    public function getFullPrettyVersion($truncate = true);
+
+    /**
      * Returns the release date of the package
      *
      * @return \DateTime

--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -69,8 +69,14 @@ class VersionParser
         return $stability === 'rc' ? 'RC' : $stability;
     }
 
+    /**
+     * @deprecated Use PackageInterface::getFullPrettyVersion instead
+     */
     public static function formatVersion(PackageInterface $package, $truncate = true)
     {
+        trigger_error(__METHOD__.' is deprecated. Use '.
+            '\Composer\Package\PackageInterface::getFullPrettyVersion() instead', E_USER_DEPRECATED);
+
         return $package->getFullPrettyVersion($truncate);
     }
 

--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -71,16 +71,7 @@ class VersionParser
 
     public static function formatVersion(PackageInterface $package, $truncate = true)
     {
-        if (!$package->isDev() || !in_array($package->getSourceType(), array('hg', 'git'))) {
-            return $package->getPrettyVersion();
-        }
-
-        // if source reference is a sha1 hash -- truncate
-        if ($truncate && strlen($package->getSourceReference()) === 40) {
-            return $package->getPrettyVersion() . ' ' . substr($package->getSourceReference(), 0, 7);
-        }
-
-        return $package->getPrettyVersion() . ' ' . $package->getSourceReference();
+        return $package->getFullPrettyVersion($truncate);
     }
 
     /**

--- a/tests/Composer/Test/Package/BasePackageTest.php
+++ b/tests/Composer/Test/Package/BasePackageTest.php
@@ -12,6 +12,8 @@
 
 namespace Composer\Test\Package;
 
+use Composer\Package\BasePackage;
+
 class BasePackageTest extends \PHPUnit_Framework_TestCase
 {
     public function testSetSameRepository()
@@ -36,5 +38,52 @@ class BasePackageTest extends \PHPUnit_Framework_TestCase
 
         $package->setRepository($this->getMock('Composer\Repository\RepositoryInterface'));
         $package->setRepository($this->getMock('Composer\Repository\RepositoryInterface'));
+    }
+
+    /**
+     * @dataProvider formattedVersions
+     */
+    public function testFormatVersionForDevPackage(BasePackage $package, $truncate, $expected)
+    {
+        $this->assertSame($expected, $package->getFullPrettyVersion($truncate));
+    }
+
+    public function formattedVersions()
+    {
+        $data = array(
+            array(
+                'sourceReference' => 'v2.1.0-RC2',
+                'truncate' => true,
+                'expected' => 'PrettyVersion v2.1.0-RC2'
+            ),
+            array(
+                'sourceReference' => 'bbf527a27356414bfa9bf520f018c5cb7af67c77',
+                'truncate' => true,
+                'expected' => 'PrettyVersion bbf527a'
+            ),
+            array(
+                'sourceReference' => 'v1.0.0',
+                'truncate' => false,
+                'expected' => 'PrettyVersion v1.0.0'
+            ),
+            array(
+                'sourceReference' => 'bbf527a27356414bfa9bf520f018c5cb7af67c77',
+                'truncate' => false,
+                'expected' => 'PrettyVersion bbf527a27356414bfa9bf520f018c5cb7af67c77'
+            ),
+        );
+
+        $self = $this;
+        $createPackage = function ($arr) use ($self) {
+            $package = $self->getMockForAbstractClass('\Composer\Package\BasePackage', array(), '', false);
+            $package->expects($self->once())->method('isDev')->will($self->returnValue(true));
+            $package->expects($self->once())->method('getSourceType')->will($self->returnValue('git'));
+            $package->expects($self->once())->method('getPrettyVersion')->will($self->returnValue('PrettyVersion'));
+            $package->expects($self->any())->method('getSourceReference')->will($self->returnValue($arr['sourceReference']));
+
+            return array($package, $arr['truncate'], $arr['expected']);
+        };
+
+        return array_map($createPackage, $data);
     }
 }

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -56,7 +56,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
 
         $self = $this;
         $createPackage = function ($arr) use ($self) {
-            $package = $self->getMock('\Composer\Package\PackageInterface');
+            $package = $self->getMockForAbstractClass('\Composer\Package\BasePackage', array(), '', false);
             $package->expects($self->once())->method('isDev')->will($self->returnValue(true));
             $package->expects($self->once())->method('getSourceType')->will($self->returnValue('git'));
             $package->expects($self->once())->method('getPrettyVersion')->will($self->returnValue('PrettyVersion'));

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -21,52 +21,6 @@ use Composer\Package\PackageInterface;
 
 class VersionParserTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @dataProvider formattedVersions
-     */
-    public function testFormatVersionForDevPackage(PackageInterface $package, $truncate, $expected)
-    {
-        $this->assertSame($expected, VersionParser::formatVersion($package, $truncate));
-    }
-
-    public function formattedVersions()
-    {
-        $data = array(
-            array(
-                'sourceReference' => 'v2.1.0-RC2',
-                'truncate' => true,
-                'expected' => 'PrettyVersion v2.1.0-RC2'
-            ),
-            array(
-                'sourceReference' => 'bbf527a27356414bfa9bf520f018c5cb7af67c77',
-                'truncate' => true,
-                'expected' => 'PrettyVersion bbf527a'
-            ),
-            array(
-                'sourceReference' => 'v1.0.0',
-                'truncate' => false,
-                'expected' => 'PrettyVersion v1.0.0'
-            ),
-            array(
-                'sourceReference' => 'bbf527a27356414bfa9bf520f018c5cb7af67c77',
-                'truncate' => false,
-                'expected' => 'PrettyVersion bbf527a27356414bfa9bf520f018c5cb7af67c77'
-            ),
-        );
-
-        $self = $this;
-        $createPackage = function ($arr) use ($self) {
-            $package = $self->getMockForAbstractClass('\Composer\Package\BasePackage', array(), '', false);
-            $package->expects($self->once())->method('isDev')->will($self->returnValue(true));
-            $package->expects($self->once())->method('getSourceType')->will($self->returnValue('git'));
-            $package->expects($self->once())->method('getPrettyVersion')->will($self->returnValue('PrettyVersion'));
-            $package->expects($self->any())->method('getSourceReference')->will($self->returnValue($arr['sourceReference']));
-
-            return array($package, $arr['truncate'], $arr['expected']);
-        };
-
-        return array_map($createPackage, $data);
-    }
 
     /**
      * @dataProvider numericAliasVersions


### PR DESCRIPTION
Working towards #3545.

formatVersion() does not belong in VersionParser since it depends upon a
Package object, and is creating a more complete pretty formatted
version, not parsing anything.

The new getFullPrettyVersion() method can be seen as an extension to
getPrettyVersion(), and is located in BasePackage as a result.

I'm also not very good at naming things, and `getFullPrettyVersion` was the best I could come up with. Better suggestions welcome :)