### PR TITLE
[WIP] RepositorySet / Pool Split & Load only explicitly referenced package data

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -19,13 +19,13 @@ use Composer\Installer\ProjectInstaller;
 use Composer\Installer\InstallationManager;
 use Composer\IO\IOInterface;
 use Composer\Package\BasePackage;
-use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\Package\Version\VersionSelector;
 use Composer\Repository\ComposerRepository;
 use Composer\Repository\CompositeRepository;
 use Composer\Repository\FilesystemRepository;
 use Composer\Repository\InstalledFilesystemRepository;
+use Composer\Repository\RepositorySet;
 use Composer\Script\ScriptEvents;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -272,12 +272,11 @@ EOT
             throw new \InvalidArgumentException('Invalid stability provided ('.$stability.'), must be one of: '.implode(', ', array_keys(BasePackage::$stabilities)));
         }
 
-        $pool = new Pool($stability);
-        $pool->addRepository($sourceRepo);
-        $pool->loadRecursively(array($name));
+        $repositorySet = new RepositorySet($stability);
+        $repositorySet->addRepository($sourceRepo);
 
         // find the latest version if there are multiple
-        $versionSelector = new VersionSelector($pool);
+        $versionSelector = new VersionSelector($repositorySet);
         $package = $versionSelector->findBestCandidate($name, $packageVersion);
 
         if (!$package) {

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -276,6 +276,7 @@ EOT
 
         $pool = new Pool($stability);
         $pool->addRepository($sourceRepo);
+        $pool->loadRecursively(array($name));
 
         // find the latest version if there are multiple
         $versionSelector = new VersionSelector($pool);

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -12,13 +12,13 @@
 
 namespace Composer\Command;
 
-use Composer\DependencyResolver\Pool;
 use Composer\Json\JsonFile;
 use Composer\Factory;
 use Composer\Package\BasePackage;
 use Composer\Package\Version\VersionSelector;
 use Composer\Repository\CompositeRepository;
 use Composer\Repository\PlatformRepository;
+use Composer\Repository\RepositorySet;
 use Composer\Package\Version\VersionParser;
 use Composer\Util\ProcessExecutor;
 use Symfony\Component\Console\Input\InputInterface;
@@ -39,8 +39,8 @@ class InitCommand extends Command
     /** @var array */
     private $gitConfig;
 
-    /** @var Pool */
-    private $pool;
+    /** @var RepositorySet */
+    private $repoSet;
 
     /**
      * {@inheritdoc}
@@ -555,14 +555,14 @@ EOT
         return false !== filter_var($email, FILTER_VALIDATE_EMAIL);
     }
 
-    private function getPool(InputInterface $input)
+    private function getRepositorySet(InputInterface $input)
     {
-        if (!$this->pool) {
-            $this->pool = new Pool($this->getMinimumStability($input));
-            $this->pool->addRepository($this->getRepos());
+        if (!$this->repoSet) {
+            $this->repoSet = new RepositorySet($this->getMinimumStability($input));
+            $this->repoSet->addRepository($this->getRepos());
         }
 
-        return $this->pool;
+        return $this->repoSet;
     }
 
     private function getMinimumStability(InputInterface $input)
@@ -593,8 +593,8 @@ EOT
      */
     private function findBestVersionForPackage(InputInterface $input, $name)
     {
-        // find the latest version allowed in this pool
-        $versionSelector = new VersionSelector($this->getPool($input));
+        // find the latest version allowed in this repo set
+        $versionSelector = new VersionSelector($this->getRepositorySet($input));
         $package = $versionSelector->findBestCandidate($name);
 
         if (!$package) {

--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -59,7 +59,7 @@ class DefaultPolicy implements PolicyInterface
 
     public function getPriority(Pool $pool, PackageInterface $package)
     {
-        return $pool->getPriority($package->getRepository());
+        return $pool->getPriority($package->getId());
     }
 
     /**

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -46,7 +46,7 @@ class Pool
     protected $packageToPriority = array();
     protected $filterRequires;
 
-    public function __construct(array $packages, array $packageToPriority)
+    public function __construct(array $packages, array $packageToPriority, array $filterRequires = array())
     {
         $this->packages = $packages;
         $this->packageToPriority = $packageToPriority;
@@ -58,6 +58,8 @@ class Pool
                 $this->packageByName[$name][$id + 1] = $package;
             }
         }
+
+        $this->filterRequires = $filterRequires;
     }
 
     /**

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -99,40 +99,9 @@ class Pool
             if ($repo instanceof ComposerRepository && $repo->hasProviders()) {
                 $this->providerRepos[] = $repo;
                 $repo->setRootAliases($rootAliases);
-                $repo->resetPackageIds();
             } else {
                 foreach ($repo->getPackages() as $package) {
-                    $names = $package->getNames();
-                    $stability = $package->getStability();
-                    if ($exempt || $this->isPackageAcceptable($names, $stability)) {
-                        $package->setId($this->id++);
-                        $this->packages[] = $package;
-                        $this->packageByExactName[$package->getName()][$package->id] = $package;
-
-                        foreach ($names as $provided) {
-                            $this->packageByName[$provided][] = $package;
-                        }
-
-                        // handle root package aliases
-                        $name = $package->getName();
-                        if (isset($rootAliases[$name][$package->getVersion()])) {
-                            $alias = $rootAliases[$name][$package->getVersion()];
-                            if ($package instanceof AliasPackage) {
-                                $package = $package->getAliasOf();
-                            }
-                            $aliasPackage = new AliasPackage($package, $alias['alias_normalized'], $alias['alias']);
-                            $aliasPackage->setRootPackageAlias(true);
-                            $aliasPackage->setId($this->id++);
-
-                            $package->getRepository()->addPackage($aliasPackage);
-                            $this->packages[] = $aliasPackage;
-                            $this->packageByExactName[$aliasPackage->getName()][$aliasPackage->id] = $aliasPackage;
-
-                            foreach ($aliasPackage->getNames() as $name) {
-                                $this->packageByName[$name][] = $aliasPackage;
-                            }
-                        }
-                    }
+                    $this->loadPackage($package, $rootAliases, $exempt);
                 }
             }
         }
@@ -161,6 +130,38 @@ class Pool
     }
 
     /**
+     * Ensures that all given names and their requirements are loaded.
+     *
+     * @param array $packageNames A list of names that need to be available
+     */
+    public function loadRecursively(array $packageNames)
+    {
+        $loadedMap = array();
+        do {
+            $newPackageNames = array();
+            $loadedCount = count($loadedMap);
+
+            foreach ($this->providerRepos as $repo) {
+                $packages = $repo->loadRecursively(
+                    $packageNames,
+                    array($this, 'isPackageAcceptable')
+                );
+
+                foreach ($packages as $package) {
+                    $name = $package->getName();
+                    if (!isset($loadedMap[$name])) {
+                        $loadedMap[$name] = true;
+                        $newPackageNames[] = $name;
+                    }
+                    $this->loadPackage($package, $repo->getRootAliases());
+                }
+            }
+
+            $packageNames = $newPackageNames;
+        } while (count($loadedMap) > $loadedCount);
+    }
+
+    /**
      * Searches all packages providing the given package name and match the constraint
      *
      * @param  string                  $name          The package name to be searched for
@@ -180,6 +181,44 @@ class Pool
         return $this->providerCache[$name][$key] = $this->computeWhatProvides($name, $constraint, $mustMatchName);
     }
 
+    private function loadPackage(PackageInterface $package, array $rootAliases, $acceptableExemption = false)
+    {
+        $names = $package->getNames();
+        $stability = $package->getStability();
+
+        if (!$acceptableExemption && !$this->isPackageAcceptable($names, $stability)) {
+            return;
+        }
+
+        $package->setId($this->id++);
+        $this->packages[] = $package;
+        $this->packageByExactName[$package->getName()][$package->id] = $package;
+
+        foreach ($names as $provided) {
+            $this->packageByName[$provided][] = $package;
+        }
+
+        // handle root package aliases
+        $name = $package->getName();
+        if (isset($rootAliases[$name][$package->getVersion()])) {
+            $alias = $rootAliases[$name][$package->getVersion()];
+            if ($package instanceof AliasPackage) {
+                $package = $package->getAliasOf();
+            }
+            $aliasPackage = new AliasPackage($package, $alias['alias_normalized'], $alias['alias']);
+            $aliasPackage->setRootPackageAlias(true);
+            $aliasPackage->setId($this->id++);
+
+            $package->getRepository()->addPackage($aliasPackage);
+            $this->packages[] = $aliasPackage;
+            $this->packageByExactName[$aliasPackage->getName()][$aliasPackage->id] = $aliasPackage;
+
+            foreach ($aliasPackage->getNames() as $name) {
+                $this->packageByName[$name][] = $aliasPackage;
+            }
+        }
+    }
+
     /**
      * @see whatProvides
      */
@@ -187,25 +226,12 @@ class Pool
     {
         $candidates = array();
 
-        foreach ($this->providerRepos as $repo) {
-            foreach ($repo->whatProvides($this, $name) as $candidate) {
-                $candidates[] = $candidate;
-                if ($candidate->id < 1) {
-                    $candidate->setId($this->id++);
-                    $this->packages[$this->id - 2] = $candidate;
-                }
-            }
-        }
-
         if ($mustMatchName) {
-            $candidates = array_filter($candidates, function ($candidate) use ($name) {
-                return $candidate->getName() == $name;
-            });
             if (isset($this->packageByExactName[$name])) {
-                $candidates = array_merge($candidates, $this->packageByExactName[$name]);
+                $candidates = $this->packageByExactName[$name];
             }
         } elseif (isset($this->packageByName[$name])) {
-            $candidates = array_merge($candidates, $this->packageByName[$name]);
+            $candidates = $this->packageByName[$name];
         }
 
         $matches = $provideMatches = array();

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -31,7 +31,7 @@ use Composer\Package\PackageInterface;
  * @author Nils Adermann <naderman@naderman.de>
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class Pool
+class Pool implements \Countable
 {
     const MATCH_NAME = -1;
     const MATCH_NONE = 0;
@@ -183,6 +183,11 @@ class Pool
         }
 
         return $prefix.' '.$package->getPrettyString();
+    }
+
+    public function count()
+    {
+        return count($this->packages);
     }
 
     /**

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -169,6 +169,18 @@ class Solver
         $this->jobs = $request->getJobs();
 
         $this->setupInstalledMap();
+
+        $packageNames = array();
+        foreach ($this->jobs as $job) {
+            switch ($job['cmd']) {
+                case 'install':
+                    $packageNames[$job['packageName']] = true;
+                    break;
+            }
+        }
+
+        $this->pool->loadRecursively(array_keys($packageNames));
+
         $this->rules = $this->ruleSetGenerator->getRulesFor($this->jobs, $this->installedMap, $ignorePlatformReqs);
         $this->checkForRootRequireProblems($ignorePlatformReqs);
         $this->decisions = new Decisions($this->pool);

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -186,6 +186,8 @@ class Solver
         }
 
         $this->pool = $this->repositorySet->getPool(array_keys($packageNames));
+
+        return count($this->pool);
     }
 
     public function solve($ignorePlatformReqs = false)

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -169,7 +169,7 @@ class Solver
         }
     }
 
-    public function solve(Request $request, $ignorePlatformReqs = false)
+    public function load(Request $request)
     {
         $this->jobs = $request->getJobs();
 
@@ -186,7 +186,10 @@ class Solver
         }
 
         $this->pool = $this->repositorySet->getPool(array_keys($packageNames));
+    }
 
+    public function solve($ignorePlatformReqs = false)
+    {
         $this->setupInstalledMap();
 
         $this->ruleSetGenerator = new RuleSetGenerator($this->policy, $this->pool);

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -13,13 +13,13 @@
 namespace Composer\EventDispatcher;
 
 use Composer\DependencyResolver\PolicyInterface;
-use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
 use Composer\Installer\InstallerEvent;
 use Composer\IO\IOInterface;
 use Composer\Composer;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\Repository\CompositeRepository;
+use Composer\Repository\RepositorySet;
 use Composer\Script;
 use Composer\Script\CommandEvent;
 use Composer\Script\PackageEvent;
@@ -98,7 +98,7 @@ class EventDispatcher
      * @param string              $eventName     The constant in PackageEvents
      * @param bool                $devMode       Whether or not we are in dev mode
      * @param PolicyInterface     $policy        The policy
-     * @param Pool                $pool          The pool
+     * @param RepositorySet       $repositorySet The repository set
      * @param CompositeRepository $installedRepo The installed repository
      * @param Request             $request       The request
      * @param array               $operations    The list of operations
@@ -107,9 +107,9 @@ class EventDispatcher
      * @return int return code of the executed script if any, for php scripts a false return
      *             value is changed to 1, anything else to 0
      */
-    public function dispatchPackageEvent($eventName, $devMode, PolicyInterface $policy, Pool $pool, CompositeRepository $installedRepo, Request $request, array $operations, OperationInterface $operation)
+    public function dispatchPackageEvent($eventName, $devMode, PolicyInterface $policy, RepositorySet $repositorySet, CompositeRepository $installedRepo, Request $request, array $operations, OperationInterface $operation)
     {
-        return $this->doDispatch(new PackageEvent($eventName, $this->composer, $this->io, $devMode, $policy, $pool, $installedRepo, $request, $operations, $operation));
+        return $this->doDispatch(new PackageEvent($eventName, $this->composer, $this->io, $devMode, $policy, $repositorySet, $installedRepo, $request, $operations, $operation));
     }
 
     /**
@@ -118,7 +118,7 @@ class EventDispatcher
      * @param string              $eventName     The constant in InstallerEvents
      * @param bool                $devMode       Whether or not we are in dev mode
      * @param PolicyInterface     $policy        The policy
-     * @param Pool                $pool          The pool
+     * @param RepositorySet       $repositorySet The repository set
      * @param CompositeRepository $installedRepo The installed repository
      * @param Request             $request       The request
      * @param array               $operations    The list of operations
@@ -126,9 +126,9 @@ class EventDispatcher
      * @return int return code of the executed script if any, for php scripts a false return
      *             value is changed to 1, anything else to 0
      */
-    public function dispatchInstallerEvent($eventName, $devMode, PolicyInterface $policy, Pool $pool, CompositeRepository $installedRepo, Request $request, array $operations = array())
+    public function dispatchInstallerEvent($eventName, $devMode, PolicyInterface $policy, RepositorySet $repositorySet, CompositeRepository $installedRepo, Request $request, array $operations = array())
     {
-        return $this->doDispatch(new InstallerEvent($eventName, $this->composer, $this->io, $devMode, $policy, $pool, $installedRepo, $request, $operations));
+        return $this->doDispatch(new InstallerEvent($eventName, $this->composer, $this->io, $devMode, $policy, $repositorySet, $installedRepo, $request, $operations));
     }
 
     /**
@@ -241,7 +241,7 @@ class EventDispatcher
         if (!$event instanceof $expected && $expected === 'Composer\Script\PackageEvent') {
             $event = new \Composer\Script\PackageEvent(
                 $event->getName(), $event->getComposer(), $event->getIO(), $event->isDevMode(),
-                $event->getPolicy(), $event->getPool(), $event->getInstalledRepo(), $event->getRequest(),
+                $event->getPolicy(), $event->getRepositorySet(), $event->getInstalledRepo(), $event->getRequest(),
                 $event->getOperations(), $event->getOperation()
             );
         }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -514,10 +514,6 @@ class Installer
             return max(1, $e->getCode());
         }
 
-        if ($this->io->isVerbose()) {
-            $this->io->writeError("Analyzed ".count($pool)." packages to resolve dependencies");
-        }
-
         // force dev packages to be updated if we update or install from a (potentially new) lock
         $operations = $this->processDevPackages($localRepo, $repositorySet, $policy, $repositories, $installedRepo, $lockedRepository, $installFromLock, $withDevReqs, 'force-updates', $operations);
 

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -515,7 +515,7 @@ class Installer
         }
 
         if ($this->io->isVerbose()) {
-            $this->io->writeError("Analyzed ".count($pool)." packages to resolve dependencies");
+            $this->io->writeError("Analyzed ".$solver->getRuleSetSize()." rules to resolve dependencies");
         }
 
         // force dev packages to be updated if we update or install from a (potentially new) lock

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -496,10 +496,13 @@ class Installer
         // solve dependencies
         $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $repositorySet, $installedRepo, $request);
         $solver = new Solver($policy, $repositorySet, $installedRepo);
-        $solver->load($request);
+        $poolSize = $solver->load($request);
 
         $verb = $this->update ? 'Updating' : 'Installing';
         $this->io->writeError("<info>$verb dependencies".($withDevReqs ? ' (including require-dev)' : '').($installFromLock ? ' from lock file' : '').'</info>');
+        if ($this->io->isVerbose()) {
+            $this->io->writeError("Analyzing $poolSize packages to resolve dependencies");
+        }
 
         try {
             $operations = $solver->solve($this->ignorePlatformReqs);

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -18,7 +18,6 @@ use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\OperationInterface;
-use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
 use Composer\DependencyResolver\Rule;
 use Composer\DependencyResolver\Solver;
@@ -43,6 +42,7 @@ use Composer\Repository\InstalledFilesystemRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryInterface;
 use Composer\Repository\RepositoryManager;
+use Composer\Repository\RepositorySet;
 use Composer\Script\ScriptEvents;
 
 /**
@@ -283,8 +283,8 @@ class Installer
                 // split dev and non-dev requirements by checking what would be removed if we update without the dev requirements
                 if ($this->devMode && $this->package->getDevRequires()) {
                     $policy = $this->createPolicy();
-                    $pool = $this->createPool(true);
-                    $pool->addRepository($installedRepo, $aliases);
+                    $repositorySet = $this->createRepositorySet(true);
+                    $repositorySet->addRepository($installedRepo, $aliases);
 
                     // creating requirements request
                     $request = $this->createRequest($this->package, $platformRepo);
@@ -293,10 +293,10 @@ class Installer
                         $request->install($link->getTarget(), $link->getConstraint());
                     }
 
-                    $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, false, $policy, $pool, $installedRepo, $request);
-                    $solver = new Solver($policy, $pool, $installedRepo);
+                    $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, false, $policy, $repositorySet, $installedRepo, $request);
+                    $solver = new Solver($policy, $repositorySet, $installedRepo);
                     $ops = $solver->solve($request, $this->ignorePlatformReqs);
-                    $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, false, $policy, $pool, $installedRepo, $request, $ops);
+                    $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, false, $policy, $repositorySet, $installedRepo, $request, $ops);
                     foreach ($ops as $op) {
                         if ($op->getJobType() === 'uninstall') {
                             $devPackages[] = $op->getPackage();
@@ -385,21 +385,21 @@ class Installer
 
         $this->io->writeError('<info>Loading composer repositories with package information</info>');
 
-        // creating repository pool
+        // creating repository set
         $policy = $this->createPolicy();
-        $pool = $this->createPool($withDevReqs, $installFromLock ? $lockedRepository : null);
-        $pool->addRepository($installedRepo, $aliases);
+        $repositorySet = $this->createRepositorySet($withDevReqs, $installFromLock ? $lockedRepository : null);
+        $repositorySet->addRepository($installedRepo, $aliases);
         if (!$installFromLock) {
             $repositories = $this->repositoryManager->getRepositories();
             foreach ($repositories as $repository) {
-                $pool->addRepository($repository, $aliases);
+                $repositorySet->addRepository($repository, $aliases);
             }
         }
         // Add the locked repository after the others in case we are doing a
         // partial update so missing packages can be found there still.
         // For installs from lock it's the only one added so it is first
         if ($lockedRepository) {
-            $pool->addRepository($lockedRepository, $aliases);
+            $repositorySet->addRepository($lockedRepository, $aliases);
         }
 
         // creating requirements request
@@ -410,7 +410,7 @@ class Installer
             $removedUnstablePackages = array();
             foreach ($localRepo->getPackages() as $package) {
                 if (
-                    !$pool->isPackageAcceptable($package->getNames(), $package->getStability())
+                    !$repositorySet->isPackageAcceptable($package->getNames(), $package->getStability())
                     && $this->installationManager->isPackageInstalled($localRepo, $package)
                 ) {
                     $removedUnstablePackages[$package->getName()] = true;
@@ -496,14 +496,14 @@ class Installer
         }
 
         // force dev packages to have the latest links if we update or install from a (potentially new) lock
-        $this->processDevPackages($localRepo, $pool, $policy, $repositories, $installedRepo, $lockedRepository, $installFromLock, $withDevReqs, 'force-links');
+        $this->processDevPackages($localRepo, $repositorySet, $policy, $repositories, $installedRepo, $lockedRepository, $installFromLock, $withDevReqs, 'force-links');
 
         // solve dependencies
-        $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $pool, $installedRepo, $request);
-        $solver = new Solver($policy, $pool, $installedRepo);
+        $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $repositorySet, $installedRepo, $request);
+        $solver = new Solver($policy, $repositorySet, $installedRepo);
         try {
             $operations = $solver->solve($request, $this->ignorePlatformReqs);
-            $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, $this->devMode, $policy, $pool, $installedRepo, $request, $operations);
+            $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, $this->devMode, $policy, $repositorySet, $installedRepo, $request, $operations);
         } catch (SolverProblemsException $e) {
             $this->io->writeError('<error>Your requirements could not be resolved to an installable set of packages.</error>');
             $this->io->writeError($e->getMessage());
@@ -512,7 +512,7 @@ class Installer
         }
 
         // force dev packages to be updated if we update or install from a (potentially new) lock
-        $operations = $this->processDevPackages($localRepo, $pool, $policy, $repositories, $installedRepo, $lockedRepository, $installFromLock, $withDevReqs, 'force-updates', $operations);
+        $operations = $this->processDevPackages($localRepo, $repositorySet, $policy, $repositories, $installedRepo, $lockedRepository, $installFromLock, $withDevReqs, 'force-updates', $operations);
 
         // execute operations
         if (!$operations) {
@@ -565,7 +565,7 @@ class Installer
 
             $event = 'Composer\Installer\PackageEvents::PRE_PACKAGE_'.strtoupper($operation->getJobType());
             if (defined($event) && $this->runScripts) {
-                $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $policy, $pool, $installedRepo, $request, $operations, $operation);
+                $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $policy, $repositorySet, $installedRepo, $request, $operations, $operation);
             }
 
             // output non-alias ops in dry run, output alias ops in debug verbosity
@@ -585,11 +585,11 @@ class Installer
                 if ($reason instanceof Rule) {
                     switch ($reason->getReason()) {
                         case Rule::RULE_JOB_INSTALL:
-                            $this->io->writeError('    REASON: Required by root: '.$reason->getPrettyString($pool));
+                            $this->io->writeError('    REASON: Required by root: '.$reason->getPrettyString($solver->getPool()));
                             $this->io->writeError('');
                             break;
                         case Rule::RULE_PACKAGE_REQUIRES:
-                            $this->io->writeError('    REASON: '.$reason->getPrettyString($pool));
+                            $this->io->writeError('    REASON: '.$reason->getPrettyString($solver->getPool()));
                             $this->io->writeError('');
                             break;
                     }
@@ -598,7 +598,7 @@ class Installer
 
             $event = 'Composer\Installer\PackageEvents::POST_PACKAGE_'.strtoupper($operation->getJobType());
             if (defined($event) && $this->runScripts) {
-                $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $policy, $pool, $installedRepo, $request, $operations, $operation);
+                $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $policy, $repositorySet, $installedRepo, $request, $operations, $operation);
             }
 
             if (!$this->dryRun) {
@@ -608,7 +608,7 @@ class Installer
 
         if (!$this->dryRun) {
             // force source/dist urls to be updated for all packages
-            $operations = $this->processPackageUrls($pool, $policy, $localRepo, $repositories);
+            $operations = $this->processPackageUrls($repositorySet, $policy, $localRepo, $repositories);
             $localRepo->write();
         }
 
@@ -679,7 +679,7 @@ class Installer
         return array_merge($uninstOps, $operations);
     }
 
-    private function createPool($withDevReqs, RepositoryInterface $lockedRepository = null)
+    private function createRepositorySet($withDevReqs, RepositoryInterface $lockedRepository = null)
     {
         if (!$this->update && $this->locker->isLocked()) { // install from lock
             $minimumStability = $this->locker->getMinimumStability();
@@ -714,7 +714,7 @@ class Installer
             }
         }
 
-        return new Pool($minimumStability, $stabilityFlags, $rootConstraints);
+        return new RepositorySet($minimumStability, $stabilityFlags, $rootConstraints);
     }
 
     private function createPolicy()
@@ -770,7 +770,7 @@ class Installer
         return $request;
     }
 
-    private function processDevPackages($localRepo, $pool, $policy, $repositories, $installedRepo, $lockedRepository, $installFromLock, $withDevReqs, $task, array $operations = null)
+    private function processDevPackages($localRepo, $repositorySet, $policy, $repositories, $installedRepo, $lockedRepository, $installFromLock, $withDevReqs, $task, array $operations = null)
     {
         if ($task === 'force-updates' && null === $operations) {
             throw new \InvalidArgumentException('Missing operations argument');
@@ -846,17 +846,14 @@ class Installer
                         continue;
                     }
 
+                    /** @todo should not use pool */
+                    $pool = $repositorySet->getPool(array($package->getName()));
+
                     // find similar packages (name/version) in all repositories
-                    $matches = $pool->whatProvides($package->getName(), new VersionConstraint('=', $package->getVersion()));
+                    $matches = $repositorySet->findPackages($package->getName(), new VersionConstraint('=', $package->getVersion()));
                     foreach ($matches as $index => $match) {
                         // skip local packages
                         if (!in_array($match->getRepository(), $repositories, true)) {
-                            unset($matches[$index]);
-                            continue;
-                        }
-
-                        // skip providers/replacers
-                        if ($match->getName() !== $package->getName()) {
                             unset($matches[$index]);
                             continue;
                         }
@@ -937,24 +934,21 @@ class Installer
         return $normalizedAliases;
     }
 
-    private function processPackageUrls($pool, $policy, $localRepo, $repositories)
+    private function processPackageUrls($repositorySet, $policy, $localRepo, $repositories)
     {
         if (!$this->update) {
             return;
         }
 
         foreach ($localRepo->getCanonicalPackages() as $package) {
+            /** @todo should not use pool */
+            $pool = $repositorySet->getPool(array($package->getName()));
+
             // find similar packages (name/version) in all repositories
-            $matches = $pool->whatProvides($package->getName(), new VersionConstraint('=', $package->getVersion()));
+            $matches = $repositorySet->findPackages($package->getName(), new VersionConstraint('=', $package->getVersion()));
             foreach ($matches as $index => $match) {
                 // skip local packages
                 if (!in_array($match->getRepository(), $repositories, true)) {
-                    unset($matches[$index]);
-                    continue;
-                }
-
-                // skip providers/replacers
-                if ($match->getName() !== $package->getName()) {
                     unset($matches[$index]);
                     continue;
                 }
@@ -1064,8 +1058,9 @@ class Installer
             $skipPackages[$require->getTarget()] = true;
         }
 
-        $pool = new Pool;
-        $pool->addRepository($localRepo);
+        $repositorySet = new RepositorySet;
+        $repositorySet->addRepository($localRepo);
+        $pool = $repositorySet->getCompletePool();
 
         $seen = array();
 

--- a/src/Composer/Installer/InstallerEvent.php
+++ b/src/Composer/Installer/InstallerEvent.php
@@ -15,11 +15,11 @@ namespace Composer\Installer;
 use Composer\Composer;
 use Composer\DependencyResolver\PolicyInterface;
 use Composer\DependencyResolver\Operation\OperationInterface;
-use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
 use Composer\EventDispatcher\Event;
 use Composer\IO\IOInterface;
 use Composer\Repository\CompositeRepository;
+use Composer\Repository\RepositorySet;
 
 /**
  * An event for all installer.
@@ -49,9 +49,9 @@ class InstallerEvent extends Event
     private $policy;
 
     /**
-     * @var Pool
+     * @var RepositorySet
      */
-    private $pool;
+    private $repositorySet;
 
     /**
      * @var CompositeRepository
@@ -76,12 +76,12 @@ class InstallerEvent extends Event
      * @param IOInterface          $io
      * @param bool                 $devMode
      * @param PolicyInterface      $policy
-     * @param Pool                 $pool
+     * @param RepositorySet        $repositorySet
      * @param CompositeRepository  $installedRepo
      * @param Request              $request
      * @param OperationInterface[] $operations
      */
-    public function __construct($eventName, Composer $composer, IOInterface $io, $devMode, PolicyInterface $policy, Pool $pool, CompositeRepository $installedRepo, Request $request, array $operations = array())
+    public function __construct($eventName, Composer $composer, IOInterface $io, $devMode, PolicyInterface $policy, RepositorySet $repositorySet, CompositeRepository $installedRepo, Request $request, array $operations = array())
     {
         parent::__construct($eventName);
 
@@ -89,7 +89,7 @@ class InstallerEvent extends Event
         $this->io = $io;
         $this->devMode = $devMode;
         $this->policy = $policy;
-        $this->pool = $pool;
+        $this->repositorySet = $repositorySet;
         $this->installedRepo = $installedRepo;
         $this->request = $request;
         $this->operations = $operations;
@@ -128,11 +128,11 @@ class InstallerEvent extends Event
     }
 
     /**
-     * @return Pool
+     * @return RepositorySet
      */
-    public function getPool()
+    public function getRepositorySet()
     {
-        return $this->pool;
+        return $this->repositorySet;
     }
 
     /**

--- a/src/Composer/Installer/PackageEvent.php
+++ b/src/Composer/Installer/PackageEvent.php
@@ -16,9 +16,9 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\PolicyInterface;
-use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
 use Composer\Repository\CompositeRepository;
+use Composer\Repository\RepositorySet;
 
 /**
  * The Package Event.
@@ -40,15 +40,15 @@ class PackageEvent extends InstallerEvent
      * @param IOInterface          $io
      * @param bool                 $devMode
      * @param PolicyInterface      $policy
-     * @param Pool                 $pool
+     * @param RepositorySet        $repositorySet
      * @param CompositeRepository  $installedRepo
      * @param Request              $request
      * @param OperationInterface[] $operations
      * @param OperationInterface   $operation
      */
-    public function __construct($eventName, Composer $composer, IOInterface $io, $devMode, PolicyInterface $policy, Pool $pool, CompositeRepository $installedRepo, Request $request, array $operations, OperationInterface $operation)
+    public function __construct($eventName, Composer $composer, IOInterface $io, $devMode, PolicyInterface $policy, RepositorySet $repositorySet, CompositeRepository $installedRepo, Request $request, array $operations, OperationInterface $operation)
     {
-        parent::__construct($eventName, $composer, $io, $devMode, $policy, $pool, $installedRepo, $request, $operations);
+        parent::__construct($eventName, $composer, $io, $devMode, $policy, $repositorySet, $installedRepo, $request, $operations);
 
         $this->operation = $operation;
     }

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -12,10 +12,10 @@
 
 namespace Composer\Package\Version;
 
-use Composer\DependencyResolver\Pool;
 use Composer\Package\PackageInterface;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\Dumper\ArrayDumper;
+use Composer\Repository\RepositorySet;
 
 /**
  * Selects the best possible version for a package
@@ -25,13 +25,12 @@ use Composer\Package\Dumper\ArrayDumper;
  */
 class VersionSelector
 {
-    private $pool;
-
+    private $repositorySet;
     private $parser;
 
-    public function __construct(Pool $pool)
+    public function __construct(RepositorySet $repositorySet)
     {
-        $this->pool = $pool;
+        $this->repositorySet = $repositorySet;
     }
 
     /**
@@ -45,7 +44,7 @@ class VersionSelector
     public function findBestCandidate($packageName, $targetPackageVersion = null)
     {
         $constraint = $targetPackageVersion ? $this->getParser()->parseConstraints($targetPackageVersion) : null;
-        $candidates = $this->pool->whatProvides(strtolower($packageName), $constraint, true);
+        $candidates = $this->repositorySet->findPackages(strtolower($packageName), $constraint);
 
         if (!$candidates) {
             return false;

--- a/src/Composer/Plugin/PluginInterface.php
+++ b/src/Composer/Plugin/PluginInterface.php
@@ -27,7 +27,7 @@ interface PluginInterface
      *
      * @var string
      */
-    const PLUGIN_API_VERSION = '1.0.0';
+    const PLUGIN_API_VERSION = '2.0.0';
 
     /**
      * Apply plugin modifications to composer

--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -27,6 +27,7 @@ use Composer\Package\LinkConstraint\VersionConstraint;
 class ArrayRepository implements RepositoryInterface
 {
     protected $packages;
+    protected $rootAliases;
 
     public function __construct(array $packages = array())
     {
@@ -189,6 +190,22 @@ class ArrayRepository implements RepositoryInterface
     public function count()
     {
         return count($this->packages);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setRootAliases(array $rootAliases)
+    {
+        $this->rootAliases = $rootAliases;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRootAliases()
+    {
+        return $this->rootAliases;
     }
 
     /**

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -16,7 +16,6 @@ use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\PackageInterface;
 use Composer\Package\AliasPackage;
 use Composer\Package\Version\VersionParser;
-use Composer\DependencyResolver\Pool;
 use Composer\Json\JsonFile;
 use Composer\Cache;
 use Composer\Config;

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -117,6 +117,7 @@ class ComposerRepository extends ArrayRepository
         }
 
         $loadedPackages = array();
+        $newNames = array();
 
         while (!$workQueue->isEmpty()) {
             $packageName = $workQueue->dequeue();
@@ -132,12 +133,16 @@ class ComposerRepository extends ArrayRepository
                 $loadedPackages[] = $package;
                 $requires = $package->getRequires();
                 foreach ($requires as $link) {
-                    $workQueue->enqueue($link->getTarget());
+                    $dependency = $link->getTarget();
+                    if (!isset($this->loadedMap[$dependency])) {
+                        $newNames[] = $dependency;
+                        $workQueue->enqueue($dependency);
+                    }
                 }
             }
         }
 
-        return $loadedPackages;
+        return array($loadedPackages, $newNames);
     }
 
     /**

--- a/src/Composer/Repository/CompositeRepository.php
+++ b/src/Composer/Repository/CompositeRepository.php
@@ -175,4 +175,20 @@ class CompositeRepository implements RepositoryInterface
             $this->repositories[] = $repository;
         }
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setRootAliases(array $rootAliases)
+    {
+        $this->rootAliases = $rootAliases;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRootAliases()
+    {
+        return $this->rootAliases;
+    }
 }

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -70,4 +70,18 @@ interface RepositoryInterface extends \Countable
      * @return array[] an array of array('name' => '...', 'description' => '...')
      */
     public function search($query, $mode = 0);
+
+    /**
+     * Store root alias definitions that apply to this repository
+     *
+     * @param array[][][] $rootAliases map of (name, version) to alias info
+     */
+    public function setRootAliases(array $rootAliases);
+
+    /**
+     * Return the stored definitions of root aliases
+     *
+     * @return array[][][] map of (name, version) to alias info
+     */
+    public function getRootAliases();
 }

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -171,7 +171,7 @@ class RepositorySet
         } while ($continue);
 
         $this->packageByExactName = array();
-        return new Pool($poolPackages, $poolPackageToPriority);
+        return new Pool($poolPackages, $poolPackageToPriority, $this->filterRequires);
     }
 
     protected function getPackagesRecursively($repo, &$loadedMap, $packageNames)

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -88,7 +88,7 @@ class RepositorySet
         $priority = array_search($repo, $this->repositories, true);
 
         if (false === $priority) {
-            throw new \RuntimeException("Could not determine repository priority. The repository was not registered in the pool.");
+            throw new \RuntimeException("Could not determine repository priority. The repository was not registered in the repository set.");
         }
 
         return -$priority;

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -1,0 +1,307 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Repository;
+
+use Composer\DependencyResolver\Pool;
+use Composer\Package\BasePackage;
+use Composer\Package\AliasPackage;
+use Composer\Package\Version\VersionParser;
+use Composer\Package\LinkConstraint\LinkConstraintInterface;
+use Composer\Package\LinkConstraint\VersionConstraint;
+use Composer\Package\LinkConstraint\EmptyConstraint;
+use Composer\Repository\RepositoryInterface;
+use Composer\Repository\CompositeRepository;
+use Composer\Repository\ComposerRepository;
+use Composer\Repository\InstalledRepositoryInterface;
+use Composer\Repository\PlatformRepository;
+use Composer\Package\PackageInterface;
+
+/**
+ * The repository set manages access to repository data.
+ *
+ * @author Nils Adermann <naderman@naderman.de>
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class RepositorySet
+{
+    protected $repositories = array();
+    protected $providerRepos = array();
+    protected $acceptableStabilities;
+    protected $stabilityFlags;
+    protected $versionParser;
+    protected $filterRequires;
+
+    public function __construct($minimumStability = 'stable', array $stabilityFlags = array(), array $filterRequires = array())
+    {
+        $this->versionParser = new VersionParser;
+        $this->acceptableStabilities = array();
+        foreach (BasePackage::$stabilities as $stability => $value) {
+            if ($value <= BasePackage::$stabilities[$minimumStability]) {
+                $this->acceptableStabilities[$stability] = $value;
+            }
+        }
+        $this->stabilityFlags = $stabilityFlags;
+        $this->filterRequires = $filterRequires;
+        foreach ($filterRequires as $name => $constraint) {
+            if (preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $name)) {
+                unset($this->filterRequires[$name]);
+            }
+        }
+    }
+
+    /**
+     * Adds a repository to this repository set
+     *
+     * @param RepositoryInterface $repo        A package repository
+     * @param array               $rootAliases
+     */
+    public function addRepository(RepositoryInterface $repo, $rootAliases = array())
+    {
+        if ($repo instanceof CompositeRepository) {
+            $repos = $repo->getRepositories();
+        } else {
+            $repos = array($repo);
+        }
+
+        foreach ($repos as $repo) {
+            $this->repositories[] = $repo;
+            $repo->setRootAliases($rootAliases);
+
+            if ($repo instanceof ComposerRepository && $repo->hasProviders()) {
+                $this->providerRepos[] = $repo;
+            }
+        }
+    }
+
+    public function getPriority(RepositoryInterface $repo)
+    {
+        $priority = array_search($repo, $this->repositories, true);
+
+        if (false === $priority) {
+            throw new \RuntimeException("Could not determine repository priority. The repository was not registered in the pool.");
+        }
+
+        return -$priority;
+    }
+
+    /**
+     * Creates a pool with all packages from all repositories. Does not work
+     * with provider repositories.
+     *
+     * @return Pool
+     */
+    public function getCompletePool()
+    {
+        $names = array();
+        foreach ($this->repositories as $repo) {
+            foreach ($repo->getPackages() as $package) {
+                $names[$package->getName()] = true;
+            }
+        }
+
+        return $this->getPool(array_keys($names));
+    }
+
+    /**
+     * Creates a pool with all given names and their requirements are loaded.
+     *
+     * @param array $packageNames A list of names that need to be available
+     * @return Pool
+     */
+    public function getPool(array $packageNames)
+    {
+        $this->packageByExactName = array();
+        foreach ($this->repositories as $repo) {
+            if ((!$repo instanceof ComposerRepository) || !$repo->hasProviders()) {
+                foreach ($repo->getPackages() as $package) {
+                    $this->loadPackage(
+                        $repo,
+                        $package
+                    );
+                }
+            }
+        }
+
+        $poolPackages = array();
+        $poolPackageToPriority = array();
+
+        $loadedMaps = array_fill(0, count($this->repositories), array());
+        do {
+            $continue = false;
+            $newPackageNames = array();
+
+            foreach ($this->repositories as $priority => $repo) {
+                $loadedCount = count($loadedMaps[$priority]);
+
+                list($packages, $foundNames) = $this->getPackagesRecursively(
+                    $repo,
+                    $loadedMaps[$priority],
+                    $packageNames
+                );
+
+                if (count($loadedMaps[$priority]) > $loadedCount) {
+                    $continue = true;
+                }
+
+                for ($id = count($poolPackages); $id < count($poolPackages) + count($packages); $id++) {
+                    $poolPackageToPriority[$id] = -$priority;
+                }
+
+                $poolPackages = array_merge(
+                    $poolPackages,
+                    $packages
+                );
+                $newPackageNames = array_merge(
+                    $newPackageNames,
+                    $foundNames
+                );
+            }
+
+            $packageNames = $newPackageNames;
+        } while ($continue);
+
+        $this->packageByExactName = array();
+        return new Pool($poolPackages, $poolPackageToPriority);
+    }
+
+    protected function getPackagesRecursively($repo, &$loadedMap, $packageNames)
+    {
+        $workQueue = new \SplQueue;
+
+        foreach ($packageNames as $packageName) {
+            $workQueue->enqueue($packageName);
+        }
+
+        $allPackages = array();
+        $foundNames = array();
+
+        while (!$workQueue->isEmpty()) {
+            $packageName = $workQueue->dequeue();
+
+            if (isset($loadedMap[$packageName])) {
+                continue;
+            }
+
+            $loadedMap[$packageName] = true;
+
+            if ($repo instanceof ComposerRepository && $repo->hasProviders()) {
+                $packages = $repo->loadName($packageName, array($this, 'isPackageAcceptable'));
+                $loadedPackages = array();
+                foreach ($packages as $package) {
+                    $loadedPackages = array_merge(
+                        $loadedPackages,
+                        $this->loadPackage($repo, $package)
+                    );
+                }
+            } else {
+                $loadedPackages = isset($this->packageByExactName[spl_object_hash($repo)][$packageName]) ?
+                    $this->packageByExactName[spl_object_hash($repo)][$packageName] : array();
+            }
+
+            foreach ($loadedPackages as $loadedPackage) {
+                $requires = $loadedPackage->getRequires();
+                foreach ($requires as $link) {
+                    $dependency = $link->getTarget();
+                    if (!isset($loadedMap[$dependency])) {
+                        $foundNames[] = $link->getTarget();
+                        $workQueue->enqueue($link->getTarget());
+                    }
+                }
+            }
+            $allPackages = array_merge($allPackages, $loadedPackages);
+        }
+
+        return array($allPackages, $foundNames);
+    }
+
+    private function loadPackage(RepositoryInterface $repo, PackageInterface $package)
+    {
+        $loaded = array();
+        $rootAliases = $repo->getRootAliases();
+
+        $names = $package->getNames();
+        $stability = $package->getStability();
+
+        if (!($repo instanceof PlatformRepository) &&
+            !($repo instanceof InstalledRepositoryInterface) &&
+            !$this->isPackageAcceptable($names, $stability)
+        ) {
+            return;
+        }
+
+        $loaded[] = $package;
+        $this->packageByExactName[spl_object_hash($repo)][$package->getName()][] = $package;
+
+        // handle root package aliases
+        $name = $package->getName();
+        if (isset($rootAliases[$name][$package->getVersion()])) {
+            $alias = $rootAliases[$name][$package->getVersion()];
+            if ($package instanceof AliasPackage) {
+                $package = $package->getAliasOf();
+            }
+            $aliasPackage = new AliasPackage($package, $alias['alias_normalized'], $alias['alias']);
+            $aliasPackage->setRootPackageAlias(true);
+
+            $package->getRepository()->addPackage($aliasPackage);
+            $loaded[] = $aliasPackage;
+            $this->packageByExactName[spl_object_hash($repo)][$aliasPackage->getName()][] = $aliasPackage;
+        }
+
+        return $loaded;
+    }
+
+    public function isPackageAcceptable($name, $stability)
+    {
+        foreach ((array) $name as $n) {
+            // allow if package matches the global stability requirement and has no exception
+            if (!isset($this->stabilityFlags[$n]) && isset($this->acceptableStabilities[$stability])) {
+                return true;
+            }
+
+            // allow if package matches the package-specific stability flag
+            if (isset($this->stabilityFlags[$n]) && BasePackage::$stabilities[$stability] <= $this->stabilityFlags[$n]) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Searches for all packages matching a name and optionally a version.
+     *
+     * @param string                                                          $name       package name
+     * @param string|\Composer\Package\LinkConstraint\LinkConstraintInterface $constraint package version or version constraint to match against
+     *
+     * @return array
+     */
+    public function findPackages($name, $constraint = null)
+    {
+        $packages = array();
+        foreach ($this->repositories as $repository) {
+            /* @var $repository RepositoryInterface */
+            $packages[] = $repository->findPackages($name, $constraint);
+        }
+
+        $candidates = $packages ? call_user_func_array('array_merge', $packages) : array();
+
+        $result = array();
+        foreach ($candidates as $candidate) {
+            if ($this->isPackageAcceptable($candidate->getNames(), $candidate->getStability())) {
+                $result[] = $candidate;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Composer/Test/Autoload/ClassLoaderTest.php
+++ b/tests/Composer/Test/Autoload/ClassLoaderTest.php
@@ -13,7 +13,7 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $loader = new ClassLoader();
         $loader->add('DirDotPhp\\', __DIR__ . '/Fixtures');
-        $loader->addPsr4('DirDotPhp\\', __DIR__ . '/Fixtures/DirDotPhp/psr4');
+//        $loader->addPsr4('DirDotPhp\\', __DIR__ . '/Fixtures/DirDotPhp/psr4');
 
         $class = 'DirDotPhp\\Dir';
         $loader->loadClass($class);

--- a/tests/Composer/Test/Autoload/ClassLoaderTest.php
+++ b/tests/Composer/Test/Autoload/ClassLoaderTest.php
@@ -13,7 +13,7 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $loader = new ClassLoader();
         $loader->add('DirDotPhp\\', __DIR__ . '/Fixtures');
-//        $loader->addPsr4('DirDotPhp\\', __DIR__ . '/Fixtures/DirDotPhp/psr4');
+        $loader->addPsr4('DirDotPhp\\', __DIR__ . '/Fixtures/DirDotPhp/psr4');
 
         $class = 'DirDotPhp\\Dir';
         $loader->loadClass($class);

--- a/tests/Composer/Test/DependencyResolver/DefaultPolicyTest.php
+++ b/tests/Composer/Test/DependencyResolver/DefaultPolicyTest.php
@@ -14,8 +14,8 @@ namespace Composer\Test\DependencyResolver;
 
 use Composer\Repository\ArrayRepository;
 use Composer\Repository\RepositoryInterface;
+use Composer\Repository\RepositorySet;
 use Composer\DependencyResolver\DefaultPolicy;
-use Composer\DependencyResolver\Pool;
 use Composer\Package\Link;
 use Composer\Package\AliasPackage;
 use Composer\Package\LinkConstraint\VersionConstraint;
@@ -23,17 +23,24 @@ use Composer\TestCase;
 
 class DefaultPolicyTest extends TestCase
 {
-    protected $pool;
     protected $repo;
+    protected $repoImportant;
     protected $repoInstalled;
+    protected $repoSet;
     protected $request;
     protected $policy;
 
     public function setUp()
     {
-        $this->pool = new Pool('dev');
         $this->repo = new ArrayRepository;
+        $this->repoImportant = new ArrayRepository;
         $this->repoInstalled = new ArrayRepository;
+
+        $this->repoSet = new RepositorySet('dev');
+
+        $this->repoSet->addRepository($this->repoInstalled);
+        $this->repoSet->addRepository($this->repoImportant);
+        $this->repoSet->addRepository($this->repo);
 
         $this->policy = new DefaultPolicy;
     }
@@ -41,12 +48,13 @@ class DefaultPolicyTest extends TestCase
     public function testSelectSingle()
     {
         $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->pool->addRepository($this->repo);
+
+        $pool = $this->repoSet->getPool(['a']);
 
         $literals = array($packageA->getId());
         $expected = array($packageA->getId());
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, array(), $literals);
+        $selected = $this->policy->selectPreferredPackages($pool, array(), $literals);
 
         $this->assertEquals($expected, $selected);
     }
@@ -55,12 +63,13 @@ class DefaultPolicyTest extends TestCase
     {
         $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0'));
         $this->repo->addPackage($packageA2 = $this->getPackage('A', '2.0'));
-        $this->pool->addRepository($this->repo);
+
+        $pool = $this->repoSet->getPool(['a']);
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA2->getId());
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, array(), $literals);
+        $selected = $this->policy->selectPreferredPackages($pool, array(), $literals);
 
         $this->assertEquals($expected, $selected);
     }
@@ -69,12 +78,13 @@ class DefaultPolicyTest extends TestCase
     {
         $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0.0'));
         $this->repo->addPackage($packageA2 = $this->getPackage('A', '1.0.1-alpha'));
-        $this->pool->addRepository($this->repo);
+
+        $pool = $this->repoSet->getPool(['a']);
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA2->getId());
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, array(), $literals);
+        $selected = $this->policy->selectPreferredPackages($pool, array(), $literals);
 
         $this->assertEquals($expected, $selected);
     }
@@ -83,13 +93,14 @@ class DefaultPolicyTest extends TestCase
     {
         $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0.0'));
         $this->repo->addPackage($packageA2 = $this->getPackage('A', '1.0.1-alpha'));
-        $this->pool->addRepository($this->repo);
+
+        $pool = $this->repoSet->getPool(['a']);
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA1->getId());
 
         $policy = new DefaultPolicy(true);
-        $selected = $policy->selectPreferredPackages($this->pool, array(), $literals);
+        $selected = $policy->selectPreferredPackages($pool, array(), $literals);
 
         $this->assertEquals($expected, $selected);
     }
@@ -98,12 +109,13 @@ class DefaultPolicyTest extends TestCase
     {
         $this->repo->addPackage($packageA1 = $this->getPackage('A', 'dev-foo'));
         $this->repo->addPackage($packageA2 = $this->getPackage('A', '1.0.0'));
-        $this->pool->addRepository($this->repo);
+
+        $pool = $this->repoSet->getPool(['a']);
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA2->getId());
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, array(), $literals);
+        $selected = $this->policy->selectPreferredPackages($pool, array(), $literals);
 
         $this->assertEquals($expected, $selected);
     }
@@ -112,40 +124,34 @@ class DefaultPolicyTest extends TestCase
     {
         $this->repo->addPackage($packageA = $this->getPackage('A', '2.0'));
         $this->repoInstalled->addPackage($packageAInstalled = $this->getPackage('A', '1.0'));
-        $this->pool->addRepository($this->repoInstalled);
-        $this->pool->addRepository($this->repo);
+
+        $pool = $this->repoSet->getPool(['a']);
 
         $literals = array($packageA->getId(), $packageAInstalled->getId());
         $expected = array($packageA->getId());
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, $this->mapFromRepo($this->repoInstalled), $literals);
+        $selected = $this->policy->selectPreferredPackages($pool, $this->mapFromRepo($this->repoInstalled), $literals);
 
         $this->assertEquals($expected, $selected);
     }
 
     public function testSelectFirstRepo()
     {
-        $this->repoImportant = new ArrayRepository;
-
         $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
         $this->repoImportant->addPackage($packageAImportant = $this->getPackage('A', '1.0'));
 
-        $this->pool->addRepository($this->repoInstalled);
-        $this->pool->addRepository($this->repoImportant);
-        $this->pool->addRepository($this->repo);
+        $pool = $this->repoSet->getPool(['a']);
 
         $literals = array($packageA->getId(), $packageAImportant->getId());
         $expected = array($packageAImportant->getId());
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, array(), $literals);
+        $selected = $this->policy->selectPreferredPackages($pool, array(), $literals);
 
         $this->assertEquals($expected, $selected);
     }
 
     public function testSelectLocalReposFirst()
     {
-        $this->repoImportant = new ArrayRepository;
-
         $this->repo->addPackage($packageA = $this->getPackage('A', 'dev-master'));
         $this->repo->addPackage($packageAAlias = new AliasPackage($packageA, '2.1.9999999.9999999-dev', '2.1.x-dev'));
         $this->repoImportant->addPackage($packageAImportant = $this->getPackage('A', 'dev-feature-a'));
@@ -154,11 +160,9 @@ class DefaultPolicyTest extends TestCase
         $this->repoImportant->addPackage($packageA2AliasImportant = new AliasPackage($packageA2Important, '2.1.9999999.9999999-dev', '2.1.x-dev'));
         $packageAAliasImportant->setRootPackageAlias(true);
 
-        $this->pool->addRepository($this->repoInstalled);
-        $this->pool->addRepository($this->repoImportant);
-        $this->pool->addRepository($this->repo);
+        $pool = $this->repoSet->getPool(['a']);
 
-        $packages = $this->pool->whatProvides('a', new VersionConstraint('=', '2.1.9999999.9999999-dev'));
+        $packages = $pool->whatProvides('a', new VersionConstraint('=', '2.1.9999999.9999999-dev'));
         $literals = array();
         foreach ($packages as $package) {
             $literals[] = $package->getId();
@@ -166,7 +170,7 @@ class DefaultPolicyTest extends TestCase
 
         $expected = array($packageAAliasImportant->getId());
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, array(), $literals);
+        $selected = $this->policy->selectPreferredPackages($pool, array(), $literals);
 
         $this->assertEquals($expected, $selected);
     }
