### PR TITLE
try to use unique test directories

### DIFF
--- a/tests/Composer/Test/AllFunctionalTest.php
+++ b/tests/Composer/Test/AllFunctionalTest.php
@@ -12,14 +12,15 @@
 
 namespace Composer\Test;
 
-use Symfony\Component\Process\Process;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Process\Process;
 
 /**
  * @group slow
  */
-class AllFunctionalTest extends \PHPUnit_Framework_TestCase
+class AllFunctionalTest extends TestCase
 {
     protected $oldcwd;
     protected $oldenv;
@@ -29,17 +30,21 @@ class AllFunctionalTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->oldcwd = getcwd();
+
         chdir(__DIR__.'/Fixtures/functional');
     }
 
     public function tearDown()
     {
         chdir($this->oldcwd);
+
         $fs = new Filesystem;
+
         if ($this->testDir) {
             $fs->removeDirectory($this->testDir);
             $this->testDir = null;
         }
+
         if ($this->oldenv) {
             $fs->removeDirectory(getenv('COMPOSER_HOME'));
             $_SERVER['COMPOSER_HOME'] = $this->oldenv;
@@ -50,7 +55,7 @@ class AllFunctionalTest extends \PHPUnit_Framework_TestCase
 
     public static function setUpBeforeClass()
     {
-        self::$pharPath = sys_get_temp_dir().'/composer-phar-test/composer.phar';
+        self::$pharPath = self::getUniqueTmpDirectory() . '/composer.phar';
     }
 
     public static function tearDownAfterClass()
@@ -66,9 +71,7 @@ class AllFunctionalTest extends \PHPUnit_Framework_TestCase
         }
 
         $target = dirname(self::$pharPath);
-        $fs = new Filesystem;
-        $fs->removeDirectory($target);
-        $fs->ensureDirectoryExists($target);
+        $fs = new Filesystem();
         chdir($target);
 
         $it = new \RecursiveDirectoryIterator(__DIR__.'/../../../', \RecursiveDirectoryIterator::SKIP_DOTS);
@@ -85,9 +88,11 @@ class AllFunctionalTest extends \PHPUnit_Framework_TestCase
 
         $proc = new Process('php '.escapeshellarg('./bin/compile'), $target);
         $exitcode = $proc->run();
+
         if ($exitcode !== 0 || trim($proc->getOutput())) {
             $this->fail($proc->getOutput());
         }
+
         $this->assertTrue(file_exists(self::$pharPath));
     }
 
@@ -140,7 +145,7 @@ class AllFunctionalTest extends \PHPUnit_Framework_TestCase
         $data = array();
         $section = null;
 
