### PR TITLE
relative path is allowed for `mirror.dist-url`

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -497,7 +497,10 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     $this->sourceMirrors['hg'][] = array('url' => $mirror['hg-url'], 'preferred' => !empty($mirror['preferred']));
                 }
                 if (!empty($mirror['dist-url'])) {
-                    $this->distMirrors[] = array('url' => $mirror['dist-url'], 'preferred' => !empty($mirror['preferred']));
+                    $this->distMirrors[] = array(
+                        'url' => $this->canonicalizeUrl($mirror['dist-url']),
+                        'preferred' => !empty($mirror['preferred'])
+                    );
                 }
             }
         }


### PR DESCRIPTION
when `mirror.dist-url` is `/file/%package%/%reference%.%type%`. it should be parsed in current domain.

such as `http://example.com/file/%package%/%reference%.%type%`.