### PR TITLE
Sort vendor/composer/installed.json deterministically

### DIFF
--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -83,6 +83,10 @@ class FilesystemRepository extends WritableArrayRepository
             $data[] = $dumper->dump($package);
         }
 
+        usort($data, function($a, $b) {
+            return strcmp($a['name'], $b['name']);
+        });
+
         $this->file->write($data);
     }
 }


### PR DESCRIPTION
Just like composer.lock, sort installed.json in order of the package
names. This makes it easier to review diffs when this file is changed.

See discussion on #4410.