### PR TITLE
Allow to get/set repositories.0 in config command

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -235,7 +235,7 @@ EOT
             $rawData = $this->configFile->read();
             $data = $this->config->all();
             if (preg_match('/^repos?(?:itories)?(?:\.(.+))?/', $settingKey, $matches)) {
-                if (empty($matches[1])) {
+                if ('' === $matches[1]) {
                     $value = isset($data['repositories']) ? $data['repositories'] : array();
                 } else {
                     if (!isset($data['repositories'][$matches[1]])) {


### PR DESCRIPTION
Actually the following command:

```
composer config repositories.0
```

will return the same output as

```
composer config repositories
```

As PHP treat 0 as an empty value.

This modification will normally treat 0 as a valid value (i did not test it, change this from a "not super dev friendly environment")