### PR TITLE
Add PHPUnit 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.7",
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
         "phpunit/phpunit-mock-objects": "^2.3 || ^3.0"
     },
     "config": {

--- a/tests/Composer/Test/ApplicationTest.php
+++ b/tests/Composer/Test/ApplicationTest.php
@@ -22,8 +22,8 @@ class ApplicationTest extends TestCase
     {
         $application = new Application;
 
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
 
         $index = 0;
         $inputMock->expects($this->at($index++))
@@ -75,8 +75,8 @@ class ApplicationTest extends TestCase
 
         $application->add(new \Composer\Command\SelfUpdateCommand);
 
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
 
         $index = 0;
         $inputMock->expects($this->at($index++))

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -92,7 +92,7 @@ class AutoloadGeneratorTest extends TestCase
         $this->vendorDir = $this->workingDir.DIRECTORY_SEPARATOR.'composer-test-autoload';
         $this->ensureDirectoryExistsAndClear($this->vendorDir);
 
-        $this->config = $this->getMock('Composer\Config');
+        $this->config = $this->getMockBuilder('Composer\Config')->getMock();
 
         $this->configValueMap = array(
             'vendor-dir' => function () use ($that) {
@@ -127,7 +127,7 @@ class AutoloadGeneratorTest extends TestCase
 
                 return $that->vendorDir.'/'.$package->getName() . ($targetDir ? '/'.$targetDir : '');
             }));
-        $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
+        $this->repository = $this->getMockBuilder('Composer\Repository\InstalledRepositoryInterface')->getMock();
 
         $this->eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
             ->disableOriginalConstructor()

--- a/tests/Composer/Test/CacheTest.php
+++ b/tests/Composer/Test/CacheTest.php
@@ -35,12 +35,11 @@ class CacheTest extends TestCase
 
         $this->finder = $this->getMockBuilder('Symfony\Component\Finder\Finder')->disableOriginalConstructor()->getMock();
 
-        $io = $this->getMock('Composer\IO\IOInterface');
-        $this->cache = $this->getMock(
-            'Composer\Cache',
-            array('getFinder'),
-            array($io, $this->root)
-        );
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $this->cache = $this->getMockBuilder('Composer\Cache')
+                        ->setMethods(array('getFinder'))
+                        ->setConstructorArgs(array($io, $this->root))
+                        ->getMock();        
         $this->cache
             ->expects($this->any())
             ->method('getFinder')

--- a/tests/Composer/Test/Command/InitCommandTest.php
+++ b/tests/Composer/Test/Command/InitCommandTest.php
@@ -77,17 +77,21 @@ class InitCommandTest extends TestCase
         $this->assertEquals('john@example.com', $author['email']);
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testParseEmptyAuthorString()
     {
         $command = new InitCommand;
-        $this->setExpectedException('InvalidArgumentException');
         $command->parseAuthorString('');
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testParseAuthorStringWithInvalidEmail()
     {
         $command = new InitCommand;
-        $this->setExpectedException('InvalidArgumentException');
         $command->parseAuthorString('John Smith <john>');
     }
 }

--- a/tests/Composer/Test/Command/RunScriptCommandTest.php
+++ b/tests/Composer/Test/Command/RunScriptCommandTest.php
@@ -28,7 +28,7 @@ class RunScriptCommandTest extends TestCase
     {
         $scriptName = 'testScript';
 
-        $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
+        $input = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
         $input
             ->method('getOption')
             ->will($this->returnValueMap(array(
@@ -48,7 +48,7 @@ class RunScriptCommandTest extends TestCase
             ->with('command')
             ->willReturn(false);
 
-        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
 
         $expectedDevMode = $dev || !$noDev;
 

--- a/tests/Composer/Test/ComposerTest.php
+++ b/tests/Composer/Test/ComposerTest.php
@@ -20,7 +20,7 @@ class ComposerTest extends TestCase
     public function testSetGetPackage()
     {
         $composer = new Composer();
-        $package = $this->getMock('Composer\Package\RootPackageInterface');
+        $package = $this->getMockBuilder('Composer\Package\RootPackageInterface')->getMock();
         $composer->setPackage($package);
 
         $this->assertSame($package, $composer->getPackage());
@@ -47,8 +47,8 @@ class ComposerTest extends TestCase
     public function testSetGetDownloadManager()
     {
         $composer = new Composer();
-        $io = $this->getMock('Composer\IO\IOInterface');
-        $manager = $this->getMock('Composer\Downloader\DownloadManager', array(), array($io));
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')->setConstructorArgs(array($io))->getMock();
         $composer->setDownloadManager($manager);
 
         $this->assertSame($manager, $composer->getDownloadManager());
@@ -57,7 +57,7 @@ class ComposerTest extends TestCase
     public function testSetGetInstallationManager()
     {
         $composer = new Composer();
-        $manager = $this->getMock('Composer\Installer\InstallationManager');
+        $manager = $this->getMockBuilder('Composer\Installer\InstallationManager')->getMock();
         $composer->setInstallationManager($manager);
 
         $this->assertSame($manager, $composer->getInstallationManager());

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test;
 
 use Composer\Config;
-use PHPUnit\Framework\TestCase;
+use Composer\TestCase;
 
 class ConfigTest extends TestCase
 {

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -432,6 +432,9 @@ class SolverTest extends TestCase
         ));
     }
 
+    /**
+     * @expectedException Composer\DependencyResolver\SolverProblemsException
+     */
     public function testInstallProvider()
     {
         $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
@@ -444,7 +447,6 @@ class SolverTest extends TestCase
         $this->request->install('A');
 
         // must explicitly pick the provider, so error in this case
-        $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
         $this->solver->solve($this->request);
     }
 
@@ -466,6 +468,9 @@ class SolverTest extends TestCase
         ));
     }
 
+    /**
+     * @expectedException Composer\DependencyResolver\SolverProblemsException
+     */
     public function testNoInstallReplacerOfMissingPackage()
     {
         $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
@@ -477,7 +482,6 @@ class SolverTest extends TestCase
 
         $this->request->install('A');
 
-        $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
         $this->solver->solve($this->request);
     }
 
@@ -619,6 +623,9 @@ class SolverTest extends TestCase
         ));
     }
 
+    /**
+     * @expectedException Composer\DependencyResolver\SolverProblemsException
+     */
     public function testIssue265()
     {
         $this->repo->addPackage($packageA1 = $this->getPackage('A', '2.0.999999-dev'));
@@ -647,8 +654,6 @@ class SolverTest extends TestCase
         $this->reposComplete();
 
         $this->request->install('C', $this->getVersionConstraint('==', '2.0.0.0-dev'));
-
-        $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
 
         $this->solver->solve($this->request);
     }

--- a/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
@@ -18,13 +18,13 @@ class ArchiveDownloaderTest extends TestCase
 {
     public function testGetFileName()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getDistUrl')
             ->will($this->returnValue('http://example.com/script.js'))
         ;
 
-        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMock('Composer\IO\IOInterface'), $this->getMock('Composer\Config')));
+        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getMockBuilder('Composer\Config')->getMock()));
         $method = new \ReflectionMethod($downloader, 'getFileName');
         $method->setAccessible(true);
 
@@ -39,12 +39,12 @@ class ArchiveDownloaderTest extends TestCase
             $this->markTestSkipped('Requires openssl');
         }
 
-        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMock('Composer\IO\IOInterface'), $this->getMock('Composer\Config')));
+        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getMockBuilder('Composer\Config')->getMock()));
         $method = new \ReflectionMethod($downloader, 'processUrl');
         $method->setAccessible(true);
 
         $expected = 'https://github.com/composer/composer/zipball/master';
-        $url = $method->invoke($downloader, $this->getMock('Composer\Package\PackageInterface'), $expected);
+        $url = $method->invoke($downloader, $this->getMockBuilder('Composer\Package\PackageInterface')->getMock(), $expected);
 
         $this->assertEquals($expected, $url);
     }
@@ -55,12 +55,12 @@ class ArchiveDownloaderTest extends TestCase
             $this->markTestSkipped('Requires openssl');
         }
 
-        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMock('Composer\IO\IOInterface'), $this->getMock('Composer\Config')));
+        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getMockBuilder('Composer\Config')->getMock()));
         $method = new \ReflectionMethod($downloader, 'processUrl');
         $method->setAccessible(true);
 
         $expected = 'https://github.com/composer/composer/archive/master.tar.gz';
-        $url = $method->invoke($downloader, $this->getMock('Composer\Package\PackageInterface'), $expected);
+        $url = $method->invoke($downloader, $this->getMockBuilder('Composer\Package\PackageInterface')->getMock(), $expected);
 
         $this->assertEquals($expected, $url);
     }
@@ -71,12 +71,12 @@ class ArchiveDownloaderTest extends TestCase
             $this->markTestSkipped('Requires openssl');
         }
 
-        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMock('Composer\IO\IOInterface'), $this->getMock('Composer\Config')));
+        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getMockBuilder('Composer\Config')->getMock()));
         $method = new \ReflectionMethod($downloader, 'processUrl');
         $method->setAccessible(true);
 
         $expected = 'https://api.github.com/repos/composer/composer/zipball/master';
-        $url = $method->invoke($downloader, $this->getMock('Composer\Package\PackageInterface'), $expected);
+        $url = $method->invoke($downloader, $this->getMockBuilder('Composer\Package\PackageInterface')->getMock(), $expected);
 
         $this->assertEquals($expected, $url);
     }
@@ -90,14 +90,14 @@ class ArchiveDownloaderTest extends TestCase
             $this->markTestSkipped('Requires openssl');
         }
 
-        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMock('Composer\IO\IOInterface'), $this->getMock('Composer\Config')));
+        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getMockBuilder('Composer\Config')->getMock()));
         $method = new \ReflectionMethod($downloader, 'processUrl');
         $method->setAccessible(true);
 
         $type = strpos($url, 'tar') ? 'tar' : 'zip';
         $expected = 'https://api.github.com/repos/composer/composer/'.$type.'ball/ref';
 
