### PR TITLE
fixed deprecated class usages

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -21,8 +21,7 @@ use Composer\Composer;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\Repository\CompositeRepository;
 use Composer\Script;
-use Composer\Script\CommandEvent;
-use Composer\Script\PackageEvent;
+use Composer\Installer\PackageEvent;
 use Composer\Installer\BinaryInstaller;
 use Composer\Util\ProcessExecutor;
 use Composer\Script\Event as ScriptEvent;
@@ -270,9 +269,9 @@ class EventDispatcher
     }
 
     /**
-     * @param  mixed              $target
-     * @param  Event              $event
-     * @return Event|CommandEvent
+     * @param  mixed $target
+     * @param  Event $event
+     * @return Event
      */
     protected function checkListenerExpectedEvent($target, Event $event)
     {

--- a/src/Composer/Installer/PackageEvents.php
+++ b/src/Composer/Installer/PackageEvents.php
@@ -22,7 +22,7 @@ class PackageEvents
     /**
      * The PRE_PACKAGE_INSTALL event occurs before a package is installed.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @var string
      */
@@ -31,7 +31,7 @@ class PackageEvents
     /**
      * The POST_PACKAGE_INSTALL event occurs after a package is installed.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @var string
      */
@@ -40,7 +40,7 @@ class PackageEvents
     /**
      * The PRE_PACKAGE_UPDATE event occurs before a package is updated.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @var string
      */
@@ -49,7 +49,7 @@ class PackageEvents
     /**
      * The POST_PACKAGE_UPDATE event occurs after a package is updated.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @var string
      */
@@ -58,7 +58,7 @@ class PackageEvents
     /**
      * The PRE_PACKAGE_UNINSTALL event occurs before a package has been uninstalled.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @var string
      */
@@ -67,7 +67,7 @@ class PackageEvents
     /**
      * The POST_PACKAGE_UNINSTALL event occurs after a package has been uninstalled.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @var string
      */

--- a/src/Composer/Script/ScriptEvents.php
+++ b/src/Composer/Script/ScriptEvents.php
@@ -23,7 +23,7 @@ class ScriptEvents
     /**
      * The PRE_INSTALL_CMD event occurs before the install command is executed.
      *
-     * The event listener method receives a Composer\Script\CommandEvent instance.
+     * The event listener method receives a Composer\Script\Event instance.
      *
      * @var string
      */
@@ -32,7 +32,7 @@ class ScriptEvents
     /**
      * The POST_INSTALL_CMD event occurs after the install command is executed.
      *
-     * The event listener method receives a Composer\Script\CommandEvent instance.
+     * The event listener method receives a Composer\Script\Event instance.
      *
      * @var string
      */
@@ -41,7 +41,7 @@ class ScriptEvents
     /**
      * The PRE_UPDATE_CMD event occurs before the update command is executed.
      *
-     * The event listener method receives a Composer\Script\CommandEvent instance.
+     * The event listener method receives a Composer\Script\Event instance.
      *
      * @var string
      */
@@ -50,7 +50,7 @@ class ScriptEvents
     /**
      * The POST_UPDATE_CMD event occurs after the update command is executed.
      *
-     * The event listener method receives a Composer\Script\CommandEvent instance.
+     * The event listener method receives a Composer\Script\Event instance.
      *
      * @var string
      */
@@ -59,7 +59,7 @@ class ScriptEvents
     /**
      * The PRE_STATUS_CMD event occurs before the status command is executed.
      *
-     * The event listener method receives a Composer\Script\CommandEvent instance.
+     * The event listener method receives a Composer\Script\Event instance.
      *
      * @var string
      */
@@ -68,7 +68,7 @@ class ScriptEvents
     /**
      * The POST_STATUS_CMD event occurs after the status command is executed.
      *
-     * The event listener method receives a Composer\Script\CommandEvent instance.
+     * The event listener method receives a Composer\Script\Event instance.
      *
      * @var string
      */
@@ -95,7 +95,7 @@ class ScriptEvents
     /**
      * The POST_ROOT_PACKAGE_INSTALL event occurs after the root package has been installed.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @var string
      */
@@ -105,7 +105,7 @@ class ScriptEvents
      * The POST_CREATE_PROJECT event occurs after the create-project command has been executed.
      * Note: Event occurs after POST_INSTALL_CMD
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @var string
      */
@@ -114,7 +114,7 @@ class ScriptEvents
     /**
      * The PRE_ARCHIVE_CMD event occurs before the update command is executed.
      *
-     * The event listener method receives a Composer\Script\CommandEvent instance.
+     * The event listener method receives a Composer\Script\Event instance.
      *
      * @var string
      */
@@ -123,7 +123,7 @@ class ScriptEvents
     /**
      * The POST_ARCHIVE_CMD event occurs after the status command is executed.
      *
-     * The event listener method receives a Composer\Script\CommandEvent instance.
+     * The event listener method receives a Composer\Script\Event instance.
      *
      * @var string
      */
@@ -134,7 +134,7 @@ class ScriptEvents
     /**
      * The PRE_PACKAGE_INSTALL event occurs before a package is installed.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::PRE_PACKAGE_INSTALL instead.
      * @var string
@@ -144,7 +144,7 @@ class ScriptEvents
     /**
      * The POST_PACKAGE_INSTALL event occurs after a package is installed.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::POST_PACKAGE_INSTALL instead.
      * @var string
@@ -154,7 +154,7 @@ class ScriptEvents
     /**
      * The PRE_PACKAGE_UPDATE event occurs before a package is updated.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::PRE_PACKAGE_UPDATE instead.
      * @var string
@@ -164,7 +164,7 @@ class ScriptEvents
     /**
      * The POST_PACKAGE_UPDATE event occurs after a package is updated.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::POST_PACKAGE_UPDATE instead.
      * @var string
@@ -174,7 +174,7 @@ class ScriptEvents
     /**
      * The PRE_PACKAGE_UNINSTALL event occurs before a package has been uninstalled.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::PRE_PACKAGE_UNINSTALL instead.
      * @var string
@@ -184,7 +184,7 @@ class ScriptEvents
     /**
      * The POST_PACKAGE_UNINSTALL event occurs after a package has been uninstalled.
      *
-     * The event listener method receives a Composer\Script\PackageEvent instance.
+     * The event listener method receives a Composer\Installer\PackageEvent instance.
      *
      * @deprecated Use Composer\Installer\PackageEvents::POST_PACKAGE_UNINSTALL instead.
      * @var string


### PR DESCRIPTION
This PR mostly updates phpdoc to reference the non-deprecated event classes. It also fixes the event dispatcher which stills uses a deprecated event class.
