### PR TITLE
Updated documentation to clarify versions and package resolution (refs #6088)

### DIFF
--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -33,18 +33,21 @@ As you can see, [`require`](04-schema.md#require) takes an object that maps
 **package names** (e.g. `monolog/monolog`) to **version constraints** (e.g.
 `1.0.*`).
 
+It uses this information to search for the right set of files in package
+"repositories" that you register using the [`repositories`](04-schema.md#repositories)
+key, or in Packagist, the default package respository. In the above example,
+since no other repository is registered in the file, it is assumed that the
+`monolog/monolog` package is registered on Packagist. (See more about Packagist
+[below](#packagist), or read more about repositories [here](05-repositories.md).
+
 ### Package Names
 
 The package name consists of a vendor name and the project's name. Often these
-will be identical - the vendor name just exists to prevent naming clashes. It
-allows two different people to create a library named `json`, which would then
-just be named `igorw/json` and `seldaek/json`.
+will be identical - the vendor name just exists to prevent naming clashes. For
+example, it would allow two different people to create a library named `json`.
+One might be named `igorw/json` while the other might be `seldaek/json`.
 
-Here we are requiring `monolog/monolog`, so the vendor name is the same as the
-project's name. For projects with a unique name this is recommended. It also
-allows adding more related projects under the same namespace later on. If you
-are maintaining a library, this would make it really easy to split it up into
-smaller decoupled parts.
+Read more about publishing packages and package naming [here](02-libraries.md)
 
 ### Package Versions
 
@@ -53,16 +56,30 @@ In the previous example we were requiring version
 Monolog. This means any version in the `1.0` development branch. It is the
 equivalent of saying versions that match `>=1.0 <1.1`.
 
-Version constraints can be specified in several ways, read
+Version constraints can be specified in several ways; please read
 [versions](articles/versions.md) for more in-depth information on this topic.
 
-### Stability
+> **How does Composer download the right files?** When you specify a dependency in
+> `composer.json`, Composer, first takes the name of the package that you've requested
+> and searches for it in any repositories that you've registered using the
+> [`repositories`](04-schema.md#repositories) key. If you haven't registered
+> any extra repositories, or it doesn't find a package with that name in the
+> repositories you've specified, it falls back to Packagist (more [below](#packagist)).
+>
+> When it finds the right package, either in Packagist or in a repo you've specified,
+> it then uses the versioning features of the package's VCS to attempt to find the
+> best match for the version you've specified. Read more on package resolution
+> [here](articles/versions.md).
 
-By default only stable releases are taken into consideration. If you would
-like to also get RC, beta, alpha or dev versions of your dependencies you can
-do so using [stability flags](04-schema.md#package-links). To change that for
-all packages instead of doing per dependency you can also use the
-[minimum-stability](04-schema.md#minimum-stability) setting.
+> **Note:** If you're trying to require a package but Composer throws an error
+> regarding package stability, the version you've specified may not meet the 
+> default minimum stability requirements that Composer establishes. By default
+> only stable releases are taken into consideration when searching for package
+> versions in your VCS.
+>
+> You might run into this if you're trying to require dev, alpha, beta, or RC
+> versions of a package. Read more about stability flags and the `minimum-stability`
+> key on the [schema page](04-schema.md).
 
 ## Installing Dependencies
 
@@ -76,7 +93,7 @@ php composer.phar install
 This will find the latest version of `monolog/monolog` that matches the
 supplied version constraint and download it into the `vendor` directory.
 It's a convention to put third party code into a directory named `vendor`.
-In case of Monolog it will put it into `vendor/monolog/monolog`.
+In the case of Monolog it will put it into `vendor/monolog/monolog`.
 
 > **Tip:** If you are using git for your project, you probably want to add
 > `vendor` in your `.gitignore`. You really don't want to add all of that
@@ -99,16 +116,16 @@ if a lock file is present, and if it is, it downloads the versions specified
 there (regardless of what `composer.json` says).
 
 This means that anyone who sets up the project will download the exact same
-version of the dependencies. Your CI server, production machines, other
-developers in your team, everything and everyone runs on the same dependencies,
-which mitigates the potential for bugs affecting only some parts of the
-deployments. Even if you develop alone, in six months when reinstalling the
-project you can feel confident the dependencies installed are still working even
-if your dependencies released many new versions since then.
+versions of the dependencies that you're using. Your CI server, production
+machines, other developers in your team, everything and everyone runs on the
+same dependencies, which mitigates the potential for bugs affecting only some
+parts of the deployments. Even if you develop alone, in six months when
+reinstalling the project you can feel confident the dependencies installed are
+still working even if your dependencies released many new versions since then.
+(See note below about using the `update` command.)
 
 If no `composer.lock` file exists, Composer will read the dependencies and
-versions from `composer.json` and  create the lock file after executing the
-[`update`](03-cli.md#update) or the [`install`](03-cli.md#install) command.
+versions from `composer.json` and  create the lock file after executing.
 
 This means that if any of the dependencies get a new version, you won't get the
 updates automatically. To update to the new version, use the
@@ -136,7 +153,8 @@ php composer.phar update monolog/monolog [...]
 [Packagist](https://packagist.org/) is the main Composer repository. A Composer
 repository is basically a package source: a place where you can get packages
 from. Packagist aims to be the central repository that everybody uses. This
-means that you can automatically `require` any package that is available there.
+means that you can automatically `require` any package that is available there,
+without further specifying where Composer should look for the package.
 
 If you go to the [Packagist website](https://packagist.org/) (packagist.org),
 you can browse and search for packages.

--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -48,7 +48,10 @@ will be identical - the vendor name just exists to prevent naming clashes. For
 example, it would allow two different people to create a library named `json`.
 One might be named `igorw/json` while the other might be `seldaek/json`.
 
-Read more about publishing packages and package naming [here](02-libraries.md)
+Read more about publishing packages and package naming [here](02-libraries.md).
+(Note that you can also specify "platform packages" as dependencies, allowing
+you to require certain versions of server software. See
+[platform packages](#platform-packages) below.)
 
 ### Package Version Constraints
 
@@ -57,8 +60,8 @@ In our example, we're requesting the Monolog package with the version constraint
 This means any version in the `1.0` development branch, or any version that is
 greater than or equal to 1.0 and less than 1.1 (`>=1.0 <1.1`).
 
-Version can be a little confusing in Composer, and version constraints can be specified
-in several ways. Please read [versions](articles/versions.md) for more in-depth information.
+(What the term "version" actually means can be a little confusing in Composer.
+Please read [versions](articles/versions.md) for more in-depth information.)
 
 > **How does Composer download the right files?** When you specify a dependency in
 > `composer.json`, Composer, first takes the name of the package that you've requested
@@ -69,7 +72,7 @@ in several ways. Please read [versions](articles/versions.md) for more in-depth 
 >
 > When it finds the right package, either in Packagist or in a repo you've specified,
 > it then uses the versioning features of the package's VCS (i.e., branches and tags)
-> to attempt to find the best match for the version you've specified. Be sure to read
+> to attempt to find the best match for the version constraint you've specified. Be sure to read
 > about versions and package resolution in the [versions article](articles/versions.md).
 
 > **Note:** If you're trying to require a package but Composer throws an error
@@ -108,7 +111,8 @@ folders under `vendor/`.
 
 When Composer has finished installing, it writes all of the packages and the exact versions
 of them that it downloaded to the `composer.lock` file, locking the project to those specific
-versions.
+versions. You should commit the `composer.lock` file to your project repo so that all people
+working on the project are locked to the same versions of dependencies (more below).
 
 ### Installing With `composer.lock`
 
@@ -122,7 +126,7 @@ all dependencies that you've listed in `composer.json`, but it uses the version 
 that it finds in `composer.lock` to ensure that the package versions are consistent for everyone
 working on your project. The result is that you have all dependencies requested by your
 `composer.json` file, but that they may not all be at the very latest available versions (since
-some of the dependencies listed in the `composer.lock` file may have released new versions since
+some of the dependencies listed in the `composer.lock` file may have released newer versions since
 the file was created). This is by design, as it ensures that your project never breaks because of
 unexpected changes in dependencies.
 
@@ -175,6 +179,31 @@ you can browse and search for packages.
 Any open source project using Composer is recommended to publish their packages
 on Packagist. A library doesn't need to be on Packagist to be used by Composer,
 but it enables discovery and adoption by other developers more quickly.
+
+## Platform packages
+
+Composer has platform packages, which are virtual packages for things that are
+installed on the system but are not actually installable by Composer. This
+includes PHP itself, PHP extensions and some system libraries.
+
+* `php` represents the PHP version of the user, allowing you to apply
+  constraints, e.g. `>=5.4.0`. To require a 64bit version of php, you can
+  require the `php-64bit` package.
+
+* `hhvm` represents the version of the HHVM runtime (aka HipHop Virtual
+  Machine) and allows you to apply a constraint, e.g., '>=2.3.3'.
+
+* `ext-<name>` allows you to require PHP extensions (includes core
+  extensions). Versioning can be quite inconsistent here, so it's often
+  a good idea to just set the constraint to `*`.  An example of an extension
+  package name is `ext-gd`.
+
+* `lib-<name>` allows constraints to be made on versions of libraries used by
+  PHP. The following are available: `curl`, `iconv`, `icu`, `libxml`,
+  `openssl`, `pcre`, `uuid`, `xsl`.
+
+You can use [`show --platform`](03-cli.md#show) to get a list of your locally
+available platform packages.
 
 ## Autoloading
 

--- a/doc/02-libraries.md
+++ b/doc/02-libraries.md
@@ -8,7 +8,7 @@ Composer.
 As soon as you have a `composer.json` in a directory, that directory is a
 package. When you add a [`require`](04-schema.md#require) to a project, you are
 making a package that depends on other packages. The only difference between
-your project and libraries is that your project is a package without a name.
+your project and a library is that your project is a package without a name.
 
 In order to make that package installable you need to give it a name. You do
 this by adding the [`name`](04-schema.md#name) property in `composer.json`:
@@ -29,40 +29,18 @@ name. Supplying a vendor name is mandatory.
 > username is usually a good bet. While package names are case insensitive, the
 > convention is all lowercase and dashes for word separation.
 
-## Platform packages
+## Library Versioning
 
-Composer has platform packages, which are virtual packages for things that are
-installed on the system but are not actually installable by Composer. This
-includes PHP itself, PHP extensions and some system libraries.
+In the vast majority of cases, you will be maintaining your library using some
+sort of version control system like git, svn, hg or fossil. In these cases,
+Composer infers versions from your VCS and you **should not** specify a version
+in your `composer.json` file. (See the [Versions article](articles/versions.md)
+to learn about how Composer uses VCS branches and tags to resolve version
+constraints.)
 
-* `php` represents the PHP version of the user, allowing you to apply
-  constraints, e.g. `>=5.4.0`. To require a 64bit version of php, you can
-  require the `php-64bit` package.
-
-* `hhvm` represents the version of the HHVM runtime (aka HipHop Virtual
-  Machine) and allows you to apply a constraint, e.g., '>=2.3.3'.
-
-* `ext-<name>` allows you to require PHP extensions (includes core
-  extensions). Versioning can be quite inconsistent here, so it's often
-  a good idea to just set the constraint to `*`.  An example of an extension
-  package name is `ext-gd`.
-
-* `lib-<name>` allows constraints to be made on versions of libraries used by
-  PHP. The following are available: `curl`, `iconv`, `icu`, `libxml`,
-  `openssl`, `pcre`, `uuid`, `xsl`.
-
-You can use [`show --platform`](03-cli.md#show) to get a list of your locally
-available platform packages.
-
-## Specifying the version
-
-When you publish your package on Packagist, it is able to infer the version
-from the VCS (git, svn, hg, fossil) information. This means you don't have to
-explicitly declare it. Read [tags](#tags) and [branches](#branches) to see how
-version numbers are extracted from these.
-
-If you are creating packages by hand and really have to specify it explicitly,
-you can just add a `version` field:
+If you are maintaining packages by hand (i.e., without a VCS), you'll need to
+specify the version explicitly by adding a `version` value in your `composer.json`
+file:
 
 ```json
 {
@@ -70,57 +48,16 @@ you can just add a `version` field:
 }
 ```
 
-> **Note:** You should avoid specifying the version field explicitly, because
-> for tags the value must match the tag name.
+### VCS Versioning
 
-### Tags
+Composer uses your VCS's branch and tag features to resolve the version
+constraints you specify in your `require` field to specific sets of files.
+When determining valid available versions, Composer looks at all of your tags
+and branches and translates their names into an internal list of options that
+it then matches against the version constraint you've provided.
 
-For every tag that looks like a version, a package version of that tag will be
-created. It should match 'X.Y.Z' or 'vX.Y.Z', with an optional suffix of
-`-patch` (`-p`), `-alpha` (`-a`), `-beta` (`-b`) or `-RC`. The suffix can also
-be followed by a number.
-
-Here are a few examples of valid tag names:
-
-- 1.0.0
-- v1.0.0
-- 1.10.5-RC1
-- v4.4.4-beta2
-- v2.0.0-alpha
-- v2.0.4-p1
-
-> **Note:** Even if your tag is prefixed with `v`, a
-> [version constraint](01-basic-usage.md#package-versions) in a `require`
-> statement has to be specified without prefix (e.g. tag `v1.0.0` will result
-> in version `1.0.0`).
-
-### Branches
-
-For every branch, a package development version will be created. If the branch
-name looks like a version, the version will be `{branchname}-dev`. For example,
-the branch `2.0` will get the `2.0.x-dev` version (the `.x` is added for
-technical reasons, to make sure it is recognized as a branch). The `2.0.x`
-branch would also be valid and be turned into `2.0.x-dev` as well. If the
-branch does not look like a version, it will be `dev-{branchname}`. `master`
-results in a `dev-master` version.
-
-Here are some examples of version branch names:
-
-- 1.x
-- 1.0 (equals 1.0.x)
-- 1.1.x
-
-> **Note:** When you install a development version, it will be automatically
-> pulled from its `source`. See the [`install`](03-cli.md#install) command
-> for more details.
-
-### Aliases
-
-It is possible to alias branch names to versions. For example, you could alias
-`dev-master` to `1.0.x-dev`, which would allow you to require `1.0.x-dev` in
-all the packages.
-
-See [Aliases](articles/aliases.md) for more information.
+For more on how Composer treats tags and branches and how it resolves package
+version constraints, read the [versions](articles/versions.md) article.
 
 ## Lock file
 

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -255,7 +255,8 @@ Optional.
 ### Package links
 
 All of the following take an object which maps package names to
-[version constraints](01-basic-usage.md#package-versions).
+versions of the package via version constraints. Read more about
+versions [here](articles/versions.md).
 
 Example:
 
@@ -680,9 +681,9 @@ it in your file to avoid surprises.
 
 All versions of each package are checked for stability, and those that are less
 stable than the `minimum-stability` setting will be ignored when resolving
-your project dependencies. Specific changes to the stability requirements of
-a given package can be done in `require` or `require-dev` (see
-[package links](#package-links)).
+your project dependencies. (Note that you can also specify stability requirements
+on a per-package basis using stability flags in the version constraints that you
+specify in a `require` block (see [package links](#package-links) for more details).
 
 Available options (in order of stability) are `dev`, `alpha`, `beta`, `RC`,
 and `stable`.


### PR DESCRIPTION
This is a first attempt at clarifying these points. I added a lot of information about the internals of Composer's process for resolving packages. I tried not to flood the user with unnecessary information, but the details I added were those that I myself found to be lacking and that, had they been present before, would have helped me better understand how to publish libraries and use Composer to manage them.

Having taken this foray into the docs, I remain convinced that they're very good, but could be better. I'd like to have a go at maybe a total rewrite of the Composer "book". There are just a few details that were hard to place in the current set of files, and I think this is because they're not structured in the best possible way.

Anyway, I know this pull request is a lot to read through, so please forgive that, but I hope the devs and users of Composer find it to be a valuable!