### PR TITLE
Fix typo in repositories doc

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -622,7 +622,7 @@ For instance, if you have the following directory structure in your repository:
   \_ composer.json
 ```
 
-Then, to add the package `my/package` as a dependency, in your `apps/my-app/composer.json`
+Then, to add the package `my-package` as a dependency, in your `apps/my-app/composer.json`
 file, you can use the following configuration:
 
 ```json
@@ -634,7 +634,7 @@ file, you can use the following configuration:
         }
     ],
     "require": {
-        "my/package": "*"
+        "my-package": "*"
     }
 }
 ```


### PR DESCRIPTION
The folder is called "my-package" in the example above, but in the implementation it says "my/package". Fixed by replacing the `/` with a `-`.