### PR TITLE
check for additional possible authentication failure strings in gitutil

### DIFF
--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -234,7 +234,12 @@ class Git
             return false;
         }
 
-        $authFailures = array('fatal: Authentication failed', 'remote error: Invalid username or password.');
+        $authFailures = array(
+            'fatal: Authentication failed',
+            'remote error: Invalid username or password.',
+            'error: 401 Unauthorized'
+        );
+
         foreach ($authFailures as $authFailure) {
             if (strpos($this->process->getErrorOutput(), $authFailure) !== false) {
                 return true;


### PR DESCRIPTION
Fixes #5543 

Using git with fcgiwraps/nginx behind basic authentication Composer currently receives the following error output from Git, which Composer does not detect as an authentication error:

```
error: The requested URL returned error: 401 Unauthorized while accessing http://git.robbast.nl/repo/test.git/info/refs

fatal: HTTP request failed
```