### PR TITLE
Improve memory usage a little by not creating new Link objects

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -28,6 +28,7 @@ class ArrayLoader implements LoaderInterface
 {
     protected $versionParser;
     protected $loadOptions;
+    protected $linksCache = array();
 
     public function __construct(SemverVersionParser $parser = null, $loadOptions = false)
     {
@@ -241,7 +242,13 @@ class ArrayLoader implements LoaderInterface
                 $parsedConstraint = $this->versionParser->parseConstraints($constraint);
             }
 
-            $res[strtolower($target)] = new Link($source, $target, $parsedConstraint, $description, $constraint);
+            $key = $source . $target . $parsedConstraint . $description . $constraint;
+
+            if (isset($this->linksCache[$key])) {
+                $res[strtolower($target)] = $this->linksCache[$key];
+            } else {
+                $res[strtolower($target)] = $this->linksCache[$key] = new Link($source, $target, $parsedConstraint, $description, $constraint);
+            }
         }
 
         return $res;


### PR DESCRIPTION
I was able to shave off only a litte memory usage (about 2% on average) by this change.
At first I did not consider it to be worth discussing about because the improvements are not significant enough (well, a penny saved is a penny earned but still). However, I still decided to make the changes public because at the end of the day this is what open source is all about. Maybe someone can improve the impact even more based on my idea 😄 

So the idea behind it is that most `Rule` instances get a `$reasonData` assigned which mostly is an instance of `Link` or `CompletePackage`. While debugging a little, I noticed that even though a big amount of `Link` instances are actually of equal content, they are not the same (they do not share the same object hash). They are different objects because every `Package` creates its `Link` objects (`requires`,  `conflicts` etc.) when it is created. So the `Link` objects are not shared across memory.
Hence, I thought by making sure to not create them but instead reference to an already created one if it is the same should decrease memory usage. This seems to be true but I was expecting an even bigger impact. Now somebody can tell me maybe why the impact is not bigger or make it bigger based on my idea 😋 