### PR TITLE
Revert the plugin versions converting from "1.0.0" to "^1.0" feature

### DIFF
--- a/doc/articles/plugins.md
+++ b/doc/articles/plugins.md
@@ -32,13 +32,7 @@ requirements:
    to define which Plugin API versions your plugin is compatible with.
 
 The required version of the `composer-plugin-api` follows the same [rules][7]
-as a normal package's, except for the `1.0`, `1.0.0` and `1.0.0.0` _exact_ 
-values. In only these three cases, Composer will assume your plugin 
-actually meant `^1.0` instead. This was introduced to maintain BC with 
-the old style of declaring the Plugin API version.  
-  
-In other words, `"require": { "composer-plugin-api": "1.0.0" }` means
-`"require": { "composer-plugin-api": "^1.0" }`.
+as a normal package's.
 
 The current composer plugin API version is 1.0.0.
 

--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -228,25 +228,10 @@ class VersionParser
                 $parsedConstraint = $this->parseConstraints($constraint);
             }
 
-            // if the required Plugin API version is exactly "1.0.0", convert it to "^1.0", to keep BC
-            if ('composer-plugin-api' === strtolower($target) && $this->isOldStylePluginApiVersion($constraint)) {
-                $parsedConstraint = $this->parseConstraints('^1.0');
-            }
-
             $res[strtolower($target)] = new Link($source, $target, $parsedConstraint, $description, $constraint);
         }
 
         return $res;
-    }
-
-    /**
-     * @param string $requiredPluginApiVersion
-     * @return bool
-     */
-    private function isOldStylePluginApiVersion($requiredPluginApiVersion)
-    {
-        // catch "1.0", "1.0.0", "1.0.0.0" etc.
-        return (bool) preg_match('#^1(\.0)++$#', trim($requiredPluginApiVersion));
     }
 
     /**

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -515,18 +515,12 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function oldStylePluginApiVersions()
+    public function pluginApiVersions()
     {
         return array(
             array('1.0'),
             array('1.0.0'),
             array('1.0.0.0'),
-        );
-    }
-
-    public function newStylePluginApiVersions()
-    {
-        return array(
             array('1'),
             array('=1.0.0'),
             array('==1.0'),
@@ -543,23 +537,9 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider oldStylePluginApiVersions
+     * @dataProvider pluginApiVersions
      */
-    public function testOldStylePluginApiVersionGetsConvertedIntoAnotherConstraintToKeepBc($apiVersion)
-    {
-        $parser = new VersionParser;
-
-        /** @var Link[] $links */
-        $links = $parser->parseLinks('Plugin', '9.9.9', '', array('composer-plugin-api' => $apiVersion));
-
-        $this->assertArrayHasKey('composer-plugin-api', $links);
-        $this->assertSame('^1.0', $links['composer-plugin-api']->getConstraint()->getPrettyString());
-    }
-
-    /**
-     * @dataProvider newStylePluginApiVersions
-     */
-    public function testNewStylePluginApiVersionAreKeptAsDeclared($apiVersion)
+    public function testPluginApiVersionAreKeptAsDeclared($apiVersion)
     {
         $parser = new VersionParser;
 

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -249,21 +249,21 @@ class PluginInstallerTest extends TestCase
         $this->pm->loadInstalledPlugins();
     }
 
-    public function testOldPluginVersionStyleWorksWithAPIUntil199()
+    public function testExactPluginVersionStyleAreRegisteredCorrectly()
     {
-        $pluginsWithOldStyleAPIVersions = array(
+        $pluginsWithFixedAPIVersions = array(
             $this->packages[0],
             $this->packages[1],
             $this->packages[2],
         );
 
-        $this->setPluginApiVersionWithPlugins('1.0.0', $pluginsWithOldStyleAPIVersions);
+        $this->setPluginApiVersionWithPlugins('1.0.0', $pluginsWithFixedAPIVersions);
         $this->assertCount(3, $this->pm->getPlugins());
 
-        $this->setPluginApiVersionWithPlugins('1.9.9', $pluginsWithOldStyleAPIVersions);
-        $this->assertCount(3, $this->pm->getPlugins());
+        $this->setPluginApiVersionWithPlugins('1.0.1', $pluginsWithFixedAPIVersions);
+        $this->assertCount(0, $this->pm->getPlugins());
 
-        $this->setPluginApiVersionWithPlugins('2.0.0-dev', $pluginsWithOldStyleAPIVersions);
+        $this->setPluginApiVersionWithPlugins('2.0.0-dev', $pluginsWithFixedAPIVersions);
         $this->assertCount(0, $this->pm->getPlugins());
     }
 


### PR DESCRIPTION
This PR relates to https://github.com/composer/composer/pull/4089, which adds an unnecessary feature - converting a plugin's constraint from `1.0.0` to `^1.0`. That was a mistake on my part. I wrongly assumed that Composer has no support for multiple Plugin versions. Poor knowledge of the VersionParser class and some misinterpreted errors lead me to that conclusion.

The tests were kept, but changed accordingly. The exclusion of plugins which didn't match was kept. The text mentioning that a plugin was not registered was kept.

Thanks, @stof, for letting me know, albeit in a very obscure and then-hidden line comment. I saw it just now.