### PR TITLE
Fixes the init event.

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -26,7 +26,6 @@ use Composer\Util\ProcessExecutor;
 use Composer\Util\RemoteFilesystem;
 use Composer\Util\Silencer;
 use Composer\Plugin\PluginEvents;
-use Composer\EventDispatcher\Event;
 use Seld\JsonLint\DuplicateKeyException;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Composer\EventDispatcher\EventDispatcher;
@@ -368,7 +367,7 @@ class Factory
         }
 
         if ($fullLoad) {
-            $initEvent = new Event(PluginEvents::INIT);
+            $initEvent = new Script\Event(PluginEvents::INIT, $composer, $io);
             $composer->getEventDispatcher()->dispatch($initEvent->getName(), $initEvent);
 
             // once everything is initialized we can


### PR DESCRIPTION
Listening to the init event introduced in https://github.com/composer/composer/commit/aeafe2fe59992efd1bc3f890b760f1a9c4874e1c actually does not work properly.

Composer gives the following error:

```
PHP Fatal error:  Call to undefined method Composer\EventDispatcher\Event::getComposer() in /Users/ladmin/projects/oss/composer/src/Composer/EventDispatcher/EventDispatcher.php on line 294
PHP Stack trace:
PHP   1. {main}() /Users/ladmin/projects/oss/composer/bin/composer:0
PHP   2. Composer\Console\Application->run() /Users/ladmin/projects/oss/composer/bin/composer:44
PHP   3. Symfony\Component\Console\Application->run() /Users/ladmin/projects/oss/composer/src/Composer/Console/Application.php:99
PHP   4. Composer\Console\Application->doRun() /Users/ladmin/projects/oss/composer/vendor/symfony/console/Application.php:123
PHP   5. Symfony\Component\Console\Application->doRun() /Users/ladmin/projects/oss/composer/src/Composer/Console/Application.php:197
PHP   6. Symfony\Component\Console\Application->doRunCommand() /Users/ladmin/projects/oss/composer/vendor/symfony/console/Application.php:192
PHP   7. Symfony\Component\Console\Command\Command->run() /Users/ladmin/projects/oss/composer/vendor/symfony/console/Application.php:844
PHP   8. Composer\Command\InstallCommand->execute() /Users/ladmin/projects/oss/composer/vendor/symfony/console/Command/Command.php:259
PHP   9. Composer\Command\BaseCommand->getComposer() /Users/ladmin/projects/oss/composer/src/Composer/Command/InstallCommand.php:84
PHP  10. Composer\Console\Application->getComposer() /Users/ladmin/projects/oss/composer/src/Composer/Command/BaseCommand.php:53
PHP  11. Composer\Factory::create() /Users/ladmin/projects/oss/composer/src/Composer/Console/Application.php:275
PHP  12. Composer\Factory->createComposer() /Users/ladmin/projects/oss/composer/src/Composer/Factory.php:540
PHP  13. Composer\EventDispatcher\EventDispatcher->dispatch() /Users/ladmin/projects/oss/composer/src/Composer/Factory.php:372
PHP  14. Composer\EventDispatcher\EventDispatcher->doDispatch() /Users/ladmin/projects/oss/composer/src/Composer/EventDispatcher/EventDispatcher.php:80
PHP  15. Composer\EventDispatcher\EventDispatcher->checkListenerExpectedEvent() /Users/ladmin/projects/oss/composer/src/Composer/EventDispatcher/EventDispatcher.php:169

Fatal error: Call to undefined method Composer\EventDispatcher\Event::getComposer() in /Users/ladmin/projects/oss/composer/src/Composer/EventDispatcher/EventDispatcher.php on line 294

Call Stack:
    0.0050     238968   1. {main}() /Users/ladmin/projects/oss/composer/bin/composer:0
    0.1388    4171264   2. Composer\Console\Application->run() /Users/ladmin/projects/oss/composer/bin/composer:44
    0.1516    4574472   3. Symfony\Component\Console\Application->run() /Users/ladmin/projects/oss/composer/src/Composer/Console/Application.php:99
    0.1555    4721144   4. Composer\Console\Application->doRun() /Users/ladmin/projects/oss/composer/vendor/symfony/console/Application.php:123
    0.1931    4931864   5. Symfony\Component\Console\Application->doRun() /Users/ladmin/projects/oss/composer/src/Composer/Console/Application.php:197
    0.1933    4932120   6. Symfony\Component\Console\Application->doRunCommand() /Users/ladmin/projects/oss/composer/vendor/symfony/console/Application.php:192
    0.1933    4932720   7. Symfony\Component\Console\Command\Command->run() /Users/ladmin/projects/oss/composer/vendor/symfony/console/Application.php:844
    0.1950    4938640   8. Composer\Command\InstallCommand->execute() /Users/ladmin/projects/oss/composer/vendor/symfony/console/Command/Command.php:259
    0.1950    4939904   9. Composer\Command\BaseCommand->getComposer() /Users/ladmin/projects/oss/composer/src/Composer/Command/InstallCommand.php:84
    0.1950    4940024  10. Composer\Console\Application->getComposer() /Users/ladmin/projects/oss/composer/src/Composer/Command/BaseCommand.php:53
    0.1950    4940312  11. Composer\Factory::create() /Users/ladmin/projects/oss/composer/src/Composer/Console/Application.php:275
    0.1950    4940440  12. Composer\Factory->createComposer() /Users/ladmin/projects/oss/composer/src/Composer/Factory.php:540
    0.7540   11705048  13. Composer\EventDispatcher\EventDispatcher->dispatch() /Users/ladmin/projects/oss/composer/src/Composer/Factory.php:372
    0.7540   11705096  14. Composer\EventDispatcher\EventDispatcher->doDispatch() /Users/ladmin/projects/oss/composer/src/Composer/EventDispatcher/EventDispatcher.php:80
    0.7545   11708368  15. Composer\EventDispatcher\EventDispatcher->checkListenerExpectedEvent() /Users/ladmin/projects/oss/composer/src/Composer/EventDispatcher/EventDispatcher.php:169
```

I am not sure if the fix is the correct one, however it makes sense to me. It is also useful for giving the plugins a chance to get the composer instance (which globally is at init stage not yet available).