### PR TITLE
Explicitly check if a file has already been required before requiring it

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -410,8 +410,9 @@ EOF;
     protected function getIncludeFilesFile(array $files, Filesystem $filesystem, $basePath, $vendorPath, $vendorPathCode, $appBaseDirCode)
     {
         $filesCode = '';
-        foreach ($files as $functionFile) {
-            $filesCode .= '    '.$this->getPathCode($filesystem, $basePath, $vendorPath, $functionFile).",\n";
+        foreach ($files as $fileIdentifier => $functionFile) {
+            $filesCode .= '    ' . $fileIdentifier . ' => '
+                . $this->getPathCode($filesystem, $basePath, $vendorPath, $functionFile) . ",\n";
         }
 
         if (!$filesCode) {
@@ -584,8 +585,8 @@ REGISTER_LOADER;
         if ($useIncludeFiles) {
             $file .= <<<INCLUDE_FILES
         \$includeFiles = require __DIR__ . '/autoload_files.php';
-        foreach (\$includeFiles as \$file) {
-            composerRequire$suffix(\$file);
+        foreach (\$includeFiles as \$fileIdentifier => \$file) {
+            composerRequire$suffix(\$fileIdentifier, \$file);
         }
 
 
@@ -603,17 +604,16 @@ METHOD_FOOTER;
         return $file . <<<FOOTER
 }
 
-function composerRequire$suffix(\$file)
+function composerRequire$suffix(\$fileIdentifier, \$file)
 {
     if (empty(\$GLOBALS['composerRequiredFiles'])) {
         \$GLOBALS['composerRequiredFiles'] = array();
     }
-    \$fileSignature = md5_file(\$file);
 
-    if (empty(\$GLOBALS['composerRequiredFiles'][\$fileSignature])) {
+    if (empty(\$GLOBALS['composerRequiredFiles'][\$fileIdentifier])) {
         require \$file;
 
-        \$GLOBALS['composerRequiredFiles'][\$fileSignature] = true;
+        \$GLOBALS['composerRequiredFiles'][\$fileIdentifier] = true;
     }
 }
 
@@ -655,7 +655,11 @@ FOOTER;
 
                     $relativePath = empty($installPath) ? (empty($path) ? '.' : $path) : $installPath.'/'.$path;
 
-                    if ($type === 'files' || $type === 'classmap') {
+                    if ($type === 'files') {
+                        $autoloads[var_export($this->getFileIdentifier($relativePath), true)]
+                            = $relativePath;
+                        continue;
+                    } elseif ($type === 'classmap') {
                         $autoloads[] = $relativePath;
                         continue;
                     }
@@ -666,6 +670,11 @@ FOOTER;
         }
 
         return $autoloads;
+    }
+
+    protected function getFileIdentifier($path)
+    {
+        return md5_file($path);
     }
 
     /**

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -606,7 +606,7 @@ METHOD_FOOTER;
 function composerRequire$suffix(\$file)
 {
     if (empty(\$GLOBALS['composerRequiredFiles'])) {
-        \$GLOBALS['composerRequiredFiles'] = [];
+        \$GLOBALS['composerRequiredFiles'] = array();
     }
     \$fileSignature = md5_file(\$file);
 

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -605,7 +605,14 @@ METHOD_FOOTER;
 
 function composerRequire$suffix(\$file)
 {
-    require \$file;
+    static \$requiredFiles = array();
+    \$fileSignature = md5_file(\$file);
+
+    if (empty(\$requiredFiles[\$fileSignature])) {
+        require \$file;
+
+        \$requiredFiles[\$fileSignature] = true;
+    }
 }
 
 FOOTER;

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -605,13 +605,15 @@ METHOD_FOOTER;
 
 function composerRequire$suffix(\$file)
 {
-    static \$requiredFiles = array();
+    if (empty(\$GLOBALS['composerRequiredFiles'])) {
+        \$GLOBALS['composerRequiredFiles'] = [];
+    }
     \$fileSignature = md5_file(\$file);
 
-    if (empty(\$requiredFiles[\$fileSignature])) {
+    if (empty(\$GLOBALS['composerRequiredFiles'][\$fileSignature])) {
         require \$file;
 
-        \$requiredFiles[\$fileSignature] = true;
+        \$GLOBALS['composerRequiredFiles'][\$fileSignature] = true;
     }
 }
 

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -1003,8 +1003,8 @@ EOF;
         $this->assertEquals($expectedNamespace, file_get_contents($vendorDir.'/composer/autoload_namespaces.php'));
         $this->assertEquals($expectedPsr4, file_get_contents($vendorDir.'/composer/autoload_psr4.php'));
         $this->assertEquals($expectedClassmap, file_get_contents($vendorDir.'/composer/autoload_classmap.php'));
-        $this->assertContains("\n    \$vendorDir . '/b/b/bootstrap.php',\n", file_get_contents($vendorDir.'/composer/autoload_files.php'));
-        $this->assertContains("\n    \$baseDir . '/test.php',\n", file_get_contents($vendorDir.'/composer/autoload_files.php'));
+        $this->assertContains("\$vendorDir . '/b/b/bootstrap.php',\n", file_get_contents($vendorDir.'/composer/autoload_files.php'));
+        $this->assertContains("\$baseDir . '/test.php',\n", file_get_contents($vendorDir.'/composer/autoload_files.php'));
     }
 
     public function testUpLevelRelativePaths()
@@ -1079,7 +1079,7 @@ EOF;
         $this->assertEquals($expectedNamespace, file_get_contents($this->vendorDir.'/composer/autoload_namespaces.php'));
         $this->assertEquals($expectedPsr4, file_get_contents($this->vendorDir.'/composer/autoload_psr4.php'));
         $this->assertEquals($expectedClassmap, file_get_contents($this->vendorDir.'/composer/autoload_classmap.php'));
-        $this->assertContains("\n    \$baseDir . '/../test.php',\n", file_get_contents($this->vendorDir.'/composer/autoload_files.php'));
+        $this->assertContains("\$baseDir . '/../test.php',\n", file_get_contents($this->vendorDir.'/composer/autoload_files.php'));
     }
 
     public function testEmptyPaths()

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_files.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_files.php
@@ -6,6 +6,6 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
-    $baseDir . '/foo.php',
-    $baseDir . '/bar.php',
+    '25b429360a61ca2629fdf9a4f484981c' => $baseDir . '/foo.php',
+    '524f65941cc9a0fa65ff0ec097ccde8a' => $baseDir . '/bar.php',
 );

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_files2.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_files2.php
@@ -6,5 +6,5 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
-    $baseDir . '/devfiles/foo.php',
+    'fc1e99cd93a6aa58e3b1565e688bcd87' => $baseDir . '/devfiles/foo.php',
 );

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_files_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_files_functions.php
@@ -6,9 +6,9 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
-    $vendorDir . '/a/a/test.php',
-    $vendorDir . '/b/b/test2.php',
-    $vendorDir . '/c/c/foo/bar/test3.php',
-    $vendorDir . '/c/c/foo/bar/test4.php',
-    $baseDir . '/root.php',
+    'b18a3c4a24b1dc69fdd96098e5c28e01' => $vendorDir . '/a/a/test.php',
+    '93797e35718fdafb825b1fe25c08a92c' => $vendorDir . '/b/b/test2.php',
+    'a57008eef928ced7c299bfea724d8441' => $vendorDir . '/c/c/foo/bar/test3.php',
+    '32e13a06a803ac6553a93454bcd3d2da' => $vendorDir . '/c/c/foo/bar/test4.php',
+    '504bb142db8acef729eeeb06b0aedec5' => $baseDir . '/root.php',
 );

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_files_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_files_target_dir.php
@@ -6,6 +6,6 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
-    $baseDir . '/foo.php',
-    $baseDir . '/bar.php',
+    '25b429360a61ca2629fdf9a4f484981c' => $baseDir . '/foo.php',
+    '524f65941cc9a0fa65ff0ec097ccde8a' => $baseDir . '/bar.php',
 );

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -52,7 +52,7 @@ class ComposerAutoloaderInitFilesAutoloadOrder
 function composerRequireFilesAutoloadOrder($file)
 {
     if (empty($GLOBALS['composerRequiredFiles'])) {
-        $GLOBALS['composerRequiredFiles'] = [];
+        $GLOBALS['composerRequiredFiles'] = array();
     }
     $fileSignature = md5_file($file);
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -51,5 +51,12 @@ class ComposerAutoloaderInitFilesAutoloadOrder
 
 function composerRequireFilesAutoloadOrder($file)
 {
-    require $file;
+    static $requiredFiles = array();
+    $fileSignature = md5_file($file);
+
+    if (empty($requiredFiles[$fileSignature])) {
+        require $file;
+
+        $requiredFiles[$fileSignature] = true;
+    }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -51,12 +51,14 @@ class ComposerAutoloaderInitFilesAutoloadOrder
 
 function composerRequireFilesAutoloadOrder($file)
 {
-    static $requiredFiles = array();
+    if (empty($GLOBALS['composerRequiredFiles'])) {
+        $GLOBALS['composerRequiredFiles'] = [];
+    }
     $fileSignature = md5_file($file);
 
-    if (empty($requiredFiles[$fileSignature])) {
+    if (empty($GLOBALS['composerRequiredFiles'][$fileSignature])) {
         require $file;
 
-        $requiredFiles[$fileSignature] = true;
+        $GLOBALS['composerRequiredFiles'][$fileSignature] = true;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -41,24 +41,23 @@ class ComposerAutoloaderInitFilesAutoloadOrder
         $loader->register(true);
 
         $includeFiles = require __DIR__ . '/autoload_files.php';
-        foreach ($includeFiles as $file) {
-            composerRequireFilesAutoloadOrder($file);
+        foreach ($includeFiles as $fileIdentifier => $file) {
+            composerRequireFilesAutoloadOrder($fileIdentifier, $file);
         }
 
         return $loader;
     }
 }
 
-function composerRequireFilesAutoloadOrder($file)
+function composerRequireFilesAutoloadOrder($fileIdentifier, $file)
 {
     if (empty($GLOBALS['composerRequiredFiles'])) {
         $GLOBALS['composerRequiredFiles'] = array();
     }
-    $fileSignature = md5_file($file);
 
-    if (empty($GLOBALS['composerRequiredFiles'][$fileSignature])) {
+    if (empty($GLOBALS['composerRequiredFiles'][$fileIdentifier])) {
         require $file;
 
-        $GLOBALS['composerRequiredFiles'][$fileSignature] = true;
+        $GLOBALS['composerRequiredFiles'][$fileIdentifier] = true;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -51,5 +51,12 @@ class ComposerAutoloaderInitFilesAutoload
 
 function composerRequireFilesAutoload($file)
 {
-    require $file;
+    static $requiredFiles = array();
+    $fileSignature = md5_file($file);
+
+    if (empty($requiredFiles[$fileSignature])) {
+        require $file;
+
+        $requiredFiles[$fileSignature] = true;
+    }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -41,24 +41,23 @@ class ComposerAutoloaderInitFilesAutoload
         $loader->register(true);
 
         $includeFiles = require __DIR__ . '/autoload_files.php';
-        foreach ($includeFiles as $file) {
-            composerRequireFilesAutoload($file);
+        foreach ($includeFiles as $fileIdentifier => $file) {
+            composerRequireFilesAutoload($fileIdentifier, $file);
         }
 
         return $loader;
     }
 }
 
-function composerRequireFilesAutoload($file)
+function composerRequireFilesAutoload($fileIdentifier, $file)
 {
     if (empty($GLOBALS['composerRequiredFiles'])) {
         $GLOBALS['composerRequiredFiles'] = array();
     }
-    $fileSignature = md5_file($file);
 
-    if (empty($GLOBALS['composerRequiredFiles'][$fileSignature])) {
+    if (empty($GLOBALS['composerRequiredFiles'][$fileIdentifier])) {
         require $file;
 
-        $GLOBALS['composerRequiredFiles'][$fileSignature] = true;
+        $GLOBALS['composerRequiredFiles'][$fileIdentifier] = true;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -52,7 +52,7 @@ class ComposerAutoloaderInitFilesAutoload
 function composerRequireFilesAutoload($file)
 {
     if (empty($GLOBALS['composerRequiredFiles'])) {
-        $GLOBALS['composerRequiredFiles'] = [];
+        $GLOBALS['composerRequiredFiles'] = array();
     }
     $fileSignature = md5_file($file);
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -51,12 +51,14 @@ class ComposerAutoloaderInitFilesAutoload
 
 function composerRequireFilesAutoload($file)
 {
-    static $requiredFiles = array();
+    if (empty($GLOBALS['composerRequiredFiles'])) {
+        $GLOBALS['composerRequiredFiles'] = [];
+    }
     $fileSignature = md5_file($file);
 
-    if (empty($requiredFiles[$fileSignature])) {
+    if (empty($GLOBALS['composerRequiredFiles'][$fileSignature])) {
         require $file;
 
-        $requiredFiles[$fileSignature] = true;
+        $GLOBALS['composerRequiredFiles'][$fileSignature] = true;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -67,12 +67,14 @@ class ComposerAutoloaderInitIncludePath
 
 function composerRequireIncludePath($file)
 {
-    static $requiredFiles = array();
+    if (empty($GLOBALS['composerRequiredFiles'])) {
+        $GLOBALS['composerRequiredFiles'] = [];
+    }
     $fileSignature = md5_file($file);
 
-    if (empty($requiredFiles[$fileSignature])) {
+    if (empty($GLOBALS['composerRequiredFiles'][$fileSignature])) {
         require $file;
 
-        $requiredFiles[$fileSignature] = true;
+        $GLOBALS['composerRequiredFiles'][$fileSignature] = true;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -67,5 +67,12 @@ class ComposerAutoloaderInitIncludePath
 
 function composerRequireIncludePath($file)
 {
-    require $file;
+    static $requiredFiles = array();
+    $fileSignature = md5_file($file);
+
+    if (empty($requiredFiles[$fileSignature])) {
+        require $file;
+
+        $requiredFiles[$fileSignature] = true;
+    }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -68,7 +68,7 @@ class ComposerAutoloaderInitIncludePath
 function composerRequireIncludePath($file)
 {
     if (empty($GLOBALS['composerRequiredFiles'])) {
-        $GLOBALS['composerRequiredFiles'] = [];
+        $GLOBALS['composerRequiredFiles'] = array();
     }
     $fileSignature = md5_file($file);
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -65,16 +65,15 @@ class ComposerAutoloaderInitIncludePath
     }
 }
 
-function composerRequireIncludePath($file)
+function composerRequireIncludePath($fileIdentifier, $file)
 {
     if (empty($GLOBALS['composerRequiredFiles'])) {
         $GLOBALS['composerRequiredFiles'] = array();
     }
-    $fileSignature = md5_file($file);
 
-    if (empty($GLOBALS['composerRequiredFiles'][$fileSignature])) {
+    if (empty($GLOBALS['composerRequiredFiles'][$fileIdentifier])) {
         require $file;
 
-        $GLOBALS['composerRequiredFiles'][$fileSignature] = true;
+        $GLOBALS['composerRequiredFiles'][$fileIdentifier] = true;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -71,12 +71,14 @@ class ComposerAutoloaderInitTargetDir
 
 function composerRequireTargetDir($file)
 {
-    static $requiredFiles = array();
+    if (empty($GLOBALS['composerRequiredFiles'])) {
+        $GLOBALS['composerRequiredFiles'] = [];
+    }
     $fileSignature = md5_file($file);
 
-    if (empty($requiredFiles[$fileSignature])) {
+    if (empty($GLOBALS['composerRequiredFiles'][$fileSignature])) {
         require $file;
 
-        $requiredFiles[$fileSignature] = true;
+        $GLOBALS['composerRequiredFiles'][$fileSignature] = true;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -71,5 +71,12 @@ class ComposerAutoloaderInitTargetDir
 
 function composerRequireTargetDir($file)
 {
-    require $file;
+    static $requiredFiles = array();
+    $fileSignature = md5_file($file);
+
+    if (empty($requiredFiles[$fileSignature])) {
+        require $file;
+
+        $requiredFiles[$fileSignature] = true;
+    }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -72,7 +72,7 @@ class ComposerAutoloaderInitTargetDir
 function composerRequireTargetDir($file)
 {
     if (empty($GLOBALS['composerRequiredFiles'])) {
-        $GLOBALS['composerRequiredFiles'] = [];
+        $GLOBALS['composerRequiredFiles'] = array();
     }
     $fileSignature = md5_file($file);
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -43,8 +43,8 @@ class ComposerAutoloaderInitTargetDir
         $loader->register(true);
 
         $includeFiles = require __DIR__ . '/autoload_files.php';
-        foreach ($includeFiles as $file) {
-            composerRequireTargetDir($file);
+        foreach ($includeFiles as $fileIdentifier => $file) {
+            composerRequireTargetDir($fileIdentifier, $file);
         }
 
         return $loader;
@@ -69,16 +69,15 @@ class ComposerAutoloaderInitTargetDir
     }
 }
 
-function composerRequireTargetDir($file)
+function composerRequireTargetDir($fileIdentifier, $file)
 {
     if (empty($GLOBALS['composerRequiredFiles'])) {
         $GLOBALS['composerRequiredFiles'] = array();
     }
-    $fileSignature = md5_file($file);
 
-    if (empty($GLOBALS['composerRequiredFiles'][$fileSignature])) {
+    if (empty($GLOBALS['composerRequiredFiles'][$fileIdentifier])) {
         require $file;
 
-        $GLOBALS['composerRequiredFiles'][$fileSignature] = true;
+        $GLOBALS['composerRequiredFiles'][$fileIdentifier] = true;
     }
 }


### PR DESCRIPTION
This would address #3003 by assigning an identifier to each included file during `AutoloadGenerator::dump`. Currently, this identifier is the value returned by `md5_file` (to address the concern raised in https://github.com/guzzle/guzzle/issues/676#issuecomment-43651280), but it could also be a logical file address such as `$packageName::$relativePath`, e.g. `guzzlehttp/guzzle::src/functions.php`. 

This is preferable to simple changing `require` to `require_once` because it prevents two copies of the same file from being loaded, as would happen if a globally installed package loads project's autoloader and both rely on the same package. A known example of this is using a globally installed copy of CodeCeption on a project requiring Guzzle.

Would also address:
https://github.com/guzzle/guzzle/issues/1146
https://github.com/guzzle/psr7/issues/22