### PR TITLE
Ensure exception is thrown when classmaps are requested for corrupted files

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -122,20 +122,20 @@ class ClassMapGenerator
             $extraTypes .= '|enum';
         }
 
-        try {
-            // Use @ here instead of Silencer to actively suppress 'unhelpful' output
-            // @link https://github.com/composer/composer/pull/4886
-            $contents = @php_strip_whitespace($path);
-            if (!$contents) {
-                if (!file_exists($path)) {
-                    throw new \RuntimeException(sprintf('File at "%s" does not exist, check your classmap definitions', $path));
-                } elseif (!is_readable($path)) {
-                    throw new \RuntimeException(sprintf('File at "%s" is not readable, check its permissions', $path));
-                }
-                throw new \RuntimeException(sprintf('File at "%s" could not be parsed as PHP - it may be binary or corrupted', $path));
+        // Use @ here instead of Silencer to actively suppress 'unhelpful' output
+        // @link https://github.com/composer/composer/pull/4886
+        error_clear_last();
+        $contents = @php_strip_whitespace($path);
+        if (!$contents) {
+            if (is_null(error_get_last())) {
+                // No error, so the input file was really empty or contained only comments
+                return array();
+            } elseif (!file_exists($path)) {
+                throw new \RuntimeException(sprintf('File at "%s" does not exist, check your classmap definitions', $path));
+            } elseif (!is_readable($path)) {
+                throw new \RuntimeException(sprintf('File at "%s" is not readable, check its permissions', $path));
             }
-        } catch (\Exception $e) {
-            throw new \RuntimeException('Could not scan for classes inside '.$path.": \n".$e->getMessage(), 0, $e);
+            throw new \RuntimeException(sprintf('File at "%s" could not be parsed as PHP - it may be binary or corrupted', $path));
         }
 
         // return early if there is no chance of matching anything in this file

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -123,6 +123,8 @@ class ClassMapGenerator
         }
 
         try {
+            // Use @ here instead of Silencer to actively suppress 'unhelpful' output
+            // @link https://github.com/composer/composer/pull/4886
             $contents = @php_strip_whitespace($path);
             if (!$contents) {
                 if (!file_exists($path)) {

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -123,14 +123,14 @@ class ClassMapGenerator
         }
 
         try {
-            $contents = Silencer::call('php_strip_whitespace', $path);
+            $contents = @php_strip_whitespace($path);
             if (!$contents) {
                 if (!file_exists($path)) {
-                    throw new \Exception('File does not exist');
+                    throw new \RuntimeException(sprintf('File at "%s" does not exist, check your classmap definitions', $path));
+                } elseif (!is_readable($path)) {
+                    throw new \RuntimeException(sprintf('File at "%s" is not readable, check its permissions', $path));
                 }
-                if (!is_readable($path)) {
-                    throw new \Exception('File is not readable');
-                }
+                throw new \RuntimeException(sprintf('File at "%s" could not be parsed as PHP - it may be binary or corrupted', $path));
             }
         } catch (\Exception $e) {
             throw new \RuntimeException('Could not scan for classes inside '.$path.": \n".$e->getMessage(), 0, $e);

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -127,15 +127,21 @@ class ClassMapGenerator
         error_clear_last();
         $contents = @php_strip_whitespace($path);
         if (!$contents) {
-            if (is_null(error_get_last())) {
-                // No error, so the input file was really empty or contained only comments
+            $error = error_get_last();
+            if (is_null($error)) {
+                // No error, so the input file was really empty and thus contains no classes
                 return array();
             } elseif (!file_exists($path)) {
-                throw new \RuntimeException(sprintf('File at "%s" does not exist, check your classmap definitions', $path));
+                $message = 'File at "%s" does not exist, check your classmap definitions';
             } elseif (!is_readable($path)) {
-                throw new \RuntimeException(sprintf('File at "%s" is not readable, check its permissions', $path));
+                $message = 'File at "%s" is not readable, check its permissions';
+            } else {
+                $message = 'File at "%s" could not be parsed as PHP, it may be binary or corrupted';
             }
-            throw new \RuntimeException(sprintf('File at "%s" could not be parsed as PHP - it may be binary or corrupted', $path));
+            if (isset($error['message'])) {
+                $message .= PHP_EOL . 'The following message may be helpful:' . PHP_EOL . $error['message'];
+            }
+            throw new \RuntimeException(sprintf($message, $path));
         }
 
         // return early if there is no chance of matching anything in this file

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -124,20 +124,19 @@ class ClassMapGenerator
 
         // Use @ here instead of Silencer to actively suppress 'unhelpful' output
         // @link https://github.com/composer/composer/pull/4886
-        error_clear_last();
         $contents = @php_strip_whitespace($path);
         if (!$contents) {
-            $error = error_get_last();
-            if (is_null($error)) {
-                // No error, so the input file was really empty and thus contains no classes
-                return array();
-            } elseif (!file_exists($path)) {
+            if (!file_exists($path)) {
                 $message = 'File at "%s" does not exist, check your classmap definitions';
             } elseif (!is_readable($path)) {
                 $message = 'File at "%s" is not readable, check its permissions';
+            } elseif ('' === trim(file_get_contents($path))) {
+                // The input file was really empty and thus contains no classes
+                return array();
             } else {
                 $message = 'File at "%s" could not be parsed as PHP, it may be binary or corrupted';
             }
+            $error = error_get_last();
             if (isset($error['message'])) {
                 $message .= PHP_EOL . 'The following message may be helpful:' . PHP_EOL . $error['message'];
             }

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -113,7 +113,7 @@ class ClassMapGeneratorTest extends TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Could not scan for classes inside
+     * @expectedExceptionMessage does not exist
      */
     public function testFindClassesThrowsWhenFileDoesNotExist()
     {


### PR DESCRIPTION
As indicated by #4885 the handling was incorrect for PHP files with invalid content.

The `Silencer` call was removed and replaced by `@` as this issue causes an `E_COMPILE_WARNING` level warning which cannot be silenced and actually points at the wrong location.