### PR TITLE
Cache: clear cache using removeDirectory

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -175,6 +175,15 @@ class Cache
         return false;
     }
 
+    public function clear()
+    {
+        if ($this->enabled) {
+            return $this->filesystem->removeDirectory($this->root);
+        }
+
+        return false;
+    }
+
     public function gc($ttl, $maxSize)
     {
         if ($this->enabled) {

--- a/src/Composer/Command/ClearCacheCommand.php
+++ b/src/Composer/Command/ClearCacheCommand.php
@@ -42,10 +42,10 @@ EOT
         $io = $this->getIO();
 
         $cachePaths = array(
-            'cache-dir' => $config->get('cache-dir'),
-            'cache-files-dir' => $config->get('cache-files-dir'),
-            'cache-repo-dir' => $config->get('cache-repo-dir'),
             'cache-vcs-dir' => $config->get('cache-vcs-dir'),
+            'cache-repo-dir' => $config->get('cache-repo-dir'),
+            'cache-files-dir' => $config->get('cache-files-dir'),
+            'cache-dir' => $config->get('cache-dir'),
         );
 
         foreach ($cachePaths as $key => $cachePath) {
@@ -63,7 +63,7 @@ EOT
             }
 
             $io->writeError("<info>Clearing cache ($key): $cachePath</info>");
-            $cache->gc(0, 0);
+            $cache->clear();
         }
 
         $io->writeError('<info>All caches cleared.</info>');

--- a/src/Composer/Command/ClearCacheCommand.php
+++ b/src/Composer/Command/ClearCacheCommand.php
@@ -43,7 +43,7 @@ EOT
 
         $cachePaths = array(
             'cache-vcs-dir' => $config->get('cache-vcs-dir'),
-            'cache-repo-dir' => $config->get('cache-repo-dir'),
+            'cache-repo-dir'  => $config->get('cache-repo-dir'),
             'cache-files-dir' => $config->get('cache-files-dir'),
             'cache-dir' => $config->get('cache-dir'),
         );

--- a/src/Composer/Command/ClearCacheCommand.php
+++ b/src/Composer/Command/ClearCacheCommand.php
@@ -43,7 +43,7 @@ EOT
 
         $cachePaths = array(
             'cache-vcs-dir' => $config->get('cache-vcs-dir'),
-            'cache-repo-dir'  => $config->get('cache-repo-dir'),
+            'cache-repo-dir' => $config->get('cache-repo-dir'),
             'cache-files-dir' => $config->get('cache-files-dir'),
             'cache-dir' => $config->get('cache-dir'),
         );

--- a/tests/Composer/Test/CacheTest.php
+++ b/tests/Composer/Test/CacheTest.php
@@ -107,4 +107,18 @@ class CacheTest extends TestCase
         }
         $this->assertFileExists("{$this->root}/cached.file3.zip");
     }
+
+    public function testClearCache()
+    {
+        $this->finder
+            ->method('removeDirectory')
+            ->with($this->root)
+            ->willReturn(true);
+
+        $this->assertTrue($this->cache->clear());
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->assertFileNotExists("{$this->root}/cached.file{$i}.zip");
+        }
+    }
 }


### PR DESCRIPTION
fixes: #6362

cc/ @barbazul @Seldaek @stof 

Hello! This is my first PR. As directed in issue #6362 I introduced a separate function for clearing the cache and just used `removeDirectory` directly instead of the `gc` command. 
 
_*Note*_: If `cache-dir` is the root directory of `cache-files-dir`, `cache-repo-dir` and `cache-vcs-dir` than it tries to remove something that is not there -- possible to optimize more?

Let me know if any questions or concerns. thanks.