### PR TITLE
error in string comparison

### DIFF
--- a/doc/faqs/how-to-install-composer-programmatically.md
+++ b/doc/faqs/how-to-install-composer-programmatically.md
@@ -13,7 +13,7 @@ EXPECTED_SIGNATURE=$(wget https://composer.github.io/installer.sig -O - -q)
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
 
-if [ "$EXPECTED_SIGNATURE" == "$ACTUAL_SIGNATURE" ]
+if [ "$EXPECTED_SIGNATURE" = "$ACTUAL_SIGNATURE" ]
 then
     php composer-setup.php --quiet
     RESULT=$?


### PR DESCRIPTION
The double equal (==) with single quote condition for string comparison gives a unexpected operator error.