### PR TITLE
Update the config of the apt addon to the new syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ cache:
     - $HOME/.composer/cache
 
 addons:
-  apt_packages:
-    - parallel
+  apt:
+    packages:
+      - parallel
 
 php:
   - 5.3.3


### PR DESCRIPTION
``apt_packages`` was the syntax for the initial beta previews of the feature.