-        $package = $this->getMock('Composer\Package\PackageInterface');
+        $package = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $package->expects($this->any())
             ->method('getDistReference')
             ->will($this->returnValue('ref'));
@@ -127,14 +127,14 @@ class ArchiveDownloaderTest extends TestCase
             $this->markTestSkipped('Requires openssl');
         }
 
-        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMock('Composer\IO\IOInterface'), $this->getMock('Composer\Config')));
+        $downloader = $this->getMockForAbstractClass('Composer\Downloader\ArchiveDownloader', array($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getMockBuilder('Composer\Config')->getMock()));
         $method = new \ReflectionMethod($downloader, 'processUrl');
         $method->setAccessible(true);
 
         $url = $url . '.' . $extension;
         $expected = 'https://bitbucket.org/davereid/drush-virtualhost/get/ref.' . $extension;
 
-        $package = $this->getMock('Composer\Package\PackageInterface');
+        $package = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $package->expects($this->any())
             ->method('getDistReference')
             ->will($this->returnValue('ref'));

--- a/tests/Composer/Test/Downloader/DownloadManagerTest.php
+++ b/tests/Composer/Test/Downloader/DownloadManagerTest.php
@@ -22,10 +22,13 @@ class DownloadManagerTest extends TestCase
 
     public function setUp()
     {
-        $this->filesystem = $this->getMock('Composer\Util\Filesystem');
-        $this->io = $this->getMock('Composer\IO\IOInterface');
+        $this->filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
+        $this->io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testSetGetDownloader()
     {
         $downloader = $this->createDownloaderMock();
@@ -34,10 +37,12 @@ class DownloadManagerTest extends TestCase
         $manager->setDownloader('test', $downloader);
         $this->assertSame($downloader, $manager->getDownloader('test'));
 
-        $this->setExpectedException('InvalidArgumentException');
         $manager->getDownloader('unregistered');
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testGetDownloaderForIncorrectlyInstalledPackage()
     {
         $package = $this->createPackageMock();
@@ -47,8 +52,6 @@ class DownloadManagerTest extends TestCase
             ->will($this->returnValue(null));
 
         $manager = new DownloadManager($this->io, false, $this->filesystem);
-
-        $this->setExpectedException('InvalidArgumentException');
 
         $manager->getDownloaderForInstalledPackage($package);
     }
@@ -85,6 +88,9 @@ class DownloadManagerTest extends TestCase
         $this->assertSame($downloader, $manager->getDownloaderForInstalledPackage($package));
     }
 
+    /**
+     * @expectedException LogicException
+     */
     public function testGetDownloaderForIncorrectlyInstalledDistPackage()
     {
         $package = $this->createPackageMock();
@@ -113,8 +119,6 @@ class DownloadManagerTest extends TestCase
             ->method('getDownloader')
             ->with('git')
             ->will($this->returnValue($downloader));
-
-        $this->setExpectedException('LogicException');
 
         $manager->getDownloaderForInstalledPackage($package);
     }
@@ -151,6 +155,9 @@ class DownloadManagerTest extends TestCase
         $this->assertSame($downloader, $manager->getDownloaderForInstalledPackage($package));
     }
 
+    /**
+     * @expectedException LogicException
+     */
     public function testGetDownloaderForIncorrectlyInstalledSourcePackage()
     {
         $package = $this->createPackageMock();
@@ -179,8 +186,6 @@ class DownloadManagerTest extends TestCase
             ->method('getDownloader')
             ->with('pear')
             ->will($this->returnValue($downloader));
-
-        $this->setExpectedException('LogicException');
 
         $manager->getDownloaderForInstalledPackage($package);
     }
@@ -290,6 +295,9 @@ class DownloadManagerTest extends TestCase
         $manager->download($package, 'target_dir');
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testBadPackageDownload()
     {
         $package = $this->createPackageMock();
@@ -304,7 +312,6 @@ class DownloadManagerTest extends TestCase
 
         $manager = new DownloadManager($this->io, false, $this->filesystem);
 
-        $this->setExpectedException('InvalidArgumentException');
         $manager->download($package, 'target_dir');
     }
 
@@ -521,6 +528,9 @@ class DownloadManagerTest extends TestCase
         $manager->download($package, 'target_dir');
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testBadPackageDownloadWithSourcePreferred()
     {
         $package = $this->createPackageMock();
@@ -536,7 +546,6 @@ class DownloadManagerTest extends TestCase
         $manager = new DownloadManager($this->io, false, $this->filesystem);
         $manager->setPreferSource(true);
 
-        $this->setExpectedException('InvalidArgumentException');
         $manager->download($package, 'target_dir');
     }
 

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -20,8 +20,8 @@ class FileDownloaderTest extends TestCase
 {
     protected function getDownloader($io = null, $config = null, $eventDispatcher = null, $cache = null, $rfs = null, $filesystem = null)
     {
-        $io = $io ?: $this->getMock('Composer\IO\IOInterface');
-        $config = $config ?: $this->getMock('Composer\Config');
+        $io = $io ?: $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $config = $config ?: $this->getMockBuilder('Composer\Config')->getMock();
         $rfs = $rfs ?: $this->getMockBuilder('Composer\Util\RemoteFilesystem')->disableOriginalConstructor()->getMock();
 
         return new FileDownloader($io, $config, $eventDispatcher, $cache, $rfs, $filesystem);
@@ -32,7 +32,7 @@ class FileDownloaderTest extends TestCase
      */
     public function testDownloadForPackageWithoutDistReference()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->once())
             ->method('getDistUrl')
             ->will($this->returnValue(null))
@@ -44,7 +44,7 @@ class FileDownloaderTest extends TestCase
 
     public function testDownloadToExistingFile()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->once())
             ->method('getDistUrl')
             ->will($this->returnValue('url'))
@@ -74,7 +74,7 @@ class FileDownloaderTest extends TestCase
 
     public function testGetFileName()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->once())
             ->method('getDistUrl')
             ->will($this->returnValue('http://example.com/script.js'))
@@ -89,7 +89,7 @@ class FileDownloaderTest extends TestCase
 
     public function testDownloadButFileIsUnsaved()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getDistUrl')
             ->will($this->returnValue($distUrl = 'http://example.com/script.js'))
@@ -104,7 +104,7 @@ class FileDownloaderTest extends TestCase
         ;
 
         $path = $this->getUniqueTmpDirectory();
-        $ioMock = $this->getMock('Composer\IO\IOInterface');
+        $ioMock = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $ioMock->expects($this->any())
             ->method('write')
             ->will($this->returnCallback(function ($messages, $newline = true) use ($path) {
@@ -137,7 +137,7 @@ class FileDownloaderTest extends TestCase
     {
         $expectedTtl = '99999999';
 
-        $configMock = $this->getMock('Composer\Config');
+        $configMock = $this->getMockBuilder('Composer\Config')->getMock();
         $configMock
             ->expects($this->at(0))
             ->method('get')
@@ -166,7 +166,7 @@ class FileDownloaderTest extends TestCase
 
     public function testDownloadFileWithInvalidChecksum()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getDistUrl')
             ->will($this->returnValue($distUrl = 'http://example.com/script.js'))
@@ -183,7 +183,7 @@ class FileDownloaderTest extends TestCase
             ->method('getDistUrls')
             ->will($this->returnValue(array($distUrl)))
         ;
-        $filesystem = $this->getMock('Composer\Util\Filesystem');
+        $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
 
         $path = $this->getUniqueTmpDirectory();
         $downloader = $this->getDownloader(null, null, null, null, null, $filesystem);

--- a/tests/Composer/Test/Downloader/FossilDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FossilDownloaderTest.php
@@ -37,10 +37,10 @@ class FossilDownloaderTest extends TestCase
 
     protected function getDownloaderMock($io = null, $config = null, $executor = null, $filesystem = null)
     {
-        $io = $io ?: $this->getMock('Composer\IO\IOInterface');
-        $config = $config ?: $this->getMock('Composer\Config');
-        $executor = $executor ?: $this->getMock('Composer\Util\ProcessExecutor');
-        $filesystem = $filesystem ?: $this->getMock('Composer\Util\Filesystem');
+        $io = $io ?: $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $config = $config ?: $this->getMockBuilder('Composer\Config')->getMock();
+        $executor = $executor ?: $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $filesystem = $filesystem ?: $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
 
         return new FossilDownloader($io, $config, $executor, $filesystem);
     }
@@ -50,7 +50,7 @@ class FossilDownloaderTest extends TestCase
      */
     public function testDownloadForPackageWithoutSourceReference()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->once())
             ->method('getSourceReference')
             ->will($this->returnValue(null));
@@ -61,14 +61,14 @@ class FossilDownloaderTest extends TestCase
 
     public function testDownload()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('trunk'));
         $packageMock->expects($this->once())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('http://fossil.kd2.org/kd2fw/')));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
         $expectedFossilCommand = $this->getCmd('fossil clone \'http://fossil.kd2.org/kd2fw/\' \'repo.fossil\'');
         $processExecutor->expects($this->at(0))
@@ -97,8 +97,8 @@ class FossilDownloaderTest extends TestCase
      */
     public function testUpdateforPackageWithoutSourceReference()
     {
-        $initialPackageMock = $this->getMock('Composer\Package\PackageInterface');
-        $sourcePackageMock = $this->getMock('Composer\Package\PackageInterface');
+        $initialPackageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
+        $sourcePackageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $sourcePackageMock->expects($this->once())
             ->method('getSourceReference')
             ->will($this->returnValue(null));
@@ -116,14 +116,14 @@ class FossilDownloaderTest extends TestCase
             touch($file);
         }
 
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('trunk'));
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('http://fossil.kd2.org/kd2fw/')));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
         $expectedFossilCommand = $this->getCmd("fossil changes");
         $processExecutor->expects($this->at(0))
@@ -144,12 +144,12 @@ class FossilDownloaderTest extends TestCase
     {
         $expectedResetCommand = $this->getCmd('cd \'composerPath\' && fossil status');
 
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->any())
             ->method('execute')
             ->with($this->equalTo($expectedResetCommand));
