### PR TITLE
Globbing while resolving path repositories now normalizes to slashes

### DIFF
--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -113,7 +113,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
         parent::initialize();
 
         foreach ($this->getUrlMatches() as $url) {
-            $path = realpath($url) . '/';
+            $path = realpath($url) . DIRECTORY_SEPARATOR;
             $composerFilePath = $path.'composer.json';
 
             if (!file_exists($composerFilePath)) {
@@ -131,7 +131,8 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             if (!isset($package['version'])) {
                 $package['version'] = $this->versionGuesser->guessVersion($package, $path) ?: 'dev-master';
             }
-            if (is_dir($path.'/.git') && 0 === $this->process->execute('git log -n1 --pretty=%H', $output, $path)) {
+            $output = '';
+            if (is_dir($path . DIRECTORY_SEPARATOR . '.git') && 0 === $this->process->execute('git log -n1 --pretty=%H', $output, $path)) {
                 $package['dist']['reference'] = trim($output);
             } else {
                 $package['dist']['reference'] = Locker::getContentHash($json);
@@ -153,6 +154,9 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
      */
     private function getUrlMatches()
     {
-        return glob($this->url, GLOB_MARK | GLOB_ONLYDIR);
+        // Ensure environment-specific path separators are normalized to URL separators
+        return array_map(function($val) {
+            return str_replace(DIRECTORY_SEPARATOR, '/', $val);
+        }, glob($this->url, GLOB_MARK | GLOB_ONLYDIR));
     }
 }

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -101,6 +101,9 @@ class PathRepositoryTest extends TestCase
 
         $package = $packages[0];
         $this->assertEquals('test/path-versioned', $package->getName());
-        $this->assertEquals(rtrim($relativeUrl, DIRECTORY_SEPARATOR), rtrim($package->getDistUrl(), DIRECTORY_SEPARATOR));
+
+        // Convert platform specific separators back to generic URL slashes
+        $relativeUrl = str_replace(DIRECTORY_SEPARATOR, '/', $relativeUrl);
+        $this->assertEquals(rtrim($relativeUrl, '/'), rtrim($package->getDistUrl(), '/'));
     }
 }


### PR DESCRIPTION
For predictable cross-platform behaviour, specifically on Windows with its backslashes. Fixes #4726