### PR TITLE
Introduce option to force copy instead of symlinking in PathDownloader

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -649,6 +649,26 @@ the console will read `Symlinked from ../../packages/my-package`. If symlinking
 is _not_ possible the package will be copied. In that case, the console will
 output `Mirrored from ../../packages/my-package`.
 
+Instead of default fallback strategy you can force to use symlink with `"symlink": true` or
+mirroring with `"symlink": false` option.
+Forcing mirroring can be useful when deploying or generating package from a monolithic repository.
+
+```json
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../packages/my-package",
+            "options": {
+                "symlink": false
+            }
+        }
+    ]
+}
+```
+
+
+
 Instead of using a relative path, an absolute path can also be used.
 
 > **Note:** Repository paths can also contain wildcards like ``*`` and ``?``.


### PR DESCRIPTION
This pull request implements the ability to force PathDownloader to use copy instead of symlink, refs:  #4636

New config option:
```json
{
    "repositories": [
        {
            "type": "path",
            "url": "../../packages/my-package",
            "options": {
                "symlink": false
            }
        }
    ]
}
```