### PR TITLE
Force @covers annotations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         forceCoversAnnotation="true"
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"

--- a/tests/complete.phpunit.xml
+++ b/tests/complete.phpunit.xml
@@ -6,6 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         forceCoversAnnotation="true"
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"


### PR DESCRIPTION
From https://phpunit.de/manual/current/en/appendixes.configuration.html:
> Code Coverage will only be recorded for tests that use the @covers annotation documented in the section called “@covers”.

This way if code coverage is being generated, tests without the @covers
annotation would cover nothing.

Code coverage does not guarantee everything, but with this option
you could be more sure the code coverage was intentional and explicit.