### PR TITLE
Ignore self references when anlaysing independent root requirements

### DIFF
--- a/src/Composer/DependencyResolver/Transaction.php
+++ b/src/Composer/DependencyResolver/Transaction.php
@@ -165,7 +165,9 @@ class Transaction
                 $possibleRequires = $this->pool->whatProvides($link->getTarget(), $link->getConstraint());
 
                 foreach ($possibleRequires as $require) {
-                    unset($roots[$require->id]);
+                    if ($require !== $package) {
+                        unset($roots[$require->id]);
+                    }
                 }
             }
         }

--- a/tests/Composer/Test/Fixtures/installer/circular-dependency2.test
+++ b/tests/Composer/Test/Fixtures/installer/circular-dependency2.test
@@ -23,10 +23,7 @@ Circular dependencies are possible between packages
                 {
                     "name": "regular/pkg",
                     "version": "1.0.0",
-                    "source": { "reference": "some.branch", "type": "git", "url": "" },
-                    "__dummy__require": {
-                        "require/itself": "1.0.0"
-                    }
+                    "source": { "reference": "some.branch", "type": "git", "url": "" }
                 }
             ]
         }

--- a/tests/Composer/Test/Fixtures/installer/circular-dependency2.test
+++ b/tests/Composer/Test/Fixtures/installer/circular-dependency2.test
@@ -1,0 +1,39 @@
+--TEST--
+Circular dependencies are possible between packages
+--COMPOSER--
+{
+    "name": "root",
+    "version": "dev-master",
+    "require": {
+        "require/itself": "1.0.0",
+        "regular/pkg": "1.0.0"
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "require/itself",
+                    "version": "1.0.0",
+                    "source": { "reference": "some.branch", "type": "git", "url": "" },
+                    "require": {
+                        "require/itself": "1.0.0"
+                    }
+                },
+                {
+                    "name": "regular/pkg",
+                    "version": "1.0.0",
+                    "source": { "reference": "some.branch", "type": "git", "url": "" },
+                    "__dummy__require": {
+                        "require/itself": "1.0.0"
+                    }
+                }
+            ]
+        }
+    ]
+}
+--RUN--
+update -v
+--EXPECT--
+Installing require/itself (1.0.0)
+Installing regular/pkg (1.0.0)


### PR DESCRIPTION
When creating a transaction we try to identify all requirements that are
not themselves required by any other package. If a package references
itself this should not mark it as being required by another package.

Includes test from https://github.com/composer/composer/pull/4977
Addresses the bug in https://github.com/composer/composer/issues/3990