### PR TITLE
load xml as string from local file, fixes #3942

### DIFF
--- a/src/Composer/Downloader/PearPackageExtractor.php
+++ b/src/Composer/Downloader/PearPackageExtractor.php
@@ -137,7 +137,7 @@ class PearPackageExtractor
     private function buildCopyActions($source, array $roles, $vars)
     {
         /** @var $package \SimpleXmlElement */
-        $package = simplexml_load_file($this->combine($source, 'package.xml'));
+        $package = simplexml_load_string(file_get_contents($this->combine($source, 'package.xml')));
         if (false === $package) {
             throw new \RuntimeException('Package definition file is not valid.');
         }

--- a/tests/Composer/Test/Downloader/PearPackageExtractorTest.php
+++ b/tests/Composer/Test/Downloader/PearPackageExtractorTest.php
@@ -18,11 +18,15 @@ class PearPackageExtractorTest extends \PHPUnit_Framework_TestCase
 {
     public function testShouldExtractPackage_1_0()
     {
+        $state = libxml_disable_entity_loader(true);
+
         $extractor = $this->getMockForAbstractClass('Composer\Downloader\PearPackageExtractor', array(), '', false);
         $method = new \ReflectionMethod($extractor, 'buildCopyActions');
         $method->setAccessible(true);
 
         $fileActions = $method->invoke($extractor, __DIR__ . '/Fixtures/Package_v1.0', array('php' => '/'), array());
+
+        libxml_disable_entity_loader($state);
 
         $expectedFileActions = array(
             'Gtk.php' => array(
@@ -49,11 +53,15 @@ class PearPackageExtractorTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldExtractPackage_2_0()
     {
+        $state = libxml_disable_entity_loader(true);
+
         $extractor = $this->getMockForAbstractClass('Composer\Downloader\PearPackageExtractor', array(), '', false);
         $method = new \ReflectionMethod($extractor, 'buildCopyActions');
         $method->setAccessible(true);
 
         $fileActions = $method->invoke($extractor, __DIR__ . '/Fixtures/Package_v2.0', array('php' => '/'), array());
+
+        libxml_disable_entity_loader($state);
 
         $expectedFileActions = array(
             'URL.php' => array(
@@ -68,11 +76,15 @@ class PearPackageExtractorTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldExtractPackage_2_1()
     {
+        $state = libxml_disable_entity_loader(true);
+
         $extractor = $this->getMockForAbstractClass('Composer\Downloader\PearPackageExtractor', array(), '', false);
         $method = new \ReflectionMethod($extractor, 'buildCopyActions');
         $method->setAccessible(true);
 
         $fileActions = $method->invoke($extractor, __DIR__ . '/Fixtures/Package_v2.1', array('php' => '/', 'script' => '/bin'), array());
+
+        libxml_disable_entity_loader($state);
 
         $expectedFileActions = array(
             'php/Zend/Authentication/Storage/StorageInterface.php' => array(


### PR DESCRIPTION
If the entity loader is disabled on a system, loading files, even from the local file system, is considered as external to the running php process, and thus not allowed by the libxml extension. Reading the file contents and loading the xml as a string is a valid alternative however.

Fixes #3942