### PR TITLE
Allow composer script call within other script group

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -200,3 +200,18 @@ simply running `composer test`:
 
 > **Note:** Composer's bin-dir is pushed on top of the PATH so that binaries
 > of dependencies are easily accessible as CLI commands when writing scripts.
+
+Composer script can also called from other scripts, by prefixing the command name
+by `@`. For example the following syntax is valid:
+
+```json
+{
+    "scripts": {
+        "test": [
+            "@clearCache",
+            "phpunit"
+        ],
+        "clearCache": "rm -rf cache/*"
+    }
+}
+```


### PR DESCRIPTION
Since I got positive feedback in Issue #4578 here's a first implementation of scripts "group".

Script prefixed by `@` are now considered alias of other script group. I've also implemented an infinite recursion detection (in a separate commit), to avoid simple configuration errors.

I'm not aware of all composer internals, so this code will need an expert review. Here's my consideration:
* prefixing by `@` can cause BC? I can't think of any real situation...
* all command (including `post-install-cmd` and the like) are callable. Is this correct?
* is the minimal documentation I've added enough?

I've made some phpunit tests, and manually tested the following configurations:

```yml
{
    "scripts": {
        "root": "@group2",
        "group2": [
            "@group1",
            "echo 2",
            "@group3"
        ],
        "group1": [
            "echo 1"
        ],
        "group3": [
            "echo 3"
        ]
    }
}
```
which result in 1 2 3 echoes.

```yml
{
    "scripts": {
        "root": "@group",
        "group" : [
            "echo 1",
            "@root"
        ]
    }
}
```
which triggers a `\RuntimeException`