### PR TITLE
Allow optionally disabling the static autoloader

### DIFF
--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -34,6 +34,7 @@ class DumpAutoloadCommand extends BaseCommand
                 new InputOption('optimize', 'o', InputOption::VALUE_NONE, 'Optimizes PSR0 and PSR4 packages to be loaded with classmaps too, good for production.'),
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables autoload-dev rules.'),
+                new InputOption('no-static', null, InputOption::VALUE_NONE, 'Disables the static autoloader for environments where pre-PHP 5.6 syntax compatibility is required.'),
             ))
             ->setHelp(<<<EOT
 <info>php composer.phar dump-autoload</info>
@@ -67,6 +68,7 @@ EOT
         $generator->setDevMode(!$input->getOption('no-dev'));
         $generator->setClassMapAuthoritative($authoritative);
         $generator->setRunScripts(!$input->getOption('no-scripts'));
+        $generator->setStaticAutoloader(!$input->getOption('no-static'));
         $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
     }
 }


### PR DESCRIPTION
The static autoloader presents a problem for environments where pre-PHP
5.6 syntax compatibility is required. Many projects have automated CI
that runs a linter across all files in the repository to prevent
developers from accidentally introdcing incompatible syntax. And while
the static autoloader properly guards itself on lower PHP versions, it
will still trip up linters. Given the number of bugs filed about this,
it appears to be a common setup: #5255, #5316, #5324, and #5407.

This adds a --no-static option to the dump-autoload command, which will
disable the static autoloader by updating autoload_real.php to not look
for the file, and removes autoload_static.php if it exists.
