### PR TITLE
Pass devMode from RunScriptCommand to Script\Event

### DIFF
--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -12,7 +12,7 @@
 
 namespace Composer\Command;
 
-use Composer\Script\CommandEvent;
+use Composer\Script\Event as ScriptEvent;
 use Composer\Script\ScriptEvents;
 use Composer\Util\ProcessExecutor;
 use Symfony\Component\Console\Input\InputInterface;
@@ -81,7 +81,9 @@ EOT
         }
 
         $composer = $this->getComposer();
-        $hasListeners = $composer->getEventDispatcher()->hasEventListeners(new CommandEvent($script, $composer, $this->getIO()));
+        $devMode = $input->getOption('dev') || !$input->getOption('no-dev');
+        $event = new ScriptEvent($script, $composer, $this->getIO(), $devMode);
+        $hasListeners = $composer->getEventDispatcher()->hasEventListeners($event);
         if (!$hasListeners) {
             throw new \InvalidArgumentException(sprintf('Script "%s" is not defined in this package', $script));
         }
@@ -96,7 +98,7 @@ EOT
             ProcessExecutor::setTimeout((int) $timeout);
         }
 
-        return $composer->getEventDispatcher()->dispatchScript($script, $input->getOption('dev') || !$input->getOption('no-dev'), $args);
+        return $composer->getEventDispatcher()->dispatchScript($script, $devMode, $args);
     }
 
     protected function listScripts()

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -24,6 +24,7 @@ use Composer\Script;
 use Composer\Script\CommandEvent;
 use Composer\Script\PackageEvent;
 use Composer\Util\ProcessExecutor;
+use Composer\Script\Event as ScriptEvent;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
@@ -415,6 +416,10 @@ class EventDispatcher
         }
 
         $generator = $this->composer->getAutoloadGenerator();
+        if ($event instanceof ScriptEvent) {
+            $generator->setDevMode($event->isDevMode());
+        }
+
         $packages = $this->composer->getRepositoryManager()->getLocalRepository()->getCanonicalPackages();
         $packageMap = $generator->buildPackageMap($this->composer->getInstallationManager(), $package, $packages);
         $map = $generator->parseAutoloads($packageMap, $package);

--- a/tests/Composer/Test/Command/RunScriptCommandTest.php
+++ b/tests/Composer/Test/Command/RunScriptCommandTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Command;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\Script\Event as ScriptEvent;
+use Composer\TestCase;
+
+class RunScriptCommandTest extends TestCase
+{
+
+    /**
+     * @dataProvider getDevOptions
+     * @param bool $dev
+     * @param bool $noDev
+     */
+    public function testDetectAndPassDevModeToEventAndToDispatching($dev, $noDev)
+    {
+        $scriptName = 'testScript';
+
+        $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
+        $input
+            ->method('getOption')
+            ->will($this->returnValueMap(array(
+                array('list', false),
+                array('dev', $dev),
+                array('no-dev', $noDev),
+            )));
+
+        $input
+            ->method('getArgument')
+            ->will($this->returnValueMap(array(
+                array('script', $scriptName),
+                array('args', array()),
+            )));
+        $input
+            ->method('hasArgument')
+            ->with('command')
+            ->willReturn(false);
+
+        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+
+        $expectedDevMode = $dev || !$noDev;
+
+        $ed = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $ed->expects($this->once())
+            ->method('hasEventListeners')
+            ->with($this->callback(function (ScriptEvent $event) use ($scriptName, $expectedDevMode) {
+                return $event->getName() === $scriptName
+                && $event->isDevMode() === $expectedDevMode;
+            }))
+            ->willReturn(true);
+
+        $ed->expects($this->once())
+            ->method('dispatchScript')
+            ->with($scriptName, $expectedDevMode, array());
+
+        $composer = $this->createComposerInstance();
+        $composer->setEventDispatcher($ed);
+
+        $command = $this->getMockBuilder('Composer\Command\RunScriptCommand')
+            ->setMethods(array(
+                'mergeApplicationDefinition',
+                'bind',
+                'getSynopsis',
+                'initialize',
+                'isInteractive',
+                'getComposer'
+            ))
+            ->getMock();
+        $command->expects($this->any())->method('getComposer')->willReturn($composer);
+        $command->method('isInteractive')->willReturn(false);
+
+        $command->run($input, $output);
+    }
+
+    public function getDevOptions()
+    {
+        return array(
+            array(true, true),
+            array(true, false),
+            array(false, true),
+            array(false, false),
+        );
+    }
+
+    private function createComposerInstance()
+    {
+        $composer = new Composer;
+        $config   = new Config;
+        $composer->setConfig($config);
+
+        return $composer;
+    }
+}

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\EventDispatcher;
 
 use Composer\EventDispatcher\Event;
