### PR TITLE
fixed direct rename() usage

### DIFF
--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -164,7 +164,7 @@ class ArchiveManager
         $filesystem->ensureDirectoryExists(dirname($tempTarget));
 
         $archivePath = $usableArchiver->archive($sourcePath, $tempTarget, $format, $package->getArchiveExcludes());
-        rename($archivePath, $target);
+        $filesystem->rename($archivePath, $target);
 
         // cleanup temporary download
         if (!$package instanceof RootPackageInterface) {


### PR DESCRIPTION
We runned into an issue with composer/satis and the dist package creation, that we couldn't create the packages properly under FreeBSD:

```
[ErrorException]
  rename(/tmp//composer_archive58061e3f534fe.tar,/path/package-v1.0.7-20d198.tar): Operation not permitted
```

This small PR resolve that issue