### PR TITLE
possibility to remove wget as dependency

### DIFF
--- a/doc/faqs/how-to-install-composer-programmatically.md
+++ b/doc/faqs/how-to-install-composer-programmatically.md
@@ -9,7 +9,7 @@ An alternative is to use this script which only works with unix utils:
 ```bash
 #!/bin/sh
 
-EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+EXPECTED_SIGNATURE=$(php -r "copy('https://composer.github.io/installer.sig', 'php://stdout');")
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
 


### PR DESCRIPTION
use php to download the signature to standard output instead of wget.

just stumbled over the installer script and used it with some docker image that had no wget and then wondered why to use wget while the other downloads in that file are done via php.

happy new years eve btw