### PR TITLE
Restart with xdebug disabled

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -7,9 +7,14 @@ if (PHP_SAPI !== 'cli') {
 
 require __DIR__.'/../src/bootstrap.php';
 
+use Composer\XdebugHandler;
 use Composer\Console\Application;
 
 error_reporting(-1);
+
+$xdebug = new XdebugHandler($argv);
+$xdebug->check();
+unset($xdebug);
 
 if (function_exists('ini_set')) {
     @ini_set('display_errors', 1);

--- a/bin/composer
+++ b/bin/composer
@@ -12,7 +12,7 @@ use Composer\Console\Application;
 
 error_reporting(-1);
 
-$xdebug = new XdebugHandler($argv);
+$xdebug = new XdebugHandler();
 $xdebug->check();
 unset($xdebug);
 

--- a/bin/composer
+++ b/bin/composer
@@ -7,12 +7,16 @@ if (PHP_SAPI !== 'cli') {
 
 require __DIR__.'/../src/bootstrap.php';
 
+use Composer\Factory;
 use Composer\XdebugHandler;
 use Composer\Console\Application;
 
 error_reporting(-1);
 
-$xdebug = new XdebugHandler();
+// Create output for XdebugHandler and Application
+$output = Factory::createOutput();
+
+$xdebug = new XdebugHandler($output);
 $xdebug->check();
 unset($xdebug);
 
@@ -46,4 +50,4 @@ if (function_exists('ini_set')) {
 
 // run the command application
 $application = new Application();
-$application->run();
+$application->run(null, $output);

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -18,8 +18,6 @@ use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Formatter\OutputFormatter;
 use Composer\Command;
 use Composer\Composer;
 use Composer\Factory;
@@ -96,9 +94,7 @@ class Application extends BaseApplication
     public function run(InputInterface $input = null, OutputInterface $output = null)
     {
         if (null === $output) {
-            $styles = Factory::createAdditionalStyles();
-            $formatter = new OutputFormatter(null, $styles);
-            $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, null, $formatter);
+            $output = Factory::createOutput();
         }
 
         return parent::run($input, $output);

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -28,7 +28,9 @@ use Composer\Util\Silencer;
 use Composer\Plugin\PluginEvents;
 use Composer\EventDispatcher\Event;
 use Seld\JsonLint\DuplicateKeyException;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\Autoload\AutoloadGenerator;
 use Composer\Package\Version\VersionParser;
@@ -223,6 +225,19 @@ class Factory
             'highlight' => new OutputFormatterStyle('red'),
             'warning' => new OutputFormatterStyle('black', 'yellow'),
         );
+    }
+
+    /**
+     * Creates a ConsoleOutput instance
+     *
+     * @return ConsoleOutput
+     */
+    public static function createOutput()
+    {
+        $styles = self::createAdditionalStyles();
+        $formatter = new OutputFormatter(null, $styles);
+
+        return new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, null, $formatter);
     }
 
     /**

--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -248,9 +248,8 @@ class XdebugHandler
             $result = ($stat['mode'] & 0170000) === 0020000;
         }
 
-        if ($result && defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $result = 0 >= version_compare('10.0.10586', PHP_WINDOWS_VERSION_MAJOR.'.'.PHP_WINDOWS_VERSION_MINOR.'.'.PHP_WINDOWS_VERSION_BUILD)
-            || false !== getenv('ANSICON')
+        if (defined('PHP_WINDOWS_VERSION_BUILD') && $result) {
+            $result = false !== getenv('ANSICON')
             || 'ON' === getenv('ConEmuANSI')
             || 'xterm' === getenv('TERM');
         }

--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -19,19 +19,16 @@ class XdebugHandler
 {
     const ENV_ALLOW = 'COMPOSER_ALLOW_XDEBUG';
 
-    private $argv;
     private $loaded;
     private $tmpIni;
     private $scanDir;
 
     /**
-     * @param array $argv The global argv passed to script
+     * Constructor
      */
-    public function __construct(array $argv)
+    public function __construct()
     {
-        $this->argv = $argv;
         $this->loaded = extension_loaded('xdebug');
-
         $tmp = sys_get_temp_dir();
         $this->tmpIni = $tmp.DIRECTORY_SEPARATOR.'composer-php.ini';
         $this->scanDir = $tmp.DIRECTORY_SEPARATOR.'composer-php-empty';
@@ -207,7 +204,7 @@ class XdebugHandler
         }
 
         $phpArgs = array(PHP_BINARY, '-c', $this->tmpIni);
-        $params = array_merge($phpArgs, $this->getScriptArgs($this->argv));
+        $params = array_merge($phpArgs, $this->getScriptArgs($_SERVER['argv']));
 
         return implode(' ', array_map(array($this, 'escape'), $params));
     }

