### PR TITLE
Fix php notice

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -369,6 +369,10 @@ class ClassLoader
 
     private function findFileWithExtension($class, $ext)
     {
+        if ($class === '') {
+            return false;
+        }
+
         // PSR-4 lookup
         $logicalPathPsr4 = strtr($class, '\\', DIRECTORY_SEPARATOR) . $ext;
 


### PR DESCRIPTION
Of course autoloading of an empty string should not actually happen (fixed that in https://github.com/twigphp/Twig/pull/2438) but if it does happen it should not throw a php notice.

```
Notice: Uninitialized string offset 0
```

The notice is thrown few lines below beacause of `$first = $class[0];`.