### PR TITLE
Revert "Avoid loading plugins that do not match the current plugin api even during installation"

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -106,26 +106,6 @@ class PluginManager
             return;
         }
 
-        $requiresComposer = null;
-        foreach ($package->getRequires() as $link) { /** @var Link $link */
-            if ('composer-plugin-api' === $link->getTarget()) {
-                $requiresComposer = $link->getConstraint();
-                break;
-            }
-        }
-
-        if (!$requiresComposer) {
-            throw new \RuntimeException("Plugin ".$package->getName()." is missing a require statement for a version of the composer-plugin-api package.");
-        }
-
-        $currentPluginApiVersion = $this->getPluginApiVersion();
-        $currentPluginApiConstraint = new Constraint('==', $this->versionParser->normalize($currentPluginApiVersion));
-
-        if (!$requiresComposer->matches($currentPluginApiConstraint)) {
-            $this->io->writeError('<warning>The "' . $package->getName() . '" plugin was skipped because it requires a Plugin API version ("' . $requiresComposer->getPrettyString() . '") that does not match your Composer installation ("' . $currentPluginApiVersion . '"). You may need to run composer update with the "--no-plugins" option.</warning>');
-            return;
-        }
-
         $oldInstallerPlugin = ($package->getType() === 'composer-installer');
 
         if (in_array($package->getName(), $this->registeredPlugins)) {
@@ -229,7 +209,28 @@ class PluginManager
                 continue;
             }
             if ('composer-plugin' === $package->getType()) {
+                $requiresComposer = null;
+                foreach ($package->getRequires() as $link) { /** @var Link $link */
+                    if ('composer-plugin-api' === $link->getTarget()) {
+                        $requiresComposer = $link->getConstraint();
+                        break;
+                    }
+                }
+
+                if (!$requiresComposer) {
+                    throw new \RuntimeException("Plugin ".$package->getName()." is missing a require statement for a version of the composer-plugin-api package.");
+                }
+
+                $currentPluginApiVersion = $this->getPluginApiVersion();
+                $currentPluginApiConstraint = new Constraint('==', $this->versionParser->normalize($currentPluginApiVersion));
+
+                if (!$requiresComposer->matches($currentPluginApiConstraint)) {
+                    $this->io->writeError('<warning>The "' . $package->getName() . '" plugin was skipped because it requires a Plugin API version ("' . $requiresComposer->getPrettyString() . '") that does not match your Composer installation ("' . $currentPluginApiVersion . '"). You may need to run composer update with the "--no-plugins" option.</warning>');
+                    continue;
+                }
+
                 $this->registerPackage($package);
+
             // Backward compatibility
             } elseif ('composer-installer' === $package->getType()) {
                 $this->registerPackage($package);


### PR DESCRIPTION
This reverts commit 21f5933e0170b9673108f05df262dbc7f98cce69.

Commit 21f5933e breaks fresh installations of cakephp applications, or
any project where a dependency uses a different composer plugin
installer than the upstream project.

Closes auraphp/Aura.Intl#20