### PR TITLE
Update GitLab personal access token URL and the token config command

### DIFF
--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -113,7 +113,7 @@ class GitLab
                     }
 
                     $this->io->writeError('You can also manually create a personal token at '.$scheme.'://'.$originUrl.'/profile/personal_access_tokens');
-                    $this->io->writeError('Add it using "composer config gitlab-token.'.$originUrl.' <token>"');
+                    $this->io->writeError('Add it using "composer config --global gitlab-token.'.$originUrl.' <token>"');
 
                     continue;
                 }

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -112,8 +112,8 @@ class GitLab
                         $this->io->writeError('Maximum number of login attempts exceeded. Please try again later.');
                     }
 
-                    $this->io->writeError('You can also manually create a personal token at '.$scheme.'://'.$originUrl.'/profile/applications');
-                    $this->io->writeError('Add it using "composer config gitlab-oauth.'.$originUrl.' <token>"');
+                    $this->io->writeError('You can also manually create a personal token at '.$scheme.'://'.$originUrl.'/profile/personal_access_tokens');
+                    $this->io->writeError('Add it using "composer config gitlab-token.'.$originUrl.' <token>"');
 
                     continue;
                 }


### PR DESCRIPTION
This change fixes two issues in the GitLab login error message:
1. The personal access tokens page is located at https://gitlab.com/profile/personal_access_tokens.
2. The generated personal access token should be stored in the config as `gitlab-token` instead of `gitlab-oauth`.

The second issue in particular confused me for a while earlier today 😃 

It also might be better to recommend that the user runs `composer global config` instead of applying it to the local config. Let me know if you want me to commit another change to add that.