### PR TITLE
Work-around for Windows opcache bug, fixes #6052

### DIFF
--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -173,7 +173,12 @@ class XdebugHandler
             $content .= $data.PHP_EOL;
         }
 
-        $content .= PHP_EOL.'memory_limit='.ini_get('memory_limit').PHP_EOL;
+        $content .= 'memory_limit='.ini_get('memory_limit').PHP_EOL;
+
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Work-around for PHP windows bug, see issue #6052
+            $content .= 'opcache.enable_cli=0'.PHP_EOL;
+        }
 
         return @file_put_contents($this->tmpIni, $content);
     }


### PR DESCRIPTION
The segfault occurs on PHP for Windows (5.5, 5.6, 7.0 and 7.1), but not on Ubuntu or Centos.

I'll submit a bug report later.