### PR TITLE
Improve IDE autocompletion

### DIFF
--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -13,6 +13,8 @@
 namespace Composer\DependencyResolver;
 
 use Composer\Package\CompletePackage;
+use Composer\Package\Link;
+use Composer\Package\PackageInterface;
 
 /**
  * @author Nils Adermann <naderman@naderman.de>
@@ -235,6 +237,12 @@ abstract class Rule
         }
     }
 
+    /**
+     * @param Pool  $pool
+     * @param array $packages
+     *
+     * @return string
+     */
     protected function formatPackagesUnique($pool, array $packages)
     {
         $prepared = array();


### PR DESCRIPTION
According to type 2nd constructor-argument `$reasonData` can either be a Link or a PackageInterface. IDEs like PhpStorm won't be able to provide autocompletion since both classes are from a different namespace.

In order to provide better autocompletion for `$reasonData` and by extension `$this->reasonData` the use statements should be included or the type hint should use the fully qualified class name.

For the same reason I added the docblock on the protected method `formatePackagesUnique()`.