### PR TITLE
Fixing empty VCS URL for file:/// paths with spaces

### DIFF
--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -73,6 +73,8 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
                     if (0 === strpos($url, $needle)) {
                         $url = substr($url, strlen($needle));
                     }
+                    // realpath() will also not understand %20 etc
+                    $url = rawurldecode($url);
                     $url = realpath($url);
                 }
                 $this->doDownload($package, $path, $url);


### PR DESCRIPTION
realpath() returns FALSE for fFile paths with URL encoding like %20 for
spaces.