### PR TITLE
Aligns the verb form of commands' description

### DIFF
--- a/src/Composer/Command/AboutCommand.php
+++ b/src/Composer/Command/AboutCommand.php
@@ -24,7 +24,7 @@ class AboutCommand extends BaseCommand
     {
         $this
             ->setName('about')
-            ->setDescription('Short information about Composer.')
+            ->setDescription('Shows the short information about Composer.')
             ->setHelp(<<<EOT
 <info>php composer.phar about</info>
 EOT

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -37,7 +37,7 @@ class ArchiveCommand extends BaseCommand
     {
         $this
             ->setName('archive')
-            ->setDescription('Create an archive of this composer package.')
+            ->setDescription('Creates an archive of this composer package.')
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'The package to archive instead of the current project'),
                 new InputArgument('version', InputArgument::OPTIONAL, 'A version constraint to find the package to archive'),

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -63,7 +63,7 @@ class ConfigCommand extends BaseCommand
     {
         $this
             ->setName('config')
-            ->setDescription('Set config options.')
+            ->setDescription('Sets config options.')
             ->setDefinition(array(
                 new InputOption('global', 'g', InputOption::VALUE_NONE, 'Apply command to the global config file'),
                 new InputOption('editor', 'e', InputOption::VALUE_NONE, 'Open editor'),

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -59,7 +59,7 @@ class CreateProjectCommand extends BaseCommand
     {
         $this
             ->setName('create-project')
-            ->setDescription('Create new project from a package into given directory.')
+            ->setDescription('Creates new project from a package into given directory.')
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package name to be installed'),
                 new InputArgument('directory', InputArgument::OPTIONAL, 'Directory where the files should be created'),

--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -26,7 +26,7 @@ class ExecCommand extends BaseCommand
     {
         $this
             ->setName('exec')
-            ->setDescription('Execute a vendored binary/script.')
+            ->setDescription('Executes a vendored binary/script.')
             ->setDefinition(array(
                 new InputOption('list', 'l', InputOption::VALUE_NONE),
                 new InputArgument('binary', InputArgument::OPTIONAL, 'The binary to run, e.g. phpunit'),

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -31,7 +31,7 @@ class LicensesCommand extends BaseCommand
     {
         $this
             ->setName('licenses')
-            ->setDescription('Show information about licenses of dependencies.')
+            ->setDescription('Shows information about licenses of dependencies.')
             ->setDefinition(array(
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),

--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -47,7 +47,7 @@ class RunScriptCommand extends BaseCommand
     {
         $this
             ->setName('run-script')
-            ->setDescription('Run the scripts defined in composer.json.')
+            ->setDescription('Runs the scripts defined in composer.json.')
             ->setDefinition(array(
                 new InputArgument('script', InputArgument::OPTIONAL, 'Script name to run.'),
                 new InputArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, ''),

--- a/src/Composer/Command/ScriptAliasCommand.php
+++ b/src/Composer/Command/ScriptAliasCommand.php
@@ -35,7 +35,7 @@ class ScriptAliasCommand extends BaseCommand
     {
         $this
             ->setName($this->script)
-            ->setDescription('Run the '.$this->script.' script as defined in composer.json.')
+            ->setDescription('Runs the '.$this->script.' script as defined in composer.json.')
             ->setDefinition(array(
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Sets the dev mode.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables the dev mode.'),

--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -38,7 +38,7 @@ class SearchCommand extends BaseCommand
     {
         $this
             ->setName('search')
-            ->setDescription('Search for packages.')
+            ->setDescription('Searches for packages.')
             ->setDefinition(array(
                 new InputOption('only-name', 'N', InputOption::VALUE_NONE, 'Search only in name'),
                 new InputOption('type', 't', InputOption::VALUE_REQUIRED, 'Search for a specific package type'),

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -58,7 +58,7 @@ class ShowCommand extends BaseCommand
         $this
             ->setName('show')
             ->setAliases(array('info'))
-            ->setDescription('Show information about packages.')
+            ->setDescription('Shows information about packages.')
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.'),
                 new InputArgument('version', InputArgument::OPTIONAL, 'Version or version constraint to inspect'),

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -40,7 +40,7 @@ class StatusCommand extends BaseCommand
     {
         $this
             ->setName('status')
-            ->setDescription('Show a list of locally modified packages.')
+            ->setDescription('Shows a list of locally modified packages.')
             ->setDefinition(array(
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Show modified files for each directory that contains changes.'),
             ))

--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -24,7 +24,7 @@ class SuggestsCommand extends BaseCommand
     {
         $this
             ->setName('suggests')
-            ->setDescription('Show package suggestions.')
+            ->setDescription('Shows package suggestions.')
             ->setDefinition(array(
                 new InputOption('by-package', null, InputOption::VALUE_NONE, 'Groups output by suggesting package'),
                 new InputOption('by-suggestion', null, InputOption::VALUE_NONE, 'Groups output by suggested package'),


### PR DESCRIPTION
Right now, the verb form in descriptions of commands is confused base form with third-person singular form. So I want to aligh this to the latter because Symfony's general commands are so.