### PR TITLE
Added type option to search

### DIFF
--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -41,6 +41,7 @@ class SearchCommand extends BaseCommand
             ->setDescription('Search for packages')
             ->setDefinition(array(
                 new InputOption('only-name', 'N', InputOption::VALUE_NONE, 'Search only in name'),
+                new InputOption('type', 't', InputOption::VALUE_REQUIRED, 'Search for a specific package type'),
                 new InputArgument('tokens', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'tokens to search for'),
             ))
             ->setHelp(<<<EOT
@@ -68,9 +69,10 @@ EOT
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
 
         $onlyName = $input->getOption('only-name');
+        $type = $input->getOption('type') ?: null;
 
         $flags = $onlyName ? RepositoryInterface::SEARCH_NAME : RepositoryInterface::SEARCH_FULLTEXT;
-        $results = $repos->search(implode(' ', $input->getArgument('tokens')), $flags);
+        $results = $repos->search(implode(' ', $input->getArgument('tokens')), $flags, $type);
 
         foreach ($results as $result) {
             $io->write($result['name'] . (isset($result['description']) ? ' '. $result['description'] : ''));

--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -89,7 +89,7 @@ class ArrayRepository extends BaseRepository
     /**
      * {@inheritDoc}
      */
-    public function search($query, $mode = 0)
+    public function search($query, $mode = 0, $type = null)
     {
         $regex = '{(?:'.implode('|', preg_split('{\s+}', $query)).')}i';
 
@@ -102,9 +102,13 @@ class ArrayRepository extends BaseRepository
             if (preg_match($regex, $name)
                 || ($mode === self::SEARCH_FULLTEXT && $package instanceof CompletePackageInterface && preg_match($regex, implode(' ', (array) $package->getKeywords()) . ' ' . $package->getDescription()))
             ) {
+                if (null !== $type && $package->getType() !== $type) {
+                    continue;
+                }
+
                 $matches[$name] = array(
                     'name' => $package->getPrettyName(),
-                    'description' => $package->getDescription(),
+                    'description' => $package instanceof CompletePackageInterface ? $package->getDescription() : null,
                 );
             }
         }

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -190,12 +190,12 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     /**
      * {@inheritDoc}
      */
-    public function search($query, $mode = 0)
+    public function search($query, $mode = 0, $type = null)
     {
         $this->loadRootServerFile();
 
         if ($this->searchUrl && $mode === self::SEARCH_FULLTEXT) {
-            $url = str_replace('%query%', $query, $this->searchUrl);
+            $url = str_replace(array('%query%', '%type%'), array($query, $type), $this->searchUrl);
 
             $hostname = parse_url($url, PHP_URL_HOST) ?: $url;
             $json = $this->rfs->getContents($hostname, $url, false);
@@ -642,6 +642,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
                 $hostname = parse_url($filename, PHP_URL_HOST) ?: $filename;
                 $rfs = $preFileDownloadEvent->getRemoteFilesystem();
+
                 $json = $rfs->getContents($hostname, $filename, false);
                 if ($sha256 && $sha256 !== hash('sha256', $json)) {
                     if ($retries) {

--- a/src/Composer/Repository/CompositeRepository.php
+++ b/src/Composer/Repository/CompositeRepository.php
@@ -97,12 +97,12 @@ class CompositeRepository extends BaseRepository
     /**
      * {@inheritdoc}
      */
-    public function search($query, $mode = 0)
+    public function search($query, $mode = 0, $type = null)
     {
         $matches = array();
         foreach ($this->repositories as $repository) {
             /* @var $repository RepositoryInterface */
-            $matches[] = $repository->search($query, $mode);
+            $matches[] = $repository->search($query, $mode, $type);
         }
 
         return $matches ? call_user_func_array('array_merge', $matches) : array();

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -65,9 +65,11 @@ interface RepositoryInterface extends \Countable
     /**
      * Searches the repository for packages containing the query
      *
-     * @param  string  $query search query
-     * @param  int     $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only
-     * @return array[] an array of array('name' => '...', 'description' => '...')
+     * @param  string $query search query
+     * @param  int    $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only
+     * @param  string $type  The type of package to search for. Defaults to all types of packages
+     *
+     * @return \array[] an array of array('name' => '...', 'description' => '...')
      */
-    public function search($query, $mode = 0);
+    public function search($query, $mode = 0, $type = null);
 }

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -13,6 +13,8 @@
 namespace Composer\Test\Repository;
 
 use Composer\IO\NullIO;
+use Composer\Repository\ComposerRepository;
+use Composer\Repository\RepositoryInterface;
 use Composer\Test\Mock\FactoryMock;
 use Composer\TestCase;
 use Composer\Package\Loader\ArrayLoader;
@@ -164,5 +166,46 @@ class ComposerRepositoryTest extends TestCase
         $this->assertInstanceOf('Composer\Package\AliasPackage', $packages['2-root']);
         $this->assertSame($packages['2'], $packages['2-root']->getAliasOf());
         $this->assertSame($packages['2'], $packages['2-alias']->getAliasOf());
+    }
+
+    public function testSearchWithType()
+    {
+        $repoConfig = array(
+            'url' => 'http://example.org',
+        );
+
+        $result = array(
+            'results' => array(
+                array(
+                    'name' => 'foo',
+                    'description' => null
+                )
+            )
+        );
+
+        $rfs = $this->getMockBuilder('Composer\Util\RemoteFilesystem')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $rfs->expects($this->at(0))
+            ->method('getContents')
+            ->with('example.org', 'http://example.org/packages.json', false)
+            ->willReturn(json_encode(array('search' => '/search.json?q=%query%&type=%type%')));
+
+        $rfs->expects($this->at(1))
+            ->method('getContents')
+            ->with('example.org', 'http://example.org/search.json?q=foo&type=composer-plugin', false)
+            ->willReturn(json_encode($result));
+
+        $repository = new ComposerRepository($repoConfig, new NullIO, FactoryMock::createConfig(), null, $rfs);
+
+        $this->assertSame(
+            array(array('name' => 'foo', 'description' => null)),
+            $repository->search('foo', RepositoryInterface::SEARCH_FULLTEXT, 'composer-plugin')
+        );
+
+        $this->assertEmpty(
+            $repository->search('foo', RepositoryInterface::SEARCH_FULLTEXT, 'library')
+        );
     }
 }


### PR DESCRIPTION
Fixes #4317

Add a `--type` parameter to the `search` function, in order to search for specific package types.

E.G
```bash
$ composer search foo --type=composer-plugin
```

Depends on composer/packagist#692