### PR TITLE
update help page on global for COMPOSER_HOME info

### DIFF
--- a/src/Composer/Command/GlobalCommand.php
+++ b/src/Composer/Command/GlobalCommand.php
@@ -42,6 +42,9 @@ is to add the COMPOSER_HOME/vendor/bin dir to your PATH env var.
 COMPOSER_HOME is c:\Users\<user>\AppData\Roaming\Composer on Windows
 and /home/<user>/.composer on unix systems.
 
+If your system uses freedesktop.org standards, then it will first check
+XDG_CONFIG_HOME or default to /home/<user>/.config/composer
+
 Note: This path may vary depending on customizations to bin-dir in
 composer.json or the environmental variable COMPOSER_BIN_DIR.
 


### PR DESCRIPTION
default installation directory for global packages
has changed since adding support for freedesktop.org standards
per confusion from http://stackoverflow.com/q/38703915/4233593

Now if your system uses freedesktop.org standards, then it will first check
`XDG_CONFIG_HOME` or default to `/home/<user>/.config/composer`