### PR TITLE
Change require to require_once for autoloading files

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -582,7 +582,7 @@ METHOD_FOOTER;
 
 function composerRequire$suffix(\$file)
 {
-    require \$file;
+    require_once \$file;
 }
 
 FOOTER;

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -51,5 +51,5 @@ class ComposerAutoloaderInitFilesAutoloadOrder
 
 function composerRequireFilesAutoloadOrder($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -51,5 +51,5 @@ class ComposerAutoloaderInitFilesAutoload
 
 function composerRequireFilesAutoload($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -67,5 +67,5 @@ class ComposerAutoloaderInitIncludePath
 
 function composerRequireIncludePath($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -71,5 +71,5 @@ class ComposerAutoloaderInitTargetDir
 
 function composerRequireTargetDir($file)
 {
-    require $file;
+    require_once $file;
 }


### PR DESCRIPTION
**Use case**

There are more and more people starting to use a single repository for their code bases.
Especially with microservices you quickly see the benefits. It lowers the amount of overhead when you have changes to multiple components, as you only need to update a single repository.

But you still want to be able to have explicit dependencies for each component. Of course you can add a composer.json to each component, but that would also mean you have to resolve dependencies for each component, which can be quit annoying in your release cycle.

With [Fiddler] Beberlei solved a big part of that problem. By having 1 composer.json in the root of your repository, you only have 1 place where you resolve your dependencies, and Fiddler makes sure that every component knows where it can find its specific dependencies. It does this by generating an autoload.php for each component. In the autoload it points back to the vendor directory in the root package.

**The problem**

When I was adding support for binaries in Fiddler, I ran into an issue with the autoloading of files.
An example project:

```text
/composer.json
/vendor/autoload.php
/vendor/bin/phpunit -> /vendor/phpunit/phpunit/phpunit
/src/Foo/fiddler.json
/src/Foo/phpunit.xml.dist
/src/Foo/vendor/autoload.php
/src/Foo/vendor/bin/phpunit -> /vendor/bin/phpunit
/src/Bar/[..]
```

If we run `/src/Foo/vendor/bin/phpunit` it will use `/vendor/autoload.php`. This is because we actually run `/vendor/phpunit/phpunit/phpunit`, which assumes `autoload.php` to be in `../../autoload.php`.
In the bootstrap of phpunit we tell it to load `/src/Foo/vendor/autoload.php`.

This works fine for classes, but for included files (f.e. function files) this causes an issue. As both autoloaders will try to require those files, causing PHP to throw Fatal errors that it can not redeclare those functions.

This issue is also present when using multiple composer.json. As soon as you have multiple autoloaders that try to load the same (function) files, this problem occurs.

This PR solves that problem. 
As this `require_once` is only used for [autoloading of files], the impact is pretty low.

[Fiddler]: https://github.com/beberlei/fiddler
[autoloading of files]: https://getcomposer.org/doc/04-schema.md#files