### PR TITLE
Added reference to logics/extcheck

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -328,7 +328,8 @@ a constraint that it otherwise would not. For more information [see the
 aliases article](articles/aliases.md).
 
 `require` and `require-dev` also support references to specific PHP versions
-and PHP extensions your project needs to run successfully.
+and PHP extensions your project needs to run successfully. Package `logics/extcheck`
+may be used to find optional PHP extensions used by your project.
 
 Example:
 


### PR DESCRIPTION
logics/extcheck leveraging composer's functionality to require PHP extensions. Unfortunately in the way it is currently stands most packages on Packagist fail to require extensions used. Because of this installation of such packages on minimal PHP installations succeeds but then fails at run time. I think it is reasonable to mention existence of such tool on Composer site.