### PR TITLE
Teach fossil to use HTTP Basic and Fossil built-in authentication

### DIFF
--- a/src/Composer/Downloader/FossilDownloader.php
+++ b/src/Composer/Downloader/FossilDownloader.php
@@ -131,15 +131,17 @@ class FossilDownloader extends VcsDownloader
         $parsed = parse_url($url);
 
         // Only for http(s) URLs.
-        if (!isset($parsed['scheme']) || ($parsed['scheme'] != 'http' && $parsed['scheme'] != 'https') || empty($parsed['host']))
+        if (!isset($parsed['scheme']) || ($parsed['scheme'] != 'http' && $parsed['scheme'] != 'https') || empty($parsed['host'])) {
             return '';
+        }
 
         $httpBasicConfig = $this->config->get('http-basic');
         if (isset($httpBasicConfig[$parsed['host']])) {
             $creds = $httpBasicConfig[$parsed['host']];
             // We don't allow empty username or password. Both must be defined.
-            if (!empty($creds['username']) && !empty($creds['password']))
+            if (!empty($creds['username']) && !empty($creds['password'])) {
                 return sprintf('-B %s', ProcessExecutor::escape($creds['username'] .':'. $creds['password']));
+            }
         }
 
         return '';
@@ -150,7 +152,7 @@ class FossilDownloader extends VcsDownloader
      *
      *   1. HTTP Basic authentication, if accessing the HTTP URL is so protected by the web server.
      *   2. Fossil authentication, if accessing the remote repo is not allowed for anonymous users.
-     * 
+     *
      * Fossil considers the username and password specified in the HTTP URL to be the credentials for Fossil authentication,
      * and provides a separate parameter for HTTP Basic authentication.
      *
@@ -175,8 +177,9 @@ class FossilDownloader extends VcsDownloader
         $parsed = parse_url($url);
 
         // Only for http(s) URLs.
-        if (!isset($parsed['scheme']) || ($parsed['scheme'] != 'http' && $parsed['scheme'] != 'https') || empty($parsed['host']))
+        if (!isset($parsed['scheme']) || ($parsed['scheme'] != 'http' && $parsed['scheme'] != 'https') || empty($parsed['host'])) {
             return $url;
+        }
 
         $remoteRepo = $parsed['host'] . $parsed['path'];
         $authentications = $this->config->get('fossil-auth');

--- a/src/Composer/Downloader/FossilDownloader.php
+++ b/src/Composer/Downloader/FossilDownloader.php
@@ -28,18 +28,20 @@ class FossilDownloader extends VcsDownloader
         // Ensure we are allowed to use this URL by config
         $this->config->prohibitUrlByConfig($url, $this->io);
 
-        $url = ProcessExecutor::escape($url);
         $ref = ProcessExecutor::escape($package->getSourceReference());
         $repoFile = $path . '.fossil';
         $this->io->writeError("Cloning ".$package->getSourceReference());
-        $command = sprintf('fossil clone %s %s', $url, ProcessExecutor::escape($repoFile));
+
+        $command = $this->getCloneCommand($url, $repoFile);
         if (0 !== $this->process->execute($command, $ignoredOutput)) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
         }
+
         $command = sprintf('fossil open %s', ProcessExecutor::escape($repoFile));
         if (0 !== $this->process->execute($command, $ignoredOutput, realpath($path))) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
         }
+
         $command = sprintf('fossil update %s', $ref);
         if (0 !== $this->process->execute($command, $ignoredOutput, realpath($path))) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
@@ -54,7 +56,6 @@ class FossilDownloader extends VcsDownloader
         // Ensure we are allowed to use this URL by config
         $this->config->prohibitUrlByConfig($url, $this->io);
 
-        $url = ProcessExecutor::escape($url);
         $ref = ProcessExecutor::escape($target->getSourceReference());
         $this->io->writeError(" Updating to ".$target->getSourceReference());
 
@@ -62,8 +63,15 @@ class FossilDownloader extends VcsDownloader
             throw new \RuntimeException('The .fslckout file is missing from '.$path.', see https://getcomposer.org/commit-deps for more information');
         }
 