@@ -179,12 +183,12 @@ class DefaultPolicyTest extends TestCase
         $packageA->setProvides(array(new Link('A', 'X', new VersionConstraint('==', '1.0'), 'provides')));
         $packageB->setProvides(array(new Link('B', 'X', new VersionConstraint('==', '1.0'), 'provides')));
 
-        $this->pool->addRepository($this->repo);
+        $pool = $this->repoSet->getPool(['a', 'b']);
 
         $literals = array($packageA->getId(), $packageB->getId());
         $expected = $literals;
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, array(), $literals);
+        $selected = $this->policy->selectPreferredPackages($pool, array(), $literals);
 
         $this->assertEquals($expected, $selected);
     }
@@ -196,12 +200,12 @@ class DefaultPolicyTest extends TestCase
 
         $packageB->setReplaces(array(new Link('B', 'A', new VersionConstraint('==', '1.0'), 'replaces')));
 
-        $this->pool->addRepository($this->repo);
+        $pool = $this->repoSet->getPool(['a', 'b']);
 
         $literals = array($packageA->getId(), $packageB->getId());
         $expected = $literals;
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, array(), $literals);
+        $selected = $this->policy->selectPreferredPackages($pool, array(), $literals);
 
         $this->assertEquals($expected, $selected);
     }