--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -1,0 +1,277 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer;
+
+/**
+ * @author John Stevenson <john-stevenson@blueyonder.co.uk>
+ */
+class XdebugHandler
+{
+    const ENV_ALLOW = 'COMPOSER_ALLOW_XDEBUG';
+
+    private $argv;
+    private $loaded;
+    private $tmpIni;
+    private $scanDir;
+
+    /**
+     * @param array $argv The global argv passed to script
+     */
+    public function __construct(array $argv)
+    {
+        $this->argv = $argv;
+        $this->loaded = extension_loaded('xdebug');
+
+        $tmp = sys_get_temp_dir();
+        $this->tmpIni = $tmp.DIRECTORY_SEPARATOR.'composer-php.ini';
+        $this->scanDir = $tmp.DIRECTORY_SEPARATOR.'composer-php-empty';
+    }
+
+    /**
+     * Checks if xdebug is loaded and composer needs to be restarted
+     *
+     * If so, then a tmp ini is created with the xdebug ini entry commented out.
+     * If additional inis have been loaded, these are combined into the tmp ini
+     * and PHP_INI_SCAN_DIR is set to an empty directory. An environment
+     * variable is set so that the new process is created only once.
+     */
+    public function check()
+    {
+        if (!$this->needsRestart()) {
+            return;
+        }
+
+        if ($this->prepareRestart($command)) {
+            $this->restart($command);
+        }
+    }
+
+    /**
+     * Executes the restarted command
+     *
+     * @param string $command
+     */
+    protected function restart($command)
+    {
+        passthru($command, $exitCode);
+        exit($exitCode);
+    }
+
+    /**
+     * Returns true if a restart is needed
+     *
+     * @return bool
+     */
+    private function needsRestart()
+    {
+        if (PHP_SAPI !== 'cli' || !defined('PHP_BINARY')) {
+            return false;
+        }
+
+        return !getenv(self::ENV_ALLOW) && $this->loaded;
+    }
+
+    /**
+     * Returns true if everything was written for the restart
+     *
+     * If any of the following fails (however unlikely) we must return false to
+     * stop potential recursion:
+     *   - tmp ini file creation
+     *   - environment variable creation
+     *   - tmp scan dir creation
+     *
+     * @param null|string $command The command to run, set by method
+     *
+     * @return bool
+     */
+    private function prepareRestart(&$command)
+    {
+        $iniFiles = array();
+        if ($loadedIni = php_ini_loaded_file()) {
+            $iniFiles[] = $loadedIni;
+        }
+
+        $additional = $this->getAdditionalInis($iniFiles, $replace);
+        if ($this->writeTmpIni($iniFiles, $replace)) {
+            $command = $this->getCommand($additional);
+        }
+
+        return !empty($command) && putenv(self::ENV_ALLOW.'=1');
+    }
+
+    /**
+     * Writes the temporary ini file, or clears its name if no ini
+     *
+     * If there are no ini files, the tmp ini name is
+     * @param array $iniFiles The php.ini locations
+     * @param bool $replace Whether we need to modify the files
+     *
+     * @return bool False if the tmp ini could not be created
+     */
+    private function writeTmpIni(array $iniFiles, $replace)
+    {
+        if (empty($iniFiles)) {
+            // Unlikely, maybe xdebug was loaded through the -d option.
+            $this->tmpIni = '';
+            return true;
+        }
+
+        $content = $this->getIniHeader($iniFiles);
+        foreach ($iniFiles as $file) {
+            $content .= $this->getIniData($file, $replace);
+        }
+
+        return @file_put_contents($this->tmpIni, $content);
+    }
+
+    /**
+     * Return true if additional inis were loaded
+     *
+     * @param array $iniFiles Populated by method
+     * @param bool $replace Whether we need to modify the files
+     *
+     * @return bool
+     */
+    private function getAdditionalInis(array &$iniFiles , &$replace)
+    {
+        $replace = true;
+
+        if ($scanned = php_ini_scanned_files()) {
+            $list = explode(',', $scanned);
+
+            foreach ($list as $file) {
+                $file = trim($file);
+                if (preg_match('/xdebug.ini$/', $file)) {
+                    // Skip the file, no need for regex replacing
+                    $replace = false;
+                } else {
+                    $iniFiles[] = $file;
+                }
+            }
+        }
+
+        return !empty($scanned);
+    }
+
+    /**
+     * Returns formatted ini file data
+     *
+     * @param string $iniFile The location of the ini file
+     * @param bool $replace Whether to regex replace content
+     *
+     * @return string The ini data
+     */
+    private function getIniData($iniFile, $replace)
+    {
+        $data = str_repeat("\n", 3);
+        $data .= sprintf('; %s%s', $iniFile, PHP_EOL);
+        $contents = file_get_contents($iniFile);
+
+        if ($replace) {
+            // Comment out xdebug config
+            $regex = '/^\s*(zend_extension\s*=.*xdebug.*)$/mi';
+            $data .= preg_replace($regex, ';$1', $contents);
+        } else {
+            $data .= $contents;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Returns the command line to restart composer
+     *
+     * @param bool $additional Whether additional inis were loaded
+     *
+     * @return string The command line
+     */
+    private function getCommand($additional)
+    {
+        if ($additional) {
+            if (!file_exists($this->scanDir) && !@mkdir($this->scanDir, 0777)) {
+                return;
+            }
+            putenv('PHP_INI_SCAN_DIR='.$this->scanDir);
+        }
+
+        $phpArgs = array(PHP_BINARY, '-c', $this->tmpIni);
+        $params = array_merge($phpArgs, $this->argv);
+
+        return implode(' ', array_map(array($this, 'escape'), $params));
+    }
+
+    /**
+     * Escapes a string to be used as a shell argument.
+     *
+     * From https://github.com/johnstevenson/winbox-args
+     * MIT Licensed (c) John Stevenson <john-stevenson@blueyonder.co.uk>
+     *
+     * @param string $arg The argument to be escaped
+     * @param bool $meta Additionally escape cmd.exe meta characters
+     *
+     * @return string The escaped argument
+     */
+    private function escape($arg, $meta = true)
+    {
+        if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
+            return escapeshellarg($arg);
+        }
+
+        $quote = strpbrk($arg, " \t") !== false || $arg === '';
+        $arg = preg_replace('/(\\\\*)"/', '$1$1\\"', $arg, -1, $dquotes);
+
+        if ($meta) {
+            $meta = $dquotes || preg_match('/%[^%]+%/', $arg);
+
+            if (!$meta && !$quote) {
+                $quote = strpbrk($arg, '^&|<>()') !== false;
+            }
+        }
+
+        if ($quote) {
+            $arg = preg_replace('/(\\\\*)$/', '$1$1', $arg);
+            $arg = '"'.$arg.'"';
+        }
+
+        if ($meta) {
+            $arg = preg_replace('/(["^&|<>()%])/', '^$1', $arg);
+        }
+
+        return $arg;
+    }
+
+    /**
+     * Returns the location of the original ini data used.
+     *
+     * @param array $iniFiles loaded php.ini locations
+     *
+     * @return string
+     */
+    private function getIniHeader($iniFiles)
+    {
+        $ini = implode(PHP_EOL.';  ', $iniFiles);
+        $header = <<<EOD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; This file was automatically generated by Composer and can now be deleted.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; It is a modified copy of your php.ini configuration, found at:
+;  {$ini}
+
+; Make any changes there because this data will not be used again.
+EOD;
+
+        $header .= str_repeat("\n", 50);
+        return $header;
+    }
+}

--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -30,8 +30,8 @@ class XdebugHandler
     {
         $this->loaded = extension_loaded('xdebug');
         $tmp = sys_get_temp_dir();
-        $this->tmpIni = $tmp.DIRECTORY_SEPARATOR.'composer-php.ini';
-        $this->scanDir = $tmp.DIRECTORY_SEPARATOR.'composer-php-empty';
+        $this->tmpIni = $tmp.'/composer-php.ini';
+        $this->scanDir = $tmp.'/composer-php-empty';
     }
 
     /**
@@ -134,14 +134,14 @@ class XdebugHandler
     }
 
     /**
-     * Return true if additional inis were loaded
+     * Returns true if additional inis were loaded
      *
      * @param array $iniFiles Populated by method
      * @param bool $replace Whether we need to modify the files
      *
      * @return bool
      */
-    private function getAdditionalInis(array &$iniFiles , &$replace)
+    private function getAdditionalInis(array &$iniFiles, &$replace)
     {
         $replace = true;
 
@@ -188,11 +188,11 @@ class XdebugHandler
     }
 
     /**
-     * Returns the command line to restart composer
+     * Creates the required environment and returns the restart command line
      *
      * @param bool $additional Whether additional inis were loaded
      *
-     * @return string The command line
+     * @return string|null The command line or null on failure
      */
     private function getCommand($additional)
     {
@@ -200,7 +200,9 @@ class XdebugHandler
             if (!file_exists($this->scanDir) && !@mkdir($this->scanDir, 0777)) {
                 return;
             }
-            putenv('PHP_INI_SCAN_DIR='.$this->scanDir);
+            if (!putenv('PHP_INI_SCAN_DIR='.$this->scanDir)) {
+                return;
+            }
         }
 
         $phpArgs = array(PHP_BINARY, '-c', $this->tmpIni);

--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -175,7 +175,7 @@ class XdebugHandler
      */
     private function getIniData($iniFile, $replace)
     {
-        $data = str_repeat("\n", 3);
+        $data = str_repeat(PHP_EOL, 3);
         $data .= sprintf('; %s%s', $iniFile, PHP_EOL);
         $contents = file_get_contents($iniFile);
 
@@ -318,7 +318,7 @@ class XdebugHandler
 ; Make any changes there because this data will not be used again.
 EOD;
 
-        $header .= str_repeat("\n", 50);
+        $header .= str_repeat(PHP_EOL, 50);
         return $header;
     }
 }