-        $command = sprintf('fossil pull && fossil up %s', $ref);
-        if (0 !== $this->process->execute($command, $ignoredOutput, realpath($path))) {
+        $realpath = realpath($path);
+
+        $command = $this->getPullCommand($url);
+        if (0 !== $this->process->execute($command, $ignoredOutput, $realpath)) {
+            throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
+        }
+
+        $command = "fossil update {$ref}";
+        if (0 !== $this->process->execute($command, $ignoredOutput, $realpath)) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
         }
     }
@@ -112,5 +120,109 @@ class FossilDownloader extends VcsDownloader
     protected function hasMetadataRepository($path)
     {
         return is_file($path . '/.fslckout') || is_file($path . '/_FOSSIL_');
+    }
+
+    /**
+     * Find username and password for HTTP authentication, if they are defined.
+     * The returned string is in the format expected by the fossil executable.
+     */
+    protected function getHttpBasicAuth($url)
+    {
+        $parsed = parse_url($url);
+
+        // Only for http(s) URLs.
+        if (!isset($parsed['scheme']) || ($parsed['scheme'] != 'http' && $parsed['scheme'] != 'https') || empty($parsed['host']))
+            return '';
+
+        $httpBasicConfig = $this->config->get('http-basic');
+        if (isset($httpBasicConfig[$parsed['host']])) {
+            $creds = $httpBasicConfig[$parsed['host']];
+            // We don't allow empty username or password. Both must be defined.
+            if (!empty($creds['username']) && !empty($creds['password']))
+                return sprintf('-B %s', ProcessExecutor::escape($creds['username'] .':'. $creds['password']));
+        }
+
+        return '';
+    }
+
+    /**
+     * To clone or pull from a remote fossil repo via HTTP URL, we might have to go through two authentications:
+     *
+     *   1. HTTP Basic authentication, if accessing the HTTP URL is so protected by the web server.
+     *   2. Fossil authentication, if accessing the remote repo is not allowed for anonymous users.
+     * 
+     * Fossil considers the username and password specified in the HTTP URL to be the credentials for Fossil authentication,
+     * and provides a separate parameter for HTTP Basic authentication.
+     *
+     * As best practice, users should probably keep all their credentials in auth.json. The composer.json should
+     * only have the URL to the remote repo as if it was accessible to the public without any credentials.
+     *
+     * This method manipulates the repo URL and adds fossil repository credentials to it.
+     *
+     * It is expected that credentials specific for each repository would be located in auth.json in the following structure:
+     *
+     * {
+     *   "fossil-auth": {
+     *     "host.com/path/to/repo": {
+     *       "username": "my-user",
+     *       "password": "my-pass"
+     *     }
+     *   }
+     * }
+     */
+    protected function getUrlWithAuth($url)
+    {
+        $parsed = parse_url($url);
+
+        // Only for http(s) URLs.
+        if (!isset($parsed['scheme']) || ($parsed['scheme'] != 'http' && $parsed['scheme'] != 'https') || empty($parsed['host']))
+            return $url;
+
+        $remoteRepo = $parsed['host'] . $parsed['path'];
+        $authentications = $this->config->get('fossil-auth');
+
+        if (isset($authentications[$remoteRepo])) {
+            $creds = $authentications[$remoteRepo];
+
+            // We don't care if username or password were provided in the URL.
+            $url = sprintf(
+                '%s://%s:%s@%s%s%s%s%s',
+                $parsed['scheme'],
+                $creds['username'],
+                $creds['password'],
+                $parsed['host'],
+                isset($parsed['port']) ? ':'.$parsed['port'] : '',
+                $parsed['path'],
+                isset($parsed['query']) ? '?'.$parsed['query'] : '',
+                isset($parsed['fragment']) ? '#'.$parsed['fragment'] : ''
+            );
+        }
+
+        return $url;
+    }
+
+    /**
+     * Returns the clone command.
+     */
+    protected function getCloneCommand($url, $repoFile)
+    {
+        return sprintf(
+            'fossil clone --once %s %s %s',
+            $this->getHttpBasicAuth($url),
+            ProcessExecutor::escape($this->getUrlWithAuth($url)),
+            ProcessExecutor::escape($repoFile)
+        );
+    }
+
+    /**
+     * Returns the pull command.
+     */
+    protected function getPullCommand($url)
+    {
+        return sprintf(
+            'fossil pull %s --once %s',
+            ProcessExecutor::escape($this->getUrlWithAuth($url)),
+            $this->getHttpBasicAuth($url)
+        );
     }
 }

