### PR TITLE
#4828 Using version guesser to pull out the commit has for git reposi…

### DIFF
--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -71,8 +71,11 @@ class RootPackageLoader extends ArrayLoader
             // override with env var if available
             if (getenv('COMPOSER_ROOT_VERSION')) {
                 $version = getenv('COMPOSER_ROOT_VERSION');
+                $commit = null;
             } else {
-                $version = $this->versionGuesser->guessVersion($config, $cwd ?: getcwd());
+                $versionData =  $this->versionGuesser->guessVersion($config, $cwd ?: getcwd());
+                $version = $versionData['version'];
+                $commit = $versionData['commit'];
             }
 
             if (!$version) {
@@ -81,6 +84,13 @@ class RootPackageLoader extends ArrayLoader
             }
 
             $config['version'] = $version;
+            if($commit){
+                $config['source'] = array(
+                    'type' => '',
+                    'url' => '',
+                    'reference' => $commit
+                );
+            }
         }
 
         $realPackage = $package = parent::load($config, $class);

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -129,7 +129,8 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             );
 
             if (!isset($package['version'])) {
-                $package['version'] = $this->versionGuesser->guessVersion($package, $path)['version'] ?: 'dev-master';
+                $versionData = $this->versionGuesser->guessVersion($package, $path);
+                $package['version'] = $versionData['version'] ?: 'dev-master';
             }
 
             $output = '';

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -129,7 +129,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             );
 
             if (!isset($package['version'])) {
-                $package['version'] = $this->versionGuesser->guessVersion($package, $path) ?: 'dev-master';
+                $package['version'] = $this->versionGuesser->guessVersion($package, $path)['version'] ?: 'dev-master';
             }
 
             $output = '';

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -25,6 +25,47 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testGuessVersionReturnsData()
+    {
+        $commitHash = '03a15d220da53c52eddd5f32ffca64a7b3801bea';
+        $anotherCommitHash = '03a15d220da53c52eddd5f32ffca64a7b3801bea';
+
+        $executor = $this->getMockBuilder('\\Composer\\Util\\ProcessExecutor')
+            ->setMethods(array('execute'))
+            ->disableArgumentCloning()
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $executor
+            ->expects($this->at(0))
+            ->method('execute')
+            ->with('git describe --exact-match --tags')
+            ->willReturn(1)
+        ;
+
+        $self = $this;
+
+        $executor
+            ->expects($this->at(1))
+            ->method('execute')
+            ->willReturnCallback(function ($command, &$output) use ($self, $commitHash, $anotherCommitHash) {
+                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $output = "* master $commitHash Commit message\n(no branch) $anotherCommitHash Commit message\n";
+
+                return 0;
+            })
+        ;
+
+        $config = new Config;
+        $config->merge(array('repositories' => array('packagist' => false)));
+        $guesser = new VersionGuesser($config, $executor, new VersionParser());
+        $versionArray = $guesser->guessVersion(array(), 'dummy/path');
+
+        $this->assertEquals("dev-master", $versionArray['version']);
+        $this->assertEquals($commitHash, $versionArray['commit']);
+    }
+
     public function testDetachedHeadBecomesDevHash()
     {
         $commitHash = '03a15d220da53c52eddd5f32ffca64a7b3801bea';
@@ -59,7 +100,7 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
         $config = new Config;
         $config->merge(array('repositories' => array('packagist' => false)));
         $guesser = new VersionGuesser($config, $executor, new VersionParser());
-        $version = $guesser->guessVersion(array(), 'dummy/path');
+        $version = $guesser->guessVersion(array(), 'dummy/path')['version'];
 
         $this->assertEquals("dev-$commitHash", $version);
     }
@@ -89,7 +130,7 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
         $config = new Config;
         $config->merge(array('repositories' => array('packagist' => false)));
         $guesser = new VersionGuesser($config, $executor, new VersionParser());
-        $version = $guesser->guessVersion(array(), 'dummy/path');
+        $version = $guesser->guessVersion(array(), 'dummy/path')['version'];
 
         $this->assertEquals("2.0.5.0-alpha2", $version);
     }
@@ -130,7 +171,7 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
         $config = new Config;
         $config->merge(array('repositories' => array('packagist' => false)));
         $guesser = new VersionGuesser($config, $executor, new VersionParser());
-        $version = $guesser->guessVersion(array(), 'dummy/path');
+        $version = $guesser->guessVersion(array(), 'dummy/path')['version'];
 
         $this->assertEquals("dev-foo", $version);
     }

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -100,9 +100,9 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
         $config = new Config;
         $config->merge(array('repositories' => array('packagist' => false)));
         $guesser = new VersionGuesser($config, $executor, new VersionParser());
-        $version = $guesser->guessVersion(array(), 'dummy/path')['version'];
+        $versionData = $guesser->guessVersion(array(), 'dummy/path');
 
-        $this->assertEquals("dev-$commitHash", $version);
+        $this->assertEquals("dev-$commitHash", $versionData['version']);
     }
 
     public function testTagBecomesVersion()
@@ -130,9 +130,9 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
         $config = new Config;
         $config->merge(array('repositories' => array('packagist' => false)));
         $guesser = new VersionGuesser($config, $executor, new VersionParser());
-        $version = $guesser->guessVersion(array(), 'dummy/path')['version'];
+        $versionData = $guesser->guessVersion(array(), 'dummy/path');
 
-        $this->assertEquals("2.0.5.0-alpha2", $version);
+        $this->assertEquals("2.0.5.0-alpha2", $versionData['version']);
     }
 
     public function testInvalidTagBecomesVersion()
@@ -171,8 +171,8 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
         $config = new Config;
         $config->merge(array('repositories' => array('packagist' => false)));
         $guesser = new VersionGuesser($config, $executor, new VersionParser());
-        $version = $guesser->guessVersion(array(), 'dummy/path')['version'];
+        $versionData = $guesser->guessVersion(array(), 'dummy/path');
 
-        $this->assertEquals("dev-foo", $version);
+        $this->assertEquals("dev-foo", $versionData['version']);
     }
 }


### PR DESCRIPTION
…tories. The return value is now an array with version and commit values.

The return array is now:
```
array( 'version' => "1.2.3", 'commit' => "8a2d1a2ee26fa7a2d29621adcf59706a891a3076" )
```

Hope this is along the right lines for #4828