@@ -211,16 +215,17 @@ class DefaultPolicyTest extends TestCase
         // test with default order
         $this->repo->addPackage($packageB = $this->getPackage('vendor-b/replacer', '1.0'));
         $this->repo->addPackage($packageA = $this->getPackage('vendor-a/replacer', '1.0'));
+        $names = ['vendor-b/replacer', 'vendor-b/replacer', 'vendor-a/package'];
 
         $packageA->setReplaces(array(new Link('vendor-a/replacer', 'vendor-a/package', new VersionConstraint('==', '1.0'), 'replaces')));
         $packageB->setReplaces(array(new Link('vendor-b/replacer', 'vendor-a/package', new VersionConstraint('==', '1.0'), 'replaces')));
 
-        $this->pool->addRepository($this->repo);
+        $pool = $this->repoSet->getPool($names);
 
         $literals = array($packageA->getId(), $packageB->getId());
         $expected = $literals;
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, array(), $literals, 'vendor-a/package');
+        $selected = $this->policy->selectPreferredPackages($pool, array(), $literals, 'vendor-a/package');
         $this->assertEquals($expected, $selected);
 
         // test with reversed order in repo
@@ -228,13 +233,15 @@ class DefaultPolicyTest extends TestCase
         $repo->addPackage($packageA = clone $packageA);
         $repo->addPackage($packageB = clone $packageB);
 
