### PR TITLE
[Config command] allow to pass options when adding a repo

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -466,6 +466,12 @@ changes to the repositories section by using it the following way:
 php composer.phar config repositories.foo vcs https://github.com/foo/bar
 ```
 
+If your repository requires more configuration options, you can instead pass its JSON representation :
+
+```sh
+php composer.phar config repositories.foo '{"type": "vcs", "url": "http://svn.example.org/my-project/", "trunk-path": "master"}'
+```
+
 ## create-project
 
 You can use Composer to create new projects from an existing package. This is

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -434,9 +434,18 @@ EOT
             }
 
             if (1 === count($values)) {
-                $bool = strtolower($values[0]);
-                if (true === $booleanValidator($bool) && false === $booleanNormalizer($bool)) {
-                    return $this->configSource->addRepository($matches[1], false);
+                $value = strtolower($values[0]);
+                if (true === $booleanValidator($value)) {
+                    if (false === $booleanNormalizer($value)) {
+                        return $this->configSource->addRepository($matches[1], false);
+                    }
+                } else {
+                    $value = json_decode($values[0], true);
+                    if (JSON_ERROR_NONE !== json_last_error()) {
+                        throw new \InvalidArgumentException(sprintf('%s is not valid JSON.', $values[0]));
+                    }
+
+                    return $this->configSource->addRepository($matches[1], $value);
                 }
             }
 

--- a/tests/Composer/Test/Config/Fixtures/config/config-with-exampletld-repository-and-options.json
+++ b/tests/Composer/Test/Config/Fixtures/config/config-with-exampletld-repository-and-options.json
@@ -1,0 +1,15 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "repositories": {
+        "example_tld": {
+            "type": "composer",
+            "url": "https://example.tld",
+            "options": {
+                "ssl": {
+                    "local_cert": "/home/composer/.ssl/composer.pem"
+                }
+            }
+        }
+    }
+}

--- a/tests/Composer/Test/Config/JsonConfigSourceTest.php
+++ b/tests/Composer/Test/Config/JsonConfigSourceTest.php
@@ -52,6 +52,24 @@ class JsonConfigSourceTest extends \PHPUnit_Framework_TestCase
         $this->assertFileEquals($this->fixturePath('config/config-with-exampletld-repository.json'), $config);
     }
 
+    public function testAddRepositoryWithOptions()
+    {
+        $config = $this->workingDir.'/composer.json';
+        copy($this->fixturePath('composer-repositories.json'), $config);
+        $jsonConfigSource = new JsonConfigSource(new JsonFile($config));
+        $jsonConfigSource->addRepository('example_tld', array(
+            'type' => 'composer',
+            'url' => 'https://example.tld',
+            'options' => array(
+                'ssl' => array(
+                    'local_cert' => '/home/composer/.ssl/composer.pem'
+                )
+            )
+        ));
+
+        $this->assertFileEquals($this->fixturePath('config/config-with-exampletld-repository-and-options.json'), $config);
+    }
+
     public function testRemoveRepository()
     {
         $config = $this->workingDir.'/composer.json';


### PR DESCRIPTION
It could help to allow an extra argument to the config command for repos, in my case it's to automate the creation of a satis repo, what do you think?

Related to #2920, also another alternative to #2604.