### PR TITLE
Warn if cache directory cannot be created, refs #1161

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -45,6 +45,7 @@ class Cache
 
         if (!is_dir($this->root)) {
             if (!@mkdir($this->root, 0777, true)) {
+                $this->io->writeError('<warning>Cannot create cache directory ' . $this->root . ', proceeding without cache</warning>');
                 $this->enabled = false;
             }
         }


### PR DESCRIPTION
Let me know if

* [ ] I should add a conditional verbosity check around this warning.

Closes #1161