### PR TITLE
Fix Repository support for Subversion 1.8

### DIFF
--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -301,8 +301,16 @@ class SvnDriver extends VcsDriver
             return true;
         }
 
+        // Subversion client 1.7 and older
         if (false !== stripos($processExecutor->getErrorOutput(), 'authorization failed:')) {
             // This is likely a remote Subversion repository that requires
+            // authentication. We will handle actual authentication later.
+            return true;
+        }
+
+        // Subversion client 1.8 and newer
+        if (false !== stripos($processExecutor->getErrorOutput(), 'Authentication failed')) {
+            // This is likely a remote Subversion or newer repository that requires
             // authentication. We will handle actual authentication later.
             return true;
         }


### PR DESCRIPTION
Fix Repository support for Subversion 1.8.x where the output of svn info has changed. This change also applies to composer 1.3.

<pre>
# svn --quiet --version
1.7.22
# svn info --non-interactive https://svswdms02/dashboard/
svn: E170001: Unable to connect to a repository at URL 'https://svswdms02/dashboard'
svn: E170001: OPTIONS of 'https://svswdms02/dashboard': authorization failed: Could not authenticate to server: rejected Digest challenge (https://svswdms02)


# svn --version --quiet
1.8.17
# svn info --non-interactive https://svswdms02/dashboard/
svn: E215004: Authentication failed and interactive prompting is disabled; see the --force-interactive option
svn: E215004: Unable to connect to a repository at URL 'https://svswdms02/dashboard'
svn: E215004: No more credentials or we tried too many times.
Authentication failed
</pre>