### PR TITLE
Cleanup processes output handling

### DIFF
--- a/src/Composer/Downloader/RarDownloader.php
+++ b/src/Composer/Downloader/RarDownloader.php
@@ -44,7 +44,7 @@ class RarDownloader extends ArchiveDownloader
 
         // Try to use unrar on *nix
         if (!Platform::isWindows()) {
-            $command = 'unrar x ' . ProcessExecutor::escape($file) . ' ' . ProcessExecutor::escape($path) . ' && chmod -R u+w ' . ProcessExecutor::escape($path);
+            $command = 'unrar x ' . ProcessExecutor::escape($file) . ' ' . ProcessExecutor::escape($path) . ' >/dev/null && chmod -R u+w ' . ProcessExecutor::escape($path);
 
             if (0 === $this->process->execute($command, $ignoredOutput)) {
                 return;

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -70,7 +70,7 @@ class ZipDownloader extends ArchiveDownloader
         $processError = null;
 
         if (self::$hasSystemUnzip && !(class_exists('ZipArchive') && Platform::isWindows())) {
-            $command = 'unzip '.ProcessExecutor::escape($file).' -d '.ProcessExecutor::escape($path);
+            $command = 'unzip -qq '.ProcessExecutor::escape($file).' -d '.ProcessExecutor::escape($path);
             if (!Platform::isWindows()) {
                 $command .= ' && chmod -R u+w ' . ProcessExecutor::escape($path);
             }


### PR DESCRIPTION
I was playing with a blackfire profile done on a composer install and figured out that `fread` was called 90k times. After investigating, it turns out that `unzip`'s output is ignored by composer, but it's not by the underlying Symfony Process object.

Let's pipe it's output to `/dev/null` (not on windows of course).

Meanwhile, some code needed a related cleanup, here it is :)