### PR TITLE
Fix: Remove key when value is null

### DIFF
--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -417,7 +417,7 @@ class JsonManipulator
     {
         $decoded = JsonFile::parseJson($this->contents);
 
-        if (!isset($decoded[$key])) {
+        if (!array_key_exists($key, $decoded)) {
             return true;
         }
 

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -2310,6 +2310,22 @@ class JsonManipulatorTest extends TestCase
 ', $manipulator->getContents());
     }
 
+    public function testRemoveMainKeyRemovesKeyWhereValueIsNull()
+    {
+        $manipulator = new JsonManipulator(json_encode(array(
+            'foo' => 9000,
+            'bar' => null,
+        )));
+
+        $manipulator->removeMainKey('bar');
+
+        $expected = json_encode(array(
+            'foo' => 9000,
+        ));
+
+        $this->assertJsonStringEqualsJsonString($expected, $manipulator->getContents());
+    }
+
     public function testIndentDetection()
     {
         $manipulator = new JsonManipulator('{


### PR DESCRIPTION
This PR

* [x] asserts that `JsonManipulator::removeMainKey()` removes a key when its value is `null`
* [x] uses `array_key_exists()` instead of `isset()` to determine if data has a key