### PR TITLE
Fix realpath() failing on Windows.

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -99,7 +99,7 @@ class AutoloadGenerator
 
         $filesystem = new Filesystem();
         $filesystem->ensureDirectoryExists($config->get('vendor-dir'));
-        $basePath = $filesystem->normalizePath(realpath(getcwd()));
+        $basePath = $filesystem->normalizePath(realpath(realpath(getcwd())));
         $vendorPath = $filesystem->normalizePath(realpath(realpath($config->get('vendor-dir'))));
         $useGlobalIncludePath = (bool) $config->get('use-include-path');
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -100,7 +100,7 @@ class AutoloadGenerator
         $filesystem = new Filesystem();
         $filesystem->ensureDirectoryExists($config->get('vendor-dir'));
         $basePath = $filesystem->normalizePath(realpath(getcwd()));
-        $vendorPath = $filesystem->normalizePath(realpath($config->get('vendor-dir')));
+        $vendorPath = $filesystem->normalizePath(realpath(realpath($config->get('vendor-dir'))));
         $useGlobalIncludePath = (bool) $config->get('use-include-path');
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
         $targetDir = $vendorPath.'/'.$targetDir;

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -101,6 +101,9 @@ class AutoloadGenerator
         $filesystem->ensureDirectoryExists($config->get('vendor-dir'));
         // Do not remove double realpath() calls.
         // Fixes failing Windows realpath() implementation.
+        // PHP bugs
+        //  https://bugs.php.net/bug.php?id=72642
+        //  https://bugs.php.net/bug.php?id=72738
         $basePath = $filesystem->normalizePath(realpath(realpath(getcwd())));
         $vendorPath = $filesystem->normalizePath(realpath(realpath($config->get('vendor-dir'))));
         $useGlobalIncludePath = (bool) $config->get('use-include-path');

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -99,6 +99,8 @@ class AutoloadGenerator
 
         $filesystem = new Filesystem();
         $filesystem->ensureDirectoryExists($config->get('vendor-dir'));
+        // Do not remove double realpath() calls.
+        // Fixes failing Windows realpath() implementation.
         $basePath = $filesystem->normalizePath(realpath(realpath(getcwd())));
         $vendorPath = $filesystem->normalizePath(realpath(realpath($config->get('vendor-dir'))));
         $useGlobalIncludePath = (bool) $config->get('use-include-path');


### PR DESCRIPTION
In certain scenarios, realpath() failing to completely unwind all symlinks, resulting in Composer producing autogenerated mappings similar to this:
```
config(vendor-dir):C:\Users\anrdaemon\Documents\.github\1/vendor
$vendorPath:C:/home/Daemon/Documents/.github/1/vendor
$targetDir:C:/home/Daemon/Documents/.github/1/vendor/composer
realpath($targetDir):C:\Users\Daemon\Documents\.github\1\vendor\composer
$vendorPathCode:dirname(dirname(dirname(dirname(dirname(dirname(dirname(__DIR__))))))).'/home/Daemon/Documents/.github/1/vendor'
```

After a rather silly looking patch, it works much better:
```
config(vendor-dir):C:\Users\anrdaemon\Documents\.github\1/vendor
$vendorPath:C:/Users/Daemon/Documents/.github/1/vendor
$targetDir:C:/Users/Daemon/Documents/.github/1/vendor/composer
realpath($targetDir):C:\Users\Daemon\Documents\.github\1\vendor\composer
$vendorPathCode:dirname(__DIR__)
```