### PR TITLE
fix compat with symfony console < 2.8

### DIFF
--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -139,13 +139,13 @@ class ConsoleIO extends BaseIO
         }
 
         if (true === $stderr && $this->output instanceof ConsoleOutputInterface) {
-            $this->output->getErrorOutput()->write($messages, $newline, $sfVerbosity);
+            $this->output->getErrorOutput()->write($messages, $newline);
             $this->lastMessageErr = join($newline ? "\n" : '', (array) $messages);
 
             return;
         }
 
-        $this->output->write($messages, $newline, $sfVerbosity);
+        $this->output->write($messages, $newline);
         $this->lastMessage = join($newline ? "\n" : '', (array) $messages);
     }
 


### PR DESCRIPTION
See https://github.com/composer/composer/commit/49d7d65933c78e163354c2c580883926f1c8daee

As verbosity is tested in the start of doWrite function

        if ($sfVerbosity > $this->output->getVerbosity()) {
            return;
        }

There is no need to pass its value to write.
This restore compatibility with old version (tested with 2.7.9 and 2.8.2)