### PR TITLE
Add json output for show command

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -232,6 +232,21 @@ EOT
             $packageListFilter = $this->getRootRequires();
         }
 
+        list($width) = $this->getApplication()->getTerminalDimensions();
+        if (null === $width) {
+            // In case the width is not detected, we're probably running the command
+            // outside of a real terminal, use space without a limit
+            $width = PHP_INT_MAX;
+        }
+        if (Platform::isWindows()) {
+            $width--;
+        }
+
+        if ($input->getOption('path') && null === $composer) {
+            $io->writeError('No composer.json found in the current directory, disabling "path" option');
+            $input->setOption('path', false);
+        }
+
         foreach ($repos as $repo) {
             if ($repo === $platformRepo) {
                 $type = 'platform';
@@ -295,20 +310,6 @@ EOT
                     } else {
                         $nameLength = max($nameLength, strlen($package));
                     }
-                }
-                list($width) = $this->getApplication()->getTerminalDimensions();
-                if (null === $width) {
-                    // In case the width is not detected, we're probably running the command
-                    // outside of a real terminal, use space without a limit
-                    $width = PHP_INT_MAX;
-                }
-                if (Platform::isWindows()) {
-                    $width--;
-                }
-
-                if ($input->getOption('path') && null === $composer) {
-                    $io->writeError('No composer.json found in the current directory, disabling "path" option');
-                    $input->setOption('path', false);
                 }
 
                 $writePath = !$input->getOption('name-only') && $input->getOption('path');

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -272,9 +272,6 @@ EOT
         $latestPackages = array();
         foreach (array('<info>platform</info>:' => true, '<comment>available</comment>:' => false, '<info>installed</info>:' => true) as $type => $showVersion) {
             if (isset($packages[$type])) {
-                if ($showAllTypes) {
-                    $io->write($type);
-                }
                 ksort($packages[$type]);
 
                 $nameLength = $versionLength = $latestLength = 0;
@@ -321,6 +318,10 @@ EOT
                     $latestLength += 2;
                 }
                 $hasOutdatedPackages = false;
+
+                if ($showAllTypes) {
+                    $io->write($type);
+                }
                 foreach ($packages[$type] as $package) {
                     if (is_object($package)) {
                         $latestPackage = null;

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -375,16 +375,13 @@ EOT
                             $replacement = (is_string($latestPackage->getReplacementPackage()))
                                 ? 'Use ' . $latestPackage->getReplacementPackage() . ' instead'
                                 : 'No replacement was suggested';
-
-                            $io->writeError('');
-                            $io->writeError(
-                                sprintf(
-                                    "<warning>Package %s is abandoned, you should avoid using it. %s.</warning>",
-                                    $package->getPrettyName(),
-                                    $replacement
-                                ),
-                                false
+                            $packageWarning = sprintf(
+                                'Package %s is abandoned, you should avoid using it. %s.',
+                                $package->getPrettyName(),
+                                $replacement
                             );
+                            $io->writeError('');
+                            $io->writeError('<warning>' . $packageWarning . '</warning>', false);
                         }
                     } else {
                         $io->write($indent . $package, false);

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -172,6 +172,9 @@ EOT
 
         // show single package or single version
         if (($packageFilter && false === strpos($packageFilter, '*')) || !empty($package)) {
+            if ('json' === $format) {
+                $io->writeError('Format "json" is only supported for package listings, falling back to format "text"');
+            }
             if (empty($package)) {
                 list($package, $versions) = $this->getPackage($installedRepo, $repos, $input->getArgument('package'), $input->getArgument('version'));
 
@@ -214,6 +217,9 @@ EOT
 
         // show tree view if requested
         if ($input->getOption('tree')) {
+            if ('json' === $format) {
+                $io->writeError('Format "json" is only supported for package listings, falling back to format "text"');
+            }
             $rootRequires = $this->getRootRequires();
             foreach ($installedRepo->getPackages() as $package) {
                 if (in_array($package->getName(), $rootRequires, true)) {

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -323,11 +323,11 @@ EOT
                 $hasOutdatedPackages = false;
                 foreach ($packages[$type] as $package) {
                     if (is_object($package)) {
-                        $latestPackackage = null;
+                        $latestPackage = null;
                         if ($showLatest && isset($latestPackages[$package->getPrettyName()])) {
-                            $latestPackackage = $latestPackages[$package->getPrettyName()];
+                            $latestPackage = $latestPackages[$package->getPrettyName()];
                         }
-                        if ($input->getOption('outdated') && $latestPackackage && $latestPackackage->getFullPrettyVersion() === $package->getFullPrettyVersion() && !$latestPackackage->isAbandoned()) {
+                        if ($input->getOption('outdated') && $latestPackage && $latestPackage->getFullPrettyVersion() === $package->getFullPrettyVersion() && !$latestPackage->isAbandoned()) {
                             continue;
                         } elseif ($input->getOption('outdated')) {
                             $hasOutdatedPackages = true;
@@ -339,9 +339,9 @@ EOT
                             $io->write(' ' . str_pad($package->getFullPrettyVersion(), $versionLength, ' '), false);
                         }
 
-                        if ($writeLatest && $latestPackackage) {
-                            $latestVersion = $latestPackackage->getFullPrettyVersion();
-                            $style = $this->getVersionStyle($latestPackackage, $package);
+                        if ($writeLatest && $latestPackage) {
+                            $latestVersion = $latestPackage->getFullPrettyVersion();
+                            $style = $this->getVersionStyle($latestPackage, $package);
                             if (!$io->isDecorated()) {
                                 $latestVersion = str_replace(array('info', 'highlight', 'comment'), array('=', '!', '~'), $style) . ' ' . $latestVersion;
                             }
@@ -365,9 +365,9 @@ EOT
                             $io->write(' ' . $path, false);
                         }
 
-                        if ($latestPackackage && $latestPackackage->isAbandoned()) {
-                            $replacement = (is_string($latestPackackage->getReplacementPackage()))
-                                ? 'Use ' . $latestPackackage->getReplacementPackage() . ' instead'
+                        if ($latestPackage && $latestPackage->isAbandoned()) {
+                            $replacement = (is_string($latestPackage->getReplacementPackage()))
+                                ? 'Use ' . $latestPackage->getReplacementPackage() . ' instead'
                                 : 'No replacement was suggested';
 
                             $io->writeError('');

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -270,6 +270,7 @@ EOT
         $showMinorOnly = $input->getOption('minor-only');
         $indent = $showAllTypes ? '  ' : '';
         $latestPackages = array();
+        $exitCode = 0;
         foreach (array('platform' => true, 'available' => false, 'installed' => true) as $type => $showVersion) {
             if (isset($packages[$type])) {
                 ksort($packages[$type]);
@@ -394,10 +395,13 @@ EOT
                     $io->write('');
                 }
                 if ($input->getOption('strict') && $hasOutdatedPackages) {
-                    return 1;
+                    $exitCode = 1;
+                    break;
                 }
             }
         }
+
+        return $exitCode;
     }
 
     protected function getRootRequires()

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -234,14 +234,14 @@ EOT
 
         foreach ($repos as $repo) {
             if ($repo === $platformRepo) {
-                $type = '<info>platform</info>:';
+                $type = 'platform';
             } elseif (
                 $repo === $installedRepo
                 || ($installedRepo instanceof CompositeRepository && in_array($repo, $installedRepo->getRepositories(), true))
             ) {
-                $type = '<info>installed</info>:';
+                $type = 'installed';
             } else {
-                $type = '<comment>available</comment>:';
+                $type = 'available';
             }
             if ($repo instanceof ComposerRepository && $repo->hasProviders()) {
                 foreach ($repo->getProviderNames() as $name) {
@@ -270,7 +270,7 @@ EOT
         $showMinorOnly = $input->getOption('minor-only');
         $indent = $showAllTypes ? '  ' : '';
         $latestPackages = array();
-        foreach (array('<info>platform</info>:' => true, '<comment>available</comment>:' => false, '<info>installed</info>:' => true) as $type => $showVersion) {
+        foreach (array('platform' => true, 'available' => false, 'installed' => true) as $type => $showVersion) {
             if (isset($packages[$type])) {
                 ksort($packages[$type]);
 
@@ -320,7 +320,11 @@ EOT
                 $hasOutdatedPackages = false;
 
                 if ($showAllTypes) {
-                    $io->write($type);
+                    if ('available' === $type) {
+                        $io->write('<comment>' . $type . '</comment>:');
+                    } else {
+                        $io->write('<info>' . $type . '</info>:');
+                    }
                 }
                 foreach ($packages[$type] as $package) {
                     if (is_object($package)) {


### PR DESCRIPTION
This PR adds JSON representation of package lists dumped by the show command, to simplify integration in quality assurance tools.

As an example (`composer show -f json --outdated`):

```json
{
    "installed": [
        {
            "name": "guzzle/guzzle",
            "version": "v3.9.3",
            "latest": "v3.9.3",
            "status": "up-to-date",
            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
            "warning": "Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead."
        },
        {
            "name": "paragonie/random_compat",
            "version": "v2.0.4",
            "latest": "v2.0.9",
            "status": "update-recommended",
            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7"
        },
        {
            "name": "zendframework/zend-code",
            "version": "2.6.3",
            "latest": "3.0.5",
            "status": "update-possible",
            "description": "provides facilities to generate arbitrary code using an object oriented interface"
        }
    ]
}
```