### PR TITLE
Fix Satis example when using `"require-all": true`

### DIFF
--- a/doc/articles/handling-private-packages-with-satis.md
+++ b/doc/articles/handling-private-packages-with-satis.md
@@ -51,7 +51,8 @@ The default file Satis looks for is `satis.json` in the root of the repository.
   "repositories": [
     { "type": "vcs", "url": "https://github.com/mycompany/privaterepo" },
     { "type": "vcs", "url": "http://svn.example.org/private/repo" },
-    { "type": "vcs", "url": "https://github.com/mycompany/privaterepo2" }
+    { "type": "vcs", "url": "https://github.com/mycompany/privaterepo2" },
+    { "packagist": false }
   ],
   "require-all": true
 }


### PR DESCRIPTION
When using `"require-all": true"` in `satis.json` if you don't also declare `{ "packagist": false }` in your list of repositories then satis will go through all packagist packages as well.

Here's an example output if you don't include `{ "packagist": false }` in your `satis.json` file (note none of these packages were declared in `repositories`:

```
$ php bin/satis build satis.json web/
Scanning packages
The contao-legacy/bit3basics * requirement did not match any package
The contao-legacy/diffiehellman * requirement did not match any package
The contao-legacy/hidepagetitle * requirement did not match any package
The contao-legacy/phpseclib * requirement did not match any package
The contao-legacy/ziparchivecto * requirement did not match any package
The crunchy/crunchysignup * requirement did not match any package
The dayax/collections * requirement did not match any package
The ellicom/mailgun * requirement did not match any package
The ellicom/markdown * requirement did not match any package
The google/adwords * requirement did not match any package
The henrikbjorn/flint * requirement did not match any package
The henrikbjorn/raekke * requirement did not match any package
The joomla/client * requirement did not match any package
The logsafe/composer-parameter-handler * requirement did not match any package
The lohini/browser-extension * requirement did not match any package
The lohini/curl-extension * requirement did not match any package
The lohini/forms-replicator * requirement did not match any package
The mmoreramerino/form-filler-bundle * requirement did not match any package
The mouf/utils.log.logger * requirement did not match any package
The nateabele/li3_mustache * requirement did not match any package
The njh/easyrdf * requirement did not match any package
The ocramius/zfphpcrodm * requirement did not match any package
The pastum/pagi * requirement did not match any package
The pastum/pami * requirement did not match any package
The pear-pear.php.net/console_getopt * requirement did not match any package
The pear-pear.php.net/pear * requirement did not match any package
The pear-pear/auth * requirement did not match any package
The popshack/popshack-common-stdlib * requirement did not match any package
The reinink/plates * requirement did not match any package
The silverstripe/frontend * requirement did not match any package
The symfony/doctrine-abstract-bundle * requirement did not match any package
The symfony/doctrine-bundle * requirement did not match any package
The undf/quizbundle * requirement did not match any package
The undf/utrans * requirement did not match any package
....
```