### PR TITLE
Check temp folder usability before runtime

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -150,9 +150,8 @@ class Application extends BaseApplication
 
             // Check system temp folder for usability as it can cause weird runtime issues otherwise
             Silencer::call(function() {
-                $tempfile = sys_get_temp_dir() . '/tempchk.tmp';
-                $usable = file_put_contents($tempfile, __FILE__) && (file_get_contents($tempfile) == __FILE__) && unlink($tempfile);
-                if (!$usable || file_exists($tempfile)) {
+                $tempfile = sys_get_temp_dir() . '/temp-' . md5(microtime());
+                if (!(file_put_contents($tempfile, __FILE__) && (file_get_contents($tempfile) == __FILE__) && unlink($tempfile) && !file_exists($tempfile))) {
                     throw new \RuntimeException(sprintf('PHP temp directory "%s" does not exist or is not writable to Composer - check sys_temp_dir in your php.ini', sys_get_temp_dir()));
                 }
             });

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -148,6 +148,15 @@ class Application extends BaseApplication
                 Silencer::call('exec', 'sudo -K > /dev/null 2>&1');
             }
 
+            // Check system temp folder for usability as it can cause weird runtime issues otherwise
+            Silencer::call(function() {
+                $tempfile = sys_get_temp_dir() . '/tempchk.tmp';
+                $usable = file_put_contents($tempfile, __FILE__) && (file_get_contents($tempfile) == __FILE__) && unlink($tempfile);
+                if (!$usable || file_exists($tempfile)) {
+                    throw new \RuntimeException(sprintf('PHP temp directory "%s" does not exist or is not writable to Composer - check sys_temp_dir in your php.ini', sys_get_temp_dir()));
+                }
+            });
+
             // switch working dir
             if ($newWorkDir = $this->getNewWorkingDir($input)) {
                 $oldWorkingDir = getcwd();


### PR DESCRIPTION
Extra startup check as #4797 and #5186 show this can cause exotic hard to find errors otherwise.