### PR TITLE
Simplify gzip encoding response header check

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -207,9 +207,7 @@ class RemoteFilesystem
             foreach ($http_response_header as $header) {
                 if (preg_match('{^content-encoding: *gzip *$}i', $header)) {
                     $decode = true;
-                    continue;
-                } elseif (preg_match('{^HTTP/}i', $header)) {
-                    $decode = false;
+                    break;
                 }
             }
 


### PR DESCRIPTION
I am not 100% sure I understood why the code looked like it did before.

The code was dependent on the order of the actual headers, so when the content-encoding header wasnt the last, it was detected as unsupported.

Blaming the line showed that it is somehow related to redirect, see https://github.com/composer/composer/commit/22149d3a70c726c7709a221bfc62f65b18049bb9 .. This info wasnt helpfull for me though.