### PR TITLE
[WIP] Default composer init settings

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -509,6 +509,66 @@ EOT
             return $this->configSource->addConfigSetting($settingKey, $values[0]);
         }
 
+        // handle defaults
+        $uniqueDefaults = array(
+            'vendor-prefix' => array('is_string', function ($val) { return $val; }),
+            'type' => array('is_string', function ($val) { return $val; }),
+            'description' => array('is_string', function ($val) { return $val; }),
+            'minimum-stability' => array(
+                function ($val) { return isset(BasePackage::$stabilities[VersionParser::normalizeStability($val)]); },
+                function ($val) { return VersionParser::normalizeStability($val); }
+            ),
+        );
+        $multiDefaults = array(
+            'license' => array(
+                function ($vals) {
+                    if (!is_array($vals)) {
+                        return 'array expected';
+                    }
+
+                    return true;
+                },
+                function ($vals) {
+                    return $vals;
+                },
+            ),
+        );
+
+        if (preg_match('/^defaults\.(.+)/', $settingKey, $matches)) {
+            if (! $input->getOption('global')) {
+                throw new \InvalidArgumentException('The '.$settingKey.' property can only be set in the global config.json file. Use `composer config -g` instead.');
+            }
+
+            if ($input->getOption('unset')) {
+                return $this->configSource->removeConfigSetting($settingKey);
+            }
+
+            if ('defaults.author' == $settingKey) {
+                // TODO: Extract parseAuthorString to Trait or Util. Not sure about best approach but this isn't it.
+                $initCmd = new InitCommand();
+                $author = $initCmd->parseAuthorString($values[0]);
+
+                return $this->configSource->addConfigSetting('defaults.author', $author);
+            }
+
+            if (preg_match('/^defaults\.author\.(.+)/', $settingKey, $authorMatches)) {
+                $composer = $this->getComposer();
+                $config = $composer->getConfig();
+                $defaults = $config->get('defaults');
+                $author = empty($defaults['author']) ? array() : $defaults['author'];
+                $author[$authorMatches[1]] = $values[0];
+
+                return $this->configSource->addConfigSetting('defaults.author', $author);
+            }
+
+            if (isset($uniqueDefaults[$matches[1]])) {
+                return $this->handleSingleValue($settingKey, $uniqueDefaults[$matches[1]], $values, 'addConfigSetting');
+            }
+            if (isset($multiDefaults[$matches[1]])) {
+                return $this->handleMultiValue($settingKey, $multiDefaults[$matches[1]], $values, 'addConfigSetting');
+            }
+        }
+
         // handle auth
         if (preg_match('/^(bitbucket-oauth|github-oauth|gitlab-oauth|gitlab-token|http-basic)\.(.+)/', $settingKey, $matches)) {
             if ($input->getOption('unset')) {

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -316,11 +316,13 @@ EOT
         );
         $input->setOption('type', $type);
 
-        $license = $input->getOption('license') ?: (! empty($defaults['license']) ? $defaults['license'] : false);
+        $license = $input->getOption('license') ?: (! empty($defaults['license']) ? implode(', ', $defaults['license']) : false);
         $license = $io->ask(
             'License [<comment>'.$license.'</comment>]: ',
             $license
         );
+        $license = preg_split('/, ?/', $license);
+        $license = count($license) > 1 ? $license : implode($license);
         $input->setOption('license', $license);
 
         $io->writeError(array('', 'Define your dependencies.', ''));


### PR DESCRIPTION
This allows setting default values for the `composer init` command, for example setting a default vendor prefix for packages, or a default author email that differs from your git email.

Defaults can be set via the `composer config` command with the `global` option set. 
The following defaults are supported:

``` js
[
   "vendor-prefix",
   "description",
   "author", // Using John Smith <john@example.com> format
   "author.name",
   "author.email",
   "minimum-stability",
   "type",
   "license"
]
```

Example `composer config` usage:

``` bash
composer config -g defaults.vendor-prefix vendor
composer config -g defaults.author John Smith <john@example.com>
composer config -g defaults.author.email john@example.com
```

TODO:
- Currently the `ConfigCommand` uses `InitCommand::parseAuthorString` to parse the author string. The `parseAuthorString` should be extracted to a `trait` or a `utility`, I'm not sure what the recommended approach is. However, creating an instance of `InitCommand` to run a single method is not the right approach, which is what I'm doing now.

Related issue: #5357
