### PR TITLE
Implement schema validation for repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "^5.3.2 || ^7.0",
-        "justinrainbow/json-schema": "^1.6 || ^2.0 || ^3.0 || ^4.0",
+        "justinrainbow/json-schema": "^3.0 || ^4.0",
         "composer/ca-bundle": "^1.0",
         "composer/semver": "^1.0",
         "composer/spdx-licenses": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "deb4df08cdd39eac7d11880586076ba1",
+    "content-hash": "e18501d127e13e3619f80abbcf372c81",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -393,7 +393,23 @@
         "repositories": {
             "type": ["object", "array"],
             "description": "A set of additional repositories where packages can be found.",
-            "additionalProperties": true
+            "additionalProperties": {
+                "oneOf": [
+                    { "$ref": "#/definitions/repository" },
+                    { "type": "boolean", "enum": [false] }
+                ]
+            },
+            "items": {
+                "oneOf": [
+                    { "$ref": "#/definitions/repository" },
+                    {
+                        "type": "object",
+                        "additionalProperties": { "type": "boolean", "enum": [false] },
+                        "minProperties": 1,
+                        "maxProperties": 1
+                    }
+                ]
+            }
         },
         "minimum-stability": {
             "type": ["string"],
@@ -547,6 +563,112 @@
         "_comment": {
             "type": ["array", "string"],
             "description": "A key to store comments in"
+        }
+    },
+    "definitions": {
+        "repository": {
+            "type": "object",
+            "oneOf": [
+                { "$ref": "#/definitions/composer-repository" },
+                { "$ref": "#/definitions/vcs-repository" },
+                { "$ref": "#/definitions/path-repository" },
+                { "$ref": "#/definitions/artifact-repository" },
+                { "$ref": "#/definitions/pear-repository" },
+                { "$ref": "#/definitions/package-repository" }
+            ]
+        },
+        "composer-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["composer"] },
+                "url": { "type": "string", "format": "uri" },
+                "options": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "allow_ssl_downgrade": { "type": "boolean" },
+                "force-lazy-providers": { "type": "boolean" }
+            }
+        },
+        "vcs-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["vcs", "github", "git", "gitlab", "git-bitbucket", "hg", "hg-bitbucket", "fossil", "perforce", "svn"] },
+                "url": { "type": "string", "format": "uri" },
+                "no-api": { "type": "boolean" },
+                "secure-http": { "type": "boolean" },
+                "svn-cache-credentials": { "type": "boolean" },
+                "trunk-path": { "type": "string" },
+                "branches-path": { "type": "string" },
+                "tags-path": { "type": "string" },
+                "package-path": { "type": "string" },
+                "depot": { "type": "string" },
+                "branch": { "type": "string" },
+                "unique_perforce_client_name": { "type": "string" },
+                "p4user": { "type": "string" },
+                "p4password": { "type": "string" }
+            }
+        },
+        "path-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["path"] },
+                "url": { "type": "string" },
+                "options": {
+                    "type": "object",
+                    "properties": {
+                        "symlink": { "type": ["boolean", "null"] }
+                    },
+                    "additionalProperties": true
+                }
+            }
+        },
+        "artifact-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["artifact"] },
+                "url": { "type": "string" }
+            }
+        },
+        "pear-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["pear"] },
+                "url": { "type": "string", "format": "uri" },
+                "vendor-alias": { "type": "string" }
+            }
+        },
+        "package-repository": {
+            "type": "object",
+            "required": ["type", "package"],
+            "properties": {
+                "type": { "type": "string", "enum": ["package"] },
+                "package": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/inline-package" },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": { "$ref": "#/definitions/inline-package" }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "inline-package": {
+            "type": "object",
+            "allOf": [
+                { "$ref": "#" },
+                {
+                    "required": ["name", "version"]
+                }
+            ]
         }
     }
 }

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -157,7 +157,13 @@ class JsonFile
         }
 
         $schemaFile = __DIR__ . '/../../../res/composer-schema.json';
-        $schemaData = json_decode(file_get_contents($schemaFile));
+
+        // Prepend with file:// only when not using a special schema already (e.g. in the phar)
+        if (false === strpos($schemaFile, '://')) {
+            $schemaFile = 'file://' . $schemaFile;
+        }
+
+        $schemaData = (object) array('$ref' => $schemaFile);
 
         if ($schema === self::LAX_SCHEMA) {
             $schemaData->additionalProperties = true;


### PR DESCRIPTION
This is the next step of the schema improvements, validating repositories. This should give a avoid mistakes putting the ``autoload`` config outside the ``package`` configuration for package repositories for instance.

For inline packages, I kept things simple by referencing the schema for the full composer.json, even though root-only properties are actually useless here as they would not be used.

The second commit changes the way we load the schema when validating so that references are resolved properly (otherwise they don't work). The previous code was working only because the schema did not have any references in it. To keep things simple, I dropped support for ``justinrainbow/json-schema`` 1.x and 2.x, as support for references was much harder for them (and maybe not working). These versions are totally outdated anyway (and Composer ships with 4.x anyway).