### PR TITLE
Fix method name

### DIFF
--- a/tests/Composer/Test/DependencyResolver/RuleSetTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetTest.php
@@ -145,7 +145,7 @@ class RuleSetTest extends TestCase
             ->method('getHash')
             ->will($this->returnValue('rule_1_hash'));
         $rule3->expects($this->any())
-            ->method('equal')
+            ->method('equals')
             ->will($this->returnValue(false));
 
         $ruleSet->add($rule, RuleSet::TYPE_LEARNED);


### PR DESCRIPTION
It makes the test fail with recent (>= 3.1) phpunit-mock-objects
version.