### PR TITLE
Adds support for gitlab installed in subfolder

### DIFF
--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -62,6 +62,9 @@ class GitLabDriver extends VcsDriver
      */
     protected $gitDriver;
 
+    const URL_REGEX = '#^((https?)://(.*)/|git@([^:]+):)([^/]+)/(.+?)(?:\.git|/)?$#';
+
+
     /**
      * Extracts information from the repository url.
      * SSH urls uses https by default.
@@ -70,7 +73,7 @@ class GitLabDriver extends VcsDriver
      */
     public function initialize()
     {
-        if (!preg_match('#^((https?)://([0-9a-zA-Z\./]+)/|git@([^:]+):)([^/]+)/(.+?)(?:\.git|/)?$#', $this->url, $match)) {
+        if (!preg_match(static::URL_REGEX, $this->url, $match)) {
             throw new \InvalidArgumentException('The URL provided is invalid. It must be the HTTP URL of a GitLab project.');
         }
 
@@ -343,7 +346,7 @@ class GitLabDriver extends VcsDriver
      */
     public static function supports(IOInterface $io, Config $config, $url, $deep = false)
     {
-        if (!preg_match('#^((https?)://([^/]+)/|git@([^:]+):)([^/]+)/(.+?)(?:\.git|/)?$#', $url, $match)) {
+        if (!preg_match(static::URL_REGEX, $url, $match)) {
             return false;
         }
 

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -70,7 +70,7 @@ class GitLabDriver extends VcsDriver
      */
     public function initialize()
     {
-        if (!preg_match('#^((https?)://([^/]+)/|git@([^:]+):)([^/]+)/(.+?)(?:\.git|/)?$#', $this->url, $match)) {
+        if (!preg_match('#^((https?)://([0-9a-zA-Z\./]+)/|git@([^:]+):)([^/]+)/(.+?)(?:\.git|/)?$#', $this->url, $match)) {
             throw new \InvalidArgumentException('The URL provided is invalid. It must be the HTTP URL of a GitLab project.');
         }
 

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -217,4 +217,14 @@ JSON;
             array('http://example.com/foo/bar', false),
         );
     }
+
+    public function testGitlabSubDirectory()
+    {
+        $url = 'https://mycompany.com/gitlab/mygroup/myproject';
+        $apiUrl = 'https://mycompany.com/gitlab/api/v3/projects/mygroup%2Fmyproject';
+
+        $driver  = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->remoteFilesystem->reveal());
+        $driver->initialize();
+        $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
+    }
 }

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -26,6 +26,7 @@ class GitLabDriverTest extends \PHPUnit_Framework_TestCase
         $this->config->merge(array(
             'config' => array(
                 'home' => sys_get_temp_dir().'/composer-test',
+                'gitlab-domains' => array('mycompany.com/gitlab', 'gitlab.com')
             ),
         ));
 
@@ -215,6 +216,7 @@ JSON;
             array('git@gitlab.com:foo/bar.git', extension_loaded('openssl')),
             array('git@example.com:foo/bar.git', false),
             array('http://example.com/foo/bar', false),
+            array('https://mycompany.com/gitlab/mygroup/myproject', true),
         );
     }
 


### PR DESCRIPTION
Since gitlab can be hosted on any url also subdirectories should be
supported. (e.g https://mycompany.com/gitlab).
This supports only http and https protocols since the gitlab api url
is derived from the package repository url. And the ssh protocol doesn't
support folders this way.