### PR TITLE
Improve solver error reporting

### DIFF
--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -129,11 +129,15 @@ class Problem
                     return "\n    - The requested package ".$job['packageName'].' could not be found, it looks like its name is invalid, "'.$illegalChars.'" is not allowed in package names.';
                 }
 
-                if (!$this->pool->whatProvides($job['packageName'])) {
-                    return "\n    - The requested package ".$job['packageName'].' could not be found in any version, there may be a typo in the package name.';
+                if ($providers = $this->pool->whatProvides($job['packageName'], $job['constraint'], true, true)) {
+                    return "\n    - The requested package ".$job['packageName'].$this->constraintToText($job['constraint']).' is satisfiable by '.$this->getPackageList($providers).' but those are rejected by your minimum-stability.';
                 }
 
-                return "\n    - The requested package ".$job['packageName'].$this->constraintToText($job['constraint']).' could not be found.';
+                if ($providers = $this->pool->whatProvides($job['packageName'], null, true, true)) {
+                    return "\n    - The requested package ".$job['packageName'].$this->constraintToText($job['constraint']).' exists as '.$this->getPackageList($providers).' but those are rejected by your constraint.';
+                }
+
+                return "\n    - The requested package ".$job['packageName'].' could not be found in any version, there may be a typo in the package name.';
             }
         }
 

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -230,6 +230,10 @@ class Rule
 
                         return $text . ' -> the requested linked library '.$lib.' has the wrong version installed or is missing from your system, make sure to have the extension providing it.';
                     } else {
+                        if ($providers = $pool->whatProvides($targetName, $this->reasonData->getConstraint(), true, true)) {
+                            return $text . ' -> satisfiable by ' . $this->formatPackagesUnique($pool, $providers) .' but these conflict with your requirements or minimum-stability';
+                        }
+
                         return $text . ' -> no matching package found.';
                     }
                 }

--- a/tests/Composer/Test/Fixtures/installer/solver-problems.test
+++ b/tests/Composer/Test/Fixtures/installer/solver-problems.test
@@ -1,0 +1,52 @@
+--TEST--
+Test the error output of solver problems.
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "unstable/package", "version": "2.0.0-alpha" },
+                { "name": "unstable/package", "version": "1.0.0" },
+                { "name": "requirer", "version": "1.0.0", "require": {"dependency": "1.0.0" } },
+                { "name": "dependency", "version": "2.0.0" },
+                { "name": "dependency", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "unstable/package": "2.*",
+        "bogus": "1.*",
+        "requirer": "1.*",
+        "dependency": "2.*"
+    }
+}
+
+--RUN--
+install
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies (including require-dev)
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - The requested package unstable/package 2.* exists as unstable/package[1.0.0] but those are rejected by your constraint.
+  Problem 2
+    - The requested package bogus could not be found in any version, there may be a typo in the package name.
+  Problem 3
+    - Installation request for requirer 1.* -> satisfiable by requirer[1.0.0].
+    - requirer 1.0.0 requires dependency 1.0.0 -> satisfiable by dependency[1.0.0] but these conflict with your requirements or minimum-stability
+
+Potential causes:
+ - A typo in the package name
+ - The package is not available in a stable-enough version according to your minimum-stability setting
+   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
+
+Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
+
+--EXPECT--
+


### PR DESCRIPTION
Fixes #5086, #2575 and #2661

Using this:

```json
{
    "require": {
        "react/socket-client": "^0.4",
        "react/http": "dev-master",
        "seld/jsonlint": "dev-nope",
        "foo/madeup": "dev-master",
        "relution-developments/carbon-php": "*",
        "php-pm/php-pm": "dev-master"
    }
}
```

We currently get:

```
  Problem 1
    - The requested package seld/jsonlint could not be found in any version, there may be a typo in the package name.
  Problem 2
    - The requested package foo/madeup could not be found in any version, there may be a typo in the package name.
  Problem 3
    - The requested package relution-developments/carbon-php could not be found in any version, there may be a typo in the package name.
  Problem 4
    - Installation request for php-pm/php-pm dev-master -> satisfiable by php-pm/php-pm[dev-master].
    - php-pm/php-pm dev-master requires react/socket-client ^0.5.0 -> no matching package found.
```

Which unhelpfully tells users that packages probably don't exist in problem 1, 3 and 4 (only 2 is correct).

With the patch, we get this:

```
  Problem 1
    - The requested package seld/jsonlint dev-nope exists as seld/jsonlint[1.0.0, 1.0.1, 1.1.0, 1.1.1, 1.1.2, 1.2.0, 1.3.0, 1.3.1, 1.4.0, dev-master] but those are rejected by your constraint.
  Problem 2
    - The requested package foo/madeup could not be found in any version, there may be a typo in the package name.
  Problem 3
    - The requested package relution-developments/carbon-php * is satisfiable by relution-developments/carbon-php[dev-master] but those are rejected by your minimum-stability.
  Problem 4
    - Installation request for php-pm/php-pm dev-master -> satisfiable by php-pm/php-pm[dev-master].
    - php-pm/php-pm dev-master requires react/socket-client ^0.5.0 -> satisfiable by react/socket-client[v0.5.0] but these conflict with your requirements or minimum-stability
```
