### PR TITLE
Fix __DIR__/getcwd() inconsistency.

### DIFF
--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -96,8 +96,12 @@ class PathRepositoryTest extends TestCase
         $loader = new ArrayLoader(new VersionParser());
         $versionGuesser = null;
 
-        $repositoryUrl = implode(DIRECTORY_SEPARATOR, array(__DIR__, 'Fixtures', 'path', 'with-version'));
-        $relativeUrl = ltrim(substr($repositoryUrl, strlen(getcwd())), DIRECTORY_SEPARATOR);
+        // realpath() does not fully expand the paths
+        // PHP Bug https://bugs.php.net/bug.php?id=72642
+        $repositoryUrl = implode(DIRECTORY_SEPARATOR, array(realpath(realpath(__DIR__)), 'Fixtures', 'path', 'with-version'));
+        // getcwd() not necessarily match __DIR__
+        // PHP Bug https://bugs.php.net/bug.php?id=73797
+        $relativeUrl = ltrim(substr($repositoryUrl, strlen(realpath(realpath(getcwd())))), DIRECTORY_SEPARATOR);
 
         $repository = new PathRepository(array('url' => $relativeUrl), $ioInterface, $config, $loader);
         $packages = $repository->getPackages();


### PR DESCRIPTION
This fixes the case, where `__DIR__` expands to a value different than `getcwd()` in length.
PHP bug https://bugs.php.net/bug.php?id=73797