### PR TITLE
Wrap final attempt to touch a cache file in Silencer.

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -143,7 +143,7 @@ class Cache
             } catch (\ErrorException $e) {
                 // fallback in case the above failed due to incorrect ownership
                 // see https://github.com/composer/composer/issues/4070
-                touch($this->root . $file);
+                Silencer::call('touch', $this->root . $file);
             }
 
             $this->io->writeError('Reading '.$this->root . $file.' from cache', true, IOInterface::DEBUG);


### PR DESCRIPTION
Permission issues in `touch` throw an E_WARNING error. Worst consequence I can see of ignoring it is extra cache misses from early GC, which is better than current 'immediate death', so wrapped it with Silencer.

Should fix #4070 