### PR TITLE
Speed git downloads by using cache dir as reference

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -49,7 +49,6 @@ class Config
         'platform' => array(),
         'archive-format' => 'tar',
         'archive-dir' => '.',
-        'home' => '$HOME'
         // valid keys without defaults (auth config stuff):
         // github-oauth
         // gitlab-oauth

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -49,6 +49,7 @@ class Config
         'platform' => array(),
         'archive-format' => 'tar',
         'archive-dir' => '.',
+        'home' => '$HOME'
         // valid keys without defaults (auth config stuff):
         // github-oauth
         // gitlab-oauth

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -41,10 +41,12 @@ class GitDownloader extends VcsDownloader
     {
         GitUtil::cleanEnv();
         $path = $this->normalizePath($path);
+        $cachePath = $this->config->get('cache-vcs-dir').'/'.preg_replace('{[^a-z0-9.]}i', '-', $url).'/';
+        $cacheOptions = file_exists($cachePath) ? $cacheOptions = '--reference '.$cachePath.' ' : '';
 
         $ref = $package->getSourceReference();
         $flag = defined('PHP_WINDOWS_VERSION_MAJOR') ? '/D ' : '';
-        $command = 'git clone --no-checkout %s %s && cd '.$flag.'%2$s && git remote add composer %1$s && git fetch composer';
+        $command = 'git clone --no-checkout %s %s '.$cacheOptions.'&& cd '.$flag.'%2$s && git remote add composer %1$s && git fetch composer';
         $this->io->writeError("    Cloning ".$ref);
 
         $commandCallable = function ($url) use ($ref, $path, $command) {

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -42,7 +42,7 @@ class GitDownloader extends VcsDownloader
         GitUtil::cleanEnv();
         $path = $this->normalizePath($path);
         $cachePath = $this->config->get('cache-vcs-dir').'/'.preg_replace('{[^a-z0-9.]}i', '-', $url).'/';
-        $cacheOptions = file_exists($cachePath) ? $cacheOptions = '--reference '.$cachePath.' ' : '';
+        $cacheOptions = file_exists($cachePath) ? '--reference '.ProcessExecutor::escape($cachePath).' ' : '';
 
         $ref = $package->getSourceReference();
         $flag = defined('PHP_WINDOWS_VERSION_MAJOR') ? '/D ' : '';

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -42,7 +42,7 @@ class GitDownloader extends VcsDownloader
         GitUtil::cleanEnv();
         $path = $this->normalizePath($path);
         $cachePath = $this->config->get('cache-vcs-dir').'/'.preg_replace('{[^a-z0-9.]}i', '-', $url).'/';
-        $cacheOptions = file_exists($cachePath) ? '--reference '.ProcessExecutor::escape($cachePath).' ' : '';
+        $cacheOptions = file_exists($cachePath) ? '--dissociate --reference '.ProcessExecutor::escape($cachePath).' ' : '';
 
         $ref = $package->getSourceReference();
         $flag = defined('PHP_WINDOWS_VERSION_MAJOR') ? '/D ' : '';

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -26,6 +26,10 @@ class GitDownloaderTest extends \PHPUnit_Framework_TestCase
         if (!$config) {
             $config = new Config();
         }
+        if (!$config->has('home')) {
+            $tmpDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'cmptest-'.md5(uniqid('', true));
+            $config->merge(array('config' => array('home' => $tmpDir)));
+        }
 
         return new GitDownloader($io, $config, $executor, $filesystem);
     }


### PR DESCRIPTION
Proposed solution for #1323

When downloading a git repository, it checks if that repository was already cached under cache-vcs-dir and if it was, use it as a "--reference".

By using this option, when downloading objects, git checks if those objects exist in that local mirror first, greatly reducing the network bandwidth usage, speeding up composer when reusing a package across multiple projects. See https://git-scm.com/docs/git-clone

The cache was already being created, when composer analyzes the dependencies of the source repo, so I only needed to check if the cache dir already existed.

Does anyone see any drawbacks of using this approach?

I tested manually on multiple situations (new repo, update, install, repo with new commits, etc.).

BTW, the original motivation to this was that trying to find a work-around to #3542 different than setting oauth tokens (which bring shared-security issues), I initially htought of using --prefer-source and was surprised that no cache was being used. Maybe with this, the performance penalty of using --prefer-source reduces enough for it to be an alternative to downloads from github api?

------------
> This pull request was made during the Open Source Day @ [beubi](http://beubi.com) :green_heart: