### PR TITLE
skip no more needed with jsonc 1.3.9

### DIFF
--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -54,7 +54,7 @@ class JsonFileTest extends \PHPUnit_Framework_TestCase
 
     public function testParseErrorDetectSingleQuotes()
     {
-        if (defined('JSON_PARSER_NOTSTRICT')) {
+        if (defined('JSON_PARSER_NOTSTRICT') && version_compare(phpversion('json'), '1.3.9', '<')) {
             $this->markTestSkipped('jsonc issue, see https://github.com/remicollet/pecl-json-c/issues/23');
         }
         $json = '{


### PR DESCRIPTION
Upstream issue is fixed in 1.3.9.