### PR TITLE
Add support for seamless execution of local binaries

### DIFF
--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -45,9 +45,10 @@ class ExecCommand extends BaseCommand
         $binDir = $composer->getConfig()->get('bin-dir');
         if ($input->getOption('list') || !$input->getArgument('binary')) {
             $bins = glob($binDir . '/*');
+            $bins = array_merge($bins, array_map(function($e) { return "$e (local)"; }, $composer->getPackage()->getBinaries()));
 
             if (!$bins) {
-                throw new \RuntimeException("No binaries found in bin-dir ($binDir)");
+                throw new \RuntimeException("No binaries found in composer.json or in bin-dir ($binDir)");
             }
 
             $this->getIO()->write(<<<EOT

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -220,6 +220,17 @@ class EventDispatcher
                 } else {
                     $this->io->writeError(sprintf('> %s', $exec));
                 }
+
+                $possibleLocalBinaries = $this->composer->getPackage()->getBinaries();
+                if ( $possibleLocalBinaries ) {
+                    foreach ( $possibleLocalBinaries as $localExec ) {
+                        if ( preg_match("/\b${callable}$/", $localExec)) {
+                            $exec = str_replace($callable, $localExec, $exec);
+                            break;
+                        }
+                    }
+                }
+
                 if (0 !== ($exitCode = $this->process->execute($exec))) {
                     $this->io->writeError(sprintf('<error>Script %s handling the %s event returned with error code '.$exitCode.'</error>', $callable, $event->getName()));
 

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -351,6 +351,8 @@ class EventDispatcherTest extends TestCase
         $composer = new Composer;
         $config = new Config;
         $composer->setConfig($config);
+        $package = $this->getMock('Composer\Package\RootPackageInterface');
+        $composer->setPackage($package);
 
         return $composer;
     }


### PR DESCRIPTION
Projects that add binaries to `vendor-bin` can now execute those via the same command as projects that consume them without installing them first.

In list overview local commands have a `(local)` tag to distinguish them from commands installed in `vendor-bin`.

Local binaries take precedence over `vendor-bin` which takes precedence over binaries in path.