### PR TITLE
Make composer see installed dev packages

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1309,7 +1309,7 @@ class Installer
             $skipPackages[$require->getTarget()] = true;
         }
 
-        $pool = new Pool;
+        $pool = new Pool('dev');
         $pool->addRepository($localOrLockRepo);
 
         $seen = array();


### PR DESCRIPTION
Consider following example:
```
$ composer require 'monolog/monolog' 'dev-master'
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 2 installs, 0 updates, 0 removals
  - Installing psr/log (1.0.2): Loading from cache
  - Installing monolog/monolog (dev-master 7b99283): Cloning 7b99283627
Writing lock file
Generating autoload files
$ composer remove 'monolog/monolog'
Package "monolog/monolog" listed for update is not installed. Ignoring.
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 0 updates, 1 removal
  - Removing monolog/monolog (dev-master)
Writing lock file
Generating autoload files
```
As you can see, composer doesn't see installed dev-* packages, so it doesn't remove (update) dependencies, and you have to do it manually.

This PR fixes it.