### PR TITLE
Properly skip GitDownloaderTest if git is not available

### DIFF
--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -25,19 +25,10 @@ class GitDownloaderTest extends TestCase
     /** @var string */
     private $workingDir;
 
-    private $skipped;
-
-    protected function initialize()
-    {
-        try {
-            $this->skipIfNotExecutable('git');
-        } catch (\PHPUnit_Framework_SkippedTestError $e) {
-            $this->skipped = 'This test needs a git binary in the PATH to be able to run';
-        }
-    }
-
     protected function setUp()
     {
+        $this->skipIfNotExecutable('git');
+
         $this->fs = new Filesystem;
         $this->workingDir = $this->getUniqueTmpDirectory();
     }


### PR DESCRIPTION
Mindless copy-paste never gets old. Sorry. This is fixed proper this time.