-        $filesystem = $this->getMock('Composer\Util\Filesystem');
+        $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $filesystem->expects($this->any())
             ->method('removeDirectory')
             ->with($this->equalTo('composerPath'))

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -60,9 +60,9 @@ class GitDownloaderTest extends TestCase
 
     protected function getDownloaderMock($io = null, $config = null, $executor = null, $filesystem = null)
     {
-        $io = $io ?: $this->getMock('Composer\IO\IOInterface');
-        $executor = $executor ?: $this->getMock('Composer\Util\ProcessExecutor');
-        $filesystem = $filesystem ?: $this->getMock('Composer\Util\Filesystem');
+        $io = $io ?: $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $executor = $executor ?: $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $filesystem = $filesystem ?: $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $config = $this->setupConfig($config);
 
         return new GitDownloader($io, $config, $executor, $filesystem);
@@ -73,7 +73,7 @@ class GitDownloaderTest extends TestCase
      */
     public function testDownloadForPackageWithoutSourceReference()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->once())
             ->method('getSourceReference')
             ->will($this->returnValue(null));
@@ -84,7 +84,7 @@ class GitDownloaderTest extends TestCase
 
     public function testDownload()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('1234567890123456789012345678901234567890'));
@@ -97,7 +97,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('dev-master'));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
         $processExecutor->expects($this->at(0))
             ->method('execute')
@@ -135,7 +135,7 @@ class GitDownloaderTest extends TestCase
 
     public function testDownloadWithCache()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('1234567890123456789012345678901234567890'));
@@ -148,7 +148,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('dev-master'));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
         $processExecutor->expects($this->at(0))
             ->method('execute')
@@ -201,7 +201,7 @@ class GitDownloaderTest extends TestCase
 
     public function testDownloadUsesVariousProtocolsAndSetsPushUrlForGithub()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
@@ -214,7 +214,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('1.0.0'));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
         $processExecutor->expects($this->at(0))
             ->method('execute')
@@ -285,7 +285,7 @@ class GitDownloaderTest extends TestCase
      */
     public function testDownloadAndSetPushUrlUseCustomVariousProtocolsForGithub($protocols, $url, $pushUrl)
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
@@ -298,7 +298,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('1.0.0'));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
         $processExecutor->expects($this->at(0))
             ->method('execute')
@@ -338,14 +338,14 @@ class GitDownloaderTest extends TestCase
     public function testDownloadThrowsRuntimeExceptionIfGitCommandFails()
     {
         $expectedGitCommand = $this->winCompat("git clone --no-checkout 'https://example.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer 'https://example.com/composer/composer' && git fetch composer");
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('https://example.com/composer/composer')));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($this->winCompat('git --version')))
@@ -368,8 +368,8 @@ class GitDownloaderTest extends TestCase
      */
     public function testUpdateforPackageWithoutSourceReference()
     {
-        $initialPackageMock = $this->getMock('Composer\Package\PackageInterface');
-        $sourcePackageMock = $this->getMock('Composer\Package\PackageInterface');
+        $initialPackageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
+        $sourcePackageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $sourcePackageMock->expects($this->once())
             ->method('getSourceReference')
             ->will($this->returnValue(null));
@@ -382,7 +382,7 @@ class GitDownloaderTest extends TestCase
     {
         $expectedGitUpdateCommand = $this->winCompat("git remote set-url composer 'https://github.com/composer/composer' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)");
 
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
@@ -392,7 +392,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('1.0.0'));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($this->winCompat("git show-ref --head -d")))
@@ -431,7 +431,7 @@ class GitDownloaderTest extends TestCase
     {
         $expectedGitUpdateCommand = $this->winCompat("git remote set-url composer 'https://github.com/composer/composer' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)");
 
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
@@ -444,7 +444,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('1.0.0'));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($this->winCompat("git show-ref --head -d")))
@@ -503,14 +503,14 @@ composer https://github.com/old/url (push)
     {
         $expectedGitUpdateCommand = $this->winCompat("git remote set-url composer 'https://github.com/composer/composer' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)");
 
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('https://github.com/composer/composer')));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($this->winCompat("git show-ref --head -d")))
@@ -542,14 +542,14 @@ composer https://github.com/old/url (push)
         $expectedFirstGitUpdateCommand = $this->winCompat("git remote set-url composer '' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)");
         $expectedSecondGitUpdateCommand = $this->winCompat("git remote set-url composer 'https://github.com/composer/composer' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)");
 
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('/foo/bar', 'https://github.com/composer/composer')));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($this->winCompat("git show-ref --head -d")))
@@ -600,13 +600,13 @@ composer https://github.com/old/url (push)
     {
         $expectedGitResetCommand = $this->winCompat("cd 'composerPath' && git status --porcelain --untracked-files=no");
 
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->any())
             ->method('execute')
             ->with($this->equalTo($expectedGitResetCommand))
             ->will($this->returnValue(0));
-        $filesystem = $this->getMock('Composer\Util\Filesystem');
+        $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $filesystem->expects($this->any())
             ->method('removeDirectory')
             ->with($this->equalTo('composerPath'))

--- a/tests/Composer/Test/Downloader/HgDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/HgDownloaderTest.php
@@ -37,10 +37,10 @@ class HgDownloaderTest extends TestCase
 
     protected function getDownloaderMock($io = null, $config = null, $executor = null, $filesystem = null)
     {
-        $io = $io ?: $this->getMock('Composer\IO\IOInterface');
-        $config = $config ?: $this->getMock('Composer\Config');
-        $executor = $executor ?: $this->getMock('Composer\Util\ProcessExecutor');
-        $filesystem = $filesystem ?: $this->getMock('Composer\Util\Filesystem');
+        $io = $io ?: $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $config = $config ?: $this->getMockBuilder('Composer\Config')->getMock();
+        $executor = $executor ?: $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $filesystem = $filesystem ?: $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
 
         return new HgDownloader($io, $config, $executor, $filesystem);
     }
@@ -50,7 +50,7 @@ class HgDownloaderTest extends TestCase
      */
     public function testDownloadForPackageWithoutSourceReference()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->once())
             ->method('getSourceReference')
             ->will($this->returnValue(null));
@@ -61,14 +61,14 @@ class HgDownloaderTest extends TestCase
 
     public function testDownload()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
         $packageMock->expects($this->once())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('https://mercurial.dev/l3l0/composer')));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
         $expectedGitCommand = $this->getCmd('hg clone \'https://mercurial.dev/l3l0/composer\' \'composerPath\'');
         $processExecutor->expects($this->at(0))
@@ -91,8 +91,8 @@ class HgDownloaderTest extends TestCase
      */
     public function testUpdateforPackageWithoutSourceReference()
     {
-        $initialPackageMock = $this->getMock('Composer\Package\PackageInterface');
-        $sourcePackageMock = $this->getMock('Composer\Package\PackageInterface');
+        $initialPackageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
+        $sourcePackageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $sourcePackageMock->expects($this->once())
             ->method('getSourceReference')
             ->will($this->returnValue(null));
@@ -105,14 +105,14 @@ class HgDownloaderTest extends TestCase
     {
         $fs = new Filesystem;
         $fs->ensureDirectoryExists($this->workingDir.'/.hg');
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('https://github.com/l3l0/composer')));
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
         $expectedHgCommand = $this->getCmd("hg st");
         $processExecutor->expects($this->at(0))
@@ -133,12 +133,12 @@ class HgDownloaderTest extends TestCase
     {
         $expectedResetCommand = $this->getCmd('cd \'composerPath\' && hg st');
 
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->any())
             ->method('execute')
             ->with($this->equalTo($expectedResetCommand));
-        $filesystem = $this->getMock('Composer\Util\Filesystem');
+        $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $filesystem->expects($this->any())
             ->method('removeDirectory')
             ->with($this->equalTo('composerPath'))

--- a/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
@@ -62,7 +62,7 @@ class PerforceDownloaderTest extends TestCase
 
     protected function getMockProcessExecutor()
     {
-        return $this->getMock('Composer\Util\ProcessExecutor');
+        return $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
     }
 
     protected function getConfig()
