### PR TITLE
Use $strict param in functions that have it

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -53,6 +53,7 @@ return PhpCsFixer\Config::create()
         'psr0' => true,
         'single_blank_line_before_namespace' => true,
         'short_scalar_cast' => true,
+        'strict_param' => true,
         'standardize_not_equals' => true,
         'ternary_operator_spaces' => true,
         'trailing_comma_in_multiline_array' => true,

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -79,7 +79,7 @@ class ClassMapGenerator
 
         foreach ($path as $file) {
             $filePath = $file->getPathname();
-            if (!in_array(pathinfo($filePath, PATHINFO_EXTENSION), array('php', 'inc', 'hh'))) {
+            if (!in_array(pathinfo($filePath, PATHINFO_EXTENSION), array('php', 'inc', 'hh'), true)) {
                 continue;
             }
 

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -361,7 +361,7 @@ EOT
             ),
             'bin-compat' => array(
                 function ($val) {
-                    return in_array($val, array('auto', 'full'));
+                    return in_array($val, array('auto', 'full'), true);
                 },
                 function ($val) {
                     return $val;
@@ -416,7 +416,7 @@ EOT
                     }
 
                     foreach ($vals as $val) {
-                        if (!in_array($val, array('git', 'https', 'ssh'))) {
+                        if (!in_array($val, array('git', 'https', 'ssh'), true)) {
                             return 'valid protocols include: git, https, ssh';
                         }
                     }
@@ -658,7 +658,7 @@ EOT
         $origK = $k;
         $io = $this->getIO();
         foreach ($contents as $key => $value) {
-            if ($k === null && !in_array($key, array('config', 'repositories'))) {
+            if ($k === null && !in_array($key, array('config', 'repositories'), true)) {
                 continue;
             }
 

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -341,7 +341,7 @@ EOT
             $package = $package->getAliasOf();
         }
 
-        if (0 === strpos($package->getPrettyVersion(), 'dev-') && in_array($package->getSourceType(), array('git', 'hg'))) {
+        if (0 === strpos($package->getPrettyVersion(), 'dev-') && in_array($package->getSourceType(), array('git', 'hg'), true)) {
             $package->setSourceReference(substr($package->getPrettyVersion(), 4));
         }
 

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -125,7 +125,7 @@ EOT
         $packages = array_filter(
             $repo->getPackages(),
             function ($package) use ($requires, $packageListNames) {
-                return in_array($package->getName(), $requires) && !in_array($package->getName(), $packageListNames);
+                return in_array($package->getName(), $requires, true) && !in_array($package->getName(), $packageListNames, true);
             }
         );
 

--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -74,7 +74,7 @@ EOT
         }
 
         $script = $input->getArgument('script');
-        if (!in_array($script, $this->scriptEvents)) {
+        if (!in_array($script, $this->scriptEvents, true)) {
             if (defined('Composer\Script\ScriptEvents::'.str_replace('-', '_', strtoupper($script)))) {
                 throw new \InvalidArgumentException(sprintf('Script "%s" cannot be run with this command', $script));
             }

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -205,11 +205,11 @@ TAGSPUBKEY
 
             $pubkeyid = openssl_pkey_get_public($sigFile);
             $algo = defined('OPENSSL_ALGO_SHA384') ? OPENSSL_ALGO_SHA384 : 'SHA384';
-            if (!in_array('SHA384', openssl_get_md_methods())) {
+            if (!in_array('SHA384', openssl_get_md_methods(), true)) {
                 throw new \RuntimeException('SHA384 is not supported by your openssl extension, could not verify the phar file integrity');
             }
             $signature = json_decode($signature, true);
-            $signature = base64_decode($signature['sha384']);
+            $signature = base64_decode($signature['sha384'], true);
             $verified = 1 === openssl_verify(file_get_contents($tempFilename), $signature, $pubkeyid, $algo);
             openssl_free_key($pubkeyid);
             if (!$verified) {

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -119,7 +119,7 @@ EOT
         }
 
         $format = $input->getOption('format');
-        if (!in_array($format, array('text', 'json'))) {
+        if (!in_array($format, array('text', 'json'), true)) {
             $io->writeError(sprintf('Unsupported format "%s". See help for supported formats.', $format));
 
             return 1;
@@ -623,7 +623,7 @@ EOT
         // highlight installed version
         if ($installedRepo->hasPackage($package)) {
             $installedVersion = $package->getPrettyVersion();
-            $key = array_search($installedVersion, $versions);
+            $key = array_search($installedVersion, $versions, true);
             if (false !== $key) {
                 $versions[$key] = '<info>* ' . $installedVersion . '</info>';
             }
@@ -776,12 +776,12 @@ EOT
                 $colorIdent = $level % count($this->colors);
                 $color = $this->colors[$colorIdent];
 
-                $circularWarn = in_array($requireName, $currentTree) ? '(circular dependency aborted here)' : '';
+                $circularWarn = in_array($requireName, $currentTree, true) ? '(circular dependency aborted here)' : '';
                 $info = rtrim(sprintf('%s──<%s>%s</%s> %s %s', $treeBar, $color, $requireName, $color, $require->getPrettyConstraint(), $circularWarn));
                 $this->writeTreeLine($info);
 
                 $treeBar = str_replace('└', ' ', $treeBar);
-                if (!in_array($requireName, $currentTree)) {
+                if (!in_array($requireName, $currentTree, true)) {
                     $currentTree[] = $requireName;
                     $this->displayTree($requireName, $require, $installedRepo, $distantRepos, $currentTree, $treeBar, $level + 1);
                 }

--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -84,7 +84,7 @@ EOT
         $suggested = array();
         foreach ($packages as $package) {
             $packageName = $package['name'];
-            if ((!empty($filter) && !in_array($packageName, $filter)) || empty($package['suggest'])) {
+            if ((!empty($filter) && !in_array($packageName, $filter, true)) || empty($package['suggest'])) {
                 continue;
             }
             foreach ($package['suggest'] as $suggestion => $reason) {

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -197,7 +197,7 @@ EOT
             }
 
             $addedPackage = strtolower($addedPackage);
-            if (!in_array($addedPackage, $packages)) {
+            if (!in_array($addedPackage, $packages, true)) {
                 $packages[] = $addedPackage;
             }
         } while (true);

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -221,7 +221,7 @@ class Compiler
         foreach (token_get_all($source) as $token) {
             if (is_string($token)) {
                 $output .= $token;
-            } elseif (in_array($token[0], array(T_COMMENT, T_DOC_COMMENT))) {
+            } elseif (in_array($token[0], array(T_COMMENT, T_DOC_COMMENT), true)) {
                 $output .= str_repeat("\n", substr_count($token[1], "\n"));
             } elseif (T_WHITESPACE === $token[0]) {
                 // reduce wide spaces

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -130,7 +130,7 @@ class Config
         // override defaults with given config
         if (!empty($config['config']) && is_array($config['config'])) {
             foreach ($config['config'] as $key => $val) {
-                if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic')) && isset($this->config[$key])) {
+                if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic'), true) && isset($this->config[$key])) {
                     $this->config[$key] = array_merge($this->config[$key], $val);
                 } elseif ('preferred-install' === $key && isset($this->config[$key])) {
                     if (is_array($val) || is_array($this->config[$key])) {
@@ -271,7 +271,7 @@ class Config
             case 'bin-compat':
                 $value = $this->getComposerEnv('COMPOSER_BIN_COMPAT') ?: $this->config[$key];
 
-                if (!in_array($value, array('auto', 'full'))) {
+                if (!in_array($value, array('auto', 'full'), true)) {
                     throw new \RuntimeException(
                         "Invalid value for 'bin-compat': {$value}. Expected auto, full"
                     );
@@ -304,7 +304,7 @@ class Config
 
             case 'github-protocols':
                 $protos = $this->config['github-protocols'];
-                if ($this->config['secure-http'] && false !== ($index = array_search('git', $protos))) {
+                if ($this->config['secure-http'] && false !== ($index = array_search('git', $protos, true))) {
                     unset($protos[$index]);
                 }
                 if (reset($protos) === 'http') {
@@ -438,7 +438,7 @@ class Config
 
         // Extract scheme and throw exception on known insecure protocols
         $scheme = parse_url($url, PHP_URL_SCHEME);
-        if (in_array($scheme, array('http', 'git', 'ftp', 'svn'))) {
+        if (in_array($scheme, array('http', 'git', 'ftp', 'svn'), true)) {
             if ($this->get('secure-http')) {
                 throw new TransportException("Your configuration does not allow connections to $url. See https://getcomposer.org/doc/06-config.md#secure-http for details.");
             } elseif ($io) {

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -148,7 +148,7 @@ class FileDownloader implements DownloaderInterface
                         break;
                     } catch (TransportException $e) {
                         // if we got an http response with a proper code, then requesting again will probably not help, abort
-                        if ((0 !== $e->getCode() && !in_array($e->getCode(), array(500, 502, 503, 504))) || !$retries) {
+                        if ((0 !== $e->getCode() && !in_array($e->getCode(), array(500, 502, 503, 504), true)) || !$retries) {
                             throw $e;
                         }
                         $this->io->writeError('');

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -107,7 +107,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
                     $fileSystem->symlink($shortestPath, $path);
                 }
             } catch (IOException $e) {
-                if (in_array(self::STRATEGY_MIRROR, $allowedStrategies)) {
+                if (in_array(self::STRATEGY_MIRROR, $allowedStrategies, true)) {
                     $this->io->writeError('');
                     $this->io->writeError('    <error>Symlink failed, fallback to use mirroring!</error>');
                     $currentStrategy = self::STRATEGY_MIRROR;

--- a/src/Composer/Downloader/PearPackageExtractor.php
+++ b/src/Composer/Downloader/PearPackageExtractor.php
@@ -213,7 +213,7 @@ class PearPackageExtractor
                     $fileName = (string) ($child['name'] ?: $child[0]); // $child[0] means text content
                     $fileSource = $this->combine($source, $fileName);
                     $fileTarget = $this->combine((string) $child['baseinstalldir'] ?: $target, $fileName);
-                    if (!in_array($fileRole, self::$rolesWithoutPackageNamePrefix)) {
+                    if (!in_array($fileRole, self::$rolesWithoutPackageNamePrefix, true)) {
                         $fileTarget = $packageName . '/' . $fileTarget;
                     }
                     $result[(string) $child['name']] = array('from' => $fileSource, 'to' => $fileTarget, 'role' => $fileRole, 'tasks' => array());
@@ -248,7 +248,7 @@ class PearPackageExtractor
                             $fileTasks[] = array('from' => (string) $taskNode->attributes()->from, 'to' => (string) $taskNode->attributes()->to);
                         }
                     }
-                    if (!in_array($fileRole, self::$rolesWithoutPackageNamePrefix)) {
+                    if (!in_array($fileRole, self::$rolesWithoutPackageNamePrefix, true)) {
                         $fileTarget = $packageName . '/' . $fileTarget;
                     }
                     $result[(string) $child['name']] = array('from' => $fileSource, 'to' => $fileTarget, 'role' => $fileRole, 'tasks' => $fileTasks);

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -487,7 +487,7 @@ class EventDispatcher
     protected function pushEvent(Event $event)
     {
         $eventName = $event->getName();
-        if (in_array($eventName, $this->eventStack)) {
+        if (in_array($eventName, $this->eventStack, true)) {
             throw new \RuntimeException(sprintf("Circular call to script handler '%s' detected", $eventName));
         }
 

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -240,7 +240,7 @@ abstract class BaseIO implements IOInterface, LoggerInterface
      */
     public function log($level, $message, array $context = array())
     {
-        if (in_array($level, array(LogLevel::EMERGENCY, LogLevel::ALERT, LogLevel::CRITICAL, LogLevel::ERROR))) {
+        if (in_array($level, array(LogLevel::EMERGENCY, LogLevel::ALERT, LogLevel::CRITICAL, LogLevel::ERROR), true)) {
             $this->writeError('<error>'.$message.'</error>', true, self::NORMAL);
         } elseif ($level === LogLevel::WARNING) {
             $this->writeError('<warning>'.$message.'</warning>', true, self::NORMAL);

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -588,7 +588,7 @@ class Installer
             $this->installationManager->execute($localRepo, $operation);
 
             // output reasons why the operation was ran, only for install/update operations
-            if ($this->verbose && $this->io->isVeryVerbose() && in_array($operation->getJobType(), array('install', 'update'))) {
+            if ($this->verbose && $this->io->isVeryVerbose() && in_array($operation->getJobType(), array('install', 'update'), true)) {
                 $reason = $operation->getReason();
                 if ($reason instanceof Rule) {
                     switch ($reason->getReason()) {
@@ -1337,7 +1337,7 @@ class Installer
                 }
             }
 
-            if (count($depPackages) == 0 && !$nameMatchesRequiredPackage && !in_array($packageName, array('nothing', 'lock', 'mirrors'))) {
+            if (count($depPackages) == 0 && !$nameMatchesRequiredPackage && !in_array($packageName, array('nothing', 'lock', 'mirrors'), true)) {
                 $this->io->writeError('<warning>Package "' . $packageName . '" listed for update is not installed. Ignoring.</warning>');
             }
 

--- a/src/Composer/Installer/SuggestedPackagesReporter.php
+++ b/src/Composer/Installer/SuggestedPackagesReporter.php
@@ -110,7 +110,7 @@ class SuggestedPackagesReporter
         }
 
         foreach ($suggestedPackages as $suggestion) {
-            if (in_array($suggestion['target'], $installedPackages)) {
+            if (in_array($suggestion['target'], $installedPackages, true)) {
                 continue;
             }
 

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -188,7 +188,7 @@ class JsonManipulator
         $decoded = JsonFile::parseJson($this->contents);
 
         $subName = null;
-        if (in_array($mainNode, array('config', 'extra')) && false !== strpos($name, '.')) {
+        if (in_array($mainNode, array('config', 'extra'), true) && false !== strpos($name, '.')) {
             list($name, $subName) = explode('.', $name, 2);
         }
 
@@ -308,7 +308,7 @@ class JsonManipulator
         }
 
         $subName = null;
-        if (in_array($mainNode, array('config', 'extra')) && false !== strpos($name, '.')) {
+        if (in_array($mainNode, array('config', 'extra'), true) && false !== strpos($name, '.')) {
             list($name, $subName) = explode('.', $name, 2);
         }
 

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -212,7 +212,7 @@ abstract class BasePackage implements PackageInterface
      */
     public function getFullPrettyVersion($truncate = true)
     {
-        if (!$this->isDev() || !in_array($this->getSourceType(), array('hg', 'git'))) {
+        if (!$this->isDev() || !in_array($this->getSourceType(), array('hg', 'git'), true)) {
             return $this->getPrettyVersion();
         }
 

--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -278,7 +278,7 @@ class ValidatingArrayLoader implements LoaderInterface
         if ($this->validateArray('autoload') && !empty($this->config['autoload'])) {
             $types = array('psr-0', 'psr-4', 'classmap', 'files', 'exclude-from-classmap');
             foreach ($this->config['autoload'] as $type => $typeConfig) {
-                if (!in_array($type, $types)) {
+                if (!in_array($type, $types, true)) {
                     $this->errors[] = 'autoload : invalid value ('.$type.'), must be one of '.implode(', ', $types);
                     unset($this->config['autoload'][$type]);
                 }

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -413,7 +413,7 @@ class Locker
         $sourceType = $package->getSourceType();
         $datetime = null;
 
-        if ($path && in_array($sourceType, array('git', 'hg'))) {
+        if ($path && in_array($sourceType, array('git', 'hg'), true)) {
             $sourceRef = $package->getSourceReference() ?: $package->getDistReference();
             switch ($sourceType) {
                 case 'git':

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -600,7 +600,7 @@ class Package extends BasePackage
                 } elseif ($urlType === 'source' && $type === 'hg') {
                     $mirrorUrl = ComposerMirror::processHgUrl($mirror['url'], $this->name, $url, $type);
                 }
-                if (!in_array($mirrorUrl, $urls)) {
+                if (!in_array($mirrorUrl, $urls, true)) {
                     $func = $mirror['preferred'] ? 'array_unshift' : 'array_push';
                     $func($urls, $mirrorUrl);
                 }

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -144,7 +144,7 @@ class PluginManager
 
         $oldInstallerPlugin = ($package->getType() === 'composer-installer');
 
-        if (in_array($package->getName(), $this->registeredPlugins)) {
+        if (in_array($package->getName(), $this->registeredPlugins, true)) {
             return;
         }
 

--- a/src/Composer/Repository/BaseRepository.php
+++ b/src/Composer/Repository/BaseRepository.php
@@ -80,7 +80,7 @@ abstract class BaseRepository implements RepositoryInterface
                     if ($link->getTarget() === $needle) {
                         if ($constraint === null || ($link->getConstraint()->matches($constraint) === !$invert)) {
                             // already displayed this node's dependencies, cutting short
-                            if (in_array($link->getSource(), $packagesInTree)) {
+                            if (in_array($link->getSource(), $packagesInTree, true)) {
                                 $results[$link->getSource()] = array($package, $link, false);
                                 continue;
                             }
@@ -93,7 +93,7 @@ abstract class BaseRepository implements RepositoryInterface
             }
 
             // When inverting, we need to check for conflicts of the needles against installed packages
-            if ($invert && in_array($package->getName(), $needles)) {
+            if ($invert && in_array($package->getName(), $needles, true)) {
                 foreach ($package->getConflicts() as $link) {
                     foreach ($this->findPackages($link->getTarget()) as $pkg) {
                         $version = new Constraint('=', $pkg->getVersion());
@@ -105,7 +105,7 @@ abstract class BaseRepository implements RepositoryInterface
             }
 
             // When inverting, we need to check for conflicts of the needles' requirements against installed packages
-            if ($invert && $constraint && in_array($package->getName(), $needles) && $constraint->matches(new Constraint('=', $package->getVersion()))) {
+            if ($invert && $constraint && in_array($package->getName(), $needles, true) && $constraint->matches(new Constraint('=', $package->getVersion()))) {
                 foreach ($package->getRequires() as $link) {
                     if (preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $link->getTarget())) {
                         if ($this->findPackage($link->getTarget(), $link->getConstraint())) {
@@ -120,7 +120,7 @@ abstract class BaseRepository implements RepositoryInterface
                     }
 
                     foreach ($this->getPackages() as $pkg) {
-                        if (!in_array($link->getTarget(), $pkg->getNames())) {
+                        if (!in_array($link->getTarget(), $pkg->getNames(), true)) {
                             continue;
                         }
 
@@ -130,7 +130,7 @@ abstract class BaseRepository implements RepositoryInterface
                             // the root requires as well to perhaps allow to find an issue there
                             if ($rootPackage) {
                                 foreach (array_merge($rootPackage->getRequires(), $rootPackage->getDevRequires()) as $rootReq) {
-                                    if (in_array($rootReq->getTarget(), $pkg->getNames()) && !$rootReq->getConstraint()->matches($link->getConstraint())) {
+                                    if (in_array($rootReq->getTarget(), $pkg->getNames(), true) && !$rootReq->getConstraint()->matches($link->getConstraint())) {
                                         $results[] = array($package, $link, false);
                                         $results[] = array($rootPackage, $rootReq, false);
                                         continue 3;

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -110,7 +110,7 @@ class PlatformRepository extends ArrayRepository
 
         // Extensions scanning
         foreach ($loadedExtensions as $name) {
-            if (in_array($name, array('standard', 'Core'))) {
+            if (in_array($name, array('standard', 'Core'), true)) {
                 continue;
             }
 

--- a/src/Composer/Repository/Vcs/BitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/BitbucketDriver.php
@@ -128,10 +128,10 @@ abstract class BitbucketDriver extends VcsDriver
             if (!isset($composer['support']['source'])) {
                 $label = array_search(
                     $identifier,
-                    $this->getTags()
+                    $this->getTags(), true
                 ) ?: array_search(
                     $identifier,
-                    $this->getBranches()
+                    $this->getBranches(), true
                 ) ?: $identifier;
 
                 if (array_key_exists($label, $tags = $this->getTags())) {

--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -81,7 +81,7 @@ class GitDriver extends VcsDriver
             // select currently checked out branch if master is not available
             $this->process->execute('git branch --no-color', $output, $this->repoDir);
             $branches = $this->process->splitLines($output);
-            if (!in_array('* master', $branches)) {
+            if (!in_array('* master', $branches, true)) {
                 foreach ($branches as $branch) {
                     if ($branch && preg_match('{^\* +(\S+)}', $branch, $match)) {
                         $this->rootIdentifier = $match[1];

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -156,7 +156,7 @@ class GitHubDriver extends VcsDriver
 
                 // specials for github
                 if (!isset($composer['support']['source'])) {
-                    $label = array_search($identifier, $this->getTags()) ?: array_search($identifier, $this->getBranches()) ?: $identifier;
+                    $label = array_search($identifier, $this->getTags(), true) ?: array_search($identifier, $this->getBranches(), true) ?: $identifier;
                     $composer['support']['source'] = sprintf('https://%s/%s/%s/tree/%s', $this->originUrl, $this->owner, $this->repository, $label);
                 }
                 if (!isset($composer['support']['issues']) && $this->hasIssues) {
@@ -188,7 +188,7 @@ class GitHubDriver extends VcsDriver
             try {
                 $resource = $this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/contents/' . $file . '?ref='.urlencode($identifier);
                 $resource = JsonFile::parseJson($this->getContents($resource));
-                if (empty($resource['content']) || $resource['encoding'] !== 'base64' || !($content = base64_decode($resource['content']))) {
+                if (empty($resource['content']) || $resource['encoding'] !== 'base64' || !($content = base64_decode($resource['content'], true))) {
                     throw new \RuntimeException('Could not retrieve ' . $file . ' for '.$identifier);
                 }
 
@@ -267,7 +267,7 @@ class GitHubDriver extends VcsDriver
                 $branchData = JsonFile::parseJson($this->getContents($resource), $resource);
                 foreach ($branchData as $branch) {
                     $name = substr($branch['ref'], 11);
-                    if (!in_array($name, $branchBlacklist)) {
+                    if (!in_array($name, $branchBlacklist, true)) {
                         $this->branches[$name] = $branch['object']['sha'];
                     }
                 }
@@ -289,7 +289,7 @@ class GitHubDriver extends VcsDriver
         }
 
         $originUrl = !empty($matches[2]) ? $matches[2] : $matches[3];
-        if (!in_array(preg_replace('{^www\.}i', '', $originUrl), $config->get('github-domains'))) {
+        if (!in_array(preg_replace('{^www\.}i', '', $originUrl), $config->get('github-domains'), true)) {
             return false;
         }
 

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -494,14 +494,14 @@ class GitLabDriver extends VcsDriver
      */
     private static function determineOrigin(array $configuredDomains, $guessedDomain, array &$urlParts)
     {
-        if (in_array($guessedDomain, $configuredDomains)) {
+        if (in_array($guessedDomain, $configuredDomains, true)) {
             return $guessedDomain;
         }
 
         while (null !== ($part = array_shift($urlParts))) {
             $guessedDomain .= '/' . $part;
 
-            if (in_array($guessedDomain, $configuredDomains)) {
+            if (in_array($guessedDomain, $configuredDomains, true)) {
                 return $guessedDomain;
             }
         }

--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -40,7 +40,7 @@ class AuthHelper
                 'Do you want to store credentials for '.$originUrl.' in '.$configSource->getName().' ? [Yn] ',
                 function ($value) {
                     $input = strtolower(substr(trim($value), 0, 1));
-                    if (in_array($input, array('y','n'))) {
+                    if (in_array($input, array('y','n'), true)) {
                         return $input;
                     }
                     throw new \RuntimeException('Please answer (y)es or (n)o');

--- a/src/Composer/Util/Bitbucket.php
+++ b/src/Composer/Util/Bitbucket.php
@@ -107,7 +107,7 @@ class Bitbucket
                 $this->io->writeError('2. You are using an OAuth consumer, but didn\'t configure a (dummy) callback url');
 
                 return false;
-            } elseif (in_array($e->getCode(), array(403, 401))) {
+            } elseif (in_array($e->getCode(), array(403, 401), true)) {
                 $this->io->writeError('<error>Invalid OAuth consumer provided.</error>');
                 $this->io->writeError('You can also add it manually later by using "composer config --global --auth bitbucket-oauth.bitbucket.org <consumer-key> <consumer-secret>"');
 

--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -51,7 +51,7 @@ class GitHub
      */
     public function authorizeOAuth($originUrl)
     {
-        if (!in_array($originUrl, $this->config->get('github-domains'))) {
+        if (!in_array($originUrl, $this->config->get('github-domains'), true)) {
             return false;
         }
 
@@ -108,7 +108,7 @@ class GitHub
                 'retry-auth-failure' => false,
             ));
         } catch (TransportException $e) {
-            if (in_array($e->getCode(), array(403, 401))) {
+            if (in_array($e->getCode(), array(403, 401), true)) {
                 $this->io->writeError('<error>Invalid token provided.</error>');
                 $this->io->writeError('You can also add it manually later by using "composer config --global --auth github-oauth.github.com <token>"');
 

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -105,7 +105,7 @@ class GitLab
             } catch (TransportException $e) {
                 // 401 is bad credentials,
                 // 403 is max login attempts exceeded
-                if (in_array($e->getCode(), array(403, 401))) {
+                if (in_array($e->getCode(), array(403, 401), true)) {
                     if (401 === $e->getCode()) {
                         $this->io->writeError('Bad credentials.');
                     } else {

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -201,7 +201,7 @@ class RemoteFilesystem
             $this->config
             && is_array($this->config->get('gitlab-domains'))
             && false === strpos($originUrl, '/')
-            && !in_array($originUrl, $this->config->get('gitlab-domains'))
+            && !in_array($originUrl, $this->config->get('gitlab-domains'), true)
         ) {
             foreach ($this->config->get('gitlab-domains') as $gitlabDomain) {
                 if (0 === strpos($gitlabDomain, $originUrl)) {

--- a/src/Composer/Util/TlsHelper.php
+++ b/src/Composer/Util/TlsHelper.php
@@ -141,7 +141,7 @@ final class TlsHelper
         $start = '-----BEGIN PUBLIC KEY-----';
         $end = '-----END PUBLIC KEY-----';
         $pemtrim = substr($pubkeypem, (strpos($pubkeypem, $start) + strlen($start)), (strlen($pubkeypem) - strpos($pubkeypem, $end)) * (-1));
-        $der = base64_decode($pemtrim);
+        $der = base64_decode($pemtrim, true);
 
         return sha1($der);
     }

--- a/src/Composer/XdebugHandler.php
+++ b/src/Composer/XdebugHandler.php
@@ -247,7 +247,7 @@ class XdebugHandler
      */
     private function getScriptArgs(array $args)
     {
-        if (in_array('--no-ansi', $args) || in_array('--ansi', $args)) {
+        if (in_array('--no-ansi', $args, true) || in_array('--ansi', $args, true)) {
             return $args;
         }
 

--- a/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchivableFilesFinderTest.php
@@ -229,7 +229,7 @@ class ArchivableFilesFinderTest extends TestCase
         );
 
         // Remove .hg_archival.txt from the expectedFiles
-        $archiveKey = array_search('/.hg_archival.txt', $expectedFiles);
+        $archiveKey = array_search('/.hg_archival.txt', $expectedFiles, true);
         array_splice($expectedFiles, $archiveKey, 1);
 
         $this->assertArchivableFiles($expectedFiles);


### PR DESCRIPTION
Some functions, e.g. `in_array`, have a third param to enable strict comparison. With PHP-CS-Fixer `strict_param` rule, we can fix all of them :shipit: