### PR TITLE
Pass more ini directives along when executing php

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -257,9 +257,11 @@ class EventDispatcher
             throw new \RuntimeException('Failed to locate PHP binary to execute '.$scriptName);
         }
 
-        $memoryFlag = ' -d memory_limit='.ini_get('memory_limit');
+        $allowUrlFOpenFlag = ' -d allow_url_fopen=' . ini_get('allow_url_fopen');
+        $disableFunctionsFlag = ' -d disable_functions="' . ini_get('disable_functions') . '"';
+        $memoryLimitFlag = ' -d memory_limit=' . ini_get('memory_limit');
 
-        return ProcessExecutor::escape($phpPath) . $memoryFlag;
+        return ProcessExecutor::escape($phpPath) . $allowUrlFOpenFlag . $disableFunctionsFlag . $memoryLimitFlag;
     }
 
     /**

--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -174,6 +174,8 @@ class XdebugHandler
             $content .= $data.PHP_EOL;
         }
 
+        $content .= 'allow_url_fopen='.ini_get('allow_url_fopen').PHP_EOL;
+        $content .= 'disable_functions="'.ini_get('disable_functions').'"'.PHP_EOL;
         $content .= 'memory_limit='.ini_get('memory_limit').PHP_EOL;
 
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {


### PR DESCRIPTION
## Problem

Composer relies on `allow_url_fopen` being enabled and uses "risky" functions like `exec()`, `passthru()`, `proc_open()` and `system()`. But on some systems `allow_url_fopen` and/or these functions might be disabled.

This is easily overcome by specifying ini directives on the command-line like so:

```sh
php -d allow_url_fopen=On -d disable_functions="" composer.phar install
```

If the system _doesn't_ have xdebug enabled, this works just fine.

When xdebug _is_ enabled, composer restarts itself (using `passthru()` to execute the php binary), the ini directives aren't propagated and we see errors like:

- `allow_url_fopen must be enabled in php.ini (https:// wrapper is disabled in the server configuration by allow_url_fopen=0, failed to open stream: no suitable wrapper could be found)`
- `The Process class relies on proc_open, which is not available on your PHP installation.`

### Reproducible steps

- Have php with xdebug installed.
- Have `allow_url_fopen = Off` and `disable_functions = "exec, passthru, shell_exec, system, proc_open, popen, curl_exec, curl_multi_exec"` in your `php.ini`.
- Run `composer.phar install` on a project with json and lock files, but no `vendor` folder yet.

### Expected result

The packages are installed successfully (according to the lock file).

### Actual result

Composer quits prematurely with one of the errors mentioned above.

## Solution

In the `XdebugHandler`, append the current values of `allow_url_fopen` and `disable_functions` to the temporary ini file (the same way as done with `memory_limit `), making sure they are passed along when executing the php binary (when restarting).

When searching for `memory_limit`, I found that the same propagation was done in the `getPhpExecCommand()` method of the `EventDispatcher`. I'm not sure why or when this is called, but it looks like it needs the same adjustment.

### Tests

I couldn't find any tests on passing `memory_limit`, so I'm unsure about how and where to add tests. I'm also not sure if they are really needed for this change, although preventing regression is a good thing IMO 🙂 