### PR TITLE
Urlencode Gitlab project names

### DIFF
--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -237,7 +237,7 @@ class GitLabDriver extends VcsDriver
      * @param string $string
      * @return string
      */
-    protected function urlEncodeAll($string)
+    private function urlEncodeAll($string)
     {
         $encoded = '';
         for ($i = 0; isset($string[$i]); $i++) {

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -228,7 +228,24 @@ class GitLabDriver extends VcsDriver
      */
     public function getApiUrl()
     {
-        return $this->scheme.'://'.$this->originUrl.'/api/v3/projects/'.$this->owner.'%2F'.$this->repository;
+        return $this->scheme.'://'.$this->originUrl.'/api/v3/projects/'.$this->urlEncodeAll($this->owner).'%2F'.$this->urlEncodeAll($this->repository);
+    }
+
+    /**
+     * Urlencode all non alphanumeric characters.
+     * 
+     * @param string $string
+     * @return string
+     */
+    protected function urlEncodeAll($string)
+    {
+        $encoded = '';
+        for ($i = 0; isset($string[$i]); $i++) {
+            $character = $string[$i];
+            if (!ctype_alnum($character)) $character = '%' . sprintf('%02X', ord($character));
+            $encoded .= $character;
+        }
+        return $encoded;
     }
 
     /**


### PR DESCRIPTION
Url encode all non alphanumeric characters in project name for GitLabDriver.

If the project name has "." characters in it, which is supported in Gitlab, the Gitlab API will 404 when requesting the branches or tags of the repository. This commit urlencodes all non alphanumeric characters in the project name in requests to the Gitlab API.

Example:
A random repo I found on Gitlab.com: https://gitlab.com/davidnind/davidnind.gitlab.io

https://gitlab.com/api/v3/projects/davidnind%2Fdavidnind.gitlab.io/repository/branches?private_token=Your-Private-Girlab.com-Token
![not working screenshot](https://cloud.githubusercontent.com/assets/4013741/16689452/b569a89e-452b-11e6-8556-d97033c98158.png)

https://gitlab.com/api/v3/projects/davidnind%2Fdavidnind%2Egitlab%2Eio/repository/branches?private_token= Your-Private-Girlab.com-Token
![working screenshot](https://cloud.githubusercontent.com/assets/4013741/16689470/d5f80448-452b-11e6-87c8-ca6b4600f1e9.png)
