### PR TITLE
fixes #4562

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -402,7 +402,11 @@ EOF;
 
         if (isset($autoloads['classmap'])) {
             foreach ($autoloads['classmap'] as $dir) {
-                $loader->addClassMap($this->generateClassMap($dir));
+                try {
+                    $loader->addClassMap($this->generateClassMap($dir));
+                } catch (\RuntimeException $e) {
+                    $this->io->writeError('<warning>'.$e->getMessage().'</warning>');
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #4562

Instead of failing on a `RuntimeException`, we can just skip the bad definition and proceed with the operation. I don't advocate this kind of configuration as it indicates an underlying problem in my opinion, but we can at least "fail" gracefully.

```
rob@macbookpro /tmp $ cat composer.json
{
    "require": { "alcohol/iso3166": "@stable" },
    "autoload": { "classmap": [ "yolo.php" ] },
    "scripts": {
        "pre-install-cmd": "touch yolo.php"
    }
}
rob@macbookpro /tmp $ /srv/git/github/composer/bin/composer install
Could not scan for classes inside "yolo.php" which does not appear to be a file nor a folder
> touch yolo.php
Loading composer repositories with package information
Installing dependencies (including require-dev)
  - Installing alcohol/iso3166 (3.0.0)
    Loading from cache

Writing lock file
Generating autoload files
```

/cc @seldaek how do you feel about this?