### PR TITLE
Mention need to require autoloader in hooks using functions

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -83,10 +83,8 @@ and command-line executable commands.
 - PHP classes containing defined callbacks must be autoloadable via Composer's
 autoload functionality.
 - If a defined callback relies on functions defined outside of a class, the 
-callback must explicitly require the composer autoloader. If used in a 
-context where`vendor/autoload.php` might not yet exist (such as during a 
-`pre-install` or `pre-update` command), the callback should explicitly require
-whatever files within your root package it needs to execute successfully.
+callback itself is responsible for loading the appropriate files, as no files 
+are autoloaded during Composer commands.
 
 Script definition example:
 
@@ -130,7 +128,7 @@ class MyClass
     public static function postAutoloadDump(Event $event)
     {
         $vendorDir = $event->getComposer()->getConfig()->get('vendor-dir');
-        require "$vendorDir/autoload.php";
+        require $vendorDir . '/autoload.php';
         
         some_function_from_an_autoloaded_file();
     }

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -82,8 +82,11 @@ For any given event:
 and command-line executable commands.
 - PHP classes containing defined callbacks must be autoloadable via Composer's
 autoload functionality.
-- If a defined callback relies on functions defined outside of a class, the callback
-must explicitly require the composer autoloader.
+- If a defined callback relies on functions defined outside of a class, the 
+callback must explicitly require the composer autoloader. If used in a 
+context where`vendor/autoload.php` might not yet exist (such as during a 
+`pre-install` or `pre-update` command), the callback should explicitly require
+whatever files within your root package it needs to execute successfully.
 
 Script definition example:
 

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -84,7 +84,8 @@ and command-line executable commands.
 autoload functionality.
 - If a defined callback relies on functions defined outside of a class, the 
 callback itself is responsible for loading the appropriate files, as no files 
-are autoloaded during Composer commands.
+beyond those required for `psr-0`, `psr-4`, and `classmap` autoloading are 
+loaded during Composer commands.
 
 Script definition example:
 
@@ -99,6 +100,9 @@ Script definition example:
             "MyVendor\\MyClass::warmCache",
             "phpunit -c app/"
         ],
+        "post-autoload-dump": [
+            "MyVendor\\MyClass::postAutoloadDump"
+        ]
         "post-create-project-cmd" : [
             "php -r \"copy('config/local-example.php', 'config/local.php');\""
         ]

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -82,6 +82,8 @@ For any given event:
 and command-line executable commands.
 - PHP classes containing defined callbacks must be autoloadable via Composer's
 autoload functionality.
+- If a defined callback relies on functions defined outside of a class, the callback
+must explicitly require the composer autoloader.
 
 Script definition example:
 
@@ -120,6 +122,14 @@ class MyClass
     {
         $composer = $event->getComposer();
         // do stuff
+    }
+    
+    public static function postAutoloadDump(Event $event)
+    {
+        $vendorDir = $event->getComposer()->getConfig()->get('vendor-dir');
+        require "$vendorDir/autoload.php";
+        
+        some_function_from_an_autoloaded_file();
     }
 
     public static function postPackageInstall(PackageEvent $event)


### PR DESCRIPTION
Add a line and example to the documentation covering the need to require the autoloader file in order to use autoloaded files.

Addresses #4184 