### PR TITLE
Fix invalid calculation on non-numeric string in GitDownloader, errors in PHP 7.1

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -251,7 +251,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
         $this->io->writeError('    <error>The package has modified files:</error>');
         $this->io->writeError(array_slice($changes, 0, 10));
         if (count($changes) > 10) {
-            $this->io->writeError('    <info>'.count($changes) - 10 . ' more files modified, choose "v" to view the full list</info>');
+            $this->io->writeError('    <info>' . (count($changes) - 10) . ' more files modified, choose "v" to view the full list</info>');
         }
 
         while (true) {


### PR DESCRIPTION
In `GitDownloader::cleanChanges()` the error message that is shown when more than 10 modified files are present in a dependency that is downloaded with git does an invalid calculation on a non-numeric string.

On older PHP versions this is ignored silently, but on PHP 7.1 this now throws the following error:

>  [ErrorException] A non-numeric value encountered

The fix is trivial.