### PR TITLE
Add missing getRepoConfig() method

### DIFF
--- a/src/Composer/Repository/PackageRepository.php
+++ b/src/Composer/Repository/PackageRepository.php
@@ -39,6 +39,11 @@ class PackageRepository extends ArrayRepository
         }
     }
 
+    public function getRepoConfig()
+    {
+        return $this->config;
+    }
+    
     /**
      * Initializes repository (reads file, or remote address).
      */


### PR DESCRIPTION
Required at https://github.com/composer/satis/blob/85ed79ce87debb4ce6bdbe3d48821945657ccc50/src/Composer/Satis/PackageSelection/PackageSelection.php#L160, at least.