### PR TITLE
Show -t incorrectly expanded self.version constraints. Fixes #4999

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -19,6 +19,7 @@ use Composer\Package\Version\VersionParser;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Composer\Package\PackageInterface;
+use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Util\Platform;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputInterface;
@@ -40,6 +41,7 @@ use Composer\Spdx\SpdxLicenses;
  */
 class ShowCommand extends BaseCommand
 {
+    /** @var VersionParser */
     protected $versionParser;
     protected $colors;
 
@@ -286,20 +288,17 @@ EOT
     /**
      * finds a package by name and version if provided
      *
-     * @param  RepositoryInterface       $installedRepo
-     * @param  RepositoryInterface       $repos
-     * @param  string                    $name
-     * @param  string                    $version
+     * @param  RepositoryInterface        $installedRepo
+     * @param  RepositoryInterface        $repos
+     * @param  string                     $name
+     * @param  ConstraintInterface|string $version
      * @throws \InvalidArgumentException
-     * @return array                     array(CompletePackageInterface, array of versions)
+     * @return array                      array(CompletePackageInterface, array of versions)
      */
     protected function getPackage(RepositoryInterface $installedRepo, RepositoryInterface $repos, $name, $version = null)
     {
         $name = strtolower($name);
-        $constraint = null;
-        if (is_string($version)) {
-            $constraint = $this->versionParser->parseConstraints($version);
-        }
+        $constraint = is_string($version) ? $this->versionParser->parseConstraints($version) : $version;
 
         $policy = new DefaultPolicy();
         $pool = new Pool('dev');

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -297,7 +297,7 @@ EOT
     {
         $name = strtolower($name);
         $constraint = null;
-        if ($version) {
+        if (is_string($version)) {
             $constraint = $this->versionParser->parseConstraints($version);
         }
 


### PR DESCRIPTION
Fixes #4999 - for self.version the constraint comes preparsed into `getPackage`.