### PR TITLE
Allow use of parent directories in PathDownloader when not mirroring the path

### DIFF
--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -45,13 +45,6 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             ));
         }
 
-        if (strpos(realpath($path) . DIRECTORY_SEPARATOR, $realUrl . DIRECTORY_SEPARATOR) === 0) {
-            throw new \RuntimeException(sprintf(
-                'Package %s cannot install to "%s" inside its source at "%s"',
-                $package->getName(), realpath($path), $realUrl
-            ));
-        }
-
         // Get the transport options with default values
         $transportOptions = $package->getTransportOptions() + array('symlink' => null);
 
@@ -70,6 +63,13 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
         } elseif (false === $transportOptions['symlink']) {
             $currentStrategy = self::STRATEGY_MIRROR;
             $allowedStrategies = array(self::STRATEGY_MIRROR);
+        }
+
+        if ($currentStrategy != self::STRATEGY_MIRROR && strpos(realpath($path) . DIRECTORY_SEPARATOR, $realUrl . DIRECTORY_SEPARATOR) === 0) {
+            throw new \RuntimeException(sprintf(
+                'Package %s cannot install to "%s" inside its source at "%s"',
+                $package->getName(), realpath($path), $realUrl
+            ));
         }
 
         $fileSystem = new Filesystem();


### PR DESCRIPTION
I'm working on my composer plugin, and I want to be able to test the plugin with actual composer.json files. In order to do this, I want to use a composer.json like this: https://github.com/cweagans/composer-patches/blob/acceptance-tests/tests/acceptance/fixtures/_fixture-template/composer.json

Currently, `composer install` in that directory yields

```
                                                                                                                       
  [RuntimeException]                                                                                                   
  Package cweagans/composer-patches cannot install to "/home/cweagans/Code/composer-patches/tests/acceptance/fixtures  
  /_fixture-template/vendor/cweagans/composer-patches" inside its source at "/home/cweagans/Code/composer-patches"     
                                                                                                                      
```

I think this PR should do what I need. If you have a different way you want to handle this, I'm all ears. Let me know and I'll update the PR.