### PR TITLE
Support alternative scp-like syntax in http-secure check

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -14,6 +14,7 @@ namespace Composer;
 
 use Composer\Config\ConfigSourceInterface;
 use Composer\Downloader\TransportException;
+use Composer\Package\Url;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -412,14 +413,14 @@ class Config
         }
 
         // Parse the URL into its separate parts
-        $parsed = parse_url($url);
-        if (false === $parsed || !isset($parsed['scheme'])) {
+        $protocol = Url::create($url)->getProtocol();
+        if (!$protocol) {
             // If the URL is malformed or does not contain a usable scheme it's not going to work anyway
             return;
         }
 
         // Throw exception on known insecure protocols
-        if (in_array($parsed['scheme'], array('http', 'git', 'ftp', 'svn'))) {
+        if (in_array($protocol, array('http', 'git', 'ftp', 'svn'))) {
             throw new TransportException("Your configuration does not allow connections to $url. See https://getcomposer.org/doc/06-config.md#secure-http for details.");
         }
     }

--- a/src/Composer/Package/Url.php
+++ b/src/Composer/Package/Url.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Package;
+
+/**
+ * Package URL, based on git-clone URLs
+ */
+class Url
+{
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @param string $url
+     * @return Url
+     */
+    public static function create($url)
+    {
+        return new Url($url);
+    }
+
+    /**
+     * Url constructor.
+     *
+     * @param string $url
+     */
+    public function __construct($url)
+    {
+        $this->url = (string)$url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProtocol()
+    {
+        $url = $this->url;
+        if (strlen($scheme = $this->scheme($url))) {
+            return $scheme;
+        }
+
+        # alternative scp-like syntax
+        $slashPos = strpos($url, '/');
+        $colonPos = strpos($url, ':');
+        if (false !== $colonPos && ($slashPos === false || $slashPos > $colonPos)) {
+            return 'ssh';
+        }
+
+        return 'file';
+    }
+
+    /**
+     * @param string $url
+     * @return null|string
+     */
+    private function scheme($url)
+    {
+        $result = preg_match('~^([a-zA-Z](?:[a-zA-Z0-9.+-])*)://~', $url, $matches);
+        if (false === $result) {
+            throw new \RuntimeException('Regex failed');
+        }
+
+        return $result ? strtolower($matches[1]) : null;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->url;
+    }
+}

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -250,6 +250,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             '\\myserver\myplace.git',
             'file://myserver.localhost/mygit.git',
             'file://example.org/mygit.git',
+            'git:Department/Repo.git',
+            'ssh://[user@]host.xz[:port]/path/to/repo.git/',
         );
 
         return array_combine($urls, array_map(function ($e) { return array($e); }, $urls));

--- a/tests/Composer/Test/Package/UrlTest.php
+++ b/tests/Composer/Test/Package/UrlTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Package;
+
+use Composer\Package\Url;
+
+class UrlTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function creation()
+    {
+        $url = new Url("");
+        $this->assertSame("", $url->__toString());
+
+        $subject = Url::create("");
+        $this->assertInstanceOf('Composer\Package\Url', $subject);
+    }
+
+    /**
+     * @see protocol
+     */
+    public function provideProtocols()
+    {
+        return array(
+            array('ssh://[user@]host.xz[:port]/path/to/repo.git/', 'ssh'),
+            array('git://host.xz[:port]/path/to/repo.git/', 'git'),
+            array('http://host.xz[:port]/path/to/repo.git/', 'http'),
+            array('https://host.xz[:port]/path/to/repo.git/', 'https'),
+            array('ftp://host.xz[:port]/path/to/repo.git/', 'ftp'),
+            array('ftps://host.xz[:port]/path/to/repo.git/', 'ftps'),
+            # alternative scp-like syntax
+            array('[user@]host.xz:path/to/repo.git/', 'ssh'),
+            # local repositories, also supported by Git natively
+            array('/path/to/repo.git/', 'file'),
+            array('file:///path/to/repo.git/', 'file'),
+            # differentiation cases
+            array('host:path/', 'ssh'),
+            array('foo:bar', 'ssh'),
+            array('./foo:bar', 'file'),
+            # more URI examples
+            array('svn://svn.host.xz:[port]/svn/uri/trunk', 'svn')
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider provideProtocols
+     */
+    public function protocol($url, $protocol)
+    {
+        $subject = new Url($url);
+        $this->assertSame($protocol, $subject->getProtocol());
+    }
+}


### PR DESCRIPTION
Also support ssh:// URIs.

References:

- Report: #5173

- URL syntax: https://www.git-scm.com/docs/git-clone#_git_urls_a_id_urls_a

- Scheme syntax: http://tools.ietf.org/html/rfc3986#section-3.1