### PR TITLE
Disable static autoloader on xcache.cacher = On

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -604,7 +604,7 @@ INCLUDE_PATH;
         }
 
         $file .= <<<STATIC_INIT
-        \$useStaticLoader = PHP_VERSION_ID >= $staticPhpVersion && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());
+        \$useStaticLoader = PHP_VERSION_ID >= $staticPhpVersion && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
         if (\$useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -604,7 +604,7 @@ INCLUDE_PATH;
         }
 
         $file .= <<<STATIC_INIT
-        \$useStaticLoader = PHP_VERSION_ID >= $staticPhpVersion && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
+        \$useStaticLoader = PHP_VERSION_ID >= $staticPhpVersion && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && (!extension_loaded('xcache') || ini_get('xcache.cacher') !== '1');
         if (\$useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -604,7 +604,7 @@ INCLUDE_PATH;
         }
 
         $file .= <<<STATIC_INIT
-        \$useStaticLoader = PHP_VERSION_ID >= $staticPhpVersion && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
+        \$useStaticLoader = PHP_VERSION_ID >= $staticPhpVersion && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
         if (\$useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitFilesAutoloadOrder
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoloadOrder', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && (!extension_loaded('xcache') || ini_get('xcache.cacher') !== '1');
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitFilesAutoloadOrder
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoloadOrder', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitFilesAutoloadOrder
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoloadOrder', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitFilesAutoload
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitFilesAutoload
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitFilesAutoload
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && (!extension_loaded('xcache') || ini_get('xcache.cacher') !== '1');
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
@@ -27,7 +27,7 @@ class ComposerAutoloaderInitFilesAutoload
         array_push($includePaths, get_include_path());
         set_include_path(implode(PATH_SEPARATOR, $includePaths));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
@@ -27,7 +27,7 @@ class ComposerAutoloaderInitFilesAutoload
         array_push($includePaths, get_include_path());
         set_include_path(implode(PATH_SEPARATOR, $includePaths));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
@@ -27,7 +27,7 @@ class ComposerAutoloaderInitFilesAutoload
         array_push($includePaths, get_include_path());
         set_include_path(implode(PATH_SEPARATOR, $includePaths));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && (!extension_loaded('xcache') || ini_get('xcache.cacher') !== '1');
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitFilesAutoload
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitFilesAutoload
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitFilesAutoload
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && (!extension_loaded('xcache') || ini_get('xcache.cacher') !== '1');
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitIncludePath
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitIncludePath', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitIncludePath
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitIncludePath', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && (!extension_loaded('xcache') || ini_get('xcache.cacher') !== '1');
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitIncludePath
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitIncludePath', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitTargetDir
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitTargetDir', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitTargetDir
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitTargetDir', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && extension_loaded('xcache') && ini_get('xcache.cacher') !== '1';
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && (!extension_loaded('xcache') || ini_get('xcache.cacher') !== '1');
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -23,7 +23,7 @@ class ComposerAutoloaderInitTargetDir
         self::$loader = $loader = new \Composer\Autoload\ClassLoader();
         spl_autoload_unregister(array('ComposerAutoloaderInitTargetDir', 'loadClassLoader'));
 
-        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded()) && ini_get('xcache.cacher') !== '1';
         if ($useStaticLoader) {
             require_once __DIR__ . '/autoload_static.php';
 


### PR DESCRIPTION
Hello,

Composer static autoloader works wrong when xcache cacher is enabled. This is due to bug in xcache https://xcache.lighttpd.net/ticket/348 which was fixed 2 years ago but still in trunk. Looks like xcache is not maintained more so there is no chance to get this fix released.

To reproduce the problem:
- install xcache with xcache.cacher = On
- create folder test1 and run `composer require symfony/console && composer update`. Then create index.php with `require_once 'vendor/autoload.php';`
- copy test1 to test2 (autoloader_static.php in test2 must have the same content as in test1 because xcache acts on file checksums)
- run test1/index.php under apache + mod_php
- remove test1/ and run test2/index.php. Fatal error raised:
`Warning: require(/var/www/html2/test1/vendor/composer/../symfony/polyfill-mbstring/bootstrap.php): failed to open stream: No such file or directory in /var/www/html2/test2/vendor/composer/autoload_real.php on line 66`

Usually `xcache_clear_cache(XC_TYPE_PHP, 0);` helps to fix the problem but in my production it does not. I suppose that due to high concurency old values cached again in xcache before the cache is cleared, and therefore there must not be any traffic before cache clearing.

This is not actually a composer's bug, but because of many users that may use composer together with xcache, this may affect them. I propose to disable static autoloader if xcache caching is enabled.