### PR TITLE
added more information in the output

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -492,6 +492,38 @@ class Installer
             $devPackages = null;
         }
 
+        if ($operations) {
+            $installs = $updates = $uninstalls = array();
+            foreach ($operations as $operation) {
+                if ($operation instanceof InstallOperation) {
+                    $installs[] = $operation->getPackage()->getPrettyName().':'.$operation->getPackage()->getFullPrettyVersion();
+                } elseif ($operation instanceof UpdateOperation) {
+                    $updates[] = $operation->getTargetPackage()->getPrettyName().':'.$operation->getTargetPackage()->getFullPrettyVersion();
+                } elseif ($operation instanceof UninstallOperation) {
+                    $uninstalls[] = $operation->getPackage()->getPrettyName();
+                }
+            }
+
+            $this->io->writeError(
+                sprintf("<info>Package operations: %d install%s, %d update%s, %d removal%s</info>",
+                count($installs),
+                1 === count($installs) ? '' : 's',
+                count($updates),
+                1 === count($updates) ? '' : 's',
+                count($uninstalls),
+                1 === count($uninstalls) ? '' : 's')
+            );
+            if ($installs) {
+                $this->io->writeError("Installs: ".implode(', ', $installs), true, IOInterface::VERBOSE);
+            }
+            if ($updates) {
+                $this->io->writeError("Updates: ".implode(', ', $updates), true, IOInterface::VERBOSE);
+            }
+            if ($uninstalls) {
+                $this->io->writeError("Removals: ".implode(', ', $uninstalls), true, IOInterface::VERBOSE);
+            }
+        }
+
         foreach ($operations as $operation) {
             // collect suggestions
             if ('install' === $operation->getJobType()) {

--- a/tests/Composer/Test/Fixtures/installer/abandoned-listed.test
+++ b/tests/Composer/Test/Fixtures/installer/abandoned-listed.test
@@ -26,6 +26,7 @@ install
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
 Updating dependencies (including require-dev)
+Package operations: 2 installs, 0 updates, 0 removals
 <warning>Package a/a is abandoned, you should avoid using it. No replacement was suggested.</warning>
 <warning>Package c/c is abandoned, you should avoid using it. Use b/b instead.</warning>
 Writing lock file

--- a/tests/Composer/Test/Fixtures/installer/github-issues-4795-2.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-4795-2.test
@@ -36,6 +36,7 @@ update a b --with-dependencies
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
 Updating dependencies (including require-dev)
+Package operations: 0 installs, 2 updates, 0 removals
 Writing lock file
 Generating autoload files
 

--- a/tests/Composer/Test/Fixtures/installer/suggest-installed.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-installed.test
@@ -21,6 +21,7 @@ install
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
 Updating dependencies (including require-dev)
+Package operations: 2 installs, 0 updates, 0 removals
 Writing lock file
 Generating autoload files
 

--- a/tests/Composer/Test/Fixtures/installer/suggest-prod.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-prod.test
@@ -19,6 +19,7 @@ install --no-dev
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
 Updating dependencies
+Package operations: 1 install, 0 updates, 0 removals
 Writing lock file
 Generating autoload files
 

--- a/tests/Composer/Test/Fixtures/installer/suggest-replaced.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-replaced.test
@@ -21,6 +21,7 @@ install
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
 Updating dependencies (including require-dev)
+Package operations: 2 installs, 0 updates, 0 removals
 Writing lock file
 Generating autoload files
 

--- a/tests/Composer/Test/Fixtures/installer/suggest-uninstalled.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-uninstalled.test
@@ -19,6 +19,7 @@ install
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
 Updating dependencies (including require-dev)
+Package operations: 1 install, 0 updates, 0 removals
 a/a suggests installing b/b (an obscure reason)
 Writing lock file
 Generating autoload files


### PR DESCRIPTION
This PR adds two pieces of output:
- One line of summary about what Composer is about to install, remove, update (always displayed, not on quiet mode of course);
- Up to 3 lines, in verbose mode only, to list the operations that are going to occur.

The goal is to give some more information upfront about what's going to happen next. A lot of package managers do that and I find it extremely useful for both informational purpose and debugging purpose as well.
