### PR TITLE
 #5716 - Add new PluginEvents: for pre/post file/vcs downloads

### DIFF
--- a/src/Composer/Plugin/FileDownloadEvent.php
+++ b/src/Composer/Plugin/FileDownloadEvent.php
@@ -19,8 +19,9 @@ use Composer\Util\RemoteFilesystem;
  * The pre file download event.
  *
  * @author Nils Adermann <naderman@naderman.de>
+ * @author Mohamed Tahrioui <mohamed.tahrioui@wheregroup.com>
  */
-class PreFileDownloadEvent extends Event
+class FileDownloadEvent extends Event
 {
     /**
      * @var RemoteFilesystem
@@ -31,7 +32,6 @@ class PreFileDownloadEvent extends Event
      * @var string
      */
     private $processedUrl;
-
     /**
      * Constructor.
      *

--- a/src/Composer/Plugin/PluginEvents.php
+++ b/src/Composer/Plugin/PluginEvents.php
@@ -16,6 +16,7 @@ namespace Composer\Plugin;
  * The Plugin Events.
  *
  * @author Nils Adermann <naderman@naderman.de>
+ * @author Mohamed Tahrioui <mohamed.tahrioui@wheregroup.com>
  */
 class PluginEvents
 {
@@ -43,9 +44,43 @@ class PluginEvents
      * The PRE_FILE_DOWNLOAD event occurs before downloading a file
      *
      * The event listener method receives a
-     * Composer\Plugin\PreFileDownloadEvent instance.
+     * Composer\Plugin\FileDownloadEvent instance.
      *
      * @var string
      */
+
     const PRE_FILE_DOWNLOAD = 'pre-file-download';
+
+
+    /**
+     * The POST_FILE_DOWNLOAD event occurs after downloading a file
+     *
+     * The event listener method receives a
+     * Composer\Plugin\FileDownloadEvent instance.
+     *
+     * @var string
+     */
+    const POST_FILE_DOWNLOAD = 'post-file-download';
+
+
+    /**
+     * The PRE_VCS_DOWNLOAD event occurs before downloading a repository
+     *
+     * The event listener method receives a
+     * Composer\Plugin\FileDownloadEvent instance.
+     *
+     * @var string
+     */
+    const PRE_VCS_DOWNLOAD = 'pre-vcs-download';
+
+
+    /**
+     * The POST_VCS_DOWNLOAD event occurs after downloading a repository
+     *
+     * The event listener method receives a
+     * Composer\Plugin\FileDownloadEvent instance.
+     *
+     * @var string
+     */
+    const POST_VCS_DOWNLOAD = 'post-vcs-download';
 }


### PR DESCRIPTION
As referenced in feature request #5716 this PR enables the FileDownloader to dispatch VCS Events.

- Also post-download events for regular file and VCS downloads were added.

- PreFileDownloadEvent was renamed to FileDownloadEvent for consistency.

Please note that VCS Downloads will **not** trigger file downloads anymore.