### PR TITLE
Ignore it for unfound packages

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -275,7 +275,12 @@ EOT
                         if ($showVersion) {
                             $versionLength = max($versionLength, strlen($package->getFullPrettyVersion()));
                             if ($showLatest) {
+
                                 $latestPackage = $this->findLatestPackage($package, $composer, $phpVersion);
+                                if ($latestPackage === false) {
+                                    continue;
+                                }
+
                                 $latestPackages[$package->getPrettyName()] = $latestPackage;
                                 $latestLength =  max($latestLength, strlen($latestPackage->getFullPrettyVersion()));
                             }


### PR DESCRIPTION
In `outdated` command, when checking for the latest packages, it will fail in case it is unable to find the latest version.

In [Composer\Command\ShowCommand.php#L280](https://github.com/composer/composer/blob/master/src/Composer/Command/ShowCommand.php#L280), the method call `$latestPackage->getFullPrettyVersion()` will throw an exception as `$latestPackage` might be `false` when there is no "bestCandidate". See [VersionSelector.php#L64](https://github.com/composer/composer/blob/master/src/Composer/Package/Version/VersionSelector.php#L64).

![Failing composer outdated](http://i.imgur.com/mY9vehx.png)