-        $pool = new Pool('dev');
-        $pool->addRepository($this->repo);
+        $repoSet = new RepositorySet('dev');
+        $repoSet->addRepository($repo);
+
+        $pool = $this->repoSet->getPool($names);
 
         $literals = array($packageA->getId(), $packageB->getId());
         $expected = $literals;
 
-        $selected = $this->policy->selectPreferredPackages($this->pool, array(), $literals, 'vendor-a/package');
+        $selected = $this->policy->selectPreferredPackages($pool, array(), $literals, 'vendor-a/package');
         $this->assertEquals($expected, $selected);
     }
 
@@ -254,12 +261,13 @@ class DefaultPolicyTest extends TestCase
 
         $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0'));
         $this->repo->addPackage($packageA2 = $this->getPackage('A', '2.0'));
-        $this->pool->addRepository($this->repo);
+
+        $pool = $this->repoSet->getPool(['a']);
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA1->getId());
 
-        $selected = $policy->selectPreferredPackages($this->pool, array(), $literals);
+        $selected = $policy->selectPreferredPackages($pool, array(), $literals);
 
         $this->assertEquals($expected, $selected);
     }

--- a/tests/Composer/Test/DependencyResolver/DefaultPolicyTest.php
+++ b/tests/Composer/Test/DependencyResolver/DefaultPolicyTest.php
@@ -49,7 +49,7 @@ class DefaultPolicyTest extends TestCase
     {
         $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
 
-        $pool = $this->repoSet->getPool(['a']);
+        $pool = $this->repoSet->getPool(array('a'));
 
         $literals = array($packageA->getId());
         $expected = array($packageA->getId());
@@ -64,7 +64,7 @@ class DefaultPolicyTest extends TestCase
         $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0'));
         $this->repo->addPackage($packageA2 = $this->getPackage('A', '2.0'));
 
-        $pool = $this->repoSet->getPool(['a']);
+        $pool = $this->repoSet->getPool(array('a'));
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA2->getId());
@@ -79,7 +79,7 @@ class DefaultPolicyTest extends TestCase
         $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0.0'));
         $this->repo->addPackage($packageA2 = $this->getPackage('A', '1.0.1-alpha'));
 
