### PR TITLE
Code quality

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -18,7 +18,6 @@
 
 namespace Composer\Autoload;
 
-use Composer\Util\Silencer;
 use Symfony\Component\Finder\Finder;
 use Composer\IO\IOInterface;
 

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -125,7 +125,6 @@ EOT
 
         // show single package or single version
         if ($input->getArgument('package') || !empty($package)) {
-            $versions = array();
             if (empty($package)) {
                 list($package, $versions) = $this->getPackage($installedRepo, $repos, $input->getArgument('package'), $input->getArgument('version'));
 
@@ -139,7 +138,7 @@ EOT
             if ($input->getOption('tree')) {
                 $this->displayPackageTree($package, $installedRepo, $repos);
             } else {
-                $this->printMeta($package, $versions, $installedRepo, $repos);
+                $this->printMeta($package, $versions, $installedRepo);
                 $this->printLinks($package, 'requires');
                 $this->printLinks($package, 'devRequires', 'requires (dev)');
                 if ($package->getSuggests()) {

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -19,7 +19,6 @@ use Composer\Downloader\ChangeReportInterface;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Composer\Script\ScriptEvents;
-use Composer\Downloader\VcsDownloader;
 use Composer\Downloader\DvcsDownloaderInterface;
 
 /**

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -79,10 +79,11 @@ class JsonConfigSource implements ConfigSourceInterface
      */
     public function addConfigSetting($name, $value)
     {
-        $this->manipulateJson('addConfigSetting', $name, $value, function (&$config, $key, $val) {
+        $that = $this;
+        $this->manipulateJson('addConfigSetting', $name, $value, function (&$config, $key, $val) use ($that) {
             if (preg_match('{^(github-oauth|gitlab-oauth|http-basic|platform)\.}', $key)) {
                 list($key, $host) = explode('.', $key, 2);
-                if ($this->authConfig) {
+                if ($that->authConfig) {
                     $config[$key][$host] = $val;
                 } else {
                     $config['config'][$key][$host] = $val;
@@ -98,10 +99,11 @@ class JsonConfigSource implements ConfigSourceInterface
      */
     public function removeConfigSetting($name)
     {
-        $this->manipulateJson('removeConfigSetting', $name, function (&$config, $key) {
+        $that = $this;
+        $this->manipulateJson('removeConfigSetting', $name, function (&$config, $key) use ($that) {
             if (preg_match('{^(github-oauth|gitlab-oauth|http-basic|platform)\.}', $key)) {
                 list($key, $host) = explode('.', $key, 2);
-                if ($this->authConfig) {
+                if ($that->authConfig) {
                     unset($config[$key][$host]);
                 } else {
                     unset($config['config'][$key][$host]);

--- a/src/Composer/DependencyResolver/PolicyInterface.php
+++ b/src/Composer/DependencyResolver/PolicyInterface.php
@@ -23,5 +23,5 @@ interface PolicyInterface
 
     public function findUpdatePackages(Pool $pool, array $installedMap, PackageInterface $package);
 
-    public function selectPreferredPackages(Pool $pool, array $installedMap, array $literals);
+    public function selectPreferredPackages(Pool $pool, array $installedMap, array $literals, $requiredPackage = null);
 }

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -789,7 +789,6 @@ class Solver
                     continue;
                 }
 
-                $oLevel = $level;
                 $level = $this->selectAndInstall($level, $decisionQueue, $disableRules, $rule);
 
                 if (0 === $level) {
@@ -810,7 +809,6 @@ class Solver
                 $lastLevel = null;
                 $lastBranchIndex = 0;
                 $lastBranchOffset  = 0;
-                $l = 0;
 
                 for ($i = count($this->branches) - 1; $i >= 0; $i--) {
                     list($literals, $l) = $this->branches[$i];
@@ -833,7 +831,6 @@ class Solver
 
                     $why = $this->decisions->lastReason();
 
-                    $oLevel = $level;
                     $level = $this->setPropagateLearn($level, $lastLiteral, $disableRules, $why);
 
                     if ($level == 0) {

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -40,6 +40,7 @@ class FileDownloader implements DownloaderInterface
     protected $cache;
     protected $outputProgress = true;
     private $lastCacheWrites = array();
+    private $eventDispatcher;
 
     /**
      * Constructor.

--- a/src/Composer/Downloader/PerforceDownloader.php
+++ b/src/Composer/Downloader/PerforceDownloader.php
@@ -21,6 +21,7 @@ use Composer\Util\Perforce;
  */
 class PerforceDownloader extends VcsDownloader
 {
+    /** @var Perforce */
     protected $perforce;
 
     /**
@@ -34,7 +35,7 @@ class PerforceDownloader extends VcsDownloader
         $this->io->writeError('    Cloning ' . $ref);
         $this->initPerforce($package, $path, $url);
         $this->perforce->setStream($ref);
-        $this->perforce->p4Login($this->io);
+        $this->perforce->p4Login();
         $this->perforce->writeP4ClientSpec();
         $this->perforce->connectClient();
         $this->perforce->syncCodeBase($label);
@@ -51,7 +52,7 @@ class PerforceDownloader extends VcsDownloader
         return null;
     }
 
-    public function initPerforce($package, $path, $url)
+    public function initPerforce(PackageInterface $package, $path, $url)
     {
         if (!empty($this->perforce)) {
             $this->perforce->initializePath($path);

--- a/src/Composer/Package/AliasPackage.php
+++ b/src/Composer/Package/AliasPackage.php
@@ -23,10 +23,11 @@ class AliasPackage extends BasePackage implements CompletePackageInterface
     protected $version;
     protected $prettyVersion;
     protected $dev;
-    protected $aliasOf;
     protected $rootPackageAlias = false;
     protected $stability;
 
+    /** @var PackageInterface */
+    protected $aliasOf;
     /** @var Link[] */
     protected $requires;
     /** @var Link[] */

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -175,10 +175,10 @@ class RootPackageLoader extends ArrayLoader
 
             // extract all sub-constraints in case it is an OR/AND multi-constraint
             $orSplit = preg_split('{\s*\|\|?\s*}', trim($reqVersion));
-            foreach ($orSplit as $constraint) {
-                $andSplit = preg_split('{(?<!^|as|[=>< ,]) *(?<!-)[, ](?!-) *(?!,|as|$)}', $constraint);
-                foreach ($andSplit as $constraint) {
-                    $constraints[] = $constraint;
+            foreach ($orSplit as $orConstraint) {
+                $andSplit = preg_split('{(?<!^|as|[=>< ,]) *(?<!-)[, ](?!-) *(?!,|as|$)}', $orConstraint);
+                foreach ($andSplit as $andConstraint) {
+                    $constraints[] = $andConstraint;
                 }
             }
 

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -17,7 +17,6 @@ use Composer\Package\BasePackage;
 use Composer\Package\PackageInterface;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\Dumper\ArrayDumper;
-use Composer\Semver\Semver;
 use Composer\Semver\Constraint\Constraint;
 
 /**

--- a/src/Composer/Repository/ArtifactRepository.php
+++ b/src/Composer/Repository/ArtifactRepository.php
@@ -30,6 +30,7 @@ class ArtifactRepository extends ArrayRepository implements ConfigurableReposito
 
     public function __construct(array $repoConfig, IOInterface $io)
     {
+        parent::__construct();
         if (!extension_loaded('zip')) {
             throw new \RuntimeException('The artifact repository requires PHP\'s zip extension');
         }

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -62,6 +62,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
     public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, RemoteFilesystem $rfs = null)
     {
+        parent::__construct();
         if (!preg_match('{^[\w.]+\??://}', $repoConfig['url'])) {
             // assume http as the default protocol
             $repoConfig['url'] = 'http://'.$repoConfig['url'];

--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -33,6 +33,7 @@ class FilesystemRepository extends WritableArrayRepository
      */
     public function __construct(JsonFile $repositoryFile)
     {
+        parent::__construct();
         $this->file = $repositoryFile;
     }
 

--- a/src/Composer/Repository/PackageRepository.php
+++ b/src/Composer/Repository/PackageRepository.php
@@ -31,6 +31,7 @@ class PackageRepository extends ArrayRepository
      */
     public function __construct(array $config)
     {
+        parent::__construct();
         $this->config = $config['package'];
 
         // make sure we have an array of package definitions

--- a/src/Composer/Repository/Pear/BaseChannelReader.php
+++ b/src/Composer/Repository/Pear/BaseChannelReader.php
@@ -74,7 +74,6 @@ abstract class BaseChannelReader
         $xml = simplexml_load_string($this->requestContent($origin, $path), "SimpleXMLElement", LIBXML_NOERROR);
 
         if (false == $xml) {
-            $url = rtrim($origin, '/') . '/' . ltrim($path, '/');
             throw new \UnexpectedValueException(sprintf('The PEAR channel at ' . $origin . ' is broken. (Invalid XML at file `%s`)', $path));
         }
 

--- a/src/Composer/Repository/PearRepository.php
+++ b/src/Composer/Repository/PearRepository.php
@@ -49,6 +49,7 @@ class PearRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
     public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $dispatcher = null, RemoteFilesystem $rfs = null)
     {
+        parent::__construct();
         if (!preg_match('{^https?://}', $repoConfig['url'])) {
             $repoConfig['url'] = 'http://'.$repoConfig['url'];
         }

--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -41,6 +41,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
 
     public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $dispatcher = null, array $drivers = null)
     {
+        parent::__construct();
         $this->drivers = $drivers ?: array(
             'github'        => 'Composer\Repository\Vcs\GitHubDriver',
             'gitlab'        => 'Composer\Repository\Vcs\GitLabDriver',

--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -38,6 +38,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
     protected $loader;
     protected $repoConfig;
     protected $branchErrorOccurred = false;
+    private $drivers;
 
     public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $dispatcher = null, array $drivers = null)
     {
@@ -77,6 +78,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
         if (isset($this->drivers[$this->type])) {
             $class = $this->drivers[$this->type];
             $driver = new $class($this->repoConfig, $this->io, $this->config);
+            /** @var VcsDriverInterface $driver */
             $driver->initialize();
 
             return $driver;
@@ -85,6 +87,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
         foreach ($this->drivers as $driver) {
             if ($driver::supports($this->io, $this->config, $this->url)) {
                 $driver = new $driver($this->repoConfig, $this->io, $this->config);
+                /** @var VcsDriverInterface $driver */
                 $driver->initialize();
 
                 return $driver;
@@ -94,6 +97,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
         foreach ($this->drivers as $driver) {
             if ($driver::supports($this->io, $this->config, $this->url, true)) {
                 $driver = new $driver($this->repoConfig, $this->io, $this->config);
+                /** @var VcsDriverInterface $driver */
                 $driver->initialize();
 
                 return $driver;

--- a/src/Composer/Util/Perforce.php
+++ b/src/Composer/Util/Perforce.php
@@ -244,6 +244,7 @@ class Perforce
                     return $value;
                 }
             }
+            return null;
         } else {
             $command = 'echo $' . $name;
             $this->executeCommand($command);
@@ -516,18 +517,22 @@ class Perforce
         return false;
     }
 
+    /**
+     * @param $reference
+     * @return mixed|null
+     */
     protected function getChangeList($reference)
     {
         $index = strpos($reference, '@');
         if ($index === false) {
-            return;
+            return null;
         }
         $label = substr($reference, $index);
         $command = $this->generateP4Command(' changes -m1 ' . $label);
         $this->executeCommand($command);
         $changes = $this->commandResult;
         if (strpos($changes, 'Change') !== 0) {
-            return;
+            return null;
         }
         $fields = explode(' ', $changes);
         $changeList = $fields[1];
@@ -535,15 +540,20 @@ class Perforce
         return $changeList;
     }
 
+    /**
+     * @param $fromReference
+     * @param $toReference
+     * @return mixed|null
+     */
     public function getCommitLogs($fromReference, $toReference)
     {
         $fromChangeList = $this->getChangeList($fromReference);
         if ($fromChangeList == null) {
-            return;
+            return null;
         }
         $toChangeList = $this->getChangeList($toReference);
         if ($toChangeList == null) {
-            return;
+            return null;
         }
         $index = strpos($fromReference, '@');
         $main = substr($fromReference, 0, $index) . '/...';

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -25,6 +25,7 @@ class RemoteFilesystem
 {
     private $io;
     private $config;
+    private $scheme;
     private $bytesMax;
     private $originUrl;
     private $fileUrl;

--- a/src/Composer/Util/TlsHelper.php
+++ b/src/Composer/Util/TlsHelper.php
@@ -247,7 +247,7 @@ EOT;
     /**
      * Convert certificate name into matching function.
      *
-     * @param $certName CN/SAN
+     * @param string $certName CN/SAN
      *
      * @return callable|null
      */

--- a/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
@@ -25,6 +25,7 @@ use Composer\Util\Filesystem;
 class PerforceDownloaderTest extends TestCase
 {
     protected $config;
+    /** @var PerforceDownloader */
     protected $downloader;
     protected $io;
     protected $package;
@@ -130,7 +131,7 @@ class PerforceDownloaderTest extends TestCase
         $perforce = $this->getMockBuilder('Composer\Util\Perforce', $perforceMethods)->disableOriginalConstructor()->getMock();
         $perforce->expects($this->at(0))->method('initializePath')->with($this->equalTo($this->testPath));
         $perforce->expects($this->at(1))->method('setStream')->with($this->equalTo($ref));
-        $perforce->expects($this->at(2))->method('p4Login')->with($this->identicalTo($this->io));
+        $perforce->expects($this->at(2))->method('p4Login');
         $perforce->expects($this->at(3))->method('writeP4ClientSpec');
         $perforce->expects($this->at(4))->method('connectClient');
         $perforce->expects($this->at(5))->method('syncCodeBase')->with($label);
@@ -153,7 +154,7 @@ class PerforceDownloaderTest extends TestCase
         $perforce = $this->getMockBuilder('Composer\Util\Perforce', $perforceMethods)->disableOriginalConstructor()->getMock();
         $perforce->expects($this->at(0))->method('initializePath')->with($this->equalTo($this->testPath));
         $perforce->expects($this->at(1))->method('setStream')->with($this->equalTo($ref));
-        $perforce->expects($this->at(2))->method('p4Login')->with($this->identicalTo($this->io));
+        $perforce->expects($this->at(2))->method('p4Login');
         $perforce->expects($this->at(3))->method('writeP4ClientSpec');
         $perforce->expects($this->at(4))->method('connectClient');
         $perforce->expects($this->at(5))->method('syncCodeBase')->with($label);


### PR DESCRIPTION
Commits are separated into repaired groups, summarized:

- Fixed some config manipulation commands not working on PHP 5.3 as it didn't support use of `$this` in closures
- Added all missing parent constructor calls (bugs waiting to happen when base functionality does become meaningful)
- Stripped a lot of unused variables and imports
- Repaired some functions being called with more parameters than used
- Fixed a bunch of implicit member variable declarations