### PR TITLE
Streamline install progress messages

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -84,7 +84,7 @@ class FileDownloader implements DownloaderInterface
         }
 
         if ($output) {
-            $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . $package->getFullPrettyVersion() . "</comment>)", false);
+            $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . $package->getFullPrettyVersion() . "</comment>): ", false);
         }
 
         $urls = $package->getDistUrls();
@@ -132,7 +132,6 @@ class FileDownloader implements DownloaderInterface
 
             // download if we don't have it in cache or the cache is invalidated
             if (!$this->cache || ($checksum && $checksum !== $this->cache->sha1($cacheKey)) || !$this->cache->copyTo($cacheKey, $fileName)) {
-                $this->io->writeError(': ', false);
                 if (!$this->outputProgress) {
                     $this->io->writeError('Downloading', false);
                 }
@@ -163,7 +162,7 @@ class FileDownloader implements DownloaderInterface
                     $this->cache->copyFrom($cacheKey, $fileName);
                 }
             } else {
-                $this->io->writeError(' from cache', false);
+                $this->io->writeError('Loading from cache', false);
             }
 
             if (!file_exists($fileName)) {
@@ -211,7 +210,7 @@ class FileDownloader implements DownloaderInterface
         $from = $initial->getPrettyVersion();
         $to = $target->getPrettyVersion();
 
-        $this->io->writeError("  - Updating <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>)", false);
+        $this->io->writeError("  - Updating <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>): ", false);
 
         $this->remove($initial, $path, false);
         $this->download($target, $path, false);

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -132,8 +132,9 @@ class FileDownloader implements DownloaderInterface
 
             // download if we don't have it in cache or the cache is invalidated
             if (!$this->cache || ($checksum && $checksum !== $this->cache->sha1($cacheKey)) || !$this->cache->copyTo($cacheKey, $fileName)) {
+                $this->io->writeError(': ', false);
                 if (!$this->outputProgress) {
-                    $this->io->writeError(' Downloading', false);
+                    $this->io->writeError('Downloading', false);
                 }
 
                 // try to download 3 times then fail hard
@@ -153,12 +154,16 @@ class FileDownloader implements DownloaderInterface
                     }
                 }
 
+                if (!$this->outputProgress) {
+                    $this->io->writeError(' (<comment>100%</comment>)', false);
+                }
+
                 if ($this->cache) {
                     $this->lastCacheWrites[$package->getName()] = $cacheKey;
                     $this->cache->copyFrom($cacheKey, $fileName);
                 }
             } else {
-                $this->io->writeError(' Loading from cache', false);
+                $this->io->writeError(' from cache', false);
             }
 
             if (!file_exists($fileName)) {

--- a/src/Composer/Downloader/FossilDownloader.php
+++ b/src/Composer/Downloader/FossilDownloader.php
@@ -31,7 +31,7 @@ class FossilDownloader extends VcsDownloader
         $url = ProcessExecutor::escape($url);
         $ref = ProcessExecutor::escape($package->getSourceReference());
         $repoFile = $path . '.fossil';
-        $this->io->writeError(" Cloning ".$package->getSourceReference());
+        $this->io->writeError("Cloning ".$package->getSourceReference());
         $command = sprintf('fossil clone %s %s', $url, ProcessExecutor::escape($repoFile));
         if (0 !== $this->process->execute($command, $ignoredOutput)) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -49,7 +49,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
 
         // --dissociate option is only available since git 2.3.0-rc0
         $gitVersion = $this->gitUtil->getVersion();
-        $msg = " Cloning ".$this->getShortHash($ref);
+        $msg = "Cloning ".$this->getShortHash($ref);
         if ($gitVersion && version_compare($gitVersion, '2.3.0-rc0', '>=')) {
             $this->io->writeError('', true, IOInterface::DEBUG);
             $this->io->writeError(sprintf('    Cloning to cache at %s', ProcessExecutor::escape($cachePath)), true, IOInterface::DEBUG);
@@ -57,7 +57,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
                 $this->gitUtil->syncMirror($url, $cachePath);
                 if (is_dir($cachePath)) {
                     $cacheOptions = sprintf('--dissociate --reference %s ', ProcessExecutor::escape($cachePath));
-                    $msg = " Cloning ".$this->getShortHash($ref).' from cache';
+                    $msg = "Cloning ".$this->getShortHash($ref).' from cache';
                 }
             } catch (\RuntimeException $e) {}
         }

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -30,7 +30,7 @@ class HgDownloader extends VcsDownloader
 
         $url = ProcessExecutor::escape($url);
         $ref = ProcessExecutor::escape($package->getSourceReference());
