### PR TITLE
Add missing "secure-http" config property

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -145,6 +145,10 @@
                     "type": "boolean",
                     "description": "Defaults to `false`. If set to true all HTTPS URLs will be tried with HTTP instead and no network level encryption is performed. Enabling this is a security risk and is NOT recommended. The better way is to enable the php_openssl extension in php.ini."
                 },
+                "secure-http": {
+                    "type": "boolean",
+                    "description": "Defaults to `true`. If set to true only HTTPS URLs are allowed to be downloaded via Composer. If you really absolutely need HTTP access to something then you can disable it, but using \"Let's Encrypt\" to get a free SSL certificate is generally a better alternative."
+                },
                 "cafile": {
                     "type": "string",
                     "description": "A way to set the path to the openssl CA file. In PHP 5.6+ you should rather set this via openssl.cafile in php.ini, although PHP 5.6+ should be able to detect your system CA file automatically."


### PR DESCRIPTION
Recently introduced "secure-http" configuration property is available in documentation [https://getcomposer.org/doc/06-config.md#secure-http](https://getcomposer.org/doc/06-config.md#secure-http) is missing in the schema.