### PR TITLE
Do not add newlines to output

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -108,7 +108,7 @@ class ProcessExecutor
         if (Process::ERR === $type) {
             $this->io->writeError($buffer);
         } else {
-            $this->io->write($buffer);
+            $this->io->write($buffer, false);
         }
     }
 

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -106,7 +106,7 @@ class ProcessExecutor
         }
 
         if (Process::ERR === $type) {
-            $this->io->writeError($buffer);
+            $this->io->writeError($buffer, false);
         } else {
             $this->io->write($buffer, false);
         }

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -356,7 +356,7 @@ class EventDispatcherTest extends TestCase
 
         $io->expects($this->once())
             ->method('write')
-            ->with($this->equalTo('foo'.PHP_EOL));
+            ->with($this->equalTo('foo'.PHP_EOL), false);
 
         $dispatcher->dispatchScript(ScriptEvents::POST_INSTALL_CMD, false);
     }

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -40,7 +40,7 @@ class ProcessExecutorTest extends TestCase
         $io = $this->getMock('Composer\IO\IOInterface');
         $io->expects($this->once())
             ->method('write')
-            ->with($this->equalTo('foo'.PHP_EOL));
+            ->with($this->equalTo('foo'.PHP_EOL), false);
 
         $process = new ProcessExecutor($io);
         $process->execute('echo foo');


### PR DESCRIPTION
This should fix the newline bug reported in #5933, #5937 & #5936

I wasn't 100% sure if the `writeError` should also get this flag but I believe it doesn't.

Thanks to @hannesvdvreken for spotting the lines where it happened.