### PR TITLE
Keep empty directories

### DIFF
--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -59,6 +59,7 @@ abstract class ArchiveDownloader extends FileDownloader
                 // move files back out of the temp dir
                 foreach ($contentDir as $file) {
                     $file = (string) $file;
+                    $this->keepEmptyDirectories($file);
                     $this->filesystem->rename($file, $path . '/' . basename($file));
                 }
 
@@ -153,5 +154,27 @@ abstract class ArchiveDownloader extends FileDownloader
             ->in($dir);
 
         return iterator_to_array($finder);
+    }
+
+    /**
+     * Check for empty folders and add a .keep file if it is empty
+     *
+     * @param string $file
+     */
+    private function keepEmptyDirectories($file) {
+        // Check if file is a directory
+        if(is_dir($file)) {
+            $directoryContent = scandir($file);
+            // Check if the folder is empty (there is more than . and ..)
+            if (count($directoryContent) <= 2) {
+                file_put_contents($file . "/.gitkeep", "");
+            } else {
+                foreach ($directoryContent as $subPath) {
+                    if($subPath !== '.' && $subPath !== '..') {
+                        $this->keepEmptyDirectories($file.'/'.$subPath);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -157,21 +157,25 @@ abstract class ArchiveDownloader extends FileDownloader
     }
 
     /**
-     * Check for empty folders and add a .keep file if it is empty
+     * Check for empty directories.
+     * If the directory is empty, add a .gitignore file.
      *
-     * @param string $file
+     * This is mainly done because Satis doesn't add empty directories to it's
+     * archives.
+     * Adding a .gitignore files makes sure that Satis doesn't forget about this
+     * directory
+     *
+     * @param string $resource
      */
-    private function keepEmptyDirectories($file) {
-        // Check if file is a directory
-        if(is_dir($file)) {
-            $directoryContent = scandir($file);
-            // Check if the folder is empty (there is more than . and ..)
-            if (count($directoryContent) <= 2) {
-                file_put_contents($file . "/.gitkeep", "");
+    private function keepEmptyDirectories($resource)
+    {
+        if (is_dir($resource)) {
+            if ($this->filesystem->isDirEmpty($resource)) {
+                file_put_contents($resource . "/.gitkeep", "");
             } else {
-                foreach ($directoryContent as $subPath) {
-                    if($subPath !== '.' && $subPath !== '..') {
-                        $this->keepEmptyDirectories($file.'/'.$subPath);
+                foreach (scandir($resource) as $subPath) {
+                    if ($subPath !== '.' && $subPath !== '..') {
+                        $this->keepEmptyDirectories($resource . '/' . $subPath);
                     }
                 }
             }

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -59,7 +59,6 @@ abstract class ArchiveDownloader extends FileDownloader
                 // move files back out of the temp dir
                 foreach ($contentDir as $file) {
                     $file = (string) $file;
-                    $this->keepEmptyDirectories($file);
                     $this->filesystem->rename($file, $path . '/' . basename($file));
                 }
 
@@ -154,31 +153,5 @@ abstract class ArchiveDownloader extends FileDownloader
             ->in($dir);
 
         return iterator_to_array($finder);
-    }
-
-    /**
-     * Check for empty directories.
-     * If the directory is empty, add a .gitkeep file.
-     *
-     * This is mainly done because Composer doesn't add empty directories to it's
-     * archives.
-     * Adding a .gitkeep files makes sure that Composer doesn't forget about this
-     * directory
-     *
-     * @param string $resource
-     */
-    private function keepEmptyDirectories($resource)
-    {
-        if (is_dir($resource)) {
-            if ($this->filesystem->isDirEmpty($resource)) {
-                file_put_contents($resource . "/.gitkeep", "");
-            } else {
-                foreach (scandir($resource) as $subPath) {
-                    if ($subPath !== '.' && $subPath !== '..') {
-                        $this->keepEmptyDirectories($resource . '/' . $subPath);
-                    }
-                }
-            }
-        }
     }
 }

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -158,11 +158,11 @@ abstract class ArchiveDownloader extends FileDownloader
 
     /**
      * Check for empty directories.
-     * If the directory is empty, add a .gitignore file.
+     * If the directory is empty, add a .gitkeep file.
      *
-     * This is mainly done because Satis doesn't add empty directories to it's
+     * This is mainly done because Composer doesn't add empty directories to it's
      * archives.
-     * Adding a .gitignore files makes sure that Satis doesn't forget about this
+     * Adding a .gitkeep files makes sure that Composer doesn't forget about this
      * directory
      *
      * @param string $resource

--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -55,6 +55,21 @@ class ArchivableFilesFinder extends \FilterIterator
                 return false;
             }
 
+            /*
+            * Check if the current \SplFileInfo instance is a directory.
+            * If it is and the directory is empty, add a .gitkeep file.
+            *
+            * This is mainly done because Composer doesn't add empty directories to it's archives.
+            * Adding a .gitkeep files makes sure that Composer doesn't forget about this directory.
+            */
+            if ($file->isDir()) {
+                $directoryContents = scandir($file->getPathname());
+
+                if (count($directoryContents) <= 2) {
+                    file_put_contents($file->getPathname() . DIRECTORY_SEPARATOR . '.gitkeep', '');
+                }
+            }
+
             $relativePath = preg_replace(
                 '#^'.preg_quote($sources, '#').'#',
                 '',


### PR DESCRIPTION
When using satis for creating archives (may it be with tar files or zip), Satis ignores empty directories. 
Usually this won't be a too big of a problem because GIT for example, does the same.
But in a recent project (Magento2) who offers soms packages in zip format, those packages can contain empty directories which are required by it's installers.
Result. No installation, no magento.

This fix checks if a given directory is empty, and when it is it places an harmless .gitkeep file inside the directory so Satis will include it.