### PR TITLE
Use random name for tmp ini and delete after use

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -19,6 +19,7 @@ use Composer\Downloader\TransportException;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Composer\Util\ConfigValidator;
+use Composer\Util\IniHelper;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\RemoteFilesystem;
 use Composer\Util\StreamContextFactory;
@@ -436,14 +437,9 @@ EOT
         // code below taken from getcomposer.org/installer, any changes should be made there and replicated here
         $errors = array();
         $warnings = array();
-
-        $iniPath = php_ini_loaded_file();
         $displayIniMessage = false;
-        if ($iniPath) {
-            $iniMessage = PHP_EOL.PHP_EOL.'The php.ini used by your command-line PHP is: ' . $iniPath;
-        } else {
-            $iniMessage = PHP_EOL.PHP_EOL.'A php.ini file does not exist. You will have to create one.';
-        }
+
+        $iniMessage = PHP_EOL.PHP_EOL.IniHelper::getMessage();
         $iniMessage .= PHP_EOL.'If you can not modify the ini file, you can also run `php -d option=value` to modify ini values on the fly. You can use -d multiple times.';
 
         if (!function_exists('json_decode')) {

--- a/src/Composer/DependencyResolver/SolverProblemsException.php
+++ b/src/Composer/DependencyResolver/SolverProblemsException.php
@@ -12,6 +12,8 @@
 
 namespace Composer\DependencyResolver;
 
+use Composer\Util\IniHelper;
+
 /**
  * @author Nils Adermann <naderman@naderman.de>
  */
@@ -58,21 +60,13 @@ class SolverProblemsException extends \RuntimeException
 
     private function createExtensionHint()
     {
-        $paths = array();
+        $paths = IniHelper::getAll();
 
-        if (($iniPath = php_ini_loaded_file()) !== false) {
-            $paths[] = $iniPath;
-        }
-
-        if (!defined('HHVM_VERSION') && $additionalIniPaths = php_ini_scanned_files()) {
-            $paths = array_merge($paths, array_map("trim", explode(",", $additionalIniPaths)));
-        }
-
-        if (count($paths) === 0) {
+        if (count($paths) === 1 && empty($paths[0])) {
             return '';
         }
 
-        $text = "\n  To enable extensions, verify that they are enabled in those .ini files:\n    - ";
+        $text = "\n  To enable extensions, verify that they are enabled in your .ini files:\n    - ";
         $text .= implode("\n    - ", $paths);
         $text .= "\n  You can also run `php --ini` inside terminal to see which files are used by PHP in CLI mode.";
 

--- a/src/Composer/Downloader/RarDownloader.php
+++ b/src/Composer/Downloader/RarDownloader.php
@@ -15,6 +15,7 @@ namespace Composer\Downloader;
 use Composer\Config;
 use Composer\Cache;
 use Composer\EventDispatcher\EventDispatcher;
+use Composer\Util\IniHelper;
 use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\RemoteFilesystem;
@@ -55,13 +56,7 @@ class RarDownloader extends ArchiveDownloader
 
         if (!class_exists('RarArchive')) {
             // php.ini path is added to the error message to help users find the correct file
-            $iniPath = php_ini_loaded_file();
-
-            if ($iniPath) {
-                $iniMessage = 'The php.ini used by your command-line PHP is: ' . $iniPath;
-            } else {
-                $iniMessage = 'A php.ini file does not exist. You will have to create one.';
-            }
+            $iniMessage = IniHelper::getMessage();
 
             $error = "Could not decompress the archive, enable the PHP rar extension or install unrar.\n"
                 . $iniMessage . "\n" . $processError;

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -16,6 +16,7 @@ use Composer\Config;
 use Composer\Cache;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\Package\PackageInterface;
+use Composer\Util\IniHelper;
 use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\RemoteFilesystem;
@@ -49,14 +50,7 @@ class ZipDownloader extends ArchiveDownloader
 
         if (!class_exists('ZipArchive') && !self::$hasSystemUnzip) {
             // php.ini path is added to the error message to help users find the correct file
-            $iniPath = php_ini_loaded_file();
-
-            if ($iniPath) {
-                $iniMessage = 'The php.ini used by your command-line PHP is: ' . $iniPath;
-            } else {
-                $iniMessage = 'A php.ini file does not exist. You will have to create one.';
-            }
-
+            $iniMessage = IniHelper::getMessage();
             $error = "The zip extension and unzip command are both missing, skipping.\n" . $iniMessage;
 
             throw new \RuntimeException($error);

--- a/src/Composer/Util/IniHelper.php
+++ b/src/Composer/Util/IniHelper.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Util;
+
+/**
+ * Provides ini file location functions that work with and without a restart.
+ * When the process has restarted it uses a tmp ini and stores the original
+ * ini locations in an environment variable.
+ *
+ * @author John Stevenson <john-stevenson@blueyonder.co.uk>
+ */
+class IniHelper
+{
+    const ENV_ORIGINAL = 'COMPOSER_ORIGINAL_INIS';
+
+    /**
+     * Returns an array of php.ini locations with at least one entry
+     *
+     * The equivalent of calling php_ini_loaded_file then php_ini_scanned_files.
+     * The loaded ini location is the first entry and may be empty.
+
+     * @return array
+     */
+    public static function getAll()
+    {
+        if ($env = strval(getenv(self::ENV_ORIGINAL))) {
+            return explode(PATH_SEPARATOR, $env);
+        }
+
+        $paths = array(strval(php_ini_loaded_file()));
+
+        if ($scanned = php_ini_scanned_files()) {
+            $paths = array_merge($paths, array_map('trim', explode(',', $scanned)));
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Describes the location of the loaded php.ini file
+     *
+     * @return string
+     */
+    public static function getMessage()
+    {
+        $paths = self::getAll();
+
+        if (empty($paths[0])) {
+            return 'A php.ini file does not exist. You will have to create one.';
+        }
+
+        return 'The php.ini used by your command-line PHP is: '.$paths[0];
+    }
+}

--- a/tests/Composer/Test/Util/IniHelperTest.php
+++ b/tests/Composer/Test/Util/IniHelperTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Util;
+
+use Composer\Util\IniHelper;
+
+/**
+ * @author John Stevenson <john-stevenson@blueyonder.co.uk>
+ */
+class IniHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public static $envOriginal;
+
+    public function testWithLoadedIni()
+    {
+        $paths = array(
+            'loaded.ini',
+        );
+
+        $this->setEnv($paths);
+        $this->assertContains('loaded.ini', IniHelper::getMessage());
+        $this->assertEquals($paths, IniHelper::getAll());
+    }
+
+    public function testWithoutLoadedIni()
+    {
+        $paths = array(
+            '',
+            'one.ini',
+            'two.ini',
+        );
+
+        $this->setEnv($paths);
+        $this->assertContains('does not exist', IniHelper::getMessage());
+        $this->assertEquals($paths, IniHelper::getAll());
+    }
+
+    public static function setUpBeforeClass()
+    {
+        // Save current state
+        self::$envOriginal = getenv(IniHelper::ENV_ORIGINAL);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        // Restore original state
+        if (false !== self::$envOriginal) {
+            putenv(IniHelper::ENV_ORIGINAL.'='.self::$envOriginal);
+        } else {
+            putenv(IniHelper::ENV_ORIGINAL);
+        }
+    }
+
+    protected function setEnv(array $paths)
+    {
+        putenv(IniHelper::ENV_ORIGINAL.'='.implode(PATH_SEPARATOR, $paths));
+    }
+}

--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test;
 
 use Composer\Test\Mock\XdebugHandlerMock;
+use Composer\Util\IniHelper;
 
 /**
  * @author John Stevenson <john-stevenson@blueyonder.co.uk>
@@ -22,8 +23,7 @@ use Composer\Test\Mock\XdebugHandlerMock;
  */
 class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    public static $envAllow;
-    public static $envIniScanDir;
+    public static $env = array();
 
     public function testRestartWhenLoaded()
     {
@@ -32,6 +32,7 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $this->assertTrue($xdebug->restarted);
+        $this->assertNotEquals(false, getenv(IniHelper::ENV_ORIGINAL));
     }
 
     public function testNoRestartWhenNotLoaded()
@@ -41,6 +42,7 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $this->assertFalse($xdebug->restarted);
+        $this->assertEquals(false, getenv(IniHelper::ENV_ORIGINAL));
     }
 
     public function testNoRestartWhenLoadedAndAllowed()
@@ -106,28 +108,35 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
 
     public static function setUpBeforeClass()
     {
-        self::$envAllow = getenv(XdebugHandlerMock::ENV_ALLOW);
-        self::$envIniScanDir = getenv('PHP_INI_SCAN_DIR');
+        // Save current state
+        $names = array(
+            XdebugHandlerMock::ENV_ALLOW,
+            'PHP_INI_SCAN_DIR',
+            IniHelper::ENV_ORIGINAL,
+        );
+
+        foreach ($names as $name) {
+            self::$env[$name] = getenv($name);
+        }
     }
 
     public static function tearDownAfterClass()
     {
-        if (false !== self::$envAllow) {
-            putenv(XdebugHandlerMock::ENV_ALLOW.'='.self::$envAllow);
-        } else {
-            putenv(XdebugHandlerMock::ENV_ALLOW);
-        }
-
-        if (false !== self::$envIniScanDir) {
-            putenv('PHP_INI_SCAN_DIR='.self::$envIniScanDir);
-        } else {
-            putenv('PHP_INI_SCAN_DIR');
+        // Restore original state
+        foreach (self::$env as $name => $value) {
+            if (false !== $value) {
+                putenv($name.'='.$value);
+            } else {
+                putenv($name);
+            }
         }
     }
 
     protected function setUp()
     {
+        // Ensure env is unset
         putenv(XdebugHandlerMock::ENV_ALLOW);
         putenv('PHP_INI_SCAN_DIR');
+        putenv(IniHelper::ENV_ORIGINAL);
     }
 }

--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -32,7 +32,7 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $this->assertTrue($xdebug->restarted);
-        $this->assertNotEquals(false, getenv(IniHelper::ENV_ORIGINAL));
+        $this->assertInternalType('string', getenv(IniHelper::ENV_ORIGINAL));
     }
 
     public function testNoRestartWhenNotLoaded()
@@ -42,7 +42,7 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $this->assertFalse($xdebug->restarted);
-        $this->assertEquals(false, getenv(IniHelper::ENV_ORIGINAL));
+        $this->assertFalse(getenv(IniHelper::ENV_ORIGINAL));
     }
 
     public function testNoRestartWhenLoadedAndAllowed()


### PR DESCRIPTION
Question: Should `php_ini_scanned_files()` use a `function_exists` guard, since it was only introduced in HHVM in September 2014? I have left this out at the moment.
