### PR TITLE
Remove ANSI control characters from suggested packages output

### DIFF
--- a/src/Composer/Installer/SuggestedPackagesReporter.php
+++ b/src/Composer/Installer/SuggestedPackagesReporter.php
@@ -15,6 +15,7 @@ namespace Composer\Installer;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Repository\RepositoryInterface;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 
 /**
  * Add suggested packages from different places to output them in the end.
@@ -116,12 +117,23 @@ class SuggestedPackagesReporter
             $this->io->writeError(sprintf(
                 '%s suggests installing %s (%s)',
                 $suggestion['source'],
-                $this->removeControlCharacters($suggestion['target']),
-                $this->removeControlCharacters($suggestion['reason'])
+                $this->escapeOutput($suggestion['target']),
+                $this->escapeOutput($suggestion['reason'])
             ));
         }
 
         return $this;
+    }
+
+    /**
+     * @param string $string
+     * @return string
+     */
+    private function escapeOutput($string)
+    {
+        return OutputFormatter::escape(
+            $this->removeControlCharacters($string)
+        );
     }
 
     /**

--- a/src/Composer/Installer/SuggestedPackagesReporter.php
+++ b/src/Composer/Installer/SuggestedPackagesReporter.php
@@ -116,11 +116,24 @@ class SuggestedPackagesReporter
             $this->io->writeError(sprintf(
                 '%s suggests installing %s (%s)',
                 $suggestion['source'],
-                $suggestion['target'],
-                $suggestion['reason']
+                $this->removeControlCharacters($suggestion['target']),
+                $this->removeControlCharacters($suggestion['reason'])
             ));
         }
 
         return $this;
+    }
+
+    /**
+     * @param string $string
+     * @return string
+     */
+    private function removeControlCharacters($string)
+    {
+        return preg_replace(
+            '/[[:cntrl:]]/',
+            '',
+            str_replace("\n", ' ', $string)
+        );
     }
 }

--- a/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
+++ b/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
@@ -149,11 +149,16 @@ class SuggestedPackagesReporterTest extends \PHPUnit_Framework_TestCase
      */
     public function testOutputIgnoresFormatting()
     {
-        $this->suggestedPackagesReporter->addPackage('source', 'target', "\x1b[1;37;42m Like us\r\non Facebook \x1b[0m");
+        $this->suggestedPackagesReporter->addPackage('source', 'target1', "\x1b[1;37;42m Like us\r\non Facebook \x1b[0m");
+        $this->suggestedPackagesReporter->addPackage('source', 'target2', "<bg=green>Like us on Facebook</>");
 
-        $this->io->expects($this->once())
+        $this->io->expects($this->at(0))
             ->method('writeError')
-            ->with("source suggests installing target ([1;37;42m Like us on Facebook [0m)");
+            ->with("source suggests installing target1 ([1;37;42m Like us on Facebook [0m)");
+
+        $this->io->expects($this->at(1))
+            ->method('writeError')
+            ->with('source suggests installing target2 (\\<bg=green>Like us on Facebook\\</>)');
 
         $this->suggestedPackagesReporter->output();
     }

--- a/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
+++ b/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
@@ -147,6 +147,20 @@ class SuggestedPackagesReporterTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers ::output
      */
+    public function testOutputIgnoresFormatting()
+    {
+        $this->suggestedPackagesReporter->addPackage('source', 'target', "\x1b[1;37;42m Like us\r\non Facebook \x1b[0m");
+
+        $this->io->expects($this->once())
+            ->method('writeError')
+            ->with("source suggests installing target ([1;37;42m Like us on Facebook [0m)");
+
+        $this->suggestedPackagesReporter->output();
+    }
+
+    /**
+     * @covers ::output
+     */
     public function testOutputMultiplePackages()
     {
         $this->suggestedPackagesReporter->addPackage('a', 'b', 'c');


### PR DESCRIPTION
With this PR, common control characters are removed from the output of suggest fields, with the exception of new line characters. This fixes the problem described in #6334.

<img width="867" alt="bildschirmfoto 2017-04-08 um 14 02 02" src="https://cloud.githubusercontent.com/assets/1506493/24828736/1e008cc8-1c64-11e7-9748-47f7b356531c.png">