-        $pool = $this->repoSet->getPool(['a']);
+        $pool = $this->repoSet->getPool(array('a'));
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA2->getId());
@@ -94,7 +94,7 @@ class DefaultPolicyTest extends TestCase
         $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0.0'));
         $this->repo->addPackage($packageA2 = $this->getPackage('A', '1.0.1-alpha'));
 
-        $pool = $this->repoSet->getPool(['a']);
+        $pool = $this->repoSet->getPool(array('a'));
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA1->getId());
@@ -110,7 +110,7 @@ class DefaultPolicyTest extends TestCase
         $this->repo->addPackage($packageA1 = $this->getPackage('A', 'dev-foo'));
         $this->repo->addPackage($packageA2 = $this->getPackage('A', '1.0.0'));
 
-        $pool = $this->repoSet->getPool(['a']);
+        $pool = $this->repoSet->getPool(array('a'));
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA2->getId());
@@ -125,7 +125,7 @@ class DefaultPolicyTest extends TestCase
         $this->repo->addPackage($packageA = $this->getPackage('A', '2.0'));
         $this->repoInstalled->addPackage($packageAInstalled = $this->getPackage('A', '1.0'));
 
-        $pool = $this->repoSet->getPool(['a']);
+        $pool = $this->repoSet->getPool(array('a'));
 
         $literals = array($packageA->getId(), $packageAInstalled->getId());
         $expected = array($packageA->getId());
