### PR TITLE
Add direct github.com downld as alternative to api

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -41,6 +41,7 @@ class RemoteFilesystem
     private $degradedMode = false;
     private $redirects;
     private $maxRedirects = 20;
+    private $githubRateLimited = false;
 
     /**
      * Constructor.
@@ -228,6 +229,10 @@ class RemoteFilesystem
         $userlandFollow = isset($options['http']['follow_location']) && !$options['http']['follow_location'];
 
         $this->io->writeError((substr($fileUrl, 0, 4) === 'http' ? 'Downloading ' : 'Reading ') . $fileUrl, true, IOInterface::DEBUG);
+
+        if ($originUrl === 'github.com' && $this->githubRateLimited && $directUrl = $this->getDirectGithubUrl($fileUrl)) {
+            $fileUrl = $this->fileUrl = $directUrl;
+        }
 
         if (isset($options['github-token'])) {
             $fileUrl .= (false === strpos($fileUrl, '?') ? '?' : '&') . 'access_token='.$options['github-token'];
@@ -530,6 +535,16 @@ class RemoteFilesystem
     {
         if ($this->config && in_array($this->originUrl, $this->config->get('github-domains'), true)) {
             $message = "\n".'Could not fetch '.$this->fileUrl.', please create a GitHub OAuth token '.($httpStatus === 404 ? 'to access private repos' : 'to go over the API rate limit');
+
+            // Try to download using an github.com instead of api.github.com
+            if ($httpStatus !== 404 && $this->getDirectGithubUrl($this->fileUrl)) {
+                $this->io->writeError($message);
+                $this->io->writeError('    <warning>Now trying to download from github.com directly.</warning>');
+                $this->retry = true;
+                $this->githubRateLimited = true;
+                throw new TransportException('RETRY');
+            }
+
             $gitHubUtil = new GitHub($this->io, $this->config, null);
             if (!$gitHubUtil->authorizeOAuth($this->originUrl)
                 && (!$this->io->isInteractive() || !$gitHubUtil->authorizeOAuthInteractively($this->originUrl, $message))
@@ -1013,5 +1028,19 @@ class RemoteFilesystem
         $port = parse_url($url, PHP_URL_PORT) ?: $defaultPort;
 
         return parse_url($url, PHP_URL_HOST).':'.$port;
+    }
+
+    /**
+     * Converts an API download url to a direct GitHub archive url.
+     *
+     * @param  string                        $url The original api.github.com url
+     * @return string|null                   null when not valid
+     */
+    private function getDirectGithubUrl($url)
+    {
+        if (preg_match('#^https://api\.github\.com/repos/([^/]++/[^/]++)/(tar|zip)ball/(.++)$#', $url, $match)) {
+            $extension = $match[2] === 'zip' ? 'zip' : 'tar.gz';
+            return 'https://github.com/'.$match[1].'/archive/'.$match[3].'.'.$extension;
+        }
     }
 }

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -217,4 +217,30 @@ class RemoteFilesystemTest extends \PHPUnit_Framework_TestCase
         $attr->setAccessible(true);
         $attr->setValue($object, $value);
     }
+
+    /**
+     * @dataProvider provideGithubArchiveUrls
+     */
+    public function testDirectGithubUrls($url, $expected)
+    {
+        $fs = new RemoteFilesystem($this->getMock('Composer\IO\IOInterface'));
+        $ref = new \ReflectionMethod($fs, 'getDirectGithubUrl');
+        $ref->setAccessible(true);
+
+        $this->assertEquals($expected, $ref->invoke($fs, $url));
+    }
+
+    public function provideGithubArchiveUrls()
+    {
+        return array(
+            array('https://api.github.com/repos/composer/composer/zipball/master', 'https://github.com/composer/composer/archive/master.zip'),
+            array('https://api.github.com/repos/composer/composer/tarball/master', 'https://github.com/composer/composer/archive/master.tar.gz'),
+            array('https://api.github.com/repos/composer/packagist/zipball/SOMESHA', 'https://github.com/composer/packagist/archive/SOMESHA.zip'),
+            array('https://api.github.com/repos/composer/packagist/zipball', null),
+            array('https://github.com/composer/composer/zipball/master', null),
+            array('https://www.github.com/composer/composer/tarball/master', null),
+            array('https://github.com/composer/composer/archive/master.zip', null),
+            array('https://github.com/composer/composer/archive/master.tar.gz', null),
+        );
+    }
 }


### PR DESCRIPTION
Potential fix for #4884 and alternative for #4737

When the Download hits the API limits, it tries to download from github.com directly, using the regex @nicolas-grekas provided in his PR.

This approach still tries the API call first and warns the users, to promote github authentication and use the API as much as possible. When this fails, it will fall back to the source like before. It just doesn't ask for OAuth tokens anymore, but just downloads from alternative source.

This should provide faster downloads for unregistered users instead of forcing them to signup on Github. Would probably also create faster CI builds and/or deployments, without having to setup authentication (which isn't always easy in open source projects).

Potential downside to this approach:
 - When the URLs change, it will clone instead of asking for credentials (but can be fixed with a new release shortly and is unlikely to change (Bower also uses these urls).
- This always calls the api.github.com before each request. The direct link could be used first when unauthorized, but as api.github.com is the 'official' way, it's perhaps cleaner to try it first. Alternatively a flag could be set once the rate limit is reached, to skip the API calls altogether (but waiting for feedback before doing more drastic changes).

As @nicolas-grekas showed, there are more then 1 way to do this, so perhaps there is a better way for this :)