### PR TITLE
Allow easier manipulation of RootAliasPackage

### DIFF
--- a/src/Composer/Package/AliasPackage.php
+++ b/src/Composer/Package/AliasPackage.php
@@ -32,8 +32,6 @@ class AliasPackage extends BasePackage implements CompletePackageInterface
     protected $conflicts;
     protected $provides;
     protected $replaces;
-    protected $recommends;
-    protected $suggests;
 
     /**
      * All descendants' constructors should call this parent constructor

--- a/src/Composer/Package/RootAliasPackage.php
+++ b/src/Composer/Package/RootAliasPackage.php
@@ -82,6 +82,33 @@ class RootAliasPackage extends AliasPackage implements RootPackageInterface
         $this->aliasOf->setDevRequires($devRequire);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function setConflicts(array $conflicts)
+    {
+        $this->conflicts = $this->replaceSelfVersionDependencies($conflicts, 'conflicts');
+        $this->aliasOf->setConflicts($conflicts);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setProvides(array $provides)
+    {
+        $this->provides = $this->replaceSelfVersionDependencies($provides, 'provides');
+        $this->aliasOf->setProvides($provides);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setReplaces(array $replaces)
+    {
+        $this->replaces = $this->replaceSelfVersionDependencies($replaces, 'replaces');
+        $this->aliasOf->setReplaces($replaces);
+    }
+
     public function __clone()
     {
         parent::__clone();

--- a/src/Composer/Package/RootAliasPackage.php
+++ b/src/Composer/Package/RootAliasPackage.php
@@ -109,6 +109,54 @@ class RootAliasPackage extends AliasPackage implements RootPackageInterface
         $this->aliasOf->setReplaces($replaces);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function setRepositories($repositories)
+    {
+        $this->aliasOf->setRepositories($repositories);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setAutoload(array $autoload)
+    {
+        $this->aliasOf->setAutoload($autoload);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setDevAutoload(array $devAutoload)
+    {
+        $this->aliasOf->setDevAutoload($devAutoload);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setStabilityFlags(array $stabilityFlags)
+    {
+        $this->aliasOf->setStabilityFlags($stabilityFlags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setSuggests(array $suggests)
+    {
+        $this->aliasOf->setSuggests($suggests);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setExtra(array $extra)
+    {
+        $this->aliasOf->setExtra($extra);
+    }
+
     public function __clone()
     {
         parent::__clone();

--- a/src/Composer/Package/RootPackageInterface.php
+++ b/src/Composer/Package/RootPackageInterface.php
@@ -71,4 +71,65 @@ interface RootPackageInterface extends CompletePackageInterface
      * @param array $devRequires A set of package links
      */
     public function setDevRequires(array $devRequires);
+
+    /**
+     * Set the conflicting packages
+     *
+     * @param array $conflicts A set of package links
+     */
+    public function setConflicts(array $conflicts);
+
+    /**
+     * Set the provided virtual packages
+     *
+     * @param array $provides A set of package links
+     */
+    public function setProvides(array $provides);
+
+    /**
+     * Set the packages this one replaces
+     *
+     * @param array $replaces A set of package links
+     */
+    public function setReplaces(array $replaces);
+
+    /**
+     * Set the repositories
+     *
+     * @param array $repositories
+     */
+    public function setRepositories($repositories);
+
+    /**
+     * Set the autoload mapping
+     *
+     * @param array $autoload Mapping of autoloading rules
+     */
+    public function setAutoload(array $autoload);
+
+    /**
+     * Set the dev autoload mapping
+     *
+     * @param array $devAutoload Mapping of dev autoloading rules
+     */
+    public function setDevAutoload(array $devAutoload);
+
+    /**
+     * Set the stabilityFlags
+     *
+     * @param array $stabilityFlags
+     */
+    public function setStabilityFlags(array $stabilityFlags);
+
+    /**
+     * Set the suggested packages
+     *
+     * @param array $suggests A set of package names/comments
+     */
+    public function setSuggests(array $suggests);
+
+    /**
+     * @param array $extra
+     */
+    public function setExtra(array $extra);
 }

