### PR TITLE
[REGRESSION] GitLabDriver fix tag/branch collection :bomb:

### DIFF
--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -280,10 +280,11 @@ class GitLabDriver extends VcsDriver
     {
         $resource = $this->getApiUrl().'/repository/'.$type.'?per_page=100';
 
+        $references = array();
         do {
             $data = JsonFile::parseJson($this->getContents($resource), $resource);
 
-            $references = array();
+
 
             foreach ($data as $datum) {
                 $references[$datum['name']] = $datum['commit']['id'];


### PR DESCRIPTION
https://github.com/composer/composer/pull/6592 introduced paging, but in fact it was wrong!
the `$refrences` was resetet on each page! i really apologize for bringing in such a lame regression.


/cc @Seldaek 