### PR TITLE
fix parallel test exit scenario shell syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ before_script:
 
 script:
     # run test suite directories in parallel using GNU parallel
-    - ls -d tests/Composer/Test/* | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/complete.phpunit.xml --colors=always {} || (echo -e "\e[41mFAILED\e[0m {}" && $(exit 1));'
+    - ls -d tests/Composer/Test/* | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/complete.phpunit.xml --colors=always {} || (echo -e "\e[41mFAILED\e[0m {}" && exit 1);'


### PR DESCRIPTION
previous code introduced in 4d8b371908 used subshell capture which would be executed, but intended is just to set exit code to 1. probably never noticed because empty command is not executed by current shell.