### PR TITLE
Explicitly check if a file has already been required before requiring it

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -605,7 +605,14 @@ METHOD_FOOTER;
 
 function composerRequire$suffix(\$file)
 {
-    require \$file;
+    static \$requiredFiles = [];
+    \$fileSignature = md5_file(\$file);
+
+    if (empty(\$requiredFiles[\$fileSignature])) {
+        require \$file;
+
+        \$requiredFiles[\$fileSignature] = true;
+    }
 }
 
 FOOTER;

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -51,5 +51,12 @@ class ComposerAutoloaderInitFilesAutoloadOrder
 
 function composerRequireFilesAutoloadOrder($file)
 {
-    require $file;
+    static $requiredFiles = [];
+    $fileSignature = md5_file($file);
+
+    if (empty($requiredFiles[$fileSignature])) {
+        require $file;
+
+        $requiredFiles[$fileSignature] = true;
+    }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -51,5 +51,12 @@ class ComposerAutoloaderInitFilesAutoload
 
 function composerRequireFilesAutoload($file)
 {
-    require $file;
+    static $requiredFiles = [];
+    $fileSignature = md5_file($file);
+
+    if (empty($requiredFiles[$fileSignature])) {
+        require $file;
+
+        $requiredFiles[$fileSignature] = true;
+    }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -67,5 +67,12 @@ class ComposerAutoloaderInitIncludePath
 
 function composerRequireIncludePath($file)
 {
-    require $file;
+    static $requiredFiles = [];
+    $fileSignature = md5_file($file);
+
+    if (empty($requiredFiles[$fileSignature])) {
+        require $file;
+
+        $requiredFiles[$fileSignature] = true;
+    }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -71,5 +71,12 @@ class ComposerAutoloaderInitTargetDir
 
 function composerRequireTargetDir($file)
 {
-    require $file;
+    static $requiredFiles = [];
+    $fileSignature = md5_file($file);
+
+    if (empty($requiredFiles[$fileSignature])) {
+        require $file;
+
+        $requiredFiles[$fileSignature] = true;
+    }
 }


### PR DESCRIPTION
This would address #3003 at the considerable cost of calculating each autoloaded file's md5 before including it. Calculating and tracking file hashes is preferable to `require_once` in this case because it prevents two copies of the same file from being loaded, as would happen if a package is installed globally and in a project.