### PR TITLE
Root package version not being calculated for SVN package #6178

### DIFF
--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -65,17 +65,17 @@ class VersionGuesser
     {
         if (function_exists('proc_open')) {
             $versionData = $this->guessGitVersion($packageConfig, $path);
-            if (null !== $versionData) {
+            if (null !== $versionData && null !== $versionData['version']) {
                 return $versionData;
             }
 
             $versionData = $this->guessHgVersion($packageConfig, $path);
-            if (null !== $versionData) {
+            if (null !== $versionData && null !== $versionData['version']) {
                 return $versionData;
             }
 
             $versionData = $this->guessFossilVersion($packageConfig, $path);
-            if (null !== $versionData) {
+            if (null !== $versionData && null !== $versionData['version']) {
                 return $versionData;
             }
 


### PR DESCRIPTION
Updated VersionGuesser to check if we actually have a version in the returned array (fixes bug originating from f6899e5 when array was first introduced) - as SVN Versions not being guessed as it would previously stop at Git check.