### PR TITLE
add another case when package is not found

### DIFF
--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -43,6 +43,10 @@ This is a list of common pitfalls on using Composer, and how to avoid them.
 5. If you are updating to a recently published version of a package, be aware that
    Packagist has a delay of up to 1 minute before new packages are visible to Composer.
 
+6. If you are updating a single package, it may depend on newer versions itself.
+   In this cases add the `--with-dependencies` argument **or** add all dependencies which
+   need an update to the command
+
 ## Package not found on travis-ci.org
 
 1. Check the ["Package not found"](#package-not-found) item above.

--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -45,7 +45,7 @@ This is a list of common pitfalls on using Composer, and how to avoid them.
 
 6. If you are updating a single package, it may depend on newer versions itself.
    In this cases add the `--with-dependencies` argument **or** add all dependencies which
-   need an update to the command
+   need an update to the command.
 
 ## Package not found on travis-ci.org
 


### PR DESCRIPTION
occurred for my when I wanted to update a meta package, where nearly **ALL** dependencies changed their version.