### PR TITLE
Change default behavior of show/list to --installed by default

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -53,6 +53,7 @@ class ShowCommand extends BaseCommand
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect'),
                 new InputArgument('version', InputArgument::OPTIONAL, 'Version or version constraint to inspect'),
                 new InputOption('all', null, InputOption::VALUE_NONE, 'List all packages'),
+                new InputOption('installed', 'i', InputOption::VALUE_NONE, 'List installed packages only (enabled by default, only present for BC).'),
                 new InputOption('platform', 'p', InputOption::VALUE_NONE, 'List platform packages only'),
                 new InputOption('available', 'a', InputOption::VALUE_NONE, 'List available packages only'),
                 new InputOption('self', 's', InputOption::VALUE_NONE, 'Show the root package information'),
@@ -78,6 +79,10 @@ EOT
 
         $composer = $this->getComposer(false);
         $io = $this->getIO();
+
+        if ($input->getOption('installed')) {
+            $io->writeError('<warning>You are using the deprecated option "installed". Only installed packages are shown by default now. The --all option can be used to show all packages.</warning>');
+        }
 
         if ($input->getOption('tree') && ($input->getOption('all') || $input->getOption('available'))) {
             $io->writeError('The --tree (-t) option is not usable in combination with --all or --available (-a)');

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -52,7 +52,7 @@ class ShowCommand extends BaseCommand
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect'),
                 new InputArgument('version', InputArgument::OPTIONAL, 'Version or version constraint to inspect'),
-                new InputOption('installed', 'i', InputOption::VALUE_NONE, 'List installed packages only'),
+                new InputOption('all', null, InputOption::VALUE_NONE, 'List all packages'),
                 new InputOption('platform', 'p', InputOption::VALUE_NONE, 'List platform packages only'),
                 new InputOption('available', 'a', InputOption::VALUE_NONE, 'List available packages only'),
                 new InputOption('self', 's', InputOption::VALUE_NONE, 'Show the root package information'),
@@ -79,9 +79,9 @@ EOT
         $composer = $this->getComposer(false);
         $io = $this->getIO();
 
-        if ($input->getOption('tree') && !$input->getOption('installed')) {
-            $io->writeError('The --tree (-t) option is only usable in combination with --installed (-i) or by passing a single package name to show, assuming -i');
-            $input->setOption('installed', true);
+        if ($input->getOption('tree') && ($input->getOption('all') || $input->getOption('available'))) {
+            $io->writeError('The --tree (-t) option is not usable in combination with --all or --available (-a)');
+            return;
         }
 
         // init repos
@@ -96,8 +96,6 @@ EOT
             $repos = $installedRepo = new ArrayRepository(array($package));
         } elseif ($input->getOption('platform')) {
             $repos = $installedRepo = $platformRepo;
-        } elseif ($input->getOption('installed')) {
-            $repos = $installedRepo = $this->getComposer()->getRepositoryManager()->getLocalRepository();
         } elseif ($input->getOption('available')) {
             $installedRepo = $platformRepo;
             if ($composer) {
@@ -107,15 +105,17 @@ EOT
                 $repos = new CompositeRepository($defaultRepos);
                 $io->writeError('No composer.json found in the current directory, showing available packages from ' . implode(', ', array_keys($defaultRepos)));
             }
-        } elseif ($composer) {
+        } elseif ($input->getOption('all') && $composer) {
             $localRepo = $composer->getRepositoryManager()->getLocalRepository();
             $installedRepo = new CompositeRepository(array($localRepo, $platformRepo));
             $repos = new CompositeRepository(array_merge(array($installedRepo), $composer->getRepositoryManager()->getRepositories()));
-        } else {
+        } elseif ($input->getOption('all')) {
             $defaultRepos = Factory::createDefaultRepositories($io);
             $io->writeError('No composer.json found in the current directory, showing available packages from ' . implode(', ', array_keys($defaultRepos)));
             $installedRepo = $platformRepo;
             $repos = new CompositeRepository(array_merge(array($installedRepo), $defaultRepos));
+        } else {
+            $repos = $installedRepo = $this->getComposer()->getRepositoryManager()->getLocalRepository();
         }
 
         if ($composer) {
@@ -209,7 +209,7 @@ EOT
             }
         }
 
-        $showAllTypes = !$input->getOption('platform') && !$input->getOption('installed') && !$input->getOption('available');
+        $showAllTypes = $input->getOption('all');
         $indent = $showAllTypes ? '  ' : '';
         foreach (array('<info>platform</info>:' => true, '<comment>available</comment>:' => false, '<info>installed</info>:' => true) as $type => $showVersion) {
             if (isset($packages[$type])) {


### PR DESCRIPTION
This might be just me, but I always feel that `--installed` is actually what I'm looking for, instead of the huge list from all the packages. This was probably more useful in the beginning with lesser packages, or with just custom repositories.

This removes the `--installed` flag and makes that the default behavior. A `--all` flag is added to show all packages (which was the old behavior).

I couldn't use the `-a` shortcut, as that is used by `--available`. Do you want to switch that, or have a better name?