### PR TITLE
Output 'composer search' results in table format

### DIFF
--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -74,8 +74,26 @@ EOT
         $flags = $onlyName ? RepositoryInterface::SEARCH_NAME : RepositoryInterface::SEARCH_FULLTEXT;
         $results = $repos->search(implode(' ', $input->getArgument('tokens')), $flags, $type);
 
+        // set the column width to the longest name
+        $name_width = 0;
         foreach ($results as $result) {
-            $io->write($result['name'] . (isset($result['description']) ? ' '. $result['description'] : ''));
+            $width = strlen($result['name']);
+            if ($width > $name_width) {
+                $name_width = $width;
+            }
+        }
+
+        // sort the results by name
+        asort($results);
+
+        // output the results in table format
+        printf("%-${name_width}s  %s\n", "Name", "Description");
+        printf("%-${name_width}s  %s\n", "----", "-----------");
+        foreach ($results as $result) {
+            if (!isset($result['description'])) {
+                $result['description'] = '';
+            }
+            printf("%-${name_width}s  %s\n", $result['name'], $result['description']);
         }
     }
 }


### PR DESCRIPTION
This PR updates the `composer search` command to format the results in a more comprehensible fashion.
Example output from `composer search coding standards` is shown below:
```
Name                                      Description
----                                      -----------
athens/standard                           PHP code standard for the Athens Framework.
drupal-standards/drupal-coding-standards  Creates a pre-push git hook that checks the Drupal coding standards.
fluidtypo3/coding-standards               The FluidTYPO3 Coding Standards
fnayou/standards                          PHP Code Sniffer configurator.
graze/standards                           Graze coding standards
greencape/coding-standards                Composer installable Joomla Coding Standards Definitions.
humanmade/coding-standards                Human Made coding standards
mito/yii2-coding-standards                Mito Yii 2 coding standards
oxid-esales/coding-standards              OXID eShop coding standards
oxid-esales/coding-standards-wrapper      OXID eShop coding standards wrapper
polderknowledge/coding-standards          The Polder Knowledge coding standards for PHP_CodeSniffer.
shopsys/coding-standards                  Coding standards definition compatible with PSR-2
usertech/coding-standards                 Usertech coding standards for PHP Code Sniffer
visono/coding-standards                   Visono coding standards
zumba/zumba-coding-standards              Zumba coding standards
```