### PR TITLE
Strip out declare strict_types from plugins

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -190,6 +190,7 @@ class PluginManager
                 $code = str_replace('__FILE__', var_export($path, true), $code);
                 $code = str_replace('__DIR__', var_export(dirname($path), true), $code);
                 $code = str_replace('__CLASS__', var_export($class, true), $code);
+                $code = preg_replace('/^(\s*<\?(?:php)?\s+)declare\s*\(\s*strict_types\s*=\s*\d+\s*\)\s*;/', '$1', $code);
                 eval('?>'.$code);
                 $class .= '_composer_tmp'.self::$classCounter;
                 self::$classCounter++;

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -190,8 +190,8 @@ class PluginManager
                 $code = str_replace('__FILE__', var_export($path, true), $code);
                 $code = str_replace('__DIR__', var_export(dirname($path), true), $code);
                 $code = str_replace('__CLASS__', var_export($class, true), $code);
-                $code = preg_replace('/^(\s*<\?(?:php)?\s+)declare\s*\(\s*strict_types\s*=\s*\d+\s*\)\s*;/', '$1', $code);
-                eval('?>'.$code);
+                $code = preg_replace('/^\s*<\?(php)?/i', '', $code, 1);
+                eval($code);
                 $class .= '_composer_tmp'.self::$classCounter;
                 self::$classCounter++;
             }

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v9/Installer/Plugin.php
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v9/Installer/Plugin.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Installer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+class Plugin implements PluginInterface
+{
+    public $version = 'installer-v9';
+
+    public function activate(Composer $composer, IOInterface $io)
+    {
+    }
+}

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v9/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v9/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "plugin-v9",
+    "version": "9.0.0",
+    "type": "composer-plugin",
+    "autoload": { "psr-0": { "Installer": "" } },
+    "extra": {
+        "class": "Installer\\Plugin"
+    },
+    "require": {
+        "composer-plugin-api": "^1.0"
+    }
+}


### PR DESCRIPTION
If a plugin file starts with `declare(strict_types=1);`, Composer fails with this error:

```
Fatal error: strict_types declaration must be the very first statement in the script
in src/Composer/Plugin/PluginManager.php(194) : eval()'d code on line 3
```

So, let's strip out the strict types declaration before evaluating the file contents.