### PR TITLE
[ClassLoader] performance improvement: use str_replace instead of strtr

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -344,7 +344,7 @@ class ClassLoader
     private function findFileWithExtension($class, $ext)
     {
         // PSR-4 lookup
-        $logicalPathPsr4 = strtr($class, '\\', DIRECTORY_SEPARATOR) . $ext;
+        $logicalPathPsr4 = str_replace('\\', DIRECTORY_SEPARATOR, $class) . $ext;
 
         $first = $class[0];
         if (isset($this->prefixLengthsPsr4[$first])) {
@@ -370,10 +370,10 @@ class ClassLoader
         if (false !== $pos = strrpos($class, '\\')) {
             // namespaced class name
             $logicalPathPsr0 = substr($logicalPathPsr4, 0, $pos + 1)
-                . strtr(substr($logicalPathPsr4, $pos + 1), '_', DIRECTORY_SEPARATOR);
+                . str_replace('_', DIRECTORY_SEPARATOR, substr($logicalPathPsr4, $pos + 1));
         } else {
             // PEAR-like class name
-            $logicalPathPsr0 = strtr($class, '_', DIRECTORY_SEPARATOR) . $ext;
+            $logicalPathPsr0 = str_replace('_', DIRECTORY_SEPARATOR, $class) . $ext;
         }
 
         if (isset($this->prefixesPsr0[$first])) {

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -344,7 +344,7 @@ class ClassLoader
     private function findFileWithExtension($class, $ext)
     {
         // PSR-4 lookup
-        $logicalPathPsr4 = str_replace('\\', DIRECTORY_SEPARATOR, $class) . $ext;
+        $logicalPathPsr4 = ('\\' !== DIRECTORY_SEPARATOR ? str_replace('\\', DIRECTORY_SEPARATOR, $class) : $class) . $ext;
 
         $first = $class[0];
         if (isset($this->prefixLengthsPsr4[$first])) {


### PR DESCRIPTION
str_replace is faster than strtr for this use-case. See symfony/symfony#15614

And we can even skip the str_replace on Windows completely.