### PR TITLE
Fix: Phrase for missing property during validation

### DIFF
--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -23,18 +23,18 @@ class ComposerSchemaTest extends \PHPUnit_Framework_TestCase
     {
         $json = '{ }';
         $this->assertEquals(array(
-            array('property' => '', 'message' => 'the property name is required'),
-            array('property' => '', 'message' => 'the property description is required'),
+            array('property' => '', 'message' => 'The property "name" is required'),
+            array('property' => '', 'message' => 'The property "description" is required'),
         ), $this->check($json));
 
         $json = '{ "name": "vendor/package" }';
         $this->assertEquals(array(
-            array('property' => '', 'message' => 'the property description is required'),
+            array('property' => '', 'message' => 'The property "description" is required'),
         ), $this->check($json));
 
         $json = '{ "description": "generic description" }';
         $this->assertEquals(array(
-            array('property' => '', 'message' => 'the property name is required'),
+            array('property' => '', 'message' => 'The property "name" is required'),
         ), $this->check($json));
     }
 


### PR DESCRIPTION
This PR

* [x] fixes the half-sentence used for displaying a missing property during schema validation

### Before

```
the property description is required
```

### After

```
The property "description" is required
```