### PR TITLE
Replaced relative path with absolute path in order to fix symlink on windows

### DIFF
--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -48,8 +48,7 @@ class PathDownloader extends FileDownloader
         }
 
         try {
-            $shortestPath = $this->filesystem->findShortestPath($path, $realUrl);
-            $fileSystem->symlink($shortestPath, $path);
+            $fileSystem->symlink($realUrl, $path);
             $this->io->writeError(sprintf('    Symlinked from %s', $url));
         } catch (IOException $e) {
             $fileSystem->mirror($realUrl, $path);


### PR DESCRIPTION
Fix symlink issue on windows
```
  [ErrorException]
  symlink(): Could not fetch file information(error 3)