### PR TITLE
Remove type parameter from RepositoryInterface

### DIFF
--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -67,9 +67,8 @@ interface RepositoryInterface extends \Countable
      *
      * @param  string $query search query
      * @param  int    $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only
-     * @param  string $type  The type of package to search for. Defaults to all types of packages
      *
      * @return \array[] an array of array('name' => '...', 'description' => '...')
      */
-    public function search($query, $mode = 0, $type = null);
+    public function search($query, $mode = 0);
 }


### PR DESCRIPTION
Fixes #5458

Remove the `$type` parameter from `RepositoryInterface` to alleviate the BC break for plugins.