### PR TITLE
Output the size of the pool after dependency resolution for users (verbose)

### DIFF
--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -31,7 +31,7 @@ use Composer\Package\PackageInterface;
  * @author Nils Adermann <naderman@naderman.de>
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class Pool
+class Pool implements \Countable
 {
     const MATCH_NAME = -1;
     const MATCH_NONE = 0;
@@ -158,6 +158,14 @@ class Pool
     public function packageById($id)
     {
         return $this->packages[$id - 1];
+    }
+
+    /**
+     * Returns how many packages have been loaded into the pool
+     */
+    public function count()
+    {
+        return count($this->packages);
     }
 
     /**

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -511,6 +511,10 @@ class Installer
             return max(1, $e->getCode());
         }
 
+        if ($this->io->isVerbose()) {
+            $this->io->writeError("Analyzed ".count($pool)." packages to resolve dependencies");
+        }
+
         // force dev packages to be updated if we update or install from a (potentially new) lock
         $operations = $this->processDevPackages($localRepo, $pool, $policy, $repositories, $installedRepo, $lockedRepository, $installFromLock, $withDevReqs, 'force-updates', $operations);
 


### PR DESCRIPTION
Useful to compare pool size changes to the new pool in https://github.com/composer/composer/pull/4163