### PR TITLE
Use github.com instead of api.github.com to fetch zip files

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -86,10 +86,17 @@ class FileDownloader implements DownloaderInterface
         $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . $package->getFullPrettyVersion() . "</comment>)");
 
         $urls = $package->getDistUrls();
+        $processUrl = true;
+
+        if (isset($urls[0]) && preg_match('#^https://api\.github\.com/repos/([^/]++/[^/]++)/zipball/(.++)$#', $urls[0], $match) && !$this->io->hasAuthentication('github.com')) {
+            array_unshift($urls, 'https://github.com/'.$match[1].'/archive/'.$match[2].'.zip');
+            $processUrl = false;
+        }
         while ($url = array_shift($urls)) {
             try {
-                return $this->doDownload($package, $path, $url);
+                return $this->doDownload($package, $path, $url, $processUrl);
             } catch (\Exception $e) {
+                $processUrl = true;
                 if ($this->io->isDebug()) {
                     $this->io->writeError('');
                     $this->io->writeError('Failed: ['.get_class($e).'] '.$e->getCode().': '.$e->getMessage());
@@ -107,13 +114,13 @@ class FileDownloader implements DownloaderInterface
         $this->io->writeError('');
     }
 
-    protected function doDownload(PackageInterface $package, $path, $url)
+    protected function doDownload(PackageInterface $package, $path, $url, $processUrl = true)
     {
         $this->filesystem->emptyDirectory($path);
 
         $fileName = $this->getFileName($package, $path);
 
-        $processedUrl = $this->processUrl($package, $url);
+        $processedUrl = $processUrl ? $this->processUrl($package, $url) : $url;
         $hostname = parse_url($processedUrl, PHP_URL_HOST);
 
         $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->rfs, $processedUrl);


### PR DESCRIPTION
This is just a patch that proves that fetching zip files on this github.com endpoint works the same as the one on api.github.com, but is not affected by rate limiting. This could speed up builds on travis by a significant factor, because we wouldn't be forced anymore to use `--prefer-source`