### PR TITLE
add check for non-strings in VersionParser

### DIFF
--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -23,6 +23,9 @@ class VersionParser extends SemverVersionParser
      */
     public function parseConstraints($constraints)
     {
+        if (!is_string($constraints)) {
+            throw new \UnexpectedValueException('Version constraint must be string.');
+        }
         if (!isset(self::$constraints[$constraints])) {
             self::$constraints[$constraints] = parent::parseConstraints($constraints);
         }

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Package\Version;
+
+
+class VersionParserTest extends \PHPUnit_Framework_TestCase
+{
+    public function testParseConstraintsRejectsArray()
+    {
+        $parser = new \Composer\Package\Version\VersionParser();
+        $invalid_constraint = array();
+        $did_throw_exception = false;
+        $exception_message = null;
+        try {
+            $parser->parseConstraints($invalid_constraint);
+        } catch (\UnexpectedValueException $e) {
+            $did_throw_exception = true;
+            $exception_message = $e->getMessage();
+        }
+        $this->assertEquals($did_throw_exception, true);
+        $this->assertEquals($exception_message, 'Version constraint must be string.');
+    }
+}


### PR DESCRIPTION
An invalid `composer.json` of the form 

``` json
{
    "name": "gregnisbet/thing",
    "require": {
        "a": ["a"]
    }
}
```

currently results in an error message that's rather difficult to interpret

```
 [ErrorException]
  Illegal offset type in isset or empty
```

I added an explicit check in `parseConstraints` to check that the parameter `$constraints` is a string before attempting to use it as a key in `$self::$constraints`, the error message now reads

```
  [UnexpectedValueException]
  Version constraint must be string.
```

Which is somewhat less than ideal because it doesn't tell you where in your `composer.json` the ill-formed constraint is, but hopefully is more informative.
