### PR TITLE
fix: missing parentheses

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -191,7 +191,7 @@ class Config
                     return $val;
                 }
 
-                return ($flags & self::RELATIVE_PATHS == self::RELATIVE_PATHS) ? $val : $this->realpath($val);
+                return (($flags & self::RELATIVE_PATHS) == self::RELATIVE_PATHS) ? $val : $this->realpath($val);
 
             case 'cache-ttl':
                 return (int) $this->config[$key];


### PR DESCRIPTION
Priority of "==" operation is higher then priority of "&" operation.

Possible defect was found by AppChecker static analyzer (http://cnpo.ru/en/solutions/appchecker.php).