### PR TITLE
Make path repository options part of the dist reference hash

### DIFF
--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -137,7 +137,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             $package['dist'] = array(
                 'type' => 'path',
                 'url' => $url,
-                'reference' => sha1($json),
+                'reference' => sha1($json . serialize($this->options)),
             );
             $package['transport-options'] = $this->options;
 


### PR DESCRIPTION
Force reinstall of packages if the repository options are changed. Practically speaking for path repositories this ensures symlink/junction/mirror preferences are correctly applied.

Fixes #5048 