### PR TITLE
>=2.3.0 now includes pre-releases, added docs for this and -stable suffix Fixes #4080.

### DIFF
--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -94,6 +94,29 @@ so using [stability flags](04-schema.md#package-links). To change that for all
 packages instead of doing per dependency you can also use the
 [minimum-stability](04-schema.md#minimum-stability) setting.
 
+If you are using range comparisons when selecting non-stable packages, and you
+specify a numeric version number (that is, no suffix indicating alpha, beta,
+rc, or stable), then both non-stable and stable versions of a particular
+release number will be treated as equally valid.
+
+ * `>=`/`<=` will accept non-stable releases as well as the stable release.
+ * `<`/`>` will reject non-stable releasese as well as the stable release.
+
+If you wish to consider only the stable release in the comparison, add the
+suffix `-stable` to the version number.
+
+Here are some examples:
+
+ Example         | Interpretation
+ --------------- | --------------
+`>=1.0.0`        | Any release, stable or non-, of 1.0.0 will be allowed
+`>=1.0.0-stable` | Only the stable release of 1.0.0 will be allowed
+`<2.0.0`         | Neither release, stable or non-, of 2.0.0 will be allowed
+`<2.0.0-stable`  | Only the stable release of 2.0.0 will be disallowed; non-stable releases will be allowed
+
+Note that the packages matched by these constraints are still checked against
+the `minimum-stability` setting and each package's stability flags.
+
 ### Test version constraints
 
 You can test version constraints using [semver.mwl.be](http://semver.mwl.be). Fill in

--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -443,9 +443,11 @@ class VersionParser
 
                 if (!empty($stabilityModifier) && $this->parseStability($version) === 'stable') {
                     $version .= '-' . $stabilityModifier;
-                } elseif ('<' === $matches[1]) {
+                } elseif ('<' === $matches[1] || '>=' === $matches[1]) {
                     if (!preg_match('/-' . self::$modifierRegex . '$/', strtolower($matches[2]))) {
-                        $version .= '-dev';
+                        if (substr($matches[2], 0, 4) !== 'dev-') {
+                            $version .= '-dev';
+                        }
                     }
                 }
 

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -244,13 +244,13 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             'greater than'      => array('>1.0.0',      new VersionConstraint('>', '1.0.0.0')),
             'lesser than'       => array('<1.2.3.4',    new VersionConstraint('<', '1.2.3.4-dev')),
             'less/eq than'      => array('<=1.2.3',     new VersionConstraint('<=', '1.2.3.0')),
-            'great/eq than'     => array('>=1.2.3',     new VersionConstraint('>=', '1.2.3.0')),
+            'great/eq than'     => array('>=1.2.3',     new VersionConstraint('>=', '1.2.3.0-dev')),
             'equals'            => array('=1.2.3',      new VersionConstraint('=', '1.2.3.0')),
             'double equals'     => array('==1.2.3',     new VersionConstraint('=', '1.2.3.0')),
             'no op means eq'    => array('1.2.3',       new VersionConstraint('=', '1.2.3.0')),
             'completes version' => array('=1.0',        new VersionConstraint('=', '1.0.0.0')),
             'shorthand beta'    => array('1.2.3b5',     new VersionConstraint('=', '1.2.3.0-beta5')),
-            'accepts spaces'    => array('>= 1.2.3',    new VersionConstraint('>=', '1.2.3.0')),
+            'accepts spaces'    => array('>= 1.2.3',    new VersionConstraint('>=', '1.2.3.0-dev')),
             'accepts spaces/2'  => array('< 1.2.3',     new VersionConstraint('<', '1.2.3.0-dev')),
             'accepts spaces/3'  => array('> 1.2.3',     new VersionConstraint('>', '1.2.3.0')),
             'accepts master'    => array('>=dev-master',    new VersionConstraint('>=', '9999999-dev')),
@@ -260,6 +260,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             'regression #935'   => array('dev-CAPS',        new VersionConstraint('=', 'dev-CAPS')),
             'ignores aliases'   => array('dev-master as 1.0.0', new VersionConstraint('=', '9999999-dev')),
             'lesser than override'       => array('<1.2.3.4-stable',    new VersionConstraint('<', '1.2.3.4')),
+            'great/eq than override'     => array('>=1.2.3.4-stable',   new VersionConstraint('>=', '1.2.3.4')),
         );
     }
 


### PR DESCRIPTION
On the 4080 ticket we concluded that the feature works correctly but could use documentation.

However, I also noticed that >=2.3.0 was inconsistent with the general rule "when stabilities aren't specified, treat all pre-releases the same way as you treat the stable release". So I've made a functional change as well.