### PR TITLE
fix gitlab repo config in composer.lock

### DIFF
--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -351,7 +351,7 @@ class GitLabDriver extends VcsDriver
 
     protected function generatePublicUrl()
     {
-        return 'https://' . $this->originUrl . '/'.$this->namespace.'/'.$this->repository.'.git';
+        return $this->scheme . '://' . $this->originUrl . '/'.$this->namespace.'/'.$this->repository.'.git';
     }
 
     protected function setupGitDriver($url)

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -196,7 +196,7 @@ class GitLabDriver extends VcsDriver
             return $this->gitDriver->getSource($identifier);
         }
 
-        return array('type' => 'git', 'url' => $this->getRepositoryUrl(), 'reference' => $identifier);
+        return array('type' => 'git', 'url' => $this->getUrl(), 'reference' => $identifier);
     }
 
     /**

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -197,12 +197,13 @@ JSON;
 
     public function testGetSource()
     {
-        $driver = $this->testInitialize('https://gitlab.com/mygroup/myproject', 'https://gitlab.com/api/v4/projects/mygroup%2Fmyproject');
+        $url = 'https://gitlab.com/mygroup/myproject';
+        $driver = $this->testInitialize($url, 'https://gitlab.com/api/v4/projects/mygroup%2Fmyproject');
 
         $reference = 'c3ebdbf9cceddb82cd2089aaef8c7b992e536363';
         $expected = array(
             'type' => 'git',
-            'url' => 'git@gitlab.com:mygroup/myproject.git',
+            'url' => $url,
             'reference' => $reference,
         );
 
@@ -211,12 +212,13 @@ JSON;
 
     public function testGetSource_GivenPublicProject()
     {
-        $driver = $this->testInitializePublicProject('https://gitlab.com/mygroup/myproject', 'https://gitlab.com/api/v4/projects/mygroup%2Fmyproject', true);
+        $url = 'https://gitlab.com/mygroup/myproject';
+        $driver = $this->testInitializePublicProject($url, 'https://gitlab.com/api/v4/projects/mygroup%2Fmyproject');
 
         $reference = 'c3ebdbf9cceddb82cd2089aaef8c7b992e536363';
         $expected = array(
             'type' => 'git',
-            'url' => 'https://gitlab.com/mygroup/myproject.git',
+            'url' => $url,
             'reference' => $reference,
         );
 


### PR DESCRIPTION
1. When `attemptCloneFallback` use `generatePublicUrl` to get public_url, we cannot forget some gitlab instance doesn't support https. **So we get `scheme` from config.**
2. When generate `composer.lock` file, we should use repo url *what user wrote* at `composer.json` , not we got from gitlab api.