### PR TITLE
Remove useless substr calls in the ClassLoader

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -376,8 +376,10 @@ class ClassLoader
         if (isset($this->prefixLengthsPsr4[$first])) {
             foreach ($this->prefixLengthsPsr4[$first] as $prefix => $length) {
                 if (0 === strpos($class, $prefix)) {
+                    $subLogicalPathPsr4 = substr($logicalPathPsr4, $length);
+
                     foreach ($this->prefixDirsPsr4[$prefix] as $dir) {
-                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
+                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $subLogicalPathPsr4)) {
                             return $file;
                         }
                     }


### PR DESCRIPTION
When multiple directories are registered for the same PSR-4 prefix, the PSR-4 subpath does not need to be recomputed for each directory. It only depends on the prefix.