### PR TITLE
Suggested fix for issue #4385

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -326,7 +326,22 @@ class ClassLoader
             return false;
         }
 
+        // Search for default .php files
         $file = $this->findFileWithExtension($class, '.php');
+
+        // Search for versioned php files (ex .php3, .php4, .php5, .php7)
+        if (false === $file) {
+
+            // Retrieve the major version of the current php environment
+            $PhpMajorVersion = explode('.', phpversion())[0];
+
+            // Append the major version to the .php extension
+            $file = $this->findFileWithExtension(
+                $class,
+                '.php' . $PhpMajorVersion
+            );
+
+        }
 
         // Search for Hack files if we are running on HHVM
         if (false === $file && defined('HHVM_VERSION')) {

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -332,14 +332,10 @@ class ClassLoader
         // Search for versioned php files (ex .php3, .php4, .php5, .php7)
         if (false === $file) {
 
-            // Retrieve the major version of the current php environment
-            $phpVersionArray = explode('.', phpversion());
-            $phpMajorVersion = array_shift($phpVersionArray);
-
             // Append the major version to the .php extension
             $file = $this->findFileWithExtension(
                 $class,
-                '.php' . $phpMajorVersion
+                '.php' . PHP_MAJOR_VERSION
             );
 
         }

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -333,12 +333,13 @@ class ClassLoader
         if (false === $file) {
 
             // Retrieve the major version of the current php environment
-            $PhpMajorVersion = explode('.', phpversion())[0];
+            $phpVersionArray = explode('.', phpversion());
+            $phpMajorVersion = array_shift($phpVersionArray);
 
             // Append the major version to the .php extension
             $file = $this->findFileWithExtension(
                 $class,
-                '.php' . $PhpMajorVersion
+                '.php' . $phpMajorVersion
             );
 
         }


### PR DESCRIPTION
WHEREAS: major revisions in PHP indicate breaking changes that
sometimes render code from older versions uncompilable AND

WHEREAS: uncompilable changes can not be resolved by if...then
statements, requiring (at times) completely different files for
different PHP versions AND

WHEREAS: a PHP developer may need to maintain code on multiple PHP
platform versions simultaneously AND

WHEREAS: in the Wikipedia article about PHP
(https://en.wikipedia.org/wiki/PHP) there is reference to version based
PHP file extensions (`.php3`, `.php4`, `.php5`, `.php7`).  (
Unfortunately there is no reference in the document as to the source of
this data.);

THEREFORE I SUGGEST: an additional if...then condition in the
autoloader that searches for the respective versioned extension
(`.php3`, `.php4`, `.php5`, `.php7`) when the default extension
(`.php`) is not found.

This would allow seamless deployment across PHP major versions.

This also prevents the developer from having to maintain multiple
copies of their entire codebase (either by having multiple independent
namespaces or VCS trees).  Only files that required different versions
would use the different versioned extensions.

Example:
```
- testClassA.php
- testClassB.php5
- testClassB.php7
- testClassC.php
```

The developer could also use the same unit tests across versions.  A
developer simply runs the unit tests in the newest version, then runs
the same library of tests on the older platform (ex. via VM).

Dropping support for an older platform would also be much simpler,
involving a fairly simple script.