### PR TITLE
download correct Bitbucket archive reference when using --prefer-dist

### DIFF
--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -115,10 +115,11 @@ abstract class ArchiveDownloader extends FileDownloader
                 // update api archives to the proper reference
                 $url = 'https://api.github.com/repos/' . $match[1] . '/'. $match[2] . '/' . $match[3] . 'ball/' . $package->getDistReference();
             }
-        }
-
-        if (!extension_loaded('openssl') && (0 === strpos($url, 'https:') || 0 === strpos($url, 'http://github.com'))) {
-            throw new \RuntimeException('You must enable the openssl extension to download files via https');
+        } else if ($package->getDistReference() && strpos($url, 'bitbucket.org')) {
+            if (preg_match('{^https?://(?:www\.)?bitbucket\.org/([^/]+)/([^/]+)/get/(.+)\.(zip|tar\.gz|tar\.bz2)$}i', $url, $match)) {
+                // update Bitbucket archives to the proper reference
+                $url = 'https://bitbucket.org/' . $match[1] . '/'. $match[2] . '/get/' . $package->getDistReference() . '.' . $match[4];
+            }
         }
 
         return parent::processUrl($package, $url);

--- a/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
@@ -115,4 +115,38 @@ class ArchiveDownloaderTest extends \PHPUnit_Framework_TestCase
             array('https://github.com/composer/composer/archive/master.tar.gz'),
         );
     }
+
+    /**
+     * @dataProvider provideBitbucketUrls
+     */
+    public function testProcessUrlRewriteBitbucketDist($url, $extension)
+    {
+        if (!extension_loaded('openssl')) {
+            $this->markTestSkipped('Requires openssl');
+        }
+
+        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMock('Composer\IO\IOInterface'), $this->getMock('Composer\Config')));
+        $method = new \ReflectionMethod($downloader, 'processUrl');
+        $method->setAccessible(true);
+
+        $url = $url . '.' . $extension;
+        $expected = 'https://bitbucket.org/davereid/drush-virtualhost/get/ref.' . $extension;
+
+        $package = $this->getMock('Composer\Package\PackageInterface');
+        $package->expects($this->any())
+            ->method('getDistReference')
+            ->will($this->returnValue('ref'));
+        $url = $method->invoke($downloader, $package, $url);
+
+        $this->assertEquals($expected, $url);
+    }
+
+    public function provideBitbucketUrls()
+    {
+        return array(
+            array('https://bitbucket.org/davereid/drush-virtualhost/get/77ca490c26ac818e024d1138aa8bd3677d1ef21f', 'zip'),
+            array('https://bitbucket.org/davereid/drush-virtualhost/get/master', 'tar.gz'),
+            array('https://bitbucket.org/davereid/drush-virtualhost/get/v1.0', 'tar.bz2'),
+        );
+    }
 }


### PR DESCRIPTION
The issue mentioned on http://benramsey.com/blog/2015/06/composer-missing-distributions/ should be fixed by this PR.

BTW I removed the throw here because the parent::processUrl call already does that check.