### PR TITLE
also support NO_PROXY

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -814,10 +814,10 @@ similar use case), and need to support proxies, please provide the `CGI_HTTP_PRO
 environment variable instead. See [httpoxy.org](https://httpoxy.org/) for further
 details.
 
-### no_proxy
+### no_proxy or NO_PROXY
 
 If you are behind a proxy and would like to disable it for certain domains, you
-can use the `no_proxy` env var. Simply set it to a comma separated list of
+can use the `no_proxy` or `NO_PROXY` env var. Simply set it to a comma separated list of
 domains the proxy should *not* be used for.
 
 The env var accepts domains, IP addresses, and IP address blocks in CIDR

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -55,8 +55,8 @@ final class StreamContextFactory
         }
 
         // Remove proxy if URL matches no_proxy directive
-        if (!empty($_SERVER['no_proxy']) && parse_url($url, PHP_URL_HOST)) {
-            $pattern = new NoProxyPattern($_SERVER['no_proxy']);
+        if (!empty($_SERVER['NO_PROXY']) || $_SERVER['no_proxy']) && parse_url($url, PHP_URL_HOST)) {
+            $pattern = new NoProxyPattern(!empty($_SERVER['no_proxy']) ? $_SERVER['no_proxy'] : $_SERVER['NO_PROXY']);
             if ($pattern->test($url)) {
                 unset($proxy);
             }

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -55,7 +55,7 @@ final class StreamContextFactory
         }
 
         // Remove proxy if URL matches no_proxy directive
-        if (!empty($_SERVER['NO_PROXY']) || $_SERVER['no_proxy']) && parse_url($url, PHP_URL_HOST)) {
+        if (!empty($_SERVER['NO_PROXY']) || !empty($_SERVER['no_proxy']) && parse_url($url, PHP_URL_HOST)) {
             $pattern = new NoProxyPattern(!empty($_SERVER['no_proxy']) ? $_SERVER['no_proxy'] : $_SERVER['NO_PROXY']);
             if ($pattern->test($url)) {
                 unset($proxy);

--- a/tests/Composer/Test/Util/StreamContextFactoryTest.php
+++ b/tests/Composer/Test/Util/StreamContextFactoryTest.php
@@ -22,6 +22,7 @@ class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
         unset($_SERVER['http_proxy']);
         unset($_SERVER['HTTPS_PROXY']);
         unset($_SERVER['https_proxy']);
+        unset($_SERVER['NO_PROXY']);
         unset($_SERVER['no_proxy']);
     }
 
@@ -31,6 +32,7 @@ class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
         unset($_SERVER['http_proxy']);
         unset($_SERVER['HTTPS_PROXY']);
         unset($_SERVER['https_proxy']);
+        unset($_SERVER['NO_PROXY']);
         unset($_SERVER['no_proxy']);
     }
 


### PR DESCRIPTION
since WINDOWS can only have one case and that is usually upperase

I rely on the all-uppercase settings to get packages from the internet but also get some from our Satis server in the local network. You can have lowercase environment variables on Windows but not both. You can only flip them by unsetting one case before setting the case again (assuming satis.local in global config.json):

```
SET no_proxy=
SET NO_PROXY=satis.local
composer update
SET NO_PROXY=
SET no_proxy=satis.local
composer update
```