### PR TITLE
Speedup autoloading with APCu class loader

### DIFF
--- a/src/Composer/Autoload/ApcuClassLoader.php
+++ b/src/Composer/Autoload/ApcuClassLoader.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Autoload;
+
+/**
+ * By-inheritance ClassLoader proxy caching results in APCu.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class ApcuClassLoader extends ClassLoader
+{
+    private $prefix;
+    private $initializer;
+
+    public function __construct($prefix, \Closure $initializer)
+    {
+        $this->prefix = $prefix;
+        $this->initializer = $initializer;
+    }
+
+    public function getPrefixes()
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        return parent::getPrefixes();
+    }
+
+    public function getPrefixesPsr4()
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        return parent::getPrefixesPsr4();
+    }
+
+    public function getFallbackDirs()
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        return parent::getFallbackDirs();
+    }
+
+    public function getFallbackDirsPsr4()
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        return parent::getFallbackDirsPsr4();
+    }
+
+    public function getClassMap()
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        return parent::getClassMap();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addClassMap(array $classMap)
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        parent::addClassMap($classMap);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($prefix, $paths, $prepend = false)
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        parent::add($prefix, $paths, $prepend);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addPsr4($prefix, $paths, $prepend = false)
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        parent::addPsr4($prefix, $paths, $prepend);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($prefix, $paths)
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        parent::set($prefix, $paths);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPsr4($prefix, $paths)
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        parent::setPsr4($prefix, $paths);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUseIncludePath($useIncludePath)
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        parent::setUseIncludePath($useIncludePath);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUseIncludePath()
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        return parent::getUseIncludePath();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setClassMapAuthoritative($classMapAuthoritative)
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        parent::setClassMapAuthoritative($classMapAuthoritative);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isClassMapAuthoritative()
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        return parent::isClassMapAuthoritative();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadClass($class)
+    {
+        $file = apcu_fetch($this->prefix.$class, $success);
+
+        if ($file || (!$success && $file = $this->findFile($class))) {
+            includeFile($file);
+
+            return true;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findFile($class)
+    {
+        if (null !== $this->initializer) {
+            $this->initialize();
+        }
+
+        apcu_store($this->prefix.$class, $file = parent::findFile($class));
+
+        return $file;
+    }
+
+    private function initialize()
+    {
+        $initializer = $this->initializer;
+        $this->initializer = null;
+        $initializer($this);
+    }
+}

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -10,6 +10,8 @@ class ComposerAutoloaderInitFilesAutoloadOrder
     {
         if ('Composer\Autoload\ClassLoader' === $class) {
             require __DIR__ . '/ClassLoader.php';
+        } elseif ('Composer\Autoload\ApcuClassLoader' === $class) {
+            require __DIR__ . '/ApcuClassLoader.php';
         }
     }
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -10,6 +10,8 @@ class ComposerAutoloaderInitFilesAutoload
     {
         if ('Composer\Autoload\ClassLoader' === $class) {
             require __DIR__ . '/ClassLoader.php';
+        } elseif ('Composer\Autoload\ApcuClassLoader' === $class) {
+            require __DIR__ . '/ApcuClassLoader.php';
         }
     }
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
@@ -10,6 +10,8 @@ class ComposerAutoloaderInitFilesAutoload
     {
         if ('Composer\Autoload\ClassLoader' === $class) {
             require __DIR__ . '/ClassLoader.php';
+        } elseif ('Composer\Autoload\ApcuClassLoader' === $class) {
+            require __DIR__ . '/ApcuClassLoader.php';
         }
     }
 
@@ -19,13 +21,13 @@ class ComposerAutoloaderInitFilesAutoload
             return self::$loader;
         }
 
-        spl_autoload_register(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
-        spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
-
         $includePaths = require __DIR__ . '/include_paths.php';
         array_push($includePaths, get_include_path());
         set_include_path(join(PATH_SEPARATOR, $includePaths));
+
+        spl_autoload_register(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'), true, true);
+        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
         $map = require __DIR__ . '/autoload_namespaces.php';
         foreach ($map as $namespace => $path) {

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
@@ -10,6 +10,8 @@ class ComposerAutoloaderInitFilesAutoload
     {
         if ('Composer\Autoload\ClassLoader' === $class) {
             require __DIR__ . '/ClassLoader.php';
+        } elseif ('Composer\Autoload\ApcuClassLoader' === $class) {
+            require __DIR__ . '/ApcuClassLoader.php';
         }
     }
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -10,6 +10,8 @@ class ComposerAutoloaderInitIncludePath
     {
         if ('Composer\Autoload\ClassLoader' === $class) {
             require __DIR__ . '/ClassLoader.php';
+        } elseif ('Composer\Autoload\ApcuClassLoader' === $class) {
+            require __DIR__ . '/ApcuClassLoader.php';
         }
     }
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -10,6 +10,8 @@ class ComposerAutoloaderInitTargetDir
     {
         if ('Composer\Autoload\ClassLoader' === $class) {
             require __DIR__ . '/ClassLoader.php';
+        } elseif ('Composer\Autoload\ApcuClassLoader' === $class) {
+            require __DIR__ . '/ApcuClassLoader.php';
         }
     }
 


### PR DESCRIPTION
The fastest autoloader we can currently get with composer is when dumping the class map in authoritative mode: this reduces autoloading to an `isset()` check, one of the fastest in PHP.
But this autoloader has one drawback: it doesn't scale with the number of classes. Even with opcache enabled, the generated class map being a php array, it becomes slower when you add more classes to it. It also consumes more memory.

That made me wonder if using APCu could help build an even better autoloader.

This PR adds an ApcuClassLoader that wraps the regular ClassLoader by inheritance so that only APCu is used when the cache is warm, and the regular autoloader is lazily initialized when needed to warm up the APCu cache.

I did not yet wire any on/off way to configure which loader to use. Just change yourself the `$apcuLoader` property if you want to try the patch for now.

Still, I wanted to share with you the following Blackfire profile:
https://blackfire.io/profiles/compare/ace900a5-4936-4998-871d-680bbf744177/graph

This profile has been generated by taking the blackfire classmap (~8300 lines) and loading ~430 classes from it, this number being quite typical for rendering a single page/response in a Symfony app.

The results are quite interesting:
- loading the classmap goes from 2.66 ms and 2.56 MB to zero
- overall loading time is reduced by 1.59 ms and 2.54 MB!

On the memory side, we have a clear win.
On the time side, 2.66 ms removal from not-loading the classmap are turned into a lower 1.59 ms general perf increase. Logically, this could mean that *once the classmap is loaded*, using it is faster that calling apcu_fetch, but since we have to load this classmap anyway, the win is still a clear win in the typical web request use case where only a short excerpt of all existing classes are loaded at once.

The only remaining question to me now is: how should we plug this into composer configuration system.
Some ideas:
- add a command line option?
- `ext-apcu` must-be in the dependencies?
- both? Other way?