### PR TITLE
Show warning when forced to fall back on PHP ZipArchive

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -44,11 +44,13 @@ class ZipDownloader extends ArchiveDownloader
     {
         if (null === self::$hasSystemUnzip) {
             $finder = new ExecutableFinder;
-            self::$hasSystemUnzip = (bool) $finder->find('unzip');
-        }
-
-        if (!class_exists('ZipArchive') && !self::$hasSystemUnzip) {
-            throw new \RuntimeException('The zip extension and unzip command are both missing, skipping');
+            if (!(self::$hasSystemUnzip = (bool) $finder->find('unzip'))) {
+                if (!class_exists('ZipArchive')) {
+                    throw new \RuntimeException('The zip extension and unzip command are both missing, skipping');
+                }
+                $this->io->writeError("<warn>As there is no 'unzip' command installed zip files will be unpacked using the PHP zip extension. This may cause</warn>");
+                $this->io->writeError("<warn>unexpected permission issues or reports of corrupted archives. Installing 'unzip' may remediate them.</warn>");
+            }
         }
 
         return parent::download($package, $path);

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -44,13 +44,16 @@ class ZipDownloader extends ArchiveDownloader
     {
         if (null === self::$hasSystemUnzip) {
             $finder = new ExecutableFinder;
-            if (!(self::$hasSystemUnzip = (bool) $finder->find('unzip'))) {
-                if (!class_exists('ZipArchive')) {
-                    throw new \RuntimeException('The zip extension and unzip command are both missing, skipping');
-                }
+            self::$hasSystemUnzip = (bool) $finder->find('unzip');
+
+            if (!self::$hasSystemUnzip && class_exists('ZipArchive')) {
                 $this->io->writeError("<warn>As there is no 'unzip' command installed zip files will be unpacked using the PHP zip extension. This may cause</warn>");
                 $this->io->writeError("<warn>unexpected permission issues or reports of corrupted archives. Installing 'unzip' may remediate them.</warn>");
             }
+        }
+
+        if (!self::$hasSystemUnzip && !class_exists('ZipArchive')) {
+            throw new \RuntimeException('The zip extension and unzip command are both missing, skipping');
         }
 
         return parent::download($package, $path);


### PR DESCRIPTION
As the ZipArchive implementation is known to cause issues with permissions or invalidly considering files corrupted. Would fix #2565 