### PR TITLE
Report multiple inis in php.ini specific messages

### DIFF
--- a/src/Composer/Util/IniHelper.php
+++ b/src/Composer/Util/IniHelper.php
@@ -33,7 +33,9 @@ class IniHelper
      */
     public static function getAll()
     {
-        if ($env = strval(getenv(self::ENV_ORIGINAL))) {
+        $env = getenv(self::ENV_ORIGINAL);
+
+        if (false !== $env) {
             return explode(PATH_SEPARATOR, $env);
         }
 
@@ -47,7 +49,7 @@ class IniHelper
     }
 
     /**
-     * Describes the location of the loaded php.ini file
+     * Describes the location of the loaded php.ini file(s)
      *
      * @return string
      */
@@ -56,9 +58,19 @@ class IniHelper
         $paths = self::getAll();
 
         if (empty($paths[0])) {
+            array_shift($paths);
+        }
+
+        $ini = array_shift($paths);
+
+        if (empty($ini)) {
             return 'A php.ini file does not exist. You will have to create one.';
         }
 
-        return 'The php.ini used by your command-line PHP is: '.$paths[0];
+        if (!empty($paths)) {
+            return 'Your command-line PHP is using multiple ini files. Run `php --ini` to show them.';
+        }
+
+        return 'The php.ini used by your command-line PHP is: '.$ini;
     }
 }

--- a/tests/Composer/Test/Util/IniHelperTest.php
+++ b/tests/Composer/Test/Util/IniHelperTest.php
@@ -21,7 +21,18 @@ class IniHelperTest extends \PHPUnit_Framework_TestCase
 {
     public static $envOriginal;
 
-    public function testWithLoadedIni()
+    public function testWithNoIni()
+    {
+        $paths = array(
+            '',
+        );
+
+        $this->setEnv($paths);
+        $this->assertContains('does not exist', IniHelper::getMessage());
+        $this->assertEquals($paths, IniHelper::getAll());
+    }
+
+    public function testWithLoadedIniOnly()
     {
         $paths = array(
             'loaded.ini',
@@ -32,7 +43,20 @@ class IniHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($paths, IniHelper::getAll());
     }
 
-    public function testWithoutLoadedIni()
+    public function testWithLoadedIniAndAdditional()
+    {
+        $paths = array(
+            'loaded.ini',
+            'one.ini',
+            'two.ini',
+        );
+
+        $this->setEnv($paths);
+        $this->assertContains('multiple ini files', IniHelper::getMessage());
+        $this->assertEquals($paths, IniHelper::getAll());
+    }
+
+    public function testWithoutLoadedIniAndAdditional()
     {
         $paths = array(
             '',
@@ -41,7 +65,7 @@ class IniHelperTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->setEnv($paths);
-        $this->assertContains('does not exist', IniHelper::getMessage());
+        $this->assertContains('multiple ini files', IniHelper::getMessage());
         $this->assertEquals($paths, IniHelper::getAll());
     }
 


### PR DESCRIPTION
Where systems use multiple ini files it is perhaps more useful to
suggest running `php --ini` to see their locations, rather than showing
the loaded php.ini (if one exists).