### PR TITLE
fix gitlab

### DIFF
--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -48,7 +48,7 @@ class Url
         } elseif (in_array($host, $config->get('github-domains'), true)) {
             $url = preg_replace('{(/repos/[^/]+/[^/]+/(zip|tar)ball)(?:/.+)?$}i', '$1/'.$ref, $url);
         } elseif (in_array($host, $config->get('gitlab-domains'), true)) {
-	       $url = preg_replace('/(.*)?sha=(.*)$/i', '$1?sha='.$ref, $url);
+	       $url = preg_replace('/(.*)\?sha=(.*)$/i', '$1?sha='.$ref, $url);
         }
 
         return $url;

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -48,7 +48,7 @@ class Url
         } elseif (in_array($host, $config->get('github-domains'), true)) {
             $url = preg_replace('{(/repos/[^/]+/[^/]+/(zip|tar)ball)(?:/.+)?$}i', '$1/'.$ref, $url);
         } elseif (in_array($host, $config->get('gitlab-domains'), true)) {
-            $url = preg_replace('{(/api/v[34]/projects/[^/]+/repository/archive\.(?:zip|tar\.gz|tar\.bz2|tar)\?sha=).+$}i', '$1'.$ref, $url);
+	       $url = preg_replace('/(.*)?sha=(.*)$/i', '$1?sha='.$ref, $url);
         }
 
         return $url;


### PR DESCRIPTION
with the recent merge of:  https://github.com/composer/composer/commit/e6114b2ca7b2eb75920fd03957070045a1ac1bc1

our internal gitlab broke.

the urls (in lock file): 

```
{
            "name": "krn/authbundle",
            "version": "v0.1.7",
            "source": {
                "type": "git",
                "url": "git@gitlab.krone.at:KRN/AuthBundle.git",
                "reference": "185614a5d70082dc4d73679c7642d5836b2e5553"
            },
            "dist": {
                "type": "zip",
                "url": "http://gitlab.krone.at/api/v4/projects/KRN%2FAuthBundle/repository/archive.zip?sha=185614a5d70082dc4d73679c7642d5836b2e5553",
                "reference": "185614a5d70082dc4d73679c7642d5836b2e5553",
                "shasum": ""
            },
            "require": {
                "php": ">=7.0.0"
            },
            "type": "library",
            "autoload": {
                "psr-4": {
                    "KRNAuthBundle\\": ""
                }
            },
            "support": {
                "src": "http://gitlab.krone.at/KRN/AuthBundle"
            },
            "time": "2017-11-07T09:58:33+00:00"
        },


```


resolved (when using `prefer-dist` ) to:  `gitlab.krone.at185614a5d70082dc4d73679c7642d5836b2e5553` and therefore faild to install.


the patch fixes the regex and now resolves to the working URL