### PR TITLE
Tilde and environment variable expansion for paths

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -649,8 +649,8 @@ the console will read `Symlinked from ../../packages/my-package`. If symlinking
 is _not_ possible the package will be copied. In that case, the console will
 output `Mirrored from ../../packages/my-package`.
 
-Instead of default fallback strategy you can force to use symlink with `"symlink": true` or
-mirroring with `"symlink": false` option.
+Instead of default fallback strategy you can force to use symlink with `"symlink": true`
+or mirroring with `"symlink": false` option.
 Forcing mirroring can be useful when deploying or generating package from a monolithic repository.
 
 ```json
@@ -667,9 +667,11 @@ Forcing mirroring can be useful when deploying or generating package from a mono
 }
 ```
 
-If present on *nix systems leading tildes are expanded to the current user's home folder, which
-can be handy when working on teams on the same packages. For example `~/git/mypackage` will
-automatically load the mypackage clone from `/home/<username>/git/mypackage` for every developer.
+Leading tildes are expanded to the current user's home folder, and environment
+variables are parsed according to host platform. For example `~/git/mypackage`
+will automatically load the mypackage clone from `/home/<username>/git/mypackage`,
+which is equivalent to `$HOME/git/mypackage` on Linux/Mac or
+`%USERPROFILE%/git/mypackage` on Windows.
 
 > **Note:** Repository paths can also contain wildcards like ``*`` and ``?``.
 > For details, see the [PHP glob function](http://php.net/glob).

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -668,10 +668,10 @@ Forcing mirroring can be useful when deploying or generating package from a mono
 ```
 
 Leading tildes are expanded to the current user's home folder, and environment
-variables are parsed according to host platform. For example `~/git/mypackage`
-will automatically load the mypackage clone from `/home/<username>/git/mypackage`,
-which is equivalent to `$HOME/git/mypackage` on Linux/Mac or
-`%USERPROFILE%/git/mypackage` on Windows.
+variables are parsed in both Windows and Linux/Mac notations. For example
+`~/git/mypackage` will automatically load the mypackage clone from
+`/home/<username>/git/mypackage`, equivalent to `$HOME/git/mypackage` or
+`%USERPROFILE%/git/mypackage`.
 
 > **Note:** Repository paths can also contain wildcards like ``*`` and ``?``.
 > For details, see the [PHP glob function](http://php.net/glob).

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -609,8 +609,8 @@ update to the latest version.
 ### Path
 
 In addition to the artifact repository, you can use the path one, which allows
-you to depend on a relative directory. This can be especially useful when dealing
-with monolith repositories.
+you to depend on a local directory, either absolute or relative. This can be
+especially useful when dealing with monolithic repositories.
 
 For instance, if you have the following directory structure in your repository:
 ```
@@ -667,9 +667,9 @@ Forcing mirroring can be useful when deploying or generating package from a mono
 }
 ```
 
-
-
-Instead of using a relative path, an absolute path can also be used.
+If present on *nix systems leading tildes are expanded to the current user's home folder, which
+can be handy when working on teams on the same packages. For example `~/git/mypackage` will
+automatically load the mypackage clone from `/home/<username>/git/mypackage` for every developer.
 
 > **Note:** Repository paths can also contain wildcards like ``*`` and ``?``.
 > For details, see the [PHP glob function](http://php.net/glob).

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -14,6 +14,7 @@ namespace Composer;
 
 use Composer\Config\ConfigSourceInterface;
 use Composer\Downloader\TransportException;
+use Composer\Util\Platform;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -207,7 +208,7 @@ class Config
                 $env = 'COMPOSER_' . strtoupper(strtr($key, '-', '_'));
 
                 $val = rtrim($this->process($this->getComposerEnv($env) ?: $this->config[$key], $flags), '/\\');
-                $val = preg_replace('#^(\$HOME|~)(/|$)#', rtrim(getenv('HOME') ?: getenv('USERPROFILE'), '/\\') . '/', $val);
+                $val = Platform::expandPath($val);
 
                 if (substr($key, -4) !== '-dir') {
                     return $val;

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -18,6 +18,7 @@ use Composer\Json\JsonFile;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\Version\VersionGuesser;
 use Composer\Package\Version\VersionParser;
+use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 
 /**
@@ -101,7 +102,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
         }
 
         $this->loader = new ArrayLoader(null, true);
-        $this->url = $repoConfig['url'];
+        $this->url = Platform::expandPath($repoConfig['url']);
         $this->process = new ProcessExecutor($io);
         $this->versionGuesser = new VersionGuesser($config, $this->process, new VersionParser());
         $this->repoConfig = $repoConfig;

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -31,6 +31,10 @@ class Platform
             return self::getUserDirectory() . substr($path, 1);
         }
         return preg_replace_callback('#^([\\$%])(\\w+)\\1?(([/\\\\].*)?)#', function($matches) {
+            // Treat HOME as an alias for USERPROFILE on Windows for legacy reasons
+            if (Platform::isWindows() && $matches[2] == 'HOME') {
+                return (getenv('HOME') ?: getenv('USERPROFILE')) . $matches[3];
+            }
             return getenv($matches[2]) . $matches[3];
         }, $path);
     }

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -20,10 +20,36 @@ namespace Composer\Util;
 class Platform
 {
     /**
+     * Parses magic constructs like tildes in paths. Right now only tildes are supported but we could add support for 
+     * environment variables on various platforms.
+     *
+     * @param string $path
+     * @return string
+     */
+    public static function expandPath($path)
+    {
+        // Tilde expansion for *nix
+        if (!self::isWindows() && 0 === strpos($path, '~/')) {
+            if (function_exists('posix_getuid') && function_exists('posix_getpwuid')) {
+                $info = posix_getpwuid(posix_getuid());
+                $home = $info['dir'];
+            } else {
+                $home = getenv('HOME');
+            }
+            // Cannot be empty or FALSE
+            if (!$home) {
+                throw new \RuntimeException(sprintf('No home folder found to expand ~ with in %s', $path));
+            }
+            $path = $home . substr($path, 1);
+        }
+        return $path;
+    }
+
+    /**
      * @return bool Whether the host machine is running a Windows OS
      */
     public static function isWindows()
     {
         return defined('PHP_WINDOWS_VERSION_BUILD');
     }
-}
+ }

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -30,8 +30,8 @@ class Platform
         if (preg_match('#^~[/\\\\]#', $path)) {
             return self::getUserDirectory() . substr($path, 1);
         }
-        return preg_replace_callback(self::isWindows() ? '#^(%(\\w+)%)[/\\\\]#' : '#^(\\$(\\w+))/#', function($matches) {
-            return getenv($matches[2]) . '/';
+        return preg_replace_callback('#^([\\$%])(\\w+)\\1?(([/\\\\].*)?)#', function($matches) {
+            return getenv($matches[2]) . $matches[3];
         }, $path);
     }
 

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -31,7 +31,7 @@ class Platform
             return self::getUserDirectory() . substr($path, 1);
         }
         return preg_replace_callback(self::isWindows() ? '#^(%(\\w+)%)[/\\\\]#' : '#^(\\$(\\w+))/#', function($matches) {
-            return getenv($matches[2]) . DIRECTORY_SEPARATOR;
+            return getenv($matches[2]) . '/';
         }, $path);
     }
 

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -13,7 +13,6 @@
 namespace Composer\Test;
 
 use Composer\Config;
-use Composer\Downloader\TransportException;
 
 class ConfigTest extends \PHPUnit_Framework_TestCase
 {
@@ -151,7 +150,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $home = rtrim(getenv('HOME') ?: getenv('USERPROFILE'), '\\/');
         $this->assertEquals('b', $config->get('c'));
-        $this->assertEquals($home.'/', $config->get('bin-dir'));
+        $this->assertEquals($home, $config->get('bin-dir'));
         $this->assertEquals($home.'/foo', $config->get('cache-dir'));
     }
 

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -21,7 +21,18 @@ use Composer\Util\Platform;
  */
 class PlatformTest extends \PHPUnit_Framework_TestCase
 {
-    public function testWindows()
+    public function testExpandPath()
+    {
+        putenv('TESTENV=/home/test');
+        if (Platform::isWindows()) {
+            $this->assertEquals('/home/test/myPath', Platform::expandPath('%TESTENV%/myPath'));
+        } else {
+            $this->assertEquals('/home/test/myPath', Platform::expandPath('$TESTENV/myPath'));
+        }
+        $this->assertEquals((getenv('HOME') ?: getenv('USERPROFILE')) . DIRECTORY_SEPARATOR . 'test', Platform::expandPath('~/test'));
+    }
+    
+    public function testIsWindows()
     {
         // Compare 2 common tests for Windows to the built-in Windows test
         $this->assertEquals(('\\' === DIRECTORY_SEPARATOR), Platform::isWindows());

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -29,7 +29,7 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         } else {
             $this->assertEquals('/home/test/myPath', Platform::expandPath('$TESTENV/myPath'));
         }
-        $this->assertEquals((getenv('HOME') ?: getenv('USERPROFILE')) . DIRECTORY_SEPARATOR . 'test', Platform::expandPath('~/test'));
+        $this->assertEquals((getenv('HOME') ?: getenv('USERPROFILE')) . '/test', Platform::expandPath('~/test'));
     }
     
     public function testIsWindows()

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -24,11 +24,8 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
     public function testExpandPath()
     {
         putenv('TESTENV=/home/test');
-        if (Platform::isWindows()) {
-            $this->assertEquals('/home/test/myPath', Platform::expandPath('%TESTENV%/myPath'));
-        } else {
-            $this->assertEquals('/home/test/myPath', Platform::expandPath('$TESTENV/myPath'));
-        }
+        $this->assertEquals('/home/test/myPath', Platform::expandPath('%TESTENV%/myPath'));
+        $this->assertEquals('/home/test/myPath', Platform::expandPath('$TESTENV/myPath'));
         $this->assertEquals((getenv('HOME') ?: getenv('USERPROFILE')) . '/test', Platform::expandPath('~/test'));
     }
     


### PR DESCRIPTION
Allows using tildes in path repositories for easier sharing of path repositories between multiple team members. For example a path repository to `~/git/mysubproject/*` will automatically load all those packages from the developer's home folder.