### PR TITLE
Example of disabling packagist.org globally

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -655,4 +655,10 @@ You can disable the default Packagist.org repository by adding this to your
 }
 ```
 
+You can disable Packagist.org globally by using the global config flag:
+
+```
+composer confg -g repo.packagist false
+```
+
 &larr; [Schema](04-schema.md)  |  [Config](06-config.md) &rarr;


### PR DESCRIPTION
Obviously this is not a common use case, but it is good for isolated networks. As far as I could tell, this was not documented, but I figured it out by looking through the code.