### PR TITLE
Added HTTP support to GitLab driver

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -253,6 +253,13 @@
                         "type": "string"
                     }
                 },
+                "gitlab-unsecure-domains": {
+                    "type": "array",
+                    "description": "A list of domains used in gitlab mode that doesn't have support for HTTPS protocol. Defaults to [].",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "archive-format": {
                     "type": "string",
                     "description": "The default archiving format when not provided on cli, defaults to \"tar\"."

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -385,6 +385,18 @@ EOT
                     return $vals;
                 },
             ),
+            'gitlab-unsecure-domains' => array(
+                function ($vals) {
+                    if (!is_array($vals)) {
+                        return 'array expected';
+                    }
+
+                    return true;
+                },
+                function ($vals) {
+                    return $vals;
+                },
+            ),
         );
 
         foreach ($uniqueConfigValues as $name => $callbacks) {

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -54,6 +54,7 @@ class Config
         'capath' => null,
         'github-expose-hostname' => true,
         'gitlab-domains' => array('gitlab.com'),
+        'gitlab-unsecure-domains' => array(),
         'store-auths' => 'prompt',
         'platform' => array(),
         'archive-format' => 'tar',

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -81,6 +81,10 @@ class GitLabDriver extends VcsDriver
         $this->owner = $match['owner'];
         $this->repository = preg_replace('#(\.git)$#', '', $match['repo']);
 
+        if (in_array($this->originUrl, (array) $this->config->get('gitlab-unsecure-domains'))) {
+            $this->scheme = 'http';
+        }
+        
         $this->cache = new Cache($this->io, $this->config->get('cache-repo-dir').'/'.$this->originUrl.'/'.$this->owner.'/'.$this->repository);
 
         $this->fetchProject();
@@ -364,6 +368,10 @@ class GitLabDriver extends VcsDriver
 
         if (!in_array($originUrl, (array) $config->get('gitlab-domains'))) {
             return false;
+        }
+        
+        if (in_array($originUrl, (array) $config->get('gitlab-unsecure-domains'))) {
+            $scheme = 'http';
         }
 
         if ('https' === $scheme && !extension_loaded('openssl')) {


### PR DESCRIPTION
Added HTTP support to GitLab driver by introducing the `gitlab-unsecure-domains` config option. This option allows GitLab API to be accessed through HTTP for the specified domains.