### PR TITLE
`sort-packages: true` is now the default when creating a composer.json…

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -115,6 +115,8 @@ EOT
             }
         }
 
+        $options['config'] = array('sort-packages' => true);
+
         $file = new JsonFile(Factory::getComposerFile());
         $json = $file->encode($options);
 


### PR DESCRIPTION
… with `composer init` (Fixes #6542)