### PR TITLE
Cast version constraints to string

### DIFF
--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -23,6 +23,7 @@ class VersionParser extends SemverVersionParser
      */
     public function parseConstraints($constraints)
     {
+        $constraints = (string) $constraints;
         if (!isset(self::$constraints[$constraints])) {
             self::$constraints[$constraints] = parent::parseConstraints($constraints);
         }


### PR DESCRIPTION
Fixes #4999 
The constraint can be an Semver Constraint object, which will cause it to fail when using it as index key.