### PR TITLE
Fix: Add missing argument name to method-level docblock

### DIFF
--- a/src/Composer/DependencyResolver/RuleWatchNode.php
+++ b/src/Composer/DependencyResolver/RuleWatchNode.php
@@ -83,7 +83,7 @@ class RuleWatchNode
     /**
      * Given one watched literal, this method returns the other watched literal
      *
-     * @param int The watched literal that should not be returned
+     * @param int $literal The watched literal that should not be returned
      * @return int A literal
      */
     public function getOtherWatch($literal)


### PR DESCRIPTION
This PR

* [x] fixes a docblock where a method argument name is missing