@@ -140,7 +140,7 @@ class DefaultPolicyTest extends TestCase
         $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
         $this->repoImportant->addPackage($packageAImportant = $this->getPackage('A', '1.0'));
 
-        $pool = $this->repoSet->getPool(['a']);
+        $pool = $this->repoSet->getPool(array('a'));
 
         $literals = array($packageA->getId(), $packageAImportant->getId());
         $expected = array($packageAImportant->getId());
@@ -160,7 +160,7 @@ class DefaultPolicyTest extends TestCase
         $this->repoImportant->addPackage($packageA2AliasImportant = new AliasPackage($packageA2Important, '2.1.9999999.9999999-dev', '2.1.x-dev'));
         $packageAAliasImportant->setRootPackageAlias(true);
 
-        $pool = $this->repoSet->getPool(['a']);
+        $pool = $this->repoSet->getPool(array('a'));
 
         $packages = $pool->whatProvides('a', new VersionConstraint('=', '2.1.9999999.9999999-dev'));
         $literals = array();
@@ -183,7 +183,7 @@ class DefaultPolicyTest extends TestCase
         $packageA->setProvides(array(new Link('A', 'X', new VersionConstraint('==', '1.0'), 'provides')));
         $packageB->setProvides(array(new Link('B', 'X', new VersionConstraint('==', '1.0'), 'provides')));
 
-        $pool = $this->repoSet->getPool(['a', 'b']);
+        $pool = $this->repoSet->getPool(array('a', 'b'));
 
         $literals = array($packageA->getId(), $packageB->getId());
         $expected = $literals;
@@ -200,7 +200,7 @@ class DefaultPolicyTest extends TestCase
 
         $packageB->setReplaces(array(new Link('B', 'A', new VersionConstraint('==', '1.0'), 'replaces')));
 
-        $pool = $this->repoSet->getPool(['a', 'b']);
+        $pool = $this->repoSet->getPool(array('a', 'b'));
 
         $literals = array($packageA->getId(), $packageB->getId());
         $expected = $literals;
@@ -215,7 +215,7 @@ class DefaultPolicyTest extends TestCase
         // test with default order
         $this->repo->addPackage($packageB = $this->getPackage('vendor-b/replacer', '1.0'));
         $this->repo->addPackage($packageA = $this->getPackage('vendor-a/replacer', '1.0'));
-        $names = ['vendor-b/replacer', 'vendor-b/replacer', 'vendor-a/package'];
+        $names = array('vendor-b/replacer', 'vendor-b/replacer', 'vendor-a/package');
 
         $packageA->setReplaces(array(new Link('vendor-a/replacer', 'vendor-a/package', new VersionConstraint('==', '1.0'), 'replaces')));
         $packageB->setReplaces(array(new Link('vendor-b/replacer', 'vendor-a/package', new VersionConstraint('==', '1.0'), 'replaces')));
@@ -262,7 +262,7 @@ class DefaultPolicyTest extends TestCase
         $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0'));
         $this->repo->addPackage($packageA2 = $this->getPackage('A', '2.0'));
 
-        $pool = $this->repoSet->getPool(['a']);
+        $pool = $this->repoSet->getPool(array('a'));
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA1->getId());

--- a/tests/Composer/Test/DependencyResolver/PoolTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of Composer.
  *
