### PR TITLE
Unix/Windows compatibility in binary file path

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -173,7 +173,7 @@ class BinaryInstaller
 
         return "@ECHO OFF\r\n".
             "setlocal DISABLEDELAYEDEXPANSION\r\n".
-            "SET BIN_TARGET=%~dp0/".trim(ProcessExecutor::escape($binPath), '"')."\r\n".
+            "SET BIN_TARGET=%~dp0/".trim(ProcessExecutor::escape($binPath), '"\'')."\r\n".
             "{$caller} \"%BIN_TARGET%\" %*\r\n";
     }
 


### PR DESCRIPTION
When `bin-compat` is set to "full", running `composer install` from Windows generates a different .bat file than when running it in Linux. `BinaryInstaller::generateWindowsProxyCode()` currently trims double quotes from `$binPath` when creating the Windows .bat file in the binary directory. The problem is that, on Linux, $binPath is surrounded by single quotes, not double. So, running `composer install` on Linux would create a .bat file that did not work on Windows (which is a problem if you want to share the binaries, like on a volume mounted in a Docker container). See the screenshot below for an example, notice the quotes on the third line.

![image](https://cloud.githubusercontent.com/assets/5074378/14513780/232b1028-019f-11e6-9c22-71415260fd8d.png)

Both single and double quotes are being trimmed now, and the .bat file created is the same if created on Windows or on Linux.