### PR TITLE
Adds --no-suggestion flag to the docummentation

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -99,6 +99,7 @@ resolution.
 * **--no-scripts:** Skips execution of scripts defined in `composer.json`.
 * **--no-progress:** Removes the progress display that can mess with some
   terminals or scripts which don't handle backspace characters.
+* **--no-suggest:** Skips suggested packages in the output.
 * **--optimize-autoloader (-o):** Convert PSR-0/4 autoloading to classmap to get a faster
   autoloader. This is recommended especially for production, but can take
   a bit of time to run so it is currently not done by default.
@@ -143,6 +144,7 @@ php composer.phar update vendor/*
 * **--no-scripts:** Skips execution of scripts defined in `composer.json`.
 * **--no-progress:** Removes the progress display that can mess with some
   terminals or scripts which don't handle backspace characters.
+* **--no-suggest:** Skips suggested packages in the output.
 * **--optimize-autoloader (-o):** Convert PSR-0/4 autoloading to classmap to get a faster
   autoloader. This is recommended especially for production, but can take
   a bit of time to run so it is currently not done by default.


### PR DESCRIPTION
At the moment, the ``--no-suggest`` flag (implemented in https://github.com/composer/composer/pull/5392) is not being documented anywhere and in my opinion this is such an awesome feature that should be know everyone as soon as possible.

Ping @aeony @donatj @Seldaek