### PR TITLE
Forward GitLab driver options to remote filesystem

### DIFF
--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -160,7 +160,9 @@ abstract class VcsDriver implements VcsDriverInterface
      */
     protected function getContents($url)
     {
-        return $this->remoteFilesystem->getContents($this->originUrl, $url, false);
+        $options = isset($this->repoConfig['options']) ? $this->repoConfig['options'] : array();
+
+        return $this->remoteFilesystem->getContents($this->originUrl, $url, false, $options);
     }
 
     /**

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -16,6 +16,7 @@ use Composer\Repository\Vcs\GitLabDriver;
 use Composer\Config;
 use Composer\TestCase;
 use Composer\Util\Filesystem;
+use Prophecy\Argument;
 
 /**
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
@@ -82,7 +83,7 @@ class GitLabDriverTest extends TestCase
 JSON;
 
         $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false)
+            ->getContents('gitlab.com', $apiUrl, false, array())
             ->willReturn($projectData)
             ->shouldBeCalledTimes(1)
         ;
@@ -121,7 +122,7 @@ JSON;
 JSON;
 
         $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false)
+            ->getContents('gitlab.com', $apiUrl, false, array())
             ->willReturn($projectData)
             ->shouldBeCalledTimes(1)
         ;
@@ -207,7 +208,7 @@ JSON;
 JSON;
 
         $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false)
+            ->getContents('gitlab.com', $apiUrl, false, array())
             ->willReturn($tagData)
             ->shouldBeCalledTimes(1)
         ;
@@ -249,7 +250,7 @@ JSON;
 JSON;
 
         $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false)
+            ->getContents('gitlab.com', $apiUrl, false, array())
             ->willReturn($branchData)
             ->shouldBeCalledTimes(1)
         ;
@@ -310,7 +311,7 @@ JSON;
 JSON;
 
         $this->remoteFilesystem
-            ->getContents('mycompany.com/gitlab', $apiUrl, false)
+            ->getContents('mycompany.com/gitlab', $apiUrl, false, array())
             ->willReturn($projectData)
             ->shouldBeCalledTimes(1)
         ;
@@ -319,5 +320,43 @@ JSON;
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
+    }
+
+    public function testForwardsOptions()
+    {
+        $options = array(
+            'ssl' => array(
+                'verify_peer' => false,
+            )
+        );
+        $projectData = <<<JSON
+{
+    "id": 17,
+    "default_branch": "mymaster",
+    "public": false,
+    "http_url_to_repo": "https://gitlab.mycompany.local/mygroup/myproject",
+    "ssh_url_to_repo": "git@gitlab.mycompany.local:mygroup/myproject.git",
+    "last_activity_at": "2014-12-01T09:17:51.000+01:00",
+    "name": "My Project",
+    "name_with_namespace": "My Group / My Project",
+    "path": "myproject",
+    "path_with_namespace": "mygroup/myproject",
+    "web_url": "https://gitlab.mycompany.local/mygroup/myproject"
+}
+JSON;
+
+        $this->remoteFilesystem
+            ->getContents(Argument::cetera(), $options)
+            ->willReturn($projectData)
+            ->shouldBeCalled();
+
+        $driver = new GitLabDriver(
+            array('url' => 'https://gitlab.mycompany.local/mygroup/myproject', 'options' => $options),
+            $this->io->reveal(),
+            $this->config,
+            $this->process->reveal(),
+            $this->remoteFilesystem->reveal()
+        );
+        $driver->initialize();
     }
 }


### PR DESCRIPTION
Fix for: https://github.com/composer/composer/commit/876f14341814d427e87dd358ed91ccc855678a5c#commitcomment-21901159

When using GitLab driver in a non-public network (e.g. company) and the GitLab server instance is using SSL with a self-signed certificate, it is not possible to retrieve repository information because SSL certificate verification errors (encountered in the context of Satis).

This could be solved by explicitly disabling SSL verification check via `options` but unfortunately composer isn't forwarding the options to the remote filesystem.

This patch fixed the issue for VCS based drivers by always forwarding `options` if available. The same has been done for the `composer` repository type as seen in the commit above.