### PR TITLE
Lock json-schema dependency at ~1.6.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "^5.3.2 || ^7.0",
-        "justinrainbow/json-schema": "^1.6",
+        "justinrainbow/json-schema": "~1.6.0.0",
         "composer/spdx-licenses": "^1.0",
         "composer/semver": "^1.0",
         "seld/jsonlint": "^1.4",


### PR DESCRIPTION
See #4882 

