### PR TITLE
Disable PHP and system exposure in stream context factory

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -737,4 +737,8 @@ If set to 1, this env var will make Composer behave as if you passed the
 
 If set to 1, this env disables the warning about having xdebug enabled.
 
+### COMPOSER_DISABLE_PHP_EXPOSE
+
+If set to 1, this env disables the php version exposure in requests.
+
 &larr; [Libraries](02-libraries.md)  |  [Schema](04-schema.md) &rarr;

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -737,8 +737,8 @@ If set to 1, this env var will make Composer behave as if you passed the
 
 If set to 1, this env disables the warning about having xdebug enabled.
 
-### COMPOSER_DISABLE_PHP_EXPOSE
+### COMPOSER_USER_AGENT
 
-If set to 1, this env disables the php version exposure in requests.
+If set to 1, this env will be defined as User-Agent header on every request.
 
 &larr; [Libraries](02-libraries.md)  |  [Schema](04-schema.md) &rarr;

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -144,7 +144,7 @@ final class StreamContextFactory
             $options['http']['header'][] = sprintf(
                 'User-Agent: Composer/%s (%s%s%s)',
                 Composer::VERSION === '@package_version@' ? 'source' : Composer::VERSION,
-                $unameStatus ? ' ' . php_uname('s') . ';' : '',
+                $unameStatus ? php_uname('s') . ';' : '',
                 $unameStatus ? ' ' . php_uname('r') . ';' : '',
                 $phpVersion
             );

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -135,11 +135,12 @@ final class StreamContextFactory
             $phpVersion = 'PHP ' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
         }
         
-        if (getenv('COMPOSER_DISABLE_PHP_EXPOSE')) {
-            $phpVersion = '';
-        }
-
-        if (!isset($options['http']['header']) || false === strpos(strtolower(implode('', $options['http']['header'])), 'user-agent')) {
+        if ($userAgent = getenv('COMPOSER_USER_AGENT')) {
+            $options['http']['header'][] = sprintf(
+                'User-Agent: %s',
+                $userAgent
+            );
+        } elseif (!isset($options['http']['header']) || false === strpos(strtolower(implode('', $options['http']['header'])), 'user-agent')) {
             $unameStatus = function_exists('php_uname');
             $options['http']['header'][] = sprintf(
                 'User-Agent: Composer/%s (%s%s%s)',

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -134,13 +134,18 @@ final class StreamContextFactory
         } else {
             $phpVersion = 'PHP ' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
         }
+        
+        if (getenv('COMPOSER_DISABLE_PHP_EXPOSE')) {
+            $phpVersion = '';
+        }
 
         if (!isset($options['http']['header']) || false === strpos(strtolower(implode('', $options['http']['header'])), 'user-agent')) {
+            $unameStatus = function_exists('php_uname');
             $options['http']['header'][] = sprintf(
-                'User-Agent: Composer/%s (%s; %s; %s)',
+                'User-Agent: Composer/%s (%s%s%s)',
                 Composer::VERSION === '@package_version@' ? 'source' : Composer::VERSION,
-                php_uname('s'),
-                php_uname('r'),
+                $unameStatus ? ' ' . php_uname('s') . ';' : '',
+                $unameStatus ? ' ' . php_uname('r') . ';' : '',
                 $phpVersion
             );
         }


### PR DESCRIPTION
This can be needed for security reasons.
In some cases, user doesn't want or allow composer to send system information in the request. So comes COMPOSER_DISABLE_PHP_EXPOSE.
The php_uname function is often disabled for security reason and must not be mandatory.