### PR TITLE
Enhancement: Also validate if lock file is up to date

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -341,8 +341,8 @@ php composer.phar validate
 ### Options
 
 * **--no-check-all:** Do not emit a warning if requirements in `composer.json` use unbound version constraints.
+* **--no-check-lock:** Do not emit an error if `composer.lock` exists and is not up to date.
 * **--no-check-publish:** Do not emit an error if `composer.json` is unsuitable for publishing as a package on Packagist but is otherwise valid.
-
 
 ## status
 


### PR DESCRIPTION
This PR

* [x] adds validation of whether `composer.lock` is up to date (if it exists), emits an error and exits with non-zero if it's not
* [x] adds a `--no-lock` option which will emit a warning instead
* [x] updates the docs

:information_desk_person: Useful if you want to break the build because someone modified `composer.json` without updating `composer.lock`.

## Example

Fiddle with `composer.json` in this repository, for example, change

```json
{
    "autoload": {
        "psr-0": { "Composer": "src/" }
    }
}
```

to 

```json
{
    "autoload": {
        "psr-0": { "Composer": "src" }
    }
}
```

### Before

```
$ ./bin/composer validate
./composer.json is valid

$ echo $?
0
```

### After

```
$  ./bin/composer validate
./composer.json is valid
The lock file is not up to date with the latest changes in composer.json.

$ echo $?
1
```

### After  (with `--no-lock` option)

```
$  ./bin/composer validate
./composer.json is valid
The lock file is not up to date with the latest changes in composer.json.

$ echo $?
0
```