### PR TITLE
Bypass `runScripts` parameter to autoload dumper in `Installer:run()`

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -340,6 +340,7 @@ class Installer
 
                 $this->autoloadGenerator->setDevMode($this->devMode);
                 $this->autoloadGenerator->setClassMapAuthoritative($this->classMapAuthoritative);
+                $this->autoloadGenerator->setRunScripts($this->runScripts);
                 $this->autoloadGenerator->dump($this->config, $localRepo, $this->package, $this->installationManager, 'composer', $this->optimizeAutoloader);
             }
 


### PR DESCRIPTION
#4626 