### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -814,9 +814,9 @@ return array(
 EOF;
 
         $this->generator->dump($this->config, $this->repository, $mainPackage, $this->im, 'composer', true, '_9');
-        $this->assertEquals($expectedNamespace, file_get_contents($this->vendorDir.'/composer/autoload_namespaces.php'));
-        $this->assertEquals($expectedPsr4, file_get_contents($this->vendorDir.'/composer/autoload_psr4.php'));
-        $this->assertEquals($expectedClassmap, file_get_contents($this->vendorDir.'/composer/autoload_classmap.php'));
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_namespaces.php', $expectedNamespace);
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_psr4.php', $expectedPsr4);
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_classmap.php', $expectedClassmap);
     }
 
     public function testIncludePathFileGeneration()
@@ -1080,9 +1080,9 @@ return array(
 
 EOF;
 
-        $this->assertEquals($expectedNamespace, file_get_contents($vendorDir.'/composer/autoload_namespaces.php'));
-        $this->assertEquals($expectedPsr4, file_get_contents($vendorDir.'/composer/autoload_psr4.php'));
-        $this->assertEquals($expectedClassmap, file_get_contents($vendorDir.'/composer/autoload_classmap.php'));
+        $this->assertStringEqualsFile($vendorDir.'/composer/autoload_namespaces.php', $expectedNamespace);
+        $this->assertStringEqualsFile($vendorDir.'/composer/autoload_psr4.php', $expectedPsr4);
+        $this->assertStringEqualsFile($vendorDir.'/composer/autoload_classmap.php', $expectedClassmap);
         $this->assertContains("\$vendorDir . '/b/b/bootstrap.php',\n", file_get_contents($vendorDir.'/composer/autoload_files.php'));
         $this->assertContains("\$baseDir . '/test.php',\n", file_get_contents($vendorDir.'/composer/autoload_files.php'));
     }
@@ -1158,9 +1158,9 @@ return array(
 
 EOF;
 
-        $this->assertEquals($expectedNamespace, file_get_contents($this->vendorDir.'/composer/autoload_namespaces.php'));
-        $this->assertEquals($expectedPsr4, file_get_contents($this->vendorDir.'/composer/autoload_psr4.php'));
-        $this->assertEquals($expectedClassmap, file_get_contents($this->vendorDir.'/composer/autoload_classmap.php'));
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_namespaces.php', $expectedNamespace);
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_psr4.php', $expectedPsr4);
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_classmap.php', $expectedClassmap);
         $this->assertContains("\$baseDir . '/../test.php',\n", file_get_contents($this->vendorDir.'/composer/autoload_files.php'));
     }
 
@@ -1226,9 +1226,9 @@ return array(
 
 EOF;
 
-        $this->assertEquals($expectedNamespace, file_get_contents($this->vendorDir.'/composer/autoload_namespaces.php'));
-        $this->assertEquals($expectedPsr4, file_get_contents($this->vendorDir.'/composer/autoload_psr4.php'));
-        $this->assertEquals($expectedClassmap, file_get_contents($this->vendorDir.'/composer/autoload_classmap.php'));
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_namespaces.php', $expectedNamespace);
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_psr4.php', $expectedPsr4);
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_classmap.php', $expectedClassmap);
     }
 
     public function testVendorSubstringPath()
@@ -1274,8 +1274,8 @@ return array(
 EOF;
 
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', false, 'VendorSubstring');
-        $this->assertEquals($expectedNamespace, file_get_contents($this->vendorDir.'/composer/autoload_namespaces.php'));
-        $this->assertEquals($expectedPsr4, file_get_contents($this->vendorDir.'/composer/autoload_psr4.php'));
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_namespaces.php', $expectedNamespace);
+        $this->assertStringEqualsFile($this->vendorDir.'/composer/autoload_psr4.php', $expectedPsr4);
     }
 
     public function testExcludeFromClassmap()

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -175,7 +175,7 @@ class ClassMapGeneratorTest extends TestCase
 
         ClassMapGenerator::createMap($finder, null, $io);
 
