### PR TITLE
Fix: Import Symfony\Component\Finder\Finder

### DIFF
--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -13,8 +13,7 @@
 namespace Composer\Package\Archiver;
 
 use Composer\Util\Filesystem;
-
-use Symfony\Component\Finder;
+use Symfony\Component\Finder\Finder;
 
 /**
  * A Symfony Finder wrapper which locates files that should go into archives
@@ -27,7 +26,7 @@ use Symfony\Component\Finder;
 class ArchivableFilesFinder extends \FilterIterator
 {
     /**
-     * @var Symfony\Component\Finder\Finder
+     * @var Finder
      */
     protected $finder;
 
@@ -49,7 +48,7 @@ class ArchivableFilesFinder extends \FilterIterator
             new ComposerExcludeFilter($sources, $excludes),
         );
 
-        $this->finder = new Finder\Finder();
+        $this->finder = new Finder();
 
         $filter = function (\SplFileInfo $file) use ($sources, $filters, $fs) {
             if ($file->isLink() && strpos($file->getLinkTarget(), $sources) !== 0) {


### PR DESCRIPTION
This PR

* [x] imports `Symfony\Component\Finder\Finder`, fixing a docblock