### PR TITLE
Simplify XDebugHandler restart process

### DIFF
--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -16,10 +16,14 @@ use Composer\Test\Mock\XdebugHandlerMock;
 
 /**
  * @author John Stevenson <john-stevenson@blueyonder.co.uk>
+ *
+ * We use PHP_BINARY which only became available in PHP 5.4 *
+ * @requires PHP 5.4
  */
 class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
 {
     public static $envAllow;
+    public static $envIniScanDir;
 
     public function testRestartWhenLoaded()
     {
@@ -27,7 +31,7 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
 
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
-        $this->assertTrue($xdebug->restarted || !defined('PHP_BINARY'));
+        $this->assertTrue($xdebug->restarted);
     }
 
     public function testNoRestartWhenNotLoaded()
@@ -49,22 +53,81 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($xdebug->restarted);
     }
 
+    public function testEnvAllow()
+    {
+        $loaded = true;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $expected = XdebugHandlerMock::RESTART_ID;
+        $this->assertEquals($expected, getenv(XdebugHandlerMock::ENV_ALLOW));
+
+        // Mimic restart
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertFalse($xdebug->restarted);
+        $this->assertFalse(getenv(XdebugHandlerMock::ENV_ALLOW));
+    }
+
+    public function testEnvAllowWithScanDir()
+    {
+        $loaded = true;
+        $dir = '/some/where';
+        putenv('PHP_INI_SCAN_DIR='.$dir);
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $expected = XdebugHandlerMock::RESTART_ID.'|'.$dir;
+        $this->assertEquals($expected, getenv(XdebugHandlerMock::ENV_ALLOW));
+
+        // Mimic setting scan dir and restart
+        putenv('PHP_INI_SCAN_DIR=');
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals($dir, getenv('PHP_INI_SCAN_DIR'));
+    }
+
+    public function testEnvAllowWithEmptyScanDir()
+    {
+        $loaded = true;
+        putenv('PHP_INI_SCAN_DIR=');
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $expected = XdebugHandlerMock::RESTART_ID.'|';
+        $this->assertEquals($expected, getenv(XdebugHandlerMock::ENV_ALLOW));
+
+        // Unset scan dir and mimic restart
+        putenv('PHP_INI_SCAN_DIR');
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals('', getenv('PHP_INI_SCAN_DIR'));
+    }
+
     public static function setUpBeforeClass()
     {
-        self::$envAllow = (bool) getenv(XdebugHandlerMock::ENV_ALLOW);
+        self::$envAllow = getenv(XdebugHandlerMock::ENV_ALLOW);
+        self::$envIniScanDir = getenv('PHP_INI_SCAN_DIR');
     }
 
     public static function tearDownAfterClass()
     {
-        if (self::$envAllow) {
-            putenv(XdebugHandlerMock::ENV_ALLOW.'=1');
+        if (false !== self::$envAllow) {
+            putenv(XdebugHandlerMock::ENV_ALLOW.'='.self::$envAllow);
         } else {
-            putenv(XdebugHandlerMock::ENV_ALLOW.'=0');
+            putenv(XdebugHandlerMock::ENV_ALLOW);
+        }
+
+        if (false !== self::$envIniScanDir) {
+            putenv('PHP_INI_SCAN_DIR='.self::$envIniScanDir);
+        } else {
+            putenv('PHP_INI_SCAN_DIR');
         }
     }
 
     protected function setUp()
     {
-        putenv(XdebugHandlerMock::ENV_ALLOW.'=0');
+        putenv(XdebugHandlerMock::ENV_ALLOW);
+        putenv('PHP_INI_SCAN_DIR');
     }
 }


### PR DESCRIPTION
To make testing easier, here is the compiled [composer.phar](https://github.com/johnstevenson/composer/releases/download/413a516/composer.phar) updated to 413a516
<hr>

There is no need to point `PHP_INI_SCAN_DIR` to an empty directory in order to bypass the compiled-in scan directory, because it can be overridden by providing an empty value.

The documentation is not entirely clear about this, but this was how it was designed. From [https://bugs.php.net/bug.php?id=45114](https://bugs.php.net/bug.php?id=45114):

> Now you can either use both -n and -c in command line options (-n disables every ini loading, -c enables loading the specified file / from specified path) or set PHP_INI_SCAN_DIR environment variable to empty (disables scanning) or to point to some other directory.

which references this [commit](https://github.com/php/php-src/commit/e5e6f553a25f972500b792170e03b5903ee924dd#diff-7cf540af7079d5a8052e0ea85871fab2R599) from August 2008.

This means that we don't have to create the tmp directory. This PR also removes the need for an extra environment variable, because we use `COMPOSER_ALLOW_XDEBUG` internally to flag that we are a restarted process and store the original value of `PHP_INI_SCAN_DIR`.