### PR TITLE
Be sure that configuration file can be manipulated by actual user

### DIFF
--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -25,7 +25,7 @@ use Composer\Util\Silencer;
 class JsonConfigSource implements ConfigSourceInterface
 {
     /**
-     * @var \Composer\Json\JsonFile
+     * @var JsonFile
      */
     private $file;
 
@@ -140,6 +140,14 @@ class JsonConfigSource implements ConfigSourceInterface
         $fallback = array_pop($args);
 
         if ($this->file->exists()) {
+            if (!is_writable($this->file->getPath())) {
+                throw new \RuntimeException(sprintf('The file "%s" is not writable.', $this->file->getPath()));
+            }
+
+            if (!is_readable($this->file->getPath())) {
+                throw new \RuntimeException(sprintf('The file "%s" is not readable.', $this->file->getPath()));
+            }
+
             $contents = file_get_contents($this->file->getPath());
         } elseif ($this->authConfig) {
             $contents = "{\n}\n";


### PR DESCRIPTION
Without this change if user runs, i.e.: `composer update` but global Composer was installed by other user, he can't store new token for Github authorization due too fact that he can't access this config file, which leads to "infinity loop" with generating new tokens.