### PR TITLE
Keep empty folders after re-zip a module

### DIFF
--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -59,6 +59,7 @@ abstract class ArchiveDownloader extends FileDownloader
                 // move files back out of the temp dir
                 foreach ($contentDir as $file) {
                     $file = (string) $file;
+                    $this->findEmptyFolders($file);
                     $this->filesystem->rename($file, $path . '/' . basename($file));
                 }
 
@@ -153,5 +154,28 @@ abstract class ArchiveDownloader extends FileDownloader
             ->in($dir);
 
         return iterator_to_array($finder);
+    }
+
+    /**
+     * Check for empty folders and add a .keep file if it is empty
+     *
+     * @param string $file
+     */
+    private function findEmptyFolders($file) {
+        // Check if file is a directory
+        if(is_dir($file)) {
+            $directoryContent = scandir($file);
+
+            // Check if the folder is empty (there is more than . and ..)
+            if (count($directoryContent) <= 2) {
+                file_put_contents($file . "/.keep", "");
+            } else {
+                foreach ($directoryContent as $subPath) {
+                    if($subPath !== '.' && $subPath !== '..') {
+                        $this->findEmptyFolders($file.'/'.$subPath);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -59,7 +59,7 @@ abstract class ArchiveDownloader extends FileDownloader
                 // move files back out of the temp dir
                 foreach ($contentDir as $file) {
                     $file = (string) $file;
-                    $this->findEmptyFolders($file);
+                    $this->keepEmptyFolders($file);
                     $this->filesystem->rename($file, $path . '/' . basename($file));
                 }
 
@@ -161,7 +161,7 @@ abstract class ArchiveDownloader extends FileDownloader
      *
      * @param string $file
      */
-    private function findEmptyFolders($file) {
+    private function keepEmptyFolders($file) {
         // Check if file is a directory
         if(is_dir($file)) {
             $directoryContent = scandir($file);
@@ -172,7 +172,7 @@ abstract class ArchiveDownloader extends FileDownloader
             } else {
                 foreach ($directoryContent as $subPath) {
                     if($subPath !== '.' && $subPath !== '..') {
-                        $this->findEmptyFolders($file.'/'.$subPath);
+                        $this->keepEmptyFolders($file.'/'.$subPath);
                     }
                 }
             }


### PR DESCRIPTION
This is a fix to keep empty folders after re-zip the module. The solution
is to add a .keep file to each empty folder.

Known reported issues:

- composer/satis#289
- magento/magento2#2787
- magento/magento2#3248