### PR TITLE
Fix Git branch parsing for detached HEAD on a commit

### DIFF
--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -98,7 +98,7 @@ class VersionGuesser
 
             // find current branch and collect all branch names
             foreach ($this->process->splitLines($output) as $branch) {
-                if ($branch && preg_match('{^(?:\* ) *(\(no branch\)|\(detached from \S+\)|\(HEAD detached at FETCH_HEAD\)|\S+) *([a-f0-9]+) .*$}', $branch, $match)) {
+                if ($branch && preg_match('{^(?:\* ) *(\(no branch\)|\(detached from \S+\)|\(HEAD detached at \S+\)|\S+) *([a-f0-9]+) .*$}', $branch, $match)) {
                     if ($match[1] === '(no branch)' || substr($match[1], 0, 10) === '(detached ' || substr($match[1], 0, 17) === '(HEAD detached at') {
                         $version = 'dev-' . $match[2];
                         $prettyVersion = $version;

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -163,7 +163,7 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
         $commitHash = 'da53c52eddd5f32ffca64a7b3801bea';
 
         $executor = $this->getMockBuilder('\\Composer\\Util\\ProcessExecutor')
-            ->setMethods(['execute'])
+            ->setMethods(array('execute'))
             ->disableArgumentCloning()
             ->disableOriginalConstructor()
             ->getMock();
@@ -181,9 +181,9 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
             });
 
         $config = new Config;
-        $config->merge(['repositories' => ['packagist' => false]]);
+        $config->merge(array('repositories' => array('packagist' => false)));
         $guesser = new VersionGuesser($config, $executor, new VersionParser());
-        $versionData = $guesser->guessVersion([], 'dummy/path');
+        $versionData = $guesser->guessVersion(array(), 'dummy/path');
 
         $this->assertEquals("dev-$commitHash", $versionData['version']);
     }
@@ -193,7 +193,7 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
         $commitHash = 'da53c52eddd5f32ffca64a7b3801bea';
 
         $executor = $this->getMockBuilder('\\Composer\\Util\\ProcessExecutor')
-            ->setMethods(['execute'])
+            ->setMethods(array('execute'))
             ->disableArgumentCloning()
             ->disableOriginalConstructor()
             ->getMock();
@@ -211,9 +211,9 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
             });
 
         $config = new Config;
-        $config->merge(['repositories' => ['packagist' => false]]);
+        $config->merge(array('repositories' => array('packagist' => false)));
         $guesser = new VersionGuesser($config, $executor, new VersionParser());
-        $versionData = $guesser->guessVersion([], 'dummy/path');
+        $versionData = $guesser->guessVersion(array(), 'dummy/path');
 
         $this->assertEquals("dev-$commitHash", $versionData['version']);
     }

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -160,7 +160,7 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
 
     public function testDetachedFetchHeadBecomesDevHashGit2()
     {
-        $commitHash = 'da53c52eddd5f32ffca64a7b3801bea';
+        $commitHash = '03a15d220da53c52eddd5f32ffca64a7b3801bea';
 
         $executor = $this->getMockBuilder('\\Composer\\Util\\ProcessExecutor')
             ->setMethods(array('execute'))
@@ -190,7 +190,7 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
 
     public function testDetachedCommitHeadBecomesDevHashGit2()
     {
-        $commitHash = 'da53c52eddd5f32ffca64a7b3801bea';
+        $commitHash = '03a15d220da53c52eddd5f32ffca64a7b3801bea';
 
         $executor = $this->getMockBuilder('\\Composer\\Util\\ProcessExecutor')
             ->setMethods(array('execute'))
@@ -205,7 +205,7 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self, $commitHash) {
                 $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
-                $output = "* (HEAD detached at da53c52ed) $commitHash Commit message\n";
+                $output = "* (HEAD detached at 03a15d220) $commitHash Commit message\n";
 
                 return 0;
             });

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -176,7 +176,7 @@ class VersionGuesserTest extends \PHPUnit_Framework_TestCase
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self, $commitHash) {
                 $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
-                $output = "* (HEAD detached at FETCH_HEAD) $commitHash Commit message\n";
+                $output = "* (HEAD detached at " . substr($commitHash, 0, 9) . ") $commitHash Commit message\n";
 
                 return 0;
             })


### PR DESCRIPTION
Current versions of Git output the commit hash as detached HEAD instead
of FETCH_HEAD. The VersionGuesser should be able to handle commit hashes
as well as FETCH_HEAD to detect the correct branch of a commit.

Resolves: #6311 