### PR TITLE
Issue #4512 Set reference in path repository

### DIFF
--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -121,6 +121,8 @@ class PathRepository extends ArrayRepository
             }
             if (is_dir($path.'/.git') && 0 === $this->process->execute('git log -n1 --pretty=%H', $output, $path)) {
                 $package['dist']['reference'] = trim($output);
+            } else {
+                $package['dist']['reference'] = sha1($json);
             }
 
             $package = $this->loader->load($package);


### PR DESCRIPTION
If there is no git folder, no reference is generated for the package, then subsequent update will never happen as for composer this will be the same version / reference as previous so it will be skipped.

In this case when the composer.json of the package is modified it is reinstalled.