+use Composer\EventDispatcher\EventDispatcher;
 use Composer\Installer\InstallerEvents;
 use Composer\Config;
 use Composer\Composer;
@@ -100,6 +101,96 @@ class EventDispatcherTest extends TestCase
             ->will($this->returnValue(0));
 
         $dispatcher->dispatchScript(ScriptEvents::POST_INSTALL_CMD, false);
+    }
+
+    /**
+     * @dataProvider getDevModes
+     * @param bool $devMode
+     */
+    public function testDispatcherPassDevModeToAutoloadGeneratorForScriptEvents($devMode)
+    {
+        $composer = $this->createComposerInstance();
+
+        $generator = $this->getGeneratorMockForDevModePassingTest();
+        $generator->expects($this->atLeastOnce())
+            ->method('setDevMode')
+            ->with($devMode);
+
+        $composer->setAutoloadGenerator($generator);
+
+        $package = $this->getMock('Composer\Package\RootPackageInterface');
+        $package->method('getScripts')->will($this->returnValue(array('scriptName' => array('scriptName'))));
+        $composer->setPackage($package);
+
+        $composer->setRepositoryManager($this->getRepositoryManagerMockForDevModePassingTest());
+        $composer->setInstallationManager($this->getMock('Composer\Installer\InstallationManager'));
+
+        $dispatcher = new EventDispatcher(
+            $composer,
+            $this->getMock('Composer\IO\IOInterface'),
+            $this->getMock('Composer\Util\ProcessExecutor')
+        );
+
+        $event = $this->getMockBuilder('Composer\Script\Event')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event->method('getName')->will($this->returnValue('scriptName'));
+        $event->expects($this->atLeastOnce())
+            ->method('isDevMode')
+            ->will($this->returnValue($devMode));
+
+        $dispatcher->hasEventListeners($event);
+    }
+
+    public function getDevModes()
+    {
+        return array(
+            array(true),
+            array(false),
+        );
+    }
+
+    private function getGeneratorMockForDevModePassingTest()
+    {
+        $generator = $this->getMockBuilder('Composer\Autoload\AutoloadGenerator')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'buildPackageMap',
+                'parseAutoloads',
+                'createLoader',
+                'setDevMode',
+            ))
+            ->getMock();
+        $generator
+            ->method('buildPackageMap')
+            ->will($this->returnValue(array()));
+        $generator
+            ->method('parseAutoloads')
+            ->will($this->returnValue(array()));
+        $generator
+            ->method('createLoader')
+            ->will($this->returnValue($this->getMock('Composer\Autoload\ClassLoader')));
+
+        return $generator;
+    }
+
+    private function getRepositoryManagerMockForDevModePassingTest()
+    {
+        $rm = $this->getMockBuilder('Composer\Repository\RepositoryManager')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getLocalRepository'))
+            ->getMock();
+
+        $repo = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
+        $repo
+            ->method('getCanonicalPackages')
+            ->will($this->returnValue(array()));
+
+        $rm
+            ->method('getLocalRepository')
+            ->will($this->returnValue($repo));
+
+        return $rm;
     }
 
     public function testDispatcherCanExecuteCliAndPhpInSameEventScriptStack()


### PR DESCRIPTION
The problem is described in #3114. `devMode` is not passed to `Script\Event`, so `AutoloadGenerator` doesn't parse `autoload-dev` section from `composer.json`