### PR TITLE
allow to use PHPUnit 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
         "seld/cli-prompt": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
-        "phpunit/phpunit-mock-objects": "2.3.0"
+        "phpunit/phpunit": "~4.5|^5.0.5",
+        "phpunit/phpunit-mock-objects": "2.3.0|~3.0"
     },
     "_": "phpunit/phpunit-mock-objects required in 2.3.0 due to https://github.com/sebastianbergmann/phpunit-mock-objects/issues/223 - needs hhvm 3.8+ on travis",
     "config": {


### PR DESCRIPTION
Test suite pass with PHPUnit >= 5.0.5
(fails with < 5.0.5, see https://github.com/sebastianbergmann/phpunit-mock-objects/pull/262).

Of course, 4.x will still be used with php < 5.6  (in fact no, because of composer.lock, 4.8.6 used everywhere)