### PR TITLE
mute first cd in win proxy stub for sh shell, fixes #6567

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -194,7 +194,7 @@ class BinaryInstaller
         $proxyCode = <<<PROXY
 #!/usr/bin/env sh
 
-dir=$(d=\${0%[/\\\\]*}; cd "\$d"; cd $binDir && pwd)
+dir=$(d=\${0%[/\\\\]*}; cd "\$d" > /dev/null; cd $binDir && pwd)
 
 # See if we are running in Cygwin by checking for cygpath program
 if command -v 'cygpath' >/dev/null 2>&1; then


### PR DESCRIPTION
in the sh script, the first cd command did output the directory it cd'ed
into did output the path itself.

fix for me is to redirect it's standard output to /dev/null

using git bash on a windows 10 box.

w/o this fix, the workaround is to invoke the .bat file which is created
as well (but this is not so handy as a non windows user for me).