### PR TITLE
Remove extra '/' when findShortestPath $from is a directory

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -316,7 +316,7 @@ class Filesystem
         $to = lcfirst($this->normalizePath($to));
 
         if ($directories) {
-            $from .= $this->isDirectory($from) ? 'dummy_file' : '/dummy_file';
+            $from = rtrim($from, '/') . '/dummy_file';
         }
 
         if (dirname($from) === dirname($to)) {
@@ -459,17 +459,6 @@ class Filesystem
     public static function isLocalPath($path)
     {
         return (bool) preg_match('{^(file://|/|[a-z]:[\\\\/]|\.\.[\\\\/]|[a-z0-9_.-]+[\\\\/])}i', $path);
-    }
-    
-    /**
-     * Return if the given path is a directory
-     *
-     * @param  string $path
-     * @return bool
-     */
-    public static function isDirectory($path)
-    {
-        return substr($path, -1) === '/';
     }
 
     public static function getPlatformPath($path)

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -316,7 +316,7 @@ class Filesystem
         $to = lcfirst($this->normalizePath($to));
 
         if ($directories) {
-            $from .= '/dummy_file';
+            $from .= $this->isDirectory($from) ? 'dummy_file' : '/dummy_file';
         }
 
         if (dirname($from) === dirname($to)) {
@@ -459,6 +459,17 @@ class Filesystem
     public static function isLocalPath($path)
     {
         return (bool) preg_match('{^(file://|/|[a-z]:[\\\\/]|\.\.[\\\\/]|[a-z0-9_.-]+[\\\\/])}i', $path);
+    }
+    
+    /**
+     * Return if the given path is a directory
+     *
+     * @param  string $path
+     * @return bool
+     */
+    public static function isDirectory($path)
+    {
+        return substr($path, -1) === '/';
     }
 
     public static function getPlatformPath($path)

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -112,6 +112,7 @@ class FilesystemTest extends TestCase
             array('/foo/bar_vendor', '/foo/bar', '../bar', true),
             array('/foo/bar_vendor', '/foo/bar/src', '../bar/src', true),
             array('/foo/bar_vendor/src2', '/foo/bar/src/lib', '../../bar/src/lib', true),
+            array('C:/', 'C:/foo/bar/', "foo/bar", true),
         );
     }
 


### PR DESCRIPTION
Resolves #3024

Passing the third argument as `true` on `findShortestPath ` method, a dummy file is added to `$from`. 
If `$from` ends with `/` (e.g. C:/ , /foo/bar/ ), a second `/` is inserted resulting on a invalid path.
