### PR TITLE
Default to dist for all versions

### DIFF
--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -317,6 +317,6 @@ class DownloadManager
             }
         }
 
-        return $package->isDev() ? 'source' : 'dist';
+        return 'dist';
     }
 }


### PR DESCRIPTION
Right now, when the version is dev, a `source` install is made. But `dist` installs are also available, with faster installs (and cacheable). This could be useful for making git changes, but the `--prefer-source` option is available for that.
Also, setting the minimum stability in composer.json doesn't actually guarantee that it will use a `dev` version. For example:

```
{
    "require": {
        "symfony/process": "^3.0",
        "paragonie/random_compat": "^1.2"
    },
    "minimum-stability": "dev"
}
```

This will install (at the time of writing) the `dev-master` source version for `process`, but a stable dist for `random_compat` (because he doesn't have a branch-alias setup to match a dev version).

This change will make the `auto` selector default to `--prefer-dist` behaviour.