### PR TITLE
Enable command line configuration for archive-dir and archive-format

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -162,7 +162,7 @@ Example:
 ```json
 {
     "config": {
-        "bin-dir": "bin"
+        "archive-dir": "/home/user/.composer/repo"
     }
 }
 ```

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -293,6 +293,8 @@ EOT
             'notify-on-install' => array($booleanValidator, $booleanNormalizer),
             'vendor-dir' => array('is_string', function ($val) { return $val; }),
             'bin-dir' => array('is_string', function ($val) { return $val; }),
+            'archive-dir' => array('is_string', function ($val) { return $val; }),
+            'archive-format' => array('is_string', function ($val) { return $val; }),
             'cache-dir' => array('is_string', function ($val) { return $val; }),
             'cache-files-dir' => array('is_string', function ($val) { return $val; }),
             'cache-repo-dir' => array('is_string', function ($val) { return $val; }),


### PR DESCRIPTION
Those 2 parameters could be defined inside the config.json but were not accepted by the command 'composer config'.
So, just adding them to the known uniqueConfigValues

The doc on archive-dir is also improved with an example of configuration;
