### PR TITLE
Fix "Invalid argument supplied for foreach()" on a new PlaformRepository obj

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -35,10 +35,10 @@ class PlatformRepository extends ArrayRepository
 
     public function __construct(array $packages = array(), array $overrides = array())
     {
-        parent::__construct($packages);
         foreach ($overrides as $name => $version) {
             $this->overrides[strtolower($name)] = array('name' => $name, 'version' => $version);
         }
+        parent::__construct($packages);
     }
 
     protected function initialize()

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -31,12 +31,11 @@ class PlatformRepository extends ArrayRepository
      *
      * @var array
      */
-    private $overrides;
+    private $overrides = array();
 
     public function __construct(array $packages = array(), array $overrides = array())
     {
         parent::__construct($packages);
-        $this->overrides = array();
         foreach ($overrides as $name => $version) {
             $this->overrides[strtolower($name)] = array('name' => $name, 'version' => $version);
         }


### PR DESCRIPTION
This happens on `new PlatformRepository(array($somePackage))`.

The parent constructor calls `\Composer\Repository\ArrayRepository::addPackage()`, which, on a brand new repo object, further calls `\Composer\Repository\PlatformRepository::initialize()` and finally this iterates over a `NULL` `$this->overrides`, triggering the error.