### PR TITLE
Be strict and return non-zero exit code for outdated packages when showing all

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -353,7 +353,7 @@ EOT
                         }
                         if ($input->getOption('outdated') && $latestPackage && $latestPackage->getFullPrettyVersion() === $package->getFullPrettyVersion() && !$latestPackage->isAbandoned()) {
                             continue;
-                        } elseif ($input->getOption('outdated')) {
+                        } elseif ($input->getOption('outdated') || $input->getOption('strict')) {
                             $hasOutdatedPackages = true;
                         }
 


### PR DESCRIPTION
Running `composer outdated --all --strict` should return a non-zero exit code.