### PR TITLE
Purging missing classes array on autoload change

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -91,6 +91,7 @@ class ClassLoader
      */
     public function addClassMap(array $classMap)
     {
+        $this->missingClasses = array();
         if ($this->classMap) {
             $this->classMap = array_merge($this->classMap, $classMap);
         } else {
@@ -108,6 +109,7 @@ class ClassLoader
      */
     public function add($prefix, $paths, $prepend = false)
     {
+        $this->missingClasses = array();
         if (!$prefix) {
             if ($prepend) {
                 $this->fallbackDirsPsr0 = array_merge(
@@ -155,6 +157,7 @@ class ClassLoader
      */
     public function addPsr4($prefix, $paths, $prepend = false)
     {
+        $this->missingClasses = array();
         if (!$prefix) {
             // Register directories for the root namespace.
             if ($prepend) {
@@ -200,6 +203,7 @@ class ClassLoader
      */
     public function set($prefix, $paths)
     {
+        $this->missingClasses = array();
         if (!$prefix) {
             $this->fallbackDirsPsr0 = (array) $paths;
         } else {
@@ -218,6 +222,7 @@ class ClassLoader
      */
     public function setPsr4($prefix, $paths)
     {
+        $this->missingClasses = array();
         if (!$prefix) {
             $this->fallbackDirsPsr4 = (array) $paths;
         } else {
@@ -237,6 +242,7 @@ class ClassLoader
      */
     public function setUseIncludePath($useIncludePath)
     {
+        $this->missingClasses = array();
         $this->useIncludePath = $useIncludePath;
     }
 

--- a/tests/Composer/Test/Autoload/ClassLoaderTest.php
+++ b/tests/Composer/Test/Autoload/ClassLoaderTest.php
@@ -58,4 +58,39 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new ClassLoader();
         $this->assertEmpty($loader->getPrefixes());
     }
+
+    /**
+     * Tests that the missing classes cache is purged when the autoloader is modified.
+     *
+     * @dataProvider getMissingLoadClassTests
+     *
+     * @param string $class            The fully-qualified class name to test, without preceding namespace separator.
+     */
+    public function testMissingClassesCachePurge($class)
+    {
+        $loader = new ClassLoader();
+
+        $isLoaded = $loader->loadClass($class);
+        $this->assertNull($isLoaded, "->loadClass() does not load '$class'");
+
+        $loader->add('Namespaced\\', __DIR__ . '/Fixtures');
+        $loader->add('Pearlike_', __DIR__ . '/Fixtures');
+        $loader->addPsr4('ShinyVendor\\ShinyPackage\\', __DIR__ . '/Fixtures');
+        $isLoaded = $loader->loadClass($class);
+        $this->assertTrue($isLoaded, "->loadClass() loads '$class'");
+    }
+
+    /**
+     * Provides arguments for ->testMissingClassesCachePurge().
+     *
+     * @return array Array of parameter sets to test with.
+     */
+    public function getMissingLoadClassTests()
+    {
+        return array(
+            array('Namespaced\\Baz'),
+            array('Pearlike_Baz'),
+            array('ShinyVendor\\ShinyPackage\\SubNamespace\\Bar'),
+        );
+    }
 }


### PR DESCRIPTION
PR #5558 added a "missing classes" array in the autoloader.

This array caches missing classes for optimization purpose.

However, this array assumes that methods that affect the classmap (like `addClassMap`, `addPsr4`...) are performed **before** the autoloader is actually used.

This is almost always true.... except for a few edge cases like Drupal 8. Haaaa Drupal :(

Drupal has a powerful module system where modules can be enabled/disabled by the user. When you enable a module, Drupal dynamically adds the PSR4 autoloader for the module into the Drupal autoloader (even if the composer autoloader has already been used before).

In some cases, Drupal performed a "class_exists" call on a given class (say class `Foo`). It does not exists. A few functions later, it performs a call to `addPsr4` (because it is in the process of enabling a module). Now, if the newly enabled module tries to access the `Foo` class, Composer autoloader will not autoload it (because it is still cached in the `$missingClasses` cache.

This PR simply resets the `$missingClasses` cache every time the autoloader is modified (because the classes in the array might now be accessible).

It also comes with the regular unit test that would fail if this PR is not applied.

