### PR TITLE
Return 1 if composer.json exists, but the package doesn't.

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -173,7 +173,7 @@ EOT
                     }
 
                     $io->writeError('Package ' . $packageFilter . ' not found in ' . $options['working-dir'] . '/composer.json');
-                    return;
+                    return 1;
                 }
             } else {
                 $versions = array($package->getPrettyVersion() => $package->getVersion());


### PR DESCRIPTION
This should resolve issue #6092.