--- a/tests/Composer/Test/Package/RootAliasPackageTest.php
+++ b/tests/Composer/Test/Package/RootAliasPackageTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Package;
+
+use Composer\Package\Link;
+use Composer\Package\RootAliasPackage;
+use Composer\TestCase;
+use Prophecy\Argument;
+
+class RootAliasPackageTest extends TestCase
+{
+
+    public function testUpdateRequires()
+    {
+        $root = $this->getMockRootPackageInterface();
+        $root->setRequires(Argument::type('array'))->shouldBeCalled();
+
+        $alias = new RootAliasPackage($root->reveal(), '1.0', '1.0.0.0');
+        $this->assertEmpty($alias->getRequires());
+        $links = array(new Link('a', 'b', null, 'foo', 'self.version'));
+        $alias->setRequires($links);
+        $this->assertNotEmpty($alias->getRequires());
+    }
+
+    public function testUpdateDevRequires()
+    {
+        $root = $this->getMockRootPackageInterface();
+        $root->setDevRequires(Argument::type('array'))->shouldBeCalled();
+
+        $alias = new RootAliasPackage($root->reveal(), '1.0', '1.0.0.0');
+        $this->assertEmpty($alias->getDevRequires());
+        $links = array(new Link('a', 'b', null, 'foo', 'self.version'));
+        $alias->setDevRequires($links);
+        $this->assertNotEmpty($alias->getDevRequires());
+    }
+
+    public function testUpdateConflicts()
+    {
+        $root = $this->getMockRootPackageInterface();
+        $root->setConflicts(Argument::type('array'))->shouldBeCalled();
+
+        $alias = new RootAliasPackage($root->reveal(), '1.0', '1.0.0.0');
+        $this->assertEmpty($alias->getConflicts());
+        $links = array(new Link('a', 'b', null, 'foo', 'self.version'));
+        $alias->setConflicts($links);
+        $this->assertNotEmpty($alias->getConflicts());
+    }
+
+    public function testUpdateProvides()
+    {
+        $root = $this->getMockRootPackageInterface();
+        $root->setProvides(Argument::type('array'))->shouldBeCalled();
+
+        $alias = new RootAliasPackage($root->reveal(), '1.0', '1.0.0.0');
+        $this->assertEmpty($alias->getProvides());
+        $links = array(new Link('a', 'b', null, 'foo', 'self.version'));
+        $alias->setProvides($links);
+        $this->assertNotEmpty($alias->getProvides());
+    }
+
+    public function testUpdateReplaces()
+    {
+        $root = $this->getMockRootPackageInterface();
+        $root->setReplaces(Argument::type('array'))->shouldBeCalled();
+
+        $alias = new RootAliasPackage($root->reveal(), '1.0', '1.0.0.0');
+        $this->assertEmpty($alias->getReplaces());
+        $links = array(new Link('a', 'b', null, 'foo', 'self.version'));
+        $alias->setReplaces($links);
+        $this->assertNotEmpty($alias->getReplaces());
+    }
+
+    protected function getMockRootPackageInterface()
+    {
+        $root = $this->prophesize('Composer\\Package\\RootPackageInterface');
+        $root->getName()->willReturn('something/something')->shouldBeCalled();
+        $root->getRequires()->willReturn(array())->shouldBeCalled();
+        $root->getDevRequires()->willReturn(array())->shouldBeCalled();
+        $root->getConflicts()->willReturn(array())->shouldBeCalled();
+        $root->getProvides()->willReturn(array())->shouldBeCalled();
+        $root->getReplaces()->willReturn(array())->shouldBeCalled();
+        return $root;
+    }
+}


### PR DESCRIPTION
While implementing https://github.com/wikimedia/composer-merge-plugin/commit/f706e5ce863ee7f3cf61f165e120d547c64b1a78 I discovered that there was no way to modify the "conflict", "provide" and "replace" collections of a RootAliasPackage after construction. Since the "require" and "require-dev" collections already have support for post-construction changes I decided to propose this patch in the hope that the lack of setters for other cached collections was just a matter of them not having been needed before.

I also boldly added a commit to the pull request that extends RootPackageInterface and RootAliasPackage to expose methods of RootPackage that [composer-merge-plugin](https://github.com/wikimedia/composer-merge-plugin) uses internally. The Package interfaces generally stick to getters and omit setters, but RootPackageInterface did already specify some setter methods. If this part of the change is unwanted here I won't be too disappointed if I'm asked ot remove it before merging, but I though it would be worth proposing as well.