### PR TITLE
write progress (of which composer.json is read) on stdout instead stderr

### DIFF
--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -134,9 +134,9 @@ class VcsRepository extends ArrayRepository
         foreach ($driver->getTags() as $tag => $identifier) {
             $msg = 'Reading composer.json of <info>' . ($this->packageName ?: $this->url) . '</info> (<comment>' . $tag . '</comment>)';
             if ($verbose) {
-                $this->io->writeError($msg);
+                $this->io->write($msg);
             } else {
-                $this->io->overwriteError($msg, false);
+                $this->io->overwrite($msg, false);
             }
 
             // strip the release- prefix from tags if present
@@ -198,9 +198,9 @@ class VcsRepository extends ArrayRepository
         foreach ($driver->getBranches() as $branch => $identifier) {
             $msg = 'Reading composer.json of <info>' . ($this->packageName ?: $this->url) . '</info> (<comment>' . $branch . '</comment>)';
             if ($verbose) {
-                $this->io->writeError($msg);
+                $this->io->write($msg);
             } else {
-                $this->io->overwriteError($msg, false);
+                $this->io->overwrite($msg, false);
             }
 
             if (!$parsedBranch = $this->validateBranch($branch)) {


### PR DESCRIPTION
The output which composer.json is currently read should be on stdout instead of stderr.

Otherwise some systems behave unexpectedly because they assume an error occurred. For example the crontab sends an email.

The following test fails, but also fails on master, so it's not introduced by our change:

```
There was 1 failure:

1) Composer\Test\Util\RemoteFilesystemTest::testCaptureAuthenticationParamsFromUrl
Failed asserting that 0 matches expected 404.
```

Thanks.