### PR TITLE
Fixed undefined variable

### DIFF
--- a/src/Composer/Repository/Vcs/HgDriver.php
+++ b/src/Composer/Repository/Vcs/HgDriver.php
@@ -49,7 +49,7 @@ class HgDriver extends VcsDriver
             }
 
             if (preg_match('{^http:}i', $this->url) && $this->config->get('secure-http')) {
-                throw new TransportException("Your configuration does not allow connection to $url. See https://getcomposer.org/doc/06-config.md#secure-http for details.");
+                throw new TransportException("Your configuration does not allow connection to " .$this->url. ". See https://getcomposer.org/doc/06-config.md#secure-http for details.");
             }
 
             // update the repo if it is a valid hg repository


### PR DESCRIPTION
Patch for wrong variable.

After updating to last version, because of undefined variable got exception when trying to run composer install/update.

composer update -vvv output:
```
Exception trace:
 () at phar:///usr/local/bin/composer.phar/src/Composer/Repository/Vcs/HgDriver.php:52
 Composer\Util\ErrorHandler::handle() at phar:///usr/local/bin/composer.phar/src/Composer/Repository/Vcs/HgDriver.php:52
 Composer\Repository\Vcs\HgDriver->initialize() at phar:///usr/local/bin/composer.phar/src/Composer/Repository/VcsRepository.php:82
 Composer\Repository\VcsRepository->getDriver() at phar:///usr/local/bin/composer.phar/src/Composer/Repository/VcsRepository.php:119
 Composer\Repository\VcsRepository->initialize() at phar:///usr/local/bin/composer.phar/src/Composer/Repository/ArrayRepository.php:179
 Composer\Repository\ArrayRepository->getPackages() at phar:///usr/local/bin/composer.phar/src/Composer/DependencyResolver/Pool.php:104
 Composer\DependencyResolver\Pool->addRepository() at phar:///usr/local/bin/composer.phar/src/Composer/Installer.php:402
 Composer\Installer->doInstall() at phar:///usr/local/bin/composer.phar/src/Composer/Installer.php:228
 Composer\Installer->run() at phar:///usr/local/bin/composer.phar/src/Composer/Command/UpdateCommand.php:173
 Composer\Command\UpdateCommand->execute() at phar:///usr/local/bin/composer.phar/vendor/symfony/console/Command/Command.php:259
 Symfony\Component\Console\Command\Command->run() at phar:///usr/local/bin/composer.phar/vendor/symfony/console/Application.php:844
 Symfony\Component\Console\Application->doRunCommand() at phar:///usr/local/bin/composer.phar/vendor/symfony/console/Application.php:192
 Symfony\Component\Console\Application->doRun() at phar:///usr/local/bin/composer.phar/src/Composer/Console/Application.php:166
 Composer\Console\Application->doRun() at phar:///usr/local/bin/composer.phar/vendor/symfony/console/Application.php:123
 Symfony\Component\Console\Application->run() at phar:///usr/local/bin/composer.phar/src/Composer/Console/Application.php:99
 Composer\Console\Application->run() at phar:///usr/local/bin/composer.phar/bin/composer:43
 require() at /usr/local/bin/composer.phar:24

```