### PR TITLE
Fix support for symlinks on Windows.

### DIFF
--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -113,13 +113,13 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             if (!$linked && Platform::isWindows()) {
                 // Use command linke symlinking as a fallback.
                 try {
-                    $return_var = 0;
+                    $exitCode = 0;
                     $output = array();
                     // Without this cleanup for backslashes symlink will
                     // be created, but completely broken.
                     $shortestPath = str_replace('/', '\\', $shortestPath);
-                    exec(sprintf('mklink /d %s %s', escapeshellarg($absolutePath), escapeshellarg($shortestPath)), $ouptput, $return_var);
-                    $linked = $return_var == 0;
+                    exec(sprintf('mklink /d %s %s', escapeshellarg($absolutePath), escapeshellarg($shortestPath)), $ouptput, $exitCode);
+                    $linked = $exitCode == 0;
                 }
                 catch (\Exception $e) {
                     $this->io->writeError($e->getMessage(), false);

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -111,7 +111,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             }
 
             if (!$linked && Platform::isWindows()) {
-                // Use command linke symlinking as a fallback.
+                // Use command-line symlinking as a fallback.
                 try {
                     $exitCode = 0;
                     $output = array();

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -37,6 +37,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
      */
     public function download(PackageInterface $package, $path, $output = true)
     {
+        // Make sure that the source path for the package exists.
         $url = $package->getDistUrl();
         $realUrl = realpath($url);
         if (false === $realUrl || !file_exists($realUrl) || !is_dir($realUrl)) {
@@ -45,6 +46,8 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             ));
         }
 
+        // Prevent target from being same as source, as this has fatal consequences
+        // when deleting packages.
         if (strpos(realpath($path) . DIRECTORY_SEPARATOR, $realUrl . DIRECTORY_SEPARATOR) === 0) {
             throw new \RuntimeException(sprintf(
                 'Package %s cannot install to "%s" inside its source at "%s"',
@@ -76,7 +79,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
         $this->filesystem->removeDirectory($path);
 
         if ($output) {
-            $this->io->writeError(sprintf(
+            $this->io->write(sprintf(
                 '  - Installing <info>%s</info> (<comment>%s</comment>)',
                 $package->getName(),
                 $package->getFullPrettyVersion()
@@ -84,31 +87,70 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
         }
 
         $isFallback = false;
+        $linked = false;
+
         if (self::STRATEGY_SYMLINK == $currentStrategy) {
+
+            $absolutePath = $path;
+            if (!$this->filesystem->isAbsolutePath($absolutePath)) {
+                $absolutePath = getcwd() . DIRECTORY_SEPARATOR . $path;
+            }
+            $shortestPath = $this->filesystem->findShortestPath($absolutePath, $realUrl);
+            $path = rtrim($path, "/");
+
             try {
-                if (Platform::isWindows()) {
+                // Creating symlinks on windows through PHP's symlink function
+                // is totally broken with relative paths.
+                // @see https://github.com/php/php-src/pull/1243
+                // @see https://bugs.php.net/bug.php?id=69473
+                $fileSystem->symlink($shortestPath, $path);
+                $this->io->writeError(sprintf(' Symlinked from %s', $url), false);
+                $linked = true;
+            }
+            catch (IOException $e) {
+                $this->io->writeError($e->getMessage(), false);
+            }
+
+            if (!$linked && Platform::isWindows()) {
+                // Use command linke symlinking as a fallback.
+                try {
+                    $return_var = 0;
+                    $output = array();
+                    // Without this cleanup for backslashes symlink will
+                    // be created, but completely broken.
+                    $shortestPath = str_replace('/', '\\', $shortestPath);
+                    exec(sprintf('mklink /d %s %s', escapeshellarg($absolutePath), escapeshellarg($shortestPath)), $ouptput, $return_var);
+                    $linked = $return_var == 0;
+                }
+                catch (\Exception $e) {
+                    $this->io->writeError($e->getMessage(), false);
+                }
+            }
+
+            if (!$linked && Platform::isWindows()) {
+                try {
                     // Implement symlinks as NTFS junctions on Windows
+                    // this 'should' be considered an error
+                    // because junctions are not portable. Yet, good
+                    // enough for dev environments.
                     $this->filesystem->junction($realUrl, $path);
                     $this->io->writeError(sprintf(' Junctioned from %s', $url), false);
-                } else {
-                    $absolutePath = $path;
-                    if (!$this->filesystem->isAbsolutePath($absolutePath)) {
-                        $absolutePath = getcwd() . DIRECTORY_SEPARATOR . $path;
-                    }
-                    $shortestPath = $this->filesystem->findShortestPath($absolutePath, $realUrl);
-                    $path = rtrim($path, "/");
-                    $fileSystem->symlink($shortestPath, $path);
-                    $this->io->writeError(sprintf(' Symlinked from %s', $url), false);
+                    $linked = true;
                 }
-            } catch (IOException $e) {
-                if (in_array(self::STRATEGY_MIRROR, $allowedStrategies)) {
-                    $this->io->writeError('');
-                    $this->io->writeError('    <error>Symlink failed, fallback to use mirroring!</error>');
-                    $currentStrategy = self::STRATEGY_MIRROR;
-                    $isFallback = true;
-                } else {
-                    throw new \RuntimeException(sprintf('Symlink from "%s" to "%s" failed!', $realUrl, $path));
+                catch (IOException $e) {
+                    $this->io->writeError($e->getMessage(), false);
                 }
+            }
+
+            if (!$linked && !in_array(self::STRATEGY_MIRROR, $allowedStrategies)) {
+                throw new \RuntimeException(sprintf('Symlink from "%s" to "%s" failed!', $realUrl, $path));
+            }
+
+            if (!$linked) {
+                $this->io->writeError('');
+                $this->io->writeError('    <error>Symlink failed, fallback to use mirroring!</error>');
+                $currentStrategy = self::STRATEGY_MIRROR;
+                $isFallback = true;
             }
         }
 

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -79,7 +79,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
         $this->filesystem->removeDirectory($path);
 
         if ($output) {
-            $this->io->write(sprintf(
+            $this->io->writeError(sprintf(
                 '  - Installing <info>%s</info> (<comment>%s</comment>)',
                 $package->getName(),
                 $package->getFullPrettyVersion()
@@ -106,8 +106,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
                 $fileSystem->symlink($shortestPath, $path);
                 $this->io->writeError(sprintf(' Symlinked from %s', $url), false);
                 $linked = true;
-            }
-            catch (IOException $e) {
+            } catch (IOException $e) {
                 $this->io->writeError($e->getMessage(), false);
             }
 


### PR DESCRIPTION
Fix for discussion on:

https://github.com/composer/composer/pull/6174

The symlink function from PHP in Windows is totally broken when using relative paths. This pull requests uses several fallback mechanisms before using a junction.

The problems with junctions is that they are not portable, making artifacts built with composer unusable for deployments.