--- a/tests/Composer/Test/Mock/XdebugHandlerMock.php
+++ b/tests/Composer/Test/Mock/XdebugHandlerMock.php
@@ -16,7 +16,6 @@ use Composer\XdebugHandler;
 
 class XdebugHandlerMock extends XdebugHandler
 {
-    public $command;
     public $restarted;
     public $output;
 
@@ -25,19 +24,17 @@ class XdebugHandlerMock extends XdebugHandler
         $this->output = Factory::createOutput();
         parent::__construct($this->output);
 
-        $loaded = $loaded === null ? true: $loaded;
+        $loaded = null === $loaded ? true: $loaded;
         $class = new \ReflectionClass(get_parent_class($this));
         $prop = $class->getProperty('loaded');
         $prop->setAccessible(true);
         $prop->setValue($this, $loaded);
 
-        $this->command = '';
         $this->restarted = false;
     }
 
     protected function restart($command)
     {
-        $this->command = $command;
         $this->restarted = true;
     }
 }

--- a/tests/Composer/Test/Mock/XdebugHandlerMock.php
+++ b/tests/Composer/Test/Mock/XdebugHandlerMock.php
@@ -11,17 +11,21 @@
 
 namespace Composer\Test\Mock;
 
+use Composer\Factory;
 use Composer\XdebugHandler;
 
 class XdebugHandlerMock extends XdebugHandler
 {
     public $command;
     public $restarted;
+    public $output;
 
-    public function __construct($loaded)
+    public function __construct($loaded = null)
     {
-        parent::__construct();
+        $this->output = Factory::createOutput();
+        parent::__construct($this->output);
 
+        $loaded = $loaded === null ? true: $loaded;
         $class = new \ReflectionClass(get_parent_class($this));
         $prop = $class->getProperty('loaded');
         $prop->setAccessible(true);

--- a/tests/Composer/Test/Mock/XdebugHandlerMock.php
+++ b/tests/Composer/Test/Mock/XdebugHandlerMock.php
@@ -18,9 +18,9 @@ class XdebugHandlerMock extends XdebugHandler
     public $command;
     public $restarted;
 
-    public function __construct(array $argv, $loaded)
+    public function __construct($loaded)
     {
-        parent::__construct($argv);
+        parent::__construct();
 
         $class = new \ReflectionClass(get_parent_class($this));
         $prop = $class->getProperty('loaded');

--- a/tests/Composer/Test/Mock/XdebugHandlerMock.php
+++ b/tests/Composer/Test/Mock/XdebugHandlerMock.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Mock;
+
+use Composer\XdebugHandler;
+
+class XdebugHandlerMock extends XdebugHandler
+{
+    public $command;
+    public $restarted;
+
+    public function __construct(array $argv, $loaded)
+    {
+        parent::__construct($argv);
+
+        $class = new \ReflectionClass(get_parent_class($this));
+        $prop = $class->getProperty('loaded');
+        $prop->setAccessible(true);
+        $prop->setValue($this, $loaded);
+
+        $this->command = '';
+        $this->restarted = false;
+    }
+
+    protected function restart($command)
+    {
+        $this->command = $command;
+        $this->restarted = true;
+    }
+}

--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -16,9 +16,6 @@ use Composer\Test\Mock\XdebugHandlerMock;
 
 /**
  * @author John Stevenson <john-stevenson@blueyonder.co.uk>
- *
- * @backupGlobals disabled
- * @runTestsInSeparateProcesses
  */
 class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
 {
@@ -48,6 +45,9 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $this->assertFalse($xdebug->restarted);
+
+        // Clear env for subsequent tests
+        putenv(XdebugHandlerMock::ENV_ALLOW.'=0');
     }
 
     public function testForceColorSupport()

--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -19,6 +19,8 @@ use Composer\Test\Mock\XdebugHandlerMock;
  */
 class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
 {
+    public static $envAllow;
+
     public function testRestartWhenLoaded()
     {
         $loaded = true;
@@ -45,29 +47,24 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $this->assertFalse($xdebug->restarted);
+    }
 
-        // Clear env for subsequent tests
+    public static function setUpBeforeClass()
+    {
+        self::$envAllow = (bool) getenv(XdebugHandlerMock::ENV_ALLOW);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        if (self::$envAllow) {
+            putenv(XdebugHandlerMock::ENV_ALLOW.'=1');
+        } else {
+            putenv(XdebugHandlerMock::ENV_ALLOW.'=0');
+        }
+    }
+
+    protected function setUp()
+    {
         putenv(XdebugHandlerMock::ENV_ALLOW.'=0');
-    }
-
-    public function testForceColorSupport()
-    {
-        $xdebug = new XdebugHandlerMock();
-        $xdebug->output->setDecorated(true);
-        $xdebug->check();
-
-        $args = explode(' ', $xdebug->command);
-        $this->assertTrue(in_array('--ansi', $args) || !defined('PHP_BINARY'));
-    }
-
-    public function testIgnoreColorSupportIfNoAnsi()
-    {
-        $xdebug = new XdebugHandlerMock();
-        $xdebug->output->setDecorated(true);
-        $_SERVER['argv'][] = '--no-ansi';
-        $xdebug->check();
-
-        $args = explode(' ', $xdebug->command);
-        $this->assertTrue(!in_array('--ansi', $args) || !defined('PHP_BINARY'));
     }
 }

--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test;
+
+use Composer\Test\Mock\XdebugHandlerMock as XdebugHandler;
+
+/**
+ * @author John Stevenson <john-stevenson@blueyonder.co.uk>
+ */
+class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $argv;
+
+    public function setup()
+    {
+        $this->argv = $GLOBALS['argv'];
+    }
+
+    public function testRestartWhenLoaded()
+    {
+        $loaded = true;
+
+        $xdebug = new XdebugHandler($this->argv, $loaded);
+        $xdebug->check();
+        $this->assertTrue($xdebug->restarted || !defined('PHP_BINARY'));
+    }
+
+    public function testNoRestartWhenNotLoaded()
+    {
+        $loaded = false;
+
+        $xdebug = new XdebugHandler($this->argv, $loaded);
+        $xdebug->check();
+        $this->assertFalse($xdebug->restarted);
+    }
+
+    public function testNoRestartWhenLoadedAndAllowed()
+    {
+        $loaded = true;
+        putenv(XdebugHandler::ENV_ALLOW.'=1');
+
+        $xdebug = new XdebugHandler($this->argv, $loaded);
+        $xdebug->check();
+        $this->assertFalse($xdebug->restarted);
+    }
+}

--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -19,18 +19,11 @@ use Composer\Test\Mock\XdebugHandlerMock as XdebugHandler;
  */
 class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    protected $argv;
-
-    public function setup()
-    {
-        $this->argv = $GLOBALS['argv'];
-    }
-
     public function testRestartWhenLoaded()
     {
         $loaded = true;
 
-        $xdebug = new XdebugHandler($this->argv, $loaded);
+        $xdebug = new XdebugHandler($loaded);
         $xdebug->check();
         $this->assertTrue($xdebug->restarted || !defined('PHP_BINARY'));
     }
@@ -39,7 +32,7 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $loaded = false;
 
-        $xdebug = new XdebugHandler($this->argv, $loaded);
+        $xdebug = new XdebugHandler($loaded);
         $xdebug->check();
         $this->assertFalse($xdebug->restarted);
     }
@@ -49,7 +42,7 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
         $loaded = true;
         putenv(XdebugHandler::ENV_ALLOW.'=1');
 
-        $xdebug = new XdebugHandler($this->argv, $loaded);
+        $xdebug = new XdebugHandler($loaded);
         $xdebug->check();
         $this->assertFalse($xdebug->restarted);
     }


