### PR TITLE
Fix support for testing exit code

### DIFF
--- a/tests/Composer/Test/AllFunctionalTest.php
+++ b/tests/Composer/Test/AllFunctionalTest.php
@@ -183,6 +183,7 @@ class AllFunctionalTest extends TestCase
 
                 case 'EXPECT-EXIT-CODE':
                     $sectionData = (integer) $sectionData;
+                    break;
 
                 case 'EXPECT':
                 case 'EXPECT-REGEX':


### PR DESCRIPTION
The `$sectionData` was being overwritten (type mismatch), causing its assertion (`$this->assertSame()`) to fail.