### PR TITLE
Clarify allowed format for repositories key

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -775,14 +775,15 @@ will look from the first to the last repository, and pick the first match.
 By default Packagist is added last which means that custom repositories can
 override packages from it.
 
-Using JSON object is also allowed. However, it is discouraged because there is no explicit order of keys in JSON object.
+Using JSON object notation is also possible. However, JSON key/value pairs
+are to be considered unordered so consistent behaviour cannot be guaranteed.
 
  ```json
 {
     "repositories": {
-         "composer": {
+         "foo": {
              "type": "composer",
-             "url": "http://packages.example.com"
+             "url": "http://packages.foo.com"
          }
     }
 }

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -775,6 +775,19 @@ will look from the first to the last repository, and pick the first match.
 By default Packagist is added last which means that custom repositories can
 override packages from it.
 
+Using JSON object is also allowed. However, it is discouraged because there is no explicit order of keys in JSON object.
+
+ ```json
+{
+    "repositories": {
+         "composer": {
+             "type": "composer",
+             "url": "http://packages.example.com"
+         }
+    }
+}
+ ```
+
 ### config <span>([root-only](04-schema.md#root-package))</span>
 
 A set of configuration options. It is only used for projects. See


### PR DESCRIPTION
Using JSON object should be discouraged as there is no explicit order
of keys in JSON object. Even though it's deterministic in current PHP
version, it may change any time. As stated on http://json.org/:
"An object is an unordered set of name/value pairs. An object begins
with { (left brace) and ends with } (right brace). Each name is
followed by : (colon) and the name/value pairs are separated
by , (comma)."

Fixes #2802.