### PR TITLE
Make remove with dependencies default

### DIFF
--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -41,7 +41,8 @@ class RemoveCommand extends BaseCommand
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
                 new InputOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies.'),
                 new InputOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.'),
-                new InputOption('update-with-dependencies', null, InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated with explicit dependencies.'),
+                new InputOption('update-with-dependencies', null, InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated with explicit dependencies. (Deprecrated, is now default behavior)'),
+                new InputOption('no-update-with-dependencies', null, InputOption::VALUE_NONE, 'Does not allow inherited dependencies to be updated with explicit dependencies.'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore platform requirements (php & ext- packages).'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
@@ -72,6 +73,10 @@ EOT
         $type = $input->getOption('dev') ? 'require-dev' : 'require';
         $altType = !$input->getOption('dev') ? 'require-dev' : 'require';
         $io = $this->getIO();
+
+        if ($input->getOption('update-with-dependencies')) {
+            $io->writeError('<warning>You are using the deprecated option "update-with-dependencies". This is now default behaviour. The --no-update-with-dependencies option can be used to remove a package without its dependencies.</warning>');
+        }
 
         foreach ($packages as $package) {
             if (isset($composer[$type][$package])) {
@@ -112,7 +117,7 @@ EOT
             ->setClassMapAuthoritative($authoritative)
             ->setUpdate(true)
             ->setUpdateWhitelist($packages)
-            ->setWhitelistDependencies($input->getOption('update-with-dependencies'))
+            ->setWhitelistDependencies( ! $input->getOption('no-update-with-dependencies'))
             ->setIgnorePlatformRequirements($input->getOption('ignore-platform-reqs'))
         ;
 


### PR DESCRIPTION
Fixes #4895

As discussed in #4895, the old behaviour was not intuitive. I deprecated the old option (`--update-with-dependencies`) and made that the default. Also added `--no-update-with-dependencies` if anyone would want to use the old behaviour. 