### PR TITLE
Add `composer exec` command

### DIFF
--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * @author Davey Shafik <me@daveyshafik.com>
+ */
+class ExecCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('exec')
+            ->setDescription('Execute a vendored binary/script')
+            ->setDefinition(array(
+                new InputOption('list', 'l', InputOption::VALUE_NONE),
+                new InputArgument('script', InputArgument::OPTIONAL, 'The script to run, e.g. phpunit'),
+                new InputArgument(
+                    'args',
+                    InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
+                    'Arguments to pass to the script. Use <info>--</info> to separate from composer arguments'
+                ),
+            ))
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $binDir = $this->getComposer()->getConfig()->get('bin-dir');
+        if ($input->hasArgument('list') || !$input->hasArgument('script') || !$input->getArgument('script')) {
+            $bins = glob($binDir . '/*');
+
+            if (!$bins) {
+                throw new \RuntimeException("No scripts found in bin-dir ($binDir)");
+            }
+
+            $this->getIO()->write(<<<EOT
+<comment>Available scripts:</comment>
+EOT
+            );
+
+            foreach ($bins as $bin) {
+                $bin = basename($bin);
+                $this->getIO()->write(<<<EOT
+<info>- $bin</info>
+EOT
+                );
+            }
+
+            return;
+        }
+
+        $script = $input->getArgument('script');
+        if (!file_exists($binDir . '/' . $script)) {
+            throw new \RuntimeException("script '$script' not found in bin-dir ($binDir)");
+        }
+
+        if ($args = $input->getArgument('args')) {
+            $args = " " . implode(" ", $args);
+        }
+
+        $this->getIO()->write(<<<EOT
+<comment>Executing $script$args:</comment>
+EOT
+        );
+
+        passthru($binDir . '/' . $script . $args);
+    }
+}

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -306,6 +306,7 @@ class Application extends BaseApplication
         $commands[] = new Command\ClearCacheCommand();
         $commands[] = new Command\RemoveCommand();
         $commands[] = new Command\HomeCommand();
+        $commands[] = new Command\ExecCommand();
 
         if ('phar:' === substr(__FILE__, 0, 5)) {
             $commands[] = new Command\SelfUpdateCommand();


### PR DESCRIPTION
This PR adds initial support for a `composer exec <script>` command. Passing in no arguments, or `--list|l` will show you the available scripts.

It allows you to pass additional arguments to the script by separating them with a `--`:

```sh
$ composer exec phpunit -- --filter ClassLoaderTest
```

**However**, if you try to pass in an argument that exists in composer (e.g. `--help` or `-V`) then it simply calls that — this is obviously sub-optimal. Preferably, anything after the `<script>` should be available as a string or an array of strings in the script, but I don't know how to make that happen.