### PR TITLE
Rollback installation of plugins if corrupted, fixes #5130

### DIFF
--- a/src/Composer/Installer/PluginInstaller.php
+++ b/src/Composer/Installer/PluginInstaller.php
@@ -59,7 +59,14 @@ class PluginInstaller extends LibraryInstaller
         }
 
         parent::install($repo, $package);
-        $this->composer->getPluginManager()->registerPackage($package, true);
+        try {
+            $this->composer->getPluginManager()->registerPackage($package, true);
+        } catch(\Exception $e) {
+            // Rollback installation
+            $this->io->writeError('Plugin installation failed, rolling back');
+            parent::uninstall($repo, $package);
+            throw $e;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #5130, sample output:
```
[64.8MB/4.70s] Analyzed 54 packages to resolve dependencies
[64.8MB/4.70s] Analyzed 55 rules to resolve dependencies
[64.9MB/4.71s]   - Installing slbmeh/gh-5130-bad-dependency (dev-master)
[64.9MB/4.73s]     Junctioned from ../libs/bad-dependency/
[64.9MB/4.73s] 
[64.9MB/4.73s] Plugin installation failed, rolling back
[64.9MB/4.73s]   - Removing junction for slbmeh/gh-5130-bad-dependency (dev-master)

                                                                                             
  [UnexpectedValueException]                                                                 
  Plugin slbmeh/gh-5130-bad-dependency could not be initialized, class not found: SomeClass  
```