### PR TITLE
Fix bug setting COMPOSER_ORIGINAL_INIS

### DIFF
--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -139,11 +139,6 @@ class XdebugHandler
         $iniPaths = IniHelper::getAll();
         $additional = count($iniPaths) > 1;
 
-        if (empty($iniPaths[0])) {
-            // There is no loaded ini
-            array_shift($iniPaths);
-        }
-
         if ($this->writeTmpIni($iniPaths)) {
             return $this->setEnvironment($additional, $iniPaths);
         }
@@ -156,20 +151,25 @@ class XdebugHandler
      *
      * The filename is passed as the -c option when the process restarts.
      *
-     * @param array $iniFiles The php.ini locations
+     * @param array $iniPaths Locations reported by the current process
      *
      * @return bool
      */
-    private function writeTmpIni(array $iniFiles)
+    private function writeTmpIni(array $iniPaths)
     {
         if (!$this->tmpIni = tempnam(sys_get_temp_dir(), '')) {
             return false;
         }
 
+        // $iniPaths has at least one item and it may be empty
+        if (empty($iniPaths[0])) {
+            array_shift($iniPaths);
+        }
+
         $content = '';
         $regex = '/^\s*(zend_extension\s*=.*xdebug.*)$/mi';
 
-        foreach ($iniFiles as $file) {
+        foreach ($iniPaths as $file) {
             $data = preg_replace($regex, ';$1', file_get_contents($file));
             $content .= $data.PHP_EOL;
         }
@@ -203,7 +203,7 @@ class XdebugHandler
      * Returns true if the restart environment variables were set
      *
      * @param bool  $additional Whether there were additional inis
-     * @param array $iniPaths   Locations used by the current prcoess
+     * @param array $iniPaths Locations reported by the current process
      *
      * @return bool
      */


### PR DESCRIPTION
This variable stores the loaded ini file and any additional scanned ini
files, separated by a path-separator. The loaded ini file should always
be present, even if it is an empty value. Unfortunately I removed any
empty value to parse the ini files, then used the truncated list to set
the variable.

This bug surfaced on docker php images. These do not have a specific
php.ini but store all their settings in the location(s) configured at
build time using --with-config-file-scan-dir.

This bug fixes https://github.com/sensiolabs/SensioDistributionBundle/issues/322
