### PR TITLE
Fix Init command to accept author names with Unicode combining marks

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -320,7 +320,7 @@ EOT
      */
     public function parseAuthorString($author)
     {
-        if (preg_match('/^(?P<name>[- .,\p{L}\p{N}\'’"()]+) <(?P<email>.+?)>$/u', $author, $match)) {
+        if (preg_match('/^(?P<name>[- .,\p{L}\p{N}\p{Mn}\'’"()]+) <(?P<email>.+?)>$/u', $author, $match)) {
             if ($this->isValidEmail($match['email'])) {
                 return array(
                     'name' => trim($match['name']),

--- a/tests/Composer/Test/Command/InitCommandTest.php
+++ b/tests/Composer/Test/Command/InitCommandTest.php
@@ -33,6 +33,16 @@ class InitCommandTest extends TestCase
         $this->assertEquals('matti@example.com', $author['email']);
     }
 
+    public function testParseValidUtf8AuthorStringWithNonSpacingMarks()
+    {
+        // \xCC\x88 is UTF-8 for U+0308 diaeresis (umlaut) combining mark
+        $utf8_expected = "Matti Meika\xCC\x88la\xCC\x88inen";
+        $command = new InitCommand;
+        $author = $command->parseAuthorString($utf8_expected." <matti@example.com>");
+        $this->assertEquals($utf8_expected, $author['name']);
+        $this->assertEquals('matti@example.com', $author['email']);
+    }
+
     public function testParseNumericAuthorString()
     {
         $command = new InitCommand;


### PR DESCRIPTION
The Init command was not accepting my author name. I have my default git `user.name` formed in a way that **Pérez** was not using the latin small "e" with acute (U+00E9), but instead using the combining diacritic mark for acute accent (U+0301).