### PR TITLE
Support gitlab private-token for easier access via Gitlab API

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -67,6 +67,12 @@ A list of domain names and oauth keys. For example using `{"gitlab.com":
 "oauthtoken"}` as the value of this option will use `oauthtoken` to access
 private repositories on gitlab.
 
+## gitlab-token
+
+A list of domain names and private tokens. For example using `{"gitlab.com":
+"privatetoken"}` as the value of this option will use `privatetoken` to access
+private repositories on gitlab.
+
 ## disable-tls
 
 Defaults to `false`. If set to true all HTTPS URLs will be tried with HTTP

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -141,6 +141,11 @@
                     "description": "A hash of domain name => gitlab API oauth tokens, typically {\"gitlab.com\":\"<token>\"}.",
                     "additionalProperties": true
                 },
+                "gitlab-token": {
+                    "type": "object",
+                    "description": "A hash of domain name => gitlab private tokens, typically {\"gitlab.com\":\"<token>\"}.",
+                    "additionalProperties": true
+                },
                 "disable-tls": {
                     "type": "boolean",
                     "description": "Defaults to `false`. If set to true all HTTPS URLs will be tried with HTTP instead and no network level encryption is performed. Enabling this is a security risk and is NOT recommended. The better way is to enable the php_openssl extension in php.ini."

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -171,7 +171,7 @@ EOT
         }
         if ($input->getOption('global') && !$this->authConfigFile->exists()) {
             touch($this->authConfigFile->getPath());
-            $this->authConfigFile->write(array('bitbucket-oauth' => new \ArrayObject, 'github-oauth' => new \ArrayObject, 'gitlab-oauth' => new \ArrayObject, 'http-basic' => new \ArrayObject));
+            $this->authConfigFile->write(array('bitbucket-oauth' => new \ArrayObject, 'github-oauth' => new \ArrayObject, 'gitlab-oauth' => new \ArrayObject, 'gitlab-token' => new \ArrayObject, 'http-basic' => new \ArrayObject));
             Silencer::call('chmod', $this->authConfigFile->getPath(), 0600);
         }
 
@@ -510,7 +510,7 @@ EOT
         }
 
         // handle auth
-        if (preg_match('/^(bitbucket-oauth|github-oauth|gitlab-oauth|http-basic)\.(.+)/', $settingKey, $matches)) {
+        if (preg_match('/^(bitbucket-oauth|github-oauth|gitlab-oauth|gitlab-token|http-basic)\.(.+)/', $settingKey, $matches)) {
             if ($input->getOption('unset')) {
                 $this->authConfigSource->removeConfigSetting($matches[1].'.'.$matches[2]);
                 $this->configSource->removeConfigSetting($matches[1].'.'.$matches[2]);
@@ -524,7 +524,7 @@ EOT
                 }
                 $this->configSource->removeConfigSetting($matches[1].'.'.$matches[2]);
                 $this->authConfigSource->addConfigSetting($matches[1].'.'.$matches[2], array('consumer-key' => $values[0], 'consumer-secret' => $values[1]));
-            } elseif ($matches[1] === 'github-oauth' || $matches[1] === 'gitlab-oauth') {
+            } elseif (in_array($matches[1], array('github-oauth', 'gitlab-oauth', 'gitlab-token'), true)) {
                 if (1 !== count($values)) {
                     throw new \RuntimeException('Too many arguments, expected only one token');
                 }

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -63,6 +63,7 @@ class Config
         // bitbucket-oauth
         // github-oauth
         // gitlab-oauth
+        // gitlab-token
         // http-basic
     );
 
@@ -125,7 +126,7 @@ class Config
         // override defaults with given config
         if (!empty($config['config']) && is_array($config['config'])) {
             foreach ($config['config'] as $key => $val) {
-                if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'http-basic')) && isset($this->config[$key])) {
+                if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic')) && isset($this->config[$key])) {
                     $this->config[$key] = array_merge($this->config[$key], $val);
                 } elseif ('preferred-install' === $key && isset($this->config[$key])) {
                     if (is_array($val) || is_array($this->config[$key])) {

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -81,7 +81,7 @@ class JsonConfigSource implements ConfigSourceInterface
     {
         $authConfig = $this->authConfig;
         $this->manipulateJson('addConfigSetting', $name, $value, function (&$config, $key, $val) use ($authConfig) {
-            if (preg_match('{^(bitbucket-oauth|github-oauth|gitlab-oauth|http-basic|platform)\.}', $key)) {
+            if (preg_match('{^(bitbucket-oauth|github-oauth|gitlab-oauth|gitlab-token|http-basic|platform)\.}', $key)) {
                 list($key, $host) = explode('.', $key, 2);
                 if ($authConfig) {
                     $config[$key][$host] = $val;
@@ -101,7 +101,7 @@ class JsonConfigSource implements ConfigSourceInterface
     {
         $authConfig = $this->authConfig;
         $this->manipulateJson('removeConfigSetting', $name, function (&$config, $key) use ($authConfig) {
-            if (preg_match('{^(bitbucket-oauth|github-oauth|gitlab-oauth|http-basic|platform)\.}', $key)) {
+            if (preg_match('{^(bitbucket-oauth|github-oauth|gitlab-oauth|gitlab-token|http-basic|platform)\.}', $key)) {
                 list($key, $host) = explode('.', $key, 2);
                 if ($authConfig) {
                     unset($config[$key][$host]);

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -90,6 +90,7 @@ abstract class BaseIO implements IOInterface, LoggerInterface
         $bitbucketOauth = $config->get('bitbucket-oauth') ?: array();
         $githubOauth = $config->get('github-oauth') ?: array();
         $gitlabOauth = $config->get('gitlab-oauth') ?: array();
+        $gitlabToken = $config->get('gitlab-token') ?: array();
         $httpBasic = $config->get('http-basic') ?: array();
 
         // reload oauth tokens from config if available
@@ -107,6 +108,10 @@ abstract class BaseIO implements IOInterface, LoggerInterface
 
         foreach ($gitlabOauth as $domain => $token) {
             $this->checkAndSetAuthentication($domain, $token, 'oauth2');
+        }
+
+        foreach ($gitlabToken as $domain => $token) {
+            $this->checkAndSetAuthentication($domain, $token, 'private-token');
         }
 
         // reload http basic credentials from config if available

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -64,6 +64,15 @@ class GitLab
             return true;
         }
 
+        // if available use token from composer config
+        $authTokens = $this->config->get('gitlab-token');
+
+        if (isset($authTokens[$originUrl])) {
+            $this->io->setAuthentication($originUrl, $authTokens[$originUrl], 'private-token');
+
+            return true;
+        }
+
         return false;
     }
 

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -714,6 +714,9 @@ class RemoteFilesystem
                 if ($auth['password'] === 'oauth2') {
                     $headers[] = 'Authorization: Bearer '.$auth['username'];
                 }
+                else if ($auth['password'] === 'private-token') {
+                    $headers[] = 'PRIVATE-TOKEN: '.$auth['username'];
+                }
             } elseif ('bitbucket.org' === $originUrl
                 && $this->fileUrl !== Bitbucket::OAUTH2_ACCESS_TOKEN_URL && 'x-token-auth' === $auth['username']
             ) {


### PR DESCRIPTION
Support gitlab private-token (or personal-access-token) for easier access via Gitlab API

Config example:

$HOME/.composer/auth.json

```json
{
	"gitlab-token": {
		"gitlab.com": "YOUR-TOKEN-HERE"
	}
}
```

Gitlab API authentication doc: http://doc.gitlab.com/ce/api/README.html