### PR TITLE
Fix for a fatal error when system temp dir is not available

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -189,7 +189,7 @@ class Application extends BaseApplication
             }
 
             // Check system temp folder for usability as it can cause weird runtime issues otherwise
-            Silencer::call(function() {
+            Silencer::call(function () use ($io) {
                 $tempfile = sys_get_temp_dir() . '/temp-' . md5(microtime());
                 if (!(file_put_contents($tempfile, __FILE__) && (file_get_contents($tempfile) == __FILE__) && unlink($tempfile) && !file_exists($tempfile))) {
                     $io->writeError(sprintf('<error>PHP temp directory (%s) does not exist or is not writable to Composer. Set sys_temp_dir in your php.ini</error>', sys_get_temp_dir()));

--- a/tests/Composer/Test/ApplicationTest.php
+++ b/tests/Composer/Test/ApplicationTest.php
@@ -113,6 +113,9 @@ class ApplicationTest extends TestCase
         $this->ensureNoDevWarning('self-up');
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testNoFatalErrorOnInvalidSysTempDir()
     {
         $inputMock = $this->getMock('\Symfony\Component\Console\Input\InputInterface');

--- a/tests/Composer/Test/ApplicationTest.php
+++ b/tests/Composer/Test/ApplicationTest.php
@@ -112,4 +112,49 @@ class ApplicationTest extends TestCase
     {
         $this->ensureNoDevWarning('self-up');
     }
+
+    public function testNoFatalErrorOnInvalidSysTempDir()
+    {
+        $inputMock = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
+        $inputMock->expects($this->at(0))
+            ->method('getParameterOption')
+            ->with($this->equalTo(array('--working-dir', '-d')))
+            ->willReturn(false)
+        ;
+
+        $outputMock = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+        $outputMock->expects($this->any())
+            ->method('getVerbosity')
+            ->willReturn(OutputInterface::VERBOSITY_NORMAL)
+        ;
+
+        $errorMessage = null;
+
+        $outputMock->expects($this->atLeastOnce())
+            ->method('write')
+            ->willReturnCallback(function ($message) use (&$errorMessage) {
+                if (substr($message, 0, strlen('<error>')) !== '<error>') {
+                    return;
+                }
+
+                $errorMessage = $message;
+            })
+        ;
+
+        eval(<<<CODE
+namespace Composer\Console {
+    function sys_get_temp_dir()
+    {
+        return '/composer-tmp-dir';
+    }
+}
+CODE
+
+        );
+
+        $application = new Application;
+        $application->doRun($inputMock, $outputMock);
+
+        $this->assertEquals('<error>PHP temp directory (/composer-tmp-dir) does not exist or is not writable to Composer. Set sys_temp_dir in your php.ini</error>', $errorMessage);
+    }
 }


### PR DESCRIPTION
 
When the temp dir is not available / writable, a fatal error occurs because a variable is not available in the function scope.

This is a simple fix accompanied by a unit test.

However, I'm not very comfortable with using `eval` for injecting `sys_get_temp_dir` function into the namespace. Comments on improving the test are welcome.