### PR TITLE
Add --with-replaces option on depends command

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -342,6 +342,8 @@ symfony/symfony
 
 * **--link-type:** The link types to match on, can be specified multiple
   times.
+* **--with-replaces:** Search for replaced packages too. Works great
+for packages like [`symfony/symfony`](https://packagist.org/packages/symfony/symfony).
 
 ## validate
 


### PR DESCRIPTION
Closes #4657.

Output sample:

```bash
$ composer depends --with-replaces symfony/symfony
a2lix/translation-form-bundle requires symfony/symfony (>=2.3)
behat/behat requires (dev) symfony/process (~2.1)
behat/behat requires symfony/class-loader (~2.1)
behat/behat requires symfony/config (~2.3)
behat/behat requires symfony/console (~2.1)
behat/behat requires symfony/dependency-injection (~2.1)
behat/behat requires symfony/event-dispatcher (~2.1)
behat/behat requires symfony/translation (~2.3)
behat/behat requires symfony/yaml (~2.1)
behat/gherkin requires (dev) symfony/yaml (~2.1)
behat/mink-browserkit-driver requires symfony/browser-kit (~2.3)
behat/mink-browserkit-driver requires symfony/dom-crawler (~2.3)
behat/mink-extension requires symfony/config (~2.2)
behat/mink requires symfony/css-selector (~2.1)
behat/symfony2-extension requires (dev) symfony/symfony (~2.1)
behat/symfony2-extension requires symfony/framework-bundle (~2.0)
behat/web-api-extension requires (dev) symfony/process (~2.1)
browscap/browscap-bundle requires (dev) symfony/symfony (>=2.1,<=2.5)
cocur/slugify requires (dev) symfony/dependency-injection (~2.4)
cocur/slugify requires (dev) symfony/http-kernel (~2.4)
doctrine/dbal requires (dev) symfony/console (2.*)
doctrine/doctrine-bundle requires (dev) symfony/validator (~2.2|~3.0)
doctrine/doctrine-bundle requires (dev) symfony/yaml (~2.2|~3.0)
doctrine/doctrine-bundle requires symfony/console (~2.3|~3.0)
doctrine/doctrine-bundle requires symfony/doctrine-bridge (~2.2|~3.0)
doctrine/doctrine-bundle requires symfony/framework-bundle (~2.3|~3.0)
doctrine/doctrine-cache-bundle requires (dev) symfony/console (~2.2|~3.0)
doctrine/doctrine-cache-bundle requires (dev) symfony/finder (~2.2|~3.0)
doctrine/doctrine-cache-bundle requires (dev) symfony/framework-bundle (~2.2|~3.0)
doctrine/doctrine-cache-bundle requires (dev) symfony/validator (~2.2|~3.0)
doctrine/doctrine-cache-bundle requires (dev) symfony/yaml (~2.2|~3.0)
doctrine/doctrine-cache-bundle requires symfony/doctrine-bridge (~2.2|~3.0)
doctrine/doctrine-fixtures-bundle requires symfony/doctrine-bridge (~2.3|~3.0)
doctrine/doctrine-migrations-bundle requires symfony/framework-bundle (~2.3|~3.0)
doctrine/migrations requires symfony/console (~2.3)
doctrine/migrations requires symfony/yaml (~2.3)
doctrine/mongodb-odm-bundle requires (dev) symfony/form (~2.3)
doctrine/mongodb-odm-bundle requires (dev) symfony/yaml (~2.1)
doctrine/mongodb-odm-bundle requires symfony/config (~2.2)
doctrine/mongodb-odm-bundle requires symfony/console (~2.1)
doctrine/mongodb-odm-bundle requires symfony/dependency-injection (~2.2)
doctrine/mongodb-odm-bundle requires symfony/doctrine-bridge (~2.1)
doctrine/mongodb-odm-bundle requires symfony/framework-bundle (~2.1)
doctrine/mongodb-odm-bundle requires symfony/options-resolver (~2.1)
doctrine/mongodb-odm requires (dev) symfony/yaml (~2.3|~3.0)
doctrine/mongodb-odm requires symfony/console (~2.3|~3.0)
doctrine/orm requires (dev) symfony/yaml (~2.3|~3.0)
doctrine/orm requires symfony/console (~2.5|~3.0)
fabpot/goutte requires symfony/browser-kit (~2.1|~3.0)
fabpot/goutte requires symfony/css-selector (~2.1|~3.0)
fabpot/goutte requires symfony/dom-crawler (~2.1|~3.0)
friendsofsymfony/jsrouting-bundle requires (dev) symfony/expression-language (~2.4)
friendsofsymfony/jsrouting-bundle requires symfony/console (~2.0)
friendsofsymfony/jsrouting-bundle requires symfony/framework-bundle (~2.0)
friendsofsymfony/jsrouting-bundle requires symfony/serializer (~2.0)
friendsofsymfony/oauth-server-bundle requires (dev) symfony/class-loader (~2.1)
friendsofsymfony/oauth-server-bundle requires (dev) symfony/yaml (~2.1)
friendsofsymfony/oauth-server-bundle requires symfony/framework-bundle (~2.1)
friendsofsymfony/oauth-server-bundle requires symfony/security-bundle (~2.1)
friendsofsymfony/oauth2-php requires symfony/http-foundation (~2.0)
friendsofsymfony/rest-bundle requires (dev) symfony/browser-kit (~2.3)
friendsofsymfony/rest-bundle requires (dev) symfony/dependency-injection (~2.3)
friendsofsymfony/rest-bundle requires (dev) symfony/form (~2.3)
friendsofsymfony/rest-bundle requires (dev) symfony/security (~2.3)
friendsofsymfony/rest-bundle requires (dev) symfony/serializer (~2.3)
friendsofsymfony/rest-bundle requires (dev) symfony/validator (~2.3)
friendsofsymfony/rest-bundle requires (dev) symfony/yaml (~2.3)
friendsofsymfony/rest-bundle requires symfony/framework-bundle (~2.3)
friendsofsymfony/rest-bundle requires symfony/http-kernel (~2.3,>=2.3.24)
friendsofsymfony/user-bundle requires (dev) symfony/validator (~2.3)
friendsofsymfony/user-bundle requires (dev) symfony/yaml (~2.3)
friendsofsymfony/user-bundle requires symfony/form (~2.3)
friendsofsymfony/user-bundle requires symfony/framework-bundle (~2.3)
friendsofsymfony/user-bundle requires symfony/security-bundle (~2.3)
friendsofsymfony/user-bundle requires symfony/twig-bundle (~2.3)
gedmo/doctrine-extensions requires (dev) symfony/yaml (~2.6)
genemu/form-bundle requires (dev) symfony/doctrine-bridge (~2.6)
genemu/form-bundle requires (dev) symfony/finder (2.*)
genemu/form-bundle requires symfony/form (~2.6)
genemu/form-bundle requires symfony/framework-bundle (~2.6)
gregwar/image-bundle requires symfony/framework-bundle (~2.3)
hackzilla/password-generator-bundle requires symfony/symfony (~2.3)
hautelook/alice-bundle requires (dev) symfony/console (~2.3)
hautelook/alice-bundle requires (dev) symfony/framework-bundle (~2.3)
hautelook/alice-bundle requires (dev) symfony/validator (~2.3)
hautelook/alice-bundle requires (dev) symfony/yaml (~2.3)
hautelook/alice-bundle requires symfony/finder (^2.7)
incenteev/composer-parameter-handler requires (dev) symfony/filesystem (~2.2)
incenteev/composer-parameter-handler requires symfony/yaml (~2.3|~3.0)
inlinestyle/inlinestyle requires symfony/css-selector (~2.1)
jms/serializer-bundle requires (dev) symfony/browser-kit (*)
jms/serializer-bundle requires (dev) symfony/class-loader (*)
jms/serializer-bundle requires (dev) symfony/css-selector (*)
jms/serializer-bundle requires (dev) symfony/finder (*)
jms/serializer-bundle requires (dev) symfony/form (*)
jms/serializer-bundle requires (dev) symfony/process (*)
jms/serializer-bundle requires (dev) symfony/stopwatch (*)
jms/serializer-bundle requires (dev) symfony/twig-bundle (*)
jms/serializer-bundle requires (dev) symfony/validator (*)
jms/serializer-bundle requires (dev) symfony/yaml (*)
jms/serializer-bundle requires symfony/framework-bundle (~2.3|~3.0)
jms/serializer requires (dev) symfony/filesystem (2.*)
jms/serializer requires (dev) symfony/form (~2.1)
jms/serializer requires (dev) symfony/translation (~2.0)
jms/serializer requires (dev) symfony/validator (~2.0)
jms/serializer requires (dev) symfony/yaml (2.*)
knplabs/knp-components requires (dev) symfony/event-dispatcher (~2.5)
knplabs/knp-markdown-bundle requires symfony/framework-bundle (~2.1)
knplabs/knp-menu-bundle requires (dev) symfony/expression-language (~2.4)
knplabs/knp-menu-bundle requires symfony/framework-bundle (~2.3)
knplabs/knp-paginator-bundle requires (dev) symfony/expression-language (~2.4|~3.0)
knplabs/knp-paginator-bundle requires symfony/framework-bundle (~2.3|~3.0)
kriswallsmith/assetic requires symfony/process (~2.1|~3.0)
kriswallsmith/spork requires symfony/event-dispatcher (*)
lexik/jwt-authentication-bundle requires symfony/framework-bundle (~2.3)
lexik/jwt-authentication-bundle requires symfony/symfony (~2.3)
lexik/paybox-bundle requires symfony/form (~2.7)
lexik/paybox-bundle requires symfony/framework-bundle (~2.7)
lexik/paybox-bundle requires symfony/options-resolver (~2.7)
mannew/hipchat-bundle requires symfony/framework-bundle (~2.1)
mopa/bootstrap-bundle requires symfony/console (~2.3|~3.0)
mopa/bootstrap-bundle requires symfony/form (~2.3|~3.0)
mopa/bootstrap-bundle requires symfony/framework-bundle (~2.3|~3.0)
mopa/bootstrap-bundle requires symfony/twig-bundle (~2.3|~3.0)
mopa/composer-bridge requires symfony/class-loader (>=2.0.0)
mopa/composer-bridge requires symfony/console (>=2.0.0)
nelmio/alice requires (dev) symfony/property-access (~2.2)
nelmio/alice requires symfony/yaml (~2.0)
nelmio/api-doc-bundle requires (dev) symfony/browser-kit (~2.3)
nelmio/api-doc-bundle requires (dev) symfony/css-selector (~2.3)
nelmio/api-doc-bundle requires (dev) symfony/finder (~2.3)
nelmio/api-doc-bundle requires (dev) symfony/form (~2.3)
nelmio/api-doc-bundle requires (dev) symfony/serializer (~2.7)
nelmio/api-doc-bundle requires (dev) symfony/validator (~2.3)
nelmio/api-doc-bundle requires (dev) symfony/yaml (~2.3)
nelmio/api-doc-bundle requires symfony/console (~2.3)
nelmio/api-doc-bundle requires symfony/framework-bundle (~2.3)
nelmio/api-doc-bundle requires symfony/twig-bundle (~2.3)
nexylan/cloudflare-host-gw requires (dev) symfony/config (~2.7)
nexylan/cloudflare-host-gw requires (dev) symfony/dependency-injection (~2.7)
nexylan/cloudflare-host-gw requires (dev) symfony/http-kernel (~2.7)
nexylan/cloudflare requires (dev) symfony/config (~2.7)
nexylan/cloudflare requires (dev) symfony/dependency-injection (~2.7)
nexylan/cloudflare requires (dev) symfony/http-kernel (~2.7)
nexylan/cloudflare requires symfony/options-resolver (~2.7)
nexylan/n-admin requires symfony/symfony (2.8.*)
ornicar/gravatar-bundle requires symfony/framework-bundle (~2.0)
rollerworks/password-strength-bundle requires symfony/console (^2.3.3)
rollerworks/password-strength-bundle requires symfony/framework-bundle (^2.3.3)
rollerworks/password-strength-bundle requires symfony/validator (^2.3.20)
sensio/distribution-bundle requires symfony/class-loader (~2.3|~3.0)
sensio/distribution-bundle requires symfony/config (~2.3|~3.0)
sensio/distribution-bundle requires symfony/dependency-injection (~2.3|~3.0)
sensio/distribution-bundle requires symfony/filesystem (~2.3|~3.0)
sensio/distribution-bundle requires symfony/http-kernel (~2.3|~3.0)
sensio/distribution-bundle requires symfony/process (~2.3|~3.0)
sensio/framework-extra-bundle requires (dev) symfony/expression-language (~2.4|~3.0)
sensio/framework-extra-bundle requires (dev) symfony/security-bundle (~2.4|~3.0)
sensio/framework-extra-bundle requires symfony/framework-bundle (~2.3|~3.0)
sensio/generator-bundle requires (dev) symfony/doctrine-bridge (~2.7|~3.0)
sensio/generator-bundle requires symfony/console (~2.7|~3.0)
sensio/generator-bundle requires symfony/framework-bundle (~2.7|~3.0)
sensio/generator-bundle requires symfony/process (~2.7|~3.0)
sensio/generator-bundle requires symfony/yaml (~2.7|~3.0)
sensiolabs/security-checker requires symfony/console (~2.0|~3.0)
sllh/iso-codes-validator requires (dev) symfony/dependency-injection (^2.3|^3.0)
sllh/iso-codes-validator requires (dev) symfony/finder (^2.3|^3.0)
sllh/iso-codes-validator requires (dev) symfony/http-kernel (^2.3|^3.0)
sllh/iso-codes-validator requires symfony/translation (^2.3|^3.0)
sllh/iso-codes-validator requires symfony/validator (^2.3.20|^3.0)
sonata-project/admin-bundle requires (dev) symfony/yaml (~2.3)
sonata-project/admin-bundle requires symfony/class-loader (~2.3)
sonata-project/admin-bundle requires symfony/config (^2.3.9)
sonata-project/admin-bundle requires symfony/console (~2.3)
sonata-project/admin-bundle requires symfony/dependency-injection (~2.3,>=2.3.3)
sonata-project/admin-bundle requires symfony/expression-language (~2.4)
sonata-project/admin-bundle requires symfony/form (~2.3)
sonata-project/admin-bundle requires symfony/http-foundation (~2.3)
sonata-project/admin-bundle requires symfony/property-access (~2.3)
sonata-project/admin-bundle requires symfony/routing (~2.3)
sonata-project/admin-bundle requires symfony/security-bundle (~2.3)
sonata-project/admin-bundle requires symfony/translation (~2.3)
sonata-project/admin-bundle requires symfony/twig-bridge (~2.3)
sonata-project/admin-bundle requires symfony/validator (~2.3)
sonata-project/block-bundle requires symfony/form (~2.3)
sonata-project/block-bundle requires symfony/http-kernel (~2.3)
sonata-project/core-bundle requires symfony/config (~2.3|~3.0)
sonata-project/core-bundle requires symfony/form (~2.3|~3.0)
sonata-project/core-bundle requires symfony/http-foundation (~2.3|~3.0)
sonata-project/core-bundle requires symfony/property-access (~2.3|~3.0)
sonata-project/core-bundle requires symfony/translation (~2.3|~3.0)
sonata-project/core-bundle requires symfony/validator (~2.3|~3.0)
sonata-project/doctrine-orm-admin-bundle requires symfony/console (~2.3)
sonata-project/doctrine-orm-admin-bundle requires symfony/doctrine-bridge (~2.2)
sonata-project/doctrine-orm-admin-bundle requires symfony/form (~2.3)
sonata-project/doctrine-orm-admin-bundle requires symfony/framework-bundle (~2.2)
sonata-project/doctrine-orm-admin-bundle requires symfony/security (~2.3)
sonata-project/easy-extends-bundle requires symfony/console (~2)
sonata-project/easy-extends-bundle requires symfony/finder (~2)
sonata-project/easy-extends-bundle requires symfony/framework-bundle (~2)
sonata-project/exporter requires (dev) symfony/property-access (~2.3|~3.0)
sonata-project/exporter requires (dev) symfony/routing (~2.3|~3.0)
sonata-project/intl-bundle requires (dev) symfony/security (~2.2)
sonata-project/intl-bundle requires symfony/dependency-injection (~2.2)
sonata-project/intl-bundle requires symfony/http-kernel (~2.2)
sonata-project/intl-bundle requires symfony/locale (~2.2)
sonata-project/intl-bundle requires symfony/templating (~2.2)
stof/doctrine-extensions-bundle requires symfony/framework-bundle (~2.1)
symfony/assetic-bundle requires (dev) symfony/class-loader (~2.3|~3.0)
symfony/assetic-bundle requires (dev) symfony/css-selector (~2.3|~3.0)
symfony/assetic-bundle requires (dev) symfony/dom-crawler (~2.3|~3.0)
symfony/assetic-bundle requires (dev) symfony/twig-bundle (~2.3|~3.0)
symfony/assetic-bundle requires symfony/console (~2.3|~3.0)
symfony/assetic-bundle requires symfony/dependency-injection (~2.3|~3.0)
symfony/assetic-bundle requires symfony/framework-bundle (~2.3|~3.0)
symfony/assetic-bundle requires symfony/yaml (~2.3|~3.0)
symfony/monolog-bundle requires (dev) symfony/console (~2.3|~3.0)
symfony/monolog-bundle requires (dev) symfony/yaml (~2.3|~3.0)
symfony/monolog-bundle requires symfony/config (~2.3|~3.0)
symfony/monolog-bundle requires symfony/dependency-injection (~2.3|~3.0)
symfony/monolog-bundle requires symfony/http-kernel (~2.3|~3.0)
symfony/monolog-bundle requires symfony/monolog-bridge (~2.3|~3.0)
symfony/polyfill-intl-icu requires symfony/intl (~2.3|~3.0)
symfony/security-acl requires symfony/security-core (~2.4)
symfony/swiftmailer-bundle requires symfony/config (~2.3|~3.0)
symfony/swiftmailer-bundle requires symfony/dependency-injection (~2.3|~3.0)
symfony/swiftmailer-bundle requires symfony/http-kernel (~2.3|~3.0)
symfony/swiftmailer-bundle requires symfony/yaml (~2.3|~3.0)
twig/extensions requires (dev) symfony/translation (~2.3)
twig/twig requires (dev) symfony/debug (~2.7)
whiteoctober/breadcrumbs-bundle requires symfony/framework-bundle (2.*)
```