--- a/src/Composer/Downloader/FossilDownloader.php
+++ b/src/Composer/Downloader/FossilDownloader.php
@@ -209,10 +209,13 @@ class FossilDownloader extends VcsDownloader
      */
     protected function getCloneCommand($url, $repoFile)
     {
+        $basicAuth = $this->getHttpBasicAuth($url);
+        $urlWithAuth = $this->getUrlWithAuth($url);
+
         return sprintf(
-            'fossil clone --once %s %s %s',
-            $this->getHttpBasicAuth($url),
-            ProcessExecutor::escape($this->getUrlWithAuth($url)),
+            'fossil clone --once %s%s %s',
+            (empty($basicAuth) ? '' : $basicAuth . ' '),
+            ProcessExecutor::escape($urlWithAuth),
             ProcessExecutor::escape($repoFile)
         );
     }
@@ -222,10 +225,13 @@ class FossilDownloader extends VcsDownloader
      */
     protected function getPullCommand($url)
     {
-        return sprintf(
+        $basicAuth = $this->getHttpBasicAuth($url);
+        $urlWithAuth = $this->getUrlWithAuth($url);
+
+        return trim(sprintf(
             'fossil pull %s --once %s',
-            ProcessExecutor::escape($this->getUrlWithAuth($url)),
-            $this->getHttpBasicAuth($url)
-        );
+            ProcessExecutor::escape($urlWithAuth),
+            $basicAuth
+        ));
     }
 }

--- a/src/Composer/Repository/Vcs/FossilDriver.php
+++ b/src/Composer/Repository/Vcs/FossilDriver.php
@@ -122,10 +122,13 @@ class FossilDriver extends VcsDriver
      */
     protected function getCloneCommand()
     {
+        $basicAuth = $this->getHttpBasicAuth();
+        $urlWithAuth = $this->getUrlWithAuth();
+
         return sprintf(
-            'fossil clone --once %s %s %s',
-            $this->getHttpBasicAuth(),
-            ProcessExecutor::escape($this->getUrlWithAuth()),
+            'fossil clone --once %s%s %s',
+            (empty($basicAuth) ? '' : $basicAuth . ' '),
+            ProcessExecutor::escape($urlWithAuth),
             ProcessExecutor::escape($this->repoFile)
         );
     }
