### PR TITLE
Fixing local file VCS URLs with encoded characters 

### DIFF
--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -70,10 +70,10 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
                     // realpath() below will not understand
                     // url that starts with "file://"
                     $needle = 'file://';
-                    $is_file_protocol = false;
+                    $isFileProtocol = false;
                     if (0 === strpos($url, $needle)) {
                         $url = substr($url, strlen($needle));
-                        $is_file_protocol = true;
+                        $isFileProtocol = true;
                     }
 
                     // realpath() below will not understand %20 spaces etc.
@@ -83,9 +83,9 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
 
                     $url = realpath($url);
 
-					if ($is_file_protocol) {
-						$url = $needle . $url;
-					}
+                    if ($isFileProtocol) {
+                        $url = $needle . $url;
+                    }
                 }
                 $this->doDownload($package, $path, $url);
                 break;

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -67,15 +67,25 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
         while ($url = array_shift($urls)) {
             try {
                 if (Filesystem::isLocalPath($url)) {
-                    # realpath() below will not understand
-                    # url that starts with "file://"
+                    // realpath() below will not understand
+                    // url that starts with "file://"
                     $needle = 'file://';
+                    $is_file_protocol = false;
                     if (0 === strpos($url, $needle)) {
                         $url = substr($url, strlen($needle));
+                        $is_file_protocol = true;
                     }
-                    // realpath() will also not understand %20 etc
-                    $url = rawurldecode($url);
+
+                    // realpath() below will not understand %20 spaces etc.
+                    if (false !== strpos($url, '%')) {
+                        $url = rawurldecode($url);
+                    }
+
                     $url = realpath($url);
+
+					if ($is_file_protocol) {
+						$url = $needle . $url;
+					}
                 }
                 $this->doDownload($package, $path, $url);
                 break;

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -73,6 +73,8 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
                     if (0 === strpos($url, $needle)) {
                         $url = substr($url, strlen($needle));
                     }
+                    // realpath() will also not understand %20 etc
+                    $url = rawurldecode($url);
                     $url = realpath($url);
                 }
                 $this->doDownload($package, $path, $url);


### PR DESCRIPTION
realpath() returns FALSE for paths with URL encoding like %20, and decoded path needs file:/// reapplied.

(this was originally pull request #5845)