### PR TITLE
Do not throw InvalidArgumentException with the 'show' command if the …

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -166,8 +166,19 @@ EOT
             if (empty($package)) {
                 list($package, $versions) = $this->getPackage($installedRepo, $repos, $input->getArgument('package'), $input->getArgument('version'));
 
-                if (!$package) {
-                    throw new \InvalidArgumentException('Package '.$input->getArgument('package').' not found');
+                if (empty($package)) {
+                    $options = $input->getOptions();
+                    if (isset($options['working-dir'])) {
+                        $composer_json = $options['working-dir'] . '/composer.json';
+                        if (file_exists($composer_json)) {
+                            $io->writeError('Package ' . $packageFilter . ' not found in ' . $composer_json);
+                            return;
+                        } else {
+                            throw new \InvalidArgumentException('Package ' . $packageFilter . ' not found');
+                        }
+                    } else {
+                        throw new \InvalidArgumentException('Package ' . $packageFilter . ' not found');
+                    }
                 }
             } else {
                 $versions = array($package->getPrettyVersion() => $package->getVersion());


### PR DESCRIPTION
…working-dir argument is set and composer.json exists

  - This prevents scripts from aborting when looping through a directory of projects