### PR TITLE
Add documentation about the `path` repository

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -606,6 +606,39 @@ imported. When an archive with a newer version is added in the artifact folder
 and you run `update`, that version will be imported as well and Composer will
 update to the latest version.
 
+### Path
+
+In addition to the artifact repository, you can use the path one, which allow
+you to depends on a relative directory. This can be especially useful when dealing
+with monolith repositories.
+
+For instance, if you have the following directory structure in your repository:
+```
+- apps
+\_ my-app
+  \_ composer.json
+- packages
+\_ my-package
+  \_ composer.json
+```
+
+Then, to add the package `my/package` as a dependency, in your `apps/my-app/composer.json`
+file, you can use the following configuration:
+
+```json
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../packages/my-package"
+        }
+    ],
+    "require": {
+        "my/package": "*@dev"
+    }
+}
+```
+
 ## Disabling Packagist
 
 You can disable the default Packagist repository by adding this to your


### PR DESCRIPTION
This is a simple documentation about the `path` repository.