### PR TITLE
Observe COMPOSER environment variable in init command

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -48,9 +48,11 @@ class InitCommand extends BaseCommand
      */
     protected function configure()
     {
+        $configFile = Factory::getComposerFile();
+
         $this
             ->setName('init')
-            ->setDescription('Creates a basic composer.json file in current directory.')
+            ->setDescription('Creates a basic ' . $configFile . ' file in current directory.')
             ->setDefinition(array(
                 new InputOption('name', null, InputOption::VALUE_REQUIRED, 'Name of the package'),
                 new InputOption('description', null, InputOption::VALUE_REQUIRED, 'Description of package'),
@@ -65,7 +67,7 @@ class InitCommand extends BaseCommand
                 new InputOption('repository', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add custom repositories, either by URL or using JSON arrays'),
             ))
             ->setHelp(<<<EOT
-The <info>init</info> command creates a basic composer.json file
+The <info>init</info> command creates a basic $configFile file
 in the current directory.
 
 <info>php composer.phar init</info>
@@ -115,7 +117,7 @@ EOT
             }
         }
 
-        $file = new JsonFile('composer.json');
+        $file = new JsonFile(Factory::getComposerFile());
         $json = $file->encode($options);
 
         if ($input->isInteractive()) {
@@ -181,7 +183,7 @@ EOT
         // namespace
         $io->writeError(array(
             '',
-            'This command will guide you through creating your composer.json config.',
+            'This command will guide you through creating your ' . Factory::getComposerFile() . ' config.',
             '',
         ));
 


### PR DESCRIPTION
The init command creates a file called "composer.json" even when the COMPOSER environment variable is set to a different filename. This means that subsequent commands like install will result in an error message saying that composer could not find the config file.

It would make sense for init to observe the COMPOSER environment variable so that this does not happen.

To test / reproduce: `COMPOSER=composer-other.json php composer.phar init`. Without patch, composer.json file created, with patch composer-other.json.