### PR TITLE
Fix partial updates from a dirty state and apply exactly the locked state

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -450,7 +450,7 @@ class Installer
                     $candidates[$link->getTarget()] = true;
                     $rootRequires[$link->getTarget()] = $link;
                 }
-                foreach ($localRepo->getPackages() as $package) {
+                foreach ($currentPackages as $package) {
                     $candidates[$package->getName()] = true;
                 }
 

--- a/tests/Composer/Test/Fixtures/installer/partial-update-downgrades-non-whitelisted-unstable.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-downgrades-non-whitelisted-unstable.test
@@ -53,7 +53,8 @@ update c/uptodate
     "packages": [
         { "name": "a/old", "version": "1.0.0", "type": "library" },
         { "name": "b/unstable", "version": "1.0.0", "type": "library" },
-        { "name": "c/uptodate", "version": "2.0.0", "type": "library" }
+        { "name": "c/uptodate", "version": "2.0.0", "type": "library" },
+        { "name": "d/removed", "version": "1.0.0", "type": "library" }
     ],
     "packages-dev": [],
     "aliases": [],
@@ -67,3 +68,4 @@ update c/uptodate
 --EXPECT--
 Updating b/unstable (1.1.0-alpha) to b/unstable (1.0.0)
 Updating a/old (0.9.0) to a/old (1.0.0)
+Installing d/removed (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/partial-update-from-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-from-lock.test
@@ -8,10 +8,13 @@ Partial update from lock file should update everything to the state of the lock,
             "package": [
                 { "name": "a/old", "version": "1.0.0" },
                 { "name": "a/old", "version": "2.0.0" },
-                { "name": "b/unstable", "version": "1.0.0" },
-                { "name": "b/unstable", "version": "1.1.0-alpha" },
+                { "name": "b/unstable", "version": "1.0.0", "require": {"f/dependency": "1.*"} },
+                { "name": "b/unstable", "version": "1.1.0-alpha", "require": {"f/dependency": "1.*"} },
                 { "name": "c/uptodate", "version": "1.0.0" },
-                { "name": "d/removed", "version": "1.0.0" }
+                { "name": "d/removed", "version": "1.0.0" },
+                { "name": "e/newreq", "version": "1.0.0" },
+                { "name": "f/dependency", "version": "1.1.0" },
+                { "name": "f/dependency", "version": "1.0.0" }
             ]
         }
     ],
@@ -25,9 +28,11 @@ Partial update from lock file should update everything to the state of the lock,
 {
     "packages": [
         { "name": "a/old", "version": "1.0.0" },
-        { "name": "b/unstable", "version": "1.1.0-alpha" },
+        { "name": "b/unstable", "version": "1.1.0-alpha", "require": {"f/dependency": "1.*"} },
         { "name": "c/uptodate", "version": "1.0.0" },
-        { "name": "d/removed", "version": "1.0.0" }
+        { "name": "d/removed", "version": "1.0.0" },
+        { "name": "e/newreq", "version": "1.0.0" },
+        { "name": "f/dependency", "version": "1.0.0" }
     ],
     "packages-dev": [],
     "aliases": [],
@@ -43,8 +48,9 @@ Partial update from lock file should update everything to the state of the lock,
 --INSTALLED--
 [
     { "name": "a/old", "version": "0.9.0" },
-    { "name": "b/unstable", "version": "1.1.0-alpha" },
-    { "name": "c/uptodate", "version": "2.0.0" }
+    { "name": "b/unstable", "version": "1.1.0-alpha", "require": {"f/dependency": "1.*"} },
+    { "name": "c/uptodate", "version": "2.0.0" },
+    { "name": "f/dependency", "version": "1.0.0" }
 ]
 --RUN--
 update b/unstable
@@ -52,8 +58,11 @@ update b/unstable
 {
     "packages": [
         { "name": "a/old", "version": "1.0.0", "type": "library" },
-        { "name": "b/unstable", "version": "1.0.0", "type": "library" },
-        { "name": "c/uptodate", "version": "1.0.0", "type": "library" }
+        { "name": "b/unstable", "version": "1.0.0", "type": "library", "require": {"f/dependency": "1.*"} },
+        { "name": "c/uptodate", "version": "1.0.0", "type": "library" },
+        { "name": "d/removed", "version": "1.0.0", "type": "library" },
+        { "name": "e/newreq", "version": "1.0.0", "type": "library" },
+        { "name": "f/dependency", "version": "1.0.0", "type": "library" }
     ],
     "packages-dev": [],
     "aliases": [],
@@ -68,3 +77,5 @@ update b/unstable
 Updating b/unstable (1.1.0-alpha) to b/unstable (1.0.0)
 Updating a/old (0.9.0) to a/old (1.0.0)
 Updating c/uptodate (2.0.0) to c/uptodate (1.0.0)
+Installing d/removed (1.0.0)
+Installing e/newreq (1.0.0)


### PR DESCRIPTION
Need a sanity check here (looking at the test files). I think it's better like this. The removed packages come back if they are still in the lock, which is maybe a bit WTF but is actually correct and I doubt it'll be much of an issue in practice. Other side-effects updates or packages that were in lock but not currently installed should not happen anymore.

Fixes #3468