### PR TITLE
[RFC] Add an update-all request when there is no lock file

### DIFF
--- a/tests/Composer/Test/Fixtures/functional/create-project-command.test
+++ b/tests/Composer/Test/Fixtures/functional/create-project-command.test
@@ -7,7 +7,7 @@ Installing seld/jsonlint (1.0.0)
 
 Created project in %testDir%
 Loading composer repositories with package information
-Installing dependencies (including require-dev)
+Updating dependencies (including require-dev)
 Nothing to install or update
 Writing lock file
 Generating autoload files

--- a/tests/Composer/Test/Fixtures/installer/abandoned-listed.test
+++ b/tests/Composer/Test/Fixtures/installer/abandoned-listed.test
@@ -25,7 +25,7 @@ Abandoned packages are flagged
 install
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
-Installing dependencies (including require-dev)
+Updating dependencies (including require-dev)
 <warning>Package a/a is abandoned, you should avoid using it. No replacement was suggested.</warning>
 <warning>Package c/c is abandoned, you should avoid using it. Use b/b instead.</warning>
 Writing lock file

--- a/tests/Composer/Test/Fixtures/installer/broken-deps-do-not-replace.test
+++ b/tests/Composer/Test/Fixtures/installer/broken-deps-do-not-replace.test
@@ -22,7 +22,7 @@ Broken dependencies should not lead to a replacer being installed which is not m
 install
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
-Installing dependencies (including require-dev)
+Updating dependencies (including require-dev)
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1

--- a/tests/Composer/Test/Fixtures/installer/github-issues-4319.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-4319.test
@@ -32,7 +32,7 @@ install
 
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
-Installing dependencies (including require-dev)
+Updating dependencies (including require-dev)
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1

--- a/tests/Composer/Test/Fixtures/installer/suggest-installed.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-installed.test
@@ -20,7 +20,7 @@ Suggestions are not displayed for installed packages
 install
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
-Installing dependencies (including require-dev)
+Updating dependencies (including require-dev)
 Writing lock file
 Generating autoload files
 

--- a/tests/Composer/Test/Fixtures/installer/suggest-prod.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-prod.test
@@ -18,7 +18,7 @@ Suggestions are not displayed in non-dev mode
 install --no-dev
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
-Installing dependencies
+Updating dependencies
 Writing lock file
 Generating autoload files
 

--- a/tests/Composer/Test/Fixtures/installer/suggest-replaced.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-replaced.test
@@ -20,7 +20,7 @@ Suggestions are not displayed for packages if they are replaced
 install
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
-Installing dependencies (including require-dev)
+Updating dependencies (including require-dev)
 Writing lock file
 Generating autoload files
 

--- a/tests/Composer/Test/Fixtures/installer/suggest-uninstalled.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-uninstalled.test
@@ -18,7 +18,7 @@ Suggestions are displayed
 install
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
-Installing dependencies (including require-dev)
+Updating dependencies (including require-dev)
 a/a suggests installing b/b (an obscure reason)
 Writing lock file
 Generating autoload files


### PR DESCRIPTION
Ping @naderman

I tried to reproduce https://twitter.com/RomainMonceau/status/707992176517640192 (update and install have different results, no lock file in any case) and indeed the [composer.json](http://pastebin.com/7EifAtSb) installs correctly when using `composer update`, but it fails when doing `composer install` with the following:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - akeneo/pim-community-dev v1.5.1 requires doctrine/doctrine-bundle 1.2.0 -> satisfiable by doctrine/doctrine-bundle[v1.2.0].
    - akeneo/pim-community-dev v1.5.0 requires doctrine/doctrine-bundle 1.2.0 -> satisfiable by doctrine/doctrine-bundle[v1.2.0].
    - Conclusion: don't install doctrine/doctrine-bundle v1.2.0
    - Installation request for akeneo/pim-community-dev 1.5.* -> satisfiable by akeneo/pim-community-dev[v1.5.1, v1.5.0].
```

The only meaningful difference I found between update and install when there is no lock file is that update sends an update-all in the solver request. Effectively this creates update rules for all installed packages, which with a clean vendor dir means:

```
jml/foobar-9999999-dev      (this is the root)
composer-plugin-api-1.0.0.0
php-7.0.3.0
php-64bit-7.0.3.0
ext-bcmath-7.0.3.0
ext-calendar-7.0.3.0
ext-ctype-7.0.3.0
ext-date-7.0.3.0
ext-filter-7.0.3.0
ext-hash-1.0.0.0
ext-iconv-7.0.3.0
ext-json-1.4.0.0
ext-mcrypt-7.0.3.0
ext-spl-7.0.3.0
ext-pcre-7.0.3.0
ext-reflection-7.0.3.0
ext-session-7.0.3.0
ext-mysqlnd-0.0.0.0
ext-tokenizer-7.0.3.0
ext-zip-1.13.0.0
ext-zlib-7.0.3.0
ext-libxml-7.0.3.0
ext-dom-20031129
ext-pdo-7.0.3.0
ext-openssl-7.0.3.0
ext-....
```

I don't really see why this has any influence at all, but it seems to fix a problem.. so is there any objection? And also why the heck is this happening is a good question :)

----

As a sidenote, we should just simplify all the code and treat an install w/o lock file as an update and be done with it, which would also fix this. I'll update the PR later.