### PR TITLE
Fix: Update docs for validate command

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -339,7 +339,8 @@ php composer.phar validate
 
 ### Options
 
-* **--no-check-all:** Whether or not Composer does a complete validation.
+* **--no-check-all:** Do not emit a warning if requirements in `composer.json` use unbound version constraints.
+* **--no-check-publish:** Do not emit an error and exit with non-zero if `composer.json` is unsuitable for publishing as a package on Packagist.
 
 ## status
 


### PR DESCRIPTION
This PR

* [x] updates the documentation for the validate command

Related to #4219, where I spotted that it's not up to date.