### PR TITLE
Added Capable plugins for a more future-proof Plugin API

### DIFF
--- a/src/Composer/Plugin/Capability/Capability.php
+++ b/src/Composer/Plugin/Capability/Capability.php
@@ -17,7 +17,6 @@ namespace Composer\Plugin\Capability;
  * Every new Capability which is added to the Plugin API must implement this interface.
  *
  * @api
- * @since Plugin API 1.1
  */
 interface Capability
 {

--- a/src/Composer/Plugin/Capability/Capability.php
+++ b/src/Composer/Plugin/Capability/Capability.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Plugin\Capability;
+
+/**
+ * Marker interface for Plugin capabilities.
+ * Every new Capability which is added to the Plugin API must implement this interface.
+ *
+ * @api
+ * @since Plugin API 1.1
+ */
+interface Capability
+{
+}

--- a/src/Composer/Plugin/Capable.php
+++ b/src/Composer/Plugin/Capable.php
@@ -28,9 +28,7 @@ interface Capable
      * The key must be a string, representing a fully qualified class/interface name
      * which Composer Plugin API exposes.
      * The value must be a string as well, representing the fully qualified class name
-     * of the API class.
-     *
-     * Every implementation will be passed a single array parameter via their constructor.
+     * of the implementing class.
      *
      * @tutorial
      *

--- a/src/Composer/Plugin/Capable.php
+++ b/src/Composer/Plugin/Capable.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Plugin;
+
+/**
+ * Plugins which need to expose various implementations
+ * of the Composer Plugin Capabilities must have their
+ * declared Plugin class implementing this interface.
+ *
+ * @api
+ * @since Plugin API 1.1
+ */
+interface Capable
+{
+    /**
+     * Method by which a Plugin announces its API implementations, through an array
+     * with a special structure.
+     *
+     * The key must be a string, representing a fully qualified class/interface name
+     * which Composer Plugin API exposes - named "API class".
+     * The value must be a string as well, representing the fully qualified class name
+     * of the API class - named "SPI class".
+     *
+     * Every SPI must implement their API class.
+     *
+     * Every SPI will be passed a single array parameter via their constructor.
+     *
+     * Example:
+     * // API as key, SPI as value
+     * return array(
+     *      'Composer\Plugin\Capability\CommandProvider' => 'My\CommandProvider',
+     *      'Composer\Plugin\Capability\Validator'       => 'My\Validator',
+     * );
+     *
+     * @return string[]
+     */
+    public function getCapabilities();
+}

--- a/src/Composer/Plugin/Capable.php
+++ b/src/Composer/Plugin/Capable.php
@@ -18,7 +18,6 @@ namespace Composer\Plugin;
  * declared Plugin class implementing this interface.
  *
  * @api
- * @since Plugin API 1.1
  */
 interface Capable
 {

--- a/src/Composer/Plugin/Capable.php
+++ b/src/Composer/Plugin/Capable.php
@@ -26,19 +26,17 @@ interface Capable
      * with a special structure.
      *
      * The key must be a string, representing a fully qualified class/interface name
-     * which Composer Plugin API exposes - named "API class".
+     * which Composer Plugin API exposes.
      * The value must be a string as well, representing the fully qualified class name
-     * of the API class - named "SPI class".
+     * of the API class.
      *
-     * Every SPI must implement their API class.
+     * Every implementation will be passed a single array parameter via their constructor.
      *
-     * Every SPI will be passed a single array parameter via their constructor.
+     * @tutorial
      *
-     * Example:
-     * // API as key, SPI as value
      * return array(
-     *      'Composer\Plugin\Capability\CommandProvider' => 'My\CommandProvider',
-     *      'Composer\Plugin\Capability\Validator'       => 'My\Validator',
+     *     'Composer\Plugin\Capability\CommandProvider' => 'My\CommandProvider',
+     *     'Composer\Plugin\Capability\Validator'       => 'My\Validator',
      * );
      *
      * @return string[]

--- a/src/Composer/Plugin/PluginInterface.php
+++ b/src/Composer/Plugin/PluginInterface.php
@@ -23,14 +23,14 @@ use Composer\IO\IOInterface;
 interface PluginInterface
 {
     /**
-     * Version number of the fake composer-plugin-api package
+     * Version number of the internal composer-plugin-api package
      *
      * @var string
      */
-    const PLUGIN_API_VERSION = '1.0.0';
+    const PLUGIN_API_VERSION = '1.1.0';
 
     /**
-     * Apply plugin modifications to composer
+     * Apply plugin modifications to Composer
      *
      * @param Composer    $composer
      * @param IOInterface $io

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v1/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v1/composer.json
@@ -7,6 +7,6 @@
         "class": "Installer\\Plugin"
     },
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "*"
     }
 }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v1/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v1/composer.json
@@ -7,6 +7,6 @@
         "class": "Installer\\Plugin"
     },
     "require": {
-        "composer-plugin-api": "*"
+        "composer-plugin-api": "^1.0"
     }
 }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v2/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v2/composer.json
@@ -7,6 +7,6 @@
         "class": "Installer\\Plugin2"
     },
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "*"
     }
 }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v2/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v2/composer.json
@@ -7,6 +7,6 @@
         "class": "Installer\\Plugin2"
     },
     "require": {
-        "composer-plugin-api": "*"
+        "composer-plugin-api": "^1.0"
     }
 }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v3/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v3/composer.json
@@ -7,6 +7,6 @@
         "class": "Installer\\Plugin2"
     },
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "*"
     }
 }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v3/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v3/composer.json
@@ -7,6 +7,6 @@
         "class": "Installer\\Plugin2"
     },
     "require": {
-        "composer-plugin-api": "*"
+        "composer-plugin-api": "^1.0"
     }
 }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v4/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v4/composer.json
@@ -10,6 +10,6 @@
         ]
     },
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "^1.0"
     }
 }

--- a/tests/Composer/Test/Plugin/Mock/Capability.php
+++ b/tests/Composer/Test/Plugin/Mock/Capability.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Plugin\Mock;
+
+class Capability implements \Composer\Plugin\Capability\Capability
+{
+    public $args;
+
+    public function __construct(array $args)
+    {
+        $this->args = $args;
+    }
+}

--- a/tests/Composer/Test/Plugin/Mock/CapablePluginInterface.php
+++ b/tests/Composer/Test/Plugin/Mock/CapablePluginInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Plugin\Mock;
+
+use Composer\Plugin\Capable;
+use Composer\Plugin\PluginInterface;
+
+interface CapablePluginInterface extends PluginInterface, Capable
+{
+}

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -249,24 +249,6 @@ class PluginInstallerTest extends TestCase
         $this->pm->loadInstalledPlugins();
     }
 
-    public function testExactPluginVersionStyleAreRegisteredCorrectly()
-    {
-        $pluginsWithFixedAPIVersions = array(
-            $this->packages[0],
-            $this->packages[1],
-            $this->packages[2],
-        );
-
-        $this->setPluginApiVersionWithPlugins('1.0.0', $pluginsWithFixedAPIVersions);
-        $this->assertCount(3, $this->pm->getPlugins());
-
-        $this->setPluginApiVersionWithPlugins('1.0.1', $pluginsWithFixedAPIVersions);
-        $this->assertCount(0, $this->pm->getPlugins());
-
-        $this->setPluginApiVersionWithPlugins('2.0.0-dev', $pluginsWithFixedAPIVersions);
-        $this->assertCount(0, $this->pm->getPlugins());
-    }
-
     public function testStarPluginVersionWorksWithAnyAPIVersion()
     {
         $starVersionPlugin = array($this->packages[4]);

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -147,7 +147,7 @@ class PluginInstallerTest extends TestCase
         $this->repository
             ->expects($this->exactly(2))
             ->method('getPackages')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue(array($this->packages[3])));
         $installer = new PluginInstaller($this->io, $this->composer);
         $this->pm->loadInstalledPlugins();
 


### PR DESCRIPTION
Plugins can now present their capabilities to the PluginManager, through which it can act accordingly, thus making Plugin API more flexible, BC-friendly and decoupled.

**The Plugin API was bumped to version `1.1.0`.** :boom: 

**a) Plugin API evolution**
Every time Composer decides that a new extension should be added, it will extend its Plugin API to support that extension point - through an interface, an abstract class or a concrete one.  
Some example of extension points would be: allowing users to add their own Composer commands, allowing users to add their own validation steps in the `validate` command, offloading certain operations to userland implementations, otherwise falling back to default etc.

Because the PluginManager and the plugins communicate via strings and arrays, the possibility of autoloading non-existent classes in case of a version mis-match between them is avoided - thus a BC break.

**b) Plugin evolution**
The plugin's job is simple: if Composer provides an API and the plugin wants to implement it, it is free to do so, provided it declares this in its capabilities method, which tells the PluginManager it can handle that particular API. 

Because plugins depend on the `Capable` interface to declare what they support, they *must* require `composer-plugin-api` versions starting from `1.1.0`, so that newer plugins will not be loaded in an older version of Composer, which doesn't have the `Capable` interface.

Examples of API capabilities:
```php
namespace Composer\Plugin\Capability;

interface CommandProvider extends Capability
{
    public function getCommands();
}

interface AdditionalValidator extends Capability
{
    public function validate();
}
```
A plugin implementation could look like this:
```php
namespace My;

use Composer\Plugin\PluginInterface;
use Composer\Plugin\Capable;
use Composer\Composer;
use Composer\IO\IOInterface;

class Plugin implements PluginInterface, Capable
{
    public function activate(Composer $composer, IOInterface $io)
    {}

    public function getCapabilities()
    {
        return array(
            'Composer\Plugin\Capability\CommandProvider' => 'My\CommandProviderImpl',
            'Composer\Plugin\Capability\AdditionalValidator' => 'My\ValidatorImpl',
        );
    }   
}
```
Note the additional `Capable` interface that can be implemented by the plugin - only if the plugin wants to provide implementations. It can very well only implement the `PluginInterface`. `Capable` and `PluginInterface` can merge in some other major version of Composer.

The PluginManager handles the instantiation and setup of the implementations:
```php
if ($commandProvider = $pm->getPluginCapability($plugin, 'Composer\Plugin\Capability\CommandProvider')) {
    var_dump($commandProvider->getCommands());
}
```
Values can be passed to implementation via a constructor-injected array. This will allow us to change what we pass to plugins, without having to change the method signature of the APIs, thus making _minor_ version bumps, instead of _major_:
```php
// args in Plugin API 1.1
$args = array('io' => $io, 'next' => $nextValidator);

// args in Plugin API 1.2
$args = array('io' => $io, 'next' => $nextValidator, 'previous' => $previousValidator);

$pm->getPluginCapability($plugin, 'Composer\Plugin\Capability\AdditionalValidator', $args);
```
PR related to https://github.com/composer/composer/pull/3377.