### PR TITLE
Add fix for incorrect encoding in getcwd() result with non-latin chars on Windows

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -75,7 +75,9 @@ class ClassMapGenerator
 
         $map = array();
         $filesystem = new Filesystem();
-        $cwd = getcwd();
+        // Do not remove realpath() call.
+        // Fixes incorrect encoding in working dir on Windows.
+        $cwd = realpath(getcwd());
 
         foreach ($path as $file) {
             $filePath = $file->getPathname();


### PR DESCRIPTION
Hello. I faced an issue when working with project, when working dir contains non-latic chars (e.g. `C:\Users\Сергей\Documents\symfony-test`). If root project has `autoload.classmap` directives, then composer generates invalid paths for files:

## Current behavior
Currently composer generates invalid classmap.

```php
<?php

// autoload_classmap.php @generated by Composer

$vendorDir = dirname(dirname(__FILE__));
$baseDir = dirname($vendorDir);

return array(
    'AppCache' => $baseDir . 'pCache.php',
    'AppKernel' => $baseDir . 'pKernel.php',
...
);
```
It cuts few more bytes from file path due to incorrect encoding in file path string.

## Where is the problem
1. Composer generates elements for **autoload_classmap.php** in [AutoloadGenerator](https://github.com/composer/composer/blob/master/src/Composer/Autoload/AutoloadGenerator.php#L271).
2. It calls [`AutoloadGenerator::addClassMapCode`](https://github.com/composer/composer/blob/master/src/Composer/Autoload/AutoloadGenerator.php#L259) to generate list.
3. It calls [`AutoloadGenerator::generateClassMap`](https://github.com/composer/composer/blob/master/src/Composer/Autoload/AutoloadGenerator.php#L319) to scan for files.
4. It calls [`ClassMapGenerator::createMap`](https://github.com/composer/composer/blob/master/src/Composer/Autoload/AutoloadGenerator.php#L336) to scan directories and find classes.
5. In this method file path is [being compiled from `$cwd` and `$filePath`](https://github.com/composer/composer/blob/master/src/Composer/Autoload/ClassMapGenerator.php#L87). `$cwd` is result of `getcwd()`, that returns working dir with incorrect encoding.
6.  After 3 step it calls [`AutoloadGenerator::getPathCode`](https://github.com/composer/composer/blob/master/src/Composer/Autoload/AutoloadGenerator.php#L320) to generate valid php string for path.
7. It calls [`Filesystem::findShortestPath`](https://github.com/composer/composer/blob/master/src/Composer/Autoload/AutoloadGenerator.php#L530) to shorten file path.
8. It compares strings incorrectly in [`findShortestPath`](https://github.com/composer/composer/blob/master/src/Composer/Util/Filesystem.php#L322) that leads to cutting more bytes from `app/appKernel.php` than needed.

## After patch applying
Composer generates valid class map:

```php
<?php

// autoload_classmap.php @generated by Composer

$vendorDir = dirname(dirname(__FILE__));
$baseDir = dirname($vendorDir);

return array(
    'AppCache' => $baseDir . '/app/AppCache.php',
    'AppKernel' => $baseDir . '/app/AppKernel.php',
...
);

```