### PR TITLE
note about Bitbucket repository slug vs. name in docs

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -292,6 +292,10 @@ GitHub and BitBucket:
 
 The only requirement is the installation of SSH keys for a git client.
 
+> **Note:** Use the Bitbucket repository slug (aka full_name) and not the
+> repository name in your composer configuration. The repository slug is
+> lowercase and contains exactly one '/'.
+
 #### Git alternatives
 
 Git is not the only version control system supported by the VCS repository.


### PR DESCRIPTION
Adding a note to the docs about Bitbucket repository naming. A user was tripped up by this when adding a Bitbucket webhook pointing to https://packagist.org/.