### PR TITLE
trim trailing slash from symlink names

### DIFF
--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -84,6 +84,7 @@ class PathDownloader extends FileDownloader
                         $absolutePath = getcwd() . DIRECTORY_SEPARATOR . $path;
                     }
                     $shortestPath = $this->filesystem->findShortestPath($absolutePath, $realUrl);
+                    $path = rtrim($path,"/");
                     $fileSystem->symlink($shortestPath, $path);
                     $this->io->writeError(sprintf('    Symlinked from %s', $url));
                 }


### PR DESCRIPTION
symlink names are not allowed to contain
a trailing slash, so trim it.