-        $this->io->writeError(" Cloning ".$package->getSourceReference());
+        $this->io->writeError("Cloning ".$package->getSourceReference());
         $command = sprintf('hg clone %s %s', $url, ProcessExecutor::escape($path));
         if (0 !== $this->process->execute($command, $ignoredOutput)) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -140,7 +140,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
                 throw new \RuntimeException('Could not reliably remove junction for package ' . $package->getName());
             }
         } else {
-            parent::remove($package, $path);
+            parent::remove($package, $path, $output);
         }
     }
 

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -77,7 +77,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
 
         if ($output) {
             $this->io->writeError(sprintf(
-                '  - Installing <info>%s</info> (<comment>%s</comment>)',
+                '  - Installing <info>%s</info> (<comment>%s</comment>): ',
                 $package->getName(),
                 $package->getFullPrettyVersion()
             ), false);
@@ -88,8 +88,8 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             try {
                 if (Platform::isWindows()) {
                     // Implement symlinks as NTFS junctions on Windows
+                    $this->io->writeError(sprintf('Junctioning from %s', $url), false);
                     $this->filesystem->junction($realUrl, $path);
-                    $this->io->writeError(sprintf(' Junctioned from %s', $url), false);
                 } else {
                     $absolutePath = $path;
                     if (!$this->filesystem->isAbsolutePath($absolutePath)) {
@@ -97,8 +97,8 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
                     }
                     $shortestPath = $this->filesystem->findShortestPath($absolutePath, $realUrl);
                     $path = rtrim($path, "/");
+                    $this->io->writeError(sprintf('Symlinking from %s', $url), false);
                     $fileSystem->symlink($shortestPath, $path);
-                    $this->io->writeError(sprintf(' Symlinked from %s', $url), false);
                 }
             } catch (IOException $e) {
                 if (in_array(self::STRATEGY_MIRROR, $allowedStrategies)) {
@@ -114,8 +114,8 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
 
         // Fallback if symlink failed or if symlink is not allowed for the package
         if (self::STRATEGY_MIRROR == $currentStrategy) {
+            $this->io->writeError(sprintf('%sMirroring from %s', $isFallback ? '    ' : '', $url), false);
             $fileSystem->mirror($realUrl, $path);
-            $this->io->writeError(sprintf('%s Mirrored from %s', $isFallback ? '   ' : '', $url), false);
         }
 
         $this->io->writeError('');

--- a/src/Composer/Downloader/PerforceDownloader.php
+++ b/src/Composer/Downloader/PerforceDownloader.php
@@ -32,7 +32,7 @@ class PerforceDownloader extends VcsDownloader
         $ref = $package->getSourceReference();
         $label = $this->getLabelFromSourceReference($ref);
 
-        $this->io->writeError(' Cloning ' . $ref);
+        $this->io->writeError('Cloning ' . $ref);
         $this->initPerforce($package, $path, $url);
         $this->perforce->setStream($ref);
         $this->perforce->p4Login();

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -60,7 +60,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
             throw new \InvalidArgumentException('Package '.$package->getPrettyName().' is missing reference information');
         }
 
-        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . $package->getFullPrettyVersion() . "</comment>)", false);
+        $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>" . $package->getFullPrettyVersion() . "</comment>): ", false);
         $this->filesystem->emptyDirectory($path);
 
         $urls = $package->getSourceUrls();
