### PR TITLE
Fail download on content-length mismatch

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -277,6 +277,11 @@ class RemoteFilesystem
         try {
             $result = file_get_contents($fileUrl, false, $ctx);
 
+            if ($this->bytesMax && strlen($result) < $this->bytesMax) {
+                // alas, this is not possible via the stream callback because STREAM_NOTIFY_COMPLETED is documented, but not implemented anywhere in PHP
+                throw new TransportException('Content-Length mismatch');
+            }
+
             if (PHP_VERSION_ID < 50600 && !empty($options['ssl']['peer_fingerprint'])) {
                 // Emulate fingerprint validation on PHP < 5.6
                 $params = stream_context_get_params($ctx);


### PR DESCRIPTION
I host packages on S3, which has a nasty habit of just closing connections in the middle of a transfer. Later in the process, this will then cause a failure to unpack the tarball.

This change checks the length of the loaded content against the size determined by the stream wrapper, if known. As the exception bubbles up, `FileDownloader::doDownload()` will retry two more times before giving up.

I initially wanted to implement this in `RemoteFilesystem::callbackGet()` using `STREAM_NOTIFY_COMPLETE`, but it turns out that that event is plainly not implemented in any PHP version.