### PR TITLE
Fix VersionGuesser pretty_version handling

### DIFF
--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -88,8 +88,7 @@ class VersionGuesser
 
     private function postprocess(array $versionData)
     {
-        // make sure that e.g. dev-1.5 gets converted to 1.5.x-dev
-        if ('dev-' !== substr($versionData['version'], 0, 4)) {
+        if ('-dev' === substr($versionData['version'], -4)) {
             $versionData['pretty_version'] = preg_replace('{(\.9{7})+}', '.x', $versionData['version']);
         }
 

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -384,6 +384,48 @@ class VersionGuesserTest extends TestCase
         $this->assertEquals("2.0.5.0-alpha2", $versionData['version']);
     }
 
+    public function testTagBecomesPrettyVersion()
+    {
+        $executor = $this->getMockBuilder('\\Composer\\Util\\ProcessExecutor')
+            ->setMethods(array('execute'))
+            ->disableArgumentCloning()
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $self = $this;
+
+        $executor
+            ->expects($this->at(0))
+            ->method('execute')
+            ->willReturnCallback(function ($command, &$output) use ($self) {
+                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $output = "* (HEAD detached at 1.0.0) c006f0c12bbbf197b5c071ffb1c0e9812bb14a4d Commit message\n";
+
+                return 0;
+            })
+        ;
+
+        $executor
+            ->expects($this->at(1))
+            ->method('execute')
+            ->willReturnCallback(function ($command, &$output) use ($self) {
+                $self->assertEquals('git describe --exact-match --tags', $command);
+                $output = '1.0.0';
+
+                return 0;
+            })
+        ;
+
+        $config = new Config;
+        $config->merge(array('repositories' => array('packagist' => false)));
+        $guesser = new VersionGuesser($config, $executor, new VersionParser());
+        $versionData = $guesser->guessVersion(array(), 'dummy/path');
+
+        $this->assertEquals('1.0.0.0', $versionData['version']);
+        $this->assertEquals('1.0.0', $versionData['pretty_version']);
+    }
+
     public function testInvalidTagBecomesVersion()
     {
         $executor = $this->getMockBuilder('\\Composer\\Util\\ProcessExecutor')


### PR DESCRIPTION
This relates to #6845, since the merged fix doesn't seem to work, see https://github.com/phpstan/phpstan/pull/649

I'm still working on this, for now I've added a regression test that expects a non-normalized version as the `pretty_version` returned by the `VersionGuesser`.