### PR TITLE
Proposed event on SolverProblemsException with power to trigger re-run.

### DIFF
--- a/src/Composer/Installer/InstallerEvents.php
+++ b/src/Composer/Installer/InstallerEvents.php
@@ -40,4 +40,19 @@ class InstallerEvents
      * @var string
      */
     const POST_DEPENDENCIES_SOLVING = 'post-dependencies-solving';
+
+    /**
+     * The DEPENDENCIES_SOLVING_PROBLEM event occurs after resolve operations
+     * when an installable set of packages was not found.
+     *
+     * The event listener method receives a
+     * Composer\Installer\InstallerEvent instance.
+     *
+     * If the listener returns TRUE, it indicates that the listener has made
+     * modifications to Composer's state that may allow an installable set of
+     * packages to be found, and resolve operations should be retried.
+     *
+     * @var string
+     */
+    const DEPENDENCIES_SOLVING_PROBLEM = 'dependencies-solving-problem';
 }


### PR DESCRIPTION
So this is definitely not ready to actually merge yet, but @naderman suggested discussing PRs early, so here goes. Oh, in case there would otherwise be confusion, this is unrelated to my work on `replace`.

The problem this helps solve is enabling Drupal installations/updates for nontechie users without exceeding the resource limitations of a webserver environment; it's a huge pain point for Drupal right now that it isn't possible to do Composer-enabled installs/updates in a browser. The way it helps solve it is by allowing a plugin to initially restrict the `Pool` to a repository containing only one version of each required package, all of which are pre-selected to be compatible with each other; this should make the sat problem and number of modeled packages/decisions trivial/very fast in execution time/low in memory. For sites that only need things available from this special repository, a complete Composer run ought to work fine within the confines of a webserver environment. When the site does also have requirements from the wider world, the first solver run will fail, but it will fail fast. This PR would allow a plugin to then introduce packagist etc to the Pool and rerun the Solver. (I believe @thom8 has talked with some Composer maintainers about the possibility of running the solver on a remote "solver as a service" host; I've got a vague idea of also swapping out the standard solver for the remote one long-term when a full-scale dependency resolution is required.)

Something like this have a chance of going in?