### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.5 || ^5.0.5",
+        "phpunit/phpunit": "^4.8.35 || ^5.7",
         "phpunit/phpunit-mock-objects": "^2.3 || ^3.0"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "88357fd4222a8102552a0d3345696e2e",
+    "content-hash": "d3c8dbadf8d41e2c7933e274b2fe1327",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/tests/Composer/Test/Autoload/ClassLoaderTest.php
+++ b/tests/Composer/Test/Autoload/ClassLoaderTest.php
@@ -13,11 +13,12 @@
 namespace Composer\Test\Autoload;
 
 use Composer\Autoload\ClassLoader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the Composer\Autoload\ClassLoader class.
  */
-class ClassLoaderTest extends \PHPUnit_Framework_TestCase
+class ClassLoaderTest extends TestCase
 {
     /**
      * Tests regular PSR-0 and PSR-4 class loading.

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test;
 
 use Composer\Config;
+use PHPUnit\Framework\TestCase;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     /**
      * @dataProvider dataAddPackagistRepository

--- a/tests/Composer/Test/Console/HtmlOutputFormatterTest.php
+++ b/tests/Composer/Test/Console/HtmlOutputFormatterTest.php
@@ -10,12 +10,13 @@
  * file that was distributed with this source code.
  */
 
-namespace Composer;
+namespace Composer\Test\Console;
 
 use Composer\Console\HtmlOutputFormatter;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 
-class HtmlOutputFormatterTest extends \PHPUnit_Framework_TestCase
+class HtmlOutputFormatterTest extends TestCase
 {
     public function testFormatting()
     {

--- a/tests/Composer/Test/DefaultConfigTest.php
+++ b/tests/Composer/Test/DefaultConfigTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test;
 
 use Composer\Config;
+use PHPUnit\Framework\TestCase;
 
-class DefaultConfigTest extends \PHPUnit_Framework_TestCase
+class DefaultConfigTest extends TestCase
 {
     /**
      * @group TLS

--- a/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
@@ -17,8 +17,9 @@ use Composer\DependencyResolver\Rule;
 use Composer\DependencyResolver\RuleSet;
 use Composer\DependencyResolver\RuleSetIterator;
 use Composer\DependencyResolver\Pool;
+use PHPUnit\Framework\TestCase;
 
-class RuleSetIteratorTest extends \PHPUnit_Framework_TestCase
+class RuleSetIteratorTest extends TestCase
 {
     protected $rules;
 

--- a/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
@@ -12,7 +12,9 @@
 
 namespace Composer\Test\Downloader;
 
-class ArchiveDownloaderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ArchiveDownloaderTest extends TestCase
 {
     public function testGetFileName()
     {

--- a/tests/Composer/Test/Downloader/DownloadManagerTest.php
+++ b/tests/Composer/Test/Downloader/DownloadManagerTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Downloader;
 
 use Composer\Downloader\DownloadManager;
+use PHPUnit\Framework\TestCase;
 
-class DownloadManagerTest extends \PHPUnit_Framework_TestCase
+class DownloadManagerTest extends TestCase
 {
     protected $filesystem;
     protected $io;

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -16,8 +16,9 @@ use Composer\Installer\InstallationManager;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
+use PHPUnit\Framework\TestCase;
 
-class InstallationManagerTest extends \PHPUnit_Framework_TestCase
+class InstallationManagerTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Composer/Test/Installer/InstallerEventTest.php
+++ b/tests/Composer/Test/Installer/InstallerEventTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Installer;
 
 use Composer\Installer\InstallerEvent;
+use PHPUnit\Framework\TestCase;
 
-class InstallerEventTest extends \PHPUnit_Framework_TestCase
+class InstallerEventTest extends TestCase
 {
     public function testGetter()
     {

--- a/tests/Composer/Test/Installer/MetapackageInstallerTest.php
+++ b/tests/Composer/Test/Installer/MetapackageInstallerTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Installer;
 
 use Composer\Installer\MetapackageInstaller;
+use PHPUnit\Framework\TestCase;
 
-class MetapackageInstallerTest extends \PHPUnit_Framework_TestCase
+class MetapackageInstallerTest extends TestCase
 {
     private $repository;
     private $installer;

--- a/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
+++ b/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
@@ -13,11 +13,12 @@
 namespace Composer\Test\Installer;
 
 use Composer\Installer\SuggestedPackagesReporter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass Composer\Installer\SuggestedPackagesReporter
  */
-class SuggestedPackagesReporterTest extends \PHPUnit_Framework_TestCase
+class SuggestedPackagesReporterTest extends TestCase
 {
     private $io;
     private $suggestedPackagesReporter;

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -13,11 +13,12 @@
 namespace Composer\Test\Json;
 
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Rob Bast <rob.bast@gmail.com>
  */
-class ComposerSchemaTest extends \PHPUnit_Framework_TestCase
+class ComposerSchemaTest extends TestCase
 {
     public function testRequiredProperties()
     {

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -14,8 +14,9 @@ namespace Composer\Test\Json;
 
 use Seld\JsonLint\ParsingException;
 use Composer\Json\JsonFile;
+use PHPUnit\Framework\TestCase;
 
-class JsonFileTest extends \PHPUnit_Framework_TestCase
+class JsonFileTest extends TestCase
 {
     public function testParseErrorDetectExtraComma()
     {

--- a/tests/Composer/Test/Json/JsonFormatterTest.php
+++ b/tests/Composer/Test/Json/JsonFormatterTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Json;
 
 use Composer\Json\JsonFormatter;
+use PHPUnit\Framework\TestCase;
 
-class JsonFormatterTest extends \PHPUnit_Framework_TestCase
+class JsonFormatterTest extends TestCase
 {
     /**
      * Test if \u0119 (196+153) will get correctly formatted

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Json;
 
 use Composer\Json\JsonManipulator;
+use PHPUnit\Framework\TestCase;
 
-class JsonManipulatorTest extends \PHPUnit_Framework_TestCase
+class JsonManipulatorTest extends TestCase
 {
     /**
      * @dataProvider linkProvider

--- a/tests/Composer/Test/Json/JsonValidationExceptionTest.php
+++ b/tests/Composer/Test/Json/JsonValidationExceptionTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Json;
 
 use Composer\Json\JsonValidationException;
+use PHPUnit\Framework\TestCase;
 
-class JsonValidationExceptionTest extends \PHPUnit_Framework_TestCase
+class JsonValidationExceptionTest extends TestCase
 {
     /**
      * @dataProvider errorProvider

--- a/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
+++ b/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Package\Archiver;
 
 use Composer\Package\Archiver\GitExcludeFilter;
+use PHPUnit\Framework\TestCase;
 
-class GitExcludeFilterTest extends \PHPUnit_Framework_TestCase
+class GitExcludeFilterTest extends TestCase
 {
     /**
      * @dataProvider patterns

--- a/tests/Composer/Test/Package/Archiver/HgExcludeFilterTest.php
+++ b/tests/Composer/Test/Package/Archiver/HgExcludeFilterTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Package\Archiver;
 
 use Composer\Package\Archiver\HgExcludeFilter;
+use PHPUnit\Framework\TestCase;
 
-class HgExcludeFilterTest extends \PHPUnit_Framework_TestCase
+class HgExcludeFilterTest extends TestCase
 {
     /**
      * @dataProvider patterns

--- a/tests/Composer/Test/Package/BasePackageTest.php
+++ b/tests/Composer/Test/Package/BasePackageTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Package;
 
 use Composer\Package\BasePackage;
+use PHPUnit\Framework\TestCase;
 
-class BasePackageTest extends \PHPUnit_Framework_TestCase
+class BasePackageTest extends TestCase
 {
     public function testSetSameRepository()
     {

--- a/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
+++ b/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
@@ -15,8 +15,9 @@ namespace Composer\Test\Package\Dumper;
 use Composer\Package\Dumper\ArrayDumper;
 use Composer\Package\Link;
 use Composer\Semver\Constraint\Constraint;
+use PHPUnit\Framework\TestCase;
 
-class ArrayDumperTest extends \PHPUnit_Framework_TestCase
+class ArrayDumperTest extends TestCase
 {
     /**
      * @var ArrayDumper

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -14,8 +14,9 @@ namespace Composer\Test\Package\Loader;
 
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\Dumper\ArrayDumper;
+use PHPUnit\Framework\TestCase;
 
-class ArrayLoaderTest extends \PHPUnit_Framework_TestCase
+class ArrayLoaderTest extends TestCase
 {
     /**
      * @var ArrayLoader

--- a/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
@@ -17,9 +17,10 @@ use Composer\Package\Loader\RootPackageLoader;
 use Composer\Package\BasePackage;
 use Composer\Package\Version\VersionGuesser;
 use Composer\Semver\VersionParser;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
-class RootPackageLoaderTest extends \PHPUnit_Framework_TestCase
+class RootPackageLoaderTest extends TestCase
 {
     protected function loadPackage($data)
     {

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -14,8 +14,9 @@ namespace Composer\Test\Package\Loader;
 
 use Composer\Package\Loader\ValidatingArrayLoader;
 use Composer\Package\Loader\InvalidPackageException;
+use PHPUnit\Framework\TestCase;
 
-class ValidatingArrayLoaderTest extends \PHPUnit_Framework_TestCase
+class ValidatingArrayLoaderTest extends TestCase
 {
     /**
      * @dataProvider successProvider

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -14,8 +14,9 @@ namespace Composer\Test\Package;
 
 use Composer\Package\Locker;
 use Composer\IO\NullIO;
+use PHPUnit\Framework\TestCase;
 
-class LockerTest extends \PHPUnit_Framework_TestCase
+class LockerTest extends TestCase
 {
     public function testIsLocked()
     {

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -15,8 +15,9 @@ namespace Composer\Test\Package\Version;
 use Composer\Config;
 use Composer\Package\Version\VersionGuesser;
 use Composer\Semver\VersionParser;
+use PHPUnit\Framework\TestCase;
 
-class VersionGuesserTest extends \PHPUnit_Framework_TestCase
+class VersionGuesserTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Package\Version;
 
 use Composer\Package\Version\VersionParser;
+use PHPUnit\Framework\TestCase;
 
-class VersionParserTest extends \PHPUnit_Framework_TestCase
+class VersionParserTest extends TestCase
 {
     /**
      * @dataProvider getParseNameVersionPairsData

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -16,8 +16,9 @@ use Composer\Package\Version\VersionSelector;
 use Composer\Package\Package;
 use Composer\Package\Link;
 use Composer\Semver\VersionParser;
+use PHPUnit\Framework\TestCase;
 
-class VersionSelectorTest extends \PHPUnit_Framework_TestCase
+class VersionSelectorTest extends TestCase
 {
     // A) multiple versions, get the latest one
     // B) targetPackageVersion will pass to pool

--- a/tests/Composer/Test/Util/BitbucketTest.php
+++ b/tests/Composer/Test/Util/BitbucketTest.php
@@ -13,11 +13,12 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Bitbucket;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Paul Wenke <wenke.paul@gmail.com>
  */
-class BitbucketTest extends \PHPUnit_Framework_TestCase
+class BitbucketTest extends TestCase
 {
     private $username = 'username';
     private $password = 'password';

--- a/tests/Composer/Test/Util/GitHubTest.php
+++ b/tests/Composer/Test/Util/GitHubTest.php
@@ -14,13 +14,14 @@ namespace Composer\Test\Util;
 
 use Composer\Downloader\TransportException;
 use Composer\Util\GitHub;
+use PHPUnit\Framework\TestCase;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 
 /**
  * @author Rob Bast <rob.bast@gmail.com>
  */
-class GitHubTest extends \PHPUnit_Framework_TestCase
+class GitHubTest extends TestCase
 {
     private $username = 'username';
     private $password = 'password';

--- a/tests/Composer/Test/Util/GitLabTest.php
+++ b/tests/Composer/Test/Util/GitLabTest.php
@@ -14,11 +14,12 @@ namespace Composer\Test\Util;
 
 use Composer\Downloader\TransportException;
 use Composer\Util\GitLab;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  */
-class GitLabTest extends \PHPUnit_Framework_TestCase
+class GitLabTest extends TestCase
 {
     private $username = 'username';
     private $password = 'password';

--- a/tests/Composer/Test/Util/IniHelperTest.php
+++ b/tests/Composer/Test/Util/IniHelperTest.php
@@ -13,11 +13,12 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\IniHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Stevenson <john-stevenson@blueyonder.co.uk>
  */
-class IniHelperTest extends \PHPUnit_Framework_TestCase
+class IniHelperTest extends TestCase
 {
     public static $envOriginal;
 

--- a/tests/Composer/Test/Util/PerforceTest.php
+++ b/tests/Composer/Test/Util/PerforceTest.php
@@ -13,11 +13,12 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Perforce;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Matt Whittom <Matt.Whittom@veteransunited.com>
  */
-class PerforceTest extends \PHPUnit_Framework_TestCase
+class PerforceTest extends TestCase
 {
     protected $perforce;
     protected $processExecutor;

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -13,13 +13,14 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Platform;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PlatformTest
  *
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
  */
-class PlatformTest extends \PHPUnit_Framework_TestCase
+class PlatformTest extends TestCase
 {
     public function testExpandPath()
     {

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\RemoteFilesystem;
+use PHPUnit\Framework\TestCase;
 
-class RemoteFilesystemTest extends \PHPUnit_Framework_TestCase
+class RemoteFilesystemTest extends TestCase
 {
     public function testGetOptionsForUrl()
     {

--- a/tests/Composer/Test/Util/SilencerTest.php
+++ b/tests/Composer/Test/Util/SilencerTest.php
@@ -13,13 +13,14 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Silencer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * SilencerTest
  *
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
  */
-class SilencerTest extends \PHPUnit_Framework_TestCase
+class SilencerTest extends TestCase
 {
     /**
      * Test succeeds when no warnings are emitted externally, and original level is restored.

--- a/tests/Composer/Test/Util/StreamContextFactoryTest.php
+++ b/tests/Composer/Test/Util/StreamContextFactoryTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\StreamContextFactory;
+use PHPUnit\Framework\TestCase;
 
-class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
+class StreamContextFactoryTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Composer/Test/Util/SvnTest.php
+++ b/tests/Composer/Test/Util/SvnTest.php
@@ -16,8 +16,9 @@ use Composer\Config;
 use Composer\IO\NullIO;
 use Composer\Util\Platform;
 use Composer\Util\Svn;
+use PHPUnit\Framework\TestCase;
 
-class SvnTest extends \PHPUnit_Framework_TestCase
+class SvnTest extends TestCase
 {
     /**
      * Test the credential string.

--- a/tests/Composer/Test/Util/TlsHelperTest.php
+++ b/tests/Composer/Test/Util/TlsHelperTest.php
@@ -13,8 +13,9 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\TlsHelper;
+use PHPUnit\Framework\TestCase;
 
-class TlsHelperTest extends \PHPUnit_Framework_TestCase
+class TlsHelperTest extends TestCase
 {
     /** @dataProvider dataCheckCertificateHost */
     public function testCheckCertificateHost($expectedResult, $hostname, $certNames)

--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test;
 
 use Composer\Test\Mock\XdebugHandlerMock;
 use Composer\Util\IniHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Stevenson <john-stevenson@blueyonder.co.uk>
@@ -21,7 +22,7 @@ use Composer\Util\IniHelper;
  * We use PHP_BINARY which only became available in PHP 5.4 *
  * @requires PHP 5.4
  */
-class XdebugHandlerTest extends \PHPUnit_Framework_TestCase
+class XdebugHandlerTest extends TestCase
 {
     public static $env = array();
 

--- a/tests/Composer/TestCase.php
+++ b/tests/Composer/TestCase.php
@@ -17,9 +17,10 @@ use Composer\Package\AliasPackage;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Util\Filesystem;
 use Composer\Util\Silencer;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Component\Process\ExecutableFinder;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
     private static $parser;
     private static $executableCache = array();


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.