### PR TITLE
Fix handling of http 400 errors

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -334,6 +334,12 @@ class RemoteFilesystem
     {
         switch ($notificationCode) {
             case STREAM_NOTIFY_FAILURE:
+                if (400 === $messageCode) {
+                    // This might happen if your host is secured by ssl client certificate authentication
+                    // but you do not send an appropriate certificate
+                    throw new TransportException("The '" . $this->fileUrl . "' URL could not be accessed: " . $message, $messageCode);
+                }
+
             case STREAM_NOTIFY_AUTH_REQUIRED:
                 if (401 === $messageCode) {
                     // Bail if the caller is going to handle authentication failures itself.


### PR DESCRIPTION
Before 400 errors were silently dropped. This caused composer to store
the returned body (usually some html) in cache. This resulted in later
errors when composer tried to extract this error response as zip.

With this exceptions thrown it handles the error gracefully and falls
back to the next URL provided by the package configuration.