### PR TITLE
Prevent plugin classes to be loaded twice

### DIFF
--- a/src/Composer/Command/Command.php
+++ b/src/Composer/Command/Command.php
@@ -41,16 +41,17 @@ abstract class Command extends BaseCommand
     /**
      * @param  bool              $required
      * @param  bool              $disablePlugins
+     * @param  array             $plugins        Plugin instances to be set before loading
      * @throws \RuntimeException
      * @return Composer
      */
-    public function getComposer($required = true, $disablePlugins = false)
+    public function getComposer($required = true, $disablePlugins = false, array $plugins = array())
     {
         if (null === $this->composer) {
             $application = $this->getApplication();
             if ($application instanceof Application) {
                 /* @var $application    Application */
-                $this->composer = $application->getComposer($required, $disablePlugins);
+                $this->composer = $application->getComposer($required, $disablePlugins, $plugins);
             } elseif ($required) {
                 throw new \RuntimeException(
                     'Could not create a Composer\Composer instance, you must inject '.

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -142,8 +142,9 @@ EOT
         $authoritative = $input->getOption('classmap-authoritative') || $composer->getConfig()->get('classmap-authoritative');
 
         // Update packages
+        $plugins = $this->getComposer()->getPluginManager()->getPlugins();
         $this->resetComposer();
-        $composer = $this->getComposer();
+        $composer = $this->getComposer(true, false, $plugins);
         $composer->getDownloadManager()->setOutputProgress(!$input->getOption('no-progress'));
 
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'require', $input, $output);

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -215,14 +215,15 @@ class Application extends BaseApplication
     /**
      * @param  bool                    $required
      * @param  bool                    $disablePlugins
+     * @param  array                   $plugins        Plugin instances to be set before loading
      * @throws JsonValidationException
      * @return \Composer\Composer
      */
-    public function getComposer($required = true, $disablePlugins = false)
+    public function getComposer($required = true, $disablePlugins = false, array $plugins = array())
     {
         if (null === $this->composer) {
             try {
-                $this->composer = Factory::create($this->io, null, $disablePlugins);
+                $this->composer = Factory::create($this->io, null, $disablePlugins, $plugins);
             } catch (\InvalidArgumentException $e) {
                 if ($required) {
                     $this->io->writeError($e->getMessage());

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -191,11 +191,12 @@ class Factory
      *                                                   read from the default filename
      * @param  bool                      $disablePlugins Whether plugins should not be loaded
      * @param  bool                      $fullLoad       Whether to initialize everything or only main project stuff (used when loading the global composer)
+     * @param  array                     $plugins        Plugin instances to be set before loading
      * @throws \InvalidArgumentException
      * @throws \UnexpectedValueException
      * @return Composer
      */
-    public function createComposer(IOInterface $io, $localConfig = null, $disablePlugins = false, $cwd = null, $fullLoad = true)
+    public function createComposer(IOInterface $io, $localConfig = null, $disablePlugins = false, $cwd = null, $fullLoad = true, array $plugins = array())
     {
         $cwd = $cwd ?: getcwd();
 
@@ -292,6 +293,9 @@ class Factory
             $composer->setPluginManager($pm);
 
             if (!$disablePlugins) {
+                foreach ($plugins as $plugin) {
+                    $pm->addPlugin($plugin, false);
+                }
                 $pm->loadInstalledPlugins();
             }
 
@@ -479,12 +483,13 @@ class Factory
      * @param  mixed       $config         either a configuration array or a filename to read from, if null it will read from
      *                                     the default filename
      * @param  bool        $disablePlugins Whether plugins should not be loaded
+     * @param  array       $plugins        Plugin instances to be set before loading
      * @return Composer
      */
-    public static function create(IOInterface $io, $config = null, $disablePlugins = false)
+    public static function create(IOInterface $io, $config = null, $disablePlugins = false, array $plugins = array())
     {
         $factory = new static();
 
-        return $factory->createComposer($io, $config, $disablePlugins);
+        return $factory->createComposer($io, $config, $disablePlugins, null, true, $plugins);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Soullivaneuh/composer-versions-check/issues/9.
Fixes https://github.com/Soullivaneuh/composer-versions-check/issues/23.

Tells composer to not load an already loaded plugin class.

Concrete case with `composer/dummy-plugin`:

Require `composer/dummy-plugin` globally:

```bash
composer global require composer/dummy-plugin
```

Then require it again locally on a random composer project:

```bash
composer require composer/dummy-plugin
```

You will get a "Cannot redeclare class" php fatal error.

This PR prevent this issue.

See also my plugin issue for another case.

cc @OskarStark @alcohol 
