### PR TITLE
add gitlab-dist-format option

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -73,6 +73,10 @@ A list of domain names and private tokens. For example using `{"gitlab.com":
 "privatetoken"}` as the value of this option will use `privatetoken` to access
 private repositories on gitlab.
 
+## gitlab-dist-format
+Type of archive to download from gitlab. Set to `zip`, `tar`, `tar.gz` or `tar.bz2`
+Defaults to `zip`.
+
 ## disable-tls
 
 Defaults to `false`. If set to true all HTTPS URLs will be tried with HTTP

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -195,6 +195,33 @@ JSON;
         $this->assertEquals($expected, $driver->getDist($reference));
     }
 
+    public function testGetDistFormat()
+    {
+        $this->config->merge(array('config' => array('gitlab-dist-format' => 'tar.gz')));
+
+        $driver = $this->testInitialize('https://gitlab.com/mygroup/myprojecttoo', 'https://gitlab.com/api/v4/projects/mygroup%2Fmyprojecttoo');
+
+        $reference = 'c3ebdbf9cceddb82cd2089aaef8c7b992e536363';
+        $expected = array(
+            'type' => 'tar',
+            'url' => 'https://gitlab.com/api/v4/projects/mygroup%2Fmyprojecttoo/repository/archive.tar.gz?sha='.$reference,
+            'reference' => $reference,
+            'shasum' => '',
+        );
+
+        $this->assertEquals($expected, $driver->getDist($reference));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetDistInvalidFormat()
+    {
+        $this->config->merge(array('config' => array('gitlab-dist-format' => 'foo')));
+        $driver = new GitLabDriver(array('url' => ''), $this->io->reveal(), $this->config, $this->process->reveal(), $this->remoteFilesystem->reveal());
+        $driver->initialize();
+    }
+
     public function testGetSource()
     {
         $driver = $this->testInitialize('https://gitlab.com/mygroup/myproject', 'https://gitlab.com/api/v4/projects/mygroup%2Fmyproject');


### PR DESCRIPTION
Add `gitlab-dist-format` configuration option for the `GitLabDriver`. It defaults to `zip` as is the current default. You can set it to `zip`, `tar.gz`, `tar` and `tar.bz2`.