### PR TITLE
cut out "file://" from VCS download() method

### DIFF
--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -67,6 +67,12 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
         while ($url = array_shift($urls)) {
             try {
                 if (Filesystem::isLocalPath($url)) {
+                    # realpath() below will not understand
+                    # url that starts with "file://"
+                    $needle = 'file://';
+                    if (0 === strpos($url, $needle)) {
+                        $url = substr($url, strlen($needle));
+                    }
                     $url = realpath($url);
                 }
                 $this->doDownload($package, $path, $url);


### PR DESCRIPTION
See issue #5596 
The bug is related to realpath() function that was used with file path starts with "file://". 

"file://" is valid filesystem url but not valid for realpath. So my change just checks if url starts with "file://" and cuts it off. 

