### PR TITLE
Fix for the unix bin proxy on cygwin if the directory contains spaces

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -356,7 +356,7 @@ if command -v 'cygpath' >/dev/null 2>&1; then
 	# we could be using cygwin PHP which does not require this, so we
 	# test if the path to PHP starts with /cygdrive/ rather than /usr/bin
 	if [[ $(which php) == /cygdrive/* ]]; then
-		dir=$(cygpath -m \$dir);
+		dir=$(cygpath -m "\$dir");
 	fi
 fi
 


### PR DESCRIPTION
Without the quotes cygpath will interpret the filename (containing spaces) as two or more different files. This results in the value of $dir being incorrect, which in turn causes the command to fail.