### PR TITLE
Allow commands to tell that they're proxy commands

### DIFF
--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -80,6 +80,18 @@ abstract class BaseCommand extends Command
     }
 
     /**
+     * Whether or not this command is meant to call another command.
+     *
+     * This is mainly needed to avoid duplicated warnings messages.
+     *
+     * @return bool
+     */
+    public function isProxyCommand()
+    {
+        return false;
+    }
+
+    /**
      * @return IOInterface
      */
     public function getIO()

--- a/src/Composer/Command/GlobalCommand.php
+++ b/src/Composer/Command/GlobalCommand.php
@@ -80,4 +80,12 @@ EOT
 
         return $this->getApplication()->run($input, $output);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isProxyCommand()
+    {
+        return true;
+    }
 }

--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -71,4 +71,12 @@ EOT
 
         return $this->getApplication()->run($input, $output);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isProxyCommand()
+    {
+        return true;
+    }
 }

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -55,6 +55,8 @@ class Application extends BaseApplication
                     /_/
 ';
 
+    private $hasPluginCommands = false;
+
     public function __construct()
     {
         static $shutdownRegistered = false;
@@ -107,16 +109,28 @@ class Application extends BaseApplication
         $io = $this->io = new ConsoleIO($input, $output, $this->getHelperSet());
         ErrorHandler::register($io);
 
-        // determine command name to be executed
+        if (!$input->hasParameterOption('--no-plugins') && !$this->hasPluginCommands) {
+            foreach ($this->getPluginCommands() as $command) {
+                if ($this->has($command->getName())) {
+                    $io->writeError('<warning>Plugin command '.$command->getName().' ('.get_class($command).') would override a Composer command and has been skipped</warning>');
+                } else {
+                    $this->add($command);
+                }
+            }
+            $this->hasPluginCommands = true;
+        }
+
+        // determine command name to be executed, and if it's a proxy command
         $commandName = '';
+        $isProxyCommand = false;
         if ($name = $this->getCommandName($input)) {
             try {
-                $commandName = $this->find($name)->getName();
+                $command = $this->find($name);
+                $commandName = $command->getName();
+                $isProxyCommand = ($command instanceof Command\BaseCommand && $command->isProxyCommand());
             } catch (\InvalidArgumentException $e) {
             }
         }
-
-        $isProxyCommand = $commandName === 'global' || $commandName === 'outdated';
 
         if (!$isProxyCommand) {
             $io->writeError(sprintf(
@@ -194,16 +208,6 @@ class Application extends BaseApplication
             if ($input->hasParameterOption('--profile')) {
                 $startTime = microtime(true);
                 $this->io->enableDebugging($startTime);
-            }
-
-            if (!$input->hasParameterOption('--no-plugins') && !$isProxyCommand) {
-                foreach ($this->getPluginCommands() as $command) {
-                    if ($this->has($command->getName())) {
-                        $io->writeError('<warning>Plugin command '.$command->getName().' ('.get_class($command).') would override a Composer command and has been skipped</warning>');
-                    } else {
-                        $this->add($command);
-                    }
-                }
             }
 
             $result = parent::doRun($input, $output);


### PR DESCRIPTION
This is mainly useful for plugin commands, otherwise there might be warnings all over the place :D 

<img width="956" alt="screen shot 2016-05-02 at 12 21 14" src="https://cloud.githubusercontent.com/assets/1205386/14952407/6d1c39ee-1060-11e6-9150-26ea69ca1a36.png">
