### PR TITLE
Stop fileloads on classMapAuthoritative 

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -544,33 +544,35 @@ class ComposerAutoloaderInit$suffix
 
 HEADER;
 
-        if ($useIncludePath) {
-            $file .= <<<'INCLUDE_PATH'
-        $includePaths = require __DIR__ . '/include_paths.php';
-        array_push($includePaths, get_include_path());
-        set_include_path(join(PATH_SEPARATOR, $includePaths));
+        if (!$this->classMapAuthoritative) {
+            if ($useIncludePath) {
+                $file .= <<<'INCLUDE_PATH'
+            $includePaths = require __DIR__ . '/include_paths.php';
+            array_push($includePaths, get_include_path());
+            set_include_path(join(PATH_SEPARATOR, $includePaths));
 
 
 INCLUDE_PATH;
-        }
+            }
 
-        $file .= <<<'PSR0'
-        $map = require __DIR__ . '/autoload_namespaces.php';
-        foreach ($map as $namespace => $path) {
-            $loader->set($namespace, $path);
-        }
+            $file .= <<<'PSR0'
+            $map = require __DIR__ . '/autoload_namespaces.php';
+            foreach ($map as $namespace => $path) {
+                $loader->set($namespace, $path);
+            }
 
 
 PSR0;
 
-        $file .= <<<'PSR4'
-        $map = require __DIR__ . '/autoload_psr4.php';
-        foreach ($map as $namespace => $path) {
-            $loader->setPsr4($namespace, $path);
-        }
+            $file .= <<<'PSR4'
+            $map = require __DIR__ . '/autoload_psr4.php';
+            foreach ($map as $namespace => $path) {
+                $loader->setPsr4($namespace, $path);
+            }
 
 
 PSR4;
+        }
 
         if ($useClassMap) {
             $file .= <<<'CLASSMAP'


### PR DESCRIPTION
When classMapAuthoritative is enabled autoload_real, will still look at and load the PSR0, PSR4, and include paths.  This is not necessary as in ClassLoader::findFile() if it's not in the classMap and we're authority, it will return false.  Only when classmap is not authority will it call findFileWithExtension, which goes and looks at PSR4/0 and IncludePaths.