### PR TITLE
Have xcopy overwrite existing files

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -266,7 +266,7 @@ class Filesystem
 
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             // Try to copy & delete - this is a workaround for random "Access denied" errors.
-            $command = sprintf('xcopy %s %s /E /I /Q', ProcessExecutor::escape($source), ProcessExecutor::escape($target));
+            $command = sprintf('xcopy %s %s /E /I /Q /Y', ProcessExecutor::escape($source), ProcessExecutor::escape($target));
             $result = $this->processExecutor->execute($command, $output);
 
             // clear stat cache because external processes aren't tracked by the php stat cache


### PR DESCRIPTION
During a `composer install` on Windows, I had warning that xcopy was timing out. It ended up being because a file already existed in the target directory (non-composer issue, was a permissions issue on my end) and `xcopy` was waiting for a response to:
```
Overwrite [filename] (Yes/No/All)?
```
Adding the `/Y` switch will have `xcopy` overwrite without prompting, just to avoid this particular timeout error.