### PR TITLE
Fix dist downloads from bitbucket private repos

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -1008,7 +1008,7 @@ class RemoteFilesystem
         // Path for a public download follows this pattern /{user}/{repo}/downloads/{whatever}
         // {@link https://blog.bitbucket.org/2009/04/12/new-feature-downloads/}
         $pathParts = explode('/', $path);
-        if (count($pathParts) >= 4 && $pathParts[2] != 'downloads') {
+        if (count($pathParts) >= 4 && $pathParts[3] == 'downloads') {
             return true;
         }
 


### PR DESCRIPTION
URL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
results in the following $pathParts:
```
array(5) {
  [0]=>
  string(0) ""
  [1]=>
  string(5) "ariya"
  [2]=>
  string(9) "phantomjs"
  [3]=>
  string(9) "downloads"
  [4]=>
  string(36) "phantomjs-2.1.1-linux-x86_64.tar.bz2"
}

```
A dist download URL like https://bitbucket.org/user/repo/get/[git-hash].zip results in the following $pathParts:
```
array(5) {
  [0]=>
  string(0) ""
  [1]=>
  string(4) "user"
  [2]=>
  string(4) "repo"
  [3]=>
  string(3) "get"
  [4]=>
  string(14) "[git-hash].zip"
}
```