### PR TITLE
Fix chocolatey php

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 build: false
-shallow_clone: true
+clone_depth: 5
 platform:
   - x86
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,22 +9,17 @@ cache:
   - c:\tools\php -> appveyor.yml
 
 init:
-  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
+  - SET PATH=c:\tools\php;%PATH%
   - SET COMPOSER_NO_INTERACTION=1
   - SET PHP=1
   - SET ANSICON=121x90 (121x90)
 
 install:
   - IF EXIST c:\tools\php (SET PHP=0)
-  - IF %PHP%==1 cinst -y OpenSSL.Light
-  - IF %PHP%==1 cinst -y php
+  - IF %PHP%==1 cinst -y php --params "/InstallDir:c:\tools\php"
   - cd c:\tools\php
-  - IF %PHP%==1 copy php.ini-production php.ini /Y
-  - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
-  - IF %PHP%==1 echo extension_dir=ext >> php.ini
   - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
   - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
-  - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
   - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
   - appveyor DownloadFile https://getcomposer.org/composer.phar
   - cd c:\projects\composer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,28 +3,29 @@ clone_depth: 5
 platform:
   - x86
   - x64
-clone_folder: c:\projects\composer
+
+environment:
+  PHP_CHOCO_VERSION: 7.2.0
+  PHP_CACHE_DIR: C:\tools\php
 
 cache:
-  - c:\tools\php -> appveyor.yml
+  - '%PHP_CACHE_DIR% -> appveyor.yml'
 
 init:
-  - SET PATH=c:\tools\php;%PATH%
+  - SET PATH=%PHP_CACHE_DIR%;%PATH%
   - SET COMPOSER_NO_INTERACTION=1
-  - SET PHP=1
+  - SET PHP=0
   - SET ANSICON=121x90 (121x90)
 
 install:
-  - IF EXIST c:\tools\php (SET PHP=0)
-  - IF %PHP%==1 cinst -y php --params "/InstallDir:c:\tools\php"
-  - cd c:\tools\php
-  - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
-  - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
-  - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
-  - appveyor DownloadFile https://getcomposer.org/composer.phar
-  - cd c:\projects\composer
+  - IF EXIST %PHP_CACHE_DIR% (SET PHP=1)
+  - IF %PHP%==0 cinst php -y --version %PHP_CHOCO_VERSION%  --params "/InstallDir:%PHP_CACHE_DIR%"
+  - IF %PHP%==0 cinst composer -y --ia "/DEV=%PHP_CACHE_DIR%"
+  - php -v
+  - IF %PHP%==0 (composer --version) ELSE (composer self-update)
+  - cd %APPVEYOR_BUILD_FOLDER%
   - composer install --prefer-dist --no-progress
 
 test_script:
-  - cd c:\projects\composer
-  - vendor/bin/phpunit --colors=always
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - vendor\bin\phpunit --colors=always


### PR DESCRIPTION
This will at least get PHP installed where we want it, so the tests can run.

Planet Chocolatey is still a wild and random place, so there is no guarantee that this will continue to work. However, their latest PHP package (7.2.0) has made some major improvements in not depending on operating system updates and VC redistributables (that are not needed on appveyor anway and break the install). Prior to this, it had already started to provide a php.ini file (copying php.ini-production and setting the extension_dir). So the evolution has been good.

I've removed setting `date.timezone` as it defaults to UTC anyway. Questions:

-  What is the purpose of installing OpenSSL.Light when php_openssl.dll is enabled?
-  What is the reason for enabling `php_fileinfo.dll`?

If these are not needed, then we could simplify things and perhaps use the chocolatey `Composer-Setup` to grab composer and set up php.ini, something like this:

```
...
environment:
    PHP_CHOCO_VERSION: 7.2.0
    PHP_CACHE_DIR: C:\tools\php

cache:
  - '%PHP_CACHE_DIR% -> appveyor.yml'

init:
  - SET PATH=%PHP_CACHE_DIR%;%PATH%
  - SET COMPOSER_NO_INTERACTION=1
  - SET PHP=0

install:
  - IF EXIST %PHP_CACHE_DIR% (SET PHP=1)
  - IF %PHP%==0 cinst -y php --version %PHP_CHOCO_VERSION%  --params "/InstallDir:%PHP_CACHE_DIR%"
  - IF %PHP%==0 cinst -y composer --ia "/DEV=%PHP_CACHE_DIR%"
  - php -v
  - IF %PHP%==0 (composer  --version) ELSE (composer self-update)
  - cd %APPVEYOR_BUILD_FOLDER%
  - composer install --prefer-dist --no-progress
...
```    

