### PR TITLE
Flex support: New event to catch errors from the installer

### DIFF
--- a/src/Composer/Installer/InstallerErrorEvent.php
+++ b/src/Composer/Installer/InstallerErrorEvent.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Installer;
+
+use Composer\EventDispatcher\Event;
+use Composer\IO\IOInterface;
+
+/**
+ * An event when the installer fails.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class InstallerErrorEvent extends Event
+{
+    private $error;
+
+    private $io;
+
+    private $statusCode = 1;
+
+    public function __construct($eventName, $error, IOInterface $io)
+    {
+        parent::__construct($eventName);
+
+        if (!$error instanceof \Throwable && !$error instanceof \Exception) {
+            throw new \InvalidArgumentException(sprintf('The error passed to InstallerErrorEvent must be an instance of \Throwable or \Exception, "%s" was passed instead.', is_object($error) ? get_class($error) : gettype($error)));
+        }
+
+        $this->error = $error;
+        $this->io = $io;
+    }
+
+    /**
+     * @return \Exception|\Throwable
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * @return IOInterface
+     */
+    public function getIo()
+    {
+        return $this->io;
+    }
+
+    /**
+     * If the status code is set to non-zero, the error will
+     * not ultimately be thrown.
+     *
+     * @param integer $statusCode
+     */
+    public function setStatusCode($statusCode)
+    {
+        $this->statusCode = $statusCode;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+}

--- a/src/Composer/Installer/InstallerEvents.php
+++ b/src/Composer/Installer/InstallerEvents.php
@@ -40,4 +40,15 @@ class InstallerEvents
      * @var string
      */
     const POST_DEPENDENCIES_SOLVING = 'post-dependencies-solving';
+
+    /**
+     * The INSTALLER_ERROR event occurs if the installer fails
+     * with an uncaught \Throwable.
+     *
+     * The event listener method receives a
+     * Composer\Installer\InstallerErrorEvent instance.
+     *
+     * @var string
+     */
+    const INSTALLER_ERROR = 'installer-error';
 }


### PR DESCRIPTION
Hi guys!

This is an issue to hopefully resolve a problem we're having with Symfony Flex: symfony/flex#142. It also fixes #6821.

After requiring a new package, it's possible that one of the post-update-cmd scripts will fail... which is actually not a big deal. BUT, this causes Composer to revert the `composer.json` file.

By adding this new event, we should be able to (in Flex):

A) Hook into this event and change the return code. This will prevent the `composer.json` file from being rolled back (https://github.com/composer/composer/blob/bfed974ae969635e622c4844e5e69526d8459baf/src/Composer/Command/RequireCommand.php#L183). We would do this if the Exception is a `ScriptExecutionException` instance.

B) We should also be able to conditionally print a different message, instead of the error.

Thanks!