### PR TITLE
[docs] mention the `memory_limit` actually being set

### DIFF
--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -91,7 +91,7 @@ If composer shows memory errors on some commands:
 
 The PHP `memory_limit` should be increased.
 
-> **Note:** Composer internally increases the `memory_limit` to `512M`.
+> **Note:** Composer internally increases the `memory_limit` to `1G`.
 > If you have memory issues when using composer, please consider [creating
 > an issue ticket](https://github.com/composer/composer/issues) so we can look into it.
 
@@ -105,7 +105,7 @@ Try increasing the limit in your `php.ini` file (ex. `/etc/php5/cli/php.ini` for
 Debian-like systems):
 
 ```ini
-; Use -1 for unlimited or define an explicit value like 512M
+; Use -1 for unlimited or define an explicit value like 2G
 memory_limit = -1
 ```
 


### PR DESCRIPTION
The [current implementation](https://github.com/composer/composer/blob/c471edc488f49f254c77ab97ecc14ea50bf3d2ab/bin/composer#L37) sets `1G`. Also, suggesting to set the `memory_limit` to `2G` would be more useful.