### PR TITLE
Configuration of gitlab-oauth via CLI followup

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -136,6 +136,11 @@
                     "description": "A hash of domain name => github API oauth tokens, typically {\"github.com\":\"<token>\"}.",
                     "additionalProperties": true
                 },
+                "gitlab-oauth": {
+                    "type": "object",
+                    "description": "A hash of domain name => gitlab API oauth tokens, typically {\"gitlab.com\":\"<token>\"}.",
+                    "additionalProperties": true
+                },
                 "http-basic": {
                     "type": "object",
                     "description": "A hash of domain name => {\"username\": \"...\", \"password\": \"...\"}.",
@@ -220,6 +225,13 @@
                 "github-expose-hostname": {
                     "type": "boolean",
                     "description": "Defaults to true. If set to false, the OAuth tokens created to access the github API will have a date instead of the machine hostname."
+                },
+                "gitlab-domains": {
+                    "type": "array",
+                    "description": "A list of domains to use in gitlab mode. This is used for custom GitLab setups, defaults to [\"gitlab.com\"].",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "archive-format": {
                     "type": "string",

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -164,7 +164,7 @@ EOT
         }
         if ($input->getOption('global') && !$this->authConfigFile->exists()) {
             touch($this->authConfigFile->getPath());
-            $this->authConfigFile->write(array('http-basic' => new \ArrayObject, 'github-oauth' => new \ArrayObject));
+            $this->authConfigFile->write(array('http-basic' => new \ArrayObject, 'github-oauth' => new \ArrayObject, 'gitlab-oauth' => new \ArrayObject));
             @chmod($this->authConfigFile->getPath(), 0600);
         }
 
@@ -358,6 +358,18 @@ EOT
                     return $vals;
                 },
             ),
+            'gitlab-domains' => array(
+                function ($vals) {
+                    if (!is_array($vals)) {
+                        return 'array expected';
+                    }
+
+                    return true;
+                },
+                function ($vals) {
+                    return $vals;
+                },
+            ),
         );
 
         foreach ($uniqueConfigValues as $name => $callbacks) {
@@ -433,7 +445,7 @@ EOT
         }
 
         // handle github-oauth
-        if (preg_match('/^(github-oauth|http-basic)\.(.+)/', $settingKey, $matches)) {
+        if (preg_match('/^(github-oauth|gitlab-oauth|http-basic)\.(.+)/', $settingKey, $matches)) {
             if ($input->getOption('unset')) {
                 $this->authConfigSource->removeConfigSetting($matches[1].'.'.$matches[2]);
                 $this->configSource->removeConfigSetting($matches[1].'.'.$matches[2]);
@@ -441,7 +453,7 @@ EOT
                 return;
             }
 
-            if ($matches[1] === 'github-oauth') {
+            if ($matches[1] === 'github-oauth' || $matches[1] === 'gitlab-oauth') {
                 if (1 !== count($values)) {
                     throw new \RuntimeException('Too many arguments, expected only one token');
                 }

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -51,6 +51,7 @@ class Config
         'archive-dir' => '.',
         // valid keys without defaults (auth config stuff):
         // github-oauth
+        // gitlab-oauth
         // http-basic
     );
 
@@ -111,7 +112,7 @@ class Config
         // override defaults with given config
         if (!empty($config['config']) && is_array($config['config'])) {
             foreach ($config['config'] as $key => $val) {
-                if (in_array($key, array('github-oauth', 'http-basic')) && isset($this->config[$key])) {
+                if (in_array($key, array('github-oauth', 'gitlab-oauth', 'http-basic')) && isset($this->config[$key])) {
                     $this->config[$key] = array_merge($this->config[$key], $val);
                 } else {
                     $this->config[$key] = $val;

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -79,7 +79,7 @@ class JsonConfigSource implements ConfigSourceInterface
     public function addConfigSetting($name, $value)
     {
         $this->manipulateJson('addConfigSetting', $name, $value, function (&$config, $key, $val) {
-            if (preg_match('{^(gitlab-oauth|github-oauth|http-basic|platform)\.}', $key)) {
+            if (preg_match('{^(github-oauth|gitlab-oauth|http-basic|platform)\.}', $key)) {
                 list($key, $host) = explode('.', $key, 2);
                 if ($this->authConfig) {
                     $config[$key][$host] = $val;
@@ -98,7 +98,7 @@ class JsonConfigSource implements ConfigSourceInterface
     public function removeConfigSetting($name)
     {
         $this->manipulateJson('removeConfigSetting', $name, function (&$config, $key) {
-            if (preg_match('{^(gitlab-oauth|github-oauth|http-basic|platform)\.}', $key)) {
+            if (preg_match('{^(github-oauth|gitlab-oauth|http-basic|platform)\.}', $key)) {
                 list($key, $host) = explode('.', $key, 2);
                 if ($this->authConfig) {
                     unset($config[$key][$host]);


### PR DESCRIPTION
First apologies are in order for not testing the previous pull #4659.

I have scanned configuration code for github occurences and added gitlab where it was necessary.
Since this is "copy paste" kind of pull please check diffs for typos I have checked it but might be suffering from authors blindness. :smiley:

This one I have tested and works ie.: it is now possible to do `composer configure -g gitlab-oauth.<domain> <token>`.
