### PR TITLE
add php version and binary to the dignose command

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -150,6 +150,14 @@ EOT
             $this->outputResult($this->checkVersion($config));
         }
 
+        $io->write(sprintf('Composer version: <comment>%s</comment>', Composer::VERSION));
+
+        $io->write(sprintf('PHP version: <comment>%s</comment>', PHP_VERSION));
+
+        if (defined('PHP_BINARY')) {
+            $io->write(sprintf('PHP binary path: <comment>%s</comment>', PHP_BINARY));
+        }
+
         return $this->exitCode;
     }
 


### PR DESCRIPTION
For those that manage multiple PHP binaries (and multiple Composer binaries), sometimes we aren't sure which PHP nor Composer is running... specially when running it behind a tool, such an IDE or CI server.

This commit expose some informations that can help us to find and fix errors.