### PR TITLE
Silently correct _empty_ namespaces, fixes #5092

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -748,6 +748,10 @@ FOOTER;
                         continue;
                     }
 
+                    // Patch corrupted namespaces through external manipulation
+                    if ($namespace = '_empty_') {
+                        $namespace = '';
+                    }
                     $autoloads[$namespace][] = $relativePath;
                 }
             }

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -749,7 +749,7 @@ FOOTER;
                     }
 
                     // Patch corrupted namespaces through external manipulation
-                    if ($namespace = '_empty_') {
+                    if ($namespace === '_empty_') {
                         $namespace = '';
                     }
                     $autoloads[$namespace][] = $relativePath;


### PR DESCRIPTION
See #5092, bit of a hack to fix it on this end but it's an invalid namespace anyway.