### PR TITLE
Add plugin Compatible interface

### DIFF
--- a/src/Composer/Plugin/Compatible.php
+++ b/src/Composer/Plugin/Compatible.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Composer\Plugin;
 

--- a/src/Composer/Plugin/Compatible.php
+++ b/src/Composer/Plugin/Compatible.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Composer\Plugin;
+
+/**
+ * Implement this interface on your plugin class to specify minimum composer version required to work with.
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+interface Compatible
+{
+    /**
+     * @return string
+     */
+    public function getMinimumComposerVersion();
+}


### PR DESCRIPTION
The goal of this interface is to permit developers to specify
which minimum version of composer is compatible with the plugin.

Since composer has now stable version (Good job BTW!), I think this will be necessary.

The idea come from my own implementation on my plugin: https://github.com/Soullivaneuh/composer-versions-check/blob/4beadb69804f6d0fd7bdcd67b4b20bb8fa47296b/src/VersionsCheckPlugin.php#L54-L66

The best thing would be to add it directly on `PluginInterface` but this will be BC break.

@Seldaek I could work on it when you'll push a 2.x-dev branch on this repo.

See also: https://github.com/composer/composer/pull/5028#issuecomment-214698485

- [x] Compatible interface
- [ ] Add tests