### PR TITLE
Skip non-empty directories in zip generation

### DIFF
--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -13,7 +13,9 @@
 namespace Composer\Package\Archiver;
 
 use Composer\Util\Filesystem;
+use FilesystemIterator;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * A Symfony Finder wrapper which locates files that should go into archives
@@ -84,6 +86,14 @@ class ArchivableFilesFinder extends \FilterIterator
 
     public function accept()
     {
-        return !$this->getInnerIterator()->current()->isDir();
+        /** @var SplFileInfo $current */
+        $current = $this->getInnerIterator()->current();
+
+        if (!$current->isDir()) {
+            return true;
+        }
+
+        $iterator = new FilesystemIterator($current, FilesystemIterator::SKIP_DOTS);
+        return !$iterator->valid();
     }
 }

--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -37,7 +37,11 @@ class ZipArchiver implements ArchiverInterface
                 /** @var $file \SplFileInfo */
                 $filepath = $file->getPath()."/".$file->getFilename();
                 $localname = str_replace($sources."/", '', $filepath);
-                $zip->addFile($filepath, $localname);
+                if ($file->isDir()) {
+                    $zip->addEmptyDir($localname);
+                } else {
+                    $zip->addFile($filepath, $localname);
+                }
             }
             if ($zip->close()) {
                 return $target;


### PR DESCRIPTION
Empty dirs get archived (leafs).

Previously it seemed ok to skip all directories in zip generation.

References:

- Ref: 6066359944642e47d03c2dd367c9e43af787a9f7

- Issue: #4865 Keep empty folders after re-zip a module