### PR TITLE
Revert "Merge pull request #3975 from marc-mabe/hotfix/3974"

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -351,7 +351,7 @@ class ClassLoader
             foreach ($this->prefixLengthsPsr4[$first] as $prefix => $length) {
                 if (0 === strpos($class, $prefix)) {
                     foreach ($this->prefixDirsPsr4[$prefix] as $dir) {
-                        if (is_file($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
+                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
                             return $file;
                         }
                     }
@@ -361,7 +361,7 @@ class ClassLoader
 
         // PSR-4 fallback dirs
         foreach ($this->fallbackDirsPsr4 as $dir) {
-            if (is_file($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr4)) {
+            if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr4)) {
                 return $file;
             }
         }
@@ -380,7 +380,7 @@ class ClassLoader
             foreach ($this->prefixesPsr0[$first] as $prefix => $dirs) {
                 if (0 === strpos($class, $prefix)) {
                     foreach ($dirs as $dir) {
-                        if (is_file($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
+                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
                             return $file;
                         }
                     }
@@ -390,7 +390,7 @@ class ClassLoader
 
         // PSR-0 fallback dirs
         foreach ($this->fallbackDirsPsr0 as $dir) {
-            if (is_file($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
+            if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
                 return $file;
             }
         }

--- a/tests/Composer/Test/Autoload/ClassLoaderTest.php
+++ b/tests/Composer/Test/Autoload/ClassLoaderTest.php
@@ -9,17 +9,6 @@ use Composer\Autoload\ClassLoader;
  */
 class ClassLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    public function testLoadClassDotPhp()
-    {
-        $loader = new ClassLoader();
-        $loader->add('DirDotPhp\\', __DIR__ . '/Fixtures');
-        $loader->addPsr4('DirDotPhp\\', __DIR__ . '/Fixtures/DirDotPhp/psr4');
-
-        $class = 'DirDotPhp\\Dir';
-        $loader->loadClass($class);
-        $this->assertTrue(class_exists($class, false), "->loadClass() loads '$class'.");
-    }
-
     /**
      * Tests regular PSR-0 and PSR-4 class loading.
      *

--- a/tests/Composer/Test/Autoload/Fixtures/DirDotPhp/Dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/DirDotPhp/Dir.php
@@ -1,6 +1,0 @@
-<?php
-
-namespace DirDotPhp;
-
-class Dir {}
-

--- a/tests/Composer/Test/Autoload/Fixtures/DirDotPhp/psr4/Dir.php/File.php
+++ b/tests/Composer/Test/Autoload/Fixtures/DirDotPhp/psr4/Dir.php/File.php
@@ -1,6 +1,0 @@
-<?php
-
-namespace DirDotPhp\Dir.php;
-
-class File {}
-


### PR DESCRIPTION
This reverts commit bdb6ecb29e9624fb767aa690d09c780249050fc6, reversing
changes made to 8a12e50a16dbc4ddf808b752ad64b412dba272d5.

While working on the [perf of the DebugClassLoader](https://github.com/symfony/symfony/pull/15443), I noticed the change.

`is_file()` makes a stat syscall, which makes it MUCH slower that `file_exists`. Given that the autoloader is already one of the most perf hungry component of the PHP stack, this slows down everyone for almost no reason (but a very rare edge case that does not deserve it).