### PR TITLE
Add RemoteFilesystem::getRemoteContents() extension point

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -297,7 +297,7 @@ class RemoteFilesystem
             $errorMessage .= preg_replace('{^file_get_contents\(.*?\): }', '', $msg);
         });
         try {
-            $result = file_get_contents($fileUrl, false, $ctx);
+            list($http_response_header, $result) = $this->getRemoteContents($originUrl, $fileUrl, $ctx);
 
             $contentLength = !empty($http_response_header[0]) ? $this->findHeaderValue($http_response_header, 'content-length') : null;
             if ($contentLength && Platform::strlen($result) < $contentLength) {
@@ -536,6 +536,22 @@ class RemoteFilesystem
         }
 
         return $result;
+    }
+
+    /**
+     * Get contents of remote URL.
+     *
+     * @param string   $originUrl The origin URL
+     * @param string   $fileUrl   The file URL
+     * @param resource $context   The stream context
+     *
+     * @return array The response headers and the contents
+     */
+    protected function getRemoteContents($originUrl, $fileUrl, $context)
+    {
+        $contents = file_get_contents($fileUrl, false, $context);
+
+        return array($http_response_header, $contents);
     }
 
     /**


### PR DESCRIPTION
Using this new extension point, I'm able to use a shared cURL connection and speed up downloads by a significant margin (depends on round-trip latency).

This is not as efficient as prefetching as done by prestissimo, but on the other side, this plays well with the existing life cycle.