### PR TITLE
Bitbucket https fallback to ssh

### DIFF
--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -112,7 +112,7 @@ class Git
                         return;
                     }
                 }
-            } elseif (preg_match('{^https://(bitbucket.org)/(.*)}', $url, $match)) { //bitbucket oauth
+            } elseif (preg_match('{^https://(bitbucket\.org)/(.*)(\.git)?$}U', $url, $match)) { //bitbucket oauth
                 $bitbucketUtil = new Bitbucket($this->io, $this->config, $this->process);
 
                 if (!$this->io->hasAuthentication($match[1])) {

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -141,6 +141,13 @@ class Git
                     if (0 === $this->process->execute($command, $ignoredOutput, $cwd)) {
                         return;
                     }
+                } else { // Falling back to ssh
+                    $sshUrl = 'git@bitbucket.org:' . $match[2] . '.git';
+                    $this->io->writeError('    No bitbucket authentication configured. Falling back to ssh.');
+                    $command = call_user_func($commandCallable, $sshUrl);
+                    if (0 === $this->process->execute($command, $ignoredOutput, $cwd)) {
+                        return;
+                    }
                 }
             } elseif ($this->isAuthenticationFailure($url, $match)) { // private non-github repo that failed to authenticate
                 if (strpos($match[2], '@')) {


### PR DESCRIPTION
This change provides a fallback to SSH when using https URLs for bitbucket.org.

A typical situations where this is needed include having a non-interactive install of dependencies in a location where oauth authentication (if it actually works) is not configured.

This also includes a fix for the problem with double .git extension metioned in #5160.