### PR TITLE
Issue #2384 allow 'prefer-stable' and 'minimum-stability' to be set 

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -322,6 +322,11 @@ EOT
             'classmap-authoritative' => array($booleanValidator, $booleanNormalizer),
             'prepend-autoloader' => array($booleanValidator, $booleanNormalizer),
             'github-expose-hostname' => array($booleanValidator, $booleanNormalizer),
+            'prefer-stable' =>  array($booleanValidator, $booleanNormalizer),
+            'minimum-stability' => array(
+                function ($val) { return in_array($val, array('dev', 'alpha', 'beta', 'RC', 'stable'), true); },
+                function ($val) { return $val; },
+            ),
         );
         $multiConfigValues = array(
             'github-protocols' => array(


### PR DESCRIPTION
Now allows 'prefer-stable' and 'minimum-stability' to be set via composer config command