### PR TITLE
Fix Xdebug warning (proper)

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -166,7 +166,7 @@ class Application extends BaseApplication
                 $io->writeError('<warning>Composer only officially supports PHP 5.3.2 and above, you will most likely encounter problems with your PHP '.PHP_VERSION.', upgrading is strongly recommended.</warning>');
             }
 
-            if (extension_loaded('xdebug') && (!getenv('COMPOSER_DISABLE_XDEBUG_WARN') || getenv('COMPOSER_ALLOW_XDEBUG'))) {
+            if (extension_loaded('xdebug') && !getenv('COMPOSER_DISABLE_XDEBUG_WARN') && !getenv('COMPOSER_ALLOW_XDEBUG')) {
                 $io->writeError('<warning>You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug</warning>');
             }
 

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -166,7 +166,7 @@ class Application extends BaseApplication
                 $io->writeError('<warning>Composer only officially supports PHP 5.3.2 and above, you will most likely encounter problems with your PHP '.PHP_VERSION.', upgrading is strongly recommended.</warning>');
             }
 
-            if (extension_loaded('xdebug') && !getenv('COMPOSER_DISABLE_XDEBUG_WARN') && !getenv('COMPOSER_ALLOW_XDEBUG')) {
+            if (extension_loaded('xdebug') && !getenv('COMPOSER_DISABLE_XDEBUG_WARN')) {
                 $io->writeError('<warning>You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug</warning>');
             }
 


### PR DESCRIPTION
Proper fix, follow-up to #6058.

Alternatively, you could undo https://github.com/composer/composer/commit/c5dcedd0db1b4f8576973b016ecc73be1c34492c, as a result it would require to set both constants `COMPOSER_ALLOW_XDEBUG` and `COMPOSER_DISABLE_XDEBUG_WARN` to allow Xdebug without warning.