### PR TITLE
Auto-skip interactive require when set by option.

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -299,16 +299,18 @@ EOT
         $io->writeError(array('', 'Define your dependencies.', ''));
 
         $question = 'Would you like to define your dependencies (require) interactively [<comment>yes</comment>]? ';
+        $require = $input->getOption('require');
         $requirements = array();
-        if ($io->askConfirmation($question, true)) {
-            $requirements = $this->determineRequirements($input, $output, $input->getOption('require'));
+        if ($require || $io->askConfirmation($question, true)) {
+            $requirements = $this->determineRequirements($input, $output, $require);
         }
         $input->setOption('require', $requirements);
 
         $question = 'Would you like to define your dev dependencies (require-dev) interactively [<comment>yes</comment>]? ';
+        $requireDev = $input->getOption('require-dev');
         $devRequirements = array();
-        if ($io->askConfirmation($question, true)) {
-            $devRequirements = $this->determineRequirements($input, $output, $input->getOption('require-dev'));
+        if ($requireDev || $io->askConfirmation($question, true)) {
+            $devRequirements = $this->determineRequirements($input, $output, $requireDev);
         }
         $input->setOption('require-dev', $devRequirements);
     }


### PR DESCRIPTION
Currently when running `composer init --require=symfony/console`, you will still get the yes/no question to define your dependencies interactively. If you answer no to this question, the `composer.json` will be initialised without the requirement passed to the command initially. I feel like this is not desired behaviour.

This PR skips the 'Would you like to define your dependencies (require) interactively?' and 'Would you like to define your dev dependencies (require-dev) interactively?' questions if the `--require` or `--require-dev` option(s) were set already.