### PR TITLE
Lock file package time inconsistency

### DIFF
--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -432,6 +432,6 @@ class Locker
             }
         }
 
-        return $datetime ? $datetime->format('Y-m-d H:i:s') : null;
+        return $datetime ? $datetime->format(DATE_RFC3339) : null;
     }
 }

--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -116,7 +116,7 @@ abstract class VcsDriver implements VcsDriverInterface
         $composer = JsonFile::parseJson($composerFileContent, $identifier . ':composer.json');
 
         if (empty($composer['time']) && $changeDate = $this->getChangeDate($identifier)) {
-            $composer['time'] = $changeDate->format('Y-m-d H:i:s');
+            $composer['time'] = $changeDate->format(DATE_RFC3339);
         }
 
         return $composer;

--- a/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
@@ -183,7 +183,7 @@ class GitBitbucketDriverTest extends TestCase
                 'require-dev' => array(
                     'phpunit/phpunit' => '~4.8',
                 ),
-                'time' => '2016-05-17 13:19:52',
+                'time' => '2016-05-17T13:19:52+00:00',
                 'support' => array(
                     'source' => 'https://bitbucket.org/user/repo/src/937992d19d72b5116c3e8c4a04f960e5fa270b22/?at=master',
                 ),


### PR DESCRIPTION
Dev packages which are installed from source  will produce time in `Y:m:d H:i:s` format according to lines 373-375, 435 in file `composer/src/Composer/Package/Locker.php`.
Other packages will have time formatted by `ArrayDumper` class and will have DATE_RFC3339 format as per line 86.