### PR TITLE
Improve memory usage resolving dependencies 

### DIFF
--- a/src/Composer/DependencyResolver/GenericRule.php
+++ b/src/Composer/DependencyResolver/GenericRule.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\DependencyResolver;
+
+use Composer\Package\PackageInterface;
+use Composer\Package\Link;
+
+/**
+ * @author Nils Adermann <naderman@naderman.de>
+ */
+class GenericRule extends Rule
+{
+    protected $literals;
+
+    /**
+     * @param array                 $literals
+     * @param int                   $reason     A RULE_* constant describing the reason for generating this rule
+     * @param Link|PackageInterface $reasonData
+     * @param array                 $job        The job this rule was created from
+     */
+    public function __construct(array $literals, $reason, $reasonData, $job = null)
+    {
+        parent::__construct($reason, $reasonData, $job);
+
+        // sort all packages ascending by id
+        sort($literals);
+
+        $this->literals = $literals;
+    }
+
+    public function getLiterals()
+    {
+        return $this->literals;
+    }
+
+    public function getHash()
+    {
+        $data = unpack('ihash', md5(implode(',', $this->literals), true));
+
+        return $data['hash'];
+    }
+
+    /**
+     * Checks if this rule is equal to another one
+     *
+     * Ignores whether either of the rules is disabled.
+     *
+     * @param  Rule $rule The rule to check against
+     * @return bool Whether the rules are equal
+     */
+    public function equals(Rule $rule)
+    {
+        return $this->literals === $rule->getLiterals();
+    }
+
+    public function isAssertion()
+    {
+        return 1 === count($this->literals);
+    }
+
+    /**
+     * Formats a rule as a string of the format (Literal1|Literal2|...)
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $result = ($this->isDisabled()) ? 'disabled(' : '(';
+
+        foreach ($this->literals as $i => $literal) {
+            if ($i != 0) {
+                $result .= '|';
+            }
+            $result .= $literal;
+        }
+
+        $result .= ')';
+
+        return $result;
+    }
+}

--- a/src/Composer/DependencyResolver/Rule2Literals.php
+++ b/src/Composer/DependencyResolver/Rule2Literals.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\DependencyResolver;
+
+use Composer\Package\PackageInterface;
+use Composer\Package\Link;
+
+/**
+ * @author Nils Adermann <naderman@naderman.de>
+ */
+class Rule2Literals extends Rule
+{
+    protected $literal1;
+    protected $literal2;
+
+    /**
+     * @param int                   $literal1
+     * @param int                   $literal2
+     * @param int                   $reason     A RULE_* constant describing the reason for generating this rule
+     * @param Link|PackageInterface $reasonData
+     * @param array                 $job        The job this rule was created from
+     */
+    public function __construct($literal1, $literal2, $reason, $reasonData, $job = null)
+    {
+        parent::__construct($reason, $reasonData, $job);
+
+        if ($literal1 < $literal2) {
+            $this->literal1 = $literal1;
+            $this->literal2 = $literal2;
+        } else {
+            $this->literal1 = $literal2;
+            $this->literal2 = $literal1;
+        }
+    }
+
+    public function getLiterals()
+    {
+        return array($this->literal1, $this->literal2);
+    }
+
+    public function getHash()
+    {
+        $data = unpack('ihash', md5($this->literal1.','.$this->literal2, true));
+
+        return $data['hash'];
+    }
+
+    /**
+     * Checks if this rule is equal to another one
+     *
+     * Ignores whether either of the rules is disabled.
+     *
+     * @param  Rule $rule The rule to check against
+     * @return bool Whether the rules are equal
+     */
+    public function equals(Rule $rule)
+    {
+        $literals = $rule->getLiterals();
+        if (2 != count($literals)) {
+            return false;
+        }
+
+        if ($this->literal1 !== $literals[0]) {
+            return false;
+        }
+
+        if ($this->literal2 !== $literals[1]) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function isAssertion()
+    {
+        return false;
+    }
+
+    /**
+     * Formats a rule as a string of the format (Literal1|Literal2|...)
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $result = ($this->isDisabled()) ? 'disabled(' : '(';
+
+        $result .= $this->literal1 . '|' . $this->literal2 . ')';
+
+        return $result;
+    }
+}

--- a/src/Composer/DependencyResolver/RuleSet.php
+++ b/src/Composer/DependencyResolver/RuleSet.php
@@ -63,8 +63,14 @@ class RuleSet implements \IteratorAggregate, \Countable
         // Do not add if rule already exists
         if (isset($this->rulesByHash[$hash])) {
             $potentialDuplicates = $this->rulesByHash[$hash];
-            foreach ($potentialDuplicates as $potentialDuplicate) {
-                if ($rule->equals($potentialDuplicate)) {
+            if (is_array($potentialDuplicates)) {
+                foreach ($potentialDuplicates as $potentialDuplicate) {
+                    if ($rule->equals($potentialDuplicate)) {
+                        return;
+                    }
+                }
+            } else {
+                if ($rule->equals($potentialDuplicates)) {
                     return;
                 }
             }
@@ -73,7 +79,7 @@ class RuleSet implements \IteratorAggregate, \Countable
         if (!isset($this->rules[$type])) {
             $this->rules[$type] = array();
         }
-        
+
         $this->rules[$type][] = $rule;
         $this->ruleById[$this->nextRuleId] = $rule;
         $rule->setType($type);
@@ -81,9 +87,12 @@ class RuleSet implements \IteratorAggregate, \Countable
         $this->nextRuleId++;
 
         if (!isset($this->rulesByHash[$hash])) {
-            $this->rulesByHash[$hash] = array($rule);
-        } else {
+            $this->rulesByHash[$hash] = $rule;
+        } elseif (is_array($this->rulesByHash[$hash])) {
             $this->rulesByHash[$hash][] = $rule;
+        } else {
+            $originalRule = $this->rulesByHash[$hash];
+            $this->rulesByHash[$hash] = array($originalRule, $rule);
         }
     }
 

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -61,7 +61,7 @@ class RuleSetGenerator
             $literals[] = $provider->id;
         }
 
-        return new Rule($literals, $reason, $reasonData);
+        return new GenericRule($literals, $reason, $reasonData);
     }
 
     /**
@@ -83,7 +83,7 @@ class RuleSetGenerator
             $literals[] = $package->id;
         }
 
-        return new Rule($literals, $reason, $job['packageName'], $job);
+        return new GenericRule($literals, $reason, $job['packageName'], $job);
     }
 
     /**
@@ -99,7 +99,7 @@ class RuleSetGenerator
      */
     protected function createRemoveRule(PackageInterface $package, $reason, $job)
     {
-        return new Rule(array(-$package->id), $reason, $job['packageName'], $job);
+        return new GenericRule(array(-$package->id), $reason, $job['packageName'], $job);
     }
 
     /**
@@ -116,14 +116,14 @@ class RuleSetGenerator
      *                                      goes with the reason
      * @return Rule             The generated rule
      */
-    protected function createConflictRule(PackageInterface $issuer, PackageInterface $provider, $reason, $reasonData = null)
+    protected function createRule2Literals(PackageInterface $issuer, PackageInterface $provider, $reason, $reasonData = null)
     {
         // ignore self conflict
         if ($issuer === $provider) {
             return null;
         }
 
-        return new Rule(array(-$issuer->id, -$provider->id), $reason, $reasonData);
+        return new Rule2Literals(-$issuer->id, -$provider->id, $reason, $reasonData);
     }
 
     /**
@@ -210,7 +210,7 @@ class RuleSetGenerator
                 $possibleConflicts = $this->pool->whatProvides($link->getTarget(), $link->getConstraint());
 
                 foreach ($possibleConflicts as $conflict) {
-                    $this->addRule(RuleSet::TYPE_PACKAGE, $this->createConflictRule($package, $conflict, Rule::RULE_PACKAGE_CONFLICT, $link));
+                    $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRule2Literals($package, $conflict, Rule::RULE_PACKAGE_CONFLICT, $link));
                 }
             }
 
@@ -227,7 +227,7 @@ class RuleSetGenerator
 
                     if (!$this->obsoleteImpossibleForAlias($package, $provider)) {
                         $reason = ($isInstalled) ? Rule::RULE_INSTALLED_PACKAGE_OBSOLETES : Rule::RULE_PACKAGE_OBSOLETES;
-                        $this->addRule(RuleSet::TYPE_PACKAGE, $this->createConflictRule($package, $provider, $reason, $link));
+                        $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRule2Literals($package, $provider, $reason, $link));
                     }
                 }
             }
@@ -243,7 +243,7 @@ class RuleSetGenerator
                     $this->addRule(RuleSet::TYPE_PACKAGE, $rule = $this->createRequireRule($package, array($provider), Rule::RULE_PACKAGE_ALIAS, $package));
                 } elseif (!$this->obsoleteImpossibleForAlias($package, $provider)) {
                     $reason = ($package->getName() == $provider->getName()) ? Rule::RULE_PACKAGE_SAME_NAME : Rule::RULE_PACKAGE_IMPLICIT_OBSOLETES;
-                    $this->addRule(RuleSet::TYPE_PACKAGE, $rule = $this->createConflictRule($package, $provider, $reason, $package));
+                    $this->addRule(RuleSet::TYPE_PACKAGE, $rule = $this->createRule2Literals($package, $provider, $reason, $package));
                 }
             }
         }

--- a/src/Composer/DependencyResolver/RuleWatchGraph.php
+++ b/src/Composer/DependencyResolver/RuleWatchGraph.php
@@ -95,7 +95,7 @@ class RuleWatchGraph
             $otherWatch = $node->getOtherWatch($literal);
 
             if (!$node->getRule()->isDisabled() && !$decisions->satisfy($otherWatch)) {
-                $ruleLiterals = $node->getRule()->literals;
+                $ruleLiterals = $node->getRule()->getLiterals();
 
                 $alternativeLiterals = array_filter($ruleLiterals, function ($ruleLiteral) use ($literal, $otherWatch, $decisions) {
                     return $literal !== $ruleLiteral &&

--- a/src/Composer/DependencyResolver/RuleWatchNode.php
+++ b/src/Composer/DependencyResolver/RuleWatchNode.php
@@ -35,7 +35,7 @@ class RuleWatchNode
     {
         $this->rule = $rule;
 
-        $literals = $rule->literals;
+        $literals = $rule->getLiterals();
 
         $this->watch1 = count($literals) > 0 ? $literals[0] : 0;
         $this->watch2 = count($literals) > 1 ? $literals[1] : 0;
@@ -51,7 +51,7 @@ class RuleWatchNode
      */
     public function watch2OnHighest(Decisions $decisions)
     {
-        $literals = $this->rule->literals;
+        $literals = $this->rule->getLiterals();
 
         // if there are only 2 elements, both are being watched anyway
         if (count($literals) < 3) {

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -97,7 +97,7 @@ class Solver
                 continue;
             }
 
-            $literals = $rule->literals;
+            $literals = $rule->getLiterals();
             $literal = $literals[0];
 
             if (!$this->decisions->decided(abs($literal))) {
@@ -139,7 +139,7 @@ class Solver
                     continue;
                 }
 
-                $assertRuleLiterals = $assertRule->literals;
+                $assertRuleLiterals = $assertRule->getLiterals();
                 $assertRuleLiteral = $assertRuleLiterals[0];
 
                 if (abs($literal) !== abs($assertRuleLiteral)) {
@@ -193,7 +193,7 @@ class Solver
 
                     if (!$this->pool->whatProvides($job['packageName'], $job['constraint'])) {
                         $problem = new Problem($this->pool);
-                        $problem->addRule(new Rule(array(), null, null, $job));
+                        $problem->addRule(new GenericRule(array(), null, null, $job));
                         $this->problems[] = $problem;
                     }
                     break;
@@ -413,7 +413,7 @@ class Solver
         while (true) {
             $this->learnedPool[count($this->learnedPool) - 1][] = $rule;
 
-            foreach ($rule->literals as $literal) {
+            foreach ($rule->getLiterals() as $literal) {
                 // skip the one true literal
                 if ($this->decisions->satisfy($literal)) {
                     continue;
@@ -498,7 +498,7 @@ class Solver
             );
         }
 
-        $newRule = new Rule($learnedLiterals, Rule::RULE_LEARNED, $why);
+        $newRule = new GenericRule($learnedLiterals, Rule::RULE_LEARNED, $why);
 
         return array($learnedLiterals[0], $ruleLevel, $newRule, $why);
     }
@@ -546,7 +546,7 @@ class Solver
         $this->problems[] = $problem;
 
         $seen = array();
-        $literals = $conflictRule->literals;
+        $literals = $conflictRule->getLiterals();
 
         foreach ($literals as $literal) {
             // skip the one true literal
@@ -569,7 +569,7 @@ class Solver
             $problem->addRule($why);
             $this->analyzeUnsolvableRule($problem, $why);
 
-            $literals = $why->literals;
+            $literals = $why->getLiterals();
 
             foreach ($literals as $literal) {
                 // skip the one true literal
@@ -703,7 +703,7 @@ class Solver
                         $decisionQueue = array();
                         $noneSatisfied = true;
 
-                        foreach ($rule->literals as $literal) {
+                        foreach ($rule->getLiterals() as $literal) {
                             if ($this->decisions->satisfy($literal)) {
                                 $noneSatisfied = false;
                                 break;
@@ -766,7 +766,7 @@ class Solver
                 }
 
                 $rule = $this->rules->ruleById[$i];
-                $literals = $rule->literals;
+                $literals = $rule->getLiterals();
 
                 if ($rule->isDisabled()) {
                     continue;

--- a/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\DependencyResolver;
 
+use Composer\DependencyResolver\GenericRule;
 use Composer\DependencyResolver\Rule;
 use Composer\DependencyResolver\RuleSet;
 use Composer\DependencyResolver\RuleSetIterator;
@@ -27,11 +28,11 @@ class RuleSetIteratorTest extends \PHPUnit_Framework_TestCase
 
         $this->rules = array(
             RuleSet::TYPE_JOB => array(
-                new Rule(array(), Rule::RULE_JOB_INSTALL, null),
-                new Rule(array(), Rule::RULE_JOB_INSTALL, null),
+                new GenericRule(array(), Rule::RULE_JOB_INSTALL, null),
+                new GenericRule(array(), Rule::RULE_JOB_INSTALL, null),
             ),
             RuleSet::TYPE_LEARNED => array(
-                new Rule(array(), Rule::RULE_INTERNAL_ALLOW_UPDATE, null),
+                new GenericRule(array(), Rule::RULE_INTERNAL_ALLOW_UPDATE, null),
             ),
             RuleSet::TYPE_PACKAGE => array(),
         );

--- a/tests/Composer/Test/DependencyResolver/RuleSetTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\DependencyResolver;
 
+use Composer\DependencyResolver\GenericRule;
 use Composer\DependencyResolver\Rule;
 use Composer\DependencyResolver\RuleSet;
 use Composer\DependencyResolver\Pool;
@@ -32,11 +33,11 @@ class RuleSetTest extends TestCase
         $rules = array(
             RuleSet::TYPE_PACKAGE => array(),
             RuleSet::TYPE_JOB => array(
-                new Rule(array(1), Rule::RULE_JOB_INSTALL, null),
-                new Rule(array(2), Rule::RULE_JOB_INSTALL, null),
+                new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null),
+                new GenericRule(array(2), Rule::RULE_JOB_INSTALL, null),
             ),
             RuleSet::TYPE_LEARNED => array(
-                new Rule(array(), Rule::RULE_INTERNAL_ALLOW_UPDATE, null),
+                new GenericRule(array(), Rule::RULE_INTERNAL_ALLOW_UPDATE, null),
             ),
         );
 
@@ -53,9 +54,9 @@ class RuleSetTest extends TestCase
     {
         $rules = array(
             RuleSet::TYPE_JOB => array(
-                new Rule(array(), Rule::RULE_JOB_INSTALL, null),
-                new Rule(array(), Rule::RULE_JOB_INSTALL, null),
-                new Rule(array(), Rule::RULE_JOB_INSTALL, null),
+                new GenericRule(array(), Rule::RULE_JOB_INSTALL, null),
+                new GenericRule(array(), Rule::RULE_JOB_INSTALL, null),
+                new GenericRule(array(), Rule::RULE_JOB_INSTALL, null),
             )
         );
 
@@ -75,15 +76,15 @@ class RuleSetTest extends TestCase
     {
         $ruleSet = new RuleSet;
 
-        $ruleSet->add(new Rule(array(), Rule::RULE_JOB_INSTALL, null), 7);
+        $ruleSet->add(new GenericRule(array(), Rule::RULE_JOB_INSTALL, null), 7);
     }
 
     public function testCount()
     {
         $ruleSet = new RuleSet;
 
-        $ruleSet->add(new Rule(array(1), Rule::RULE_JOB_INSTALL, null), RuleSet::TYPE_JOB);
-        $ruleSet->add(new Rule(array(2), Rule::RULE_JOB_INSTALL, null), RuleSet::TYPE_JOB);
+        $ruleSet->add(new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null), RuleSet::TYPE_JOB);
+        $ruleSet->add(new GenericRule(array(2), Rule::RULE_JOB_INSTALL, null), RuleSet::TYPE_JOB);
 
         $this->assertEquals(2, $ruleSet->count());
     }
@@ -92,7 +93,7 @@ class RuleSetTest extends TestCase
     {
         $ruleSet = new RuleSet;
 
-        $rule = new Rule(array(), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(), Rule::RULE_JOB_INSTALL, null);
         $ruleSet->add($rule, RuleSet::TYPE_JOB);
 
         $this->assertSame($rule, $ruleSet->ruleById[0]);
@@ -102,8 +103,8 @@ class RuleSetTest extends TestCase
     {
         $ruleSet = new RuleSet;
 
-        $rule1 = new Rule(array(1), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new Rule(array(2), Rule::RULE_JOB_INSTALL, null);
+        $rule1 = new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null);
+        $rule2 = new GenericRule(array(2), Rule::RULE_JOB_INSTALL, null);
         $ruleSet->add($rule1, RuleSet::TYPE_JOB);
         $ruleSet->add($rule2, RuleSet::TYPE_LEARNED);
 
@@ -117,8 +118,8 @@ class RuleSetTest extends TestCase
     public function testGetIteratorFor()
     {
         $ruleSet = new RuleSet;
-        $rule1 = new Rule(array(1), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new Rule(array(2), Rule::RULE_JOB_INSTALL, null);
+        $rule1 = new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null);
+        $rule2 = new GenericRule(array(2), Rule::RULE_JOB_INSTALL, null);
 
         $ruleSet->add($rule1, RuleSet::TYPE_JOB);
         $ruleSet->add($rule2, RuleSet::TYPE_LEARNED);
@@ -131,8 +132,8 @@ class RuleSetTest extends TestCase
     public function testGetIteratorWithout()
     {
         $ruleSet = new RuleSet;
-        $rule1 = new Rule(array(1), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new Rule(array(2), Rule::RULE_JOB_INSTALL, null);
+        $rule1 = new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null);
+        $rule2 = new GenericRule(array(2), Rule::RULE_JOB_INSTALL, null);
 
         $ruleSet->add($rule1, RuleSet::TYPE_JOB);
         $ruleSet->add($rule2, RuleSet::TYPE_LEARNED);
@@ -150,7 +151,7 @@ class RuleSetTest extends TestCase
 
         $ruleSet = new RuleSet;
         $literal = $p->getId();
-        $rule = new Rule(array($literal), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array($literal), Rule::RULE_JOB_INSTALL, null);
 
         $ruleSet->add($rule, RuleSet::TYPE_JOB);
 

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\DependencyResolver;
 
+use Composer\DependencyResolver\GenericRule;
 use Composer\DependencyResolver\Rule;
 use Composer\DependencyResolver\RuleSet;
 use Composer\DependencyResolver\Pool;
@@ -29,7 +30,7 @@ class RuleTest extends TestCase
 
     public function testGetHash()
     {
-        $rule = new Rule(array(123), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(123), Rule::RULE_JOB_INSTALL, null);
 
         $hash = unpack('ihash', md5('123', true));
         $this->assertEquals($hash['hash'], $rule->getHash());
@@ -37,31 +38,31 @@ class RuleTest extends TestCase
 
     public function testEqualsForRulesWithDifferentHashes()
     {
-        $rule = new Rule(array(1, 2), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new Rule(array(1, 3), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(1, 2), Rule::RULE_JOB_INSTALL, null);
+        $rule2 = new GenericRule(array(1, 3), Rule::RULE_JOB_INSTALL, null);
 
         $this->assertFalse($rule->equals($rule2));
     }
 
     public function testEqualsForRulesWithDifferLiteralsQuantity()
     {
-        $rule = new Rule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new Rule(array(1), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
+        $rule2 = new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null);
 
         $this->assertFalse($rule->equals($rule2));
     }
 
     public function testEqualsForRulesWithSameLiterals()
     {
-        $rule = new Rule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new Rule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
+        $rule2 = new GenericRule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
 
         $this->assertTrue($rule->equals($rule2));
     }
 
     public function testSetAndGetType()
     {
-        $rule = new Rule(array(), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(), Rule::RULE_JOB_INSTALL, null);
         $rule->setType(RuleSet::TYPE_JOB);
 
         $this->assertEquals(RuleSet::TYPE_JOB, $rule->getType());
@@ -69,7 +70,7 @@ class RuleTest extends TestCase
 
     public function testEnable()
     {
-        $rule = new Rule(array(), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(), Rule::RULE_JOB_INSTALL, null);
         $rule->disable();
         $rule->enable();
 
@@ -79,7 +80,7 @@ class RuleTest extends TestCase
 
     public function testDisable()
     {
-        $rule = new Rule(array(), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(), Rule::RULE_JOB_INSTALL, null);
         $rule->enable();
         $rule->disable();
 
@@ -89,8 +90,8 @@ class RuleTest extends TestCase
 
     public function testIsAssertions()
     {
-        $rule = new Rule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new Rule(array(1), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
+        $rule2 = new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null);
 
         $this->assertFalse($rule->isAssertion());
         $this->assertTrue($rule2->isAssertion());
@@ -103,7 +104,7 @@ class RuleTest extends TestCase
         $repo->addPackage($p2 = $this->getPackage('baz', '1.1'));
         $this->pool->addRepository($repo);
 
-        $rule = new Rule(array($p1->getId(), -$p2->getId()), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array($p1->getId(), -$p2->getId()), Rule::RULE_JOB_INSTALL, null);
 
         $this->assertEquals('Install command rule (don\'t install baz 1.1|install foo 2.1)', $rule->getPrettyString($this->pool));
     }


### PR DESCRIPTION
It is known that composer update takes a lot of memory: #5915, #5902, #5847, #5879

I am playing with a profiler (@blackfireio) to make a demo in my local PHP meetup (@phpvigo) and I found out a way to use less memory. These are my first tests:

* Private project using PHP 5.6: 
  * Memory: from 1.31GB to 1.07GB 
  * Wall Time: from 2min 8s to 1min 33s

* symfony-demo using PHP 7.1 in my old mac book:
  * Memory: from 667MB to 523MB 
  * Wall Time: from  5min 29s to 5min 28s

Not use an array inside conflict rules is this improvement main idea:

```php
<?php
//Memory 38MB
gc_collect_cycles();
gc_disable();


class Rule
{
    public $literals;

    public function __construct(array $literals)
    {
        $this->literals = $literals;
    }
}

$rules = array();

$i = 0;
while ($i<80000){ //
    $i++;

    $array = array(-$i, $i);
    $rule = new Rule($array);
    $rules[] = $rule;
}
```

```php
<?php
//Memory 11.1MB
gc_collect_cycles();
gc_disable();


class ConflictRule
{
    public $literal1;
    public $literal2;

    public function __construct($literal1, $literal2)
    {
        $this->literal1 = $literal1;
        $this->literal2 = $literal2;
    }
}

$rules = array();

$i = 0;
while ($i<80000){ //
    $i++;

    $rule = new ConflictRule(-$i, $i);
    $rules[] = $rule;
}
```

This is a WIP pull request to get feedback. I have to:

 - [x] Test with more public projects
 - [x] Check and add more unit test
 - [x] Doc