### PR TITLE
Add full stop to all command descriptions

### DIFF
--- a/src/Composer/Command/AboutCommand.php
+++ b/src/Composer/Command/AboutCommand.php
@@ -24,7 +24,7 @@ class AboutCommand extends BaseCommand
     {
         $this
             ->setName('about')
-            ->setDescription('Short information about Composer')
+            ->setDescription('Short information about Composer.')
             ->setHelp(<<<EOT
 <info>php composer.phar about</info>
 EOT

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -37,7 +37,7 @@ class ArchiveCommand extends BaseCommand
     {
         $this
             ->setName('archive')
-            ->setDescription('Create an archive of this composer package')
+            ->setDescription('Create an archive of this composer package.')
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'The package to archive instead of the current project'),
                 new InputArgument('version', InputArgument::OPTIONAL, 'A version constraint to find the package to archive'),

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -63,7 +63,7 @@ class ConfigCommand extends BaseCommand
     {
         $this
             ->setName('config')
-            ->setDescription('Set config options')
+            ->setDescription('Set config options.')
             ->setDefinition(array(
                 new InputOption('global', 'g', InputOption::VALUE_NONE, 'Apply command to the global config file'),
                 new InputOption('editor', 'e', InputOption::VALUE_NONE, 'Open editor'),

--- a/src/Composer/Command/DependsCommand.php
+++ b/src/Composer/Command/DependsCommand.php
@@ -30,7 +30,7 @@ class DependsCommand extends BaseDependencyCommand
         $this
             ->setName('depends')
             ->setAliases(array('why'))
-            ->setDescription('Shows which packages cause the given package to be installed')
+            ->setDescription('Shows which packages cause the given package to be installed.')
             ->setHelp(<<<EOT
 Displays detailed information about where a package is referenced.
 

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -28,7 +28,7 @@ class DumpAutoloadCommand extends BaseCommand
         $this
             ->setName('dump-autoload')
             ->setAliases(array('dumpautoload'))
-            ->setDescription('Dumps the autoloader')
+            ->setDescription('Dumps the autoloader.')
             ->setDefinition(array(
                 new InputOption('no-scripts', null, InputOption::VALUE_NONE, 'Skips the execution of all scripts defined in composer.json file.'),
                 new InputOption('optimize', 'o', InputOption::VALUE_NONE, 'Optimizes PSR0 and PSR4 packages to be loaded with classmaps too, good for production.'),

--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -26,7 +26,7 @@ class ExecCommand extends BaseCommand
     {
         $this
             ->setName('exec')
-            ->setDescription('Execute a vendored binary/script')
+            ->setDescription('Execute a vendored binary/script.')
             ->setDefinition(array(
                 new InputOption('list', 'l', InputOption::VALUE_NONE),
                 new InputArgument('binary', InputArgument::OPTIONAL, 'The binary to run, e.g. phpunit'),

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -31,7 +31,7 @@ class LicensesCommand extends BaseCommand
     {
         $this
             ->setName('licenses')
-            ->setDescription('Show information about licenses of dependencies')
+            ->setDescription('Show information about licenses of dependencies.')
             ->setDefinition(array(
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),

--- a/src/Composer/Command/ProhibitsCommand.php
+++ b/src/Composer/Command/ProhibitsCommand.php
@@ -30,7 +30,7 @@ class ProhibitsCommand extends BaseDependencyCommand
         $this
             ->setName('prohibits')
             ->setAliases(array('why-not'))
-            ->setDescription('Shows which packages prevent the given package from being installed')
+            ->setDescription('Shows which packages prevent the given package from being installed.')
             ->setHelp(<<<EOT
 Displays detailed information about why a package cannot be installed.
 

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -33,7 +33,7 @@ class RemoveCommand extends BaseCommand
     {
         $this
             ->setName('remove')
-            ->setDescription('Removes a package from the require or require-dev')
+            ->setDescription('Removes a package from the require or require-dev.')
             ->setDefinition(array(
                 new InputArgument('packages', InputArgument::IS_ARRAY, 'Packages that should be removed.'),
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Removes a package from the require-dev section.'),

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -36,7 +36,7 @@ class RequireCommand extends InitCommand
     {
         $this
             ->setName('require')
-            ->setDescription('Adds required packages to your composer.json and installs them')
+            ->setDescription('Adds required packages to your composer.json and installs them.')
             ->setDefinition(array(
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Required package name optionally including a version constraint, e.g. foo/bar or foo/bar:1.0.0 or foo/bar=1.0.0 or "foo/bar 1.0.0"'),
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Add requirement to require-dev.'),

--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -38,7 +38,7 @@ class SearchCommand extends BaseCommand
     {
         $this
             ->setName('search')
-            ->setDescription('Search for packages')
+            ->setDescription('Search for packages.')
             ->setDefinition(array(
                 new InputOption('only-name', 'N', InputOption::VALUE_NONE, 'Search only in name'),
                 new InputOption('type', 't', InputOption::VALUE_REQUIRED, 'Search for a specific package type'),

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -57,7 +57,7 @@ class ShowCommand extends BaseCommand
         $this
             ->setName('show')
             ->setAliases(array('info'))
-            ->setDescription('Show information about packages')
+            ->setDescription('Show information about packages.')
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.'),
                 new InputArgument('version', InputArgument::OPTIONAL, 'Version or version constraint to inspect'),

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -41,7 +41,7 @@ class StatusCommand extends BaseCommand
     {
         $this
             ->setName('status')
-            ->setDescription('Show a list of locally modified packages')
+            ->setDescription('Show a list of locally modified packages.')
             ->setDefinition(array(
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Show modified files for each directory that contains changes.'),
             ))

--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -24,7 +24,7 @@ class SuggestsCommand extends BaseCommand
     {
         $this
             ->setName('suggests')
-            ->setDescription('Show package suggestions')
+            ->setDescription('Show package suggestions.')
             ->setDefinition(array(
                 new InputOption('by-package', null, InputOption::VALUE_NONE, 'Groups output by suggesting package'),
                 new InputOption('by-suggestion', null, InputOption::VALUE_NONE, 'Groups output by suggested package'),

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -37,7 +37,7 @@ class ValidateCommand extends BaseCommand
     {
         $this
             ->setName('validate')
-            ->setDescription('Validates a composer.json and composer.lock')
+            ->setDescription('Validates a composer.json and composer.lock.')
             ->setDefinition(array(
                 new InputOption('no-check-all', null, InputOption::VALUE_NONE, 'Do not make a complete validation'),
                 new InputOption('no-check-lock', null, InputOption::VALUE_NONE, 'Do not check if lock file is up to date'),


### PR DESCRIPTION
Simple but effective, I simply added a full stop to each command's description if it was not already there.