### PR TITLE
require-dev package repository options get copied into composer.lock (fix for #5600)

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -29,7 +29,7 @@ class ArrayLoader implements LoaderInterface
     protected $versionParser;
     protected $loadOptions;
 
-    public function __construct(SemverVersionParser $parser = null, $loadOptions = false)
+    public function __construct(SemverVersionParser $parser = null, $loadOptions = true)
     {
         if (!$parser) {
             $parser = new VersionParser;


### PR DESCRIPTION
commit 3994b556dcffcde7b1801c8bc712f3127e8f8e7c
Author: John Whitley 
Date:   Tue Aug 16 09:02:53 2016 +0100

https://github.com/composer/composer/issues/5600

This alters the default flag for loadOptions in \Composer\Package\Loader\ArrayLoader to true; and alters the assumption of the test to reflect this change.

**Rationale**

The `\Composer\Package\Loader\ArrayLoader` test (defined in tests/Composer/Test/Package/Loader/ArrayLoaderTest.php) assumed that a new `\Composer\Package\Loader\ArrayLoader` instance would be always created with the optional flag loadOptions set to true.

```php
$this->loader = new \Composer\Package\Loader\ArrayLoader(null, true);
```

This change alters the general case to reflect the default assumption as defined in the test.

commit b75fc4ad7238bc50f724bd29446ccbc33e82c34c
Author: John Whitley 
Date:   Mon Aug 15 16:55:27 2016 +0100

Altered the test for ArrayLoader to use the default loadConfig flag, and to test the true and false states for the loadConfig flag