### PR TITLE
Fix for issue 6602 - warning when running composer as another user

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -112,7 +112,7 @@ EOT
             $composeUser = posix_getpwuid(posix_geteuid());
             $homeOwner = posix_getpwuid(fileowner($home));
             if ($composeUser !== $homeOwner) {
-              $io->writeError('<warning>You are running composer as "'.$composeUser.'", while "'.$home.'" is owned by "'.$homeOwner.'"</warning>');
+                $io->writeError('<warning>You are running composer as "'.$composeUser.'", while "'.$home.'" is owned by "'.$homeOwner.'"</warning>');
             }
         }
 


### PR DESCRIPTION
Raising a warning if the current user doesn't match the initial ownership of the $home directory. 
Not sure how this works on let's say Windows, might have to add some extra checks for that.

Would love some feedback on how I can improve this PR in order to merge into master.