### PR TITLE
Return non-zero exit code with --strict and single package

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -43,6 +43,7 @@ use Composer\Semver\Semver;
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Jérémy Romey <jeremyFreeAgent>
+ * @author Mihai Plasoianu <mihai@plasoianu.de>
  */
 class ShowCommand extends BaseCommand
 {
@@ -196,8 +197,12 @@ EOT
                 $this->displayPackageTree($package, $installedRepo, $repos);
             } else {
                 $latestPackage = null;
+                $exitCode = 0;
                 if ($input->getOption('latest')) {
                     $latestPackage = $this->findLatestPackage($package, $composer, $phpVersion);
+                }
+                if ($input->getOption('outdated') && $input->getOption('strict') && $latestPackage && $latestPackage->getFullPrettyVersion() !== $package->getFullPrettyVersion() && !$latestPackage->isAbandoned()) {
+                    $exitCode = 1;
                 }
                 $this->printMeta($package, $versions, $installedRepo, $latestPackage ?: null);
                 $this->printLinks($package, 'requires');
@@ -213,7 +218,7 @@ EOT
                 $this->printLinks($package, 'replaces');
             }
 
-            return;
+            return $exitCode;
         }
 
         // show tree view if requested


### PR DESCRIPTION
Currently, the --strict option is not taken into consideration when a package name is specified. This would be helpful for scripts that only need to check that a single package is up to date.