### PR TITLE
Prefer 'editor' on a system that supports alternatives

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -188,7 +188,7 @@ EOT
                 if (Platform::isWindows()) {
                     $editor = 'notepad';
                 } else {
-                    foreach (array('vim', 'vi', 'nano', 'pico', 'ed') as $candidate) {
+                    foreach (array('editor', 'vim', 'vi', 'nano', 'pico', 'ed') as $candidate) {
                         if (exec('which '.$candidate)) {
                             $editor = $candidate;
                             break;


### PR DESCRIPTION
On Linux systems that support [alternatives](http://linux.about.com/library/cmd/blcmdl8_alternatives.htm), which would be pretty much all of them, the `editor` symlink refers to the preferred editor by the current user, so if it exists it should be preferred over all other editors.

Wouldn't want to start an [editor war](https://en.wikipedia.org/wiki/Editor_war) ;)