### PR TITLE
Adjustments in self-update command in case of corrupted file

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -203,6 +203,7 @@ TAGSPUBKEY
         }
 
         if ($err = $this->setLocalPhar($localFilename, $tempFilename, $backupFile)) {
+            @unlink($tempFilename);
             $io->writeError('<error>The file is corrupted ('.$err->getMessage().').</error>');
             $io->writeError('<error>Please re-run the self-update command to try again.</error>');
 
@@ -312,9 +313,6 @@ TAGSPUBKEY
 
             rename($newFilename, $localFilename);
         } catch (\Exception $e) {
-            if ($backupTarget) {
-                @unlink($newFilename);
-            }
             if (!$e instanceof \UnexpectedValueException && !$e instanceof \PharException) {
                 throw $e;
             }

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -281,7 +281,7 @@ TAGSPUBKEY
         $io = $this->getIO();
         $io->writeError(sprintf("Rolling back to version <info>%s</info>.", $rollbackVersion));
         if ($err = $this->setLocalPhar($localFilename, $oldFile)) {
-            $io->writeError('<error>The backup file was corrupted ('.$err->getMessage().') and has been removed.</error>');
+            $io->writeError('<error>The backup file was corrupted ('.$err->getMessage().').</error>');
 
             return 1;
         }


### PR DESCRIPTION
Follow-up to #5020.

I also moved the `unlink` instruction. Only change in behavior is that if an unexpected exception were to occur (unrelated to test of phar validity) the file wouldn't be deleted. 1) that's in fact better 2) such an exception just can't happen.