### PR TITLE
Fix the validation of required properties for inline packages

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -662,13 +662,8 @@
             }
         },
         "inline-package": {
-            "type": "object",
-            "oneOf": [
-                { "$ref": "#" },
-                {
-                    "required": ["name", "version"]
-                }
-            ]
+            "$ref": "#",
+            "required": ["name", "version"]
         }
     }
 }


### PR DESCRIPTION
Closes #6021 

This replaces the list of required properties of the root schema instead of adding a second list of required properties, because the ``description`` property should not be required for inline packages (it is necessary only when publishing).