### PR TITLE
use array as default value

### DIFF
--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -49,12 +49,14 @@ abstract class BasePackage implements PackageInterface
      * @var int
      */
     public $id;
-
+    /** @var string */
     protected $name;
+    /** @var string */
     protected $prettyName;
-
+    /** @var RepositoryInterface */
     protected $repository;
-    protected $transportOptions;
+    /** @var array */
+    protected $transportOptions = array();
 
     /**
      * All descendants' constructors should call this parent constructor
@@ -66,7 +68,6 @@ abstract class BasePackage implements PackageInterface
         $this->prettyName = $name;
         $this->name = strtolower($name);
         $this->id = -1;
-        $this->transportOptions = array();
     }
 
     /**

--- a/src/Composer/Package/Dumper/ArrayDumper.php
+++ b/src/Composer/Package/Dumper/ArrayDumper.php
@@ -118,7 +118,7 @@ class ArrayDumper
             }
         }
 
-        if (count($package->getTransportOptions()) > 0) {
+        if (is_array($package->getTransportOptions()) && count($package->getTransportOptions()) > 0) {
             $data['transport-options'] = $package->getTransportOptions();
         }
 

--- a/src/Composer/Package/Dumper/ArrayDumper.php
+++ b/src/Composer/Package/Dumper/ArrayDumper.php
@@ -118,7 +118,7 @@ class ArrayDumper
             }
         }
 
-        if (is_array($package->getTransportOptions()) && count($package->getTransportOptions()) > 0) {
+        if (count($package->getTransportOptions()) > 0) {
             $data['transport-options'] = $package->getTransportOptions();
         }
 

--- a/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
+++ b/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
@@ -31,6 +31,7 @@ class ArrayDumperTest extends \PHPUnit_Framework_TestCase
     {
         $this->dumper = new ArrayDumper();
         $this->package = $this->getMock('Composer\Package\CompletePackageInterface');
+        $this->packageExpects('getTransportOptions', array());
     }
 
     public function testRequiredInformation()
@@ -38,7 +39,8 @@ class ArrayDumperTest extends \PHPUnit_Framework_TestCase
         $this
             ->packageExpects('getPrettyName', 'foo')
             ->packageExpects('getPrettyVersion', '1.0')
-            ->packageExpects('getVersion', '1.0.0.0');
+            ->packageExpects('getVersion', '1.0.0.0')
+        ;
 
         $config = $this->dumper->dump($this->package);
         $this->assertEquals(
@@ -56,7 +58,9 @@ class ArrayDumperTest extends \PHPUnit_Framework_TestCase
         $this->package = $this->getMock('Composer\Package\RootPackageInterface');
 
         $this
-            ->packageExpects('getMinimumStability', 'dev');
+            ->packageExpects('getMinimumStability', 'dev')
+            ->packageExpects('getTransportOptions', array())
+        ;
 
         $config = $this->dumper->dump($this->package);
         $this->assertSame('dev', $config['minimum-stability']);
@@ -87,8 +91,14 @@ class ArrayDumperTest extends \PHPUnit_Framework_TestCase
      */
     public function testKeys($key, $value, $method = null, $expectedValue = null)
     {
+        $this->package = $this->getMock('Composer\Package\RootPackageInterface');
+
         $this->packageExpects('get'.ucfirst($method ?: $key), $value);
         $this->packageExpects('isAbandoned', $value);
+
+        if ($method !== 'transportOptions') {
+            $this->packageExpects('getTransportOptions', array());
+        }
 
         $config = $this->dumper->dump($this->package);
 

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -118,6 +118,13 @@ class LockerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersion')
             ->will($this->returnValue('0.1.10.0'));
 
+        foreach (array($package1, $package2) as $package) {
+            $package
+                ->expects($this->atLeastOnce())
+                ->method('getTransportOptions')
+                ->will($this->returnValue(array()));
+        }
+
         $contentHash = md5(trim($jsonContent));
 
         $json

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -198,18 +198,26 @@ class VersionSelectorTest extends \PHPUnit_Framework_TestCase
         $versionParser = new VersionParser();
 
         $package = $this->getMock('\Composer\Package\PackageInterface');
-        $package->expects($this->any())
+        $package
+            ->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue($prettyVersion));
-        $package->expects($this->any())
+        $package
+            ->expects($this->any())
             ->method('getVersion')
             ->will($this->returnValue($versionParser->normalize($prettyVersion)));
-        $package->expects($this->any())
+        $package
+            ->expects($this->any())
             ->method('isDev')
             ->will($this->returnValue($isDev));
-        $package->expects($this->any())
+        $package
+            ->expects($this->any())
             ->method('getStability')
             ->will($this->returnValue($stability));
+        $package
+            ->expects($this->any())
+            ->method('getTransportOptions')
+            ->will($this->returnValue(array()));
 
         $branchAlias = $branchAlias === null ? array() : array('branch-alias' => array($prettyVersion => $branchAlias));
         $package->expects($this->any())


### PR DESCRIPTION
Rather than assigning empty array in constructor, simply default to an array on the class attribute. Also add a guard clause in the dumper. This resolves failing tests on php 7.2.0 which no longer accepts non-countable arguments for `count()`.