### PR TITLE
Enable wildcards in path names for path repositories

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -608,8 +608,8 @@ update to the latest version.
 
 ### Path
 
-In addition to the artifact repository, you can use the path one, which allow
-you to depends on a relative directory. This can be especially useful when dealing
+In addition to the artifact repository, you can use the path one, which allows
+you to depend on a relative directory. This can be especially useful when dealing
 with monolith repositories.
 
 For instance, if you have the following directory structure in your repository:
@@ -638,6 +638,9 @@ file, you can use the following configuration:
     }
 }
 ```
+
+Repository paths can also contain wildcards like ``*`` and ``?``.
+For details, see the [PHP glob function](http://php.net/glob).
 
 ## Disabling Packagist
 

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -639,8 +639,8 @@ file, you can use the following configuration:
 }
 ```
 
-Repository paths can also contain wildcards like ``*`` and ``?``.
-For details, see the [PHP glob function](http://php.net/glob).
+> **Note:** Repository paths can also contain wildcards like ``*`` and ``?``.
+> For details, see the [PHP glob function](http://php.net/glob).
 
 ## Disabling Packagist
 

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -101,8 +101,6 @@ class PathRepository extends ArrayRepository
     {
         parent::initialize();
 
-        $foundPackage = false;
-
         foreach ($this->getPaths() as $path) {
             $path = realpath($path) . '/';
 
@@ -111,7 +109,6 @@ class PathRepository extends ArrayRepository
                 continue;
             }
 
-            $foundPackage = true;
             $json = file_get_contents($composerFilePath);
             $package = JsonFile::parseJson($json, $composerFilePath);
             $package['dist'] = array(
@@ -131,7 +128,7 @@ class PathRepository extends ArrayRepository
             $this->addPackage($package);
         }
 
-        if (!$foundPackage) {
+        if (count($this) == 0) {
             throw new \RuntimeException(sprintf('No `composer.json` file found in any path repository in "%s"', $this->url));
         }
     }

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -38,6 +38,10 @@ use Composer\Util\ProcessExecutor;
  *     {
  *         "type": "path",
  *         "url": "/absolute/path/to/package/"
+ *     },
+ *     {
+ *         "type": "path",
+ *         "url": "/absolute/path/to/several/packages/*"
  *     }
  * ]
  * @endcode

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -101,12 +101,15 @@ class PathRepository extends ArrayRepository
     {
         parent::initialize();
 
+        $foundPackage = false;
+
         foreach ($this->getPaths() as $path) {
             $composerFilePath = $path.'composer.json';
             if (!file_exists($composerFilePath)) {
                 continue;
             }
 
+            $foundPackage = true;
             $json = file_get_contents($composerFilePath);
             $package = JsonFile::parseJson($json, $composerFilePath);
             $package['dist'] = array(
@@ -124,6 +127,10 @@ class PathRepository extends ArrayRepository
 
             $package = $this->loader->load($package);
             $this->addPackage($package);
+        }
+
+        if (!$foundPackage) {
+            throw new \RuntimeException(sprintf('No `composer.json` file found in any path repository in "%s"', $this->url));
         }
     }
 

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -135,7 +135,7 @@ class PathRepository extends ArrayRepository
     }
 
     /**
-     * Get a list of all absolute path names matching the supplied urls
+     * Get a list of all absolute path names matching given url (supports globbing).
      *
      * @return string[]
      */

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -104,8 +104,8 @@ class PathRepository extends ArrayRepository
         $foundPackage = false;
 
         foreach ($this->getPaths() as $path) {
-            $path = realpath($path);
-            
+            $path = realpath($path) . '/';
+
             $composerFilePath = $path.'composer.json';
             if (!file_exists($composerFilePath)) {
                 continue;

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -135,7 +135,7 @@ class PathRepository extends ArrayRepository
     }
 
     /**
-     * Get a list of all absolute path names matching given url (supports globbing).
+     * Get a list of all path names matching given url (supports globbing).
      *
      * @return string[]
      */

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -107,7 +107,7 @@ class PathRepository extends ArrayRepository
             $package = JsonFile::parseJson($json, $composerFilePath);
             $package['dist'] = array(
                 'type' => 'path',
-                'url' => $this->url,
+                'url' => $path,
                 'reference' => '',
             );
 

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -104,6 +104,8 @@ class PathRepository extends ArrayRepository
         $foundPackage = false;
 
         foreach ($this->getPaths() as $path) {
+            $path = realpath($path);
+            
             $composerFilePath = $path.'composer.json';
             if (!file_exists($composerFilePath)) {
                 continue;

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -128,7 +128,7 @@ class PathRepository extends ArrayRepository
             $this->addPackage($package);
         }
 
-        if (count($this) == 0) {
+        if (count($this->getPackages()) == 0) {
             throw new \RuntimeException(sprintf('No `composer.json` file found in any path repository in "%s"', $this->url));
         }
     }

--- a/tests/Composer/Test/Repository/Fixtures/path/with-version/composer.json
+++ b/tests/Composer/Test/Repository/Fixtures/path/with-version/composer.json
@@ -1,4 +1,4 @@
 {
-  "name": "test/path",
+  "name": "test/path-versioned",
   "version": "0.0.2"
 }

--- a/tests/Composer/Test/Repository/Fixtures/path/without-version/composer.json
+++ b/tests/Composer/Test/Repository/Fixtures/path/without-version/composer.json
@@ -1,3 +1,3 @@
 {
-  "name": "test/path"
+  "name": "test/path-unversioned"
 }

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -35,7 +35,7 @@ class PathRepositoryTest extends TestCase
         $repository->getPackages();
 
         $this->assertEquals(1, $repository->count());
-        $this->assertTrue($repository->hasPackage($this->getPackage('test/path', '0.0.2')));
+        $this->assertTrue($repository->hasPackage($this->getPackage('test/path-versioned', '0.0.2')));
     }
 
     public function testLoadPackageFromFileSystemWithoutVersion()
@@ -54,9 +54,31 @@ class PathRepositoryTest extends TestCase
         $this->assertEquals(1, $repository->count());
 
         $package = $packages[0];
-        $this->assertEquals('test/path', $package->getName());
+        $this->assertEquals('test/path-unversioned', $package->getName());
 
         $packageVersion = $package->getVersion();
         $this->assertTrue(!empty($packageVersion));
+    }
+
+    public function testLoadPackageFromFileSystemWithWildcard()
+    {
+        $ioInterface = $this->getMockBuilder('Composer\IO\IOInterface')
+            ->getMock();
+
+        $config = new \Composer\Config();
+        $loader = new ArrayLoader(new VersionParser());
+        $versionGuesser = null;
+
+        $repositoryUrl = implode(DIRECTORY_SEPARATOR, array(__DIR__, 'Fixtures', 'path', '*'));
+        $repository = new PathRepository(array('url' => $repositoryUrl), $ioInterface, $config, $loader);
+        $packages = $repository->getPackages();
+
+        $this->assertEquals(2, $repository->count());
+
+        $package = $packages[0];
+        $this->assertEquals('test/path-versioned', $package->getName());
+
+        $package = $packages[1];
+        $this->assertEquals('test/path-unversioned', $package->getName());
     }
 }


### PR DESCRIPTION
I extended the path repositories feature to use glob to resolve wildcards. It would be nice if you consider it for inclusion.