### PR TITLE
Trying to fix the new setExecuteOperations() on the installer

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -605,7 +605,7 @@ class Installer
                 $this->eventDispatcher->dispatchPackageEvent(constant($event), $this->devMode, $policy, $pool, $installedRepo, $request, $operations, $operation);
             }
 
-            if ($this->executeOperations) {
+            if ($this->executeOperations || $this->writeLock) {
                 $localRepo->write();
             }
         }


### PR DESCRIPTION
This is a follow up for https://github.com/composer/composer/pull/5787.
As mentioned there, @Seldaek's implementation unfortunately doesn't quite work for me.

The problem is that when you call

```php
$installer
    ->setWriteLock(true)
    ->setExecuteOperations(false);
```

a `composer.lock` file will never be written because the `$localRepo` has no packages.