### PR TITLE
Warn identical names w/ different capitalization for unzip

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -113,6 +113,7 @@ class ZipDownloader extends ArchiveDownloader
         }
 
         $this->io->writeError('    '.$processError->getMessage());
+        $this->io->writeError('    The archive may contain identical file names with different capitalization (which fails on case insensitive filesystems)');
         $this->io->writeError('    Unzip with unzip command failed, falling back to ZipArchive class');
 
         return $this->extractWithZipArchive($file, $path, true);


### PR DESCRIPTION
Warn about identical names with different capitalization on unzip archive
extract failure (Not a directory)

Issue #5938