### PR TITLE
[docs] Few typographical fixes

### DIFF
--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -192,7 +192,7 @@ includes PHP itself, PHP extensions and some system libraries.
   require the `php-64bit` package.
 
 * `hhvm` represents the version of the HHVM runtime and allows you to apply
-  a constraint, e.g., '>=2.3.3'.
+  a constraint, e.g., `>=2.3.3`.
 
 * `ext-<name>` allows you to require PHP extensions (includes core
   extensions). Versioning can be quite inconsistent here, so it's often
@@ -255,7 +255,7 @@ In addition to PSR-4 autoloading, Composer also supports PSR-0, classmap and
 files autoloading. See the [`autoload`](04-schema.md#autoload) reference for
 more information.
 
-See also the docs on [`optimizing the autoloader`](articles/autoloader-optimization.md).
+See also the docs on [optimizing the autoloader](articles/autoloader-optimization.md).
 
 > **Note:** Composer provides its own autoloader. If you don't want to use that
 > one, you can just include `vendor/composer/autoload_*.php` files, which return

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -625,7 +625,7 @@ would set `"extra": { "foo": { "bar": "value" } }`.
 ## create-project
 
 You can use Composer to create new projects from an existing package. This is
-the equivalent of doing a git clone/svn checkout followed by a "composer install"
+the equivalent of doing a git clone/svn checkout followed by a `composer install`
 of the vendors.
 
 There are several applications for this:
@@ -635,7 +635,7 @@ There are several applications for this:
 3. Projects with multiple developers can use this feature to bootstrap the
    initial application for development.
 
-To create a new project using Composer you can use the "create-project" command.
+To create a new project using Composer you can use the `create-project` command.
 Pass it a package name, and the directory to create the project in. You can also
 provide a version as third argument, otherwise the latest version is used.
 
@@ -677,7 +677,7 @@ By default the command checks for the packages on packagist.org.
 ## dump-autoload (dumpautoload)
 
 If you need to update the autoloader because of new classes in a classmap
-package for example, you can use "dump-autoload" to do that without having to
+package for example, you can use `dump-autoload` to do that without having to
 go through an install or update.
 
 Additionally, it can dump an optimized autoloader that converts PSR-0/4 packages
@@ -688,7 +688,7 @@ using this option you can still use PSR-0/4 for convenience and classmaps for
 performance.
 
 ### Options
-* **--no-scripts:** Skips the execution of all scripts defined in composer.json file.
+* **--no-scripts:** Skips the execution of all scripts defined in `composer.json` file.
 * **--optimize (-o):** Convert PSR-0/4 autoloading to classmap to get a faster
   autoloader. This is recommended especially for production, but can take
   a bit of time to run so it is currently not done by default.

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -571,7 +571,7 @@ Example:
 #### Files
 
 If you want to require certain files explicitly on every request then you can use
-the 'files' autoloading mechanism. This is useful if your package includes PHP functions
+the `files` autoloading mechanism. This is useful if your package includes PHP functions
 that cannot be autoloaded by PHP.
 
 Example:
@@ -586,7 +586,7 @@ Example:
 
 #### Exclude files from classmaps
 
-If you want to exclude some files or folders from the classmap you can use the 'exclude-from-classmap' property.
+If you want to exclude some files or folders from the classmap you can use the `exclude-from-classmap` property.
 This might be useful to exclude test classes in your live environment, for example, as those will be skipped
 from the classmap even when building an optimized autoloader.
 
@@ -608,7 +608,7 @@ Example:
 
 The autoloader can have quite a substantial impact on your request time
 (50-100ms per request in large frameworks using a lot of classes). See the
-[`article about optimizing the autoloader`](articles/autoloader-optimization.md)
+[article about optimizing the autoloader](articles/autoloader-optimization.md)
 for more details on how to reduce this impact.
 
 ### autoload-dev <span>([root-only](04-schema.md#root-package))</span>
@@ -883,7 +883,7 @@ but the same branch is installed (in the example: latest-testing).
 An example:
 
 If you have a testing branch, that is heavily maintained during a testing phase and is
-deployed to your staging environment, normally "composer show -s" will give you `versions : * dev-master`.
+deployed to your staging environment, normally `composer show -s` will give you `versions : * dev-master`.
 
 If you configure `latest-.*` as a pattern for non-feature-branches like this:
 
@@ -893,7 +893,7 @@ If you configure `latest-.*` as a pattern for non-feature-branches like this:
 }
 ```
 
-Then "composer show -s" will give you `versions : * dev-latest-testing`.
+Then `composer show -s` will give you `versions : * dev-latest-testing`.
 
 Optional.
 


### PR DESCRIPTION
I was reading the documentation and I found a few places where the `code` formatting was missing or superfluous. 