### PR TITLE
Exclude non-essential files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,6 @@
 *.json  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
 *.test  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
 *.yml   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=2
+
+# Exclude non-essential files from dist
+/tests export-ignore


### PR DESCRIPTION
[Exclude non-essential files in .gitattributes](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/). This way users of this package don't have to download non-essential files such as the `tests` directory, which is a whopping 4MB.