### PR TITLE
Fix platform package as version bug

### DIFF
--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Package\Version;
 
+use Composer\Repository\PlatformRepository;
 use Composer\Semver\VersionParser as SemverVersionParser;
 
 class VersionParser extends SemverVersionParser
@@ -47,7 +48,11 @@ class VersionParser extends SemverVersionParser
 
         for ($i = 0, $count = count($pairs); $i < $count; $i++) {
             $pair = preg_replace('{^([^=: ]+)[=: ](.*)$}', '$1 $2', trim($pairs[$i]));
-            if (false === strpos($pair, ' ') && isset($pairs[$i + 1]) && false === strpos($pairs[$i + 1], '/')) {
+            if (false === strpos($pair, ' ')
+                && isset($pairs[$i + 1])
+                && false === strpos($pairs[$i + 1], '/')
+                && 0 === preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $pairs[$i + 1])
+            ) {
                 $pair .= ' '.$pairs[$i + 1];
                 $i++;
             }

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Composer\Test\Package\Version;
+
+use Composer\Package\Version\VersionParser;
+
+class VersionParserTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var VersionParser */
+    private $versionParser;
+
+    protected function setUp()
+    {
+        $this->versionParser = new VersionParser();
+    }
+
+    /**
+     * @dataProvider packageNameProvider
+     *
+     * @param array $input
+     * @param array $expected
+     */
+    public function testParseNameVersionPairs($input, $expected)
+    {
+        $versionParser = $this->versionParser;
+
+        $actual = $versionParser->parseNameVersionPairs($input);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function packageNameProvider()
+    {
+        return array(
+            'Package with version, two fields' => array(
+                array('foo/bar', '1.0.0'),
+                array(array('name' => 'foo/bar', 'version' => '1.0.0'))
+            ),
+            'Package with version, space separated' => array(
+                array('foo/bar 1.0.0'),
+                array(array('name' => 'foo/bar', 'version' => '1.0.0'))
+            ),
+            'Package with version, colon separated' => array(
+                array('foo/bar:1.0.0'),
+                array(array('name' => 'foo/bar', 'version' => '1.0.0'))
+            ),
+            'Package with version, equals separated' => array(
+                array('foo/bar=1.0.0'),
+                array(array('name' => 'foo/bar', 'version' => '1.0.0'))
+            ),
+            'Packages without version' => array(
+                array('foo/bar', 'foo/baz'),
+                array(array('name' => 'foo/bar'), array('name' => 'foo/baz'))
+            ),
+            'Platform packages' => array(
+                array('ext-acpu', 'ext-ds'),
+                array(array('name' => 'ext-acpu'), array('name' => 'ext-ds'))
+            ),
+        );
+    }
+}


### PR DESCRIPTION
- Uses platform package regex to determine if string is a platform package
- Adds tests to verify behaviour of the VersionParser

This fixes #6704