### PR TITLE
add a warning when xdebug is loaded while running composer commands

### DIFF
--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -131,6 +131,23 @@ Or, you can increase the limit with a command-line argument:
 php -d memory_limit=-1 composer.phar <...>
 ```
 
+## Xdebug impact on Composer
+
+Running Composer console commands while the php extension "xdebug" is loaded reduces speed considerably.
+This is even the case when all "xdebug" related features are disabled per php.ini flags,
+but the php extension itself is loaded into the PHP engine.
+Compared to a cli command run with "xdebug" enabled a speed improvement by a factor of up to 3 is not uncommon.
+
+> **Note:** This is a general issue when running PHP with "xdebug" enabled. You shouldn't
+> load the extension in production like environments per se.
+
+Disable "xdebug" in your `php.ini` (ex. `/etc/php5/cli/php.ini` for Debian-like systems) by
+locating the related `zend_extension` directive and prepending it with `;` (semicolon):
+
+```sh
+;zend_extension = "/path/to/my/xdebug.so"
+```
+
 ## "The system cannot find the path specified" (Windows)
 
 1. Open regedit.

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -94,6 +94,10 @@ class Application extends BaseApplication
         if (PHP_VERSION_ID < 50302) {
             $io->writeError('<warning>Composer only officially supports PHP 5.3.2 and above, you will most likely encounter problems with your PHP '.PHP_VERSION.', upgrading is strongly recommended.</warning>');
         }
+        
+        if (extension_loaded('xdebug')) {
+            $io->write('<warning>You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug</warning>');
+        }        
 
         if (defined('COMPOSER_DEV_WARNING_TIME')) {
             $commandName = '';


### PR DESCRIPTION
As discussed in https://github.com/composer/composer/pull/4554#issuecomment-157357335
this adds a warning when xdebug is loaded, while composer cli commands run.

![xdebug](https://cloud.githubusercontent.com/assets/120441/11267607/9f07f528-8eac-11e5-9a2c-4f28869aa6ea.png)
