### PR TITLE
Prevent automatic parent directory composer.json discovery if working-dir parameter is set

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -127,7 +127,7 @@ class Application extends BaseApplication
         }
 
         // prompt user for dir change if no composer.json is present in current dir
-        if ($io->isInteractive() && !in_array($commandName, array('', 'list', 'init', 'about', 'help', 'diagnose', 'self-update', 'global', 'create-project'), true) && !file_exists(Factory::getComposerFile())) {
+        if ($io->isInteractive() && !$input->getParameterOption('--working-dir') && !in_array($commandName, array('', 'list', 'init', 'about', 'help', 'diagnose', 'self-update', 'global', 'create-project'), true) && !file_exists(Factory::getComposerFile())) {
             $dir = dirname(getcwd());
             $home = realpath(getenv('HOME') ?: getenv('USERPROFILE') ?: '/');
 


### PR DESCRIPTION
#6426 - _Look “up” for composer.json if one doesn’t appear in the current folder_ is a massive UX improvement. However, I believe that Composer should listen to, if set, the `--working-dir` option and not try to discover `composer.json` files in parent directories. 

One use case is at bamarni/composer-bin-plugin#30. This plugin lets you have namespaces and have a separate `composer.json` file in each namespace. With Composer 1.5, users are now prompted if they want to use the upper directory's `composer.json` file (which they should not, in this plugins use case). I'm trying to change this plugin so the plugin can set the working directory and force composer to create the `compsoer.json` file at the same directory. 