### PR TITLE
Allows repositories to implement ConfigurableRepositoryInterface

### DIFF
--- a/src/Composer/Repository/ArtifactRepository.php
+++ b/src/Composer/Repository/ArtifactRepository.php
@@ -20,12 +20,13 @@ use Composer\Package\Loader\LoaderInterface;
 /**
  * @author Serge Smertin <serg.smertin@gmail.com>
  */
-class ArtifactRepository extends ArrayRepository
+class ArtifactRepository extends ArrayRepository implements ConfigurableRepositoryInterface
 {
     /** @var LoaderInterface */
     protected $loader;
 
     protected $lookup;
+    protected $repoConfig;
 
     public function __construct(array $repoConfig, IOInterface $io)
     {
@@ -36,6 +37,12 @@ class ArtifactRepository extends ArrayRepository
         $this->loader = new ArrayLoader();
         $this->lookup = $repoConfig['url'];
         $this->io = $io;
+        $this->repoConfig = $repoConfig;
+    }
+
+    public function getRepoConfig()
+    {
+        return $this->repoConfig;
     }
 
     protected function initialize()

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -31,9 +31,10 @@ use Composer\Semver\Constraint\Constraint;
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class ComposerRepository extends ArrayRepository
+class ComposerRepository extends ArrayRepository implements ConfigurableRepositoryInterface
 {
     protected $config;
+    protected $repoConfig;
     protected $options;
     protected $url;
     protected $baseUrl;
@@ -90,6 +91,12 @@ class ComposerRepository extends ArrayRepository
         $this->loader = new ArrayLoader();
         $this->rfs = new RemoteFilesystem($this->io, $this->config, $this->options);
         $this->eventDispatcher = $eventDispatcher;
+        $this->repoConfig = $repoConfig;
+    }
+
+    public function getRepoConfig()
+    {
+        return $this->repoConfig;
     }
 
     public function setRootAliases(array $rootAliases)

--- a/src/Composer/Repository/ConfigurableRepositoryInterface.php
+++ b/src/Composer/Repository/ConfigurableRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Repository;
+
+/**
+ * Configurable repository interface.
+ *
+ * @author Lukas Homza <lukashomz@gmail.com>
+ */
+interface ConfigurableRepositoryInterface
+{
+    public function getRepoConfig();
+}

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -49,7 +49,7 @@ use Composer\Util\ProcessExecutor;
  * @author Samuel Roze <samuel.roze@gmail.com>
  * @author Johann Reinke <johann.reinke@gmail.com>
  */
-class PathRepository extends ArrayRepository
+class PathRepository extends ArrayRepository implements ConfigurableRepositoryInterface
 {
     /**
      * @var ArrayLoader
@@ -65,6 +65,11 @@ class PathRepository extends ArrayRepository
      * @var string
      */
     private $url;
+
+    /**
+     * @var array
+     */
+    private $repoConfig;
 
     /**
      * @var ProcessExecutor
@@ -88,8 +93,14 @@ class PathRepository extends ArrayRepository
         $this->url = $repoConfig['url'];
         $this->process = new ProcessExecutor($io);
         $this->versionGuesser = new VersionGuesser($config, $this->process, new VersionParser());
+        $this->repoConfig = $repoConfig;
 
         parent::__construct();
+    }
+
+    public function getRepoConfig()
+    {
+        return $this->repoConfig;
     }
 
     /**

--- a/src/Composer/Repository/PearRepository.php
+++ b/src/Composer/Repository/PearRepository.php
@@ -32,12 +32,13 @@ use Composer\Config;
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class PearRepository extends ArrayRepository
+class PearRepository extends ArrayRepository implements ConfigurableRepositoryInterface
 {
     private $url;
     private $io;
     private $rfs;
     private $versionParser;
+    private $repoConfig;
 
     /** @var string vendor makes additional alias for each channel as {prefix}/{packagename}. It allows smoother
      * package transition to composer-like repositories.
@@ -60,6 +61,12 @@ class PearRepository extends ArrayRepository
         $this->rfs = $rfs ?: new RemoteFilesystem($this->io, $config);
         $this->vendorAlias = isset($repoConfig['vendor-alias']) ? $repoConfig['vendor-alias'] : null;
         $this->versionParser = new VersionParser();
+        $this->repoConfig = $repoConfig;
+    }
+
+    public function getRepoConfig()
+    {
+        return $this->repoConfig;
     }
 
     protected function initialize()

--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -26,7 +26,7 @@ use Composer\Config;
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class VcsRepository extends ArrayRepository
+class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInterface
 {
     protected $url;
     protected $packageName;


### PR DESCRIPTION
This PR attempts to solve an issue described here - https://github.com/composer/satis/pull/266#discussion_r45597333 by providing a new interface for all repository classes that use `$repoConfig` to implement. Which affects:

- `VcsRepository`
- `PearRepository`
- `ComposerRepository`
- `ArtifactRepository`
- `PathRepository`