### PR TITLE
Fix the platform requirement check command

### DIFF
--- a/src/Composer/Command/CheckPlatformReqsCommand.php
+++ b/src/Composer/Command/CheckPlatformReqsCommand.php
@@ -82,7 +82,7 @@ EOT
                     $version = $currentPlatformPackageMap[$require]->getVersion();
 
                     foreach ($links as $link) {
-                        if (!$link->getConstraint()->matches(new Constraint('<=', $version))) {
+                        if (!$link->getConstraint()->matches(new Constraint('=', $version))) {
                             $results[] = array(
                                 $currentPlatformPackageMap[$require]->getPrettyName(),
                                 $currentPlatformPackageMap[$require]->getPrettyVersion(),


### PR DESCRIPTION
The command must validate that the current package matches the constraint, not that any newer package matches it.

Closes #6925