### PR TITLE
Change the casting type of the argument of "memory limit".

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -16,7 +16,7 @@ if (function_exists('ini_set')) {
 
     $memoryInBytes = function ($value) {
         $unit = strtolower(substr($value, -1, 1));
-        $value = (int) $value;
+        $value = (float) $value;
         switch($unit) {
             case 'g':
                 $value *= 1024;


### PR DESCRIPTION
This change enables to increase "memory_limit" by "float" value.
Composer currently get the "memory_limit" in php.ini as a type of "integer".