### PR TITLE
Allow fetching auth credentials from an envvar

### DIFF
--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -60,6 +60,19 @@ abstract class BaseIO implements IOInterface
      */
     public function loadConfiguration(Config $config)
     {
+        // Use COMPOSER_AUTH environment variable if set
+        if ($envvar_data = getenv('COMPOSER_AUTH')) {
+            $auth_data = json_decode($envvar_data);
+
+            if (is_null($auth_data)) {
+                throw new \UnexpectedValueException('COMPOSER_AUTH environment variable is malformed');
+            }
+
+            foreach ($auth_data as $domain => $credentials) {
+                $this->setAuthentication($domain, $credentials->username, $credentials->password);
+            }
+        }
+
         // reload oauth token from config if available
         if ($tokens = $config->get('github-oauth')) {
             foreach ($tokens as $domain => $token) {

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -207,6 +207,16 @@ class RemoteFilesystem
         $this->retryAuthFailure = true;
         $this->lastHeaders = array();
 
+        // Use COMPOSER_AUTH environment variable if set
+        if (getenv('COMPOSER_AUTH')) {
+            $credentials = [];
+            preg_match('/(.+):(.+)/', getenv('COMPOSER_AUTH'), $credentials);
+
+            if (count($credentials) === 2) {
+                $this->io->setAuthentication($originUrl, $credentials[0], $credentials[1]);
+            }
+        }
+
         // capture username/password from URL if there is one
         if (preg_match('{^https?://(.+):(.+)@([^/]+)}i', $fileUrl, $match)) {
             $this->io->setAuthentication($originUrl, urldecode($match[1]), urldecode($match[2]));

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -209,8 +209,7 @@ class RemoteFilesystem
 
         // Use COMPOSER_AUTH environment variable if set
         if (getenv('COMPOSER_AUTH')) {
-            $credentials = [];
-            preg_match('/(.+):(.+)/', getenv('COMPOSER_AUTH'), $credentials);
+            $credentials = explode(':', getenv('COMPOSER_AUTH'), 2);
 
             if (count($credentials) === 2) {
                 $this->io->setAuthentication($originUrl, $credentials[0], $credentials[1]);

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -207,15 +207,6 @@ class RemoteFilesystem
         $this->retryAuthFailure = true;
         $this->lastHeaders = array();
 
-        // Use COMPOSER_AUTH environment variable if set
-        if (getenv('COMPOSER_AUTH')) {
-            $credentials = explode(':', getenv('COMPOSER_AUTH'), 2);
-
-            if (count($credentials) === 2) {
-                $this->io->setAuthentication($originUrl, $credentials[0], $credentials[1]);
-            }
-        }
-
         // capture username/password from URL if there is one
         if (preg_match('{^https?://(.+):(.+)@([^/]+)}i', $fileUrl, $match)) {
             $this->io->setAuthentication($originUrl, urldecode($match[1]), urldecode($match[2]));


### PR DESCRIPTION
When an environmental variable named "COMPOSER_AUTH" is set
as $USERNAME:$PASSWORD, it is automatically used for authentication
e.g. when fetching packages from Satis.

The envvar credentials are of lower priority than URL credentials.

Fixes #4285