### PR TITLE
InstallationManager: notifyInstalls: append authorization header

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -318,7 +318,7 @@ EOT
         $im = $this->createInstallationManager();
         $im->addInstaller($projectInstaller);
         $im->install(new InstalledFilesystemRepository(new JsonFile('php://memory')), new InstallOperation($package));
-        $im->notifyInstalls();
+        $im->notifyInstalls($io);
 
         $installedFromVcs = 'source' === $package->getInstallationSource();
 

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -234,11 +234,11 @@ class Installer
                 return $res;
             }
         } catch (\Exception $e) {
-            $this->installationManager->notifyInstalls();
+            $this->installationManager->notifyInstalls($this->io);
 
             throw $e;
         }
-        $this->installationManager->notifyInstalls();
+        $this->installationManager->notifyInstalls($this->io);
 
         // output suggestions if we're in dev mode
         if ($this->devMode) {


### PR DESCRIPTION
Notify installs should use repository auth info if it's set, otherwise request will be denied (unauthorized).

I'm not sure this is the most elegant way of doing it as I haven't checked much of composer internals. I'd be more than happy to rework it if there are any suggestions.

Thanks!