### PR TITLE
Reduce memory usage of Rule objects

### DIFF
--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -47,7 +47,7 @@ class Problem
      */
     public function addRule(Rule $rule)
     {
-        $this->addReason($rule->getId(), array(
+        $this->addReason(spl_object_hash($rule), array(
             'rule' => $rule,
             'job' => $rule->getJob(),
         ));

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -29,6 +29,10 @@ class Rule
     const RULE_LEARNED = 12;
     const RULE_PACKAGE_ALIAS = 13;
 
+    const BITFIELD_TYPE = 0;
+    const BITFIELD_REASON = 8;
+    const BITFIELD_DISABLED = 16;
+
     /**
      * READ-ONLY: The literals this rule consists of.
      * @var array
@@ -50,7 +54,9 @@ class Rule
             $this->job = $job;
         }
 
-        $this->bitfield = (0 << 16) | ($reason << 8) | (255 << 0);
+        $this->bitfield = (0 << self::BITFIELD_DISABLED) |
+            ($reason << self::BITFIELD_REASON) |
+            (255 << self::BITFIELD_TYPE);
     }
 
     public function getHash()
@@ -66,7 +72,7 @@ class Rule
 
     public function getReason()
     {
-        return $this->getBitfield(1);
+        return $this->getBitfield(self::BITFIELD_REASON);
     }
 
     public function getReasonData()
@@ -110,32 +116,32 @@ class Rule
 
     public function setType($type)
     {
-        return $this->setBitfield(0, $type);
+        return $this->setBitfield(self::BITFIELD_TYPE, $type);
     }
 
     public function getType()
     {
-        return $this->getBitfield(0);
+        return $this->getBitfield(self::BITFIELD_TYPE);
     }
 
     public function disable()
     {
-        return $this->setBitfield(2, 1);
+        return $this->setBitfield(self::BITFIELD_DISABLED, 1);
     }
 
     public function enable()
     {
-        return $this->setBitfield(2, 0);
+        return $this->setBitfield(self::BITFIELD_DISABLED, 0);
     }
 
     public function isDisabled()
     {
-        return (bool) $this->getBitfield(2);
+        return (bool) $this->getBitfield(self::BITFIELD_DISABLED);
     }
 
     public function isEnabled()
     {
-        return !$this->getBitfield(2);
+        return !$this->getBitfield(self::BITFIELD_DISABLED);
     }
 
     /**
@@ -253,15 +259,13 @@ class Rule
         return implode(', ', $prepared);
     }
 
-    private function getBitfield($var)
+    private function getBitfield($offset)
     {
-        $offset = 8*$var;
         return ($this->bitfield & (255 << $offset)) >> $offset;
     }
 
-    private function setBitfield($var, $value)
+    private function setBitfield($offset, $value)
     {
-        $offset = 8*$var;
         $this->bitfield = ($this->bitfield & ~(255 << $offset)) | ((255 & $value) << $offset);
     }
 

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -116,7 +116,7 @@ class Rule
 
     public function setType($type)
     {
-        return $this->setBitfield(self::BITFIELD_TYPE, $type);
+        $this->setBitfield(self::BITFIELD_TYPE, $type);
     }
 
     public function getType()
@@ -126,12 +126,12 @@ class Rule
 
     public function disable()
     {
-        return $this->setBitfield(self::BITFIELD_DISABLED, 1);
+        $this->setBitfield(self::BITFIELD_DISABLED, 1);
     }
 
     public function enable()
     {
-        return $this->setBitfield(self::BITFIELD_DISABLED, 0);
+        $this->setBitfield(self::BITFIELD_DISABLED, 0);
     }
 
     public function isDisabled()

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -72,7 +72,7 @@ class Rule
 
     public function getReason()
     {
-        return $this->getBitfield(self::BITFIELD_REASON);
+        return ($this->bitfield & (255 << self::BITFIELD_REASON)) >> self::BITFIELD_REASON;
     }
 
     public function getReasonData()
@@ -116,32 +116,32 @@ class Rule
 
     public function setType($type)
     {
-        $this->setBitfield(self::BITFIELD_TYPE, $type);
+        $this->bitfield = ($this->bitfield & ~(255 << self::BITFIELD_TYPE)) | ((255 & $type) << self::BITFIELD_TYPE);
     }
 
     public function getType()
     {
-        return $this->getBitfield(self::BITFIELD_TYPE);
+        return ($this->bitfield & (255 << self::BITFIELD_TYPE)) >> self::BITFIELD_TYPE;
     }
 
     public function disable()
     {
-        $this->setBitfield(self::BITFIELD_DISABLED, 1);
+        $this->bitfield = ($this->bitfield & ~(255 << self::BITFIELD_DISABLED)) | (1 << self::BITFIELD_DISABLED);
     }
 
     public function enable()
     {
-        $this->setBitfield(self::BITFIELD_DISABLED, 0);
+        $this->bitfield = $this->bitfield & ~(255 << self::BITFIELD_DISABLED);
     }
 
     public function isDisabled()
     {
-        return (bool) $this->getBitfield(self::BITFIELD_DISABLED);
+        return (bool) (($this->bitfield & (255 << self::BITFIELD_DISABLED)) >> self::BITFIELD_DISABLED);
     }
 
     public function isEnabled()
     {
-        return !$this->getBitfield(self::BITFIELD_DISABLED);
+        return !(($this->bitfield & (255 << self::BITFIELD_DISABLED)) >> self::BITFIELD_DISABLED);
     }
 
     /**
@@ -257,16 +257,6 @@ class Rule
         }
 
         return implode(', ', $prepared);
-    }
-
-    private function getBitfield($offset)
-    {
-        return ($this->bitfield & (255 << $offset)) >> $offset;
-    }
-
-    private function setBitfield($offset, $value)
-    {
-        $this->bitfield = ($this->bitfield & ~(255 << $offset)) | ((255 & $value) << $offset);
     }
 
     /**

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -50,7 +50,7 @@ class Rule
             $this->job = $job;
         }
 
-        $this->blob = pack('ccc', -1, $reason, false);
+        $this->blob = (0 << 16) | ($reason << 8) | (255 << 0);
     }
 
     public function getHash()
@@ -66,7 +66,7 @@ class Rule
 
     public function getReason()
     {
-        return $this->getBlob('a2');
+        return $this->getBlob(1);
     }
 
     public function getReasonData()
@@ -110,32 +110,32 @@ class Rule
 
     public function setType($type)
     {
-        return $this->setBlob('a1', $type);
+        return $this->setBlob(0, $type);
     }
 
     public function getType()
     {
-        return $this->getBlob('a1');
+        return $this->getBlob(0);
     }
 
     public function disable()
     {
-        return $this->setBlob('a3', true);
+        return $this->setBlob(2, 1);
     }
 
     public function enable()
     {
-        return $this->setBlob('a3', false);
+        return $this->setBlob(2, 0);
     }
 
     public function isDisabled()
     {
-        return (bool) $this->getBlob('a3');
+        return (bool) $this->getBlob(2);
     }
 
     public function isEnabled()
     {
-        return !$this->getBlob('a3');
+        return !$this->getBlob(2);
     }
 
     /**
@@ -255,16 +255,14 @@ class Rule
 
     private function getBlob($var)
     {
-        $current = unpack('c3a', $this->blob);
-        return $current[$var];
+        $offset = 8*$var;
+        return ($this->blob & (255 << $offset)) >> $offset;
     }
 
     private function setBlob($var, $value)
     {
-        $current = unpack('c3a', $this->blob);
-        $current[$var] = $value;
-        array_unshift($current, 'ccc');
-        $this->blob = call_user_func_array('pack', $current);
+        $offset = 8*$var;
+        $this->blob = ($this->blob & ~(255 << $offset)) | ((255 & $value) << $offset);
     }
 
     /**

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -35,7 +35,7 @@ class Rule
      */
     public $literals;
 
-    protected $blob;
+    protected $bitfield;
     protected $reasonData;
 
     public function __construct(array $literals, $reason, $reasonData, $job = null)
@@ -50,7 +50,7 @@ class Rule
             $this->job = $job;
         }
 
-        $this->blob = (0 << 16) | ($reason << 8) | (255 << 0);
+        $this->bitfield = (0 << 16) | ($reason << 8) | (255 << 0);
     }
 
     public function getHash()
@@ -66,7 +66,7 @@ class Rule
 
     public function getReason()
     {
-        return $this->getBlob(1);
+        return $this->getBitfield(1);
     }
 
     public function getReasonData()
@@ -110,32 +110,32 @@ class Rule
 
     public function setType($type)
     {
-        return $this->setBlob(0, $type);
+        return $this->setBitfield(0, $type);
     }
 
     public function getType()
     {
-        return $this->getBlob(0);
+        return $this->getBitfield(0);
     }
 
     public function disable()
     {
-        return $this->setBlob(2, 1);
+        return $this->setBitfield(2, 1);
     }
 
     public function enable()
     {
-        return $this->setBlob(2, 0);
+        return $this->setBitfield(2, 0);
     }
 
     public function isDisabled()
     {
-        return (bool) $this->getBlob(2);
+        return (bool) $this->getBitfield(2);
     }
 
     public function isEnabled()
     {
-        return !$this->getBlob(2);
+        return !$this->getBitfield(2);
     }
 
     /**
@@ -253,16 +253,16 @@ class Rule
         return implode(', ', $prepared);
     }
 
-    private function getBlob($var)
+    private function getBitfield($var)
     {
         $offset = 8*$var;
-        return ($this->blob & (255 << $offset)) >> $offset;
+        return ($this->bitfield & (255 << $offset)) >> $offset;
     }
 
-    private function setBlob($var, $value)
+    private function setBitfield($var, $value)
     {
         $offset = 8*$var;
-        $this->blob = ($this->blob & ~(255 << $offset)) | ((255 & $value) << $offset);
+        $this->bitfield = ($this->bitfield & ~(255 << $offset)) | ((255 & $value) << $offset);
     }
 
     /**

--- a/src/Composer/DependencyResolver/RuleSet.php
+++ b/src/Composer/DependencyResolver/RuleSet.php
@@ -30,7 +30,7 @@ class RuleSet implements \IteratorAggregate, \Countable
     public $ruleById;
 
     protected static $types = array(
-        -1 => 'UNKNOWN',
+        255 => 'UNKNOWN',
         self::TYPE_PACKAGE => 'PACKAGE',
         self::TYPE_JOB => 'JOB',
         self::TYPE_LEARNED => 'LEARNED',
@@ -130,7 +130,7 @@ class RuleSet implements \IteratorAggregate, \Countable
     public function getTypes()
     {
         $types = self::$types;
-        unset($types[-1]);
+        unset($types[255]);
 
         return array_keys($types);
     }

--- a/src/Composer/DependencyResolver/RuleSet.php
+++ b/src/Composer/DependencyResolver/RuleSet.php
@@ -66,7 +66,6 @@ class RuleSet implements \IteratorAggregate, \Countable
         $this->ruleById[$this->nextRuleId] = $rule;
         $rule->setType($type);
 
-        $rule->setId($this->nextRuleId);
         $this->nextRuleId++;
 
         $hash = $rule->getHash();

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -319,7 +319,7 @@ class Solver
 
             $this->rules->add($newRule, RuleSet::TYPE_LEARNED);
 
-            $this->learnedWhy[$newRule->getId()] = $why;
+            $this->learnedWhy[spl_object_hash($newRule)] = $why;
 
             $ruleNode = new RuleWatchNode($newRule);
             $ruleNode->watch2OnHighest($this->decisions);
@@ -454,7 +454,7 @@ class Solver
 
     private function analyzeUnsolvableRule($problem, $conflictRule)
     {
-        $why = $conflictRule->getId();
+        $why = spl_object_hash($conflictRule);
 
         if ($conflictRule->getType() == RuleSet::TYPE_LEARNED) {
             $learnedWhy = $this->learnedWhy[$why];
@@ -572,7 +572,7 @@ class Solver
     private function enableDisableLearnedRules()
     {
         foreach ($this->rules->getIteratorFor(RuleSet::TYPE_LEARNED) as $rule) {
-            $why = $this->learnedWhy[$rule->getId()];
+            $why = $this->learnedWhy[spl_object_hash($rule)];
             $problemRules = $this->learnedPool[$why];
 
             $foundDisabled = false;

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\DependencyResolver;
 
 use Composer\DependencyResolver\Rule;
+use Composer\DependencyResolver\RuleSet;
 use Composer\DependencyResolver\Pool;
 use Composer\Repository\ArrayRepository;
 use Composer\TestCase;
@@ -32,14 +33,6 @@ class RuleTest extends TestCase
 
         $hash = unpack('ihash', md5('123', true));
         $this->assertEquals($hash['hash'], $rule->getHash());
-    }
-
-    public function testSetAndGetId()
-    {
-        $rule = new Rule(array(), 'job1', null);
-        $rule->setId(666);
-
-        $this->assertEquals(666, $rule->getId());
     }
 
     public function testEqualsForRulesWithDifferentHashes()
@@ -69,9 +62,9 @@ class RuleTest extends TestCase
     public function testSetAndGetType()
     {
         $rule = new Rule(array(), 'job1', null);
-        $rule->setType('someType');
+        $rule->setType(RuleSet::TYPE_JOB);
 
-        $this->assertEquals('someType', $rule->getType());
+        $this->assertEquals(RuleSet::TYPE_JOB, $rule->getType());
     }
 
     public function testEnable()


### PR DESCRIPTION
Storing the Rule data in a bitfield and getting rid of their id values saves up to 10% of memory.

This PR includes the commits from the rule hash changes in https://github.com/composer/composer/pull/4234

Comparison before/after: 
- Composer:
```
[96.2MB/1.63s] Analyzed 15693 rules to resolve dependencies
[67.7MB/1.80s] Memory usage: 67.7MB (peak: 96.48MB), time: 1.8s

[90.9MB/1.72s] Analyzed 15693 rules to resolve dependencies
[67.1MB/1.87s] Memory usage: 67.09MB (peak: 91.17MB), time: 1.87s
```
- Packagist:
```
[429.2MB/9.40s] Analyzed 144469 rules to resolve dependencies
[157.1MB/9.97s] Memory usage: 157.1MB (peak: 429.89MB), time: 9.97s

[386.0MB/10.05s] Analyzed 144469 rules to resolve dependencies
[157.1MB/10.52s] Memory usage: 157.09MB (peak: 386.64MB), time: 10.52s
```
- Symfony Standard:
```
[328.9MB/7.58s] Analyzed 94972 rules to resolve dependencies
[148.9MB/7.99s] Memory usage: 148.9MB (peak: 329.47MB), time: 7.99s

[299.4MB/7.15s] Analyzed 94972 rules to resolve dependencies
[148.3MB/7.69s] Memory usage: 148.35MB (peak: 299.88MB), time: 7.69s
```