@@ -21,91 +20,40 @@ class PoolTest extends TestCase
 {
     public function testPool()
     {
-        $pool = new Pool;
-        $repo = new ArrayRepository;
         $package = $this->getPackage('foo', '1');
 
-        $repo->addPackage($package);
-        $pool->addRepository($repo);
+        $pool = new Pool(
+            array($package),
+            array(0)
+        );
 
         $this->assertEquals(array($package), $pool->whatProvides('foo'));
         $this->assertEquals(array($package), $pool->whatProvides('foo'));
     }
 
-    public function testPoolIgnoresIrrelevantPackages()
+    public function testWhatProvidesSamePackageForDifferentPriorities()
     {
-        $pool = new Pool('stable', array('bar' => BasePackage::STABILITY_BETA));
-        $repo = new ArrayRepository;
-        $repo->addPackage($package = $this->getPackage('bar', '1'));
-        $repo->addPackage($betaPackage = $this->getPackage('bar', '1-beta'));
-        $repo->addPackage($alphaPackage = $this->getPackage('bar', '1-alpha'));
-        $repo->addPackage($package2 = $this->getPackage('foo', '1'));
-        $repo->addPackage($rcPackage2 = $this->getPackage('foo', '1rc'));
-
-        $pool->addRepository($repo);
-
-        $this->assertEquals(array($package, $betaPackage), $pool->whatProvides('bar'));
-        $this->assertEquals(array($package2), $pool->whatProvides('foo'));
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testGetPriorityForNotRegisteredRepository()
-    {
-        $pool = new Pool;
-        $repository = new ArrayRepository;
-
-        $pool->getPriority($repository);
-    }
-
-    public function testGetPriorityWhenRepositoryIsRegistered()
-    {
-        $pool = new Pool;
-        $firstRepository = new ArrayRepository;
-        $pool->addRepository($firstRepository);
-        $secondRepository = new ArrayRepository;
-        $pool->addRepository($secondRepository);
-
-        $firstPriority = $pool->getPriority($firstRepository);
-        $secondPriority = $pool->getPriority($secondRepository);
-
-        $this->assertEquals(0, $firstPriority);
-        $this->assertEquals(-1, $secondPriority);
-    }
-
-    public function testWhatProvidesSamePackageForDifferentRepositories()
-    {
-        $pool = new Pool;
-        $firstRepository = new ArrayRepository;
-        $secondRepository = new ArrayRepository;
-
         $firstPackage = $this->getPackage('foo', '1');
         $secondPackage = $this->getPackage('foo', '1');
         $thirdPackage = $this->getPackage('foo', '2');
 
-        $firstRepository->addPackage($firstPackage);
-        $secondRepository->addPackage($secondPackage);
-        $secondRepository->addPackage($thirdPackage);
-
-        $pool->addRepository($firstRepository);
-        $pool->addRepository($secondRepository);
+        $pool = new Pool(
+            array($firstPackage, $secondPackage, $thirdPackage),
+            array(0, -1, -1)
+        );
 
         $this->assertEquals(array($firstPackage, $secondPackage, $thirdPackage), $pool->whatProvides('foo'));
     }
 
     public function testWhatProvidesPackageWithConstraint()
     {
-        $pool = new Pool;
-        $repository = new ArrayRepository;
-
         $firstPackage = $this->getPackage('foo', '1');
         $secondPackage = $this->getPackage('foo', '2');
 
-        $repository->addPackage($firstPackage);
-        $repository->addPackage($secondPackage);
-
-        $pool->addRepository($repository);
+        $pool = new Pool(
+            array($firstPackage, $secondPackage),
+            array(0, 0)
+        );
 
         $this->assertEquals(array($firstPackage, $secondPackage), $pool->whatProvides('foo'));
         $this->assertEquals(array($secondPackage), $pool->whatProvides('foo', $this->getVersionConstraint('==', '2')));
@@ -113,19 +61,16 @@ class PoolTest extends TestCase
 
     public function testPackageById()
     {
-        $pool = new Pool;
-        $repository = new ArrayRepository;
         $package = $this->getPackage('foo', '1');
 
-        $repository->addPackage($package);
-        $pool->addRepository($repository);
+        $pool = new Pool(array($package), array(0));
 
         $this->assertSame($package, $pool->packageById(1));
     }
 
     public function testWhatProvidesWhenPackageCannotBeFound()
     {
-        $pool = new Pool;
+        $pool = new Pool(array(), array());
 
         $this->assertEquals(array(), $pool->whatProvides('foo'));
     }

--- a/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
@@ -23,8 +23,6 @@ class RuleSetIteratorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->pool = new Pool;
-
         $this->rules = array(
             RuleSet::TYPE_JOB => array(
                 new Rule(array(), 'job1', null),

--- a/tests/Composer/Test/DependencyResolver/RuleSetTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetTest.php
@@ -20,13 +20,6 @@ use Composer\TestCase;
 
 class RuleSetTest extends TestCase
 {
-    protected $pool;
-
-    public function setUp()
-    {
-        $this->pool = new Pool;
-    }
-
     public function testAdd()
     {
         $rules = array(
@@ -157,9 +150,7 @@ class RuleSetTest extends TestCase
 
     public function testPrettyString()
     {
-        $repo = new ArrayRepository;
-        $repo->addPackage($p = $this->getPackage('foo', '2.1'));
-        $this->pool->addRepository($repo);
+        $pool = new Pool(array($p = $this->getPackage('foo', '2.1')), array(0));
 
         $ruleSet = new RuleSet;
         $literal = $p->getId();
@@ -167,7 +158,7 @@ class RuleSetTest extends TestCase
 
         $ruleSet->add($rule, RuleSet::TYPE_JOB);
 
-        $this->assertContains('JOB     : (install foo 2.1)', $ruleSet->getPrettyString($this->pool));
+        $this->assertContains('JOB     : (install foo 2.1)', $ruleSet->getPrettyString($pool));
     }
 
     private function getRuleMock()

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -19,13 +19,6 @@ use Composer\TestCase;
 
 class RuleTest extends TestCase
 {
-    protected $pool;
-
-    public function setUp()
-    {
-        $this->pool = new Pool;
-    }
-
     public function testGetHash()
     {
         $rule = new Rule(array(123), 'job1', null);
@@ -104,13 +97,13 @@ class RuleTest extends TestCase
 
     public function testPrettyString()
     {
-        $repo = new ArrayRepository;
-        $repo->addPackage($p1 = $this->getPackage('foo', '2.1'));
-        $repo->addPackage($p2 = $this->getPackage('baz', '1.1'));
-        $this->pool->addRepository($repo);
+        $p1 = $this->getPackage('foo', '2.1');
+        $p2 = $this->getPackage('baz', '1.1');
+
+        $pool = new Pool(array($p1, $p2), array(0, 0));
 
         $rule = new Rule(array($p1->getId(), -$p2->getId()), 'job1', null);
 
-        $this->assertEquals('(don\'t install baz 1.1|install foo 2.1)', $rule->getPrettyString($this->pool));
+        $this->assertEquals('(don\'t install baz 1.1|install foo 2.1)', $rule->getPrettyString($pool));
     }
 }

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -67,7 +67,9 @@ class SolverTest extends TestCase
         $this->request->install('B', $this->getVersionConstraint('==', '1'));
 
         try {
-            $transaction = $this->getSolver()->solve($this->request);
+            $solver = $this->getSolver();
+            $solver->load($this->request);
+            $transaction = $solver->solve();
             $this->fail('Unsolvable conflict did not result in exception.');
         } catch (SolverProblemsException $e) {
             $problems = $e->getProblems();
@@ -410,7 +412,9 @@ class SolverTest extends TestCase
 
         // must explicitly pick the provider, so error in this case
         $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
-        $this->getSolver()->solve($this->request);
+        $solver = $this->getSolver();
+        $solver->load($this->request);
+        $solver->solve();
     }
 
     public function testSkipReplacerOfExistingPackage()
@@ -439,7 +443,9 @@ class SolverTest extends TestCase
         $this->request->install('A');
 
         $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
-        $this->getSolver()->solve($this->request);
+        $solver = $this->getSolver();
+        $solver->load($this->request);
+        $solver->solve();
     }
 
     public function testSkipReplacedPackageIfReplacerIsSelected()
@@ -599,7 +605,9 @@ class SolverTest extends TestCase
 
         $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
 
-        $this->getSolver()->solve($this->request);
+        $solver = $this->getSolver();
+        $solver->load($this->request);
+        $solver->solve();
     }
 
     public function testConflictResultEmpty()
@@ -614,7 +622,9 @@ class SolverTest extends TestCase
         $this->request->install('B');
 
         try {
-            $transaction = $this->getSolver()->solve($this->request);
+            $solver = $this->getSolver();
+            $solver->load($this->request);
+            $transaction = $solver->solve();
             $this->fail('Unsolvable conflict did not result in exception.');
         } catch (SolverProblemsException $e) {
             $problems = $e->getProblems();
@@ -641,7 +651,9 @@ class SolverTest extends TestCase
         $this->request->install('A');
 
         try {
-            $transaction = $this->getSolver()->solve($this->request);
+            $solver = $this->getSolver();
+            $solver->load($this->request);
+            $transaction = $solver->solve();
             $this->fail('Unsolvable conflict did not result in exception.');
         } catch (SolverProblemsException $e) {
             $problems = $e->getProblems();
@@ -685,7 +697,9 @@ class SolverTest extends TestCase
         $this->request->install('A');
 
         try {
-            $transaction = $this->getSolver()->solve($this->request);
+            $solver = $this->getSolver();
+            $solver->load($this->request);
+            $transaction = $solver->solve();
             $this->fail('Unsolvable conflict did not result in exception.');
         } catch (SolverProblemsException $e) {
             $problems = $e->getProblems();
@@ -787,7 +801,8 @@ class SolverTest extends TestCase
     {
         $this->solver = $this->getSolver($skipDefaultRepos);
 
-        $transaction = $this->solver->solve($this->request);
+        $this->solver->load($this->request);
+        $transaction = $this->solver->solve();
 
         $result = array();
         foreach ($transaction as $operation) {

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -243,12 +243,12 @@ class EventDispatcherTest extends TestCase
             ->will($this->returnValue(array()));
 
         $policy = $this->getMock('Composer\DependencyResolver\PolicyInterface');
-        $pool = $this->getMockBuilder('Composer\DependencyResolver\Pool')->disableOriginalConstructor()->getMock();
+        $repositorySet = $this->getMockBuilder('Composer\Repository\RepositorySet')->disableOriginalConstructor()->getMock();
         $installedRepo = $this->getMockBuilder('Composer\Repository\CompositeRepository')->disableOriginalConstructor()->getMock();
         $request = $this->getMockBuilder('Composer\DependencyResolver\Request')->disableOriginalConstructor()->getMock();
 
-        $dispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, true, $policy, $pool, $installedRepo, $request);
-        $dispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, true, $policy, $pool, $installedRepo, $request, array());
+        $dispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, true, $policy, $repositorySet, $installedRepo, $request);
+        $dispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, true, $policy, $repositorySet, $installedRepo, $request, array());
     }
 
     public static function call()

--- a/tests/Composer/Test/Fixtures/installer/replaced-packages-wrong-version-install-from-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/replaced-packages-wrong-version-install-from-lock.test
@@ -1,5 +1,5 @@
 --TEST--
-Requiring a replaced package in a version, that is not provided by the replacing package, should install correctly (although that is not a very smart idea) also when installing from lock
+Requiring a replaced package in a version, that is not provided by the replacing package, should not be installable from lock either.
 --COMPOSER--
 {
     "repositories": [
@@ -35,7 +35,5 @@ Requiring a replaced package in a version, that is not provided by the replacing
 --RUN--
 install
 --EXPECT-EXIT-CODE--
-0
+2
 --EXPECT--
-Installing foo/original (1.0.0)
-Installing foo/replaced (2.0.0)

--- a/tests/Composer/Test/Fixtures/installer/replaced-packages-wrong-version-install-from-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/replaced-packages-wrong-version-install-from-lock.test
@@ -1,5 +1,5 @@
 --TEST--
-Requiring a replaced package in a version, that is not provided by the replacing package, should not be installable from lock either.
+Requiring a replaced package in a version, that is not provided by the replacing package, should install correctly (although that is not a very smart idea) also when installing from lock
 --COMPOSER--
 {
     "repositories": [
@@ -35,5 +35,7 @@ Requiring a replaced package in a version, that is not provided by the replacing
 --RUN--
 install
 --EXPECT-EXIT-CODE--
-2
+0
 --EXPECT--
+Installing foo/original (1.0.0)
+Installing foo/replaced (2.0.0)

--- a/tests/Composer/Test/Fixtures/installer/replaced-packages-wrong-version-install.test
+++ b/tests/Composer/Test/Fixtures/installer/replaced-packages-wrong-version-install.test
@@ -1,5 +1,5 @@
 --TEST--
-Requiring a replaced package in a version, that is not provided by the replacing package, should not be installable anyway.
+Requiring a replaced package in a version, that is not provided by the replacing package, should install correctly (although that is not a very smart idea)
 --COMPOSER--
 {
     "repositories": [
@@ -19,7 +19,23 @@ Requiring a replaced package in a version, that is not provided by the replacing
 }
 --RUN--
 install
+--EXPECT-LOCK--
+{
+    "packages": [
+        { "name": "foo/original", "version": "1.0.0", "replace": {"foo/replaced": "1.0.0"}, "type": "library" },
+        { "name": "foo/replaced", "version": "2.0.0", "type": "library" }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
 --EXPECT-EXIT-CODE--
-2
+0
 --EXPECT--
-
+Installing foo/original (1.0.0)
+Installing foo/replaced (2.0.0)

--- a/tests/Composer/Test/Fixtures/installer/replaced-packages-wrong-version-install.test
+++ b/tests/Composer/Test/Fixtures/installer/replaced-packages-wrong-version-install.test
@@ -1,5 +1,5 @@
 --TEST--
-Requiring a replaced package in a version, that is not provided by the replacing package, should install correctly (although that is not a very smart idea)
+Requiring a replaced package in a version, that is not provided by the replacing package, should not be installable anyway.
 --COMPOSER--
 {
     "repositories": [
@@ -19,23 +19,7 @@ Requiring a replaced package in a version, that is not provided by the replacing
 }
 --RUN--
 install
---EXPECT-LOCK--
-{
-    "packages": [
-        { "name": "foo/original", "version": "1.0.0", "replace": {"foo/replaced": "1.0.0"}, "type": "library" },
-        { "name": "foo/replaced", "version": "2.0.0", "type": "library" }
-    ],
-    "packages-dev": [],
-    "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": {},
-    "prefer-stable": false,
-    "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": []
-}
 --EXPECT-EXIT-CODE--
-0
+2
 --EXPECT--
-Installing foo/original (1.0.0)
-Installing foo/replaced (2.0.0)
+

--- a/tests/Composer/Test/Installer/InstallerEventTest.php
+++ b/tests/Composer/Test/Installer/InstallerEventTest.php
@@ -21,18 +21,18 @@ class InstallerEventTest extends \PHPUnit_Framework_TestCase
         $composer = $this->getMock('Composer\Composer');
         $io = $this->getMock('Composer\IO\IOInterface');
         $policy = $this->getMock('Composer\DependencyResolver\PolicyInterface');
-        $pool = $this->getMockBuilder('Composer\DependencyResolver\Pool')->disableOriginalConstructor()->getMock();
+        $repositorySet = $this->getMockBuilder('Composer\Repository\RepositorySet')->disableOriginalConstructor()->getMock();
         $installedRepo = $this->getMockBuilder('Composer\Repository\CompositeRepository')->disableOriginalConstructor()->getMock();
         $request = $this->getMockBuilder('Composer\DependencyResolver\Request')->disableOriginalConstructor()->getMock();
         $operations = array($this->getMock('Composer\DependencyResolver\Operation\OperationInterface'));
-        $event = new InstallerEvent('EVENT_NAME', $composer, $io, true, $policy, $pool, $installedRepo, $request, $operations);
+        $event = new InstallerEvent('EVENT_NAME', $composer, $io, true, $policy, $repositorySet, $installedRepo, $request, $operations);
 
         $this->assertSame('EVENT_NAME', $event->getName());
         $this->assertInstanceOf('Composer\Composer', $event->getComposer());
         $this->assertInstanceOf('Composer\IO\IOInterface', $event->getIO());
         $this->assertTrue($event->isDevMode());
         $this->assertInstanceOf('Composer\DependencyResolver\PolicyInterface', $event->getPolicy());
-        $this->assertInstanceOf('Composer\DependencyResolver\Pool', $event->getPool());
+        $this->assertInstanceOf('Composer\Repository\RepositorySet', $event->getRepositorySet());
         $this->assertInstanceOf('Composer\Repository\CompositeRepository', $event->getInstalledRepo());
         $this->assertInstanceOf('Composer\DependencyResolver\Request', $event->getRequest());
         $this->assertCount(1, $event->getOperations());

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -18,7 +18,7 @@ use Composer\Package\Version\VersionParser;
 class VersionSelectorTest extends \PHPUnit_Framework_TestCase
 {
     // A) multiple versions, get the latest one
-    // B) targetPackageVersion will pass to pool
+    // B) targetPackageVersion will pass to repository set
     // C) No results, throw exception
 
     public function testLatestVersionIsReturned()
@@ -30,13 +30,13 @@ class VersionSelectorTest extends \PHPUnit_Framework_TestCase
         $package3 = $this->createMockPackage('1.2.0');
         $packages = array($package1, $package2, $package3);
 
-        $pool = $this->createMockPool();
-        $pool->expects($this->once())
-            ->method('whatProvides')
-            ->with($packageName, null, true)
+        $repoSet = $this->createMockRepositorySet();
+        $repoSet->expects($this->once())
+            ->method('findPackages')
+            ->with($packageName, null)
             ->will($this->returnValue($packages));
 
-        $versionSelector = new VersionSelector($pool);
+        $versionSelector = new VersionSelector($repoSet);
         $best = $versionSelector->findBestCandidate($packageName);
 
         // 1.2.2 should be returned because it's the latest of the returned versions
@@ -45,12 +45,12 @@ class VersionSelectorTest extends \PHPUnit_Framework_TestCase
 
     public function testFalseReturnedOnNoPackages()
     {
-        $pool = $this->createMockPool();
-        $pool->expects($this->once())
-            ->method('whatProvides')
+        $repoSet = $this->createMockRepositorySet();
+        $repoSet->expects($this->once())
+            ->method('findPackages')
             ->will($this->returnValue(array()));
 
-        $versionSelector = new VersionSelector($pool);
+        $versionSelector = new VersionSelector($repoSet);
         $best = $versionSelector->findBestCandidate('foobaz');
         $this->assertFalse($best, 'No versions are available returns false');
     }
@@ -60,8 +60,8 @@ class VersionSelectorTest extends \PHPUnit_Framework_TestCase
      */
     public function testFindRecommendedRequireVersion($prettyVersion, $isDev, $stability, $expectedVersion, $branchAlias = null)
     {
-        $pool = $this->createMockPool();
-        $versionSelector = new VersionSelector($pool);
+        $repoSet = $this->createMockRepositorySet();
+        $versionSelector = new VersionSelector($repoSet);
         $versionParser = new VersionParser();
 
         $package = $this->getMock('\Composer\Package\PackageInterface');
@@ -134,8 +134,8 @@ class VersionSelectorTest extends \PHPUnit_Framework_TestCase
         return $package;
     }
 
-    private function createMockPool()
+    private function createMockRepositorySet()
     {
-        return $this->getMock('Composer\DependencyResolver\Pool', array(), array(), '', true);
+        return $this->getMock('Composer\Repository\RepositorySet', array(), array(), '', true);
     }
 }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v1/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v1/composer.json
@@ -7,6 +7,6 @@
         "class": "Installer\\Plugin"
     },
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "2.0.0"
     }
 }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v2/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v2/composer.json
@@ -7,6 +7,6 @@
         "class": "Installer\\Plugin2"
     },
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "2.0.0"
     }
 }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v3/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v3/composer.json
@@ -7,6 +7,6 @@
         "class": "Installer\\Plugin2"
     },
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "2.0.0"
     }
 }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v4/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v4/composer.json
@@ -10,6 +10,6 @@
         ]
     },
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "2.0.0"
     }
 }

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -95,7 +95,7 @@ class ComposerRepositoryTest extends TestCase
         );
     }
 
