### PR TITLE
Add a --timeout parameter to run-script to override default timeout

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -562,6 +562,7 @@ Lists the name, version and license of every package installed. Use
 
 ### Options
 
+* **--timeout:** Set the script timeout in seconds, or 0 for no timeout.
 * **--no-dev:** Disable dev mode
 * **--list:** List user defined scripts
 


### PR DESCRIPTION
Fixes #4918 