### PR TITLE
GitlabDriver V4 Paging

### DIFF
--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -314,7 +314,7 @@ JSON;
             ->shouldBeCalledTimes(1)
         ;
         $this->remoteFilesystem->getLastHeaders()
-          ->willReturn([]);
+          ->willReturn(array());
 
         $driver->setRemoteFilesystem($this->remoteFilesystem->reveal());
 

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -217,7 +217,7 @@ JSON;
             ->shouldBeCalledTimes(1)
         ;
         $this->remoteFilesystem->getLastHeaders()
-          ->willReturn([]);
+          ->willReturn(array());
         
         $driver->setRemoteFilesystem($this->remoteFilesystem->reveal());
 
@@ -268,7 +268,7 @@ JSON;
         ;
 
         $this->remoteFilesystem->getLastHeaders()
-          ->willReturn(['Link: <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=2&per_page=20>; rel="next", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=1&per_page=20>; rel="first", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=3&per_page=20>; rel="last"'], ['Link: <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=2&per_page=20>; rel="prev", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=1&per_page=20>; rel="first", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=3&per_page=20>; rel="last"'])
+          ->willReturn(array('Link: <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=2&per_page=20>; rel="next", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=1&per_page=20>; rel="first", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=3&per_page=20>; rel="last"'), array('Link: <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=2&per_page=20>; rel="prev", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=1&per_page=20>; rel="first", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=3&per_page=20>; rel="last"'))
           ->shouldBeCalledTimes(2);
 
         $driver->setRemoteFilesystem($this->remoteFilesystem->reveal());

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -230,7 +230,7 @@ JSON;
         $this->assertEquals($expected, $driver->getTags(), 'Tags are cached');
     }
 
-    public function testGetTagsPaginated() {
+    public function testGetPaginatedRefs() {
         $driver = $this->testInitialize('https://gitlab.com/mygroup/myproject', 'https://gitlab.com/api/v4/projects/mygroup%2Fmyproject');
 
         $apiUrl = 'https://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/branches';


### PR DESCRIPTION
this commit introduced V4 gitlab api -
 https://github.com/composer/composer/commit/6832eacb0161ecec4666a7d2456a474e3f8e903d


however the branches/tags endpoints: `http://gitlab.krone.at/api/v4/projects/XXX%2FYYY/repository/branches`

in V4 require to be paginated, where as in v3 it was not, resulting in composer only downloading the first couple of branches -> resulting in wrong version picks.

which was kind a nuklear 💣  on our ci machines deploying stone age  old code to different systems.
(one could say - do not use `--snapshot` in production 😆 )

this PR adds support for pagination!
