### PR TITLE
Clear xdebug version if restart fails, fixes #5995

### DIFF
--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -79,6 +79,11 @@ class XdebugHandler
                     putenv('PHP_INI_SCAN_DIR');
                 }
             }
+
+            // Clear version if the restart failed to disable xdebug
+            if ($this->loaded) {
+                putenv(self::ENV_VERSION);
+            }
         }
     }
 

--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -113,12 +113,31 @@ class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $this->assertEquals($xdebug->testVersion, getenv(XdebugHandlerMock::ENV_VERSION));
+
+        // Mimic successful restart
+        $loaded = false;
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals($xdebug->testVersion, getenv(XdebugHandlerMock::ENV_VERSION));
     }
 
     public function testEnvVersionWhenNotLoaded()
     {
         $loaded = false;
 
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals(false, getenv(XdebugHandlerMock::ENV_VERSION));
+    }
+
+    public function testEnvVersionWhenRestartFails()
+    {
+        $loaded = true;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+
+        // Mimic failed restart
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $this->assertEquals(false, getenv(XdebugHandlerMock::ENV_VERSION));


### PR DESCRIPTION
This clears the `COMPOSER_XDEBUG_VERSION` environment variable if the restart fails and xdebug is still loaded.

Here is the compiled [composer.phar](https://github.com/johnstevenson/composer/releases/download/2b8ad7d/composer.phar)

I had to mock the failure to test this, so it would be appreciated if those affected by this issue could confirm if this now works for them.