### PR TITLE
Fix root package pretty version

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -47,18 +47,13 @@ class ArrayLoader implements LoaderInterface
             throw new \UnexpectedValueException('Package '.$config['name'].' has no version defined.');
         }
 
-        $prettyVersion = $config['version'];
-        if (isset($config['pretty_version'])) {
-            $prettyVersion = $config['pretty_version'];
-        }
-
         // handle already normalized versions
         if (isset($config['version_normalized'])) {
             $version = $config['version_normalized'];
         } else {
             $version = $this->versionParser->normalize($config['version']);
         }
-        $package = new $class($config['name'], $version, $prettyVersion);
+        $package = new $class($config['name'], $version, $config['version']);
         $package->setType(isset($config['type']) ? strtolower($config['type']) : 'library');
 
         if (isset($config['target-dir'])) {

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -47,13 +47,18 @@ class ArrayLoader implements LoaderInterface
             throw new \UnexpectedValueException('Package '.$config['name'].' has no version defined.');
         }
 
+        $prettyVersion = $config['version'];
+        if (isset($config['pretty_version'])) {
+            $prettyVersion = $config['pretty_version'];
+        }
+
         // handle already normalized versions
         if (isset($config['version_normalized'])) {
             $version = $config['version_normalized'];
         } else {
             $version = $this->versionParser->normalize($config['version']);
         }
-        $package = new $class($config['name'], $version, $config['version']);
+        $package = new $class($config['name'], $version, $prettyVersion);
         $package->setType(isset($config['type']) ? strtolower($config['type']) : 'library');
 
         if (isset($config['target-dir'])) {

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -68,20 +68,22 @@ class RootPackageLoader extends ArrayLoader
         }
         $autoVersioned = false;
         if (!isset($config['version'])) {
+            $commit = null;
+            
             // override with env var if available
             if (getenv('COMPOSER_ROOT_VERSION')) {
-                $config['version'] = $config['pretty_version'] = getenv('COMPOSER_ROOT_VERSION');
-                $commit = null;
+                $config['version'] = getenv('COMPOSER_ROOT_VERSION');
             } else {
                 $versionData = $this->versionGuesser->guessVersion($config, $cwd ?: getcwd());
-                $config['version'] = $versionData['version'];
-                $config['pretty_version'] = $versionData['pretty_version'];
-                $commit = $versionData['commit'];
+                if ($versionData) {
+                    $config['version'] = $versionData['pretty_version'];
+                    $config['version_normalized'] = $versionData['version'];
+                    $commit = $versionData['commit'];
+                }
             }
 
-            if (! $config['version']) {
+            if (!isset($config['version'])) {
                 $config['version'] = '1.0.0';
-                $config['pretty_version'] = '1.0';
                 $autoVersioned = true;
             }
 

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -70,23 +70,21 @@ class RootPackageLoader extends ArrayLoader
         if (!isset($config['version'])) {
             // override with env var if available
             if (getenv('COMPOSER_ROOT_VERSION')) {
-                $version = $prettyVersion = getenv('COMPOSER_ROOT_VERSION');
+                $config['version'] = $config['pretty_version'] = getenv('COMPOSER_ROOT_VERSION');
                 $commit = null;
             } else {
                 $versionData = $this->versionGuesser->guessVersion($config, $cwd ?: getcwd());
-                $version = $versionData['version'];
-                $prettyVersion = $versionData['pretty_version'];
+                $config['version'] = $versionData['version'];
+                $config['pretty_version'] = $versionData['pretty_version'];
                 $commit = $versionData['commit'];
             }
 
-            if (!$version) {
-                $version = '1.0.0';
-                $prettyVersion = '1.0';
+            if (! $config['version']) {
+                $config['version'] = '1.0.0';
+                $config['pretty_version'] = '1.0';
                 $autoVersioned = true;
             }
 
-            $config['version'] = $version;
-            $config['pretty_version'] = $prettyVersion;
             if ($commit) {
                 $config['source'] = array(
                     'type' => '',

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -70,20 +70,23 @@ class RootPackageLoader extends ArrayLoader
         if (!isset($config['version'])) {
             // override with env var if available
             if (getenv('COMPOSER_ROOT_VERSION')) {
-                $version = getenv('COMPOSER_ROOT_VERSION');
+                $version = $prettyVersion = getenv('COMPOSER_ROOT_VERSION');
                 $commit = null;
             } else {
                 $versionData = $this->versionGuesser->guessVersion($config, $cwd ?: getcwd());
                 $version = $versionData['version'];
+                $prettyVersion = $versionData['pretty_version'];
                 $commit = $versionData['commit'];
             }
 
             if (!$version) {
                 $version = '1.0.0';
+                $prettyVersion = '1.0';
                 $autoVersioned = true;
             }
 
             $config['version'] = $version;
+            $config['pretty_version'] = $prettyVersion;
             if ($commit) {
                 $config['source'] = array(
                     'type' => '',

--- a/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
@@ -17,6 +17,7 @@ use Composer\Package\Loader\RootPackageLoader;
 use Composer\Package\BasePackage;
 use Composer\Package\Version\VersionGuesser;
 use Composer\Semver\VersionParser;
+use Prophecy\Argument;
 
 class RootPackageLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -89,6 +90,26 @@ class RootPackageLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals("1.0.0.0", $package->getVersion());
         $this->assertEquals("No version set (parsed as 1.0.0)", $package->getPrettyVersion());
+    }
+
+    public function testPrettyVersionForRootPackageInVersionBranch()
+    {
+        // see #6845
+        $manager = $this->prophesize('\\Composer\\Repository\\RepositoryManager');
+        $versionGuesser = $this->prophesize('Composer\Package\Version\VersionGuesser');
+        $versionGuesser->guessVersion(Argument::cetera())
+            ->willReturn(array(
+                'name' => 'A',
+                'version' => '3.0.9999999.9999999-dev',
+                'pretty_version' => '3.0-dev',
+                'commit' => 'aabbccddee',
+            ));
+        $config = new Config;
+        $config->merge(array('repositories' => array('packagist' => false)));
+        $loader = new RootPackageLoader($manager->reveal(), $config, null, $versionGuesser->reveal());
+        $package = $loader->load(array());
+
+        $this->assertEquals('3.0-dev', $package->getPrettyVersion());
     }
 
     public function testFeatureBranchPrettyVersion()

--- a/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
@@ -96,7 +96,7 @@ class RootPackageLoaderTest extends \PHPUnit_Framework_TestCase
     {
         // see #6845
         $manager = $this->prophesize('\\Composer\\Repository\\RepositoryManager');
-        $versionGuesser = $this->prophesize('Composer\Package\Version\VersionGuesser');
+        $versionGuesser = $this->prophesize('\\Composer\\Package\\Version\\VersionGuesser');
         $versionGuesser->guessVersion(Argument::cetera())
             ->willReturn(array(
                 'name' => 'A',


### PR DESCRIPTION
This solves issue #6845.

`RootPackageLoader` was not passing `pretty_version` from the `VersionGuesser` to its parent constructor; PR is conveniently splitted into 2 separated commits, the second one is just a small refactoring to avoid unuseful intermediate variables.