### PR TITLE
Revert "Fixed an issue when a phar file is used in "files" option in composer.json"

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -534,10 +534,6 @@ EOF;
             }
         }
 
-        if (preg_match('/\.phar$/', $path)) {
-            $baseDir = "'phar://' . " . $baseDir;
-        }
-
         return $baseDir . (($path !== false) ? var_export($path, true) : "");
     }
 


### PR DESCRIPTION
This reverts commit 41e91f3064cee51dd52f45831dc48748ce37a095.

The commit 41e91f3 in current codebase generates absolute path in
`autoload_static.php` for phar file.

Example: https://github.com/chuangbo/composer-phar-test

Also according to http://php.net/manual/en/phar.using.intro.php, the `phar://`
prefix is not needed.
