### PR TITLE
removed obsolete code

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -313,11 +313,6 @@ class ClassLoader
      */
     public function findFile($class)
     {
-        // work around for PHP 5.3.0 - 5.3.2 https://bugs.php.net/50731
-        if ('\\' == $class[0]) {
-            $class = substr($class, 1);
-        }
-
         // class map lookup
         if (isset($this->classMap[$class])) {
             return $this->classMap[$class];

--- a/tests/Composer/Test/Autoload/ClassLoaderTest.php
+++ b/tests/Composer/Test/Autoload/ClassLoaderTest.php
@@ -25,26 +25,15 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
      * @dataProvider getLoadClassTests
      *
      * @param string $class            The fully-qualified class name to test, without preceding namespace separator.
-     * @param bool   $prependSeparator Whether to call ->loadClass() with a class name with preceding
-     *                                 namespace separator, as it happens in PHP 5.3.0 - 5.3.2. See https://bugs.php.net/50731
      */
-    public function testLoadClass($class, $prependSeparator = false)
+    public function testLoadClass($class)
     {
         $loader = new ClassLoader();
         $loader->add('Namespaced\\', __DIR__ . '/Fixtures');
         $loader->add('Pearlike_', __DIR__ . '/Fixtures');
         $loader->addPsr4('ShinyVendor\\ShinyPackage\\', __DIR__ . '/Fixtures');
-
-        if ($prependSeparator) {
-            $prepend = '\\';
-            $message = "->loadClass() loads '$class'.";
-        } else {
-            $prepend = '';
-            $message = "->loadClass() loads '\\$class', as required in PHP 5.3.0 - 5.3.2.";
-        }
-
-        $loader->loadClass($prepend . $class);
-        $this->assertTrue(class_exists($class, false), $message);
+        $loader->loadClass($class);
+        $this->assertTrue(class_exists($class, false), "->loadClass() loads '$class'");
     }
 
     /**
@@ -58,11 +47,6 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
             array('Namespaced\\Foo'),
             array('Pearlike_Foo'),
             array('ShinyVendor\\ShinyPackage\\SubNamespace\\Foo'),
-            // "Bar" would not work here, since it is defined in a ".inc" file,
-            // instead of a ".php" file. So, use "Baz" instead.
-            array('Namespaced\\Baz', true),
-            array('Pearlike_Bar', true),
-            array('ShinyVendor\\ShinyPackage\\SubNamespace\\Bar', true),
         );
     }
 


### PR DESCRIPTION
Composer requires PHP 5.3.2 as a minimum.

The code I've removed in this PR is for a bug that was fixed in 5.3.2, so it should be safe (https://github.com/php/php-src/blob/PHP-5.3.29/NEWS#L2080).