@@ -130,7 +130,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
             $to = $target->getFullPrettyVersion();
         }
 
-        $this->io->writeError("  - Updating <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>)", false);
+        $this->io->writeError("  - Updating <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>): ", false);
 
         $this->cleanChanges($initial, $path, true);
         $urls = $target->getSourceUrls();

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -276,7 +276,7 @@ class RemoteFilesystem
         }
 
         if ($this->progress && !$isRedirect) {
-            $this->io->writeError(" Downloading: <comment>Connecting...</comment>", false);
+            $this->io->writeError("Downloading (<comment>connecting...</comment>)", false);
         }
 
         $errorMessage = '';
@@ -367,7 +367,7 @@ class RemoteFilesystem
         if ($statusCode && $statusCode >= 400 && $statusCode <= 599) {
             if (!$this->retry) {
                 if ($this->progress && !$this->retry && !$isRedirect) {
-                    $this->io->overwriteError(" Downloading: <error>Failed</error>", false);
+                    $this->io->overwriteError("Downloading (<error>failed</error>)", false);
                 }
 
                 $e = new TransportException('The "'.$this->fileUrl.'" file could not be downloaded ('.$http_response_header[0].')', $statusCode);
@@ -380,7 +380,7 @@ class RemoteFilesystem
         }
 
         if ($this->progress && !$this->retry && !$isRedirect) {
-            $this->io->overwriteError(" Downloading: ".($result === false ? '<error>Failed</error>' : '<comment>100%</comment>'), false);
+            $this->io->overwriteError("Downloading (".($result === false ? '<error>failed</error>' : '<comment>100%</comment>)'), false);
         }
 
         // decode gzip
@@ -567,7 +567,7 @@ class RemoteFilesystem
 
                     if ((0 === $progression % 5) && 100 !== $progression && $progression !== $this->lastProgress) {
                         $this->lastProgress = $progression;
-                        $this->io->overwriteError(" Downloading: <comment>$progression%</comment>", false);
+                        $this->io->overwriteError("Downloading (<comment>$progression%</comment>)", false);
                     }
                 }
                 break;

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -380,7 +380,7 @@ class RemoteFilesystem
         }
 
         if ($this->progress && !$this->retry && !$isRedirect) {
-            $this->io->overwriteError("Downloading (".($result === false ? '<error>failed</error>' : '<comment>100%</comment>)'), false);
+            $this->io->overwriteError("Downloading (".($result === false ? '<error>failed</error>' : '<comment>100%</comment>').")", false);
         }
 
         // decode gzip

--- a/tests/Composer/Test/Fixtures/functional/create-project-command.test
+++ b/tests/Composer/Test/Fixtures/functional/create-project-command.test
@@ -2,7 +2,7 @@
 create-project seld/jsonlint %testDir% 1.0.0 --prefer-source -n
 --EXPECT-ERROR--
 Installing seld/jsonlint (1.0.0)
-  - Installing seld/jsonlint (1.0.0) Cloning 3b4bc2a96f
+  - Installing seld/jsonlint (1.0.0): Cloning 3b4bc2a96f
 Created project in %testDir%
 Loading composer repositories with package information
 Updating dependencies (including require-dev)


### PR DESCRIPTION
This PR streamlines the messages printed during package installs. It cleans up several small discrepancies and issues:

1. ensure output is the same with and without `--no-progress`;
1. ensure the message doesn't say just "Downloading" after completion with `--no-progress` by appending "(100%)" when done;
1. proper-ish grammar (there should be some kind of separator before "Downloading");
1. print all progress indicators before the operation (e.g. for symlink/mirroring), which is useful in particular if the operation fails with an exception

Current, no cache:

