### PR TITLE
Added ignore-empty option for Path repositories, fixes #4903

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -651,6 +651,23 @@ output `Mirrored from ../../packages/my-package`.
 
 Instead of using a relative path, an absolute path can also be used.
 
+If you want to ignore errors when no packages could be found in the supplied path,
+for example when using the `composer.json` in different environments, use the
+`ignore-empty` option:
+
+```json
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../packages/my-package",
+            "ignore-empty": true
+        }
+    ]
+}
+```
+
+
 > **Note:** Repository paths can also contain wildcards like ``*`` and ``?``.
 > For details, see the [PHP glob function](http://php.net/glob).
 

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -71,7 +71,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
     /**
      * @var boolean
      */
-    private $ignoreEmpty;
+    private $ignoreEmpty = false;
 
     /**
      * @var array
@@ -108,11 +108,6 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
         $this->repoConfig = $repoConfig;
 
         parent::__construct();
-    }
-
-    function __call($name, $arguments)
-    {
-        // TODO: Implement __call() method.
     }
 
     public function getRepoConfig()
@@ -158,7 +153,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             $this->addPackage($package);
         }
 
-        if (count($this->getPackages()) == 0 && $this->ignoreEmpty !== true) {
+        if ($this->ignoreEmpty !== true && count($this->getPackages()) == 0) {
             throw new \RuntimeException(sprintf('No `composer.json` file found in any path repository in "%s"', $this->url));
         }
     }

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -41,13 +41,15 @@ use Composer\Util\ProcessExecutor;
  *     },
  *     {
  *         "type": "path",
- *         "url": "/absolute/path/to/several/packages/*"
+ *         "url": "/absolute/path/to/several/packages/*",
+ *         "ignore-empty": true
  *     }
  * ]
  * @endcode
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
  * @author Johann Reinke <johann.reinke@gmail.com>
+ * @author Gert Wijnalda <gert@redant.nl>
  */
 class PathRepository extends ArrayRepository implements ConfigurableRepositoryInterface
 {
@@ -65,6 +67,11 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
      * @var string
      */
     private $url;
+
+    /**
+     * @var boolean
+     */
+    private $ignoreEmpty;
 
     /**
      * @var array
@@ -91,11 +98,21 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
         $this->loader = new ArrayLoader();
         $this->url = $repoConfig['url'];
+
+        if (isset($repoConfig['ignore-empty'])) {
+            $this->ignoreEmpty = (bool) $repoConfig['ignore-empty'];
+        }
+
         $this->process = new ProcessExecutor($io);
         $this->versionGuesser = new VersionGuesser($config, $this->process, new VersionParser());
         $this->repoConfig = $repoConfig;
 
         parent::__construct();
+    }
+
+    function __call($name, $arguments)
+    {
+        // TODO: Implement __call() method.
     }
 
     public function getRepoConfig()
@@ -141,7 +158,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             $this->addPackage($package);
         }
 
-        if (count($this->getPackages()) == 0) {
+        if (count($this->getPackages()) == 0 && $this->ignoreEmpty !== true) {
             throw new \RuntimeException(sprintf('No `composer.json` file found in any path repository in "%s"', $this->url));
         }
     }


### PR DESCRIPTION
Adds a new option to ignore empty Path repositories to the config. Fixes issues #4903.