### PR TITLE
Set xdebug version in environment, fixes #5967

### DIFF
--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -21,11 +21,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 class XdebugHandler
 {
     const ENV_ALLOW = 'COMPOSER_ALLOW_XDEBUG';
+    const ENV_VERSION = 'COMPOSER_XDEBUG_VERSION';
     const RESTART_ID = 'internal';
 
     private $output;
     private $loaded;
     private $envScanDir;
+    private $version;
     private $tmpIni;
 
     /**
@@ -36,6 +38,11 @@ class XdebugHandler
         $this->output = $output;
         $this->loaded = extension_loaded('xdebug');
         $this->envScanDir = getenv('PHP_INI_SCAN_DIR');
+
+        if ($this->loaded) {
+            $ext = new \ReflectionExtension('xdebug');
+            $this->version = strval($ext->getVersion());
+        }
     }
 
     /**
@@ -247,6 +254,11 @@ class XdebugHandler
 
         // Make original inis available to restarted process
         if (!putenv(IniHelper::ENV_ORIGINAL.'='.implode(PATH_SEPARATOR, $iniPaths))) {
+            return false;
+        }
+
+        // Make xdebug version available to restarted process
+        if (!putenv(self::ENV_VERSION.'='.$this->version)) {
             return false;
         }
 

--- a/tests/Composer/Test/Mock/XdebugHandlerMock.php
+++ b/tests/Composer/Test/Mock/XdebugHandlerMock.php
@@ -18,6 +18,7 @@ class XdebugHandlerMock extends XdebugHandler
 {
     public $restarted;
     public $output;
+    public $testVersion = '2.5.0';
 
     public function __construct($loaded = null)
     {
@@ -26,9 +27,15 @@ class XdebugHandlerMock extends XdebugHandler
 
         $loaded = null === $loaded ? true: $loaded;
         $class = new \ReflectionClass(get_parent_class($this));
+
         $prop = $class->getProperty('loaded');
         $prop->setAccessible(true);
         $prop->setValue($this, $loaded);
+
+        $prop = $class->getProperty('version');
+        $prop->setAccessible(true);
+        $version = $loaded ? $this->testVersion : '';
+        $prop->setValue($this, $version);
 
         $this->restarted = false;
     }

--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -106,11 +106,30 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', getenv('PHP_INI_SCAN_DIR'));
     }
 
+    public function testEnvVersionWhenLoaded()
+    {
+        $loaded = true;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals($xdebug->testVersion, getenv(XdebugHandlerMock::ENV_VERSION));
+    }
+
+    public function testEnvVersionWhenNotLoaded()
+    {
+        $loaded = false;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals(false, getenv(XdebugHandlerMock::ENV_VERSION));
+    }
+
     public static function setUpBeforeClass()
     {
         // Save current state
         $names = array(
             XdebugHandlerMock::ENV_ALLOW,
+            XdebugHandlerMock::ENV_VERSION,
             'PHP_INI_SCAN_DIR',
             IniHelper::ENV_ORIGINAL,
         );
@@ -136,6 +155,7 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
     {
         // Ensure env is unset
         putenv(XdebugHandlerMock::ENV_ALLOW);
+        putenv(XdebugHandlerMock::ENV_VERSION);
         putenv('PHP_INI_SCAN_DIR');
         putenv(IniHelper::ENV_ORIGINAL);
     }


### PR DESCRIPTION
Adds the internal `COMPOSER_XDEBUG_VERSION` environment variable for the restarted process.