### PR TITLE
Make a named repository definition leading/immutable

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -264,6 +264,50 @@ GitHub and BitBucket:
 
 The only requirement is the installation of SSH keys for a git client.
 
+#### Using named private repositories
+
+When working with private repositories it's sometimes required to use different 
+ways to access a repository.
+While your CI system might use SSH to read from your repository a developer 
+needs to access the same repository using another resource or authentication.
+
+You'll need to define a named repository in your `composer.json` file:
+
+```json
+{
+    "require": {
+        "vendor/my-private-repo": "dev-master"
+    },
+    "repositories": {
+        "my-private-repo": {
+            "type": "vcs",
+            "url":  "git@bitbucket.org:vendor/my-private-repo.git"
+        }
+    }
+}
+```
+
+Any developer who cannot access the default repository source can now 
+define an own source for this named repository in his global Composer `config.json`.
+Adding `"immutable": true` to the repository config will override any same named
+repository configuration.
+
+```json
+{
+    "config": {
+    
+    },
+    "repositories": {
+        "my-private-repo": {
+            "type": "vcs",
+            "url":  "https://bitbucket.org:vendor/my-private-repo.git",
+            "immutable": true
+        }
+    }
+}
+```
+
+
 #### Git alternatives
 
 Git is not the only version control system supported by the VCS repository.

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -173,10 +173,12 @@ class Config
                 if (is_int($name)) {
                     $this->repositories[] = $repository;
                 } else {
-                    if ($name === 'packagist') { // BC support for default "packagist" named repo
-                        $this->repositories[$name . '.org'] = $repository;
-                    } else {
-                        $this->repositories[$name] = $repository;
+                    if (!isset($this->repositories[$name]) || !array_key_exists('immutable', $this->repositories[$name]) || !$this->repositories[$name]['immutable']) {
+                        if ($name === 'packagist') { // BC support for default "packagist" named repo
+                            $this->repositories[$name . '.org'] = $repository;
+                        } else {
+                            $this->repositories[$name] = $repository;
+                        }
                     }
                 }
             }

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -219,6 +219,32 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('https', 'git'), $config->get('github-protocols'));
     }
 
+    public function testNamedRepositorySourceWillBeOverruledByLast()
+    {
+        $config = new Config(false);
+
+        $namedRepository = array('named-repository' => array('type' => 'git', 'url' => 'https://127.0.0.1'));
+        $config->merge(array('repositories' => $namedRepository + array("packagist" => false)));
+        $this->assertEquals($namedRepository, $config->getRepositories());
+
+        $namedRepositoryVersionTwo = array('named-repository' => array('type' => 'git', 'url' => 'https://localhost'));
+        $config->merge(array('repositories' => $namedRepositoryVersionTwo));
+        $this->assertEquals($namedRepositoryVersionTwo, $config->getRepositories());
+    }
+
+    public function testNamedRepositorySourceFlaggedWithImmutableWillLast()
+    {
+        $config = new Config(false);
+
+        $namedRepository = array('named-repository' => array('type' => 'git', 'url' => 'https://127.0.0.1', 'immutable' => true));
+        $config->merge(array('repositories' => $namedRepository + array("packagist" => false)));
+        $this->assertEquals($namedRepository, $config->getRepositories());
+
+        $namedRepositoryVersionTwo = array('named-repository' => array('type' => 'git', 'url' => 'https://localhost'));
+        $config->merge(array('repositories' => $namedRepositoryVersionTwo));
+        $this->assertEquals($namedRepository, $config->getRepositories());
+    }
+
     /**
      * @dataProvider allowedUrlProvider
      *


### PR DESCRIPTION
I was looking for a way to redefine a repository source which was already named in a projects composer configuration. This is needed as the repository which is providing one of the required components is available on different networks, depending where the consumer is located. (Just imagine you need to change from ssh to https.)
First approach was to define that repository in global composer config, but as it turns out it don't make sense to define a named repository in that config, as it will always be overruled by any same named repository, if located in a project composer file.
So I added merge logic for a new attribute `immutable`. If any named repository has that attribute enabled, it will not be overruled by any other repository config for the same name.
- allows to define named repositories that will not be overruled by another same named repository
- allows to define required repository sources that can have a different source configuration

Expected usage / example:
global composer config

``` json
{
    "config": {
    },
    "repositories": {
        "a-company-component-repository": {
            "type": "git",
            "url": "https://1.2.3.4/scm/component.git",
            "immutable": true
        },
    }
}
```

project composer config

``` json
    "autoload-dev": {
    ...
    },
    "repositories": {
        "a-company-component-repository": {
            "type": "git",
            "url": "ssh://4.3.2.1:8150/intranet/whatever/component.git"
        },
    ...
    },
    ....
```

When it now comes to any composer action, `ssh://4.3.2.1:8150/intranet/whatever/component.git` should not be involved, as it's configuration is shadowed by the global composer entry for `a-company-component-repository`.

If there is already another way to solve this problem, please let me now - I spend already some time searching for this. (I don't want to host a proxy for this ;) )
