### PR TITLE
Add support for empty CommonName in a certificate for php <5.6

### DIFF
--- a/src/Composer/Util/TlsHelper.php
+++ b/src/Composer/Util/TlsHelper.php
@@ -34,11 +34,7 @@ final class TlsHelper
     {
         $names = self::getCertificateNames($certificate);
 
-        if (empty($names)) {
-            return false;
-        }
-
-        $combinedNames = array_merge($names['san'], array($names['cn']));
+        $combinedNames = array_filter(array_merge($names['san'], array($names['cn'])));
         $hostname = strtolower($hostname);
 
         foreach ($combinedNames as $certName) {
@@ -69,11 +65,11 @@ final class TlsHelper
             $info = openssl_x509_parse($certificate, false);
         }
 
-        if (!isset($info['subject']['commonName'])) {
-            return;
+        $commonName = '';
+        if (isset($info['subject']['commonName'])) {
+            $commonName = strtolower($info['subject']['commonName']);
         }
 
-        $commonName = strtolower($info['subject']['commonName']);
         $subjectAltNames = array();
 
         if (isset($info['extensions']['subjectAltName'])) {


### PR DESCRIPTION
Just to explain what is going on here:

- on <5.6, we handle SSL ourselves as PHP is kinda useless.
- wpml.org has a certificate without  Common Name, only subjectAltNames present, one of which matches wpml.org, so the certificate is valid
- PHP fails to find/match the cert (`Unable to locate peer certificate CN`), so I trigger the legacy handling of SSL (first change in RemoteFilesystem)
- I then fixed TlsHelper so that it returns an empty CN as is, instead of failing
- Then in RemoteFilesystem the problem is if we use wpml.org as `CN_match`, PHP fails the request somehow, and does not retrieve the certificate, so [the check for certificate fingerprint](https://github.com/composer/composer/blob/49524bc4baa41ea7b7464cfd5820c4526300a020/src/Composer/Util/RemoteFilesystem.php#L280-L290) fails. Due to that, I have to set verify_peer to false so that the request passes in case we have an empty CN in the cert, and then I hope that the fingerprint verification of the cert is enough to trust the request is OK.

Ping @cs278 @stormtide I need people to review the above and the patch for sanity because I really have no clue if the assumptions are correct (especially the last one). It does fix the problem, but it might also poke a giant hole, so I don't want to push it out blindly.

Fixes #5075 (for more context)