### PR TITLE
VersionParser: remove a few hundred/thousand array_merge calls

### DIFF
--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -257,11 +257,12 @@ class VersionParser
         foreach ($orConstraints as $constraints) {
             $andConstraints = preg_split('{(?<!^|as|[=>< ,]) *(?<!-)[, ](?!-) *(?!,|as|$)}', $constraints);
             if (count($andConstraints) > 1) {
-                $constraintObjects = array(array());
+                $constraintObjects = array();
                 foreach ($andConstraints as $constraint) {
-                    $constraintObjects[] = $this->parseConstraint($constraint);
+                    foreach ($this->parseConstraint($constraint) as $parsedConstraint) {
+                        $constraintObjects[] = $parsedConstraint;
+                    }
                 }
-                $constraintObjects = call_user_func_array('array_merge', $constraintObjects);
             } else {
                 $constraintObjects = $this->parseConstraint($andConstraints[0]);
             }

--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -257,10 +257,11 @@ class VersionParser
         foreach ($orConstraints as $constraints) {
             $andConstraints = preg_split('{(?<!^|as|[=>< ,]) *(?<!-)[, ](?!-) *(?!,|as|$)}', $constraints);
             if (count($andConstraints) > 1) {
-                $constraintObjects = array();
+                $constraintObjects = array(array());
                 foreach ($andConstraints as $constraint) {
-                    $constraintObjects = array_merge($constraintObjects, $this->parseConstraint($constraint));
+                    $constraintObjects[] = $this->parseConstraint($constraint);
                 }
+                $constraintObjects = call_user_func_array('array_merge', $constraintObjects);
             } else {
                 $constraintObjects = $this->parseConstraint($andConstraints[0]);
             }


### PR DESCRIPTION
This reduces array_merge calls on larger projects by thousands and saves a few hundred kilobytes through fewer more efficient memory allocations: So mostly a small time saver.

Packagist before/after:
```
[148.3MB/7.25s] Memory usage: 148.25MB (peak: 328.81MB), time: 7.25s
[148.2MB/7.01s] Memory usage: 148.24MB (peak: 328.72MB), time: 7.01s
```