### PR TITLE
[Archive] exclude option in composer.json accepts files

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -325,7 +325,7 @@
             "description": "Options for creating package archives for distribution.",
             "properties": {
                 "exclude": {
-                    "type": "array",
+                    "type": ["array", "string"],
                     "description": "A list of patterns for paths to exclude or include if prefixed with an exclamation mark."
                 }
             }

--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -38,7 +38,7 @@ class ArchivableFilesFinder extends \FilterIterator
      * @param string $sources  Path to source files to be archived
      * @param array  $excludes Composer's own exclude rules from composer.json
      */
-    public function __construct($sources, array $excludes)
+    public function __construct($sources, $excludes)
     {
         $fs = new Filesystem();
 

--- a/src/Composer/Package/Archiver/ArchiverInterface.php
+++ b/src/Composer/Package/Archiver/ArchiverInterface.php
@@ -22,14 +22,14 @@ interface ArchiverInterface
     /**
      * Create an archive from the sources.
      *
-     * @param string $sources  The sources directory
-     * @param string $target   The target file
-     * @param string $format   The format used for archive
-     * @param array  $excludes A list of patterns for files to exclude
+     * @param string       $sources  The sources directory
+     * @param string       $target   The target file
+     * @param string       $format   The format used for archive
+     * @param array|string $excludes A list of patterns for files to exclude
      *
      * @return string The path to the written archive file
      */
-    public function archive($sources, $target, $format, array $excludes = array());
+    public function archive($sources, $target, $format, $excludes = array());
 
     /**
      * Format supported by the archiver.

--- a/src/Composer/Package/Archiver/ComposerExcludeFilter.php
+++ b/src/Composer/Package/Archiver/ComposerExcludeFilter.php
@@ -20,12 +20,47 @@ namespace Composer\Package\Archiver;
 class ComposerExcludeFilter extends BaseExcludeFilter
 {
     /**
-     * @param string $sourcePath   Directory containing sources to be filtered
-     * @param array  $excludeRules An array of exclude rules from composer.json
+     * @param string       $sourcePath   Directory containing sources to be filtered
+     * @param array|string $excludeRules An array of exclude rules from composer.json
      */
-    public function __construct($sourcePath, array $excludeRules)
+    public function __construct($sourcePath, $excludeRules = array())
     {
         parent::__construct($sourcePath);
-        $this->excludePatterns = $this->generatePatterns($excludeRules);
+
+        if ($excludeRules) {
+            $this->parseExcludes($excludeRules);
+        }
+    }
+
+    /**
+     * parses the exclude rules from the composer.json itself (either array or file path)
+     *
+     * @param $excludeRules
+     *
+     * @throws \InvalidArgumentException if the archive.exclude contains something unparsable
+     */
+    private function parseExcludes($excludeRules)
+    {
+        if (is_string($excludeRules) && is_readable($excludeRules) && is_file($excludeRules)) {
+            $this->excludePatterns = $this->parseLines(
+                file($excludeRules),
+                array($this, 'parseIgnoreFileLine')
+            );
+        } elseif (is_array($excludeRules)) {
+            $this->excludePatterns = $this->generatePatterns($excludeRules);
+        } else {
+            throw new \InvalidArgumentException('"archive.exclude" is invalid, either provide an array of excludes or a readable file path ');
+        }
+    }
+
+    /**
+     * Callback line parser which process ignore file lines
+     *
+     * @param string $line
+     * @return array
+     */
+    public function parseIgnoreFileLine($line)
+    {
+        return $this->generatePattern($line);
     }
 }

--- a/src/Composer/Package/Archiver/PharArchiver.php
+++ b/src/Composer/Package/Archiver/PharArchiver.php
@@ -34,7 +34,7 @@ class PharArchiver implements ArchiverInterface
     /**
      * {@inheritdoc}
      */
