### PR TITLE
Use shortest relative paths for symlinks with `path` repository

### DIFF
--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -48,7 +48,8 @@ class PathDownloader extends FileDownloader
         }
 
         try {
-            $fileSystem->symlink($realUrl, $path);
+            $shortestPath = $this->filesystem->findShortestPath($path, $realUrl);
+            $fileSystem->symlink($shortestPath, $path);
             $this->io->writeError(sprintf('    Symlinked from %s', $url));
         } catch (IOException $e) {
             $fileSystem->mirror($realUrl, $path);


### PR DESCRIPTION
When dealing with environment using VMs or Docker containers, the same filesystem will be shared between different environments and absolute paths won't work anymore.

This PR uses the `findShortestPath` method to find the shortest relative path to create the symlink. That will allow to have valid symlinks on all the different systems that share the project file system.
