### PR TITLE
Simplify composer output to take less lines

### DIFF
--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -28,14 +28,14 @@ abstract class ArchiveDownloader extends FileDownloader
     /**
      * {@inheritDoc}
      */
-    public function download(PackageInterface $package, $path)
+    public function download(PackageInterface $package, $path, $output = true)
     {
         $temporaryDir = $this->config->get('vendor-dir').'/composer/'.substr(md5(uniqid('', true)), 0, 8);
         $retries = 3;
         while ($retries--) {
-            $fileName = parent::download($package, $path);
+            $fileName = parent::download($package, $path, $output);
 
-            $this->io->writeError('    Extracting archive', true, IOInterface::VERBOSE);
+            $this->io->writeError(' Extracting archive', false, IOInterface::VERBOSE);
 
             try {
                 $this->filesystem->ensureDirectoryExists($temporaryDir);
@@ -76,6 +76,7 @@ abstract class ArchiveDownloader extends FileDownloader
 
                 // retry downloading if we have an invalid zip file
                 if ($retries && $e instanceof \UnexpectedValueException && class_exists('ZipArchive') && $e->getCode() === \ZipArchive::ER_NOZIP) {
+                    $this->io->writeError('');
                     if ($this->io->isDebug()) {
                         $this->io->writeError('    Invalid zip file ('.$e->getMessage().'), retrying...');
                     } else {
@@ -91,7 +92,9 @@ abstract class ArchiveDownloader extends FileDownloader
             break;
         }
 
-        $this->io->writeError('');
+        if ($output) {
+            $this->io->writeError('');
+        }
     }
 
     /**

--- a/src/Composer/Downloader/FossilDownloader.php
+++ b/src/Composer/Downloader/FossilDownloader.php
@@ -31,7 +31,7 @@ class FossilDownloader extends VcsDownloader
         $url = ProcessExecutor::escape($url);
         $ref = ProcessExecutor::escape($package->getSourceReference());
         $repoFile = $path . '.fossil';
-        $this->io->writeError("    Cloning ".$package->getSourceReference($repoFile));
+        $this->io->writeError(" Cloning ".$package->getSourceReference($repoFile));
         $command = sprintf('fossil clone %s %s', $url, ProcessExecutor::escape($repoFile));
         if (0 !== $this->process->execute($command, $ignoredOutput)) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
@@ -56,7 +56,7 @@ class FossilDownloader extends VcsDownloader
 
         $url = ProcessExecutor::escape($url);
         $ref = ProcessExecutor::escape($target->getSourceReference());
-        $this->io->writeError("    Updating to ".$target->getSourceReference());
+        $this->io->writeError(" Updating to ".$target->getSourceReference());
 
         if (!$this->hasMetadataRepository($path)) {
             throw new \RuntimeException('The .fslckout file is missing from '.$path.', see https://getcomposer.org/commit-deps for more information');

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -49,14 +49,15 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
 
         // --dissociate option is only available since git 2.3.0-rc0
         $gitVersion = $this->gitUtil->getVersion();
-        $msg = "    Cloning ".$ref;
+        $msg = " Cloning ".$ref;
         if ($gitVersion && version_compare($gitVersion, '2.3.0-rc0', '>=')) {
+            $this->io->writeError('', true, IOInterface::DEBUG);
             $this->io->writeError(sprintf('    Cloning to cache at %s', ProcessExecutor::escape($cachePath)), true, IOInterface::DEBUG);
             try {
                 $this->gitUtil->syncMirror($url, $cachePath);
                 if (is_dir($cachePath)) {
                     $cacheOptions = sprintf('--dissociate --reference %s ', ProcessExecutor::escape($cachePath));
-                    $msg = "    Cloning ".$ref.' from cache';
+                    $msg = " Cloning ".$ref.' from cache';
                 }
             } catch (\RuntimeException $e) {}
         }
@@ -104,7 +105,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
         }
 
         $ref = $target->getSourceReference();
-        $this->io->writeError("    Checking out ".$ref);
+        $this->io->writeError(" Checking out ".$ref);
         $command = 'git remote set-url composer %s && git rev-parse --quiet --verify %s^{commit} || (git fetch composer && git fetch --tags composer)';
 
         $commandCallable = function ($url) use ($command, $ref) {

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -30,7 +30,7 @@ class HgDownloader extends VcsDownloader
 
         $url = ProcessExecutor::escape($url);
         $ref = ProcessExecutor::escape($package->getSourceReference());
-        $this->io->writeError("    Cloning ".$package->getSourceReference());
+        $this->io->writeError(" Cloning ".$package->getSourceReference());
         $command = sprintf('hg clone %s %s', $url, ProcessExecutor::escape($path));
         if (0 !== $this->process->execute($command, $ignoredOutput)) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
@@ -51,7 +51,7 @@ class HgDownloader extends VcsDownloader
 
         $url = ProcessExecutor::escape($url);
         $ref = ProcessExecutor::escape($target->getSourceReference());
-        $this->io->writeError("    Updating to ".$target->getSourceReference());
+        $this->io->writeError(" Updating to ".$target->getSourceReference());
 
         if (!$this->hasMetadataRepository($path)) {
             throw new \RuntimeException('The .hg directory is missing from '.$path.', see https://getcomposer.org/commit-deps for more information');

--- a/src/Composer/Downloader/PerforceDownloader.php
+++ b/src/Composer/Downloader/PerforceDownloader.php
@@ -32,7 +32,7 @@ class PerforceDownloader extends VcsDownloader
         $ref = $package->getSourceReference();
         $label = $this->getLabelFromSourceReference($ref);
 
-        $this->io->writeError('    Cloning ' . $ref);
+        $this->io->writeError(' Cloning ' . $ref);
         $this->initPerforce($package, $path, $url);
         $this->perforce->setStream($ref);
         $this->perforce->p4Login();

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -40,7 +40,7 @@ class SvnDownloader extends VcsDownloader
             }
         }
 
-        $this->io->writeError("    Checking out ".$package->getSourceReference());
+        $this->io->writeError(" Checking out ".$package->getSourceReference());
         $this->execute($url, "svn co", sprintf("%s/%s", $url, $ref), null, $path);
     }
 
@@ -63,7 +63,7 @@ class SvnDownloader extends VcsDownloader
             }
         }
 
-        $this->io->writeError("    Checking out " . $ref);
+        $this->io->writeError(" Checking out " . $ref);
         $this->execute($url, "svn switch" . $flags, sprintf("%s/%s", $url, $ref), $path);
     }
 

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -60,7 +60,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
             throw new \InvalidArgumentException('Package '.$package->getPrettyName().' is missing reference information');
         }
 
-        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . $package->getFullPrettyVersion() . "</comment>)");
+        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . $package->getFullPrettyVersion() . "</comment>)", false);
         $this->filesystem->emptyDirectory($path);
 
         $urls = $package->getSourceUrls();
@@ -104,8 +104,6 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
                 }
             }
         }
-
-        $this->io->writeError('');
     }
 
     /**
@@ -132,7 +130,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
             $to = $target->getFullPrettyVersion();
         }
 
-        $this->io->writeError("  - Updating <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>)");
+        $this->io->writeError("  - Updating <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>)", false);
 
         $this->cleanChanges($initial, $path, true);
         $urls = $target->getSourceUrls();
@@ -189,8 +187,6 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
         if (!$urls && $exception) {
             throw $exception;
         }
-
-        $this->io->writeError('');
     }
 
     /**

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -41,7 +41,7 @@ class ZipDownloader extends ArchiveDownloader
     /**
      * {@inheritDoc}
      */
-    public function download(PackageInterface $package, $path)
+    public function download(PackageInterface $package, $path, $output = true)
     {
         if (null === self::$hasSystemUnzip) {
             $finder = new ExecutableFinder;
@@ -56,7 +56,7 @@ class ZipDownloader extends ArchiveDownloader
             throw new \RuntimeException($error);
         }
 
-        return parent::download($package, $path);
+        return parent::download($package, $path, $output);
     }
 
     protected function extract($file, $path)

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -575,10 +575,8 @@ class Installer
             // output non-alias ops when not executing operations (i.e. dry run), output alias ops in debug verbosity
             if (!$this->executeOperations && false === strpos($operation->getJobType(), 'Alias')) {
                 $this->io->writeError('  - ' . $operation);
-                $this->io->writeError('');
             } elseif ($this->io->isDebug() && false !== strpos($operation->getJobType(), 'Alias')) {
                 $this->io->writeError('  - ' . $operation);
-                $this->io->writeError('');
             }
 
             $this->installationManager->execute($localRepo, $operation);

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -276,7 +276,7 @@ class RemoteFilesystem
         }
 
         if ($this->progress && !$isRedirect) {
-            $this->io->writeError("    Downloading: <comment>Connecting...</comment>", false);
+            $this->io->writeError(" Downloading: <comment>Connecting...</comment>", false);
         }
 
         $errorMessage = '';
@@ -325,6 +325,7 @@ class RemoteFilesystem
         if (isset($e) && !$this->retry) {
             if (!$this->degradedMode && false !== strpos($e->getMessage(), 'Operation timed out')) {
                 $this->degradedMode = true;
+                $this->io->writeError('');
                 $this->io->writeError(array(
                     '<error>'.$e->getMessage().'</error>',
                     '<error>Retrying with degraded mode, check https://getcomposer.org/doc/articles/troubleshooting.md#degraded-mode for more info</error>',
@@ -366,7 +367,7 @@ class RemoteFilesystem
         if ($statusCode && $statusCode >= 400 && $statusCode <= 599) {
             if (!$this->retry) {
                 if ($this->progress && !$this->retry && !$isRedirect) {
-                    $this->io->overwriteError("    Downloading: <error>Failed</error>");
+                    $this->io->overwriteError(" Downloading: <error>Failed</error>", false);
                 }
 
                 $e = new TransportException('The "'.$this->fileUrl.'" file could not be downloaded ('.$http_response_header[0].')', $statusCode);
@@ -379,7 +380,7 @@ class RemoteFilesystem
         }
 
         if ($this->progress && !$this->retry && !$isRedirect) {
-            $this->io->overwriteError("    Downloading: ".($result === false ? '<error>Failed</error>' : '<comment>100%</comment>'));
+            $this->io->overwriteError(" Downloading: ".($result === false ? '<error>Failed</error>' : '<comment>100%</comment>'), false);
         }
 
         // decode gzip
@@ -405,6 +406,7 @@ class RemoteFilesystem
 
                     $this->degradedMode = true;
                     $this->io->writeError(array(
+                        '',
                         '<error>Failed to decode response: '.$e->getMessage().'</error>',
                         '<error>Retrying with degraded mode, check https://getcomposer.org/doc/articles/troubleshooting.md#degraded-mode for more info</error>',
                     ));
@@ -461,6 +463,7 @@ class RemoteFilesystem
                     $this->retry = true;
                 }
             } else {
+                $this->io->writeError('');
                 $this->io->writeError(sprintf(
                     '<error>Your version of PHP, %s, is affected by CVE-2013-6420 and cannot safely perform certificate validation, we strongly suggest you upgrade.</error>',
                     PHP_VERSION
@@ -490,6 +493,7 @@ class RemoteFilesystem
 
             if (!$this->degradedMode && false !== strpos($e->getMessage(), 'Operation timed out')) {
                 $this->degradedMode = true;
+                $this->io->writeError('');
                 $this->io->writeError(array(
                     '<error>'.$e->getMessage().'</error>',
                     '<error>Retrying with degraded mode, check https://getcomposer.org/doc/articles/troubleshooting.md#degraded-mode for more info</error>',
@@ -563,7 +567,7 @@ class RemoteFilesystem
 
                     if ((0 === $progression % 5) && 100 !== $progression && $progression !== $this->lastProgress) {
                         $this->lastProgress = $progression;
-                        $this->io->overwriteError("    Downloading: <comment>$progression%</comment>", false);
+                        $this->io->overwriteError(" Downloading: <comment>$progression%</comment>", false);
                     }
                 }
                 break;
@@ -638,7 +642,8 @@ class RemoteFilesystem
                 throw new TransportException("Invalid credentials for '" . $this->fileUrl . "', aborting.", $httpStatus);
             }
 
-            $this->io->overwriteError('    Authentication required (<info>'.parse_url($this->fileUrl, PHP_URL_HOST).'</info>):');
+            $this->io->overwriteError('');
+            $this->io->writeError('    Authentication required (<info>'.parse_url($this->fileUrl, PHP_URL_HOST).'</info>):');
             $username = $this->io->ask('      Username: ');
             $password = $this->io->askAndHideAnswer('      Password: ');
             $this->io->setAuthentication($this->originUrl, $username, $password);
@@ -681,6 +686,7 @@ class RemoteFilesystem
                 // Handle subjectAltName on lesser PHP's.
                 $certMap = $this->peerCertificateMap[$urlAuthority];
 
+                $this->io->writeError('', true, IOInterface::DEBUG);
                 $this->io->writeError(sprintf(
                     'Using <info>%s</info> as CN for subjectAltName enabled host <info>%s</info>',
                     $certMap['cn'],
@@ -766,6 +772,7 @@ class RemoteFilesystem
         if (!empty($targetUrl)) {
             $this->redirects++;
 
+            $this->io->writeError('', true, IOInterface::DEBUG);
             $this->io->writeError(sprintf('Following redirect (%u) %s', $this->redirects, $targetUrl), true, IOInterface::DEBUG);
 
             $additionalOptions['redirects'] = $this->redirects;

--- a/tests/Composer/Test/Fixtures/functional/create-project-command.test
+++ b/tests/Composer/Test/Fixtures/functional/create-project-command.test
@@ -2,9 +2,7 @@
 create-project seld/jsonlint %testDir% 1.0.0 --prefer-source -n
 --EXPECT-ERROR--
 Installing seld/jsonlint (1.0.0)
-  - Installing seld/jsonlint (1.0.0)
-    Cloning 3b4bc2a96ff5d3fe6866bfe9dd0c845246705791
-
+  - Installing seld/jsonlint (1.0.0) Cloning 3b4bc2a96ff5d3fe6866bfe9dd0c845246705791
 Created project in %testDir%
 Loading composer repositories with package information
 Updating dependencies (including require-dev)


### PR DESCRIPTION
As you can see below, this reformats the output slightly to save vertical space at a little horizontal space cost.

Less blank lines, and dist updates are shown as updates and not remove+install.

I'd be happy to get feedback here, from users perspective but also from people that may be doing wonky things with the output (/cc @dzuelke @fabpot ;) and might see breakage.

> Note that you should click the images to see them full size for a fair comparison..

Before:

![image](https://cloud.githubusercontent.com/assets/183678/20947848/628874f4-bc11-11e6-9fe8-9176a4a801ca.png)

After:

![image](https://cloud.githubusercontent.com/assets/183678/20947852/67a86ba6-bc11-11e6-9345-058012d34610.png)
