### PR TITLE
Always optimize autoloader when classmap is authoritative

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -53,6 +53,10 @@ class AutoloadGenerator
 
     public function dump(Config $config, InstalledRepositoryInterface $localRepo, PackageInterface $mainPackage, InstallationManager $installationManager, $targetDir, $scanPsr0Packages = false, $suffix = '')
     {
+        if ($config->get('classmap-authoritative')) {
+            $scanPsr0Packages = true;
+        }
+
         $this->eventDispatcher->dispatchScript(ScriptEvents::PRE_AUTOLOAD_DUMP, $this->devMode, array(), array(
             'optimize' => (bool) $scanPsr0Packages,
         ));


### PR DESCRIPTION
When the classmap is authoritative, a non-optimized classmap
will mean the autoloader does not load some of the files it is
supposed to. composer require/remove have no way of generating
optimized classmaps and thus would break an installation using
composer in authoritative mode. Thus, there is reason not to use
optimization when classmap-authoritative is enabled.

Fixes #4244