### PR TITLE
Add the hash of the parsed content of the composer.json to the lock file, and use it to verify the json is not changed

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -496,7 +496,26 @@ class Factory
     private function getContentHash($composerFilePath)
     {
         $content = json_decode(file_get_contents($composerFilePath), true);
-        ksort($content);
-        return md5(json_encode($content));
+
+        $relevantKeys = array(
+            'require',
+            'require-dev',
+            'conflict',
+            'replace',
+            'provide',
+            'suggest',
+            'minimum-stability',
+            'prefer-stable',
+            'repositories',
+        );
+
+        $relevantContent = array();
+
+        foreach (array_intersect($relevantKeys, array_keys($content)) as $key) {
+            $relevantContent[$key] = $content[$key];
+        }
+
+        ksort($relevantContent);
+        return md5(json_encode($relevantContent));
     }
 }

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -306,7 +306,7 @@ class Factory
             $lockFile = "json" === pathinfo($composerFile, PATHINFO_EXTENSION)
                 ? substr($composerFile, 0, -4).'lock'
                 : $composerFile . '.lock';
-            $locker = new Package\Locker($io, new JsonFile($lockFile, new RemoteFilesystem($io, $config)), $rm, $im, md5_file($composerFile));
+            $locker = new Package\Locker($io, new JsonFile($lockFile, new RemoteFilesystem($io, $config)), $rm, $im, md5_file($composerFile), $this->getContentHash($composerFile));
             $composer->setLocker($locker);
         }
 
@@ -484,5 +484,19 @@ class Factory
         $factory = new static();
 
         return $factory->createComposer($io, $config, $disablePlugins);
+    }
+
+    /**
+     * Returns the md5 hash of the sorted content of the composer file.
+     *
+     * @param string $composerFilePath Path to the composer file.
+     *
+     * @return string
+     */
+    private function getContentHash($composerFilePath)
+    {
+        $content = json_decode(file_get_contents($composerFilePath), true);
+        ksort($content);
+        return md5(json_encode($content));
     }
 }

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -306,7 +306,7 @@ class Factory
             $lockFile = "json" === pathinfo($composerFile, PATHINFO_EXTENSION)
                 ? substr($composerFile, 0, -4).'lock'
                 : $composerFile . '.lock';
-            $locker = new Package\Locker($io, new JsonFile($lockFile, new RemoteFilesystem($io, $config)), $rm, $im, md5_file($composerFile), $this->getContentHash($composerFile));
+            $locker = new Package\Locker($io, new JsonFile($lockFile, new RemoteFilesystem($io, $config)), $rm, $im, file_get_contents($composerFile));
             $composer->setLocker($locker);
         }
 
@@ -484,39 +484,5 @@ class Factory
         $factory = new static();
 
         return $factory->createComposer($io, $config, $disablePlugins);
-    }
-
-    /**
-     * Returns the md5 hash of the sorted content of the composer file.
-     *
-     * @param string $composerFilePath Path to the composer file.
-     *
-     * @return string
-     */
-    private function getContentHash($composerFilePath)
-    {
-        $content = json_decode(file_get_contents($composerFilePath), true);
-
-        $relevantKeys = array(
-            'require',
-            'require-dev',
-            'conflict',
-            'replace',
-            'provide',
-            'suggest',
-            'minimum-stability',
-            'prefer-stable',
-            'repositories',
-            'extra',
-        );
-
-        $relevantContent = array();
-
-        foreach (array_intersect($relevantKeys, array_keys($content)) as $key) {
-            $relevantContent[$key] = $content[$key];
-        }
-
-        ksort($relevantContent);
-        return md5(json_encode($relevantContent));
     }
 }

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -507,6 +507,7 @@ class Factory
             'minimum-stability',
             'prefer-stable',
             'repositories',
+            'extra',
         );
 
         $relevantContent = array();

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -89,7 +89,7 @@ class Locker
 
         if (!empty($lock['content-hash'])) {
             // There is a content hash key, use that instead of the file hash
-            return $this->contentHash == $lock['content-hash'];
+            return $this->contentHash === $lock['content-hash'];
         }
 
         return $this->hash === $lock['hash'];

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -191,8 +191,8 @@ class InstallerTest extends TestCase
                 }));
         }
 
-        $hash   = md5(json_encode($composerConfig));
-        $locker = new Locker($io, $lockJsonMock, $repositoryManager, $composer->getInstallationManager(), $hash, $hash);
+        $contents = json_encode($composerConfig);
+        $locker   = new Locker($io, $lockJsonMock, $repositoryManager, $composer->getInstallationManager(), $contents);
         $composer->setLocker($locker);
 
         $eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -191,7 +191,8 @@ class InstallerTest extends TestCase
                 }));
         }
 
