### PR TITLE
Drop test dependency on http://www.example.com

### DIFF
--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -136,14 +136,14 @@ class RemoteFilesystemTest extends \PHPUnit_Framework_TestCase
         $io = $this->getMock('Composer\IO\IOInterface');
         $io->expects($this->once())
             ->method('setAuthentication')
-            ->with($this->equalTo('example.com'), $this->equalTo('user'), $this->equalTo('pass'));
+            ->with($this->equalTo('github.com'), $this->equalTo('user'), $this->equalTo('pass'));
 
         $fs = new RemoteFilesystem($io);
         try {
-            $fs->getContents('example.com', 'http://user:pass@www.example.com/something');
+            $fs->getContents('github.com', 'https://user:pass@github.com/composer/composer/404');
         } catch (\Exception $e) {
             $this->assertInstanceOf('Composer\Downloader\TransportException', $e);
-            $this->assertEquals(404, $e->getCode());
+            $this->assertNotEquals(200, $e->getCode());
         }
     }
 


### PR DESCRIPTION
Now, test fails because http://www.example.com.
https://travis-ci.org/composer/composer/builds/128466456

```
$ curl -v 'http://user:pass@www.example.com/something'
*   Trying 93.184.216.34...
* Connected to www.example.com (93.184.216.34) port 80 (#0)
* Server auth using Basic with user 'user'
> GET /something HTTP/1.1
> Host: www.example.com
> Authorization: Basic dXNlcjpwYXNz
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 500 Internal Server Error
< X-Error: too many internal redirects
< Content-Type: text/html
< Content-Length: 369
< Date: Sat, 07 May 2016 07:25:33 GMT
< Server: ECSF (cpm/F9F7)
< 
<?xml version="1.0" encoding="iso-8859-1"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
        <head>
                <title>500 - Internal Server Error</title>
        </head>
        <body>
                <h1>500 - Internal Server Error</h1>
        </body>
</html>
* Connection #0 to host www.example.com left intact
```
