### PR TITLE
Fix crash when listing root package without versions

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -179,7 +179,7 @@ EOT
                 if ($input->getOption('latest')) {
                     $latestPackage = $this->findLatestPackage($package, $composer, $phpVersion);
                 }
-                $this->printMeta($package, $versions, $installedRepo, $latestPackage);
+                $this->printMeta($package, $versions, $installedRepo, $latestPackage ?: null);
                 $this->printLinks($package, 'requires');
                 $this->printLinks($package, 'devRequires', 'requires (dev)');
                 if ($package->getSuggests()) {


### PR DESCRIPTION
When using certain parameters together in 'composer show', specifically '-s --outdated', the root package itself is inspected for its latest version. If the git repository it belongs to does not have any tags yet this would return FALSE, while the next call to printMeta requires a PackageInterface or NULL, causing a crash.

Refs #5808 