### PR TITLE
Clarified language on branch naming for forks

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -205,8 +205,8 @@ project to use the patched version. If the library is on GitHub (this is the
 case most of the time), you can simply fork it there and push your changes to
 your fork. After that you update the project's `composer.json`. All you have
 to do is add your fork as a repository and update the version constraint to
-point to your custom branch. Your custom branch name must be prefixed with
-`"dev-"`. For version constraint naming conventions see
+point to your custom branch. In `composer.json`, you should prefix your custom 
+branch name with `"dev-"`. For version constraint naming conventions see
 [Libraries](02-libraries.md) for more information.
 
 Example assuming you patched monolog to fix a bug in the `bugfix` branch:


### PR DESCRIPTION
The current language here implies that the branch name on your remote repo should be named according to a certain pattern (`dev-*`), which isn't accurate. You can name the branch whatever you want, but in composer.json you should _reference_ it as `dev-*`.