### PR TITLE
Fix generated static map...

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -783,11 +783,6 @@ HEADER;
             }
         }
 
-        // BC handling when converting to a new ClassLoader
-        if (isset($maps['prefixLengthsPsr4'])) {
-            $maps['firstCharsPsr4'] = array_map('is_array', $maps['prefixLengthsPsr4']);
-        }
-
         foreach ($maps as $prop => $value) {
             if (count($value) > 32767) {
                 // Static arrays are limited to 32767 values on PHP 5.6

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -43,8 +43,7 @@ namespace Composer\Autoload;
 class ClassLoader
 {
     // PSR-4
-    private $firstCharsPsr4 = array();
-    private $prefixLengthsPsr4 = array(); // For BC with legacy static maps
+    private $prefixLengthsPsr4 = array();
     private $prefixDirsPsr4 = array();
     private $fallbackDirsPsr4 = array();
 
@@ -171,10 +170,11 @@ class ClassLoader
             }
         } elseif (!isset($this->prefixDirsPsr4[$prefix])) {
             // Register directories for a new namespace.
-            if ('\\' !== substr($prefix, -1)) {
+            $length = strlen($prefix);
+            if ('\\' !== $prefix[$length - 1]) {
                 throw new \InvalidArgumentException("A non-empty PSR-4 prefix must end with a namespace separator.");
             }
-            $this->firstCharsPsr4[$prefix[0]] = true;
+            $this->prefixLengthsPsr4[$prefix[0]][$prefix] = $length;
             $this->prefixDirsPsr4[$prefix] = (array) $paths;
         } elseif ($prepend) {
             // Prepend directories for an already registered namespace.
@@ -221,10 +221,11 @@ class ClassLoader
         if (!$prefix) {
             $this->fallbackDirsPsr4 = (array) $paths;
         } else {
-            if ('\\' !== substr($prefix, -1)) {
+            $length = strlen($prefix);
+            if ('\\' !== $prefix[$length - 1]) {
                 throw new \InvalidArgumentException("A non-empty PSR-4 prefix must end with a namespace separator.");
             }
-            $this->firstCharsPsr4[$prefix[0]] = true;
+            $this->prefixLengthsPsr4[$prefix[0]][$prefix] = $length;
             $this->prefixDirsPsr4[$prefix] = (array) $paths;
         }
     }
@@ -372,7 +373,7 @@ class ClassLoader
         $logicalPathPsr4 = strtr($class, '\\', DIRECTORY_SEPARATOR) . $ext;
 
         $first = $class[0];
-        if (isset($this->firstCharsPsr4[$first]) || isset($this->prefixLengthsPsr4[$first])) {
+        if (isset($this->prefixLengthsPsr4[$first])) {
             $subPath = $class;
             while (false !== $lastPos = strrpos($subPath, '\\')) {
                 $subPath = substr($subPath, 0, $lastPos);


### PR DESCRIPTION
Follow up of #6937 - No urgency on Symfony's side: I cleared the Travis cache :)

I completely missed this: the generated static map relies on the actual properties of the ClassLoader at compile time. Thus, the `prefixLengthsPsr4` property must be populated if we want the static map to be correcty built (for compat with legacy ClassLoader implementations).

As a bonus (hum...), the static initializer now only considers existing properties. The legacy one created public dynamic properties. This should improve BC/FC in the future.
  
  