### PR TITLE
Update bitbucket oauth instructions

### DIFF
--- a/src/Composer/Util/Bitbucket.php
+++ b/src/Composer/Util/Bitbucket.php
@@ -122,6 +122,7 @@ class Bitbucket
         $url = 'https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html';
         $this->io->writeError(sprintf('Follow the instructions on %s', $url));
         $this->io->writeError(sprintf('to create a consumer. It will be stored in "%s" for future use by Composer.', $this->config->getAuthConfigSource()->getName()));
+        $this->io->writeError('Ensure you enter a "Callback URL" or it will not be possible to create an Access Token (this callback url will not be used by composer)');
 
         $consumerKey = trim($this->io->askAndHideAnswer('Consumer Key (hidden): '));
 


### PR DESCRIPTION
I had similar issues described in #5166 and after investigation, I found out that Bitbucket needs you to set **Callback URL** in the **OAuth consumer** configuration to be able to generate access tokens.

If you leave this field blank the api `https://bitbucket.org/site/oauth2/access_token` will give the following error:

```
{
  "error_description": "No callback uri defined for the OAuth client.",
  "error": "invalid_request"
}
```

The grant type `client_credentials` will not actually use this callback URL, but it seems Bitbucket is enforcing that it is configured anyway.

This PR updates the log messages to inform the user that the `Callback URL` needs to be set to something. *Ensure you enter a "Callback URL" or it will not be possible to create an Access Token (this callback url will not be used by composer)*