-        $locker = new Locker($io, $lockJsonMock, $repositoryManager, $composer->getInstallationManager(), md5(json_encode($composerConfig)));
+        $hash   = md5(json_encode($composerConfig));
+        $locker = new Locker($io, $lockJsonMock, $repositoryManager, $composer->getInstallationManager(), $hash, $hash);
         $composer->setLocker($locker);
 
         $eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
@@ -237,6 +238,7 @@ class InstallerTest extends TestCase
 
         if ($expectLock) {
             unset($actualLock['hash']);
+            unset($actualLock['content-hash']);
             unset($actualLock['_readme']);
             $this->assertEquals($expectLock, $actualLock);
         }

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -20,7 +20,8 @@ class LockerTest extends \PHPUnit_Framework_TestCase
     public function testIsLocked()
     {
         $json   = $this->createJsonFileMock();
-        $locker = new Locker(new NullIO, $json, $this->createRepositoryManagerMock(), $this->createInstallationManagerMock(), 'md5', 'contentMd5');
+        $locker = new Locker(new NullIO, $json, $this->createRepositoryManagerMock(), $this->createInstallationManagerMock(),
+            $this->getJsonContent());
 
         $json
             ->expects($this->any())
@@ -40,7 +41,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, $this->getJsonContent());
 
         $json
             ->expects($this->once())
@@ -58,7 +59,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, $this->getJsonContent());
 
         $json
             ->expects($this->once())
@@ -85,7 +86,8 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
+        $jsonContent = $this->getJsonContent() . '  ';
+        $locker = new Locker(new NullIO, $json, $repo, $inst, $jsonContent);
 
         $package1 = $this->createPackageMock();
         $package2 = $this->createPackageMock();
@@ -116,6 +118,9 @@ class LockerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersion')
             ->will($this->returnValue('0.1.10.0'));
 
+        $hash = md5($jsonContent);
+        $contentHash = md5(trim($jsonContent));
+
         $json
             ->expects($this->once())
             ->method('write')
@@ -123,8 +128,8 @@ class LockerTest extends \PHPUnit_Framework_TestCase
                 '_readme' => array('This file locks the dependencies of your project to a known state',
                                    'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file',
                                    'This file is @gener'.'ated automatically'),
-                'hash' => 'md5',
-                'content-hash' => 'contentMd5',
+                'hash' => $hash,
+                'content-hash' => $contentHash,
                 'packages' => array(
                     array('name' => 'pkg1', 'version' => '1.0.0-beta'),
                     array('name' => 'pkg2', 'version' => '0.1.10')
@@ -149,7 +154,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'md5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, $this->getJsonContent());
 
         $package1 = $this->createPackageMock();
         $package1
@@ -168,12 +173,13 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
+        $jsonContent = $this->getJsonContent();
+        $locker = new Locker(new NullIO, $json, $repo, $inst, $jsonContent);
 
         $json
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue(array('hash' => 'md5')));
+            ->will($this->returnValue(array('hash' => md5($jsonContent))));
 
         $this->assertTrue($locker->isFresh());
     }
@@ -184,12 +190,12 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, $this->getJsonContent());
 
         $json
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue(array('hash' => 'oldmd5')));
+            ->will($this->returnValue(array('hash' => $this->getJsonContent(array('name' => 'test2')))));
 
         $this->assertFalse($locker->isFresh());
     }
@@ -200,12 +206,13 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
+        $jsonContent = $this->getJsonContent();
+        $locker = new Locker(new NullIO, $json, $repo, $inst, $jsonContent);
 
         $json
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue(array('hash' => 'oldMd5', 'content-hash' => 'contentMd5')));
+            ->will($this->returnValue(array('hash' => md5($jsonContent . '  '), 'content-hash' => md5($jsonContent))));
 
         $this->assertTrue($locker->isFresh());
     }
@@ -216,12 +223,14 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, $this->getJsonContent());
+
+        $differentHash = md5($this->getJsonContent(['name' => 'test2']));
 
         $json
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue(array('hash' => 'md5', 'content-hash' => 'oldMd5')));
+            ->will($this->returnValue(array('hash' => $differentHash, 'content-hash' => $differentHash)));
 
         $this->assertFalse($locker->isFresh());
     }
