### PR TITLE
Attempt to use shallow clones, fixes #3449

### DIFF
--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -331,9 +331,9 @@ for everyone.
 
 ## Composer hangs with SSH ControlMaster
 
-When you try to install packages from a Git repository and you use the ```ControlMaster```
-setting for you SSH connection  Composer might just hang endlessly and you see a ```sh```
-process in the ```defunct``` state in your process list
+When you try to install packages from a Git repository and you use the `ControlMaster`
+setting for you SSH connection  Composer might just hang endlessly and you see a `sh`
+process in the `defunct` state in your process list
 
 The reason for this is a SSH Bug: https://bugzilla.mindrot.org/show_bug.cgi?id=1988
 

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -238,6 +238,10 @@
                         "type": "string"
                     }
                 },
+                "git-clone-depth": {
+                    "type": "integer",
+                    "description": "Defaults to 1 (shallow clone). Set to the desired history size. If set to -1, the source will be cloned in full."
+                },
                 "github-expose-hostname": {
                     "type": "boolean",
                     "description": "Defaults to true. If set to false, the OAuth tokens created to access the github API will have a date instead of the machine hostname."

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -340,6 +340,7 @@ EOT
                 function ($val) { return is_dir($val) && is_readable($val); },
                 function ($val) { return $val === 'null' ? null : $val; },
             ),
+            'git-clone-depth' => array('is_numeric', 'intval'),
             'github-expose-hostname' => array($booleanValidator, $booleanNormalizer),
         );
         $multiConfigValues = array(

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -49,6 +49,7 @@ class Config
         'secure-http' => true,
         'cafile' => null,
         'capath' => null,
+        'git-clone-depth' => 1,
         'github-expose-hostname' => true,
         'gitlab-domains' => array('gitlab.com'),
         'store-auths' => 'prompt',

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -45,7 +45,11 @@ class GitDownloader extends VcsDownloader
 
         $ref = $package->getSourceReference();
         $flag = Platform::isWindows() ? '/D ' : '';
-        $command = '(git clone --no-checkout --depth 1 --single-branch %s %s --branch %s || git clone --no-checkout %1$s %2$s)'.
+        $cloneDepth = '';
+        if ($this->config->get('git-clone-depth') !== -1) {
+            $cloneDepth = '--depth '.$this->config->get('git-clone-depth');
+        }
+        $command = '(git clone --no-checkout '.$cloneDepth.' --single-branch %s %s --branch %s || git clone --no-checkout %1$s %2$s)'.
             ' && cd '.$flag.'%2$s && git remote add composer %1$s && (git fetch composer %3$s || git fetch composer)';
         $this->io->writeError("    Cloning ".$ref);
 

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -81,7 +81,7 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue('dev-master'));
         $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
 
-        $expectedGitCommand = $this->winCompat("git clone --no-checkout 'https://example.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer 'https://example.com/composer/composer' && git fetch composer");
+        $expectedGitCommand = $this->winCompat("(git clone --no-checkout --depth 1 --single-branch 'https://example.com/composer/composer' 'composerPath' --branch 'master' || git clone --no-checkout 'https://example.com/composer/composer' 'composerPath') && cd 'composerPath' && git remote add composer 'https://example.com/composer/composer' && (git fetch composer 'master' || git fetch composer)");
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($expectedGitCommand))
@@ -123,13 +123,13 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue('1.0.0'));
         $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
 
-        $expectedGitCommand = $this->winCompat("git clone --no-checkout 'git://github.com/mirrors/composer' 'composerPath' && cd 'composerPath' && git remote add composer 'git://github.com/mirrors/composer' && git fetch composer");
+        $expectedGitCommand = $this->winCompat("(git clone --no-checkout --depth 1 --single-branch 'git://github.com/mirrors/composer' 'composerPath' --branch '1.0.0' || git clone --no-checkout 'git://github.com/mirrors/composer' 'composerPath') && cd 'composerPath' && git remote add composer 'git://github.com/mirrors/composer' && (git fetch composer '1.0.0' || git fetch composer)");
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($expectedGitCommand))
             ->will($this->returnValue(1));
 
-        $expectedGitCommand = $this->winCompat("git clone --no-checkout 'https://github.com/mirrors/composer' 'composerPath' && cd 'composerPath' && git remote add composer 'https://github.com/mirrors/composer' && git fetch composer");
+        $expectedGitCommand = $this->winCompat("(git clone --no-checkout --depth 1 --single-branch 'https://github.com/mirrors/composer' 'composerPath' --branch '1.0.0' || git clone --no-checkout 'https://github.com/mirrors/composer' 'composerPath') && cd 'composerPath' && git remote add composer 'https://github.com/mirrors/composer' && (git fetch composer '1.0.0' || git fetch composer)");
         $processExecutor->expects($this->at(2))
             ->method('execute')
             ->with($this->equalTo($expectedGitCommand))
@@ -189,7 +189,7 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue('1.0.0'));
         $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
 
