### PR TITLE
semver.mwl.be moved to HTTPS

### DIFF
--- a/doc/articles/versions.md
+++ b/doc/articles/versions.md
@@ -118,7 +118,7 @@ can be installed in a different stability than your default
 
 ## Test version constraints
 
-You can test version constraints using [semver.mwl.be](http://semver.mwl.be).
+You can test version constraints using [semver.mwl.be](https://semver.mwl.be).
 Fill in a package name and it will autofill the default version constraint
 which Composer would add to your `composer.json` file. You can adjust the
 version constraint and the tool will highlight all releases that match.


### PR DESCRIPTION
http://semver.mwl.be/ produce a 404, it moved to https://semver.mwl.be/