### PR TITLE
Correctly extract username/password from URL

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -207,7 +207,7 @@ class RemoteFilesystem
         $this->redirects = 1; // The first request counts.
 
         // capture username/password from URL if there is one
-        if (preg_match('{^https?://(.+):(.+)@([^/]+)}i', $fileUrl, $match)) {
+        if (preg_match('{^https?://([^:]+):([^@]+)@([^/]+)}i', $fileUrl, $match)) {
             $this->io->setAuthentication($originUrl, urldecode($match[1]), urldecode($match[2]));
         }
 


### PR DESCRIPTION
Corrected regexp. Otherwise it was impossible to use urls with credentials **and** @ character somewhere in the path url segment - it was capturing the whole part of the url (down to the last @ char) as a password.

Not sure if i need to add unit test for this small edge case.