### PR TITLE
Enhance performance by removing count() from Solver's main loop

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -758,8 +758,10 @@ class Solver
                 $systemLevel = $level;
             }
 
-            for ($i = 0, $n = 0; $n < count($this->rules); $i++, $n++) {
-                if ($i == count($this->rules)) {
+            $rulesCount = count($this->rules);
+
+            for ($i = 0, $n = 0; $n < $rulesCount; $i++, $n++) {
+                if ($i == $rulesCount) {
                     $i = 0;
                 }
 
@@ -805,6 +807,7 @@ class Solver
                 }
 
                 // something changed, so look at all rules again
+                $rulesCount = count($this->rules);
                 $n = -1;
             }
 


### PR DESCRIPTION
Thanks to [blackfire.io](https://blackfire.io), I spotted that `count()` is hurting performance for no reason here. It was called 730023965 times in the case I was working on, not unusual.

Using `time` to "profile" the patch, `composer up` dropped from 290s to 140s (PHP7.1)!