-    public function archive($sources, $target, $format, array $excludes = array())
+    public function archive($sources, $target, $format, $excludes = array())
     {
         $sources = realpath($sources);
 

--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -27,7 +27,7 @@ class ZipArchiver implements ArchiverInterface
     /**
      * {@inheritdoc}
      */
-    public function archive($sources, $target, $format, array $excludes = array())
+    public function archive($sources, $target, $format, $excludes = array())
     {
         $fs = new Filesystem();
         $sources = $fs->normalizePath($sources);

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -57,7 +57,7 @@ class Package extends BasePackage
     protected $autoload = array();
     protected $devAutoload = array();
     protected $includePaths = array();
-    protected $archiveExcludes = array();
+    protected $archiveExcludes;
 
     /**
      * Creates a new in memory package.
@@ -554,9 +554,9 @@ class Package extends BasePackage
     /**
      * Sets a list of patterns to be excluded from archives
      *
-     * @param array $excludes
+     * @param array|string $excludes
      */
-    public function setArchiveExcludes(array $excludes)
+    public function setArchiveExcludes($excludes)
     {
         $this->archiveExcludes = $excludes;
     }

--- a/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
@@ -92,6 +92,61 @@ class ArchivableFilesFinderTest extends TestCase
         $fs->removeDirectory($this->sources);
     }
 
+    public function testFileExcludes()
+    {
+        file_put_contents($this->sources.'/.dockerignore', implode("\n", array(
+            'prefixB.foo',
+            '!/prefixB.foo',
+            '/prefixA.foo',
+            'prefixC.*',
+            '!*/*/*/prefixC.foo',
+            '.dockerignore'
+        )));
+
+        $excludes = $this->sources.'/.dockerignore';
+
+        $this->finder = new ArchivableFilesFinder($this->sources, $excludes);
+
+        $this->assertArchivableFiles(array(
+            '/!important!.txt',
+            '/!important_too!.txt',
+            '/#weirdfile',
+            '/A/prefixA.foo',
+            '/A/prefixD.foo',
+            '/A/prefixE.foo',
+            '/A/prefixF.foo',
+            '/B/sub/prefixA.foo',
+            '/B/sub/prefixC.foo',
+            '/B/sub/prefixD.foo',
+            '/B/sub/prefixE.foo',
+            '/B/sub/prefixF.foo',
+            '/C/prefixA.foo',
+            '/C/prefixD.foo',
+            '/C/prefixE.foo',
+            '/C/prefixF.foo',
+            '/D/prefixA',
+            '/D/prefixB',
+            '/D/prefixC',
+            '/D/prefixD',
+            '/D/prefixE',
+            '/D/prefixF',
+            '/E/subtestA.foo',
+            '/F/subtestA.foo',
+            '/G/subtestA.foo',
+            '/H/subtestA.foo',
+            '/I/J/subtestA.foo',
+            '/K/dirJ/subtestA.foo',
+            '/parameters.yml',
+            '/parameters.yml.dist',
+            '/prefixB.foo',
+            '/prefixD.foo',
+            '/prefixE.foo',
+            '/prefixF.foo',
+            '/toplevelA.foo',
+            '/toplevelB.foo',
+        ));
+    }
+
     public function testManualExcludes()
     {
         $excludes = array(


### PR DESCRIPTION
with this PR the "archive.exclude" accepts files to (beside the legacy? array)

```json
{
    "archive" :  {
        "exclude" : ".myignore"
    }
}
```
```
# file .myignore
/test
/build
```

that would exclude `test` and `build` from the archive.

i needed the feature for creating Docker Contexts from Composer Archives:

* my Application in Git itself should contain `doc` and `tests` (so `.gitignore` wont help)
* `.gitattributes` is unhandy here, since it would exclude those folders in normal artifacts too
* `.dockerignore` wont help because i build the context/archive in a `build` folder, but this folder is in `.gitignore`
* providing an ignore pattern list in a json array felt ugly to me, and if you ask me, i would deprecate that feature completely and maybe create an own `.composerignore` file, that would clean up a lot code since we can handle it like a normal `.gitignore` file