### PR TITLE
RepositoryManager::prependRepository()

### DIFF
--- a/src/Composer/Repository/RepositoryManager.php
+++ b/src/Composer/Repository/RepositoryManager.php
@@ -90,6 +90,18 @@ class RepositoryManager
     }
 
     /**
+     * Adds a repository to the beginning of the chain
+     *
+     * This is useful when injecting additional repositories that should trump Packagist, e.g. from a plugin.
+     *
+     * @param RepositoryInterface $repository repository instance
+     */
+    public function prependRepository(RepositoryInterface $repository)
+    {
+        array_unshift($this->repositories, $repository);
+    }
+
+    /**
      * Returns a new repository for a specific installation type.
      *
      * @param  string                    $type   repository type

--- a/tests/Composer/Test/Repository/RepositoryManagerTest.php
+++ b/tests/Composer/Test/Repository/RepositoryManagerTest.php
@@ -32,6 +32,22 @@ class RepositoryManagerTest extends TestCase
         }
     }
 
+    public function testPrepend()
+    {
+        $rm = new RepositoryManager(
+            $this->getMock('Composer\IO\IOInterface'),
+            $this->getMock('Composer\Config'),
+            $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock()
+        );
+
+        $repository1 = $this->getMock('Composer\Repository\RepositoryInterface');
+        $repository2 = $this->getMock('Composer\Repository\RepositoryInterface');
+        $rm->addRepository($repository1);
+        $rm->prependRepository($repository2);
+
+        $this->assertEquals(array($repository2, $repository1), $rm->getRepositories());
+    }
+
     /**
      * @dataProvider creationCases
      */


### PR DESCRIPTION
This method is useful for dynamically adding repositories with higher priority than Packagist, e.g. from a Composer plugin.

Use case:
This would allow me to finally finish the new version of my [Studio plugin](https://github.com/franzliedke/studio) for Composer. It essentially allows installing project dependencies from a local path repository, without editing the composer.json file (as that is checked into Git, and only project maintainers may want such a setup). We have found this to be very useful over at Flarum: In our working copy, the flarum/flarum project requires the flarum/core project as well as several bundled extensions (all installed with Composer), and developing them from within the vendor folder is no fun. Thus, this solution was born.

@alcohol You may remember me asking questions about this stuff at the #composer-dev channel some time before Christmas.