### PR TITLE
Fix: Do not suggest to avoid exact version constraints for unstable package

### DIFF
--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -151,6 +151,7 @@ class ValidatingArrayLoader implements LoaderInterface
         }
 
         $unboundConstraint = new Constraint('=', $this->versionParser->normalize('dev-master'));
+        $stableConstraint = new Constraint('=', '1.0.0');
 
         foreach (array_keys(BasePackage::$supportedLinkTypes) as $linkType) {
             if ($this->validateArray($linkType) && isset($this->config[$linkType])) {
@@ -183,6 +184,7 @@ class ValidatingArrayLoader implements LoaderInterface
                             ($this->flags & self::CHECK_STRICT_CONSTRAINTS)
                             && 'require' === $linkType
                             && substr($linkConstraint, 0, 1) === '='
+                            && $stableConstraint->versionCompare($stableConstraint, $linkConstraint, '<=')
                         ) {
                             $this->warnings[] = $linkType.'.'.$package.' : exact version constraints ('.$constraint.') should be avoided if the package follows semantic versioning';
                         }

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -329,6 +329,18 @@ class ValidatingArrayLoaderTest extends \PHPUnit_Framework_TestCase
             array(
                 array(
                     'name' => 'foo/bar',
+                    'require' => array(
+                        'bar/unstable' => '0.3.0',
+                    ),
+                ),
+                array(
+                    // using an exact version constraint for an unstable version should not trigger a warning
+                ),
+                false,
+            ),
+            array(
+                array(
+                    'name' => 'foo/bar',
                     'extra' => array(
                         'branch-alias' => array(
                             '5.x-dev' => '3.1.x-dev',


### PR DESCRIPTION
This PR

* [x] asserts that no warning is issued when using an exact version constraint for an unstable package
* [x] issues a warning only when the version for which an exact constraint is used isn't stable

Fixes https://github.com/composer/composer/issues/5339.