### PR TITLE
Pre-validates composer packages before adding them to the pool

### DIFF
--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -296,6 +296,16 @@ class Pool implements \Countable
         return $prefix.' '.$package->getPrettyString();
     }
 
+    public function doesPackageMatchRequires($name, $version)
+    {
+        if (isset($this->filterRequires[$name])) {
+            $constraint = new VersionConstraint('=', $this->versionParser->normalize($version));
+            return $this->filterRequires[$name]->matches($constraint);
+        }
+
+        return true;
+    }
+
     public function isPackageAcceptable($name, $stability)
     {
         foreach ((array) $name as $n) {

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -324,10 +324,11 @@ class ComposerRepository extends ArrayRepository
                         }
                     }
                 } else {
-                    if (!$pool->isPackageAcceptable(strtolower($version['name']), VersionParser::parseStability($version['version']))) {
+                    $loweredName = strtolower($version['name']);
+                    if (!$pool->isPackageAcceptable($loweredName, VersionParser::parseStability($version['version']))) {
                         continue;
                     }
-                    if (!$pool->doesPackageMatchRequires(strtolower($version['name']), $version['version'])) {
+                    if (!$pool->doesPackageMatchRequires($loweredName, $version['version'])) {
                         continue;
                     }
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -327,6 +327,9 @@ class ComposerRepository extends ArrayRepository
                     if (!$pool->isPackageAcceptable(strtolower($version['name']), VersionParser::parseStability($version['version']))) {
                         continue;
                     }
+                    if (!$pool->doesPackageMatchRequires(strtolower($version['name']), $version['version'])) {
+                        continue;
+                    }
 
                     // load acceptable packages in the providers
                     $package = $this->createPackage($version, 'Composer\Package\Package');

--- a/tests/Composer/Test/DependencyResolver/PoolTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\DependencyResolver;
 
 use Composer\DependencyResolver\Pool;
+use Composer\Package\LinkConstraint\VersionConstraint;
 use Composer\Repository\ArrayRepository;
 use Composer\Package\BasePackage;
 use Composer\TestCase;
@@ -128,5 +129,21 @@ class PoolTest extends TestCase
         $pool = new Pool;
 
         $this->assertEquals(array(), $pool->whatProvides('foo'));
+    }
+
+    public function testDoesPackageMatchRequires()
+    {
+        $pool = new Pool('stable', array(), array(
+            'bar' => new VersionConstraint('=', '1.0.0.0'),
+            'foo' => new VersionConstraint('>', '1.0.0.0'),
+        ));
+
+        $this->assertEquals(true, $pool->doesPackageMatchRequires('bar', '1'));
+        $this->assertEquals(false, $pool->doesPackageMatchRequires('bar', '1-beta'));
+        $this->assertEquals(false, $pool->doesPackageMatchRequires('bar', '2'));
+        $this->assertEquals(false, $pool->doesPackageMatchRequires('foo', '1'));
+        $this->assertEquals(false, $pool->doesPackageMatchRequires('foo', '1rc'));
+        $this->assertEquals(true, $pool->doesPackageMatchRequires('foo', '2'));
+        $this->assertEquals(true, $pool->doesPackageMatchRequires('foobar', '2'));
     }
 }

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -148,6 +148,10 @@ class ComposerRepositoryTest extends TestCase
             ->method('isPackageAcceptable')
             ->will($this->returnValue(true));
 
+        $pool->expects($this->any())
+            ->method('doesPackageMatchRequires')
+            ->will($this->returnValue(true));
+
         $versionParser = new VersionParser();
         $repo->setRootAliases(array(
             'a' => array(


### PR DESCRIPTION
Pre validates the packages coming from a composer repo against the root package
constraints before adding them to the pool. In order to save memory and computation time.

`php /opt/composer.phar require 'symfony/translation:2.8.*@dev'`
[Blackfire comparison](https://blackfire.io/profiles/compare/13937aa9-540b-4aea-979d-107aa831d918/graph?callname=main()&selected=Composer%5CDependencyResolver%5CSolver%3A%3Asolve&settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=focused&settings%5BtabPane%5D=nodes)

`A composer.json requiring mostly exact  versions, a more favourable case`
[Blackfire comparison](https://blackfire.io/profiles/compare/9b4b97a3-73bd-4d39-a741-f122d9b35787/graph?callname=Composer%5CDependencyResolver%5CSolver%3A%3Asolve&selected=&settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=focused&settings%5BtabPane%5D=nodes)

Note: It might be useful in some other places but I don't know the composer source code well enough to be sure...