### PR TITLE
Warn about possible retag of version

### DIFF
--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -188,7 +188,7 @@ EOT
                     $io->write(sprintf('    From <comment>%s</comment> to <comment>%s</comment>', $previousVersion, $currentVersion));
 
                     if ($currentVersion === $previousVersion) {
-                        $io->write('    <warning>Version may have been updated since composer.lock was last updated</warning>');
+                        $io->writeError('    <warning>Version may have been updated since composer.lock was last updated</warning>');
                     }
                 } else {
                     $io->write($path);

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -186,6 +186,10 @@ EOT
 
                     $io->write('<info>'.$path.'</info>:');
                     $io->write(sprintf('    From <comment>%s</comment> to <comment>%s</comment>', $previousVersion, $currentVersion));
+
+                    if ($currentVersion === $previousVersion) {
+                        $io->write('    <warning>Version may have been updated since composer.lock was last updated</warning>');
+                    }
                 } else {
                     $io->write($path);
                 }


### PR DESCRIPTION
In the inadvisable event that a package has been retagged, it’s possible to be in a state where the versions are the same, but the underlying ref is different. We report that there has been a version variation, but the output is not helpful (`From 1.1.3 to 1.1.3`, which just causes more confusion).

Since this is an exceptional case, it makes sense to give some insight into why things may appear strange.

I'm not 100% that this message encompasses all possible reasons why we'd be in this state, so suggestions are welcome, but I think it is important to show some sort of messaging with possible explanations for the super confusing status.
