### PR TITLE
Reduce rule hash size

### DIFF
--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -43,8 +43,6 @@ class Rule
 
     protected $job;
 
-    protected $ruleHash;
-
     public function __construct(array $literals, $reason, $reasonData, $job = null)
     {
         // sort all packages ascending by id
@@ -58,13 +56,12 @@ class Rule
         $this->job = $job;
         $this->type = -1;
 
-        $data = unpack('ihash', md5(implode(',', $this->literals), true));
-        $this->ruleHash = $data['hash'];
     }
 
     public function getHash()
     {
-        return $this->ruleHash;
+        $data = unpack('ihash', md5(implode(',', $this->literals), true));
+        return $data['hash'];
     }
 
     public function setId($id)
@@ -113,10 +110,6 @@ class Rule
      */
     public function equals(Rule $rule)
     {
-        if ($this->ruleHash !== $rule->ruleHash) {
-            return false;
-        }
-
         if (count($this->literals) != count($rule->literals)) {
             return false;
         }

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -55,12 +55,11 @@ class Rule
         $this->reasonData = $reasonData;
 
         $this->disabled = false;
-
         $this->job = $job;
-
         $this->type = -1;
 
-        $this->ruleHash = substr(md5(implode(',', $this->literals)), 0, 5);
+        $data = unpack('ihash', md5(implode(',', $this->literals), true));
+        $this->ruleHash = $data['hash'];
     }
 
     public function getHash()

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -30,7 +30,8 @@ class RuleTest extends TestCase
     {
         $rule = new Rule(array(123), 'job1', null);
 
-        $this->assertEquals(substr(md5('123'), 0, 5), $rule->getHash());
+        $hash = unpack('ihash', md5('123', true));
+        $this->assertEquals($hash['hash'], $rule->getHash());
     }
 
     public function testSetAndGetId()


### PR DESCRIPTION
The old hash calculation function goes back to a commit 40b3391 from 2012: `substr(md5(implode(',', $this->literals)), 0, 5)` - it uses only 20bit and inefficiently stores them in a 5 byte string. This PR changes this to a 4byte integer, and does not store the hash outside of the rule set.


Before/after comparisons for a few projects:

Composer:
```
[95.5MB/5.78s] Analyzed 15693 rules to resolve dependencies
[67.0MB/1.88s] Memory usage: 67.01MB (peak: 95.75MB), time: 1.88s

[95.5MB/1.67s] Analyzed 15693 rules to resolve dependencies
[67.0MB/1.90s] Memory usage: 67.05MB (peak: 94.3MB), time: 1.9s
```

Packagist:
```
[429.1MB/9.34s] Analyzed 144469 rules to resolve dependencies
[157.0MB/10.96s] Memory usage: 157MB (peak: 429.72MB), time: 10.96s

[417.4MB/13.39s] Analyzed 144469 rules to resolve dependencies
[157.0MB/10.63s] Memory usage: 156.99MB (peak: 417.52MB), time: 10.63s
```

Symfony Standard:
```
[328.2MB/6.68s] Analyzed 94972 rules to resolve dependencies
[148.3MB/7.28s] Memory usage: 148.26MB (peak: 328.74MB), time: 7.28s

[319.6MB/7.02s] Analyzed 94972 rules to resolve dependencies
[148.3MB/7.43s] Memory usage: 148.26MB (peak: 320.1MB), time: 7.43s
```
