### PR TITLE
Loosen the validation for the URL field of VCS repositories

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -596,7 +596,7 @@
             "required": ["type", "url"],
             "properties": {
                 "type": { "type": "string", "enum": ["vcs", "github", "git", "gitlab", "git-bitbucket", "hg", "hg-bitbucket", "fossil", "perforce", "svn"] },
-                "url": { "type": "string", "format": "uri" },
+                "url": { "type": "string" },
                 "no-api": { "type": "boolean" },
                 "secure-http": { "type": "boolean" },
                 "svn-cache-credentials": { "type": "boolean" },


### PR DESCRIPTION
The URL of the VCS repository may not match the uri pattern of the JSON schema spec, for instance when using a SSH URL of the repository.

Closes #6026