### PR TITLE
Improve findFileWithExtension PSR-4 code

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -379,8 +379,8 @@ class ClassLoader
                 $subPath = substr($subPath, 0, $lastPos);
                 $search = $subPath.'\\';
                 if (isset($this->prefixDirsPsr4[$search])) {
+                    $length = $this->prefixLengthsPsr4[$first][$search];
                     foreach ($this->prefixDirsPsr4[$search] as $dir) {
-                        $length = $this->prefixLengthsPsr4[$first][$search];
                         if (file_exists($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
                             return $file;
                         }


### PR DESCRIPTION
the `foreach` over the `prefixDirsPsr4[$search]` won't affect `$length`. 

It's used for the offset of `$logicalPathPsr4`.