### PR TITLE
add support for GitLab subgroups

### DIFF
--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -320,4 +320,37 @@ JSON;
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
     }
+
+    public function testGitlabSubGroup()
+    {
+        $url = 'https://mycompany.com/gitlab/mygroup/mysubgroup/myproject';
+        $apiUrl = 'https://mycompany.com/gitlab/api/v3/projects/mygroup%2Fmysubgroup%2Fmyproject';
+
+        $projectData = <<<JSON
+{
+    "id": 17,
+    "default_branch": "mymaster",
+    "public": false,
+    "http_url_to_repo": "https://gitlab.com/mygroup/mysubgroup/myproject",
+    "ssh_url_to_repo": "git@gitlab.com:mygroup/mysubgroup/myproject.git",
+    "last_activity_at": "2014-12-01T09:17:51.000+01:00",
+    "name": "My Project",
+    "name_with_namespace": "My Group / My Subgroup / My Project",
+    "path": "myproject",
+    "path_with_namespace": "mygroup/mysubgroup/myproject",
+    "web_url": "https://gitlab.com/mygroup/mysubgroup/myproject"
+}
+JSON;
+
+        $this->remoteFilesystem
+            ->getContents('mycompany.com/gitlab', $apiUrl, false)
+            ->willReturn($projectData)
+            ->shouldBeCalledTimes(1)
+        ;
+
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->remoteFilesystem->reveal());
+        $driver->initialize();
+
+        $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
+    }
 }


### PR DESCRIPTION
Fix #6349 

Now that GitLab supports subgroups, repositories namespace can contain an arbitrary number of slashes which means we cannot get the gitlab domain through the regex, so now we have to parse the URL as well.

I know there is duplicated logic but I don't really know how to improve this.