### PR TITLE
Fix config add/remove/unset/merge for Bitbucket OAuth

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -58,10 +58,10 @@ class Config
         'archive-format' => 'tar',
         'archive-dir' => '.',
         // valid keys without defaults (auth config stuff):
+        // bitbucket-oauth
         // github-oauth
         // gitlab-oauth
         // http-basic
-        // bitbucket-oauth
     );
 
     public static $defaultRepositories = array(
@@ -121,7 +121,7 @@ class Config
         // override defaults with given config
         if (!empty($config['config']) && is_array($config['config'])) {
             foreach ($config['config'] as $key => $val) {
-                if (in_array($key, array('github-oauth', 'gitlab-oauth', 'http-basic')) && isset($this->config[$key])) {
+                if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'http-basic')) && isset($this->config[$key])) {
                     $this->config[$key] = array_merge($this->config[$key], $val);
                 } elseif ('preferred-install' === $key && isset($this->config[$key])) {
                     if (is_array($val) || is_array($this->config[$key])) {

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -81,7 +81,7 @@ class JsonConfigSource implements ConfigSourceInterface
     {
         $authConfig = $this->authConfig;
         $this->manipulateJson('addConfigSetting', $name, $value, function (&$config, $key, $val) use ($authConfig) {
-            if (preg_match('{^(github-oauth|gitlab-oauth|http-basic|platform|bitbucket-oauth)\.}', $key)) {
+            if (preg_match('{^(bitbucket-oauth|github-oauth|gitlab-oauth|http-basic|platform)\.}', $key)) {
                 list($key, $host) = explode('.', $key, 2);
                 if ($authConfig) {
                     $config[$key][$host] = $val;
@@ -101,7 +101,7 @@ class JsonConfigSource implements ConfigSourceInterface
     {
         $authConfig = $this->authConfig;
         $this->manipulateJson('removeConfigSetting', $name, function (&$config, $key) use ($authConfig) {
-            if (preg_match('{^(github-oauth|gitlab-oauth|http-basic|platform)\.}', $key)) {
+            if (preg_match('{^(bitbucket-oauth|github-oauth|gitlab-oauth|http-basic|platform)\.}', $key)) {
                 list($key, $host) = explode('.', $key, 2);
                 if ($authConfig) {
                     unset($config[$key][$host]);

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -85,12 +85,17 @@ abstract class BaseIO implements IOInterface
      */
     public function loadConfiguration(Config $config)
     {
+        $bitbucketOauth = $config->get('bitbucket-oauth') ?: array();
         $githubOauth = $config->get('github-oauth') ?: array();
         $gitlabOauth = $config->get('gitlab-oauth') ?: array();
         $httpBasic = $config->get('http-basic') ?: array();
-        $bitbucketOauth = $config->get('bitbucket-oauth') ?: array();
 
-        // reload oauth token from config if available
+        // reload oauth tokens from config if available
+
+        foreach ($bitbucketOauth as $domain => $cred) {
+            $this->checkAndSetAuthentication($domain, $cred['consumer-key'], $cred['consumer-secret']);
+        }
+
         foreach ($githubOauth as $domain => $token) {
             if (!preg_match('{^[a-z0-9]+$}', $token)) {
                 throw new \UnexpectedValueException('Your github oauth token for '.$domain.' contains invalid characters: "'.$token.'"');
@@ -105,10 +110,6 @@ abstract class BaseIO implements IOInterface
         // reload http basic credentials from config if available
         foreach ($httpBasic as $domain => $cred) {
             $this->checkAndSetAuthentication($domain, $cred['username'], $cred['password']);
-        }
-
-        foreach ($bitbucketOauth as $domain => $cred) {
-            $this->checkAndSetAuthentication($domain, $cred['consumer-key'], $cred['consumer-secret']);
         }
 
         // setup process timeout


### PR DESCRIPTION
Not sure why the code to handle `bitbucket-oauth` was in its own section, but it prevented `--unset` from working for that key. Moved it where it belongs.