### PR TITLE
Do not use realpath() with exclude-from-classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "symfony/filesystem": "^2.7 || ^3.0",
         "seld/phar-utils": "^1.0",
         "seld/cli-prompt": "^1.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0",
+        "webmozart/path-util": "^2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.5 || ^5.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "696d16729ae31dafdd42432da4d74aae",
+    "content-hash": "fe586132ed353b896e7f45e45e0c346e",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -765,6 +765,102 @@
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
             "time": "2017-03-04T12:20:59+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -21,6 +21,7 @@ use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Util\Filesystem;
 use Composer\Script\ScriptEvents;
+use Webmozart\PathUtil\Path;
 
 /**
  * @author Igor Wiedler <igor@wiedler.ch>
@@ -866,7 +867,7 @@ INITIALIZER;
                             $installPath = strtr(getcwd(), '\\', '/');
                         }
 
-                        $resolvedPath = rtrim($installPath . '/' . $updir, '/');
+                        $resolvedPath = Path::canonicalize($installPath . '/' . $updir);
                         $autoloads[] = preg_quote(strtr($resolvedPath, '\\', '/')) . '/' . $path;
                         continue;
                     }

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -866,7 +866,7 @@ INITIALIZER;
                             $installPath = strtr(getcwd(), '\\', '/');
                         }
 
-                        $resolvedPath = realpath($installPath . '/' . $updir);
+                        $resolvedPath = rtrim($installPath . '/' . $updir, '/');
                         $autoloads[] = preg_quote(strtr($resolvedPath, '\\', '/')) . '/' . $path;
                         continue;
                     }


### PR DESCRIPTION
Using `realpath()` when resolving the `exclude-from-classmap` paths will also resolve symlinks to their real path. However, they will not match the `$blacklist` regexp after that anymore and thus they will not be applied.

```
project/
    vendor/
        foo/
            bar/  <-- this is a symlink to ../../../../forks/bar/
                src/
                    exclude/

forks/
    bar/
        src/
            exclude/
```

The relevant `composer.json` part is:

```json
"exclude-from-classmap": [
    "src/exclude/"
]
```

Now run `composer dump-autoload`.

**Current situation**

* `$resolvedPath`: `/var/www/forks/bar/src/exclude`
* `$blacklist`: `{(/var/www/project/vendor/foo/bar/src/exclude)}`
* No match

**With the patch**

* `$resolvedPath`: `/var/www/project/vendor/foo/bar/src/exclude`
* `$blacklist`: `{(/var/www/project/vendor/foo/bar/src/exclude)}`
* Match
