### PR TITLE
[Perf gain] Exclude tests folder in no-dev mode

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -48,6 +48,12 @@ class AutoloadGenerator
      */
     private $classMapAuthoritative = false;
 
+    /**
+     * Tests folder exclusion pattern
+     */
+    const EXCLUDE_TEST_PATTERN = '\\Tests\\';
+
+
     public function __construct(EventDispatcher $eventDispatcher, IOInterface $io = null)
     {
         $this->eventDispatcher = $eventDispatcher;
@@ -234,6 +240,9 @@ EOF;
 
         ksort($classMap);
         foreach ($classMap as $class => $code) {
+            if (!$this->devMode && strstr($class, self::EXCLUDE_TEST_PATTERN)) {
+                continue;
+            }
             $classmapFile .= '    '.var_export($class, true).' => '.$code;
         }
         $classmapFile .= ");\n";


### PR DESCRIPTION
Hi,

Recently I've just saw on different performance tools how composer file "autoload_classmap.php" can impact memory usage on each request. Regardless the project size, this file is very important.

So I've look closer to this file content and I've been surprise to see the number of files used for the differents projects librarys self-tests onto a production server.

So I made a very small patch excluding thoses files on "no-dev" mode (best choice for production).

On a "out of the box" Symfony 2.7.6, it concern 1288 lines on a total of 4332 (still 3044 line).
So I've choice to exclude them on no-dev mode.

Here's a blackfire stacktrace on a optimized autoload 
https://blackfire.io/profiles/bf86642d-285c-481c-ae78-06447739b795/graph
And here a normal one to compare:
https://blackfire.io/profiles/4892e5be-07d2-480d-9249-95543599f136/graph

I've think that Test class hasn't utility on a server production mode, and reduce composer footprint is always welcome.