### PR TITLE
Added Ctrl+C support to create-project command for unix-like systems

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -293,11 +293,10 @@ EOT
         // handler Ctrl+C for unix-like systems
         if (function_exists('pcntl_signal')) {
             declare(ticks = 100);
-            $isPcntlHandler = true;
             pcntl_signal(SIGINT, function() use ($directory) {
                 $fs = new Filesystem();
                 $fs->removeDirectory($directory);
-                exit();
+                exit(130);
             });
         }
 

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -290,6 +290,17 @@ EOT
             $directory = getcwd() . DIRECTORY_SEPARATOR . array_pop($parts);
         }
 
+        // handler Ctrl+C for unix-like systems
+        if (function_exists('pcntl_signal')) {
+            declare(ticks = 100);
+            $isPcntlHandler = true;
+            pcntl_signal(SIGINT, function() use ($directory) {
+                $fs = new Filesystem();
+                $fs->removeDirectory($directory);
+                exit();
+            });
+        }
+
         $io->writeError('<info>Installing ' . $package->getName() . ' (' . VersionParser::formatVersion($package, false) . ')</info>');
 
         if ($disablePlugins) {


### PR DESCRIPTION
Realized feature in #2947. When press `Ctrl+C` in time processing `create-project` command target directory will be removed. Work on unix-like systems only.