### PR TITLE
Improve installer extensibility

### DIFF
--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -112,7 +112,7 @@ class InstallerTest extends TestCase
         $repositoryManager = new RepositoryManager($io, $config);
         $repositoryManager->setLocalRepository(new InstalledArrayRepository());
 
-        $composer = FactoryMock::create($io, []);
+        $composer = FactoryMock::create($io, array());
         $composer->setLocker($locker);
         $composer->setEventDispatcher($eventDispatcher);
         $composer->setRepositoryManager($repositoryManager);

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -96,6 +96,37 @@ class InstallerTest extends TestCase
         $this->assertSame($expectedUninstalled, $uninstalled);
     }
 
+    public function testDisableImplicitOperations()
+    {
+        $locker = $this->getMockBuilder('Composer\Package\Locker')->disableOriginalConstructor()->getMock();
+        $locker->expects($this->once())
+            ->method('setLockData');
+
+        $eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
+        $eventDispatcher->expects($this->exactly(2))
+            ->method('dispatchScript');
+
+        $io = new BufferIO('', OutputInterface::VERBOSITY_NORMAL, new OutputFormatter(false));
+        $config = $this->getMock('Composer\Config');
+
+        $repositoryManager = new RepositoryManager($io, $config);
+        $repositoryManager->setLocalRepository(new InstalledArrayRepository());
+
+        $composer = FactoryMock::create($io, []);
+        $composer->setLocker($locker);
+        $composer->setEventDispatcher($eventDispatcher);
+        $composer->setRepositoryManager($repositoryManager);
+
+
+        $installer = Installer::create($io, $composer);
+        $installer->setDryRun(true)
+            ->setRunScripts(true)
+            ->setWriteLock(true)
+            ->setDisableImplicitOperations(true);
+
+        $installer->run();
+    }
+
     public function provideInstaller()
     {
         $cases = array();


### PR DESCRIPTION
Hi everyone,

This is a follow up PR on https://github.com/composer/composer/pull/4946.
I'm quoting what @Seldaek wrote in the other PR:

> I think requiring composer/composer as dependency and doing things there how you want it makes more sense than adding a flag for anyone to shoot themselves in the foot with :)

This is what I set out to do now. Now the problem is that `Installer::run()` does a few things "hardcoded". For example, if the dry run mode is enabled, the output is always verbose an scripts are never run. Also, I cannot force composer to write my lock file even in dry run mode. It's all hard coded in the `run()` method and even if I'd extend the `Installer` and tried to override the `run()` method, it's not working because the method is so huge and does so many things that I cannot really call like `parent::run()` and then in addition to this do something else again, because all the variables are obviously missing (in my case e.g. `$aliases` etc.).

So I reworked the `Installer` just a little bit by moving the defaults for the dry run mode to the `setDryRun()` method instead. That way, everybody can be more flexible on working with the installer.
