### PR TITLE
Delete last coma if deleting last element before end of file

### DIFF
--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -430,6 +430,11 @@ class JsonManipulator
                 return false;
             }
 
+            //check if we do not left a coma alone on previous line if it was the last line
+            if(preg_match('#,\s*$#', $matches['start']) && preg_match('#^\}$#', $matches['end'])) {
+                $matches['start'] = rtrim(preg_replace('#,(\s*)$#', '$1', $matches['start']), $this->indent);
+            }
+
             $this->contents = $matches['start'] . $matches['end'];
             if (preg_match('#^\{\s*\}\s*$#', $this->contents)) {
                 $this->contents = "{\n}";

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -2331,4 +2331,34 @@ class JsonManipulatorTest extends \PHPUnit_Framework_TestCase
 }
 ', $manipulator->getContents());
     }
+
+    public function testRemoveMainKeyAtEndOfFile()
+    {
+        $manipulator = new JsonManipulator('{
+    "require": {
+        "package/a": "*"
+    }
+}
+');
+        $this->assertTrue($manipulator->addMainKey('homepage', 'http...'));
+        $this->assertTrue($manipulator->addMainKey('license', 'mit'));
+        $this->assertEquals('{
+    "require": {
+        "package/a": "*"
+    },
+    "homepage": "http...",
+    "license": "mit"
+}
+', $manipulator->getContents());
+
+        $this->assertTrue($manipulator->removeMainKey('homepage'));
+        $this->assertTrue($manipulator->removeMainKey('license'));
+        $this->assertEquals('{
+    "require": {
+        "package/a": "*"
+    }
+}
+', $manipulator->getContents());
+
+    }
 }


### PR DESCRIPTION
This PR aims to fix #6636.

I worked on the deletion of the last element before ending `}` that was breaking the file by leaving the coma.

There must be an other way to fix this, so just let me know if you prefer an other way.

