### PR TITLE
Issue 5769 dev mode varaible

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -22,15 +22,19 @@ Composer fires the following named events during its execution process:
 
 ### Command Events
 
-- **pre-install-cmd**: occurs before the `install` command is executed with a lock file present.
-- **post-install-cmd**: occurs after the `install` command has been executed with a lock file present.
-- **pre-update-cmd**: occurs before the `update` command is executed, or before the `install` command is executed without a lock file present.
-- **post-update-cmd**: occurs after the `update` command has been executed, or after the `install` command has been executed without a lock file present.
+- **pre-install-cmd**: occurs before the `install` command is executed with a
+  lock file present.
+- **post-install-cmd**: occurs after the `install` command has been executed
+  with a lock file present.
+- **pre-update-cmd**: occurs before the `update` command is executed, or before
+  the `install` command is executed without a lock file present.
+- **post-update-cmd**: occurs after the `update` command has been executed, or
+  after the `install` command has been executed without a lock file present.
 - **post-status-cmd**: occurs after the `status` command has been executed.
 - **pre-archive-cmd**: occurs before the `archive` command is executed.
 - **post-archive-cmd**: occurs after the `archive` command has been executed.
-- **pre-autoload-dump**: occurs before the autoloader is dumped, either
-  during `install`/`update`, or via the `dump-autoload` command.
+- **pre-autoload-dump**: occurs before the autoloader is dumped, either during
+  `install`/`update`, or via the `dump-autoload` command.
 - **post-autoload-dump**: occurs after the autoloader has been dumped, either
   during `install`/`update`, or via the `dump-autoload` command.
 - **post-root-package-install**: occurs after the root package has been
@@ -150,7 +154,10 @@ class MyClass
 }
 ```
 
-**Note:** During composer install / update, a `COMPOSER_DEV_MODE` php environment variable is set. If composer install / update was run with the `--no-dev option`, this variable will be set to 0, otherwise it will be set to 1. This exposes the mode in which the install / update was run, to any post-install / update commands.
+**Note:** During a composer install or update process, a variable named
+`COMPOSER_DEV_MODE` will be added to the environment. If the command was run
+with the `--no-dev` flag, this variable will be set to 0, otherwise it will be
+set to 1.
 
 ## Event classes
 

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -150,6 +150,8 @@ class MyClass
 }
 ```
 
+**Note:** During composer install / update, a `COMPOSER_DEV_MODE` php environment variable is set. If composer install / update was run with the `--no-dev option`, this variable will be set to 0, otherwise it will be set to 1. This exposes the mode in which the install / update was run, to any post-install / update commands.
+
 ## Event classes
 
 When an event is fired, your PHP callback receives as first argument a

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -292,6 +292,9 @@ class Installer
             }
 
             if ($this->runScripts) {
+                $devMode = (int) $this->devMode;
+                putenv("COMPOSER_DEV_MODE=$devMode");
+
                 // dispatch post event
                 $eventName = $this->update ? ScriptEvents::POST_UPDATE_CMD : ScriptEvents::POST_INSTALL_CMD;
                 $this->eventDispatcher->dispatchScript($eventName, $this->devMode);


### PR DESCRIPTION
**Issue addressed**
https://github.com/composer/composer/issues/5769

**Summary**
Sets a php environment variable during the composer install/update, to expose to any post-install/update scripts which mode the install/update was run in.

**Example Usage (In post install/update script)**

```
if (getenv("COMPOSER_DEV_MODE") ==1) {
    // do something
}
```
