### PR TITLE
Install / Update script event changed, now documented

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -22,11 +22,10 @@ Composer fires the following named events during its execution process:
 
 ### Command Events
 
-- **pre-install-cmd**: occurs before the `install` command is executed.
-- **post-install-cmd**: occurs after the `install` command has been executed.
-- **pre-update-cmd**: occurs before the `update` command is executed.
-- **post-update-cmd**: occurs after the `update` command has been executed.
-- **pre-status-cmd**: occurs before the `status` command is executed.
+- **pre-install-cmd**: occurs before the `install` command is executed with a lock file present.
+- **post-install-cmd**: occurs after the `install` command has been executed with a lock file present.
+- **pre-update-cmd**: occurs before the `update` command is executed, or before the `install` command is executed without a lock file present.
+- **post-update-cmd**: occurs after the `update` command has been executed, or after the `install` command has been executed without a lock file present.
 - **post-status-cmd**: occurs after the `status` command has been executed.
 - **pre-archive-cmd**: occurs before the `archive` command is executed.
 - **post-archive-cmd**: occurs after the `archive` command has been executed.


### PR DESCRIPTION
Since this commit https://github.com/composer/composer/commit/55b0ed8c8be74af348d9fec6702da3efd50feb46 the command events related to the `install` command are no longer tightened to the raw command `install`.

In my humple opinion this is a weird change, and I hope you will be able to merge https://github.com/composer/composer/issues/5034 needs to old doc behaviour.

But if you are not going to revert the expected behaviour, at least let's document it :smile: 