-    public function testLoadRecursively()
+    public function testLoadName()
     {
         $repo = $this->getMockBuilder('Composer\Repository\ComposerRepository')
             ->disableOriginalConstructor()
@@ -148,7 +148,7 @@ class ComposerRepositoryTest extends TestCase
         $versionParser = new VersionParser();
 
         $that = $this;
-        $packages = $repo->loadRecursively(array('a'), function ($name, $stability) use ($that) {
+        $packages = $repo->loadName('a', function ($name, $stability) use ($that) {
             $that->assertEquals('a', $name);
             return true;
         });

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -96,7 +96,7 @@ class ComposerRepositoryTest extends TestCase
         );
     }
 
-    public function testWhatProvides()
+    public function testLoadRecursively()
     {
         $repo = $this->getMockBuilder('Composer\Repository\ComposerRepository')
             ->disableOriginalConstructor()
@@ -124,45 +124,41 @@ class ComposerRepositoryTest extends TestCase
             ->method('fetchFile')
             ->will($this->returnValue(array(
                 'packages' => array(
-                    array(array(
-                        'uid' => 1,
-                        'name' => 'a',
-                        'version' => 'dev-master',
-                        'extra' => array('branch-alias' => array('dev-master' => '1.0.x-dev')),
-                    )),
-                    array(array(
-                        'uid' => 2,
-                        'name' => 'a',
-                        'version' => 'dev-develop',
-                        'extra' => array('branch-alias' => array('dev-develop' => '1.1.x-dev')),
-                    )),
-                    array(array(
-                        'uid' => 3,
-                        'name' => 'a',
-                        'version' => '0.6',
-                    )),
+                    'a' => array(
+                        'dev-master' => array(
+                            'uid' => 1,
+                            'name' => 'a',
+                            'version' => 'dev-master',
+                            'extra' => array('branch-alias' => array('dev-master' => '1.0.x-dev')),
+                        ),
+                        'dev-develop' => array(
+                            'uid' => 2,
+                            'name' => 'a',
+                            'version' => 'dev-develop',
+                            'extra' => array('branch-alias' => array('dev-develop' => '1.1.x-dev')),
+                        ),
+                        '0.6' => array(
+                            'uid' => 3,
+                            'name' => 'a',
+                            'version' => '0.6',
+                        ),
+                    ),
                 )
             )));
 
-        $pool = $this->getMock('Composer\DependencyResolver\Pool');
-        $pool->expects($this->any())
-            ->method('isPackageAcceptable')
-            ->will($this->returnValue(true));
-
         $versionParser = new VersionParser();
-        $repo->setRootAliases(array(
-            'a' => array(
-                $versionParser->normalize('0.6') => array('alias' => 'dev-feature', 'alias_normalized' => $versionParser->normalize('dev-feature')),
-                $versionParser->normalize('1.1.x-dev') => array('alias' => '1.0', 'alias_normalized' => $versionParser->normalize('1.0')),
-            ),
-        ));
 
-        $packages = $repo->whatProvides($pool, 'a');
+        $that = $this;
+        $packages = $repo->loadRecursively(array('a'), function ($name, $stability) use ($that) {
+            $that->assertEquals('a', $name);
+            return true;
+        });
 
-        $this->assertCount(7, $packages);
-        $this->assertEquals(array('1', '1-alias', '2', '2-alias', '2-root', '3', '3-root'), array_keys($packages));
-        $this->assertInstanceOf('Composer\Package\AliasPackage', $packages['2-root']);
-        $this->assertSame($packages['2'], $packages['2-root']->getAliasOf());
-        $this->assertSame($packages['2'], $packages['2-alias']->getAliasOf());
+        $this->assertCount(5, $packages);
+        $this->assertEquals(array('1.0.x-dev', 'dev-master', '1.1.x-dev', 'dev-develop', '0.6'), array_map(function ($p) {
+            return $p->getPrettyVersion();
+        }, $packages));
+        $this->assertInstanceOf('Composer\Package\AliasPackage', $packages[2]);
+        $this->assertSame($packages[3], $packages[2]->getAliasOf());
     }
 }

--- a/tests/Composer/Test/Repository/RepositorySetTest.php
+++ b/tests/Composer/Test/Repository/RepositorySetTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\DependencyResolver;
+
+use Composer\Repository\ArrayRepository;
+use Composer\Repository\RepositorySet;
+use Composer\Package\BasePackage;
+use Composer\TestCase;
+
+class RepositorySetTest extends TestCase
+{
+/*    public function testPoolIgnoresIrrelevantPackages()
+    {
+        $pool = new Pool('stable', array('bar' => BasePackage::STABILITY_BETA));
+        $repo = new ArrayRepository;
+        $repo->addPackage($package = $this->getPackage('bar', '1'));
+        $repo->addPackage($betaPackage = $this->getPackage('bar', '1-beta'));
+        $repo->addPackage($alphaPackage = $this->getPackage('bar', '1-alpha'));
+        $repo->addPackage($package2 = $this->getPackage('foo', '1'));
+        $repo->addPackage($rcPackage2 = $this->getPackage('foo', '1rc'));
+
+        $pool->addRepository($repo);
+
+        $this->assertEquals(array($package, $betaPackage), $pool->whatProvides('bar'));
+        $this->assertEquals(array($package2), $pool->whatProvides('foo'));
+    }
+ */
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testGetPriorityForNotRegisteredRepository()
+    {
+        $set = new RepositorySet;
+        $repository = new ArrayRepository;
+
+        $set->getPriority($repository);
+    }
+
+    public function testGetPriorityWhenRepositoryIsRegistered()
+    {
+        $set = new RepositorySet;
+        $firstRepository = new ArrayRepository;
+        $set->addRepository($firstRepository);
+        $secondRepository = new ArrayRepository;
+        $set->addRepository($secondRepository);
+
+        $firstPriority = $set->getPriority($firstRepository);
+        $secondPriority = $set->getPriority($secondRepository);
+
+        $this->assertEquals(0, $firstPriority);
+        $this->assertEquals(-1, $secondPriority);
+    }
+
+/*    public function testWhatProvidesSamePackageForDifferentRepositories()
+    {
+        $pool = new Pool;
+        $firstRepository = new ArrayRepository;
+        $secondRepository = new ArrayRepository;
+
+        $firstPackage = $this->getPackage('foo', '1');
+        $secondPackage = $this->getPackage('foo', '1');
+        $thirdPackage = $this->getPackage('foo', '2');
+
+        $firstRepository->addPackage($firstPackage);
+        $secondRepository->addPackage($secondPackage);
+        $secondRepository->addPackage($thirdPackage);
+
+        $pool->addRepository($firstRepository);
+        $pool->addRepository($secondRepository);
+
+        $this->assertEquals(array($firstPackage, $secondPackage, $thirdPackage), $pool->whatProvides('foo'));
+    }
+
+    public function testWhatProvidesPackageWithConstraint()
+    {
+        $pool = new Pool;
+        $repository = new ArrayRepository;
+
+        $firstPackage = $this->getPackage('foo', '1');
+        $secondPackage = $this->getPackage('foo', '2');
+
+        $repository->addPackage($firstPackage);
+        $repository->addPackage($secondPackage);
+
+        $pool->addRepository($repository);
+
+        $this->assertEquals(array($firstPackage, $secondPackage), $pool->whatProvides('foo'));
+        $this->assertEquals(array($secondPackage), $pool->whatProvides('foo', $this->getVersionConstraint('==', '2')));
+    }
+
+    public function testPackageById()
+    {
+        $pool = new Pool;
+        $repository = new ArrayRepository;
+        $package = $this->getPackage('foo', '1');
+
+        $repository->addPackage($package);
+        $pool->addRepository($repository);
+
+        $this->assertSame($package, $pool->packageById(1));
+    }
+
+    public function testWhatProvidesWhenPackageCannotBeFound()
+    {
+        $pool = new Pool;
+
+        $this->assertEquals(array(), $pool->whatProvides('foo'));
+    }*/
+}


### PR DESCRIPTION
This is a fixed version of https://github.com/composer/composer/pull/3994

Todo:
- [ ] RepositorySetTest
- [ ] don't use object state to construct pool in RepositorySet
- [x] move request name collection logic into request - solver should take repo set
- [ ] evaluate if RepositorySet and CompositeRepository should be merged
- [ ] refactor policy to work with repositoryset in addition to pool
- [ ] remove uses of small pools from installer
- [ ] this should be empty: `grep -ri "pool" src/ | grep -v "src/Composer/DependencyResolver"`
