### PR TITLE
Fixed error, when composer.phar could be broken

### DIFF
--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -164,10 +164,24 @@ class Compiler
         $util->save($pharFile, \Phar::SHA1);
     }
 
+    /**
+     * @param \SplFileInfo $file
+     * @return string
+     */
+    private function getRelativeFilePath($file)
+    {
+        $realPath = $file->getRealPath();
+        $pathPrefix = dirname(dirname(__DIR__)).DIRECTORY_SEPARATOR;
+
+        $pos = strpos($realPath, $pathPrefix);
+        $relativePath = ($pos !== false) ? substr_replace($realPath, '', $pos, strlen($pathPrefix)) : $realPath;
+
+        return strtr($relativePath, '\\', '/');
+    }
+
     private function addFile($phar, $file, $strip = true)
     {
-        $path = strtr(str_replace(dirname(dirname(__DIR__)).DIRECTORY_SEPARATOR, '', $file->getRealPath()), '\\', '/');
-
+        $path = $this->getRelativeFilePath($file);
         $content = file_get_contents($file);
         if ($strip) {
             $content = $this->stripWhitespace($content);


### PR DESCRIPTION
Fixed error, when composer.phar was broken, if it was compiled inside folder, that has /composer in path. For example, if project repository will be located in /composer directory on linux, then str_replace will produce wrong result for such files, as /vendor/composer/autoload_real.php, because it will replace all occurrences of "/vendor" inside path, and not only the first one.