### PR TITLE
adding "fatal: unable to access" to authFailures

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -189,16 +189,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "4.0.1",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "10d1f6977f6be5f177dded8f585a11debdc27591"
+                "reference": "d39c56a46b3ebe1f3696479966cd2b9f50aaa24f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/10d1f6977f6be5f177dded8f585a11debdc27591",
-                "reference": "10d1f6977f6be5f177dded8f585a11debdc27591",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/d39c56a46b3ebe1f3696479966cd2b9f50aaa24f",
+                "reference": "d39c56a46b3ebe1f3696479966cd2b9f50aaa24f",
                 "shasum": ""
             },
             "require": {
@@ -251,7 +251,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2016-11-09T16:32:33+00:00"
+            "time": "2016-12-22T16:43:46+00:00"
         },
         {
             "name": "psr/log",
@@ -440,16 +440,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.14",
+            "version": "v2.8.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a871ba00e0f604dceac64c56c27f99fbeaf4854e"
+                "reference": "d5643cd095e5e37d31e004bb2606b5dd7e96602f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a871ba00e0f604dceac64c56c27f99fbeaf4854e",
-                "reference": "a871ba00e0f604dceac64c56c27f99fbeaf4854e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d5643cd095e5e37d31e004bb2606b5dd7e96602f",
+                "reference": "d5643cd095e5e37d31e004bb2606b5dd7e96602f",
                 "shasum": ""
             },
             "require": {
@@ -497,11 +497,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-15T23:02:12+00:00"
+            "time": "2016-12-06T11:59:35+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.14",
+            "version": "v2.8.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -558,7 +558,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.14",
+            "version": "v2.8.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -607,16 +607,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.14",
+            "version": "v2.8.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "0023b024363dfc0cd21262e556f25a291fe8d7fd"
+                "reference": "c0f10576335743b881ac1ed39d18c0fa66048775"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/0023b024363dfc0cd21262e556f25a291fe8d7fd",
-                "reference": "0023b024363dfc0cd21262e556f25a291fe8d7fd",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/c0f10576335743b881ac1ed39d18c0fa66048775",
+                "reference": "c0f10576335743b881ac1ed39d18c0fa66048775",
                 "shasum": ""
             },
             "require": {
@@ -652,7 +652,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03T07:52:58+00:00"
+            "time": "2016-12-13T09:38:12+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -715,16 +715,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.14",
+            "version": "v2.8.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "024de37f8a6b9e5e8244d9eb3fcf3e467dd2a93f"
+                "reference": "1a1bd056395540d0bc549d39818316513565d278"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/024de37f8a6b9e5e8244d9eb3fcf3e467dd2a93f",
-                "reference": "024de37f8a6b9e5e8244d9eb3fcf3e467dd2a93f",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1a1bd056395540d0bc549d39818316513565d278",
+                "reference": "1a1bd056395540d0bc549d39818316513565d278",
                 "shasum": ""
             },
             "require": {
@@ -760,7 +760,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-29T14:03:54+00:00"
+            "time": "2016-11-24T00:43:03+00:00"
         }
     ],
     "packages-dev": [
@@ -1175,16 +1175,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.30",
+            "version": "4.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a534e04d0bd39c557c2881c341efd06fa6f1292a"
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a534e04d0bd39c557c2881c341efd06fa6f1292a",
-                "reference": "a534e04d0bd39c557c2881c341efd06fa6f1292a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
                 "shasum": ""
             },
             "require": {
@@ -1243,7 +1243,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-01T17:05:48+00:00"
+            "time": "2016-12-09T02:45:31+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1675,7 +1675,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.14",
+            "version": "v2.8.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -50,7 +50,7 @@ class Git
         }
 
         if (preg_match('{^ssh://[^@]+@[^:]+:[^0-9]+}', $url)) {
-            throw new \InvalidArgumentException('The source URL '.$url.' is invalid, ssh URLs should have a port number after ":".'."\n".'Use ssh://git@example.com:22/path or just git@example.com:path if you do not want to provide a password or custom port.');
+            throw new \InvalidArgumentException('The source URL ' . $url . ' is invalid, ssh URLs should have a port number after ":".' . "\n" . 'Use ssh://git@example.com:22/path or just git@example.com:path if you do not want to provide a password or custom port.');
         }
 
         if (!$initialClone) {
@@ -63,16 +63,16 @@ class Git
 
         $protocols = $this->config->get('github-protocols');
         if (!is_array($protocols)) {
-            throw new \RuntimeException('Config value "github-protocols" must be an array, got '.gettype($protocols));
+            throw new \RuntimeException('Config value "github-protocols" must be an array, got ' . gettype($protocols));
         }
         // public github, autoswitch protocols
-        if (preg_match('{^(?:https?|git)://'.self::getGitHubDomainsRegex($this->config).'/(.*)}', $url, $match)) {
+        if (preg_match('{^(?:https?|git)://' . self::getGitHubDomainsRegex($this->config) . '/(.*)}', $url, $match)) {
             $messages = array();
             foreach ($protocols as $protocol) {
                 if ('ssh' === $protocol) {
                     $protoUrl = "git@" . $match[1] . ":" . $match[2];
                 } else {
-                    $protoUrl = $protocol ."://" . $match[1] . "/" . $match[2];
+                    $protoUrl = $protocol . "://" . $match[1] . "/" . $match[2];
                 }
 
                 if (0 === $this->process->execute(call_user_func($commandCallable, $protoUrl), $ignoredOutput, $cwd)) {
@@ -85,18 +85,18 @@ class Git
             }
 
             // failed to checkout, first check git accessibility
-            $this->throwException('Failed to clone ' . $url .' via '.implode(', ', $protocols).' protocols, aborting.' . "\n\n" . implode("\n", $messages), $url);
+            $this->throwException('Failed to clone ' . $url . ' via ' . implode(', ', $protocols) . ' protocols, aborting.' . "\n\n" . implode("\n", $messages), $url);
         }
 
         // if we have a private github url and the ssh protocol is disabled then we skip it and directly fallback to https
-        $bypassSshForGitHub = preg_match('{^git@'.self::getGitHubDomainsRegex($this->config).':(.+?)\.git$}i', $url) && !in_array('ssh', $protocols, true);
+        $bypassSshForGitHub = preg_match('{^git@' . self::getGitHubDomainsRegex($this->config) . ':(.+?)\.git$}i', $url) && !in_array('ssh', $protocols, true);
 
         $command = call_user_func($commandCallable, $url);
 
         $auth = null;
         if ($bypassSshForGitHub || 0 !== $this->process->execute($command, $ignoredOutput, $cwd)) {
             // private github repository without git access, try https with auth
-            if (preg_match('{^git@'.self::getGitHubDomainsRegex($this->config).':(.+?)\.git$}i', $url, $match)) {
+            if (preg_match('{^git@' . self::getGitHubDomainsRegex($this->config) . ':(.+?)\.git$}i', $url, $match)) {
                 if (!$this->io->hasAuthentication($match[1])) {
                     $gitHubUtil = new GitHub($this->io, $this->config, $this->process);
                     $message = 'Cloning failed using an ssh key for authentication, enter your GitHub credentials to access private repos';
@@ -131,7 +131,7 @@ class Git
                     //We already have an access_token from a previous request.
                     if ($auth['username'] !== 'x-token-auth') {
                         $token = $bitbucketUtil->requestToken($match[1], $auth['username'], $auth['password']);
-                        if (! empty($token)) {
+                        if (!empty($token)) {
                             $this->io->setAuthentication($match[1], 'x-token-auth', $token['access_token']);
                         }
                     }
@@ -165,22 +165,22 @@ class Git
                     $defaultUsername = null;
                     if (isset($authParts) && $authParts) {
                         if (false !== strpos($authParts, ':')) {
-                            list($defaultUsername, ) = explode(':', $authParts, 2);
+                            list($defaultUsername,) = explode(':', $authParts, 2);
                         } else {
                             $defaultUsername = $authParts;
                         }
                     }
 
-                    $this->io->writeError('    Authentication required (<info>'.parse_url($url, PHP_URL_HOST).'</info>):');
+                    $this->io->writeError('    Authentication required (<info>' . parse_url($url, PHP_URL_HOST) . '</info>):');
                     $auth = array(
-                        'username'  => $this->io->ask('      Username: ', $defaultUsername),
-                        'password'  => $this->io->askAndHideAnswer('      Password: '),
+                        'username' => $this->io->ask('      Username: ', $defaultUsername),
+                        'password' => $this->io->askAndHideAnswer('      Password: '),
                     );
                     $storeAuth = $this->config->get('store-auths');
                 }
 
                 if ($auth) {
-                    $authUrl = $match[1].rawurlencode($auth['username']).':'.rawurlencode($auth['password']).'@'.$match[2].$match[3];
+                    $authUrl = $match[1] . rawurlencode($auth['username']) . ':' . rawurlencode($auth['password']) . '@' . $match[2] . $match[3];
 
                     $command = call_user_func($commandCallable, $authUrl);
                     if (0 === $this->process->execute($command, $ignoredOutput, $cwd)) {
@@ -237,7 +237,8 @@ class Git
         $authFailures = array(
             'fatal: Authentication failed',
             'remote error: Invalid username or password.',
-            'error: 401 Unauthorized'
+            'error: 401 Unauthorized',
+            'fatal: unable to access'
         );
 
         foreach ($authFailures as $authFailure) {
@@ -283,7 +284,7 @@ class Git
 
     public static function getGitHubDomainsRegex(Config $config)
     {
-        return '('.implode('|', array_map('preg_quote', $config->get('github-domains'))).')';
+        return '(' . implode('|', array_map('preg_quote', $config->get('github-domains'))) . ')';
     }
 
     public static function sanitizeUrl($message)
@@ -293,7 +294,7 @@ class Git
                 return '://***:***@';
             }
 
-            return '://'.$m[1].':***@';
+            return '://' . $m[1] . ':***@';
         }, $message);
     }
 
@@ -303,7 +304,7 @@ class Git
         clearstatcache();
 
         if (0 !== $this->process->execute('git --version', $ignoredOutput)) {
-            throw new \RuntimeException(self::sanitizeUrl('Failed to clone '.$url.', git was not found, check that it is installed and in your PATH env.' . "\n\n" . $this->process->getErrorOutput()));
+            throw new \RuntimeException(self::sanitizeUrl('Failed to clone ' . $url . ', git was not found, check that it is installed and in your PATH env.' . "\n\n" . $this->process->getErrorOutput()));
         }
 
         throw new \RuntimeException(self::sanitizeUrl($message));


### PR DESCRIPTION
I am using private repository hosted with AWS CodeCommit. 
```
  "repositories": [
    {
      "url": "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/example-repostory",
      "type": "git"
    }
  ],
  "require": {
    "vendor/example-repostory": "dev-master"
  }
```
```
export COMPOSER_AUTH='{"http-basic": {"git-codecommit.us-east-1.amazonaws.com": {"username": "git-user-name","password": "git-user-password"}}}'
```
Running git clone directly without providing username and password goes like this:
```
$ git clone --mirror "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/example-reposotory"
Cloning into bare repository 'example-reposotory.git'...
Username for 'https://git-codecommit.us-east-1.amazonaws.com':
Password for 'https://git-codecommit.us-east-1.amazonaws.com':
fatal: unable to access 'https://git-codecommit.us-east-1.amazonaws.com/v1/repos/example-reposotory/': The requested URL returned error: 403
```

So when composer runs  and encounters a repository with type of "git" it tries to figure out if the repository needs authentication by examining the ```$this->process->getErrorOutput()``` and matching it to an array of error strings. 
The error that is returned when accessing CodeCommit repository is **not found** to be one of the defined options.  
From there 
- the method ```isAuthenticationFailure``` returns **false**, 
- the section ```} elseif ($this->isAuthenticationFailure($url, $match)) {``` in the ```runCommand``` **method is not executed** 
- and ```composer update```  **fails**.    

I am suggesting adding "fatal: unable to access" to ```$authFailures``` array in ```isAuthenticationFailure``` method to accommodate this workflow.
```
        $authFailures = array(
            'fatal: Authentication failed',
            'remote error: Invalid username or password.',
            'error: 401 Unauthorized',
            'fatal: unable to access' <= added here
        );
```

 
