### PR TITLE
Improve the error on init/require if a package could not be found

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -641,7 +641,7 @@ EOT
                 ));
             }
             throw new \InvalidArgumentException(sprintf(
-                'Could not find package %s at any version for your minimum-stability (%s). Check the package spelling or your minimum-stability',
+                'Could not find a matching version of package %s. Check the package spelling, your version constraint and that the package is available in a stability which matches your minimum-stability (%s).',
                 $name,
                 $this->getMinimumStability($input)
             ));


### PR DESCRIPTION
Make it clearer that the issue is not necessarily about stability. It simply did not find a matching version, there are different types of reasons this could happen.