### PR TITLE
Added instruction to disable xdebug cli

### DIFF
--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -153,6 +153,13 @@ This issue can also happen on cPanel instances, when the shell fork bomb protect
 To improve performance when the xdebug extension is enabled, Composer automatically restarts PHP without it.
 You can override this behavior by using an environment variable: `COMPOSER_ALLOW_XDEBUG=1`.
 
+You can also disable xdebug, only in cli, using the following command (on Linux boxes):
+
+```bash
+# As root:
+phpdismod -s cli xdebug
+```
+
 Composer will always show a warning if xdebug is being used, but you can override this with an environment variable:
 `COMPOSER_DISABLE_XDEBUG_WARN=1`. If you see this warning unexpectedly, then the restart process has failed:
 please report this [issue](https://github.com/composer/composer/issues).


### PR DESCRIPTION
Hello guys,

I've found this solution [here](https://chrisloftus.github.io/tooling/2016/05/05/how-to-disable-xdebug-php7-cli-ubuntu/), that helps when setting up the composer environment.

Worked fine for me and is a simple solution for solving the xdebug performance issue globally, without having to mess up with aliases.
  