### PR TITLE
Include static files on runtime autolad generation (fix #3578)

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -53,6 +53,11 @@ class AutoloadGenerator
      */
     private $runScripts = false;
 
+    /**
+     * @var array
+     */
+    private static $autoloadedPackages = array();
+
     public function __construct(EventDispatcher $eventDispatcher, IOInterface $io = null)
     {
         $this->eventDispatcher = $eventDispatcher;
@@ -139,7 +144,7 @@ EOF;
 
         // Collect information from all packages.
         $packageMap = $this->buildPackageMap($installationManager, $mainPackage, $localRepo->getCanonicalPackages());
-        $autoloads = $this->parseAutoloads($packageMap, $mainPackage);
+        $autoloads = $this->parseAutoloads($packageMap, $mainPackage, false);
 
         // Process the 'psr-0' base directories.
         foreach ($autoloads['psr-0'] as $namespace => $paths) {
@@ -366,9 +371,10 @@ EOF;
      *
      * @param  array            $packageMap  array of array(package, installDir-relative-to-composer.json)
      * @param  PackageInterface $mainPackage root package instance
+     * @param  bool             $requireFilesOneTime Should require autoload files only one time per package
      * @return array            array('psr-0' => array('Ns\\Foo' => array('installDir')))
      */
-    public function parseAutoloads(array $packageMap, PackageInterface $mainPackage)
+    public function parseAutoloads(array $packageMap, PackageInterface $mainPackage, $requireFilesOneTime = true)
     {
         $mainPackageMap = array_shift($packageMap);
         $sortedPackageMap = $this->sortPackageMap($packageMap);
@@ -378,7 +384,7 @@ EOF;
         $psr0 = $this->parseAutoloadsType($packageMap, 'psr-0', $mainPackage);
         $psr4 = $this->parseAutoloadsType($packageMap, 'psr-4', $mainPackage);
         $classmap = $this->parseAutoloadsType(array_reverse($sortedPackageMap), 'classmap', $mainPackage);
-        $files = $this->parseAutoloadsType($sortedPackageMap, 'files', $mainPackage);
+        $files = $this->parseAutoloadsType($sortedPackageMap, 'files', $mainPackage, $requireFilesOneTime);
         $exclude = $this->parseAutoloadsType($sortedPackageMap, 'exclude-from-classmap', $mainPackage);
 
         krsort($psr0);
@@ -425,7 +431,23 @@ EOF;
             }
         }
 
+        if (isset($autoloads['files'])) {
+            foreach ($autoloads['files'] as $file) {
+                require_once $file;
+            }
+        }
+
         return $loader;
+    }
+
+    /**
+     * Prevent to package autoload don't be reinserted
+     *
+     * @param  PackageInterface $package Package to be autoloaded
+     * @return bool             The autoload files of this package were required?
+     */
+    protected function packageFilesRequired(PackageInterface $package) {
+        return in_array($package->getName(), self::$autoloadedPackages);
     }
 
     protected function getIncludePathsFile(array $packageMap, Filesystem $filesystem, $basePath, $vendorPath, $vendorPathCode, $appBaseDirCode)
@@ -782,7 +804,7 @@ $initializer
 INITIALIZER;
     }
 
-    protected function parseAutoloadsType(array $packageMap, $type, PackageInterface $mainPackage)
+    protected function parseAutoloadsType(array $packageMap, $type, PackageInterface $mainPackage, $requireFilesOneTime = true)
     {
         $autoloads = array();
 
@@ -798,6 +820,16 @@ INITIALIZER;
             if (!isset($autoload[$type]) || !is_array($autoload[$type])) {
                 continue;
             }
+
+            // only require files one time to prevent redeclare (function, class, etc.) error
+            if ($type === 'files') {
+                if ($requireFilesOneTime && $this->packageFilesRequired($package)) {
+                    continue;
+                } else {
+                    static::$autoloadedPackages[] = $package->getName();
+                }
+            }
+
             if (null !== $package->getTargetDir() && $package !== $mainPackage) {
                 $installPath = substr($installPath, 0, -strlen('/'.$package->getTargetDir()));
             }


### PR DESCRIPTION
This PR fixes runtime autoload generation.

Without it, composer fail to include static files on run-scripts and execute plugins (composer globally).

Only `EventDispatcher::getScriptListeners` and `PluginManager::registerPackage` calls this method (`AutoloadGenerator::createLoader`)