### PR TITLE
Test PHP 5.3 on Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
       - parallel
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -24,6 +23,9 @@ php:
   - nightly
 
 matrix:
+  include:
+    - dist: precise
+      php: 5.3
   fast_finish: true
   allow_failures:
     - php: nightly


### PR DESCRIPTION
Since PHP 5.3 is not supported on Trusty, this PR moves tests for PHP 5.3 over to Ubuntu Precise.