-        $testDir = sys_get_temp_dir().'/composer_functional_test'.uniqid(mt_rand(), true);
+        $testDir = self::getUniqueTmpDirectory();
         $this->testDir = $testDir;
         $varRegex = '#%([a-zA-Z_-]+)%#';
         $variableReplacer = function ($match) use (&$data, $testDir) {

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -88,8 +88,7 @@ class AutoloadGeneratorTest extends TestCase
         $this->fs = new Filesystem;
         $that = $this;
 
-        $this->workingDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'cmptest-'.md5(uniqid('', true));
-        $this->fs->ensureDirectoryExists($this->workingDir);
+        $this->workingDir = $this->getUniqueTmpDirectory();
         $this->vendorDir = $this->workingDir.DIRECTORY_SEPARATOR.'composer-test-autoload';
         $this->ensureDirectoryExistsAndClear($this->vendorDir);
 
@@ -144,6 +143,7 @@ class AutoloadGeneratorTest extends TestCase
         if (is_dir($this->workingDir)) {
             $this->fs->removeDirectory($this->workingDir);
         }
+
         if (is_dir($this->vendorDir)) {
             $this->fs->removeDirectory($this->vendorDir);
         }

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -19,10 +19,11 @@
 namespace Composer\Test\Autoload;
 
 use Composer\Autoload\ClassMapGenerator;
+use Composer\TestCase;
 use Symfony\Component\Finder\Finder;
 use Composer\Util\Filesystem;
 
-class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
+class ClassMapGeneratorTest extends TestCase
 {
     /**
      * @dataProvider getTestCreateMapTests
@@ -127,10 +128,8 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->checkIfFinderIsAvailable();
 
-        $tempDir = sys_get_temp_dir().'/ComposerTestAmbiguousRefs';
-        if (!is_dir($tempDir.'/other')) {
-            mkdir($tempDir.'/other', 0777, true);
-        }
+        $tempDir = $this->getUniqueTmpDirectory();
+        $this->ensureDirectoryExistsAndClear($tempDir.'/other');
 
         $finder = new Finder();
         $finder->files()->in($tempDir);
@@ -171,13 +170,9 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testUnambiguousReference()
     {
-        $tempDir = sys_get_temp_dir().'/ComposerTestUnambiguousRefs';
-        if (!is_dir($tempDir)) {
-            mkdir($tempDir, 0777, true);
-        }
+        $tempDir = $this->getUniqueTmpDirectory();
 
         file_put_contents($tempDir.'/A.php', "<?php\nclass A {}");
-
         file_put_contents(
             $tempDir.'/B.php',
             "<?php

--- a/tests/Composer/Test/CacheTest.php
+++ b/tests/Composer/Test/CacheTest.php
@@ -25,15 +25,15 @@ class CacheTest extends TestCase
             $this->markTestSkipped('Test causes intermittent failures on Travis');
         }
 
-        $this->root = sys_get_temp_dir() . '/composer_testdir';
-        $this->ensureDirectoryExistsAndClear($this->root);
-
+        $this->root = $this->getUniqueTmpDirectory();
         $this->files = array();
         $zeros = str_repeat('0', 1000);
+
         for ($i = 0; $i < 4; $i++) {
             file_put_contents("{$this->root}/cached.file{$i}.zip", $zeros);
             $this->files[] = new \SplFileInfo("{$this->root}/cached.file{$i}.zip");
         }
+
         $this->finder = $this->getMockBuilder('Symfony\Component\Finder\Finder')->disableOriginalConstructor()->getMock();
 
         $io = $this->getMock('Composer\IO\IOInterface');

--- a/tests/Composer/Test/Config/JsonConfigSourceTest.php
+++ b/tests/Composer/Test/Config/JsonConfigSourceTest.php
@@ -14,9 +14,10 @@ namespace Composer\Test\Json;
 
 use Composer\Config\JsonConfigSource;
 use Composer\Json\JsonFile;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 
-class JsonConfigSourceTest extends \PHPUnit_Framework_TestCase
+class JsonConfigSourceTest extends TestCase
 {
     /** @var Filesystem */
     private $fs;
@@ -31,8 +32,7 @@ class JsonConfigSourceTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->fs = new Filesystem;
-        $this->workingDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'cmptest';
-        $this->fs->ensureDirectoryExists($this->workingDir);
+        $this->workingDir = $this->getUniqueTmpDirectory();
     }
 
     protected function tearDown()

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -13,9 +13,10 @@
 namespace Composer\Test\Downloader;
 
 use Composer\Downloader\FileDownloader;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 
-class FileDownloaderTest extends \PHPUnit_Framework_TestCase
+class FileDownloaderTest extends TestCase
 {
     protected function getDownloader($io = null, $config = null, $eventDispatcher = null, $cache = null, $rfs = null, $filesystem = null)
     {
@@ -53,9 +54,9 @@ class FileDownloaderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(array('url')))
         ;
 
-        $path = tempnam(sys_get_temp_dir(), 'c');
-
+        $path = tempnam($this->getUniqueTmpDirectory(), 'c');
         $downloader = $this->getDownloader();
+
         try {
             $downloader->download($packageMock, $path);
             $this->fail();
@@ -102,10 +103,7 @@ class FileDownloaderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(array()))
         ;
 
-        do {
-            $path = sys_get_temp_dir().'/'.md5(time().mt_rand());
-        } while (file_exists($path));
-
+        $path = $this->getUniqueTmpDirectory();
         $ioMock = $this->getMock('Composer\IO\IOInterface');
         $ioMock->expects($this->any())
             ->method('write')
@@ -187,14 +185,9 @@ class FileDownloaderTest extends \PHPUnit_Framework_TestCase
         ;
         $filesystem = $this->getMock('Composer\Util\Filesystem');
 
-        do {
-            $path = sys_get_temp_dir().'/'.md5(time().mt_rand());
-        } while (file_exists($path));
-
+        $path = $this->getUniqueTmpDirectory();
         $downloader = $this->getDownloader(null, null, null, null, null, $filesystem);
-
         // make sure the file expected to be downloaded is on disk already
-        mkdir($path, 0777, true);
         touch($path.'/script.js');
 
         try {

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -14,9 +14,10 @@ namespace Composer\Test\Downloader;
 
 use Composer\Downloader\GitDownloader;
 use Composer\Config;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 
-class GitDownloaderTest extends \PHPUnit_Framework_TestCase
+class GitDownloaderTest extends TestCase
 {
     /** @var Filesystem */
     private $fs;
@@ -26,7 +27,7 @@ class GitDownloaderTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->fs = new Filesystem;
-        $this->workingDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'cmptest-'.md5(uniqid('', true));
+        $this->workingDir = $this->getUniqueTmpDirectory();
     }
 
     protected function tearDown()
@@ -317,7 +318,7 @@ class GitDownloaderTest extends \PHPUnit_Framework_TestCase
             ->method('execute')
             ->with($this->equalTo($expectedGitUpdateCommand))
             ->will($this->returnValue(1));
-        
+
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
         $downloader = $this->getDownloaderMock(null, new Config(), $processExecutor);
         $downloader->update($packageMock, $packageMock, $this->workingDir);

--- a/tests/Composer/Test/Downloader/HgDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/HgDownloaderTest.php
@@ -13,16 +13,17 @@
 namespace Composer\Test\Downloader;
 
 use Composer\Downloader\HgDownloader;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 
-class HgDownloaderTest extends \PHPUnit_Framework_TestCase
+class HgDownloaderTest extends TestCase
 {
     /** @var string */
     private $workingDir;
 
     protected function setUp()
     {
-        $this->workingDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'cmptest-'.md5(uniqid('', true));
+        $this->workingDir = $this->getUniqueTmpDirectory();
     }
 
     protected function tearDown()

--- a/tests/Composer/Test/Downloader/PearPackageExtractorTest.php
+++ b/tests/Composer/Test/Downloader/PearPackageExtractorTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Downloader;
 
 use Composer\Downloader\PearPackageExtractor;
+use Composer\TestCase;
 
-class PearPackageExtractorTest extends \PHPUnit_Framework_TestCase
+class PearPackageExtractorTest extends TestCase
 {
     public function testShouldExtractPackage_1_0()
     {
@@ -122,7 +123,7 @@ class PearPackageExtractorTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldPerformReplacements()
     {
-        $from = tempnam(sys_get_temp_dir(), 'pear-extract');
+        $from = tempnam($this->getUniqueTmpDirectory(), 'pear-extract');
         $to = $from.'-to';
 
         $original = 'replaced: @placeholder@; not replaced: @another@; replaced again: @placeholder@';

--- a/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
@@ -16,12 +16,13 @@ use Composer\Downloader\PerforceDownloader;
 use Composer\Config;
 use Composer\Repository\VcsRepository;
 use Composer\IO\IOInterface;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 
 /**
  * @author Matt Whittom <Matt.Whittom@veteransunited.com>
  */
-class PerforceDownloaderTest extends \PHPUnit_Framework_TestCase
+class PerforceDownloaderTest extends TestCase
 {
     protected $config;
     protected $downloader;
@@ -34,7 +35,7 @@ class PerforceDownloaderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->testPath        = sys_get_temp_dir() . '/composer-test';
+        $this->testPath        = $this->getUniqueTmpDirectory();
         $this->repoConfig      = $this->getRepoConfig();
         $this->config          = $this->getConfig();
         $this->io              = $this->getMockIoInterface();

--- a/tests/Composer/Test/Downloader/XzDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/XzDownloaderTest.php
@@ -13,10 +13,11 @@
 namespace Composer\Test\Downloader;
 
 use Composer\Downloader\XzDownloader;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Util\RemoteFilesystem;
 
-class XzDownloaderTest extends \PHPUnit_Framework_TestCase
+class XzDownloaderTest extends TestCase
 {
     /**
      * @var Filesystem
@@ -33,7 +34,7 @@ class XzDownloaderTest extends \PHPUnit_Framework_TestCase
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->markTestSkipped('Skip test on Windows');
         }
-        $this->testDir = sys_get_temp_dir().'/composer-xz-test-vendor';
+        $this->testDir = $this->getUniqueTmpDirectory();
     }
 
     public function tearDown()
@@ -67,7 +68,7 @@ class XzDownloaderTest extends \PHPUnit_Framework_TestCase
         $downloader = new XzDownloader($io, $config, null, null, null, new RemoteFilesystem($io));
 
         try {
-            $downloader->download($packageMock, sys_get_temp_dir().'/composer-xz-test');
+            $downloader->download($packageMock, $this->getUniqueTmpDirectory());
             $this->fail('Download of invalid tarball should throw an exception');
         } catch (\RuntimeException $e) {
             $this->assertContains('File format not recognized', $e->getMessage());

--- a/tests/Composer/Test/Downloader/ZipDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ZipDownloaderTest.php
@@ -13,9 +13,10 @@
 namespace Composer\Test\Downloader;
 
 use Composer\Downloader\ZipDownloader;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 
-class ZipDownloaderTest extends \PHPUnit_Framework_TestCase
+class ZipDownloaderTest extends TestCase
 {
 
     /**
@@ -28,7 +29,8 @@ class ZipDownloaderTest extends \PHPUnit_Framework_TestCase
         if (!class_exists('ZipArchive')) {
             $this->markTestSkipped('zip extension missing');
         }
-        $this->testDir = sys_get_temp_dir().'/composer-zip-test-vendor';
+
+        $this->testDir = $this->getUniqueTmpDirectory();
     }
 
     public function tearDown()

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -22,6 +22,7 @@ class LibraryInstallerTest extends TestCase
 {
     protected $composer;
     protected $config;
+    protected $rootDir;
     protected $vendorDir;
     protected $binDir;
     protected $dm;
@@ -37,10 +38,11 @@ class LibraryInstallerTest extends TestCase
         $this->config = new Config();
         $this->composer->setConfig($this->config);
 
-        $this->vendorDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'composer-test-vendor';
+        $this->rootDir = $this->getUniqueTmpDirectory();
+        $this->vendorDir = $this->rootDir.'/vendor';
         $this->ensureDirectoryExistsAndClear($this->vendorDir);
 
-        $this->binDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'composer-test-bin';
+        $this->binDir = $this->rootDir.'/bin';
         $this->ensureDirectoryExistsAndClear($this->binDir);
 
         $this->config->merge(array(
@@ -61,8 +63,7 @@ class LibraryInstallerTest extends TestCase
 
     protected function tearDown()
     {
-        $this->fs->removeDirectory($this->vendorDir);
-        $this->fs->removeDirectory($this->binDir);
+        $this->fs->removeDirectory($this->rootDir);
     }
 
     public function testInstallerCreationShouldNotCreateVendorDirectory()

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -39,10 +39,10 @@ class LibraryInstallerTest extends TestCase
         $this->composer->setConfig($this->config);
 
         $this->rootDir = $this->getUniqueTmpDirectory();
-        $this->vendorDir = $this->rootDir.'/vendor';
+        $this->vendorDir = $this->rootDir.DIRECTORY_SEPARATOR.'vendor';
         $this->ensureDirectoryExistsAndClear($this->vendorDir);
 
-        $this->binDir = $this->rootDir.'/bin';
+        $this->binDir = $this->rootDir.DIRECTORY_SEPARATOR.'bin';
         $this->ensureDirectoryExistsAndClear($this->binDir);
 
         $this->config->merge(array(

--- a/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
@@ -13,11 +13,12 @@
 namespace Composer\Test\Package\Archiver;
 
 use Composer\Package\Archiver\ArchivableFilesFinder;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ExecutableFinder;
 
-class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
+class ArchivableFilesFinderTest extends TestCase
 {
     protected $sources;
     protected $finder;
@@ -29,7 +30,7 @@ class ArchivableFilesFinderTest extends \PHPUnit_Framework_TestCase
         $this->fs = $fs;
 
         $this->sources = $fs->normalizePath(
-            realpath(sys_get_temp_dir()).'/composer_archiver_test'.uniqid(mt_rand(), true)
+            $this->getUniqueTmpDirectory()
         );
 
         $fileTree = array(

--- a/tests/Composer/Test/Package/Archiver/ArchiverTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchiverTest.php
@@ -12,11 +12,12 @@
 
 namespace Composer\Test\Package\Archiver;
 
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Util\ProcessExecutor;
 use Composer\Package\Package;
 
-abstract class ArchiverTest extends \PHPUnit_Framework_TestCase
+abstract class ArchiverTest extends TestCase
 {
     /**
      * @var \Composer\Util\Filesystem
@@ -37,8 +38,7 @@ abstract class ArchiverTest extends \PHPUnit_Framework_TestCase
     {
         $this->filesystem = new Filesystem();
         $this->process    = new ProcessExecutor();
-        $this->testDir    = sys_get_temp_dir().'/composer_archiver_test_'.mt_rand();
-        $this->filesystem->ensureDirectoryExists($this->testDir);
+        $this->testDir    = $this->getUniqueTmpDirectory();
     }
 
     public function tearDown()

--- a/tests/Composer/Test/Package/Archiver/PharArchiverTest.php
+++ b/tests/Composer/Test/Package/Archiver/PharArchiverTest.php
@@ -21,14 +21,14 @@ class PharArchiverTest extends ArchiverTest
         // Set up repository
         $this->setupDummyRepo();
         $package = $this->setupPackage();
-        $target  = sys_get_temp_dir().'/composer_archiver_test.tar';
+        $target  = $this->getUniqueTmpDirectory().'/composer_archiver_test.tar';
 
         // Test archive
         $archiver = new PharArchiver();
         $archiver->archive($package->getSourceUrl(), $target, 'tar', array('foo/bar', 'baz', '!/foo/bar/baz'));
         $this->assertFileExists($target);
 
-        unlink($target);
+        $this->filesystem->removeDirectory(dirname($target));
     }
 
     public function testZipArchive()
@@ -36,14 +36,14 @@ class PharArchiverTest extends ArchiverTest
         // Set up repository
         $this->setupDummyRepo();
         $package = $this->setupPackage();
-        $target  = sys_get_temp_dir().'/composer_archiver_test.zip';
+        $target  = $this->getUniqueTmpDirectory().'/composer_archiver_test.zip';
 
         // Test archive
         $archiver = new PharArchiver();
         $archiver->archive($package->getSourceUrl(), $target, 'zip');
         $this->assertFileExists($target);
 
-        unlink($target);
+        $this->filesystem->removeDirectory(dirname($target));
     }
 
     /**

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -69,7 +69,7 @@ class PluginInstallerTest extends TestCase
     {
         $loader = new JsonLoader(new ArrayLoader());
         $this->packages = array();
-        $this->directory = sys_get_temp_dir() . '/' . uniqid();
+        $this->directory = $this->getUniqueTmpDirectory();
         for ($i = 1; $i <= 7; $i++) {
             $filename = '/Fixtures/plugin-v'.$i.'/composer.json';
             mkdir(dirname($this->directory . $filename), 0777, true);

--- a/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
@@ -42,7 +42,7 @@ class FilesystemRepositoryTest extends TestCase
     }
 
     /**
-     * @expectedException Composer\Repository\InvalidRepositoryException
+     * @expectedException \Composer\Repository\InvalidRepositoryException
      */
     public function testCorruptedRepositoryFile()
     {

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -14,19 +14,22 @@ namespace Composer\Test\Repository\Vcs;
 
 use Composer\Downloader\TransportException;
 use Composer\Repository\Vcs\GitHubDriver;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Config;
 
-class GitHubDriverTest extends \PHPUnit_Framework_TestCase
+class GitHubDriverTest extends TestCase
 {
+    private $home;
     private $config;
 
     public function setUp()
     {
+        $this->home = $this->getUniqueTmpDirectory();
         $this->config = new Config();
         $this->config->merge(array(
             'config' => array(
-                'home' => sys_get_temp_dir() . '/composer-test',
+                'home' => $this->home,
             ),
         ));
     }
@@ -34,7 +37,7 @@ class GitHubDriverTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $fs = new Filesystem;
-        $fs->removeDirectory(sys_get_temp_dir() . '/composer-test');
+        $fs->removeDirectory($this->home);
     }
 
     public function testPrivateRepository()

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -14,27 +14,40 @@ namespace Composer\Test\Repository\Vcs;
 
 use Composer\Repository\Vcs\GitLabDriver;
 use Composer\Config;
+use Composer\TestCase;
+use Composer\Util\Filesystem;
 
 /**
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  */
-class GitLabDriverTest extends \PHPUnit_Framework_TestCase
+class GitLabDriverTest extends TestCase
 {
+    private $home;
+    private $config;
+    private $io;
+    private $process;
+    private $remoteFilesystem;
+
     public function setUp()
     {
+        $this->home = $this->getUniqueTmpDirectory();
         $this->config = new Config();
         $this->config->merge(array(
             'config' => array(
-                'home' => sys_get_temp_dir().'/composer-test',
+                'home' => $this->home,
                 'gitlab-domains' => array('mycompany.com/gitlab', 'gitlab.com')
             ),
         ));
 
         $this->io = $this->prophesize('Composer\IO\IOInterface');
-
         $this->process = $this->prophesize('Composer\Util\ProcessExecutor');
-
         $this->remoteFilesystem = $this->prophesize('Composer\Util\RemoteFilesystem');
+    }
+
+    public function tearDown()
+    {
+        $fs = new Filesystem();
+        $fs->removeDirectory($this->home);
     }
 
     public function getInitializeUrls()

--- a/tests/Composer/Test/Repository/Vcs/PerforceDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/PerforceDriverTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\Repository\Vcs;
 
 use Composer\Repository\Vcs\PerforceDriver;
+use Composer\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Config;
 use Composer\Util\Perforce;
@@ -20,7 +21,7 @@ use Composer\Util\Perforce;
 /**
  * @author Matt Whittom <Matt.Whittom@veteransunited.com>
  */
-class PerforceDriverTest extends \PHPUnit_Framework_TestCase
+class PerforceDriverTest extends TestCase
 {
     protected $config;
     protected $io;
@@ -29,6 +30,7 @@ class PerforceDriverTest extends \PHPUnit_Framework_TestCase
     protected $testPath;
     protected $driver;
     protected $repoConfig;
+    protected $perforce;
 
     const TEST_URL    = 'TEST_PERFORCE_URL';
     const TEST_DEPOT  = 'TEST_DEPOT_CONFIG';
@@ -36,7 +38,7 @@ class PerforceDriverTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->testPath         = sys_get_temp_dir() . '/composer-test';
+        $this->testPath         = $this->getUniqueTmpDirectory();
         $this->config           = $this->getTestConfig($this->testPath);
         $this->repoConfig       = $this->getTestRepoConfig();
         $this->io               = $this->getMockIOInterface();

--- a/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
@@ -14,9 +14,31 @@ namespace Composer\Test\Repository\Vcs;
 
 use Composer\Repository\Vcs\SvnDriver;
 use Composer\Config;
+use Composer\TestCase;
+use Composer\Util\Filesystem;
 
-class SvnDriverTest extends \PHPUnit_Framework_TestCase
+class SvnDriverTest extends TestCase
 {
+    protected $home;
+    protected $config;
+
+    public function setUp()
+    {
+        $this->home = $this->getUniqueTmpDirectory();
+        $this->config = new Config();
+        $this->config->merge(array(
+            'config' => array(
+                'home' => $this->home,
+            ),
+        ));
+    }
+
+    public function tearDown()
+    {
+        $fs = new Filesystem();
+        $fs->removeDirectory($this->home);
+    }
+
     /**
      * @expectedException RuntimeException
      */
@@ -39,17 +61,11 @@ class SvnDriverTest extends \PHPUnit_Framework_TestCase
             ->method('execute')
             ->will($this->returnValue(0));
 
-        $config = new Config();
-        $config->merge(array(
-            'config' => array(
-                'home' => sys_get_temp_dir() . '/composer-test',
-            ),
-        ));
         $repoConfig = array(
             'url' => 'http://till:secret@corp.svn.local/repo',
         );
 
-        $svn = new SvnDriver($repoConfig, $console, $config, $process);
+        $svn = new SvnDriver($repoConfig, $console, $this->config, $process);
         $svn->initialize();
     }
 

--- a/tests/Composer/Test/Repository/VcsRepositoryTest.php
+++ b/tests/Composer/Test/Repository/VcsRepositoryTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\Repository;
 
+use Composer\TestCase;
 use Symfony\Component\Process\ExecutableFinder;
 use Composer\Package\Dumper\ArrayDumper;
 use Composer\Repository\VcsRepository;
@@ -23,7 +24,7 @@ use Composer\Config;
 /**
  * @group slow
  */
-class VcsRepositoryTest extends \PHPUnit_Framework_TestCase
+class VcsRepositoryTest extends TestCase
 {
     private static $composerHome;
     private static $gitRepo;
@@ -32,8 +33,8 @@ class VcsRepositoryTest extends \PHPUnit_Framework_TestCase
     protected function initialize()
     {
         $oldCwd = getcwd();
-        self::$composerHome = sys_get_temp_dir() . '/composer-home-'.mt_rand().'/';
-        self::$gitRepo = sys_get_temp_dir() . '/composer-git-'.mt_rand().'/';
+        self::$composerHome = $this->getUniqueTmpDirectory();
+        self::$gitRepo = $this->getUniqueTmpDirectory();
 
         $locator = new ExecutableFinder();
         if (!$locator->find('git')) {

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -44,8 +44,8 @@ class FilesystemTest extends TestCase
     public function setUp()
     {
         $this->fs = new Filesystem;
-        $this->workingDir = sys_get_temp_dir() . '/composer_testdir';
-        $this->testFile = sys_get_temp_dir() . '/composer_test_file';
+        $this->workingDir = $this->getUniqueTmpDirectory();
+        $this->testFile = $this->getUniqueTmpDirectory() . '/composer_test_file';
     }
 
     public function tearDown()
@@ -54,7 +54,7 @@ class FilesystemTest extends TestCase
             $this->fs->removeDirectory($this->workingDir);
         }
         if (is_file($this->testFile)) {
-            $this->fs->remove($this->testFile);
+            $this->fs->removeDirectory(dirname($this->testFile));
         }
     }
 

--- a/tests/Composer/TestCase.php
+++ b/tests/Composer/TestCase.php
@@ -64,7 +64,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         do {
             $unique = $root . DIRECTORY_SEPARATOR . uniqid('composer-test-');
             if (!file_exists($unique) && mkdir($unique, 0777)) {
-                return $unique;
+                return realpath($unique);
             }
         } while (--$attempts);
 

--- a/tests/Composer/TestCase.php
+++ b/tests/Composer/TestCase.php
@@ -56,12 +56,29 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         return new AliasPackage($package, $normVersion, $version);
     }
 
-    protected function ensureDirectoryExistsAndClear($directory)
+    protected static function getUniqueTmpDirectory()
+    {
+        $attempts = 5;
+        $root = sys_get_temp_dir();
+
+        do {
+            $unique = $root . DIRECTORY_SEPARATOR . uniqid('composer-test-');
+            if (!file_exists($unique) && mkdir($unique, 0777)) {
+                return $unique;
+            }
+        } while (--$attempts);
+
+        throw new \RuntimeException('Failed to create a unique temporary directory.');
+    }
+
+    protected static function ensureDirectoryExistsAndClear($directory)
     {
         $fs = new Filesystem();
+
         if (is_dir($directory)) {
             $fs->removeDirectory($directory);
         }
+
         mkdir($directory, 0777, true);
     }
 }


### PR DESCRIPTION
Any tests that use the filesystem should have their own unique directory, as we run our test suite in parallel and cleanup of tests (removing directories) should not interfere with currently running tests.

Right now, this PR breaks testing locally on OSX due to the incredibly convoluted way the temporary directory is setup there. Need to find out why it breaks so many of our tests, cause I need to be able to run the test suite locally (have a hunch that it might be related to not enough use of `realpath()`).