### PR TITLE
Handle OpenSSL's many patch releases

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -146,8 +146,18 @@ class PlatformRepository extends ArrayRepository
                     break;
 
                 case 'openssl':
-                    $prettyVersion = preg_replace_callback('{^(?:OpenSSL\s*)?([0-9.]+)([a-z]?).*}', function ($match) {
-                        return $match[1] . (empty($match[2]) ? '' : '.'.(ord($match[2]) - 96));
+                    $prettyVersion = preg_replace_callback('{^(?:OpenSSL\s*)?([0-9.]+)([a-z]+).*}', function ($match) {
+                        if (empty($match[2])) {
+                            return $match[1];
+                        }
+
+                        // OpenSSL versions add another letter when they reach Z.
+                        // e.g. OpenSSL 0.9.8zh 3 Dec 2015
+                        $patchVersion = array_sum(array_map(function ($letter) {
+                            return ord($letter) - 96;
+                        }, str_split($match[2])));
+
+                        return $match[1].'.'.$patchVersion;
                     }, OPENSSL_VERSION_TEXT);
                     break;
 

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -114,6 +114,7 @@ class PlatformRepository extends ArrayRepository
         // relying on them.
         foreach ($loadedExtensions as $name) {
             $prettyVersion = null;
+            $description = 'The '.$name.' PHP library';
             switch ($name) {
                 case 'curl':
                     $curlVersion = curl_version();
@@ -159,6 +160,8 @@ class PlatformRepository extends ArrayRepository
 
                         return $match[1].'.'.$patchVersion;
                     }, OPENSSL_VERSION_TEXT);
+
+                    $description = OPENSSL_VERSION_TEXT;
                     break;
 
                 case 'pcre':
@@ -185,7 +188,7 @@ class PlatformRepository extends ArrayRepository
             }
 
             $lib = new CompletePackage('lib-'.$name, $version, $prettyVersion);
-            $lib->setDescription('The '.$name.' PHP library');
+            $lib->setDescription($description);
             $this->addPackage($lib);
         }
 


### PR DESCRIPTION
OpenSSL 0.9.8 reached a crazy `zh` patch level but Composer didn't handle this, previously it would have been detected as `0.9.8.26` now it is detected as `0.9.8.34`.

Also changed the package description to use `OPENSSL_VERSION_TEXT` so the original version number is available.