### PR TITLE
Allow bin key to receive string

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -368,8 +368,8 @@
             "description": "If set to true, stable packages will be preferred to dev packages when possible, even if the minimum-stability allows unstable packages."
         },
         "bin": {
-            "type": ["array"],
-            "description": "A set of files that should be treated as binaries and symlinked into bin-dir (from config).",
+            "type": ["string", "array"],
+            "description": "A set of files, or a single file, that should be treated as binaries and symlinked into bin-dir (from config).",
             "items": {
                 "type": "string"
             }
@@ -776,8 +776,8 @@
                     }
                 },
                 "bin": {
-                    "type": ["array"],
-                    "description": "A set of files that should be treated as binaries and symlinked into bin-dir (from config).",
+                    "type": ["string", "array"],
+                    "description": "A set of files, or a single file, that should be treated as binaries and symlinked into bin-dir (from config).",
                     "items": {
                         "type": "string"
                     }

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -65,13 +65,10 @@ class ArrayLoader implements LoaderInterface
         }
 
         if (isset($config['bin'])) {
-            if (!is_array($config['bin'])) {
-                throw new \UnexpectedValueException('Package '.$config['name'].'\'s bin key should be an array, '.gettype($config['bin']).' given.');
-            }
-            foreach ($config['bin'] as $key => $bin) {
+            foreach ((array) $config['bin'] as $key => $bin) {
                 $config['bin'][$key] = ltrim($bin, '/');
             }
-            $package->setBinaries($config['bin']);
+            $package->setBinaries((array) $config['bin']);
         }
 
         if (isset($config['installation-source'])) {

--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -77,7 +77,15 @@ class ValidatingArrayLoader implements LoaderInterface
         $this->validateRegex('type', '[A-Za-z0-9-]+');
         $this->validateString('target-dir');
         $this->validateArray('extra');
-        $this->validateFlatArray('bin');
+
+        if (isset($this->config['bin'])) {
+            if (is_string($this->config['bin'])) {
+                $this->validateString('bin');
+            } else {
+                $this->validateFlatArray('bin');
+            }
+        }
+
         $this->validateArray('scripts'); // TODO validate event names & listener syntax
         $this->validateString('description');
         $this->validateUrl('homepage');

--- a/tests/Composer/Test/Json/Fixtures/composer.json
+++ b/tests/Composer/Test/Json/Fixtures/composer.json
@@ -47,7 +47,7 @@
     "autoload-dev": {
         "psr-0": { "Composer\\Test": "tests/" }
     },
-    "bin": ["bin/composer"],
+    "bin": "bin/composer",
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -151,10 +151,16 @@ class ValidatingArrayLoaderTest extends TestCase
                     'transport-options' => array('ssl' => array('local_cert' => '/opt/certs/test.pem')),
                 ),
             ),
-            array( // test as array
+            array( // test licenses as array
                 array(
                     'name' => 'foo/bar',
                     'license' => array('MIT', 'WTFPL'),
+                ),
+            ),
+            array( // test bin as string
+                array(
+                    'name' => 'foo/bar',
+                    'bin' => 'bin1',
                 ),
             ),
         );


### PR DESCRIPTION
Something that I always see in packages, including `Composer`, is an `array` wrapper in a single bin file:
```json
"bin": ["bin/composer"],
```

So, the way we do with our `licenses` key, why not support `array` and `string` in the `bin` key? :nerd_face: 