### PR TITLE
Composer init - abandoned package warning

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -391,7 +391,17 @@ EOT
                 $exactMatch = null;
                 $choices = array();
                 foreach ($matches as $position => $foundPackage) {
-                    $choices[] = sprintf(' <info>%5s</info> %s', "[$position]", $foundPackage['name']);
+                    $abandoned = '';
+                    if (isset($foundPackage['abandoned'])) {
+                        if (is_string($foundPackage['abandoned'])) {
+                            $replacement = sprintf('Use %s instead', $foundPackage['abandoned']);
+                        } else {
+                            $replacement = 'No replacement was suggested';
+                        }
+                        $abandoned = sprintf('<warning>Abandoned. %s.</warning>', $replacement);
+                    }
+
+                    $choices[] = sprintf(' <info>%5s</info> %s %s',"[$position]", $foundPackage['name'], $abandoned);
                     if ($foundPackage['name'] === $package) {
                         $exactMatch = true;
                         break;


### PR DESCRIPTION
Added warning for abandoned packages in case more than one package is found for require / require-dev in composer init.

Fixes #6652 