### PR TITLE
Added minor-only option to show command to only show packages with minor updates

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -332,6 +332,7 @@ php composer.phar show monolog/monolog 1.0.2
 * **--name-only (-N):** List package names only.
 * **--path (-P):** List package paths.
 * **--outdated (-o):** Implies --latest, but this lists *only* packages that have a newer version available.
+* **--minor-only (-m):** Use with --latest. Only shows packages that have minor SemVer-compatiable updates.
 * **--direct (-D):** Restricts the list of packages to your direct dependencies.
 
 ## outdated
@@ -351,6 +352,7 @@ The color coding is as such:
 
 * **--all (-a):** Show all packages, not just outdated (alias for `composer show -l`).
 * **--direct (-D):** Restricts the list of packages to your direct dependencies.
+* **--minor-only (-m):** Only shows packages that have minor SemVer-compatiable updates.
 
 ## browse / home
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -332,7 +332,7 @@ php composer.phar show monolog/monolog 1.0.2
 * **--name-only (-N):** List package names only.
 * **--path (-P):** List package paths.
 * **--outdated (-o):** Implies --latest, but this lists *only* packages that have a newer version available.
-* **--minor-only (-m):** Use with --latest. Only shows packages that have minor SemVer-compatiable updates.
+* **--minor-only (-m):** Use with --latest. Only shows packages that have minor SemVer-compatible updates.
 * **--direct (-D):** Restricts the list of packages to your direct dependencies.
 
 ## outdated
@@ -352,7 +352,7 @@ The color coding is as such:
 
 * **--all (-a):** Show all packages, not just outdated (alias for `composer show -l`).
 * **--direct (-D):** Restricts the list of packages to your direct dependencies.
-* **--minor-only (-m):** Only shows packages that have minor SemVer-compatiable updates.
+* **--minor-only (-m):** Only shows packages that have minor SemVer-compatible updates.
 
 ## browse / home
 

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -71,7 +71,7 @@ class ShowCommand extends BaseCommand
                 new InputOption('tree', 't', InputOption::VALUE_NONE, 'List the dependencies as a tree'),
                 new InputOption('latest', 'l', InputOption::VALUE_NONE, 'Show the latest version'),
                 new InputOption('outdated', 'o', InputOption::VALUE_NONE, 'Show the latest version but only for packages that are outdated'),
-                new InputOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show the latest version but only for packages that have minor SemVer-compatible updates'),
+                new InputOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show only packages that have minor SemVer-compatible updates. Use with the --outdated option.'),
                 new InputOption('direct', 'D', InputOption::VALUE_NONE, 'Shows only packages that are directly required by the root package'),
             ))
             ->setHelp(<<<EOT

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -71,7 +71,6 @@ class ShowCommand extends BaseCommand
                 new InputOption('tree', 't', InputOption::VALUE_NONE, 'List the dependencies as a tree'),
                 new InputOption('latest', 'l', InputOption::VALUE_NONE, 'Show the latest version'),
                 new InputOption('outdated', 'o', InputOption::VALUE_NONE, 'Show the latest version but only for packages that are outdated'),
-                new InputOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show only packages which have minor updates. Use in combination with --outdated'),
                 new InputOption('direct', 'D', InputOption::VALUE_NONE, 'Shows only packages that are directly required by the root package'),
             ))
             ->setHelp(<<<EOT
@@ -315,11 +314,6 @@ EOT
                         if ($showLatest && isset($latestPackages[$package->getPrettyName()])) {
                             $latestPackackage = $latestPackages[$package->getPrettyName()];
                         }
-
-                        if ($input->getOption('outdated') && $input->getOption('minor-only') && $latestPackackage && (!$this->isImmediateSemverCompliantUpgradeNeeded($package, $latestPackackage) || $latestPackackage->isAbandoned())) {
-                            continue;
-                        }
-
                         if ($input->getOption('outdated') && $latestPackackage && $latestPackackage->getFullPrettyVersion() === $package->getFullPrettyVersion() && !$latestPackackage->isAbandoned()) {
                             continue;
                         }
@@ -396,23 +390,17 @@ EOT
             return 'info';
         }
 
-        if ($this->isImmediateSemverCompliantUpgradeNeeded($package, $latestPackage)) {
+        $constraint = $package->getVersion();
+        if (0 !== strpos($constraint, 'dev-')) {
+            $constraint = '^'.$constraint;
+        }
+        if ($latestPackage->getVersion() && Semver::satisfies($latestPackage->getVersion(), $constraint)) {
             // print red as it needs an immediate semver-compliant upgrade
             return 'highlight';
         }
 
         // print yellow as it needs an upgrade but has potential BC breaks so is not urgent
         return 'comment';
-    }
-
-    protected function isImmediateSemverCompliantUpgradeNeeded(PackageInterface $package, PackageInterface $latestPackage)
-    {
-        $constraint = $package->getVersion();
-        if (0 !== strpos($constraint, 'dev-')) {
-            $constraint = '^'.$constraint;
-        }
-
-        return $latestPackage->getVersion() && Semver::satisfies($latestPackage->getVersion(), $constraint);
     }
 
     /**


### PR DESCRIPTION
This adds a new option to the show command: --minor-only.

When used in combination with --outdated, it will only show packages that have minor semver-compatible updates.

The use case for this is that we want to use composer to check if our project has any direct dependencies with minor semver-compatible updates, and fail our CI build if that's the case. The alternative would've been either trying to parse the original output checking for minor versions, or write a separate tool that hooks into composer to do the check.

This seemed like the simplest option.

Looking forward to your feedback.