### PR TITLE
Fixed self-update command with non-sha1 version argument

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -83,9 +83,8 @@ EOT
         $latestVersion = trim($remoteFilesystem->getContents(self::HOMEPAGE, $baseUrl. '/version', false));
         $updateVersion = $input->getArgument('version') ?: $latestVersion;
 
-        if (preg_match('{^[0-9a-f]{40}$}', $updateVersion) && $updateVersion !== $latestVersion) {
+        if (!preg_match('{^[0-9a-f]{40}$}', $updateVersion)){
             $this->getIO()->writeError('<error>You can not update to a specific SHA-1 as those phars are not available for download</error>');
-
             return 1;
         }
 


### PR DESCRIPTION
Hi,
I have updated this command that have a weird behavior when we use non corrects arguments:

![composer](https://cloud.githubusercontent.com/assets/1247388/8912842/9ca1017e-3495-11e5-90b3-ed08a8c04393.png)


I think the if statment shouldn't check for 2 conditions but only one on the validity of the hash, because the check between ~~actual~~  updated one and latest sha1 version is already done later.


@Seldaek does it solve the issue ? 

Also, How to realy test it ? This command is not loaded when we are outside of "Phar" context.

