### PR TITLE
Allow setting default transport strategy for path repositories

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -868,4 +868,10 @@ If set to 1, this env disables the warning about running commands as root/super 
 It also disables automatic clearing of sudo sessions, so you should really only set this
 if you use Composer as super user at all times like in docker containers.
 
+### COMPOSER_MIRROR_PATH_REPOS
+
+If set to 1, this env changes the default path repository strategy to `mirror` instead
+of `symlink`. As it is the default strategy being set it can still be overwritten by
+repository options.
+
 &larr; [Libraries](02-libraries.md)  |  [Schema](04-schema.md) &rarr;

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -59,6 +59,11 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
         $currentStrategy = self::STRATEGY_SYMLINK;
         $allowedStrategies = array(self::STRATEGY_SYMLINK, self::STRATEGY_MIRROR);
 
+        $mirrorPathRepos = getenv('COMPOSER_MIRROR_PATH_REPOS');
+        if (true === (bool)$mirrorPathRepos) {
+            $currentStrategy = self::STRATEGY_MIRROR;
+        }
+
         if (true === $transportOptions['symlink']) {
             $currentStrategy = self::STRATEGY_SYMLINK;
             $allowedStrategies = array(self::STRATEGY_SYMLINK);

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -60,7 +60,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
         $allowedStrategies = array(self::STRATEGY_SYMLINK, self::STRATEGY_MIRROR);
 
         $mirrorPathRepos = getenv('COMPOSER_MIRROR_PATH_REPOS');
-        if (true === (bool)$mirrorPathRepos) {
+        if ($mirrorPathRepos) {
             $currentStrategy = self::STRATEGY_MIRROR;
         }
 


### PR DESCRIPTION
This change allows setting COMPOSER_DEFAULT_TRANSPORT_STRATEGY
in the environment to set the default strategy to 'mirror' if you like.

This allows using 'mirror' during deployments while still symlinking
on a development machine. The default is still overwritten by the
options on the repository configuration.