### PR TITLE
Move all plugins and their dependencies to the front

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -755,9 +755,9 @@ class Installer
                 continue;
             }
 
-            if ($package->getType() === 'composer-plugin' 
+            if ($package->getType() === 'composer-plugin'
                 || $package->getType() === 'composer-installer'
-                || in_array($package->getName(), $installerRequires)
+                || count(array_intersect($package->getNames(), $installerRequires))
             ) {
                 // capture the requirements for this package so those packages will be moved up as well
                 $installerRequires = array_merge($installerRequires, array_keys($package->getRequires()));

--- a/tests/Composer/Test/Fixtures/installer/plugins-are-installed-first.test
+++ b/tests/Composer/Test/Fixtures/installer/plugins-are-installed-first.test
@@ -1,5 +1,5 @@
 --TEST--
-Composer installers are installed first if they have no meaningful requirements
+Composer installers and their requirements are installed first
 --COMPOSER--
 {
     "repositories": [
@@ -25,7 +25,7 @@ Composer installers are installed first if they have no meaningful requirements
 install
 --EXPECT--
 Installing inst (1.0.0)
-Installing inst-with-req (1.0.0)
-Installing pkg (1.0.0)
 Installing pkg2 (1.0.0)
 Installing inst-with-req2 (1.0.0)
+Installing inst-with-req (1.0.0)
+Installing pkg (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/plugins-are-installed-first.test
+++ b/tests/Composer/Test/Fixtures/installer/plugins-are-installed-first.test
@@ -25,7 +25,7 @@ Composer installers and their requirements are installed first
 install
 --EXPECT--
 Installing inst (1.0.0)
+Installing inst-with-req (1.0.0)
 Installing pkg2 (1.0.0)
 Installing inst-with-req2 (1.0.0)
-Installing inst-with-req (1.0.0)
 Installing pkg (1.0.0)


### PR DESCRIPTION
Currently plugins are only moved to the front to be installed first when they don't have dependencies beyond platform requirements and `composer-plugin-api`. This causes an issue for our plugin [`oomphinc/composer-installers-extender`](https://github.com/oomphinc/composer-installers-extender) which is built atop `composer/composer-installers` and thus requires it. Users are seeing the same issue as https://github.com/composer/composer/issues/1147, see: https://github.com/oomphinc/composer-installers-extender/issues/6.

What this does is instead of skipping plugins that have additional dependencies, it moves the plugin and those dependencies to the front as well. This works on the assumption that install/update operations for a package's dependencies come before the package that required it. I'm not sure if that is a completely safe assumption to make, but it seemed to be the case in my testing.

I'm not sure if there were other reasons why plugins that had additional dependencies were skipped over from being moved in the first place; are there any other implications here that I am neglecting? As well, do you think this approach guaranteed to move plugins and all their dependencies properly or do you think more robust logic is necessary?

Please let me know your thoughts!