### PR TITLE
Allow to specific custom version for path repositories

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -637,7 +637,14 @@
                 "options": {
                     "type": "object",
                     "properties": {
-                        "symlink": { "type": ["boolean", "null"] }
+                        "symlink": { "type": ["boolean", "null"] },
+                        "versions": {
+                            "type": "object",
+                            "description": "This is a maps of package name (keys) and version.",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "additionalProperties": true
                 }

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -47,7 +47,8 @@ use Composer\Util\ProcessExecutor;
  *         "type": "path",
  *         "url": "../../relative/path/to/package/",
  *         "options": {
- *             "symlink": false
+ *             "symlink": false,
+ *             "versions": {"symfony/symfony": "3.3.0"}
  *         }
  *     },
  * ]
@@ -143,8 +144,12 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             $package['transport-options'] = $this->options;
 
             if (!isset($package['version'])) {
-                $versionData = $this->versionGuesser->guessVersion($package, $path);
-                $package['version'] = $versionData['version'] ?: 'dev-master';
+                if (isset($this->options['versions'][$package['name']])) {
+                    $package['version'] = $this->options['versions'][$package['name']];
+                } else {
+                    $versionData = $this->versionGuesser->guessVersion($package, $path);
+                    $package['version'] = $versionData['version'] ?: 'dev-master';
+                }
             }
 
             $output = '';


### PR DESCRIPTION
### Purpose

As developer I want to ignore guess version for path repository and specific it in main composer.json. For example I develop new feature for composer installable package (local branch name "feature/example") and want to test it on my project. But I can not install this package without modification main composer.json or composer.json in this package.
These changes allow to ignore guess version.

**Second example** 
I want to install for testing "symfony/symfony": "dev-master", but some package requires a specific symfony version.
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - incenteev/composer-parameter-handler v2.1.2 requires symfony/yaml ~2.3|~3.0 -> satisfiable by symfony/symfony[v3.3.5], s
```
But I use this approach, I can circumvent these requirements and install master from path
![selection_073](https://user-images.githubusercontent.com/21358010/28757426-7a92b832-758b-11e7-9c74-3d4fababd0f3.png)

### Usage
```json
    "repositories": [
        {
            "type": "path",
            "url": "package/*",
            "options": {
                "versions": {"symfony/symfony": "3.3.6"}
            }
        }
    ]
```