@@ -135,11 +138,14 @@ class FossilDriver extends VcsDriver
      */
     protected function getPullCommand()
     {
-        return sprintf(
+        $basicAuth = $this->getHttpBasicAuth();
+        $urlWithAuth = $this->getUrlWithAuth();
+
+        return trim(sprintf(
             'fossil pull %s --once %s',
-            ProcessExecutor::escape($this->getUrlWithAuth()),
-            $this->getHttpBasicAuth()
-        );
+            ProcessExecutor::escape($urlWithAuth),
+            $basicAuth
+        ));
     }
 
     /**

--- a/src/Composer/Repository/Vcs/FossilDriver.php
+++ b/src/Composer/Repository/Vcs/FossilDriver.php
@@ -84,8 +84,7 @@ class FossilDriver extends VcsDriver
             if (0 !== $this->process->execute($cmd, $output, $this->checkoutDir)) {
                 $this->io->writeError('<error>Failed to update '.$this->url.', package information from this repository may be outdated ('.$this->process->getErrorOutput().')</error>');
             }
-        }
-        else {
+        } else {
             // clean up directory and do a fresh clone into it
             $fs->removeDirectory($this->checkoutDir);
             $fs->remove($this->repoFile);
@@ -163,17 +162,20 @@ class FossilDriver extends VcsDriver
         $parsed = parse_url($this->url);
 
         // Only for http(s) URLs.
-        if (!isset($parsed['scheme']) || ($parsed['scheme'] != 'http' && $parsed['scheme'] != 'https') || empty($parsed['host']))
+        if (!isset($parsed['scheme']) || ($parsed['scheme'] != 'http' && $parsed['scheme'] != 'https') || empty($parsed['host'])) {
             return '';
+        }
 
-        if ($this->io->hasAuthentication($parsed['host']))
+        if ($this->io->hasAuthentication($parsed['host'])) {
             $creds = $this->io->getAuthentication($parsed['host']);
-        else
+        } else {
             return '';
+        }
 
         // We don't allow empty username or password. Both must be defined.
-        if (!empty($creds['username']) && !empty($creds['password']))
+        if (!empty($creds['username']) && !empty($creds['password'])) {
             return sprintf('-B %s', ProcessExecutor::escape($creds['username'] .':'. $creds['password']));
+        }
 
         return '';
     }
@@ -183,7 +185,7 @@ class FossilDriver extends VcsDriver
      *
      *   1. HTTP Basic authentication, if accessing the HTTP URL is so protected by the web server.
      *   2. Fossil authentication, if accessing the remote repo is not allowed for anonymous users.
-     * 
+     *
      * Fossil considers the username and password specified in the HTTP URL to be the credentials for Fossil authentication,
      * and provides a separate parameter for HTTP Basic authentication.
      *
@@ -209,8 +211,9 @@ class FossilDriver extends VcsDriver
         $parsed = parse_url($url);
 
         // Only for http(s) URLs.
-        if (!isset($parsed['scheme']) || ($parsed['scheme'] != 'http' && $parsed['scheme'] != 'https') || empty($parsed['host']))
+        if (!isset($parsed['scheme']) || ($parsed['scheme'] != 'http' && $parsed['scheme'] != 'https') || empty($parsed['host'])) {
             return $url;
+        }
 
         $remoteRepo = $parsed['host'] . $parsed['path'];
         $authentications = $this->config->get('fossil-auth');

--- a/tests/Composer/Test/Downloader/FossilDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FossilDownloaderTest.php
@@ -70,7 +70,7 @@ class FossilDownloaderTest extends TestCase
             ->will($this->returnValue(array('http://fossil.kd2.org/kd2fw/')));
         $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
 
-        $expectedFossilCommand = $this->getCmd('fossil clone \'http://fossil.kd2.org/kd2fw/\' \'repo.fossil\'');
+        $expectedFossilCommand = $this->getCmd('fossil clone --once \'http://fossil.kd2.org/kd2fw/\' \'repo.fossil\'');
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($expectedFossilCommand))
@@ -130,8 +130,13 @@ class FossilDownloaderTest extends TestCase
             ->method('execute')
             ->with($this->equalTo($expectedFossilCommand))
             ->will($this->returnValue(0));
-        $expectedFossilCommand = $this->getCmd("fossil pull && fossil up 'trunk'");
+        $expectedFossilCommand = $this->getCmd("fossil pull 'http://fossil.kd2.org/kd2fw/' --once");
         $processExecutor->expects($this->at(1))
+            ->method('execute')
+            ->with($this->equalTo($expectedFossilCommand))
+            ->will($this->returnValue(0));
+        $expectedFossilCommand = $this->getCmd("fossil update 'trunk'");
+        $processExecutor->expects($this->at(2))
             ->method('execute')
             ->with($this->equalTo($expectedFossilCommand))
             ->will($this->returnValue(0));


### PR DESCRIPTION
Composer was unable to clone/pull from a Fossil repo that was protected by either HTTP Basic or Fossil  authentication. This patch attempts to fix that. Both (or either) authentications are stored in auth.json. HTTP Basic auth is specified as before, per domain. Fossil credentials are specified per remote repository, in case pulling from multiple remote repositories with different credentials for each.