### PR TITLE
Break early when a provider name is matched

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -136,6 +136,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                         }
                     }
                 }
+                break;
             }
         }
     }
@@ -169,6 +170,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                         }
                     }
                 }
+                break;
             }
         }
 


### PR DESCRIPTION
I believe `getProviderNames()` always returns an array of unique names, in which case the iteration of these names can break as soon as the first match is found, because, by definition, it would be impossible to get another match.

I am not familiar with the BC format of `providers-includes`, so I can't say with certainty that after applying `substr($provider, 2, -5)` on each item in the provider listing this would yield a completely unique set, but I'm guessing that it would. In that case, breaking early would offer a slight performance improvement. :)