### PR TITLE
Added getter for global composer

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -91,6 +91,16 @@ class PluginManager
     }
 
     /**
+     * Gets global composer or null when main composer is not fully loaded
+     *
+     * @return Composer|null
+     */
+    public function getGlobalComposer()
+    {
+        return $this->globalComposer;
+    }
+
+    /**
      * Register a plugin package, activate it etc.
      *
      * If it's of type composer-installer it is registered as an installer


### PR DESCRIPTION
I need access to global composer from my plugin and didn't find other way to get it.