### PR TITLE
Fix check for flag in case RELATIVE_PATHS should be changed somehow

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -180,7 +180,7 @@ class Config
                     return $val;
                 }
 
-                return ($flags & self::RELATIVE_PATHS == 1) ? $val : $this->realpath($val);
+                return ($flags & self::RELATIVE_PATHS == self::RELATIVE_PATHS) ? $val : $this->realpath($val);
 
             case 'cache-ttl':
                 return (int) $this->config[$key];


### PR DESCRIPTION
Just a minor fix in the flag check as "1" is the hardcoded value of RELATIVE_PATHS. Alternative the check could be ``$flags & self::RELATIVE_PATHS > 0``