### PR TITLE
Make sure to use an absolute path for symlinking in PathDownloader.

### DIFF
--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -79,7 +79,11 @@ class PathDownloader extends FileDownloader
                     $this->filesystem->junction($realUrl, $path);
                     $this->io->writeError(sprintf('    Junctioned from %s', $url));
                 } else {
-                    $shortestPath = $this->filesystem->findShortestPath($path, $realUrl);
+                    $absolutePath = $path;
+                    if ( ! $this->filesystem->isAbsolutePath($absolutePath)) {
+                        $absolutePath = getcwd() . DIRECTORY_SEPARATOR . $path;
+                    }
+                    $shortestPath = $this->filesystem->findShortestPath($absolutePath, $realUrl);
                     $fileSystem->symlink($shortestPath, $path);
                     $this->io->writeError(sprintf('    Symlinked from %s', $url));
                 }


### PR DESCRIPTION
The `PathDownloader` may be confronted to relative paths that have been set through a `repositories` entry in `composer.json`.

The symlinking code only works with absolute paths. So, to deal with these relative paths, we append them to the current working directory first, in order to transform them into an absolute path.

Resolves #4451