### PR TITLE
Changed ComposerStaticInit$suffix::\$$prop; with self

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -791,7 +791,7 @@ HEADER;
 
             $file .= sprintf("    public static $%s = %s;\n\n", $prop, $value);
             if ('files' !== $prop) {
-                $initializer .= "            \$loader->$prop = ComposerStaticInit$suffix::\$$prop;\n";
+                $initializer .= "            \$loader->$prop = self::\$$prop;\n";
             }
         }
 


### PR DESCRIPTION
Since the generated points to the same container class, we use self instead of generated class name