### PR TITLE
Fixes from PHPStan level 0

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -34,7 +34,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DiagnoseCommand extends BaseCommand
 {
-    /** @var RemoteFileSystem */
+    /** @var RemoteFilesystem */
     protected $rfs;
 
     /** @var ProcessExecutor */

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -279,7 +279,7 @@ EOT
         $minimumStability = $input->getOption('stability') ?: null;
         $minimumStability = $io->askAndValidate(
             'Minimum Stability [<comment>'.$minimumStability.'</comment>]: ',
-            function ($value) use ($self, $minimumStability) {
+            function ($value) use ($minimumStability) {
                 if (null === $value) {
                     return $minimumStability;
                 }

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -41,6 +41,7 @@ abstract class Rule
     const BITFIELD_DISABLED = 16;
 
     protected $bitfield;
+    protected $job;
     protected $reasonData;
 
     /**

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -30,7 +30,7 @@ class Solver
     protected $pool;
     /** @var RepositoryInterface */
     protected $installed;
-    /** @var Ruleset */
+    /** @var RuleSet */
     protected $rules;
     /** @var RuleSetGenerator */
     protected $ruleSetGenerator;

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -546,7 +546,7 @@ class Factory
         $im->addInstaller(new Installer\LibraryInstaller($io, $composer, null));
         $im->addInstaller(new Installer\PearInstaller($io, $composer, 'pear-library'));
         $im->addInstaller(new Installer\PluginInstaller($io, $composer));
-        $im->addInstaller(new Installer\MetapackageInstaller($io));
+        $im->addInstaller(new Installer\MetapackageInstaller());
     }
 
     /**

--- a/src/Composer/Installer/PluginInstaller.php
+++ b/src/Composer/Installer/PluginInstaller.php
@@ -32,9 +32,8 @@ class PluginInstaller extends LibraryInstaller
      *
      * @param IOInterface $io
      * @param Composer    $composer
-     * @param string      $type
      */
-    public function __construct(IOInterface $io, Composer $composer, $type = 'library')
+    public function __construct(IOInterface $io, Composer $composer)
     {
         parent::__construct($io, $composer, 'composer-plugin');
         $this->installationManager = $composer->getInstallationManager();

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -229,7 +229,7 @@ class JsonManipulator
         // child exists
         $childRegex = '{'.self::$DEFINES.'(?P<start>"'.preg_quote($name).'"\s*:\s*)(?P<content>(?&json))(?P<end>,?)}x';
         if ($this->pregMatch($childRegex, $children, $matches)) {
-            $children = preg_replace_callback($childRegex, function ($matches) use ($name, $subName, $value, $that) {
+            $children = preg_replace_callback($childRegex, function ($matches) use ($subName, $value, $that) {
                 if ($subName !== null) {
                     $curVal = json_decode($matches['content'], true);
                     if (!is_array($curVal)) {

--- a/src/Composer/Package/Archiver/BaseExcludeFilter.php
+++ b/src/Composer/Package/Archiver/BaseExcludeFilter.php
@@ -71,7 +71,7 @@ abstract class BaseExcludeFilter
      * Processes a file containing exclude rules of different formats per line
      *
      * @param array    $lines      A set of lines to be parsed
-     * @param callback $lineParser The parser to be used on each line
+     * @param callable $lineParser The parser to be used on each line
      *
      * @return array Exclude patterns to be used in filter()
      */

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -68,7 +68,7 @@ interface RepositoryInterface extends \Countable
      * @param string $query search query
      * @param int    $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only
      *
-     * @return \array[] an array of array('name' => '...', 'description' => '...')
+     * @return array[] an array of array('name' => '...', 'description' => '...')
      */
     public function search($query, $mode = 0);
 }

--- a/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 class RuleSetIteratorTest extends TestCase
 {
     protected $rules;
+    protected $pool;
 
     protected function setUp()
     {

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -20,6 +20,8 @@ use PHPUnit\Framework\TestCase;
 
 class InstallationManagerTest extends TestCase
 {
+    protected $repository;
+
     public function setUp()
     {
         $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');

--- a/tests/Composer/Test/Mock/RemoteFilesystemMock.php
+++ b/tests/Composer/Test/Mock/RemoteFilesystemMock.php
@@ -20,6 +20,8 @@ use Composer\Downloader\TransportException;
  */
 class RemoteFilesystemMock extends RemoteFilesystem
 {
+    protected $contentMap;
+
     /**
      * @param array $contentMap associative array of locations and content
      */

--- a/tests/Composer/Test/Util/PerforceTest.php
+++ b/tests/Composer/Test/Util/PerforceTest.php
@@ -22,6 +22,7 @@ class PerforceTest extends TestCase
 {
     protected $perforce;
     protected $processExecutor;
+    protected $repoConfig;
     protected $io;
 
     const TEST_DEPOT = 'depot';
@@ -224,7 +225,7 @@ class PerforceTest extends TestCase
             'p4user' => 'user',
             'p4password' => 'TEST_PASSWORD',
         );
-        $this->perforce = new Perforce($repoConfig, 'port', 'path', $this->processExecutor, false, $this->getMockIOInterface(), 'TEST');
+        $this->perforce = new Perforce($repoConfig, 'port', 'path', $this->processExecutor, false, $this->getMockIOInterface());
         $password = $this->perforce->queryP4Password();
         $this->assertEquals('TEST_PASSWORD', $password);
     }
@@ -289,7 +290,7 @@ class PerforceTest extends TestCase
                 $this->assertStringStartsWith($expected, fgets($stream));
             }
             $this->assertFalse(fgets($stream));
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             fclose($stream);
             throw $e;
         }
@@ -310,7 +311,7 @@ class PerforceTest extends TestCase
                 $this->assertStringStartsWith($expected, fgets($stream));
             }
             $this->assertFalse(fgets($stream));
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             fclose($stream);
             throw $e;
         }


### PR DESCRIPTION
Some, not all, fixes found by running [`PHPStan`](https://github.com/phpstan/phpstan) at level 0:

File | Problem
---- | ----
src/Composer/DependencyResolver/Rule.php:56 | Access to an undefined property Composer\DependencyResolver\Rule::$job.
src/Composer/Factory.php:549 | Class Composer\Installer\MetapackageInstaller does not have a constructor and must be instantiated without any parameters.
src/Composer/Command/DiagnoseCommand.php:38 | Property Composer\Command\DiagnoseCommand::$rfs has unknown class Composer\Command\RemoteFileSystem as its type.
src/Composer/Command/InitCommand.php:282 | Anonymous function has an unused use $self.
src/Composer/Repository/RepositoryInterface.php:73 | Return typehint of method Composer\Repository\RepositoryInterface::search() has invalid type array.
src/Composer/Package/Archiver/BaseExcludeFilter.php:78 | Parameter $lineParser of method Composer\Package\Archiver\BaseExcludeFilter::parseLines() has invalid typehint type Composer\Package\Archiver\callback.
src/Composer/Installer/PluginInstaller.php: 37 | Constructor of class Composer\Installer\PluginInstaller has an unused parameter $type.
src/Composer/Json/JsonManipulator.php:232 | Anonymous function has an unused use $name.