### PR TITLE
Add warning for identical names with different capitalization when zip archive extract failure

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -156,6 +156,8 @@ class ZipDownloader extends ArchiveDownloader
             } else {
                 $processError = new \UnexpectedValueException(rtrim($this->getErrorMessage($retval, $file)."\n"), $retval);
             }
+        } catch (\ErrorException $ex) {
+            $processError = new \ErrorException('Archive may contain identical directory or file name with different capitalization (fails on case insensitive filesystems)');
         } catch (\Exception $e) {
             $processError = $e;
         }

--- a/tests/Composer/Test/Downloader/ZipDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ZipDownloaderTest.php
@@ -128,6 +128,28 @@ class ZipDownloaderTest extends TestCase
     }
 
     /**
+     * @expectedException \ErrorException
+     * @expectedExceptionMessage Archive may contain identical directory or file name with different capitalization (fails on case insensitive filesystems)
+     */
+    public function testZipArchiveExtractOnlyFailed()
+    {
+        $this->setPrivateProperty('hasSystemUnzip', false);
+        $this->setPrivateProperty('hasZipArchive', true);
+        $downloader = new MockedZipDownloader($this->io, $this->config);
+
+        $zipArchive = $this->getMock('ZipArchive');
+        $zipArchive->expects($this->at(0))
+            ->method('open')
+            ->will($this->returnValue(true));
+        $zipArchive->expects($this->at(1))
+            ->method('extractTo')
+            ->will($this->throwException(new \ErrorException('Not a directory')));
+
+        $this->setPrivateProperty('zipArchiveObject', $zipArchive, $downloader);
+        $downloader->extract('testfile.zip', 'vendor/dir');
+    }
+
+    /**
      * @group only
      */
     public function testZipArchiveOnlyGood()


### PR DESCRIPTION
This pull request add a warning about identical names with different capitalization on zip archive whenever extract failure with `\ErrorException` (Not a directory)

Issue #5938