### PR TITLE
Add a specific message for stupid users that put useless spaces in license

### DIFF
--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -86,7 +86,7 @@ class ConfigValidator
             $licenseValidator = new SpdxLicenses();
             if ('proprietary' !== $manifest['license'] && array() !== $manifest['license'] && !$licenseValidator->validate($manifest['license']) && $licenseValidator->validate(trim($manifest['license']))) {
                 $warnings[] = sprintf(
-                    'Trim the license identifier (remove useless spaces, etc).',
+                    'License %s must not contain extra spaces, make sure to trim it.',
                     json_encode($manifest['license'])
                 );
             } else if ('proprietary' !== $manifest['license'] && array() !== $manifest['license'] && !$licenseValidator->validate($manifest['license'])) {

--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -84,10 +84,16 @@ class ConfigValidator
             }
 
             $licenseValidator = new SpdxLicenses();
-            if ('proprietary' !== $manifest['license'] && array() !== $manifest['license'] && !$licenseValidator->validate($manifest['license'])) {
+            if ('proprietary' !== $manifest['license'] && array() !== $manifest['license'] && !$licenseValidator->validate($manifest['license']) && $licenseValidator->validate(trim($manifest['license']))) {
+                $warnings[] = sprintf(
+                    'Trim the license identifier (remove useless spaces, etc).',
+                    json_encode($manifest['license'])
+                );
+            } else if ('proprietary' !== $manifest['license'] && array() !== $manifest['license'] && !$licenseValidator->validate($manifest['license'])) {
                 $warnings[] = sprintf(
                     'License %s is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.'
-                    ."\nIf the software is closed-source, you may use \"proprietary\" as license.",
+                    . PHP_EOL .
+                    'If the software is closed-source, you may use "proprietary" as license.',
                     json_encode($manifest['license'])
                 );
             }


### PR DESCRIPTION
I was one of this stupid users, so I would like to help future ones.