### PR TITLE
Switch autoload files to require_once rather than require

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -605,7 +605,7 @@ METHOD_FOOTER;
 
 function composerRequire$suffix(\$file)
 {
-    require \$file;
+    require_once \$file;
 }
 
 FOOTER;

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -51,5 +51,5 @@ class ComposerAutoloaderInitFilesAutoloadOrder
 
 function composerRequireFilesAutoloadOrder($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -51,5 +51,5 @@ class ComposerAutoloaderInitFilesAutoload
 
 function composerRequireFilesAutoload($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
@@ -55,5 +55,5 @@ class ComposerAutoloaderInitFilesAutoload
 
 function composerRequireFilesAutoload($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
@@ -46,5 +46,5 @@ class ComposerAutoloaderInitFilesAutoload
 
 function composerRequireFilesAutoload($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -67,5 +67,5 @@ class ComposerAutoloaderInitIncludePath
 
 function composerRequireIncludePath($file)
 {
-    require $file;
+    require_once $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -71,5 +71,5 @@ class ComposerAutoloaderInitTargetDir
 
 function composerRequireTargetDir($file)
 {
-    require $file;
+    require_once $file;
 }


### PR DESCRIPTION
Not quire sure why this was ever `require` given that composer loads classes not side effect files.