```ShellSession
$ COMPOSER_CACHE_DIR=/dev/null composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 11 installs, 0 updates, 0 removals
  - Installing psr/log (1.0.2) Downloading: 100%         
  - Installing monolog/monolog (1.22.0) Downloading: 100%         
  - Installing symfony/routing (v3.2.2) Downloading: 100%         
  - Installing symfony/polyfill-mbstring (v1.3.0) Downloading: 100%         
  - Installing symfony/http-foundation (v3.2.2) Downloading: 100%         
  - Installing symfony/event-dispatcher (v3.2.2) Downloading: 100%         
  - Installing symfony/debug (v3.2.2) Downloading: 100%         
  - Installing symfony/http-kernel (v3.2.2) Downloading: 100%         
  - Installing pimple/pimple (v3.0.2) Downloading: 100%         
  - Installing silex/silex (v2.0.4) Downloading: 100%         
  - Installing heroku/heroku-buildpack-php (dev-gracefulstop 0892abb) Cloning 0892abb496
…
```

Current, no cache, `--no-progress`:

```ShellSession
$ COMPOSER_CACHE_DIR=/dev/null composer install --no-progress
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 11 installs, 0 updates, 0 removals
  - Installing psr/log (1.0.2) Downloading
  - Installing monolog/monolog (1.22.0) Downloading
  - Installing symfony/routing (v3.2.2) Downloading
  - Installing symfony/polyfill-mbstring (v1.3.0) Downloading
  - Installing symfony/http-foundation (v3.2.2) Downloading
  - Installing symfony/event-dispatcher (v3.2.2) Downloading
  - Installing symfony/debug (v3.2.2) Downloading
  - Installing symfony/http-kernel (v3.2.2) Downloading
  - Installing pimple/pimple (v3.0.2) Downloading
  - Installing silex/silex (v2.0.4) Downloading
  - Installing heroku/heroku-buildpack-php (dev-gracefulstop 0892abb) Cloning 0892abb496
…
```

Current, with cache:

```ShellSession
$ composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 11 installs, 0 updates, 0 removals
  - Installing psr/log (1.0.2) Loading from cache
  - Installing monolog/monolog (1.22.0) Loading from cache
  - Installing symfony/routing (v3.2.2) Loading from cache
  - Installing symfony/polyfill-mbstring (v1.3.0) Loading from cache
  - Installing symfony/http-foundation (v3.2.2) Loading from cache
  - Installing symfony/event-dispatcher (v3.2.2) Loading from cache
  - Installing symfony/debug (v3.2.2) Loading from cache
  - Installing symfony/http-kernel (v3.2.2) Loading from cache
  - Installing pimple/pimple (v3.0.2) Loading from cache
  - Installing silex/silex (v2.0.4) Loading from cache
  - Installing heroku/heroku-buildpack-php (dev-gracefulstop 0892abb) Cloning 0892abb496 from cache
…
```

Current, with cache, `--no-progress`:

```ShellSession
$ composer install --no-progress
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 11 installs, 0 updates, 0 removals
  - Installing psr/log (1.0.2) Loading from cache
  - Installing monolog/monolog (1.22.0) Loading from cache
  - Installing symfony/routing (v3.2.2) Loading from cache
  - Installing symfony/polyfill-mbstring (v1.3.0) Loading from cache
  - Installing symfony/http-foundation (v3.2.2) Loading from cache
  - Installing symfony/event-dispatcher (v3.2.2) Loading from cache
  - Installing symfony/debug (v3.2.2) Loading from cache
  - Installing symfony/http-kernel (v3.2.2) Loading from cache
  - Installing pimple/pimple (v3.0.2) Loading from cache
  - Installing silex/silex (v2.0.4) Loading from cache
  - Installing heroku/heroku-buildpack-php (dev-gracefulstop 0892abb) Cloning 0892abb496 from cache
…
```

Proposed, no cache:

