### PR TITLE
use curl instead of wget for example script

### DIFF
--- a/doc/faqs/how-to-install-composer-programmatically.md
+++ b/doc/faqs/how-to-install-composer-programmatically.md
@@ -9,7 +9,7 @@ An alternative is to use this script which only works with unix utils:
 ```bash
 #!/bin/sh
 
-EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+EXPECTED_SIGNATURE=$(curl https://composer.github.io/installer.sig)
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
 


### PR DESCRIPTION
curl seems to be more widely installed, especially in php docker images.
This sort of command is exactly what curl is for, really. See
https://daniel.haxx.se/docs/curl-vs-wget.html, particularly for the
analogy: "curl works more like the traditional unix cat command, it
sends more stuff to stdout, and reads more from stdin in a "everything
is a pipe" manner. Wget is more like cp, using the same analogue."