### PR TITLE
support COMPOSER env var in validate command

### DIFF
--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -66,7 +66,11 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $file = $input->getArgument('file');
+        if ($input->hasArgument('file)) {
+            $file = $input->getArgument('file');
+        } else {
+            $file = Factory::getComposerFile();
+        }
         $io = $this->getIO();
 
         if (!file_exists($file)) {

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -66,11 +66,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($input->hasArgument('file')) {
-            $file = $input->getArgument('file');
-        } else {
-            $file = Factory::getComposerFile();
-        }
+        $file = $input->getArgument('file') ?: Factory::getComposerFile();
         $io = $this->getIO();
 
         if (!file_exists($file)) {

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -44,7 +44,7 @@ class ValidateCommand extends BaseCommand
                 new InputOption('no-check-publish', null, InputOption::VALUE_NONE, 'Do not check for publish errors'),
                 new InputOption('with-dependencies', 'A', InputOption::VALUE_NONE, 'Also validate the composer.json of all installed dependencies'),
                 new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code for warnings as well as errors'),
-                new InputArgument('file', InputArgument::OPTIONAL, 'path to composer.json file', './composer.json'),
+                new InputArgument('file', InputArgument::OPTIONAL, 'path to composer.json file'),
             ))
             ->setHelp(<<<EOT
 The validate command validates a given composer.json and composer.lock

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -66,7 +66,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($input->hasArgument('file)) {
+        if ($input->hasArgument('file')) {
             $file = $input->getArgument('file');
         } else {
             $file = Factory::getComposerFile();


### PR DESCRIPTION
using

```
COMPOSER=composer_dev.json composer validate
```

you get

```
./composer.json is valid for simple usage with composer but has...
```

but expect

```
./composer_dev.json is valid for simple usage with composer but has...
```
