### PR TITLE
Added the --no-install option to the composer udpate

### DIFF
--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -52,6 +52,7 @@ class UpdateCommand extends Command
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump.'),
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
+                new InputOption('no-install', null, InputOption::VALUE_NONE, 'Whether to skip installation of the package dependencies (only writes the composer.lock file).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore platform requirements (php & ext- packages).'),
                 new InputOption('prefer-stable', null, InputOption::VALUE_NONE, 'Prefer stable versions of dependencies.'),
                 new InputOption('prefer-lowest', null, InputOption::VALUE_NONE, 'Prefer lowest versions of dependencies.'),
@@ -149,6 +150,7 @@ EOT
             ->setIgnorePlatformRequirements($input->getOption('ignore-platform-reqs'))
             ->setPreferStable($input->getOption('prefer-stable'))
             ->setPreferLowest($input->getOption('prefer-lowest'))
+            ->setNoInstall($input->getOption('no-install'))
         ;
 
         if ($input->getOption('no-plugins')) {

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -113,6 +113,7 @@ class Installer
     protected $ignorePlatformReqs = false;
     protected $preferStable = false;
     protected $preferLowest = false;
+    protected $noInstall = false;
     /**
      * Array of package names/globs flagged for update
      *
@@ -168,8 +169,12 @@ class Installer
         gc_collect_cycles();
         gc_disable();
 
-        if ($this->dryRun) {
-            $this->verbose = true;
+        if ($this->dryRun || $this->noInstall) {
+            if ($this->dryRun) {
+                $this->verbose = true;
+            } else {
+                $this->dumpAutoloader = false;
+            }
             $this->runScripts = false;
             $this->installationManager->addInstaller(new NoopInstaller);
             $this->mockLocalRepositories($this->repositoryManager);
@@ -219,13 +224,13 @@ class Installer
                 return $res;
             }
         } catch (\Exception $e) {
-            if (!$this->dryRun) {
+            if (!($this->dryRun || $this->noInstall)) {
                 $this->installationManager->notifyInstalls($this->io);
             }
 
             throw $e;
         }
-        if (!$this->dryRun) {
+        if (!($this->dryRun || $this->noInstall)) {
             $this->installationManager->notifyInstalls($this->io);
         }
 
@@ -1482,6 +1487,24 @@ class Installer
     public function setPreferLowest($preferLowest = true)
     {
         $this->preferLowest = (boolean) $preferLowest;
+
+        return $this;
+    }
+
+    /**
+     * Should packages be installed?
+     *
+     * Call this if you want Composer to update the composer.lock but not
+     * effectively download the packages from the respective sources.
+     * Useful if you want to call "composer install" later.
+     *
+     * @param boolean $noInstall
+     *
+     * @return Installer
+     */
+    public function setNoInstall($noInstall = true)
+    {
+        $this->noInstall = $noInstall;
 
         return $this;
     }


### PR DESCRIPTION
Hi everybody,

I've added the option to pass `--no-install` to `composer update` so it does solve the dependencies, writes the `composer.lock` file but does not effectively download all the packages.

Why?
Composer gets more and more attention and for us php developers it's a must-have for many years already. However, there are a lot of content management systems still providing their own plugin system with their own package/extension/module managers and they slowly start to migrate or find solutions on how to make use of Composer and use it for their own plugin systems.
Now, the thing is, a `composer update` uses a lot of memory and for us developers it's not a real issue because we execute that command locally anyway. However, I guess the majority of all these plugin managers of the respective CMS (or be it whatever software you want to) have been executed on the web server itself, right? The old way of doing stuff was uploading the php files to your server and then call some `install.php` or `config.php` do setup the system and load or install extensions/plugins to it.

These times have long gone for us developers. We use deployment scripts, CI servers and software etc. But for a lot of smaller software and rather regular users of those systems, things haven't changed much. They don't want to use the command line and they certainly don't want to install locally and deploy the data using scripts they have to configure.
So we still have to provide some kind of GUI and web installer which we can build on top of Composer. It's not an easy task but it is certainly feasible. However, I think we all agree that a `composer update` command requires a lot more RAM than you would normally expect a regular shared hosting to provide and it's not needed quite frankly because a `composer update` !== delivery of a regular website.
However, `composer update` is the only thing that really needs a lot of RAM. If you already have a `composer.lock` and just call `composer install` you obviously won't have any memory issues normally.

This leads me to this PR. It's the foundation for any cloud based solution (`config/platform` already exists to mock a given platform) or anything else that resolves the dependencies using `composer update` and delivers the `composer.lock` so you can later install the dependencies using `composer install` yourself on the target server (like any deployment tool does as well). Whether it's a cloud based solution or you execute the command on your local computer and upload the `composer.lock` manually later doesn't really matter. In these cases it's just useless to download all the packages because you simply don't need them :smile: 

It's my first PR for Composer, so please bear with me if I completely forgot about a use case. And please, if somebody could give me a hint on how I can integrate a unit test for this in the existing test suite, please feel free. I'm a bit lost in the mass of fixtures :smile: 