### PR TITLE
Ensure the bin directory exists before checking empty

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -268,7 +268,7 @@ class LibraryInstaller implements InstallerInterface
         }
 
         // attempt removing the bin dir in case it is left empty
-        if ($this->filesystem->isDirEmpty($this->binDir)) {
+        if ((is_dir($this->binDir)) && ($this->filesystem->isDirEmpty($this->binDir))) {
             @rmdir($this->binDir);
         }
     }


### PR DESCRIPTION
Line 130 has similar logic so avoided doing the check withiin `isDirEmpty()`

This prevents an InvalidArgumentException from the Symfony component when the directory doesn't exist

Relates to this https://github.com/composer/composer/commit/80f1e4372a10427aaf06d5cda87a9bf74db200ab