### PR TITLE
Follow symlinks when searching for artifacts

### DIFF
--- a/src/Composer/Repository/ArtifactRepository.php
+++ b/src/Composer/Repository/ArtifactRepository.php
@@ -48,7 +48,7 @@ class ArtifactRepository extends ArrayRepository
     {
         $io = $this->io;
 
-        $directory = new \RecursiveDirectoryIterator($path);
+        $directory = new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
         $iterator = new \RecursiveIteratorIterator($directory);
         $regex = new \RegexIterator($iterator, '/^.+\.(zip|phar)$/i');
         foreach ($regex as $file) {


### PR DESCRIPTION
Follow symlinks when searching for artifacts.

When working locally, we have a maven project that creates an artifact containing a generated api client library. Obviously we could set the artifact directory directly to the other project like this:

```json
{"type": "artifact", "url": "../my-other-project/target"}
```

However, doing this means if we don't have my-other-project cloned down under the same relative path, in other environments, then doing a composer update will blow up because the directory doesn't exist...even though we may not be trying to get an artifact from that directory (ie we might be trying to pull it from the production released artifacts...which are in satis).

I see 2 ways to resolve this:

1. Silently (or print a warning) ignore artifact directories that don't exist 
2. Add a directory to my project which contains only a .gitignore file (and tells it to ignore everything in there except the .gitignore file). We then point the artifact repository to that directory since it will always exist and then we manually symlink our other project(s) target directories into that directory. Going this route also provides flexibility so that devs can pull down the other projects wherever they see fit.  

So we can have something like this:

```json
{"type": "artifact", "url": "./composer-artifact-repo"}
```

However, I found that it doesn't currently pick up anything under symlinks :(