### PR TITLE
Update source type and reference along with URLs

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1023,9 +1023,15 @@ class Installer
                 $newPackage = $pool->literalToPackage($matches[0]);
 
                 // update the dist and source URLs
-                $package->setSourceType($newPackage->getSourceType());
-                $package->setSourceUrl($newPackage->getSourceUrl());
-                $package->setSourceReference($newPackage->getSourceReference());
+                $sourceUrl = $package->getSourceUrl();
+                $newSourceUrl = $newPackage->getSourceUrl();
+
+                if ($sourceUrl !== $newSourceUrl) {
+                    $package->setSourceType($newPackage->getSourceType());
+                    $package->setSourceUrl($newSourceUrl);
+                    $package->setSourceReference($newPackage->getSourceReference());
+                }
+
                 // only update dist url for github/bitbucket dists as they use a combination of dist url + dist reference to install
                 // but for other urls this is ambiguous and could result in bad outcomes
                 if (preg_match('{^https?://(?:(?:www\.)?bitbucket\.org|(api\.)?github\.com)/}', $newPackage->getDistUrl())) {

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1023,7 +1023,9 @@ class Installer
                 $newPackage = $pool->literalToPackage($matches[0]);
 
                 // update the dist and source URLs
+                $package->setSourceType($newPackage->getSourceType());
                 $package->setSourceUrl($newPackage->getSourceUrl());
+                $package->setSourceReference($newPackage->getSourceReference());
                 // only update dist url for github/bitbucket dists as they use a combination of dist url + dist reference to install
                 // but for other urls this is ambiguous and could result in bad outcomes
                 if (preg_match('{^https?://(?:(?:www\.)?bitbucket\.org|(api\.)?github\.com)/}', $newPackage->getDistUrl())) {

--- a/tests/Composer/Test/Fixtures/installer/update-picks-up-change-of-vcs-type.test
+++ b/tests/Composer/Test/Fixtures/installer/update-picks-up-change-of-vcs-type.test
@@ -1,0 +1,57 @@
+--TEST--
+Converting from one VCS type to another (including an URL change) should update the lock file.
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "a/a", "version": "1.0.0",
+                    "source": { "reference": "new-git-ref", "type": "git", "url": "new-git-url" }
+                }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    }
+}
+--INSTALLED--
+[
+    {
+        "name": "a/a", "version": "1.0.0",
+        "source": { "reference": "old-hg-ref", "type": "hg", "url": "old-hg-url" }
+    }
+]
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "a/a", "version": "1.0.0",
+            "source": { "reference": "old-hg-ref", "type": "hg", "url": "old-hg-url" }
+        }
+    ]
+}
+--RUN--
+update
+--EXPECT-LOCK--
+{
+    "packages": [
+        {
+            "name": "a/a", "version": "1.0.0",
+            "source": { "reference": "new-git-ref", "type": "git", "url": "new-git-url" },
+            "type": "library"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--EXPECT--
+


### PR DESCRIPTION
In #3985, the source URL for all repos is updated during the `update` task. However, the change did not include take the source type and reference.

So, when moving a repo from `hg` to `git`, only the new git URL was written to the .lock file but the repository type and commit ID were not updated. 


