### PR TITLE
Fix #4183 - exclude pattern containing delimiter used throws error

### DIFF
--- a/src/Composer/Package/Archiver/BaseExcludeFilter.php
+++ b/src/Composer/Package/Archiver/BaseExcludeFilter.php
@@ -123,7 +123,7 @@ abstract class BaseExcludeFilter
     protected function generatePattern($rule)
     {
         $negate = false;
-        $pattern = '#';
+        $pattern = '{';
 
         if (strlen($rule) && $rule[0] === '!') {
             $negate = true;
@@ -143,6 +143,6 @@ abstract class BaseExcludeFilter
         // remove delimiters as well as caret (^) and dollar sign ($) from the regex
         $pattern .= substr(Finder\Glob::toRegex($rule), 2, -2) . '(?=$|/)';
 
-        return array($pattern . '#', $negate, false);
+        return array($pattern . '}', $negate, false);
     }
 }

--- a/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
@@ -75,7 +75,8 @@ class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
             'parameters.yml',
             'parameters.yml.dist',
             '!important!.txt',
-            '!important_too!.txt'
+            '!important_too!.txt',
+            '#weirdfile',
         );
 
         foreach ($fileTree as $relativePath) {
@@ -98,7 +99,7 @@ class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
             '!/prefixB.foo',
             '/prefixA.foo',
             'prefixC.*',
-            '!*/*/*/prefixC.foo'
+            '!*/*/*/prefixC.foo',
         );
 
         $this->finder = new ArchivableFilesFinder($this->sources, $excludes);
@@ -106,6 +107,7 @@ class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
         $this->assertArchivableFiles(array(
             '/!important!.txt',
             '/!important_too!.txt',
+            '/#weirdfile',
             '/A/prefixA.foo',
             '/A/prefixD.foo',
             '/A/prefixE.foo',
@@ -170,7 +172,8 @@ class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
             'H/**',
             'J/',
             'parameters.yml',
-            '\!important!.txt'
+            '\!important!.txt',
+            '\#*',
         )));
 
         // git does not currently support negative git attributes
@@ -181,7 +184,7 @@ class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
             //'!/prefixB.foo export-ignore',
             '/prefixA.foo export-ignore',
             'prefixC.* export-ignore',
-            //'!/*/*/prefixC.foo export-ignore'
+            //'!/*/*/prefixC.foo export-ignore',
         )));
 
         $this->finder = new ArchivableFilesFinder($this->sources, array());

--- a/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
+++ b/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
@@ -29,8 +29,8 @@ class GitExcludeFilterTest extends \PHPUnit_Framework_TestCase
     public function patterns()
     {
         return array(
-            array('app/config/parameters.yml', array('#(?=[^\.])app/(?=[^\.])config/(?=[^\.])parameters\.yml(?=$|/)#', false, false)),
-            array('!app/config/parameters.yml', array('#(?=[^\.])app/(?=[^\.])config/(?=[^\.])parameters\.yml(?=$|/)#', true, false)),
+            array('app/config/parameters.yml', array('{(?=[^\.])app/(?=[^\.])config/(?=[^\.])parameters\.yml(?=$|/)}', false, false)),
+            array('!app/config/parameters.yml', array('{(?=[^\.])app/(?=[^\.])config/(?=[^\.])parameters\.yml(?=$|/)}', true, false)),
         );
     }
 }


### PR DESCRIPTION
Added test to reproduce #4183

Not sure on what the best way to fix it would be..

* Escape any delimiter characters used in the pattern?
* Use a different delimiter?

/cc @Seldaek @stof 