@@ -259,5 +268,17 @@ class LockerTest extends \PHPUnit_Framework_TestCase
     {
         return $this->getMockBuilder('Composer\Package\PackageInterface')
             ->getMock();
+    }
+
+    private function getJsonContent(array $customData = array())
+    {
+        $data = array_merge(array(
+            'minimum-stability' => 'beta',
+            'name' => 'test',
+        ), $customData);
+
+        ksort($data);
+
+        return json_encode($data);
     }
 }

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -20,7 +20,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
     public function testIsLocked()
     {
         $json   = $this->createJsonFileMock();
-        $locker = new Locker(new NullIO, $json, $this->createRepositoryManagerMock(), $this->createInstallationManagerMock(), 'md5');
+        $locker = new Locker(new NullIO, $json, $this->createRepositoryManagerMock(), $this->createInstallationManagerMock(), 'md5', 'contentMd5');
 
         $json
             ->expects($this->any())
@@ -40,7 +40,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
 
         $json
             ->expects($this->once())
@@ -58,7 +58,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
 
         $json
             ->expects($this->once())
@@ -85,7 +85,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
 
         $package1 = $this->createPackageMock();
         $package2 = $this->createPackageMock();
@@ -124,6 +124,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
                                    'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file',
                                    'This file is @gener'.'ated automatically'),
                 'hash' => 'md5',
+                'content-hash' => 'contentMd5',
                 'packages' => array(
                     array('name' => 'pkg1', 'version' => '1.0.0-beta'),
                     array('name' => 'pkg2', 'version' => '0.1.10')
@@ -148,7 +149,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'md5');
 
         $package1 = $this->createPackageMock();
         $package1
@@ -167,7 +168,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
 
         $json
             ->expects($this->once())
@@ -183,12 +184,44 @@ class LockerTest extends \PHPUnit_Framework_TestCase
         $repo = $this->createRepositoryManagerMock();
         $inst = $this->createInstallationManagerMock();
 
-        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5');
+        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
 
         $json
             ->expects($this->once())
             ->method('read')
             ->will($this->returnValue(array('hash' => 'oldmd5')));
+
+        $this->assertFalse($locker->isFresh());
+    }
+
+    public function testIsFreshWithContentHash()
+    {
+        $json = $this->createJsonFileMock();
+        $repo = $this->createRepositoryManagerMock();
+        $inst = $this->createInstallationManagerMock();
+
+        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
+
+        $json
+            ->expects($this->once())
+            ->method('read')
+            ->will($this->returnValue(array('hash' => 'oldMd5', 'content-hash' => 'contentMd5')));
+
+        $this->assertTrue($locker->isFresh());
+    }
+
+    public function testIsFreshFalseWithContentHash()
+    {
+        $json = $this->createJsonFileMock();
+        $repo = $this->createRepositoryManagerMock();
+        $inst = $this->createInstallationManagerMock();
+
+        $locker = new Locker(new NullIO, $json, $repo, $inst, 'md5', 'contentMd5');
+
+        $json
+            ->expects($this->once())
+            ->method('read')
+            ->will($this->returnValue(array('hash' => 'md5', 'content-hash' => 'oldMd5')));
 
         $this->assertFalse($locker->isFresh());
     }

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -225,7 +225,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
 
         $locker = new Locker(new NullIO, $json, $repo, $inst, $this->getJsonContent());
 
-        $differentHash = md5($this->getJsonContent(['name' => 'test2']));
+        $differentHash = md5($this->getJsonContent(array('name' => 'test2')));
 
         $json
             ->expects($this->once())


### PR DESCRIPTION
Changing the formatting of the composer.json (ie. if there is a convention of vertically aligning the versions of the dependencies), the hash in the lock file will not match that of the JSON file. Instead if we use the hash of the parsed content, this is not going to be an issue.

This change adds a content-hash key to the lock file with the hash, which is the MD5 of the parsed and sorted content (decode to an associative array, sort it then re-encode and hash). 

This change should be backwards compatible.

Example use case. Given this composer.json:
```javascript
{
    "name": "composer/composer",
// SNIP
    "require": {
        "php":                       ">=5.3.2",
        "justinrainbow/json-schema": "~1.4",
        "seld/jsonlint":             "~1.0",
        "symfony/console":           "~2.5",
        "symfony/finder":            "~2.2",
        "symfony/process":           "~2.1",
        "seld/phar-utils":           "~1.0"
    },
// SNIP
}
```

running `composer.phar require "seld/cli-prompt ~1.0"` would result in the following composer.json:

```javascript
{
    "name": "composer/composer",
// SNIP
    "require": {
        "php":                       ">=5.3.2",
        "justinrainbow/json-schema": "~1.4",
        "seld/jsonlint":             "~1.0",
        "symfony/console":           "~2.5",
        "symfony/finder":            "~2.2",
        "symfony/process":           "~2.1",
        "seld/phar-utils":           "~1.0",
        "seld/cli-prompt": "~1.0"
    },
// SNIP
}
```

After fixing the alignment in the JSON file, the file's hash no longer matches. Having a hash of the contents solves the issue. Currently the other way to solve is to generate a new MD5 for the file and changing the hash value in the lock file.