-        $this->assertTrue(in_array($msg, $messages, true), $msg . ' not found in expected messages (' . var_export($messages, true) . ')');
+        $this->assertContains($msg, $messages, $msg . ' not found in expected messages (' . var_export($messages, true) . ')');
 
         $fs = new Filesystem();
         $fs->removeDirectory($tempDir);
@@ -242,7 +242,7 @@ class ClassMapGeneratorTest extends TestCase
         ClassMapGenerator::dump(array($tempDir), $resultFile);
 
         $fileInDirectory = str_replace('\\', '\\\\', $fileInDirectory);
-        $this->assertEquals("<?php return array (\n  'TestClass' => '$fileInDirectory',\n);", file_get_contents($resultFile));
+        $this->assertStringEqualsFile($resultFile, "<?php return array (\n  'TestClass' => '$fileInDirectory',\n);");
 
         $fs = new Filesystem();
         $fs->removeDirectory($tempDir);

--- a/tests/Composer/Test/Repository/ArtifactRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ArtifactRepositoryTest.php
@@ -61,7 +61,7 @@ class ArtifactRepositoryTest extends TestCase
         $repo = new ArtifactRepository($coordinates, new NullIO(), new Config());
 
         foreach ($repo->getPackages() as $package) {
-            $this->assertTrue(strpos($package->getDistUrl(), strtr($absolutePath, '\\', '/')) === 0);
+            $this->assertSame(strpos($package->getDistUrl(), strtr($absolutePath, '\\', '/')), 0);
         }
     }
 
@@ -72,7 +72,7 @@ class ArtifactRepositoryTest extends TestCase
         $repo = new ArtifactRepository($coordinates, new NullIO(), new Config());
 
         foreach ($repo->getPackages() as $package) {
-            $this->assertTrue(strpos($package->getDistUrl(), $relativePath) === 0);
+            $this->assertSame(strpos($package->getDistUrl(), $relativePath), 0);
         }
     }
 }

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -55,7 +55,7 @@ class PathRepositoryTest extends TestCase
         $this->assertEquals('test/path-unversioned', $package->getName());
 
         $packageVersion = $package->getVersion();
-        $this->assertTrue(!empty($packageVersion));
+        $this->assertNotEmpty($packageVersion);
     }
 
     public function testLoadPackageFromFileSystemWithWildcard()

--- a/tests/Composer/Test/Util/ConfigValidatorTest.php
+++ b/tests/Composer/Test/Util/ConfigValidatorTest.php
@@ -29,9 +29,9 @@ class ConfigValidatorTest extends TestCase
         $configValidator = new ConfigValidator(new NullIO());
         list(, , $warnings) = $configValidator->validate(__DIR__ . '/Fixtures/composer_commit-ref.json');
 
-        $this->assertEquals(true, in_array(
+        $this->assertContains(
             'The package "some/package" is pointing to a commit-ref, this is bad practice and can cause unforeseen issues.',
             $warnings
-        ));
+        );
     }
 }

--- a/tests/Composer/Test/XdebugHandlerTest.php
+++ b/tests/Composer/Test/XdebugHandlerTest.php
@@ -128,7 +128,7 @@ class XdebugHandlerTest extends TestCase
 
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
-        $this->assertEquals(false, getenv(XdebugHandlerMock::ENV_VERSION));
+        $this->assertFalse(getenv(XdebugHandlerMock::ENV_VERSION));
     }
 
     public function testEnvVersionWhenRestartFails()
@@ -141,7 +141,7 @@ class XdebugHandlerTest extends TestCase
         // Mimic failed restart
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
-        $this->assertEquals(false, getenv(XdebugHandlerMock::ENV_VERSION));
+        $this->assertFalse(getenv(XdebugHandlerMock::ENV_VERSION));
     }
 
     public static function setUpBeforeClass()


### PR DESCRIPTION
Continuing to refactored tests, like #6849, using:
- `assertNotEmpty` instead of `empty` method;
- `assertFalse` instead of strict comparisons with `false` keyword;
- `assertSame` instead of strict comparisons;
- `assertContains` instead of `in_array` method;
- `assertStringEqualsFile` when comparing `string` and files.