### PR TITLE
Deploy PHAR to GitHub releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ before_script:
 script:
     # run test suite directories in parallel using GNU parallel
     - ls -d tests/Composer/Test/* | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/complete.phpunit.xml --colors=always {} || (echo -e "\e[41mFAILED\e[0m {}" && exit 1);'
+
+before_deploy:
     - php -d phar.readonly=0 bin/compile
 
 deploy:
@@ -67,4 +69,4 @@ deploy:
   on:
     tags: true
     repo: composer/composer
-    php:  '5.3'
+    php:  '7.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,3 +57,14 @@ before_script:
 script:
     # run test suite directories in parallel using GNU parallel
     - ls -d tests/Composer/Test/* | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/complete.phpunit.xml --colors=always {} || (echo -e "\e[41mFAILED\e[0m {}" && exit 1);'
+    - php -d phar.readonly=0 bin/compile
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  file: composer.phar
+  skip_cleanup: true
+  on:
+    tags: true
+    repo: composer/composer
+    php:  '5.3'


### PR DESCRIPTION
Add the PHAR file to GitHub releases. Amon other things, it will allow to use the GitHub API to download current and old versions.

Before merging this PR, a maintainer will have to add a `GITHUB_TOKEN` secret environment variable using the Travis UI. This GitHub token must have the `repo` scope.