### PR TITLE
Remove usage of echo when executing Composer script

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -99,7 +99,17 @@ class ProcessExecutor
             return;
         }
 
-        echo $buffer;
+        if (null === $this->io) {
+            echo $buffer;
+
+            return;
+        }
+
+        if (Process::ERR === $type) {
+            $this->io->writeError($buffer);
+        } else {
+            $this->io->write($buffer);
+        }
     }
 
     public static function getTimeout()

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -340,7 +340,7 @@ class EventDispatcherTest extends TestCase
             ->setConstructorArgs(array(
                 $this->createComposerInstance(),
                 $io = $this->getMock('Composer\IO\IOInterface'),
-                new ProcessExecutor,
+                new ProcessExecutor($io),
             ))
             ->setMethods(array('getListeners'))
             ->getMock();
@@ -354,9 +354,11 @@ class EventDispatcherTest extends TestCase
             ->method('writeError')
             ->with($this->equalTo('> echo foo'));
 
-        ob_start();
+        $io->expects($this->once())
+            ->method('write')
+            ->with($this->equalTo('foo'.PHP_EOL));
+
         $dispatcher->dispatchScript(ScriptEvents::POST_INSTALL_CMD, false);
-        $this->assertEquals('foo', trim(ob_get_clean()));
     }
 
     public function testDispatcherOutputsErrorOnFailedCommand()

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -35,6 +35,17 @@ class ProcessExecutorTest extends TestCase
         $this->assertEquals("foo".PHP_EOL, $output);
     }
 
+    public function testUseIOIsNotNullAndIfNotCaptured()
+    {
+        $io = $this->getMock('Composer\IO\IOInterface');
+        $io->expects($this->once())
+            ->method('write')
+            ->with($this->equalTo('foo'.PHP_EOL));
+
+        $process = new ProcessExecutor($io);
+        $process->execute('echo foo');
+    }
+
     public function testExecuteCapturesStderr()
     {
         $process = new ProcessExecutor;


### PR DESCRIPTION
All output go through the IO object, except the output of the script executions, which is output directly via `echo`. This PR fixes this bug.
