### PR TITLE
Set this test as slow

### DIFF
--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -137,6 +137,9 @@ class RemoteFilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->callCallbackGet($fs, STREAM_NOTIFY_FAILURE, 0, 'HTTP/1.1 404 Not Found', 404, 0, 0));
     }
 
+    /**
+     * @group slow
+     */
     public function testCaptureAuthenticationParamsFromUrl()
     {
         $io = $this->getMock('Composer\IO\IOInterface');


### PR DESCRIPTION
This test requires internet connectivity.

I notice other test are set as "slow" (the pear ones).
Perhaps a group "online" will be better.

This will allow to run test suite from computer without network.

Reproducer:

    echo "# nothing" > /etc/resolv.conf
    phpunit -v
    1) Composer\Test\Util\RemoteFilesystemTest::testCaptureAuthenticationParamsFromUrl
Failed asserting that 0 matches expected 404.

