### PR TITLE
make root server file url configurable

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -38,6 +38,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     protected $config;
     protected $repoConfig;
     protected $options;
+    protected $rootServerFileUrl;
     protected $url;
     protected $baseUrl;
     protected $io;
@@ -87,6 +88,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         $this->config = $config;
         $this->options = $repoConfig['options'];
         $this->url = $repoConfig['url'];
+        $this->rootServerFileUrl = isset($repoConfig['root-server-file-url']) ? $repoConfig['root-server-file-url'] : null;
         $this->baseUrl = rtrim(preg_replace('{^(.*)(?:/[^/\\]+.json)?(?:[?#].*)?$}', '$1', $this->url), '/');
         $this->io = $io;
         $this->cache = new Cache($io, $config->get('cache-repo-dir').'/'.preg_replace('{[^a-z0-9.]}i', '-', $this->url), 'a-z0-9.$');
@@ -441,16 +443,18 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             return $this->rootData;
         }
 
-        if (!extension_loaded('openssl') && 'https' === substr($this->url, 0, 5)) {
-            throw new \RuntimeException('You must enable the openssl extension in your php.ini to load information from '.$this->url);
+        $url = $this->rootServerFileUrl ?: $this->url;
+
+        if (!extension_loaded('openssl') && 'https' === substr($url, 0, 5)) {
+            throw new \RuntimeException('You must enable the openssl extension in your php.ini to load information from '.$url);
         }
 
-        $jsonUrlParts = parse_url($this->url);
+        $jsonUrlParts = parse_url($url);
 
         if (isset($jsonUrlParts['path']) && false !== strpos($jsonUrlParts['path'], '.json')) {
-            $jsonUrl = $this->url;
+            $jsonUrl = $url;
         } else {
-            $jsonUrl = $this->url . '/packages.json';
+            $jsonUrl = $url . '/packages.json';
         }
 
         $data = $this->fetchFile($jsonUrl, 'packages.json');


### PR DESCRIPTION
Connection to `packagist.org` from my network is very poor but to `api.github.com` is good. So I want to put a CDN before packagist.org  and set packagist repo like this:
```
{
    "repositories": {
        "packagist": {
            "type": "composer",
            "url": "CDN_URL"
        }
    }
}
```
CDN is set to be a mirror of `packagist.org`. It works! After package provider files is cached in CDN, the speed of `composer install & update` is acceptable.

Because there isn't version-related info in root server file url, my CDN cannot update it immediately.

In this PR, I make root server file url configurable. So I can put root server file in a dynamic content server and other package provider files in CDN.

Now the CDN mirror is updated passively. Next step I will make it updated actively.
Any suggestion is welcome.