### PR TITLE
Fix addMainKey method of JsonManipulator with content having $n

### DIFF
--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -353,7 +353,7 @@ class JsonManipulator
         if ($this->pregMatch('#[^{\s](\s*)\}$#', $this->contents, $match)) {
             $this->contents = preg_replace(
                 '#'.$match[1].'\}$#',
-                addcslashes(',' . $this->newline . $this->indent . JsonFile::encode($key). ': '. $content . $this->newline . '}', '\\'),
+                addcslashes(',' . $this->newline . $this->indent . JsonFile::encode($key). ': '. $content . $this->newline . '}', '\\$'),
                 $this->contents
             );
 
@@ -363,7 +363,7 @@ class JsonManipulator
         // append at the end of the file
         $this->contents = preg_replace(
             '#\}$#',
-            addcslashes($this->indent . JsonFile::encode($key). ': '.$content . $this->newline . '}', '\\'),
+            addcslashes($this->indent . JsonFile::encode($key). ': '.$content . $this->newline . '}', '\\$'),
             $this->contents
         );
 

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -2045,6 +2045,31 @@ class JsonManipulatorTest extends \PHPUnit_Framework_TestCase
 ', $manipulator->getContents());
     }
 
+    public function testAddMainKeyWithContentHavingDollarSignFollowedByDigit()
+    {
+        $manipulator = new JsonManipulator('{
+    "foo": "bar"
+}');
+        
+        $this->assertTrue($manipulator->addMainKey('bar', '$1baz'));
+        $this->assertEquals('{
+    "foo": "bar",
+    "bar": "$1baz"
+}
+', $manipulator->getContents());
+    }
+
+    public function testAddMainKeyWithContentHavingDollarSignFollowedByDigit2()
+    {
+        $manipulator = new JsonManipulator('{}');
+
+        $this->assertTrue($manipulator->addMainKey('foo', '$1bar'));
+        $this->assertEquals('{
+    "foo": "$1bar"
+}
+', $manipulator->getContents());
+    }
+    
     public function testUpdateMainKey()
     {
         $manipulator = new JsonManipulator('{
@@ -2105,6 +2130,19 @@ class JsonManipulatorTest extends \PHPUnit_Framework_TestCase
 ', $manipulator->getContents());
     }
 
+    public function testUpdateMainKeyWithContentHavingDollarSignFollowedByDigit()
+    {
+        $manipulator = new JsonManipulator('{
+    "foo": "bar"
+}');
+
+        $this->assertTrue($manipulator->addMainKey('foo', '$1bar'));
+        $this->assertEquals('{
+    "foo": "$1bar"
+}
+', $manipulator->getContents());
+    }
+    
     public function testIndentDetection()
     {
         $manipulator = new JsonManipulator('{


### PR DESCRIPTION
This will allow a dollar sign followed by a digit to be used in the password stored in auth.json file.
If the content variable contains a dollar sign followed by a digit ("$n", where n consists of digits) it will match as a replacement reference for preg_replace and thus it will be replaced by the text captured by the n'th paranthesized pattern or blank if there's no such paranthesized pattern. A replacement reference can also be in the form of "\\\n", but "$n" is preferred (and also mentioned in the PHP documentation), being made available since PHP 4.0.4.