### PR TITLE
Improve error message about platform php version

### DIFF
--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -207,7 +207,7 @@ class Rule
                         } elseif ($targetName === 'hhvm') {
                             $text .= ' -> you are running this with PHP and not HHVM.';
                         } else {
-                            $text .= ' -> your PHP version ('. phpversion() .') or "config.platform.php" value does not satisfy that requirement.';
+                            $text .= ' -> your PHP version ('. phpversion() .') or "config.platform.php" setting in composer.json does not satisfy that requirement.';
                         }
                     } elseif (0 === strpos($targetName, 'ext-')) {
                         // handle php extensions

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -207,7 +207,7 @@ class Rule
                         } elseif ($targetName === 'hhvm') {
                             $text .= ' -> you are running this with PHP and not HHVM.';
                         } else {
-                            $text .= ' -> your PHP version ('. phpversion() .') or "config.platform.php" setting in composer.json does not satisfy that requirement.';
+                            $text .= ' -> your PHP version ('. phpversion() .') or value of "config.platform.php" in composer.json does not satisfy that requirement.';
                         }
                     } elseif (0 === strpos($targetName, 'ext-')) {
                         // handle php extensions


### PR DESCRIPTION
When seeing the error message, I though "config.platform.php" was some file/value configured for platform.sh instead of a setting value in composer.json. I propose to make it a bit more clear that this value is set in composer.json