-        $expectedGitCommand = $this->winCompat("git clone --no-checkout '{$protocol}://github.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer '{$protocol}://github.com/composer/composer' && git fetch composer");
+        $expectedGitCommand = $this->winCompat("(git clone --no-checkout --depth 1 --single-branch '{$protocol}://github.com/composer/composer' 'composerPath' --branch '1.0.0' || git clone --no-checkout '{$protocol}://github.com/composer/composer' 'composerPath') && cd 'composerPath' && git remote add composer '{$protocol}://github.com/composer/composer' && (git fetch composer '1.0.0' || git fetch composer)");
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($expectedGitCommand))
@@ -217,7 +217,7 @@ class GitDownloaderTest extends TestCase
      */
     public function testDownloadThrowsRuntimeExceptionIfGitCommandFails()
     {
-        $expectedGitCommand = $this->winCompat("git clone --no-checkout 'https://example.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer 'https://example.com/composer/composer' && git fetch composer");
+        $expectedGitCommand = $this->winCompat("(git clone --no-checkout --depth 1 --single-branch 'https://example.com/composer/composer' 'composerPath' --branch '1.0.0' || git clone --no-checkout 'https://example.com/composer/composer' 'composerPath') && cd 'composerPath' && git remote add composer 'https://example.com/composer/composer' && (git fetch composer '1.0.0' || git fetch composer)");
         $packageMock = $this->getMock('Composer\Package\PackageInterface');
         $packageMock->expects($this->any())
             ->method('getSourceReference')
@@ -225,6 +225,9 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('https://example.com/composer/composer')));
+        $packageMock->expects($this->any())
+            ->method('getPrettyVersion')
+            ->will($this->returnValue('1.0.0'));
         $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
         $processExecutor->expects($this->at(0))
             ->method('execute')
@@ -252,7 +255,7 @@ class GitDownloaderTest extends TestCase
 
     public function testUpdate()
     {
-        $expectedGitUpdateCommand = $this->winCompat("git remote set-url composer 'git://github.com/composer/composer' && git fetch composer && git fetch --tags composer");
+        $expectedGitUpdateCommand = $this->winCompat("git remote set-url composer 'git://github.com/composer/composer' && (git fetch composer '1.0.0' || git fetch composer) && git fetch --tags composer");
 
         $packageMock = $this->getMock('Composer\Package\PackageInterface');
         $packageMock->expects($this->any())
@@ -297,7 +300,7 @@ class GitDownloaderTest extends TestCase
      */
     public function testUpdateThrowsRuntimeExceptionIfGitCommandFails()
     {
-        $expectedGitUpdateCommand = $this->winCompat("git remote set-url composer 'git://github.com/composer/composer' && git fetch composer && git fetch --tags composer");
+        $expectedGitUpdateCommand = $this->winCompat("git remote set-url composer 'git://github.com/composer/composer' && (git fetch composer '1.0.0' || git fetch composer) && git fetch --tags composer");
 
         $packageMock = $this->getMock('Composer\Package\PackageInterface');
         $packageMock->expects($this->any())
@@ -306,6 +309,9 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('https://github.com/composer/composer')));
+        $packageMock->expects($this->any())
+            ->method('getPrettyVersion')
+            ->will($this->returnValue('1.0.0'));
         $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
         $processExecutor->expects($this->at(0))
             ->method('execute')
@@ -327,8 +333,8 @@ class GitDownloaderTest extends TestCase
 
     public function testUpdateDoesntThrowsRuntimeExceptionIfGitCommandFailsAtFirstButIsAbleToRecover()
     {
-        $expectedFirstGitUpdateCommand = $this->winCompat("git remote set-url composer '' && git fetch composer && git fetch --tags composer");
-        $expectedSecondGitUpdateCommand = $this->winCompat("git remote set-url composer 'git://github.com/composer/composer' && git fetch composer && git fetch --tags composer");
+        $expectedFirstGitUpdateCommand = $this->winCompat("git remote set-url composer '' && (git fetch composer '1.0.0' || git fetch composer) && git fetch --tags composer");
+        $expectedSecondGitUpdateCommand = $this->winCompat("git remote set-url composer 'git://github.com/composer/composer' && (git fetch composer '1.0.0' || git fetch composer) && git fetch --tags composer");
 
         $packageMock = $this->getMock('Composer\Package\PackageInterface');
         $packageMock->expects($this->any())
@@ -337,6 +343,9 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('/foo/bar', 'https://github.com/composer/composer')));
+        $packageMock->expects($this->any())
+            ->method('getPrettyVersion')
+            ->will($this->returnValue('1.0.0'));
         $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
         $processExecutor->expects($this->at(0))
             ->method('execute')


### PR DESCRIPTION
This should do shallow clones but as we can not always know 100% the branch name (there's one edge case like both `2.0` and `2.0.x` branches will become `2.0.x-dev` so from that we can not know for sure which was the original name. In case it fails due to that or just an outdated git then there's a fallback to the complete fetch/clone.

In theory this makes initial installs a lot faster, but once it updates it has to fetch more data and I believe this will always result in a full fetch, so the first update will take the time hit vs the initial install. Further updates should still be fast as usual though.

This can be tried out using this phar file:

https://seld.be/composer-shallow.phar

To try it, use `composer install --prefer-source --profile` or similar to get timing info and force clones.

I'd love to get some more feedback from people before merging this because it has a high chance of unforeseen repercussions :)