@@ -76,12 +76,12 @@ class PerforceDownloaderTest extends TestCase
 
     protected function getMockIoInterface()
     {
-        return $this->getMock('Composer\IO\IOInterface');
+        return $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
     }
 
     protected function getMockPackageInterface(VcsRepository $repository)
     {
-        $package = $this->getMock('Composer\Package\PackageInterface');
+        $package = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $package->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
 
         return $package;
@@ -97,7 +97,7 @@ class PerforceDownloaderTest extends TestCase
         $class = 'Composer\Repository\VcsRepository';
         $methods = array('getRepoConfig');
         $args = array($repoConfig, $io, $config);
-        $repository = $this->getMock($class, $methods, $args);
+        $repository = $this->getMockBuilder($class)->setMethods($methods)->setConstructorArgs($args)->getMock();
         $repository->expects($this->any())->method('getRepoConfig')->will($this->returnValue($repoConfig));
 
         return $repository;

--- a/tests/Composer/Test/Downloader/XzDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/XzDownloaderTest.php
@@ -46,7 +46,7 @@ class XzDownloaderTest extends TestCase
 
     public function testErrorMessages()
     {
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getDistUrl')
             ->will($this->returnValue($distUrl = 'file://'.__FILE__))
@@ -60,8 +60,8 @@ class XzDownloaderTest extends TestCase
             ->will($this->returnValue(array()))
         ;
 
-        $io = $this->getMock('Composer\IO\IOInterface');
-        $config = $this->getMock('Composer\Config');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $config = $this->getMockBuilder('Composer\Config')->getMock();
         $config->expects($this->any())
             ->method('get')
             ->with('vendor-dir')

--- a/tests/Composer/Test/Downloader/ZipDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ZipDownloaderTest.php
@@ -28,8 +28,8 @@ class ZipDownloaderTest extends TestCase
     public function setUp()
     {
         $this->testDir = $this->getUniqueTmpDirectory();
-        $this->io = $this->getMock('Composer\IO\IOInterface');
-        $this->config = $this->getMock('Composer\Config');
+        $this->io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $this->config = $this->getMockBuilder('Composer\Config')->getMock();
     }
 
     public function tearDown()
@@ -78,7 +78,7 @@ class ZipDownloaderTest extends TestCase
             ->with('vendor-dir')
             ->will($this->returnValue($this->testDir));
 
-        $packageMock = $this->getMock('Composer\Package\PackageInterface');
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getDistUrl')
             ->will($this->returnValue($distUrl = 'file://'.__FILE__))
@@ -118,7 +118,7 @@ class ZipDownloaderTest extends TestCase
         $this->setPrivateProperty('hasZipArchive', true);
         $downloader = new MockedZipDownloader($this->io, $this->config);
 
-        $zipArchive = $this->getMock('ZipArchive');
+        $zipArchive = $this->getMockBuilder('ZipArchive')->getMock();
         $zipArchive->expects($this->at(0))
             ->method('open')
             ->will($this->returnValue(true));
@@ -144,7 +144,7 @@ class ZipDownloaderTest extends TestCase
         $this->setPrivateProperty('hasZipArchive', true);
         $downloader = new MockedZipDownloader($this->io, $this->config);
 
-        $zipArchive = $this->getMock('ZipArchive');
+        $zipArchive = $this->getMockBuilder('ZipArchive')->getMock();
         $zipArchive->expects($this->at(0))
             ->method('open')
             ->will($this->returnValue(true));
@@ -169,7 +169,7 @@ class ZipDownloaderTest extends TestCase
         $this->setPrivateProperty('hasZipArchive', true);
         $downloader = new MockedZipDownloader($this->io, $this->config);
 
-        $zipArchive = $this->getMock('ZipArchive');
+        $zipArchive = $this->getMockBuilder('ZipArchive')->getMock();
         $zipArchive->expects($this->at(0))
             ->method('open')
             ->will($this->returnValue(true));
@@ -193,7 +193,7 @@ class ZipDownloaderTest extends TestCase
 
         $this->setPrivateProperty('hasSystemUnzip', true);
         $this->setPrivateProperty('hasZipArchive', false);
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->will($this->returnValue(1));
@@ -210,7 +210,7 @@ class ZipDownloaderTest extends TestCase
 
         $this->setPrivateProperty('hasSystemUnzip', true);
         $this->setPrivateProperty('hasZipArchive', false);
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->will($this->returnValue(0));
@@ -229,12 +229,12 @@ class ZipDownloaderTest extends TestCase
         $this->setPrivateProperty('hasSystemUnzip', true);
         $this->setPrivateProperty('hasZipArchive', true);
 
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->will($this->returnValue(1));
 
-        $zipArchive = $this->getMock('ZipArchive');
+        $zipArchive = $this->getMockBuilder('ZipArchive')->getMock();
         $zipArchive->expects($this->at(0))
             ->method('open')
             ->will($this->returnValue(true));
@@ -261,12 +261,12 @@ class ZipDownloaderTest extends TestCase
         $this->setPrivateProperty('hasSystemUnzip', true);
         $this->setPrivateProperty('hasZipArchive', true);
 
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->at(0))
           ->method('execute')
           ->will($this->returnValue(1));
 
-        $zipArchive = $this->getMock('ZipArchive');
+        $zipArchive = $this->getMockBuilder('ZipArchive')->getMock();
         $zipArchive->expects($this->at(0))
           ->method('open')
           ->will($this->returnValue(true));
@@ -289,12 +289,12 @@ class ZipDownloaderTest extends TestCase
         $this->setPrivateProperty('hasSystemUnzip', true);
         $this->setPrivateProperty('hasZipArchive', true);
 
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->atLeastOnce())
             ->method('execute')
             ->will($this->returnValue(0));
 
-        $zipArchive = $this->getMock('ZipArchive');
+        $zipArchive = $this->getMockBuilder('ZipArchive')->getMock();
         $zipArchive->expects($this->at(0))
             ->method('open')
             ->will($this->returnValue(true));
@@ -321,12 +321,12 @@ class ZipDownloaderTest extends TestCase
         $this->setPrivateProperty('hasSystemUnzip', true);
         $this->setPrivateProperty('hasZipArchive', true);
 
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->atLeastOnce())
           ->method('execute')
           ->will($this->returnValue(1));
 
-        $zipArchive = $this->getMock('ZipArchive');
+        $zipArchive = $this->getMockBuilder('ZipArchive')->getMock();
         $zipArchive->expects($this->at(0))
           ->method('open')
           ->will($this->returnValue(true));

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -31,7 +31,7 @@ class EventDispatcherTest extends TestCase
      */
     public function testListenerExceptionsAreCaught()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $dispatcher = $this->getDispatcherStubForListenersTest(array(
             'Composer\Test\EventDispatcher\EventDispatcherTest::call',
         ), $io);
@@ -56,7 +56,7 @@ class EventDispatcherTest extends TestCase
      */
     public function testDispatcherCanConvertScriptEventToCommandEventForListener()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $dispatcher = $this->getDispatcherStubForListenersTest(array(
             'Composer\Test\EventDispatcher\EventDispatcherTest::expectsCommandEvent',
         ), $io);
@@ -66,7 +66,7 @@ class EventDispatcherTest extends TestCase
 
     public function testDispatcherDoesNotAttemptConversionForListenerWithoutTypehint()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $dispatcher = $this->getDispatcherStubForListenersTest(array(
             'Composer\Test\EventDispatcher\EventDispatcherTest::expectsVariableEvent',
         ), $io);
@@ -80,11 +80,11 @@ class EventDispatcherTest extends TestCase
      */
     public function testDispatcherCanExecuteSingleCommandLineScript($command)
     {
-        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $dispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
             ->setConstructorArgs(array(
                 $this->createComposerInstance(),
-                $this->getMock('Composer\IO\IOInterface'),
+                $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
                 $process,
             ))
             ->setMethods(array('getListeners'))
@@ -118,17 +118,17 @@ class EventDispatcherTest extends TestCase
 
         $composer->setAutoloadGenerator($generator);
 
-        $package = $this->getMock('Composer\Package\RootPackageInterface');
+        $package = $this->getMockBuilder('Composer\Package\RootPackageInterface')->getMock();
         $package->method('getScripts')->will($this->returnValue(array('scriptName' => array('scriptName'))));
         $composer->setPackage($package);
 
         $composer->setRepositoryManager($this->getRepositoryManagerMockForDevModePassingTest());
-        $composer->setInstallationManager($this->getMock('Composer\Installer\InstallationManager'));
+        $composer->setInstallationManager($this->getMockBuilder('Composer\Installer\InstallationManager')->getMock());
 
         $dispatcher = new EventDispatcher(
             $composer,
-            $this->getMock('Composer\IO\IOInterface'),
-            $this->getMock('Composer\Util\ProcessExecutor')
+            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock()
         );
 
         $event = $this->getMockBuilder('Composer\Script\Event')
@@ -169,7 +169,7 @@ class EventDispatcherTest extends TestCase
             ->will($this->returnValue(array()));
         $generator
             ->method('createLoader')
-            ->will($this->returnValue($this->getMock('Composer\Autoload\ClassLoader')));
+            ->will($this->returnValue($this->getMockBuilder('Composer\Autoload\ClassLoader')->getMock()));
 
         return $generator;
     }
@@ -181,7 +181,7 @@ class EventDispatcherTest extends TestCase
             ->setMethods(array('getLocalRepository'))
             ->getMock();
 
-        $repo = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
+        $repo = $this->getMockBuilder('Composer\Repository\InstalledRepositoryInterface')->getMock();
         $repo
             ->method('getCanonicalPackages')
             ->will($this->returnValue(array()));
