### PR TITLE
Fix case insensitivity of ‘require’ command

### DIFF
--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -109,6 +109,28 @@ class JsonManipulatorTest extends \PHPUnit_Framework_TestCase
 }
 ',
             ),
+
+
+            array(
+                '{
+    "require":
+    {
+        "foo": "bar",
+        "vendor/baz": "baz"
+    }
+}',
+                'require',
+                'vEnDoR/bAz',
+                'qux',
+                '{
+    "require":
+    {
+        "foo": "bar",
+        "vendor/baz": "qux"
+    }
+}
+',
+            ),
             array(
                 '{
     "require":
@@ -119,6 +141,26 @@ class JsonManipulatorTest extends \PHPUnit_Framework_TestCase
 }',
                 'require',
                 'vendor/baz',
+                'qux',
+                '{
+    "require":
+    {
+        "foo": "bar",
+        "vendor/baz": "qux"
+    }
+}
+',
+            ),
+            array(
+                '{
+    "require":
+    {
+        "foo": "bar",
+        "vendor\/baz": "baz"
+    }
+}',
+                'require',
+                'vEnDoR/bAz',
                 'qux',
                 '{
     "require":


### PR DESCRIPTION
When currently executing the `require` command for a package that is already listed in `require(-dev)`, one must use the exact same, case matching package name as written in `composer.json`. That is, if one changes the case of a character in the package name, the `require` command will add a new entry to `require(-dev)`, instead of updating the existing one:

```json
// Initial composer.json
{
  "require": {
    "foo/bar": "^1"
  }
}

// composer.json after running `composer require fOo/BaR:^2`
{
  "require": {
    "foo/bar": "^1",
    "fOo/BaR": "^2"
  }
}
```

This commit fixes the described behaviour to make it consistent with other commands like `update` that are already case insensitive:

```json
// composer.json after running `composer require fOo/BaR:^2` with this PR
{
  "require": {
    "foo/bar": "^2"
  }
}
```