### PR TITLE
Allow custom script descriptions.

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -271,3 +271,19 @@ resolve to whatever php process is currently being used:
 One limitation of this is that you can not call multiple commands in
 a row like `@php install && @php foo`. You must split them up in a
 JSON array of commands.
+
+## Custom descriptions.
+
+You can set custom script descriptions with the following extra in your composer.json:
+
+ ```json
+ {
+     "extra": {
+        "scripts-description": {
+            "test": "Run all tests!"
+        }
+     }
+ }
+ ```
+
+> **Note:** You can only set custom descriptions of custom commands.

--- a/src/Composer/Command/ScriptAliasCommand.php
+++ b/src/Composer/Command/ScriptAliasCommand.php
@@ -23,10 +23,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ScriptAliasCommand extends BaseCommand
 {
     private $script;
+    private $description;
 
-    public function __construct($script)
+    public function __construct($script, $description)
     {
         $this->script = $script;
+        $this->description = empty($description) ? 'Runs the '.$script.' script as defined in composer.json.' : $description;
 
         parent::__construct();
     }
@@ -35,7 +37,7 @@ class ScriptAliasCommand extends BaseCommand
     {
         $this
             ->setName($this->script)
-            ->setDescription('Runs the '.$this->script.' script as defined in composer.json.')
+            ->setDescription($this->description)
             ->setDefinition(array(
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Sets the dev mode.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables the dev mode.'),

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -228,7 +228,8 @@ class Application extends BaseApplication
                             if ($this->has($script)) {
                                 $io->writeError('<warning>A script named '.$script.' would override a Composer command and has been skipped</warning>');
                             } else {
-                                $this->add(new Command\ScriptAliasCommand($script));
+                                $description = isset($composer['extra']['scripts-description'][$script]) ? $composer['extra']['scripts-description'][$script]:NULL;
+                                $this->add(new Command\ScriptAliasCommand($script, $description));
                             }
                         }
                     }


### PR DESCRIPTION
Allows you to add custom descriptions for custom scripts which is useful for providing some basic inline documentation.

```json
    "extra": {
        "scripts-description": {
            "test": "Run all tests!"
        }
    }
```

Each script can have it's own description set in `extra.scripts-description` and it will still show the default if nothing is set.

![image](https://user-images.githubusercontent.com/331453/30267822-1988bede-9727-11e7-8022-15488250004f.png)
