### PR TITLE
Enabling autoload-dev for child repos, if root repo allows them

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -49,6 +49,10 @@ class AutoloadGenerator
     private $classMapAuthoritative = false;
 
     /**
+     * @var array
+     */
+    private $allowedAutoloadDevRepos = [];
+    /**
      * @var bool
      */
     private $runScripts = false;
@@ -62,6 +66,13 @@ class AutoloadGenerator
     public function setDevMode($devMode = true)
     {
         $this->devMode = (boolean) $devMode;
+    }
+
+    /**
+     * @param array $autoloadDevMode
+     */
+    public function setAutoloadDevModeRepos(array $autoloadDevMode = []) {
+        $this->allowedAutoloadDevRepos =  $autoloadDevMode;
     }
 
     /**
@@ -103,6 +114,9 @@ class AutoloadGenerator
         $vendorPath = $filesystem->normalizePath(realpath($config->get('vendor-dir')));
         $useGlobalIncludePath = (bool) $config->get('use-include-path');
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
+
+        $this->setAutoloadDevModeRepos($config->getEnableAutoloadDevForChild());
+
         $targetDir = $vendorPath.'/'.$targetDir;
         $filesystem->ensureDirectoryExists($targetDir);
 
@@ -790,7 +804,14 @@ INITIALIZER;
             list($package, $installPath) = $item;
 
             $autoload = $package->getAutoload();
-            if ($this->devMode && $package === $mainPackage) {
+
+            //IF Root repo enable-child repos name matches with given package name.
+            $allowAutoloadDev = false;
+
+            if(in_array($package->getName(),$this->allowedAutoloadDevRepos)) {
+                $allowAutoloadDev = true;
+            }
+            if ($this->devMode && ($package === $mainPackage || ($type == "psr-4" && $allowAutoloadDev))) {
                 $autoload = array_merge_recursive($autoload, $package->getDevAutoload());
             }
 

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -82,6 +82,7 @@ class Config
     private $authConfigSource;
     private $useEnvironment;
     private $warnedHosts = array();
+    private $enableAutoloadDevForChild;
 
     /**
      * @param bool   $useEnvironment Use COMPOSER_ environment variables to replace config settings
@@ -94,6 +95,7 @@ class Config
         $this->repositories = static::$defaultRepositories;
         $this->useEnvironment = (bool) $useEnvironment;
         $this->baseDir = $baseDir;
+        $this->enableAutoloadDevForChild = [];
     }
 
     public function setConfigSource(ConfigSourceInterface $source)
@@ -152,6 +154,12 @@ class Config
             }
         }
 
+        if(!empty($config["enable-autoload-dev-for-child"]) && is_array($config['enable-autoload-dev-for-child'])) {
+            $repoNames = array_reverse($config['enable-autoload-dev-for-child'], true);
+            foreach ($repoNames as $key =>$repoName) {
+                $this->enableAutoloadDevForChild[] = $repoName;
+            }
+        }
         if (!empty($config['repositories']) && is_array($config['repositories'])) {
             $this->repositories = array_reverse($this->repositories, true);
             $newRepos = array_reverse($config['repositories'], true);
@@ -187,6 +195,13 @@ class Config
         return $this->repositories;
     }
 
+    /**
+     * @return array
+     */
+    public function getEnableAutoloadDevForChild()
+    {
+        return $this->enableAutoloadDevForChild;
+    }
     /**
      * Returns a setting
      *


### PR DESCRIPTION
In our company. We have a parent repository and have multiple child repository[Having individual test cases]. So in-order to test them, we require autoload-dev to work in child and also not giving other dependant repos the priviledge of autoload-dev. So i have changed some code and put in a key in composer.json.

"enable-autoload-dev-for-child": [
        "child1",
        "child2"
    ]

So if that child1,child2 composer file has autoload-dev defined, that it will pick that namespace.

Please suggest .. 