@@ -195,7 +195,7 @@ class EventDispatcherTest extends TestCase
 
     public function testDispatcherCanExecuteCliAndPhpInSameEventScriptStack()
     {
-        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $dispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
             ->setConstructorArgs(array(
                 $this->createComposerInstance(),
@@ -231,7 +231,7 @@ class EventDispatcherTest extends TestCase
 
     public function testDispatcherCanExecuteComposerScriptGroups()
     {
-        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $dispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
             ->setConstructorArgs(array(
                 $composer = $this->createComposerInstance(),
@@ -279,11 +279,11 @@ class EventDispatcherTest extends TestCase
      */
     public function testDispatcherDetectInfiniteRecursion()
     {
-        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $dispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
         ->setConstructorArgs(array(
             $composer = $this->createComposerInstance(),
-            $io = $this->getMock('Composer\IO\IOInterface'),
+            $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
             $process,
         ))
         ->setMethods(array(
@@ -339,7 +339,7 @@ class EventDispatcherTest extends TestCase
         $dispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
             ->setConstructorArgs(array(
                 $this->createComposerInstance(),
-                $io = $this->getMock('Composer\IO\IOInterface'),
+                $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
                 new ProcessExecutor($io),
             ))
             ->setMethods(array('getListeners'))
@@ -361,12 +361,15 @@ class EventDispatcherTest extends TestCase
         $dispatcher->dispatchScript(ScriptEvents::POST_INSTALL_CMD, false);
     }
 
+    /**
+     * @expectedException RuntimeException
+     */
     public function testDispatcherOutputsErrorOnFailedCommand()
     {
         $dispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
             ->setConstructorArgs(array(
                 $this->createComposerInstance(),
-                $io = $this->getMock('Composer\IO\IOInterface'),
+                $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
                 new ProcessExecutor,
             ))
             ->setMethods(array('getListeners'))
@@ -390,17 +393,16 @@ class EventDispatcherTest extends TestCase
             ->method('writeError')
             ->with($this->equalTo('<error>Script '.$code.' handling the post-install-cmd event returned with error code 1</error>'));
 
-        $this->setExpectedException('RuntimeException');
         $dispatcher->dispatchScript(ScriptEvents::POST_INSTALL_CMD, false);
     }
 
     public function testDispatcherInstallerEvents()
     {
-        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $dispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
             ->setConstructorArgs(array(
                     $this->createComposerInstance(),
-                    $this->getMock('Composer\IO\IOInterface'),
+                    $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
                     $process,
                 ))
             ->setMethods(array('getListeners'))
@@ -410,7 +412,7 @@ class EventDispatcherTest extends TestCase
             ->method('getListeners')
             ->will($this->returnValue(array()));
 
-        $policy = $this->getMock('Composer\DependencyResolver\PolicyInterface');
+        $policy = $this->getMockBuilder('Composer\DependencyResolver\PolicyInterface')->getMock();
         $pool = $this->getMockBuilder('Composer\DependencyResolver\Pool')->disableOriginalConstructor()->getMock();
         $installedRepo = $this->getMockBuilder('Composer\Repository\CompositeRepository')->disableOriginalConstructor()->getMock();
         $request = $this->getMockBuilder('Composer\DependencyResolver\Request')->disableOriginalConstructor()->getMock();
@@ -444,7 +446,7 @@ class EventDispatcherTest extends TestCase
         $composer = new Composer;
         $config = new Config;
         $composer->setConfig($config);
-        $package = $this->getMock('Composer\Package\RootPackageInterface');
+        $package = $this->getMockBuilder('Composer\Package\RootPackageInterface')->getMock();
         $composer->setPackage($package);
 
         return $composer;

--- a/tests/Composer/Test/IO/ConsoleIOTest.php
+++ b/tests/Composer/Test/IO/ConsoleIOTest.php
@@ -20,7 +20,7 @@ class ConsoleIOTest extends TestCase
 {
     public function testIsInteractive()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
         $inputMock->expects($this->at(0))
             ->method('isInteractive')
             ->will($this->returnValue(true));
@@ -28,8 +28,8 @@ class ConsoleIOTest extends TestCase
             ->method('isInteractive')
             ->will($this->returnValue(false));
 
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $consoleIO = new ConsoleIO($inputMock, $outputMock, $helperMock);
 
@@ -39,15 +39,15 @@ class ConsoleIOTest extends TestCase
 
     public function testWrite()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
         $outputMock->expects($this->once())
             ->method('getVerbosity')
             ->willReturn(OutputInterface::VERBOSITY_NORMAL);
         $outputMock->expects($this->once())
             ->method('write')
             ->with($this->equalTo('some information about something'), $this->equalTo(false));
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $consoleIO = new ConsoleIO($inputMock, $outputMock, $helperMock);
         $consoleIO->write('some information about something', false);
@@ -55,8 +55,8 @@ class ConsoleIOTest extends TestCase
 
     public function testWriteError()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\ConsoleOutputInterface');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\ConsoleOutputInterface')->getMock();
         $outputMock->expects($this->once())
             ->method('getVerbosity')
             ->willReturn(OutputInterface::VERBOSITY_NORMAL);
@@ -66,7 +66,7 @@ class ConsoleIOTest extends TestCase
         $outputMock->expects($this->once())
             ->method('write')
             ->with($this->equalTo('some information about something'), $this->equalTo(false));
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $consoleIO = new ConsoleIO($inputMock, $outputMock, $helperMock);
         $consoleIO->writeError('some information about something', false);
@@ -74,8 +74,8 @@ class ConsoleIOTest extends TestCase
 
     public function testWriteWithMultipleLineStringWhenDebugging()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
         $outputMock->expects($this->once())
             ->method('getVerbosity')
             ->willReturn(OutputInterface::VERBOSITY_NORMAL);
@@ -90,7 +90,7 @@ class ConsoleIOTest extends TestCase
                 }),
                 $this->equalTo(false)
             );
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $consoleIO = new ConsoleIO($inputMock, $outputMock, $helperMock);
         $startTime = microtime(true);
@@ -102,8 +102,8 @@ class ConsoleIOTest extends TestCase
 
     public function testOverwrite()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
 
         $outputMock->expects($this->any())
             ->method('getVerbosity')
@@ -130,7 +130,7 @@ class ConsoleIOTest extends TestCase
             ->method('write')
             ->with($this->equalTo('something longer than initial (<info>34</info>)'));
 
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $consoleIO = new ConsoleIO($inputMock, $outputMock, $helperMock);
         $consoleIO->write('something (<question>strlen = 23</question>)');
@@ -140,10 +140,10 @@ class ConsoleIOTest extends TestCase
 
     public function testAsk()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
-        $setMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')->getMock();
+        $setMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $helperMock
             ->expects($this->once())
@@ -168,10 +168,10 @@ class ConsoleIOTest extends TestCase
 
     public function testAskConfirmation()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
-        $setMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')->getMock();
+        $setMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $helperMock
             ->expects($this->once())
@@ -196,10 +196,10 @@ class ConsoleIOTest extends TestCase
 
     public function testAskAndValidate()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
-        $setMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')->getMock();
+        $setMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $helperMock
             ->expects($this->once())
@@ -227,10 +227,10 @@ class ConsoleIOTest extends TestCase
 
     public function testSelect()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
-        $setMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')->getMock();
+        $setMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $helperMock
             ->expects($this->once())
@@ -255,9 +255,9 @@ class ConsoleIOTest extends TestCase
 
     public function testSetAndgetAuthentication()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $consoleIO = new ConsoleIO($inputMock, $outputMock, $helperMock);
         $consoleIO->setAuthentication('repoName', 'l3l0', 'passwd');
@@ -270,9 +270,9 @@ class ConsoleIOTest extends TestCase
 
     public function testGetAuthenticationWhenDidNotSet()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $consoleIO = new ConsoleIO($inputMock, $outputMock, $helperMock);
 
@@ -284,9 +284,9 @@ class ConsoleIOTest extends TestCase
 
     public function testHasAuthentication()
     {
-        $inputMock = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $helperMock = $this->getMock('Symfony\Component\Console\Helper\HelperSet');
+        $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+        $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
+        $helperMock = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
 
         $consoleIO = new ConsoleIO($inputMock, $outputMock, $helperMock);
         $consoleIO->setAuthentication('repoName', 'l3l0', 'passwd');

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -24,9 +24,12 @@ class InstallationManagerTest extends TestCase
 
     public function setUp()
     {
-        $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
+        $this->repository = $this->getMockBuilder('Composer\Repository\InstalledRepositoryInterface')->getMock();
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testAddGetInstaller()
     {
         $installer = $this->createInstallerMock();
@@ -43,7 +46,6 @@ class InstallationManagerTest extends TestCase
         $manager->addInstaller($installer);
         $this->assertSame($installer, $manager->getInstaller('vendor'));
 
-        $this->setExpectedException('InvalidArgumentException');
         $manager->getInstaller('unregistered');
     }
 

--- a/tests/Composer/Test/Installer/InstallerEventTest.php
+++ b/tests/Composer/Test/Installer/InstallerEventTest.php
@@ -19,13 +19,13 @@ class InstallerEventTest extends TestCase
 {
     public function testGetter()
     {
-        $composer = $this->getMock('Composer\Composer');
-        $io = $this->getMock('Composer\IO\IOInterface');
-        $policy = $this->getMock('Composer\DependencyResolver\PolicyInterface');
+        $composer = $this->getMockBuilder('Composer\Composer')->getMock();
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $policy = $this->getMockBuilder('Composer\DependencyResolver\PolicyInterface')->getMock();
         $pool = $this->getMockBuilder('Composer\DependencyResolver\Pool')->disableOriginalConstructor()->getMock();
         $installedRepo = $this->getMockBuilder('Composer\Repository\CompositeRepository')->disableOriginalConstructor()->getMock();
         $request = $this->getMockBuilder('Composer\DependencyResolver\Request')->disableOriginalConstructor()->getMock();
-        $operations = array($this->getMock('Composer\DependencyResolver\Operation\OperationInterface'));
+        $operations = array($this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock());
         $event = new InstallerEvent('EVENT_NAME', $composer, $io, true, $policy, $pool, $installedRepo, $request, $operations);
 
         $this->assertSame('EVENT_NAME', $event->getName());

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -57,8 +57,8 @@ class LibraryInstallerTest extends TestCase
             ->getMock();
         $this->composer->setDownloadManager($this->dm);
 
-        $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
-        $this->io = $this->getMock('Composer\IO\IOInterface');
+        $this->repository = $this->getMockBuilder('Composer\Repository\InstalledRepositoryInterface')->getMock();
+        $this->io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
     }
 
     protected function tearDown()
@@ -129,6 +129,7 @@ class LibraryInstallerTest extends TestCase
     /**
      * @depends testInstallerCreationShouldNotCreateVendorDirectory
      * @depends testInstallerCreationShouldNotCreateBinDirectory
+     * @expectedException InvalidArgumentException
      */
     public function testUpdate()
     {
@@ -187,11 +188,12 @@ class LibraryInstallerTest extends TestCase
         $this->assertFileExists($this->vendorDir, 'Vendor dir should be created');
         $this->assertFileExists($this->binDir, 'Bin dir should be created');
 
-        $this->setExpectedException('InvalidArgumentException');
-
         $library->update($this->repository, $initial, $target);
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testUninstall()
     {
         $library = new LibraryInstaller($this->io, $this->composer);
@@ -219,8 +221,6 @@ class LibraryInstallerTest extends TestCase
             ->with($package);
 
         $library->uninstall($this->repository, $package);
-
-        $this->setExpectedException('InvalidArgumentException');
 
         $library->uninstall($this->repository, $package);
     }

--- a/tests/Composer/Test/Installer/MetapackageInstallerTest.php
+++ b/tests/Composer/Test/Installer/MetapackageInstallerTest.php
@@ -23,9 +23,9 @@ class MetapackageInstallerTest extends TestCase
 
     protected function setUp()
     {
-        $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
+        $this->repository = $this->getMockBuilder('Composer\Repository\InstalledRepositoryInterface')->getMock();
 
-        $this->io = $this->getMock('Composer\IO\IOInterface');
+        $this->io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
 
         $this->installer = new MetapackageInstaller();
     }
@@ -42,6 +42,9 @@ class MetapackageInstallerTest extends TestCase
         $this->installer->install($this->repository, $package);
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testUpdate()
     {
         $initial = $this->createPackageMock();
@@ -65,11 +68,12 @@ class MetapackageInstallerTest extends TestCase
 
         $this->installer->update($this->repository, $initial, $target);
 
-        $this->setExpectedException('InvalidArgumentException');
-
         $this->installer->update($this->repository, $initial, $target);
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testUninstall()
     {
         $package = $this->createPackageMock();
@@ -86,8 +90,6 @@ class MetapackageInstallerTest extends TestCase
             ->with($package);
 
         $this->installer->uninstall($this->repository, $package);
-
-        $this->setExpectedException('InvalidArgumentException');
 
         $this->installer->uninstall($this->repository, $package);
     }

--- a/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
+++ b/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
@@ -25,7 +25,7 @@ class SuggestedPackagesReporterTest extends TestCase
 
     protected function setUp()
     {
-        $this->io = $this->getMock('Composer\IO\IOInterface');
+        $this->io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
 
         $this->suggestedPackagesReporter = new SuggestedPackagesReporter($this->io);
     }
@@ -185,9 +185,9 @@ class SuggestedPackagesReporterTest extends TestCase
      */
     public function testOutputSkipInstalledPackages()
     {
-        $repository = $this->getMock('Composer\Repository\RepositoryInterface');
-        $package1 = $this->getMock('Composer\Package\PackageInterface');
-        $package2 = $this->getMock('Composer\Package\PackageInterface');
+        $repository = $this->getMockBuilder('Composer\Repository\RepositoryInterface')->getMock();
+        $package1 = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
+        $package2 = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
 
         $package1->expects($this->once())
             ->method('getNames')
@@ -219,7 +219,7 @@ class SuggestedPackagesReporterTest extends TestCase
      */
     public function testOutputNotGettingInstalledPackagesWhenNoSuggestions()
     {
-        $repository = $this->getMock('Composer\Repository\RepositoryInterface');
+        $repository = $this->getMockBuilder('Composer\Repository\RepositoryInterface')->getMock();
         $repository->expects($this->exactly(0))
             ->method('getPackages');
 

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -57,10 +57,10 @@ class InstallerTest extends TestCase
      */
     public function testInstaller(RootPackageInterface $rootPackage, $repositories, array $options)
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
 
-        $downloadManager = $this->getMock('Composer\Downloader\DownloadManager', array(), array($io));
-        $config = $this->getMock('Composer\Config');
+        $downloadManager = $this->getMockBuilder('Composer\Downloader\DownloadManager')->setConstructorArgs(array($io))->getMock();
+        $config = $this->getMockBuilder('Composer\Config')->getMock();
 
         $repositoryManager = new RepositoryManager($io, $config);
         $repositoryManager->setLocalRepository(new InstalledArrayRepository());
@@ -202,7 +202,7 @@ class InstallerTest extends TestCase
         $composer->setLocker($locker);
 
         $eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
-        $autoloadGenerator = $this->getMock('Composer\Autoload\AutoloadGenerator', array(), array($eventDispatcher));
+        $autoloadGenerator = $this->getMockBuilder('Composer\Autoload\AutoloadGenerator')->setConstructorArgs(array($eventDispatcher))->getMock();
         $composer->setAutoloadGenerator($autoloadGenerator);
         $composer->setEventDispatcher($eventDispatcher);
 

--- a/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
@@ -34,10 +34,11 @@ class ArchiveManagerTest extends ArchiverTest
         $this->targetDir = $this->testDir.'/composer_archiver_tests';
     }
 
+    /**
+     * @expectedException RuntimeException
+     */
     public function testUnknownFormat()
     {
-        $this->setExpectedException('RuntimeException');
-
         $package = $this->setupPackage();
 
         $this->manager->archive($package, '__unknown_format__', $this->targetDir);

--- a/tests/Composer/Test/Package/BasePackageTest.php
+++ b/tests/Composer/Test/Package/BasePackageTest.php
@@ -20,7 +20,7 @@ class BasePackageTest extends TestCase
     public function testSetSameRepository()
     {
         $package = $this->getMockForAbstractClass('Composer\Package\BasePackage', array('foo'));
-        $repository = $this->getMock('Composer\Repository\RepositoryInterface');
+        $repository = $this->getMockBuilder('Composer\Repository\RepositoryInterface')->getMock();
 
         $package->setRepository($repository);
         try {
@@ -37,8 +37,8 @@ class BasePackageTest extends TestCase
     {
         $package = $this->getMockForAbstractClass('Composer\Package\BasePackage', array('foo'));
 
-        $package->setRepository($this->getMock('Composer\Repository\RepositoryInterface'));
-        $package->setRepository($this->getMock('Composer\Repository\RepositoryInterface'));
+        $package->setRepository($this->getMockBuilder('Composer\Repository\RepositoryInterface')->getMock());
+        $package->setRepository($this->getMockBuilder('Composer\Repository\RepositoryInterface')->getMock());
     }
 
     /**

--- a/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
+++ b/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
@@ -31,7 +31,7 @@ class ArrayDumperTest extends TestCase
     public function setUp()
     {
         $this->dumper = new ArrayDumper();
-        $this->package = $this->getMock('Composer\Package\CompletePackageInterface');
+        $this->package = $this->getMockBuilder('Composer\Package\CompletePackageInterface')->getMock();
         $this->packageExpects('getTransportOptions', array());
     }
 
@@ -56,7 +56,7 @@ class ArrayDumperTest extends TestCase
 
     public function testRootPackage()
     {
-        $this->package = $this->getMock('Composer\Package\RootPackageInterface');
+        $this->package = $this->getMockBuilder('Composer\Package\RootPackageInterface')->getMock();
 
         $this
             ->packageExpects('getMinimumStability', 'dev')
@@ -92,7 +92,7 @@ class ArrayDumperTest extends TestCase
      */
     public function testKeys($key, $value, $method = null, $expectedValue = null)
     {
-        $this->package = $this->getMock('Composer\Package\RootPackageInterface');
+        $this->package = $this->getMockBuilder('Composer\Package\RootPackageInterface')->getMock();
 
         $this->packageExpects('get'.ucfirst($method ?: $key), $value);
         $this->packageExpects('isAbandoned', $value);

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -23,7 +23,7 @@ class ValidatingArrayLoaderTest extends TestCase
      */
     public function testLoadSuccess($config)
     {
-        $internalLoader = $this->getMock('Composer\Package\Loader\LoaderInterface');
+        $internalLoader = $this->getMockBuilder('Composer\Package\Loader\LoaderInterface')->getMock();
         $internalLoader
             ->expects($this->once())
             ->method('load')
@@ -171,7 +171,7 @@ class ValidatingArrayLoaderTest extends TestCase
      */
     public function testLoadFailureThrowsException($config, $expectedErrors)
     {
-        $internalLoader = $this->getMock('Composer\Package\Loader\LoaderInterface');
+        $internalLoader = $this->getMockBuilder('Composer\Package\Loader\LoaderInterface')->getMock();
         $loader = new ValidatingArrayLoader($internalLoader, true, null, ValidatingArrayLoader::CHECK_ALL);
         try {
             $loader->load($config);
@@ -189,7 +189,7 @@ class ValidatingArrayLoaderTest extends TestCase
      */
     public function testLoadWarnings($config, $expectedWarnings)
     {
-        $internalLoader = $this->getMock('Composer\Package\Loader\LoaderInterface');
+        $internalLoader = $this->getMockBuilder('Composer\Package\Loader\LoaderInterface')->getMock();
         $loader = new ValidatingArrayLoader($internalLoader, true, null, ValidatingArrayLoader::CHECK_ALL);
 
         $loader->load($config);
@@ -209,7 +209,7 @@ class ValidatingArrayLoaderTest extends TestCase
 
             return;
         }
-        $internalLoader = $this->getMock('Composer\Package\Loader\LoaderInterface');
+        $internalLoader = $this->getMockBuilder('Composer\Package\Loader\LoaderInterface')->getMock();
         $internalLoader
             ->expects($this->once())
             ->method('load')

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -36,6 +36,9 @@ class LockerTest extends TestCase
         $this->assertTrue($locker->isLocked());
     }
 
+    /**
+     * @expectedException LogicException
+     */
     public function testGetNotLockedPackages()
     {
         $json = $this->createJsonFileMock();
@@ -48,8 +51,6 @@ class LockerTest extends TestCase
             ->expects($this->once())
             ->method('exists')
             ->will($this->returnValue(false));
-
-        $this->setExpectedException('LogicException');
 
         $locker->getLockedRepository();
     }
@@ -154,6 +155,9 @@ class LockerTest extends TestCase
         $locker->setLockData(array($package1, $package2), array(), array(), array(), array(), 'dev', array(), false, false, array('foo/bar' => '1.0'));
     }
 
+    /**
+     * @expectedException LogicException
+     */
     public function testLockBadPackages()
     {
         $json = $this->createJsonFileMock();
@@ -167,8 +171,6 @@ class LockerTest extends TestCase
             ->expects($this->once())
             ->method('getPrettyName')
             ->will($this->returnValue('pkg1'));
-
-        $this->setExpectedException('LogicException');
 
         $locker->setLockData(array($package1), array(), array(), array(), array(), 'dev', array(), false, false, array());
     }

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -198,7 +198,7 @@ class VersionSelectorTest extends TestCase
         $versionSelector = new VersionSelector($pool);
         $versionParser = new VersionParser();
 
-        $package = $this->getMock('\Composer\Package\PackageInterface');
+        $package = $this->getMockBuilder('\Composer\Package\PackageInterface')->getMock();
         $package
             ->expects($this->any())
             ->method('getPrettyVersion')
@@ -275,6 +275,6 @@ class VersionSelectorTest extends TestCase
 
     private function createMockPool()
     {
-        return $this->getMock('Composer\DependencyResolver\Pool', array(), array(), '', true);
+        return $this->getMockBuilder('Composer\DependencyResolver\Pool')->getMock();
     }
 }

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -80,7 +80,7 @@ class PluginInstallerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
+        $this->repository = $this->getMockBuilder('Composer\Repository\InstalledRepositoryInterface')->getMock();
 
         $rm = $this->getMockBuilder('Composer\Repository\RepositoryManager')
             ->disableOriginalConstructor()
@@ -89,14 +89,14 @@ class PluginInstallerTest extends TestCase
             ->method('getLocalRepository')
             ->will($this->returnValue($this->repository));
 
-        $im = $this->getMock('Composer\Installer\InstallationManager');
+        $im = $this->getMockBuilder('Composer\Installer\InstallationManager')->getMock();
         $im->expects($this->any())
             ->method('getInstallPath')
             ->will($this->returnCallback(function ($package) {
                 return __DIR__.'/Fixtures/'.$package->getPrettyName();
             }));
 
-        $this->io = $this->getMock('Composer\IO\IOInterface');
+        $this->io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
 
         $dispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
         $this->autoloadGenerator = new AutoloadGenerator($dispatcher);

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -31,18 +31,17 @@ class ComposerRepositoryTest extends TestCase
             'url' => 'http://example.org',
         );
 
-        $repository = $this->getMock(
-            'Composer\Repository\ComposerRepository',
-            array(
-                'loadRootServerFile',
-                'createPackage',
-            ),
-            array(
-                $repoConfig,
-                new NullIO,
-                FactoryMock::createConfig(),
-            )
-        );
+        $repository = $this->getMockBuilder('Composer\Repository\ComposerRepository')
+                        ->setMethods(array(
+                            'loadRootServerFile',
+                            'createPackage',
+                        ))
+                        ->setConstructorArgs(array(
+                            $repoConfig,
+                            new NullIO,
+                            FactoryMock::createConfig(),
+                        ))
+                        ->getMock();
 
         $repository
             ->expects($this->exactly(2))
@@ -146,7 +145,7 @@ class ComposerRepositoryTest extends TestCase
                 ),
             )));
 
-        $pool = $this->getMock('Composer\DependencyResolver\Pool');
+        $pool = $this->getMockBuilder('Composer\DependencyResolver\Pool')->getMock();
         $pool->expects($this->any())
             ->method('isPackageAcceptable')
             ->will($this->returnValue(true));

--- a/tests/Composer/Test/Repository/RepositoryFactoryTest.php
+++ b/tests/Composer/Test/Repository/RepositoryFactoryTest.php
@@ -20,8 +20,8 @@ class RepositoryFactoryTest extends TestCase
     public function testManagerWithAllRepositoryTypes()
     {
         $manager = RepositoryFactory::manager(
-            $this->getMock('Composer\IO\IOInterface'),
-            $this->getMock('Composer\Config')
+            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder('Composer\Config')->getMock()
         );
 
         $ref = new \ReflectionProperty($manager, 'repositoryClasses');

--- a/tests/Composer/Test/Repository/RepositoryManagerTest.php
+++ b/tests/Composer/Test/Repository/RepositoryManagerTest.php
@@ -36,13 +36,13 @@ class RepositoryManagerTest extends TestCase
     public function testPrepend()
     {
         $rm = new RepositoryManager(
-            $this->getMock('Composer\IO\IOInterface'),
-            $this->getMock('Composer\Config'),
+            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder('Composer\Config')->getMock(),
             $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock()
         );
 
-        $repository1 = $this->getMock('Composer\Repository\RepositoryInterface');
-        $repository2 = $this->getMock('Composer\Repository\RepositoryInterface');
+        $repository1 = $this->getMockBuilder('Composer\Repository\RepositoryInterface')->getMock();
+        $repository2 = $this->getMockBuilder('Composer\Repository\RepositoryInterface')->getMock();
         $rm->addRepository($repository1);
         $rm->prependRepository($repository2);
 
@@ -59,8 +59,8 @@ class RepositoryManagerTest extends TestCase
         }
 
         $rm = new RepositoryManager(
-            $this->getMock('Composer\IO\IOInterface'),
-            $config = $this->getMock('Composer\Config', array('get')),
+            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $config = $this->getMockBuilder('Composer\Config')->setMethods(array('get'))->getMock(),
             $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock()
         );
 

--- a/tests/Composer/Test/Repository/Vcs/FossilDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/FossilDriverTest.php
@@ -64,7 +64,7 @@ class FossilDriverTest extends TestCase
     public function testSupport($url, $assertion)
     {
         $config = new Config();
-        $result = FossilDriver::supports($this->getMock('Composer\IO\IOInterface'), $config, $url);
+        $result = FossilDriver::supports($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $config, $url);
         $this->assertEquals($assertion, $result);
     }
 }

--- a/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
@@ -35,7 +35,7 @@ class GitBitbucketDriverTest extends TestCase
 
     protected function setUp()
     {
-        $this->io = $this->getMock('Composer\IO\IOInterface');
+        $this->io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
 
         $this->home = $this->getUniqueTmpDirectory();
 
@@ -76,13 +76,12 @@ class GitBitbucketDriverTest extends TestCase
         return $driver;
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage https://bitbucket.org/user/repo.git does not appear to be a git repository, use https://bitbucket.org/user/repo if this is a mercurial bitbucket repository
+     */
     public function testGetRootIdentifierWrongScmType()
     {
-        $this->setExpectedException(
-            '\RuntimeException',
-            'https://bitbucket.org/user/repo.git does not appear to be a git repository, use https://bitbucket.org/user/repo if this is a mercurial bitbucket repository'
-        );
-
         $this->rfs->expects($this->once())
             ->method('getContents')
             ->with(

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -48,7 +48,7 @@ class GitHubDriverTest extends TestCase
         $identifier = 'v0.0.0';
         $sha = 'SOMESHA';
 
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io->expects($this->any())
             ->method('isInteractive')
             ->will($this->returnValue(true));
@@ -57,7 +57,7 @@ class GitHubDriverTest extends TestCase
             ->setConstructorArgs(array($io))
             ->getMock();
 
-        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $process->expects($this->any())
             ->method('execute')
             ->will($this->returnValue(1));
@@ -86,8 +86,8 @@ class GitHubDriverTest extends TestCase
             ->with($this->equalTo('github.com'), $this->equalTo($repoApiUrl), $this->equalTo(false))
             ->will($this->returnValue('{"master_branch": "test_master", "private": true, "owner": {"login": "composer"}, "name": "packagist"}'));
 
-        $configSource = $this->getMock('Composer\Config\ConfigSourceInterface');
-        $authConfigSource = $this->getMock('Composer\Config\ConfigSourceInterface');
+        $configSource = $this->getMockBuilder('Composer\Config\ConfigSourceInterface')->getMock();
+        $authConfigSource = $this->getMockBuilder('Composer\Config\ConfigSourceInterface')->getMock();
         $this->config->setConfigSource($configSource);
         $this->config->setAuthConfigSource($authConfigSource);
 
@@ -119,7 +119,7 @@ class GitHubDriverTest extends TestCase
         $identifier = 'v0.0.0';
         $sha = 'SOMESHA';
 
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io->expects($this->any())
             ->method('isInteractive')
             ->will($this->returnValue(true));
@@ -162,7 +162,7 @@ class GitHubDriverTest extends TestCase
         $identifier = 'feature/3.2-foo';
         $sha = 'SOMESHA';
 
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io->expects($this->any())
             ->method('isInteractive')
             ->will($this->returnValue(true));
@@ -222,7 +222,7 @@ class GitHubDriverTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io->expects($this->any())
             ->method('isInteractive')
             ->will($this->returnValue(false));

--- a/tests/Composer/Test/Repository/Vcs/HgDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/HgDriverTest.php
@@ -28,7 +28,7 @@ class HgDriverTest extends TestCase
 
     public function setUp()
     {
-        $this->io = $this->getMock('Composer\IO\IOInterface');
+        $this->io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $this->home = $this->getUniqueTmpDirectory();
         $this->config = new Config();
         $this->config->merge(array(

--- a/tests/Composer/Test/Repository/Vcs/PerforceDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/PerforceDriverTest.php
@@ -91,12 +91,12 @@ class PerforceDriverTest extends TestCase
 
     protected function getMockIOInterface()
     {
-        return $this->getMock('Composer\IO\IOInterface');
+        return $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
     }
 
     protected function getMockProcessExecutor()
     {
-        return $this->getMock('Composer\Util\ProcessExecutor');
+        return $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
     }
 
     protected function getMockRemoteFilesystem()

--- a/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
@@ -45,13 +45,13 @@ class SvnDriverTest extends TestCase
      */
     public function testWrongCredentialsInUrl()
     {
-        $console = $this->getMock('Composer\IO\IOInterface');
+        $console = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
 
         $output = "svn: OPTIONS of 'https://corp.svn.local/repo':";
         $output .= " authorization failed: Could not authenticate to server:";
         $output .= " rejected Basic challenge (https://corp.svn.local/)";
 
-        $process = $this->getMock('Composer\Util\ProcessExecutor');
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $process->expects($this->at(1))
             ->method('execute')
             ->will($this->returnValue(1));
@@ -95,7 +95,7 @@ class SvnDriverTest extends TestCase
     public function testSupport($url, $assertion)
     {
         $config = new Config();
-        $result = SvnDriver::supports($this->getMock('Composer\IO\IOInterface'), $config, $url);
+        $result = SvnDriver::supports($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $config, $url);
         $this->assertEquals($assertion, $result);
     }
 }

--- a/tests/Composer/Test/Util/BitbucketTest.php
+++ b/tests/Composer/Test/Util/BitbucketTest.php
@@ -53,7 +53,7 @@ class BitbucketTest extends TestCase
             ->getMock()
         ;
 
-        $this->config = $this->getMock('Composer\Config');
+        $this->config = $this->getMockBuilder('Composer\Config')->getMock();
 
         $this->time = time();
 
@@ -258,7 +258,7 @@ class BitbucketTest extends TestCase
 
     private function setExpectationsForStoringAccessToken($removeBasicAuth = false)
     {
-        $configSourceMock = $this->getMock('Composer\Config\ConfigSourceInterface');
+        $configSourceMock = $this->getMockBuilder('Composer\Config\ConfigSourceInterface')->getMock();
         $this->config->expects($this->once())
             ->method('getConfigSource')
             ->willReturn($configSourceMock);
@@ -267,7 +267,7 @@ class BitbucketTest extends TestCase
             ->method('removeConfigSetting')
             ->with('bitbucket-oauth.' . $this->origin);
 
-        $authConfigSourceMock = $this->getMock('Composer\Config\ConfigSourceInterface');
+        $authConfigSourceMock = $this->getMockBuilder('Composer\Config\ConfigSourceInterface')->getMock();
         $this->config->expects($this->atLeastOnce())
             ->method('getAuthConfigSource')
             ->willReturn($authConfigSourceMock);

--- a/tests/Composer/Test/Util/ErrorHandlerTest.php
+++ b/tests/Composer/Test/Util/ErrorHandlerTest.php
@@ -20,26 +20,26 @@ use Composer\TestCase;
  */
 class ErrorHandlerTest extends TestCase
 {
-    /**
-     * Test ErrorHandler handles notices
-     */
+     /**
+      * Test ErrorHandler handles notices
+      * @expectedException ErrorException
+      * @expectedExceptionMessage Undefined index: baz
+      */
     public function testErrorHandlerCaptureNotice()
     {
-        $this->setExpectedException('\ErrorException', 'Undefined index: baz');
-
         ErrorHandler::register();
 
         $array = array('foo' => 'bar');
         $array['baz'];
     }
 
-    /**
-     * Test ErrorHandler handles warnings
-     */
+     /**
+      * Test ErrorHandler handles warnings
+      * @expectedException ErrorException
+      * @expectedExceptionMessage array_merge
+      */
     public function testErrorHandlerCaptureWarning()
     {
-        $this->setExpectedException('\ErrorException', 'array_merge');
-
         ErrorHandler::register();
 
         array_merge(array(), 'string');

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -283,6 +283,10 @@ class FilesystemTest extends TestCase
         $this->assertFileNotExists($symlinked);
     }
 
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage not available on non-Windows platform
+     */
     public function testJunctions()
     {
         @mkdir($this->workingDir . '/real/nesting/testing', 0777, true);
@@ -292,7 +296,6 @@ class FilesystemTest extends TestCase
         if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->assertFalse($fs->isJunction($this->workingDir));
             $this->assertFalse($fs->removeJunction($this->workingDir));
-            $this->setExpectedException('LogicException', 'not available on non-Windows platform');
         }
 
         $target = $this->workingDir . '/real/../real/nesting';

--- a/tests/Composer/Test/Util/GitHubTest.php
+++ b/tests/Composer/Test/Util/GitHubTest.php
@@ -117,7 +117,7 @@ class GitHubTest extends TestCase
 
     private function getConfigMock()
     {
-        return $this->getMock('Composer\Config');
+        return $this->getMockBuilder('Composer\Config')->getMock();
     }
 
     private function getRemoteFilesystemMock()

--- a/tests/Composer/Test/Util/GitLabTest.php
+++ b/tests/Composer/Test/Util/GitLabTest.php
@@ -126,7 +126,7 @@ class GitLabTest extends TestCase
 
     private function getConfigMock()
     {
-        return $this->getMock('Composer\Config');
+        return $this->getMockBuilder('Composer\Config')->getMock();
     }
 
     private function getRemoteFilesystemMock()

--- a/tests/Composer/Test/Util/PerforceTest.php
+++ b/tests/Composer/Test/Util/PerforceTest.php
@@ -34,7 +34,7 @@ class PerforceTest extends TestCase
 
     protected function setUp()
     {
-        $this->processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $this->processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $this->repoConfig = $this->getTestRepoConfig();
         $this->io = $this->getMockIOInterface();
         $this->createNewPerforceWithWindowsFlag(true);
@@ -60,7 +60,7 @@ class PerforceTest extends TestCase
 
     public function getMockIOInterface()
     {
-        return $this->getMock('Composer\IO\IOInterface');
+        return $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
     }
 
     protected function createNewPerforceWithWindowsFlag($flag)
@@ -619,7 +619,7 @@ class PerforceTest extends TestCase
 
     public function testCheckServerExists()
     {
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
         $expectedCommand = 'p4 -p perforce.does.exist:port info -s';
         $processExecutor->expects($this->at(0))
@@ -640,7 +640,7 @@ class PerforceTest extends TestCase
      */
     public function testCheckServerClientError()
     {
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
         $expectedCommand = 'p4 -p perforce.does.exist:port info -s';
         $processExecutor->expects($this->at(0))
@@ -708,7 +708,7 @@ class PerforceTest extends TestCase
 
     public function testCleanupClientSpecShouldDeleteClient()
     {
-        $fs = $this->getMock('Composer\Util\Filesystem');
+        $fs = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $this->perforce->setFilesystem($fs);
 
         $testClient = $this->perforce->getClient();

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -37,7 +37,7 @@ class ProcessExecutorTest extends TestCase
 
     public function testUseIOIsNotNullAndIfNotCaptured()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io->expects($this->once())
             ->method('write')
             ->with($this->equalTo('foo'.PHP_EOL), false);

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -19,7 +19,7 @@ class RemoteFilesystemTest extends TestCase
 {
     public function testGetOptionsForUrl()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io
             ->expects($this->once())
             ->method('hasAuthentication')
@@ -32,7 +32,7 @@ class RemoteFilesystemTest extends TestCase
 
     public function testGetOptionsForUrlWithAuthorization()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io
             ->expects($this->once())
             ->method('hasAuthentication')
@@ -57,7 +57,7 @@ class RemoteFilesystemTest extends TestCase
 
     public function testGetOptionsForUrlWithStreamOptions()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io
             ->expects($this->once())
             ->method('hasAuthentication')
@@ -74,7 +74,7 @@ class RemoteFilesystemTest extends TestCase
 
     public function testGetOptionsForUrlWithCallOptionsKeepsHeader()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io
             ->expects($this->once())
             ->method('hasAuthentication')
@@ -101,14 +101,14 @@ class RemoteFilesystemTest extends TestCase
 
     public function testCallbackGetFileSize()
     {
-        $fs = new RemoteFilesystem($this->getMock('Composer\IO\IOInterface'));
+        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock());
         $this->callCallbackGet($fs, STREAM_NOTIFY_FILE_SIZE_IS, 0, '', 0, 0, 20);
         $this->assertAttributeEquals(20, 'bytesMax', $fs);
     }
 
     public function testCallbackGetNotifyProgress()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io
             ->expects($this->once())
             ->method('overwriteError')
@@ -124,7 +124,7 @@ class RemoteFilesystemTest extends TestCase
 
     public function testCallbackGetPassesThrough404()
     {
-        $fs = new RemoteFilesystem($this->getMock('Composer\IO\IOInterface'));
+        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock());
 
         $this->assertNull($this->callCallbackGet($fs, STREAM_NOTIFY_FAILURE, 0, 'HTTP/1.1 404 Not Found', 404, 0, 0));
     }
@@ -134,7 +134,7 @@ class RemoteFilesystemTest extends TestCase
      */
     public function testCaptureAuthenticationParamsFromUrl()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $io->expects($this->once())
             ->method('setAuthentication')
             ->with($this->equalTo('github.com'), $this->equalTo('user'), $this->equalTo('pass'));
@@ -150,14 +150,14 @@ class RemoteFilesystemTest extends TestCase
 
     public function testGetContents()
     {
-        $fs = new RemoteFilesystem($this->getMock('Composer\IO\IOInterface'));
+        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock());
 
         $this->assertContains('testGetContents', $fs->getContents('http://example.org', 'file://'.__FILE__));
     }
 
     public function testCopy()
     {
-        $fs = new RemoteFilesystem($this->getMock('Composer\IO\IOInterface'));
+        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock());
 
         $file = tempnam(sys_get_temp_dir(), 'c');
         $this->assertTrue($fs->copy('http://example.org', 'file://'.__FILE__, $file));
@@ -171,7 +171,7 @@ class RemoteFilesystemTest extends TestCase
      */
     public function testGetOptionsForUrlCreatesSecureTlsDefaults()
     {
-        $io = $this->getMock('Composer\IO\IOInterface');
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
 
         $res = $this->callGetOptionsForUrl($io, array('example.org', array('ssl' => array('cafile' => '/some/path/file.crt'))), array(), 'http://www.example.org');
 

--- a/tests/Composer/Test/Util/SilencerTest.php
+++ b/tests/Composer/Test/Util/SilencerTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Silencer;
-use PHPUnit\Framework\TestCase;
+use Composer\TestCase;
 
 /**
  * SilencerTest

--- a/tests/Composer/TestCase.php
+++ b/tests/Composer/TestCase.php
@@ -105,4 +105,28 @@ abstract class TestCase extends BaseTestCase
             $this->markTestSkipped($executableName . ' is not found or not executable.');
         }
     }
+
+    /**
+     * Method to keep PHPUnit 4.x compatibility.
+     *
+     * @param mixed  $exceptionName
+     * @param string $exceptionMessage
+     * @param int    $exceptionCode
+     */
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($exception);
+
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
 }


### PR DESCRIPTION
I've added `PHPUnit 6` support to `Composer`. Changes:
- Define mocks with fluent interface;
- `setExpectedException` isn't available in version `6`, so I substitute to `@expectedException` and `@expectedExceptionMessage` notations. But, there are some tests that these expectations are variables, so, I created a method layer in `Composer\TestCase` and extend those TestCases that need this method.

One question: why not extend all TestCases from `Composer\TestCase`? I guess is easier for maintenance, isn't?