### PR TITLE
Refactor the validation of inline package definitions

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -46,33 +46,7 @@
             "description": "License name. Or an array of license names."
         },
         "authors": {
-            "type": "array",
-            "description": "List of authors that contributed to the package. This is typically the main maintainers, not the full list.",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": [ "name"],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "Full name of the author."
-                    },
-                    "email": {
-                        "type": "string",
-                        "description": "Email address of the author.",
-                        "format": "email"
-                    },
-                    "homepage": {
-                        "type": "string",
-                        "description": "Homepage URL for the author.",
-                        "format": "uri"
-                    },
-                    "role": {
-                        "type": "string",
-                        "description": "Author's role in the project."
-                    }
-                }
-            }
+            "$ref": "#/definitions/authors"
         },
         "require": {
             "type": "object",
@@ -309,42 +283,7 @@
             "additionalProperties": true
         },
         "autoload": {
-            "type": "object",
-            "description": "Description of how the package can be autoloaded.",
-            "properties": {
-                "psr-0": {
-                    "type": "object",
-                    "description": "This is a hash of namespaces (keys) and the directories they can be found in (values, can be arrays of paths) by the autoloader.",
-                    "additionalProperties": {
-                        "type": ["string", "array"],
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "psr-4": {
-                    "type": "object",
-                    "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
-                    "additionalProperties": {
-                        "type": ["string", "array"],
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "classmap": {
-                    "type": "array",
-                    "description": "This is an array of directories that contain classes to be included in the class-map generation process."
-                },
-                "files": {
-                    "type": "array",
-                    "description": "This is an array of files that are always required on every request."
-                },
-                "exclude-from-classmap": {
-                    "type": "array",
-                    "description": "This is an array of patterns to exclude from autoload classmap generation. (e.g. \"exclude-from-classmap\": [\"/test/\", \"/tests/\", \"/Tests/\"]"
-                }
-            }
+            "$ref": "#/definitions/autoload"
         },
         "autoload-dev": {
             "type": "object",
@@ -566,6 +505,73 @@
         }
     },
     "definitions": {
+        "authors": {
+            "type": "array",
+            "description": "List of authors that contributed to the package. This is typically the main maintainers, not the full list.",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [ "name"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Full name of the author."
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "Email address of the author.",
+                        "format": "email"
+                    },
+                    "homepage": {
+                        "type": "string",
+                        "description": "Homepage URL for the author.",
+                        "format": "uri"
+                    },
+                    "role": {
+                        "type": "string",
+                        "description": "Author's role in the project."
+                    }
+                }
+            }
+        },
+        "autoload": {
+            "type": "object",
+            "description": "Description of how the package can be autoloaded.",
+            "properties": {
+                "psr-0": {
+                    "type": "object",
+                    "description": "This is a hash of namespaces (keys) and the directories they can be found in (values, can be arrays of paths) by the autoloader.",
+                    "additionalProperties": {
+                        "type": ["string", "array"],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "psr-4": {
+                    "type": "object",
+                    "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
+                    "additionalProperties": {
+                        "type": ["string", "array"],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "classmap": {
+                    "type": "array",
+                    "description": "This is an array of directories that contain classes to be included in the class-map generation process."
+                },
+                "files": {
+                    "type": "array",
+                    "description": "This is an array of files that are always required on every request."
+                },
+                "exclude-from-classmap": {
+                    "type": "array",
+                    "description": "This is an array of patterns to exclude from autoload classmap generation. (e.g. \"exclude-from-classmap\": [\"/test/\", \"/tests/\", \"/Tests/\"]"
+                }
+            }
+        },
         "repository": {
             "type": "object",
             "oneOf": [
@@ -662,8 +668,153 @@
             }
         },
         "inline-package": {
-            "$ref": "#",
-            "required": ["name", "version"]
+            "required": ["name", "version"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Package name, including 'vendor-name/' prefix."
+                },
+                "type": {
+                    "type": "string"
+                },
+                "target-dir": {
+                    "description": "DEPRECATED: Forces the package to be installed into the given subdirectory path. This is used for autoloading PSR-0 packages that do not contain their full path. Use forward slashes for cross-platform compatibility.",
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "homepage": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "string"
+                },
+                "license": {
+                    "type": [
+                        "string",
+                        "array"
+                    ]
+                },
+                "authors": {
+                    "$ref": "#/definitions/authors"
+                },
+                "require": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "replace": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "conflict": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "provide": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "require-dev": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "suggest": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "extra": {
+                    "type": ["object", "array"],
+                    "additionalProperties": true
+                },
+                "autoload": {
+                    "$ref": "#/definitions/autoload"
+                },
+                "archive": {
+                    "type": ["object"],
+                    "properties": {
+                        "exclude": {
+                            "type": "array",
+                        }
+                    }
+                },
+                "bin": {
+                    "type": ["array"],
+                    "description": "A set of files that should be treated as binaries and symlinked into bin-dir (from config).",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "include-path": {
+                    "type": ["array"],
+                    "description": "DEPRECATED: A list of directories which should get added to PHP's include path. This is only present to support legacy projects, and all new code should preferably use autoloading.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "type": "object",
+                    "required": ["type", "url", "reference"],
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "reference": {
+                            "type": "string"
+                        },
+                        "mirrors": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "dist": {
+                    "type": "object",
+                    "required": ["type", "url"],
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "reference": {
+                            "type": "string"
+                        },
+                        "shasum": {
+                            "type": "string"
+                        },
+                        "mirrors": {
+                            "type": "array"
+                        }
+                    }
+                }
+            },
+            "additionalProperties": true
         }
     }
 }

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -756,7 +756,7 @@
                     "type": ["object"],
                     "properties": {
                         "exclude": {
-                            "type": "array",
+                            "type": "array"
                         }
                     }
                 },

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -95,9 +95,8 @@ class ComposerSchemaTest extends \PHPUnit_Framework_TestCase
 
     private function check($json)
     {
-        $schema = json_decode(file_get_contents(__DIR__ . '/../../../../res/composer-schema.json'));
         $validator = new Validator();
-        $validator->check(json_decode($json), $schema);
+        $validator->check(json_decode($json), (object) array('$ref' => 'file://' . __DIR__ . '/../../../../res/composer-schema.json'));
 
         if (!$validator->isValid()) {
             $errors = $validator->getErrors();


### PR DESCRIPTION
Reusing the root schema was a mistake, because the root schema does not have the dist and source properties (which are populated by repository objects).
And adding new properties in a referenced schema using ``additionalProperties: false`` is not possible in json-schema draft 4.

closes #6028 (tested with the files given by @skors and @Rudloff)