### PR TITLE
Fix CTRL+C handling during create-project

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -319,13 +319,16 @@ EOT
         }
 
         // handler Ctrl+C for unix-like systems
-        if (function_exists('pcntl_signal')) {
-            declare(ticks=100);
-            pcntl_signal(SIGINT, function () use ($directory) {
-                $fs = new Filesystem();
-                $fs->removeDirectory($directory);
-                exit(130);
-            });
+        if (function_exists('pcntl_async_signals')) {
+            @mkdir($directory, 0777, true);
+            if ($realDir = realpath($directory)) {
+                pcntl_async_signals(true);
+                pcntl_signal(SIGINT, function () use ($realDir) {
+                    $fs = new Filesystem();
+                    $fs->removeDirectory($realDir);
+                    exit(130);
+                });
+            }
         }
 
         $io->writeError('<info>Installing ' . $package->getName() . ' (' . $package->getFullPrettyVersion(false) . ')</info>');


### PR DESCRIPTION
Since I'm doing a lot of "create-project" these days, I noticed that CTRL+C just doesn't work while that command runs.
The culprit is this logic, which is totally broken:
1. ticks apply to the current file/script only, which means they are useless here and signals are just put on a process queue for the full command execution. The correct fix on PHP <7.1 would be to call explicitly `pcntl_signal_dispatch()` at key points everywhere in the code base. No-go, isn't it? So let's restrict this feature to PHP >=7.1, where we can leverage `pcntl_async_signals()`.
2. the `$directory` variable holds a folder that might be relative. But since composer does `chdir()` at other places, this "relative" aspect means `$fs->removeDirectory($directory);` is basically random...

Here is something that works better (locally at least ;) )
  
  