```ShellSession
$ COMPOSER_CACHE_DIR=/dev/null ~/Code/oss/composer/bin/composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 11 installs, 0 updates, 0 removals
  - Installing psr/log (1.0.2): Downloading (100%)         
  - Installing monolog/monolog (1.22.0): Downloading (100%)         
  - Installing symfony/routing (v3.2.2): Downloading (100%)         
  - Installing symfony/polyfill-mbstring (v1.3.0): Downloading (100%)         
  - Installing symfony/http-foundation (v3.2.2): Downloading (100%)         
  - Installing symfony/event-dispatcher (v3.2.2): Downloading (100%)         
  - Installing symfony/debug (v3.2.2): Downloading (100%)         
  - Installing symfony/http-kernel (v3.2.2): Downloading (100%)         
  - Installing pimple/pimple (v3.0.2): Downloading (100%)         
  - Installing silex/silex (v2.0.4): Downloading (100%)         
  - Installing heroku/heroku-buildpack-php (dev-gracefulstop 0892abb): Cloning 0892abb496
…
```

Proposed, no cache, `--no-progress`:

```ShellSession
$ COMPOSER_CACHE_DIR=/dev/null ~/Code/oss/composer/bin/composer install --no-progress
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 11 installs, 0 updates, 0 removals
  - Installing psr/log (1.0.2): Downloading (100%)
  - Installing monolog/monolog (1.22.0): Downloading (100%)
  - Installing symfony/routing (v3.2.2): Downloading (100%)
  - Installing symfony/polyfill-mbstring (v1.3.0): Downloading (100%)
  - Installing symfony/http-foundation (v3.2.2): Downloading (100%)
  - Installing symfony/event-dispatcher (v3.2.2): Downloading (100%)
  - Installing symfony/debug (v3.2.2): Downloading (100%)
  - Installing symfony/http-kernel (v3.2.2): Downloading (100%)
  - Installing pimple/pimple (v3.0.2): Downloading (100%)
  - Installing silex/silex (v2.0.4): Downloading (100%)
  - Installing heroku/heroku-buildpack-php (dev-gracefulstop 0892abb): Cloning 0892abb496
…
```

Proposed, with cache:

```ShellSession
$ ~/Code/oss/composer/bin/composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 11 installs, 0 updates, 0 removals
  - Installing psr/log (1.0.2): Loading from cache
  - Installing monolog/monolog (1.22.0): Loading from cache
  - Installing symfony/routing (v3.2.2): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.3.0): Loading from cache
  - Installing symfony/http-foundation (v3.2.2): Loading from cache
  - Installing symfony/event-dispatcher (v3.2.2): Loading from cache
  - Installing symfony/debug (v3.2.2): Loading from cache
  - Installing symfony/http-kernel (v3.2.2): Loading from cache
  - Installing pimple/pimple (v3.0.2): Loading from cache
  - Installing silex/silex (v2.0.4): Loading from cache
  - Installing heroku/heroku-buildpack-php (dev-gracefulstop 0892abb): Cloning 0892abb496 from cache
…
```

Proposed, with cache, `--no-progress`:

```ShellSession
$ ~/Code/oss/composer/bin/composer install --no-progress
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 11 installs, 0 updates, 0 removals
  - Installing psr/log (1.0.2): Loading from cache
  - Installing monolog/monolog (1.22.0): Loading from cache
  - Installing symfony/routing (v3.2.2): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.3.0): Loading from cache
  - Installing symfony/http-foundation (v3.2.2): Loading from cache
  - Installing symfony/event-dispatcher (v3.2.2): Loading from cache
  - Installing symfony/debug (v3.2.2): Loading from cache
  - Installing symfony/http-kernel (v3.2.2): Loading from cache
  - Installing pimple/pimple (v3.0.2): Loading from cache
  - Installing silex/silex (v2.0.4): Loading from cache
  - Installing heroku/heroku-buildpack-php (dev-gracefulstop 0892abb): Cloning 0892abb496 from cache
…
```

I initially had "`Installing silex/silex (v2.0.4) from cache`" in place, but there has to be a colon too, because of various possible combinations of updates and installs, with symlinks etc, so it's "`Installing silex/silex (v2.0.4): Loading from cache`", which is then also consistent with other messages.

Lower-casing the "downloading" etc status is not feasible, as all that stuff is designed to wrap to a newline on failure, and then it would look odd. Not grammatically correct, but better than before and not worth the hassle, I'd say.

Also pretty certain I've missed a spot or two.

Thoughts?