### PR TITLE
fix Windows Path Info

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -145,13 +145,18 @@ class EventDispatcher
      */
     protected function doDispatch(Event $event)
     {
+        $pathStr = 'PATH';
+        if (!isset($_SERVER[$pathStr])) {
+            $pathStr = 'Path';
+        }
+        
         // add the bin dir to the PATH to make local binaries of deps usable in scripts
         $binDir = $this->composer->getConfig()->get('bin-dir');
         if (is_dir($binDir)) {
             $binDir = realpath($binDir);
-            if (isset($_SERVER['PATH']) && !preg_match('{(^|'.PATH_SEPARATOR.')'.preg_quote($binDir).'($|'.PATH_SEPARATOR.')}', $_SERVER['PATH'])) {
-                $_SERVER['PATH'] = $binDir.PATH_SEPARATOR.getenv('PATH');
-                putenv('PATH='.$_SERVER['PATH']);
+            if (isset($_SERVER[$pathStr]) && !preg_match('{(^|'.PATH_SEPARATOR.')'.preg_quote($binDir).'($|'.PATH_SEPARATOR.')}', $_SERVER[$pathStr])) {
+                $_SERVER[$pathStr] = $binDir.PATH_SEPARATOR.getenv($pathStr);
+                putenv($pathStr.'='.$_SERVER[$pathStr]);
             }
         }
 


### PR DESCRIPTION
Fix #5045 

Windows a case-insensitive letter for system environment variables.
And, PHP sets environments on `$_SYSTEM`.

Any windows users use `Path` for PATH environment.  It is legal on Windows.
In this case, `$_SYSTEM['Path']` is enabled, but `$_SYSTEM['PATH']` is disabled...

So, `composer exec` cannot set `PATH` environment.

I fixed this problem.