### PR TITLE
Re-install binaries on update/install

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -292,7 +292,6 @@ class Factory
         }
 
         $vendorDir = $config->get('vendor-dir');
-        $binDir = $config->get('bin-dir');
 
         // initialize composer
         $composer = new Composer();

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -340,7 +340,7 @@ class Installer
             // force binaries re-generation
             $this->io->writeError('<info>Installing binaries files</info>');
             foreach ($localRepo->getPackages() as $package) {
-               $this->installationManager->installBinary($package);
+                $this->installationManager->installBinary($package);
             }
 
             $vendorDir = $this->config->get('vendor-dir');

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -337,6 +337,12 @@ class Installer
                 $this->eventDispatcher->dispatchScript($eventName, $this->devMode);
             }
 
+            // force binaries re-generation
+            $this->io->writeError('<info>Installing binaries files</info>');
+            foreach ($localRepo->getPackages() as $package) {
+               $this->installationManager->installBinary($package);
+            }
+
             $vendorDir = $this->config->get('vendor-dir');
             if (is_dir($vendorDir)) {
                 // suppress errors as this fails sometimes on OSX for no apparent reason

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -128,6 +128,22 @@ class InstallationManager
     }
 
     /**
+     * Install binary for the given package.
+     * If the installer associated to this package doesn't handle that function, it'll do nothing.
+     *
+     * @param PackageInterface $package Package instance
+     */
+    public function installBinary(PackageInterface $package)
+    {
+        try {
+            $installer = $this->getInstaller($package->getType());
+            $installer->installBinary($package);
+        } catch (\InvalidArgumentException $e) {
+            // the given installer doesn't support installing binaries
+        }
+    }
+
+    /**
      * Executes solver operation.
      *
      * @param RepositoryInterface $repo      repository in which to check

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -137,9 +137,14 @@ class InstallationManager
     {
         try {
             $installer = $this->getInstaller($package->getType());
-            $installer->installBinary($package);
         } catch (\InvalidArgumentException $e) {
-            // the given installer doesn't support installing binaries
+            // no installer found for the current package type (@see `getInstaller()`)
+            return;
+        }
+
+        // if the given installer support installing binaries
+        if ($installer instanceof InstallerBinaryInterface) {
+            $installer->installBinary($package);
         }
     }
 

--- a/src/Composer/Installer/InstallerBinaryInterface.php
+++ b/src/Composer/Installer/InstallerBinaryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Installer;
+
+use Composer\Package\PackageInterface;
+
+/**
+ * Interface for the package installation manager that handle binary installation.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+interface InstallerBinaryInterface
+{
+    /**
+     * Installs binary file for a specific package.
+     *
+     * @param PackageInterface $package package instance
+     */
+    public function installBinary(PackageInterface $package);
+}

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -25,7 +25,7 @@ use Composer\Util\Silencer;
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class LibraryInstaller implements InstallerInterface
+class LibraryInstaller implements InstallerInterface, InstallerBinaryInterface
 {
     protected $composer;
     protected $vendorDir;

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -150,6 +150,17 @@ class LibraryInstaller implements InstallerInterface
     }
 
     /**
+     * Re-install binary by removing previous one
+     *
+     * @param PackageInterface $package Package instance
+     */
+    public function installBinary(PackageInterface $package)
+    {
+        $this->binaryInstaller->removeBinaries($package);
+        $this->binaryInstaller->installBinaries($package, $this->getInstallPath($package));
+    }
+
+    /**
      * Returns the base path of the package without target-dir path
      *
      * It is used for BC as getInstallPath tends to be overridden by

--- a/tests/Composer/Test/Fixtures/functional/create-project-command.test
+++ b/tests/Composer/Test/Fixtures/functional/create-project-command.test
@@ -11,3 +11,4 @@ Updating dependencies (including require-dev)
 Nothing to install or update
 Writing lock file
 Generating autoload files
+Installing binaries files

--- a/tests/Composer/Test/Fixtures/installer/abandoned-listed.test
+++ b/tests/Composer/Test/Fixtures/installer/abandoned-listed.test
@@ -30,6 +30,7 @@ Updating dependencies (including require-dev)
 <warning>Package c/c is abandoned, you should avoid using it. Use b/b instead.</warning>
 Writing lock file
 Generating autoload files
+Installing binaries files
 
 --EXPECT--
 Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/github-issues-4795-2.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-4795-2.test
@@ -38,6 +38,7 @@ Loading composer repositories with package information
 Updating dependencies (including require-dev)
 Writing lock file
 Generating autoload files
+Installing binaries files
 
 --EXPECT--
 Updating a (1.0.0) to a (1.1.0)

--- a/tests/Composer/Test/Fixtures/installer/github-issues-4795.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-4795.test
@@ -40,5 +40,6 @@ Updating dependencies (including require-dev)
 Nothing to install or update
 Writing lock file
 Generating autoload files
+Installing binaries files
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/suggest-installed.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-installed.test
@@ -23,6 +23,7 @@ Loading composer repositories with package information
 Updating dependencies (including require-dev)
 Writing lock file
 Generating autoload files
+Installing binaries files
 
 --EXPECT--
 Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/suggest-prod.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-prod.test
@@ -21,6 +21,7 @@ Loading composer repositories with package information
 Updating dependencies
 Writing lock file
 Generating autoload files
+Installing binaries files
 
 --EXPECT--
 Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/suggest-replaced.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-replaced.test
@@ -23,6 +23,7 @@ Loading composer repositories with package information
 Updating dependencies (including require-dev)
 Writing lock file
 Generating autoload files
+Installing binaries files
 
 --EXPECT--
 Installing c/c (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/suggest-uninstalled.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-uninstalled.test
@@ -22,6 +22,7 @@ Updating dependencies (including require-dev)
 a/a suggests installing b/b (an obscure reason)
 Writing lock file
 Generating autoload files
+Installing binaries files
 
 --EXPECT--
 Installing a/a (1.0.0)

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -240,6 +240,35 @@ class InstallationManagerTest extends \PHPUnit_Framework_TestCase
         $manager->uninstall($this->repository, $operation);
     }
 
+    public function testInstallBinary()
+    {
+        $installer = $this->getMockBuilder('Composer\Installer\LibraryInstaller')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $manager   = new InstallationManager();
+        $manager->addInstaller($installer);
+
+        $package   = $this->createPackageMock();
+
+        $package
+            ->expects($this->once())
+            ->method('getType')
+            ->will($this->returnValue('library'));
+
+        $installer
+            ->expects($this->once())
+            ->method('supports')
+            ->with('library')
+            ->will($this->returnValue(true));
+
+        $installer
+            ->expects($this->once())
+            ->method('installBinary')
+            ->with($package);
+
+        $manager->installBinary($package);
+    }
+
     private function createInstallerMock()
     {
         return $this->getMockBuilder('Composer\Installer\InstallerInterface')

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -255,6 +255,32 @@ class LibraryInstallerTest extends TestCase
         $this->assertEquals($this->vendorDir.'/'.$package->getPrettyName().'/Some/Namespace', $library->getInstallPath($package));
     }
 
+    /**
+     * @depends testInstallerCreationShouldNotCreateVendorDirectory
+     * @depends testInstallerCreationShouldNotCreateBinDirectory
+     */
+    public function testInstallBinary()
+    {
+        $binaryInstallerMock = $this->getMockBuilder('Composer\Installer\BinaryInstaller')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $library = new LibraryInstaller($this->io, $this->composer, 'library', null, $binaryInstallerMock);
+        $package = $this->createPackageMock();
+
+        $binaryInstallerMock
+            ->expects($this->once())
+            ->method('removeBinaries')
+            ->with($package);
+
+        $binaryInstallerMock
+            ->expects($this->once())
+            ->method('installBinaries')
+            ->with($package, $library->getInstallPath($package));
+
+        $library->installBinary($package);
+    }
+
     protected function createPackageMock()
     {
         return $this->getMockBuilder('Composer\Package\Package')


### PR DESCRIPTION
Binaries are re-installed after an update/install (ie: removed and then installed).
This is a working draft that fix https://github.com/composer/composer/issues/1209.

For the moment it removes all binaries links and re-create them on every update/install.

I have few questions:

1. Re-installing binaries are performed every time on an update or installation. Should I run it only when user re-define the bin dir? If yes, how can I detect that the config is overridden in the `composer.json` with `"bin-dir": "bin"` ?
2. In `InstallationManager` I retrieve the installer but since I only updated the `LibraryInstaller`, I try/catch to avoid other installer to throw exception. Is there a better way?
3. I also display a message when installing binaries: _Installing binaries files_ Is that necessary? Or should be displayed only in verbose mode?
4. Should we just install binaries (and then displaying messages when binaries files exists, ie _Skipped installation of bin BIN_FILES for package PACKAGE_NAME: name conflicts with an existing file_)) instead of removing/installing? Or do we have create a new option to force that removal?