### PR TITLE
config -l output breaks on listing keys with several colons [fixes #4459]

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -475,13 +475,7 @@ EOT
             if (is_array($value) && (!is_numeric(key($value)) || ($key === 'repositories' && null === $k))) {
                 $k .= preg_replace('{^config\.}', '', $key . '.');
                 $this->listConfiguration($value, $rawVal, $output, $k);
-
-                if (substr_count($k, '.') > 1) {
-                    $k = str_split($k, strrpos($k, '.', -2));
-                    $k = $k[0] . '.';
-                } else {
-                    $k = $origK;
-                }
+                $k = $origK;
 
                 continue;
             }


### PR DESCRIPTION
Fixes #4459

Not sure why this if/else construct was in there. The code is not documented nor is it very self-explaining. Removing these lines seems to fix the issue. It still displays any other info correctly. However, since I don't know what it was for in the first place, I can't specifically test it.

With a `auth.json` file as follows:

```javascript
{
    "http-basic": {
        "a.b.c": {
            "username": "username",
            "password": "password"
        },
        "d.e.f": {
            "username": "username",
            "password": "password"
        }
    }
}
```

Before:

```
[repositories.packagist.type] composer
[repositories.packagist.url] https?://packagist.org
[repositories.packagist.allow_ssl_downgrade] true
[process-timeout] 300
[use-include-path] false
[preferred-install] auto
[notify-on-install] true
[github-protocols] [git, https, ssh]
[vendor-dir] vendor (/private/tmp/trololol/vendor)
[bin-dir] {$vendor-dir}/bin (/private/tmp/trololol/vendor/bin)
[cache-dir] /Users/rob/.composer/cache
[cache-files-dir] {$cache-dir}/files (/Users/rob/.composer/cache/files)
[cache-repo-dir] {$cache-dir}/repo (/Users/rob/.composer/cache/repo)
[cache-vcs-dir] {$cache-dir}/vcs (/Users/rob/.composer/cache/vcs)
[cache-ttl] 15552000
[cache-files-ttl] 15552000
[cache-files-maxsize] 300MiB (314572800)
[discard-changes] false
[autoloader-suffix]
[optimize-autoloader] false
[classmap-authoritative] false
[prepend-autoloader] true
[github-domains] [github.com]
[github-expose-hostname] true
[store-auths] prompt
[archive-format] tar
[archive-dir] .
[home] /Users/rob/.composer
[http-basic.a.b.c.username] username
[http-basic.a.b.c.password] password
[http-basic.a.b.d.e.f.username] username
[http-basic.a.b.d.e.f.password] password
```

After:

```
[repositories.packagist.type] composer
[repositories.packagist.url] https?://packagist.org
[repositories.packagist.allow_ssl_downgrade] true
[process-timeout] 300
[use-include-path] false
[preferred-install] auto
[notify-on-install] true
[github-protocols] [git, https, ssh]
[vendor-dir] vendor (/private/tmp/trololol/vendor)
[bin-dir] {$vendor-dir}/bin (/private/tmp/trololol/vendor/bin)
[cache-dir] /Users/rob/.composer/cache
[cache-files-dir] {$cache-dir}/files (/Users/rob/.composer/cache/files)
[cache-repo-dir] {$cache-dir}/repo (/Users/rob/.composer/cache/repo)
[cache-vcs-dir] {$cache-dir}/vcs (/Users/rob/.composer/cache/vcs)
[cache-ttl] 15552000
[cache-files-ttl] 15552000
[cache-files-maxsize] 300MiB (314572800)
[discard-changes] false
[autoloader-suffix]
[optimize-autoloader] false
[classmap-authoritative] false
[prepend-autoloader] true
[github-domains] [github.com]
[github-expose-hostname] true
[store-auths] prompt
[archive-format] tar
[archive-dir] .
[home] /Users/rob/.composer
[http-basic.a.b.c.username] username
[http-basic.a.b.c.password] password
[http-basic.d.e.f.username] username
[http-basic.d.e.f.password] password
```