### PR TITLE
JSON standard do not allow trailing comma

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -232,7 +232,7 @@ resolve to whatever composer.phar is currently being used:
         "test": [
             "@composer install",
             "phpunit"
-        ],
+        ]
     }
 }
 ```


### PR DESCRIPTION
remove trailing comma from JSON.