### PR TITLE
disabling packagist.org did not work

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -662,7 +662,7 @@ You can disable the default Packagist repository by adding this to your
 {
     "repositories": [
         {
-            "packagist.org": false
+            "packagist": false
         }
     ]
 }


### PR DESCRIPTION
While testing i found that 

"packagist.org": false 

didn't work to disable packagist.

I have read following issue 

https://github.com/composer/composer/issues/3713

afterwards i've testet 

"composer config repositories.packagist false"

did the review on the composer.json and found that 

"packagist": false 

actually disabled packagist.