### PR TITLE
Show channel even if there is no new version on the current channel

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -117,7 +117,7 @@ EOT
         }
 
         if (Composer::VERSION === $updateVersion) {
-            $io->writeError('<info>You are already using composer version '.$updateVersion.'.</info>');
+            $io->writeError(sprintf('<info>You are already using composer version %s (%s channel).</info>', $updateVersion, $versionsUtil->getChannel()));
 
             // remove all backups except for the most recent, if any
             if ($input->getOption('clean-backups')) {


### PR DESCRIPTION
At the moment using composer self-update you just get the message that you are on the current version:

````
$ composer self-update
You are already using composer version 1.0.0.
````

This PR adds the channel information so that a user can decide if he wants to select another channel.