### PR TITLE
Check for metapackage before looking for a dist or source.

### DIFF
--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -184,6 +184,10 @@ class DownloadManager
         $sourceType = $package->getSourceType();
         $distType = $package->getDistType();
 
+        if ('metapackage' === $package->getType()) {
+            return;
+        }
+
         $sources = array();
         if ($sourceType) {
             $sources[] = 'source';


### PR DESCRIPTION
Unfortunately I am not able to reproduce this bug outside of a pretty complicated setup with lots of private repos.

In a local test this problem did not occur, however there is _some_ path somewhere which leads to the DownloadManager to try to download a metapackage.

Then it errors with the following message:

```                                                 
  [InvalidArgumentException]                                                  
  Package drupal/drafty_enforce-1.0.0.0 must have a source or dist specified                                                              
```

I clearly have this even in my composer.json be set up as a metapackage (also set as metapackage in the composer repo):

```
{
  "name": "mylocal-config",
  "repositories": [
    {
      "type": "composer",
      "url": "https://packages.drupal.org/7"
    },
    {
      "type": "package",
      "package": {
        "name": "drupal/drafty_enforce",
        "type": "metapackage",
        "version": "1.0.0"
      }
    }
  ],
}
```

I was not able to figure out why it tries to download the metapackage in the first place, but the below additional check fixes the problem at least locally for me so that I can continue working on this project.

Also the override was necessary as it tried to apply minimum stability settings to the metapackage as well, which might be related or a different bug.

TL;DR: I am not sure this PR is correct, but I am posting it so that it might give someone pointers that run into the same issue or I might get information on where this bug might be fixed properly in the code base.