### PR TITLE
Don’t add github specials if there is no composer data

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -152,14 +152,16 @@ class GitHubDriver extends VcsDriver
             }
 
             $composer = $this->getBaseComposerInformation($identifier);
+            if ($composer) {
 
-            // specials for github
-            if (!isset($composer['support']['source'])) {
-                $label = array_search($identifier, $this->getTags()) ?: array_search($identifier, $this->getBranches()) ?: $identifier;
-                $composer['support']['source'] = sprintf('https://%s/%s/%s/tree/%s', $this->originUrl, $this->owner, $this->repository, $label);
-            }
-            if (!isset($composer['support']['issues']) && $this->hasIssues) {
-                $composer['support']['issues'] = sprintf('https://%s/%s/%s/issues', $this->originUrl, $this->owner, $this->repository);
+                // specials for github
+                if (!isset($composer['support']['source'])) {
+                    $label = array_search($identifier, $this->getTags()) ?: array_search($identifier, $this->getBranches()) ?: $identifier;
+                    $composer['support']['source'] = sprintf('https://%s/%s/%s/tree/%s', $this->originUrl, $this->owner, $this->repository, $label);
+                }
+                if (!isset($composer['support']['issues']) && $this->hasIssues) {
+                    $composer['support']['issues'] = sprintf('https://%s/%s/%s/issues', $this->originUrl, $this->owner, $this->repository);
+                }
             }
 
             if ($this->shouldCache($identifier)) {


### PR DESCRIPTION
This can happen if an identifier doesn’t have a composer.json file (but other identifiers do)

VCSRepository->initialize() cycles through tags/branches. GitHubDriver->getComposerInformation() will always return data even if there is nothing returned by getBaseComposerInformation()

This request does not add the GitHub information if there is no composer file. Thus skipping the identifier. 