### PR TITLE
Optimize the regex detecting timestamps

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -147,7 +147,7 @@ class ArrayLoader implements LoaderInterface
         }
 
         if (!empty($config['time'])) {
-            $time = preg_match('/^\d+$/D', $config['time']) ? '@'.$config['time'] : $config['time'];
+            $time = preg_match('/^\d++$/D', $config['time']) ? '@'.$config['time'] : $config['time'];
 
             try {
                 $date = new \DateTime($time, new \DateTimeZone('UTC'));


### PR DESCRIPTION
Using a possessive quantifier avoids useless backtracking.