### PR TITLE
skip diag. which are only for phar mode

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -134,11 +134,13 @@ EOT
         $io->write('Checking disk free space: ', false);
         $this->outputResult($this->checkDiskSpace($config));
 
-        $io->write('Checking pubkeys: ', false);
-        $this->outputResult($this->checkPubKeys($config));
+        if ('phar:' === substr(__FILE__, 0, 5)) {
+            $io->write('Checking pubkeys: ', false);
+            $this->outputResult($this->checkPubKeys($config));
 
-        $io->write('Checking composer version: ', false);
-        $this->outputResult($this->checkVersion());
+            $io->write('Checking composer version: ', false);
+            $this->outputResult($this->checkVersion());
+        }
 
         return $this->failures;
     }


### PR DESCRIPTION
Version can be updated using "self-update" which is only available in phar mode

Pubkeys can be updated using "self-update --update-keys" which is also only available in phar mode

        if ('phar:' === substr(__FILE__, 0, 5)) {
            $commands[] = new Command\SelfUpdateCommand();
        }

So, this simple patch skip those diag when not in phar mode.
