### PR TITLE
Implementation of array for `repositories.tags-path` and `repositories.branches-path`

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -344,6 +344,23 @@ repository like this:
 If you have no branches or tags directory you can disable them entirely by
 setting the `branches-path` or `tags-path` to `false`.
 
+If you have a more complex repository directory structure, you may also implement 
+an array of paths against the `branches-path` and `tags-path` clauses.
+For example:
+
+```json
+{
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "http://svn.example.org/projectA/",
+            "branches-path": ["branches/development","branches/staging"],
+            "tags-path": ["tags/releases","tags/patches"]
+        }
+    ]
+}
+```
+
 If the package is in a sub-directory, e.g. `/trunk/foo/bar/composer.json` and
 `/tags/1.0/foo/bar/composer.json`, then you can make Composer access it by
 setting the `"package-path"` option to the sub-directory, in this example it

--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -219,8 +219,16 @@ class VersionGuesser
         // try to fetch current version from svn
         if (0 === $this->process->execute('svn info --xml', $output, $path)) {
             $trunkPath = isset($packageConfig['trunk-path']) ? preg_quote($packageConfig['trunk-path'], '#') : 'trunk';
-            $branchesPath = isset($packageConfig['branches-path']) ? preg_quote($packageConfig['branches-path'], '#') : 'branches';
-            $tagsPath = isset($packageConfig['tags-path']) ? preg_quote($packageConfig['tags-path'], '#') : 'tags';
+            $branchesPath = 'branches';
+            $tagsPath = 'tags';
+            if (isset($packageConfig['branches-path'])) {
+                $branchesPath = (is_array($packageConfig['branches-path'])) ? implode('|', $packageConfig['branches-path']) : $packageConfig['branches-path'];
+                $branchesPath = preg_quote($branchesPath, '#');
+            }
+            if (isset($packageConfig['tags-path'])) {
+                $tagsPath = (is_array($packageConfig['tags-path'])) ? implode('|', $packageConfig['tags-path']) : $packageConfig['tags-path'];
+                $tagsPath = preg_quote($tagsPath, '#');
+            }
 
             $urlPattern = '#<url>.*/(' . $trunkPath . '|(' . $branchesPath . '|' . $tagsPath . ')/(.*))</url>#';
 

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -173,23 +173,7 @@ class SvnDriver extends VcsDriver
     {
         if (null === $this->tags) {
             $this->tags = array();
-
-            if ($this->tagsPath !== false) {
-                $output = $this->execute('svn ls --verbose', $this->baseUrl . '/' . $this->tagsPath);
-                if ($output) {
-                    foreach ($this->process->splitLines($output) as $line) {
-                        $line = trim($line);
-                        if ($line && preg_match('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
-                            if (isset($match[1]) && isset($match[2]) && $match[2] !== './') {
-                                $this->tags[rtrim($match[2], '/')] = $this->buildIdentifier(
-                                    '/' . $this->tagsPath . '/' . $match[2],
-                                    $match[1]
-                                );
-                            }
-                        }
-                    }
-                }
-            }
+            $this->processTags();
         }
 
         return $this->tags;
@@ -202,47 +186,8 @@ class SvnDriver extends VcsDriver
     {
         if (null === $this->branches) {
             $this->branches = array();
-
-            if (false === $this->trunkPath) {
-                $trunkParent = $this->baseUrl . '/';
-            } else {
-                $trunkParent = $this->baseUrl . '/' . $this->trunkPath;
-            }
-
-            $output = $this->execute('svn ls --verbose', $trunkParent);
-            if ($output) {
-                foreach ($this->process->splitLines($output) as $line) {
-                    $line = trim($line);
-                    if ($line && preg_match('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
-                        if (isset($match[1]) && isset($match[2]) && $match[2] === './') {
-                            $this->branches['trunk'] = $this->buildIdentifier(
-                                '/' . $this->trunkPath,
-                                $match[1]
-                            );
-                            $this->rootIdentifier = $this->branches['trunk'];
-                            break;
-                        }
-                    }
-                }
-            }
-            unset($output);
-
-            if ($this->branchesPath !== false) {
-                $output = $this->execute('svn ls --verbose', $this->baseUrl . '/' . $this->branchesPath);
-                if ($output) {
-                    foreach ($this->process->splitLines(trim($output)) as $line) {
-                        $line = trim($line);
-                        if ($line && preg_match('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
-                            if (isset($match[1]) && isset($match[2]) && $match[2] !== './') {
-                                $this->branches[rtrim($match[2], '/')] = $this->buildIdentifier(
-                                    '/' . $this->branchesPath . '/' . $match[2],
-                                    $match[1]
-                                );
-                            }
-                        }
-                    }
-                }
-            }
+            $this->processTrunk();
+            $this->processBranches();
         }
 
         return $this->branches;
@@ -341,5 +286,116 @@ class SvnDriver extends VcsDriver
     protected function buildIdentifier($baseDir, $revision)
     {
         return rtrim($baseDir, '/') . $this->packagePath . '/@' . $revision;
+    }
+
+    /**
+     * Process the "trunk" branch
+     */
+    private function processTrunk()
+    {
+        if (false === $this->trunkPath) {
+            $trunkParent = $this->baseUrl . '/';
+        } else {
+            $trunkParent = $this->baseUrl . '/' . $this->trunkPath;
+        }
+
+        $output = $this->execute('svn ls --verbose', $trunkParent);
+        if ($output) {
+            foreach ($this->process->splitLines($output) as $line) {
+                $line = trim($line);
+                if ($line && preg_match('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
+                    if (isset($match[1]) && isset($match[2]) && $match[2] === './') {
+                        $this->branches['trunk'] = $this->buildIdentifier(
+                            '/' . $this->trunkPath,
+                            $match[1]
+                        );
+                        $this->rootIdentifier = $this->branches['trunk'];
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Process the configured branches path(s)
+     */
+    private function processBranches()
+    {
+        if ($this->branchesPath !== false) {
+            if (is_array($this->branchesPath)) {
+                // multiple branch paths specified for processing
+                foreach ($this->branchesPath as $branchPath) {
+                    $this->processBranch($branchPath);
+                }
+            } else {
+                // single branches directory specified for processing
+                $this->processBranch($this->branchesPath);
+            }
+        }
+    }
+
+    /**
+     * Process the configured tag path(s)
+     */
+    private function processTags()
+    {
+        if ($this->tagsPath !== false) {
+            if (is_array($this->tagsPath)) {
+                // multiple tag directories specified for processing
+                foreach ($this->tagsPath as $tagPath) {
+                    $this->processTag($tagPath);
+                }
+            } else {
+                // single tags directory specified for processing
+                $this->processTag($this->tagsPath);
+            }
+        }
+    }
+
+    /**
+     * Process a specific branch directory path
+     *
+     * @param string $branchPath The SVN path to a specific branch directory
+     */
+    private function processBranch($branchPath)
+    {
+        $output = $this->execute('svn ls --verbose', $this->baseUrl . '/' . $branchPath);
+        if ($output) {
+            foreach ($this->process->splitLines(trim($output)) as $line) {
+                $line = trim($line);
+                if ($line && preg_match('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
+                    if (isset($match[1]) && isset($match[2]) && $match[2] !== './') {
+                        $this->branches[rtrim($match[2], '/')] = $this->buildIdentifier(
+                            '/' . $branchPath . '/' . $match[2],
+                            $match[1]
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Process a specific tag directory path
+     *
+     * @param string $tagPath The SVN path to a specific tag directory
+     */
+    private function processTag($tagPath)
+    {
+        $output = $this->execute('svn ls --verbose', $this->baseUrl . '/' . $tagPath);
+        if ($output) {
+            foreach ($this->process->splitLines($output) as $line) {
+                $line = trim($line);
+                if ($line && preg_match('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
+                    if (isset($match[1]) && isset($match[2]) && $match[2] !== './') {
+                        $this->tags[rtrim($match[2], '/')] = $this->buildIdentifier(
+                            '/' . $tagPath . '/' . $match[2],
+                            $match[1]
+                        );
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
I've implemented `array` awareness to the `repositories.tags-path` and `repositories.branches-path` configuration clauses, because in SVN you are able to create more complex tags and branches directories, where you may have multiple sub-directories (as my employer does). 

This relates to a issue I submitted to the "composer/satis": https://github.com/composer/satis/issues/312

I'll also be submitting a JSON schema update for the satis.json definition.