### PR DESCRIPTION
I was asked about implementing a solution regarding xdebug performance ([Windows-Setup: issue#58](https://github.com/composer/windows-setup/issues/58)) and wondered whether this functionality would be more useful inside Composer - if it can be made to work reliably. This PR is an initial stab at that.

To make testing easier, here is the compiled [composer.phar](https://github.com/johnstevenson/composer/releases/tag/v1.2-dev.0256f62)  (updated to 0256f62)

I have assumed that the preferred use-case is running Composer without `xdebug`, so this is the default behaviour. It can be controlled by setting an environment variable beforehand:

* `COMPOSER_ALLOW_XDEBUG=0` Composer will restart without xdebug if it has been enabled. This is the default behaviour and does not require any variable to be set.
* `COMPOSER_ALLOW_XDEBUG=1` Composer will continue and not care about xdebug.

### Downsides
So far:
* The APC warnings will be displayed twice if Composer is restarted.
* Now fixed ~~The ansi-colors disappear running linux distros via Vagrant on Windows. It can be overcome by adding an `--ansi` option to the restart arguments (not implemented as I have no idea yet why this happens).~~ I was thrown by Symfony `Console` always assuming that `STDOUT` is a terminal on current Win10 (even when it is a pipe or file) and overlooked the fact that colored output needed to be handled here. 
* ... 