### PR TITLE
Fix hg command to retrieve file content

### DIFF
--- a/src/Composer/Repository/Vcs/HgDriver.php
+++ b/src/Composer/Repository/Vcs/HgDriver.php
@@ -119,7 +119,7 @@ class HgDriver extends VcsDriver
     public function getFileContent($file, $identifier)
     {
         $resource = sprintf('hg cat -r %s %s', ProcessExecutor::escape($identifier), ProcessExecutor::escape($file));
-        $this->process->execute(sprintf('hg cat -r %s', $resource), $content, $this->repoDir);
+        $this->process->execute($resource, $content, $this->repoDir);
 
         if (!trim($content)) {
             return;


### PR DESCRIPTION
getFileContent generated command like hg cat -r hg cat -r CHANGESET FILE that caused errors "Skipping missing sub" while fetching composer.json files in repositories containing subrepositories.

This fixes that error.