### PR TITLE
Enhance the json schema with validation for map objects

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -77,32 +77,44 @@
         "require": {
             "type": "object",
             "description": "This is a hash of package name (keys) and version constraints (values) that are required to run this package.",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "replace": {
             "type": "object",
             "description": "This is a hash of package name (keys) and version constraints (values) that can be replaced by this package.",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "conflict": {
             "type": "object",
             "description": "This is a hash of package name (keys) and version constraints (values) that conflict with this package.",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "provide": {
             "type": "object",
             "description": "This is a hash of package name (keys) and version constraints (values) that this package provides in addition to this package's name.",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "require-dev": {
             "type": "object",
             "description": "This is a hash of package name (keys) and version constraints (values) that this package requires for developing it (testing tools and such).",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "suggest": {
             "type": "object",
             "description": "This is a hash of package name (keys) and descriptions (values) that this package suggests work well with it (this will be suggested to the user during installation).",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "config": {
             "type": "object",
@@ -134,12 +146,16 @@
                 "github-oauth": {
                     "type": "object",
                     "description": "A hash of domain name => github API oauth tokens, typically {\"github.com\":\"<token>\"}.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "gitlab-oauth": {
                     "type": "object",
                     "description": "A hash of domain name => gitlab API oauth tokens, typically {\"gitlab.com\":\"<token>\"}.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "disable-tls": {
                     "type": "boolean",
@@ -160,7 +176,20 @@
                 "http-basic": {
                     "type": "object",
                     "description": "A hash of domain name => {\"username\": \"...\", \"password\": \"...\"}.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": "object",
+                        "required": ["username", "password"],
+                        "properties": {
+                            "username": {
+                                "type": "string",
+                                "description": "The username used for HTTP Basic authentication"
+                            },
+                            "password": {
+                                "type": "string",
+                                "description": "The password used for HTTP Basic authentication"
+                            }
+                        }
+                    }
                 },
                 "store-auths": {
                     "type": ["string", "boolean"],
@@ -169,7 +198,9 @@
                 "platform": {
                     "type": "object",
                     "description": "This is a hash of package name (keys) and version (values) that will be used to mock the platform packages on this machine.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "vendor-dir": {
                     "type": "string",
@@ -275,12 +306,22 @@
                 "psr-0": {
                     "type": "object",
                     "description": "This is a hash of namespaces (keys) and the directories they can be found in (values, can be arrays of paths) by the autoloader.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": ["string", "array"],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "psr-4": {
                     "type": "object",
                     "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": ["string", "array"],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "classmap": {
                     "type": "array",
@@ -303,12 +344,22 @@
                 "psr-0": {
                     "type": "object",
                     "description": "This is a hash of namespaces (keys) and the directories they can be found into (values, can be arrays of paths) by the autoloader.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": ["string", "array"],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "psr-4": {
                     "type": "object",
                     "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": ["string", "array"],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "classmap": {
                     "type": "array",

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -44,6 +44,14 @@ class ComposerSchemaTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->check($json));
     }
 
+    public function testRequireTypes()
+    {
+        $json = '{"name": "name", "description": "description", "require": {"a": ["b"]} }';
+        $this->assertEquals(array(
+            array('property' => 'require.a', 'message' => 'Array value found, but a string is required', 'constraint' => 'type'),
+        ), $this->check($json));
+    }
+
     public function testMinimumStabilityValues()
     {
         $json = '{ "name": "vendor/package", "description": "generic description", "minimum-stability": "" }';


### PR DESCRIPTION
``additionalProperties`` does not only accept a boolean, but also a schema object, in which case the value of the additional property must validate this schema (``true`` is equivalent to adding a catch-all schema).

I added this extra validation for all places using ``additionalProperties`` except 2 of them:

- ``extra`` because the content is really free-form
- ``repositories`` because the inner content is very complex, and I prefer keeping this in a separate PR (looking at a way to avoid duplicating things in Satis, where we already worked on adding validation for it, and probably submitted to master as it would make bigger changes to the schema)

Refs #5807