### PR TITLE
Add failing test for #3990

### DIFF
--- a/tests/Composer/Test/Fixtures/installer/circular-dependency2.test
+++ b/tests/Composer/Test/Fixtures/installer/circular-dependency2.test
@@ -1,0 +1,39 @@
+--TEST--
+Circular dependencies are possible between packages
+--COMPOSER--
+{
+    "name": "root",
+    "version": "dev-master",
+    "require": {
+        "require/itself": "1.0.0",
+        "regular/pkg": "1.0.0"
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "require/itself",
+                    "version": "1.0.0",
+                    "source": { "reference": "some.branch", "type": "git", "url": "" },
+                    "require": {
+                        "require/itself": "1.0.0"
+                    }
+                },
+                {
+                    "name": "regular/pkg",
+                    "version": "1.0.0",
+                    "source": { "reference": "some.branch", "type": "git", "url": "" },
+                    "__dummy__require": {
+                        "require/itself": "1.0.0"
+                    }
+                }
+            ]
+        }
+    ]
+}
+--RUN--
+update -v
+--EXPECT--
+Installing require/itself (1.0.0)
+Installing regular/pkg (1.0.0)


### PR DESCRIPTION
This reproduces the weird case in #3990 - it certainly isn't the smartest package definition that is requiring itself, but the outcome is weird nonetheless.

Basically:

- if root requires A, and A requires itself, A is skipped entirely
- if root requires A and B, A requires itself still, but B requires A as well, then A and B are installed.

You can see the second case by changing `__dummy__require` into `require`, which makes the test pass. All quite odd.

cc @naderman 