### PR TITLE
Implement experimental O(Depth) class dir lookup

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -43,6 +43,7 @@ namespace Composer\Autoload;
 class ClassLoader
 {
     // PSR-4
+    private $prefixDepthPsr4 = 0;
     private $prefixLengthsPsr4 = array();
     private $prefixDirsPsr4 = array();
     private $fallbackDirsPsr4 = array();
@@ -174,6 +175,7 @@ class ClassLoader
             if ('\\' !== $prefix[$length - 1]) {
                 throw new \InvalidArgumentException("A non-empty PSR-4 prefix must end with a namespace separator.");
             }
+            $this->prefixDepthPsr4 = max($this->prefixDepthPsr4, count(explode('\\', $prefix)) - 1);
             $this->prefixLengthsPsr4[$prefix[0]][$prefix] = $length;
             $this->prefixDirsPsr4[$prefix] = (array) $paths;
         } elseif ($prepend) {
@@ -225,6 +227,7 @@ class ClassLoader
             if ('\\' !== $prefix[$length - 1]) {
                 throw new \InvalidArgumentException("A non-empty PSR-4 prefix must end with a namespace separator.");
             }
+            $this->prefixDepthPsr4 = max($this->prefixDepthPsr4, count(explode('\\', $prefix)) - 1);
             $this->prefixLengthsPsr4[$prefix[0]][$prefix] = $length;
             $this->prefixDirsPsr4[$prefix] = (array) $paths;
         }
@@ -374,6 +377,24 @@ class ClassLoader
 
         $first = $class[0];
         if (isset($this->prefixLengthsPsr4[$first])) {
+            // PSR-4 O(d) lookup
+            $nodes = explode('\\', $class);
+            array_pop($nodes);
+            $depth = min($this->prefixDepthPsr4, count($nodes));
+            for ($i = $depth; $i > 0; $i--) {
+                $lookup = implode('\\', $nodes) . '\\';
+                if (isset($this->prefixLengthsPsr4[$first][$lookup]) && isset($this->prefixDirsPsr4[$lookup])) {
+                    $length = $this->prefixLengthsPsr4[$first][$lookup];
+                    foreach ($this->prefixDirsPsr4[$lookup] as $dir) {
+                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
+                            return $file;
+                        }
+                    }
+                }
+                array_pop($nodes);
+            }
+
+            // PSR-4 O(n) lookup
             foreach ($this->prefixLengthsPsr4[$first] as $prefix => $length) {
                 if (0 === strpos($class, $prefix)) {
                     foreach ($this->prefixDirsPsr4[$prefix] as $dir) {


### PR DESCRIPTION
# Objective

Speed up composer PSR-4 class resolution by looking up namespace depth

# Approach

To look up a class, instead of loop through each matching leading prefix (e.g, `M`), we look up the exact match of nested namespace and bound it by a depth.

### Example

1. Namespace registering

  ```json
  {
    "autoload-dev": {
          "psr-4": {
              "Magento\\Framework\\": "lib/internal/Magento/Framework/"
          }
      },
  }
  ```

  On registering phrase, we cache the max depth so far, that is, `$depth = max($depth, count(explode('\\', 'Magento\\Framework')))`. In this example, it is `2`.

2. Class resolution

```
\Magento\Framework\App\ObjectManager
```

  On class resolution phrase, we create a list of namespace candidates by the class and depth. Then use `isset($prefixLengthsPsr4[$namespace])` to look up the exact namespace.

In the example, there the candidates are:

```
$namespaces = [
  `Magento\Framework\',
  `Magento\',
];
```

### Computation Complexity

```diff
n = the number of classes live under a namespace which share the same leading character
d = the maximum nested level of namespace used among all classes
- O(n) // in the example, n = 132
+ O(d) // in the example, n = 4
```

Using Magento as an example, there are 132 namespace start with `M` and the depth is only 4. It is common that number of sub-namespace sharing the same parent namespace is far more than the number of the namespace nested level.