### PR TITLE
Add a public setter for package name

### DIFF
--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -65,9 +65,17 @@ abstract class BasePackage implements PackageInterface
      */
     public function __construct($name)
     {
+        $this->setName($name);
+        $this->id = -1;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
         $this->prettyName = $name;
         $this->name = strtolower($name);
-        $this->id = -1;
     }
 
     /**


### PR DESCRIPTION
We have extended Satis in order to generate static virtual packages from real packages but we don't have a way to change virtual package name (after a clone) and this is quite dirty to use a class override for this. Maybe you could add this simple setter.

BTW, thanks for the great software.