### PR TITLE
Added a test to confirm issue #6994.

### DIFF
--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -48,7 +48,7 @@ class Url
         } elseif (in_array($host, $config->get('github-domains'), true)) {
             $url = preg_replace('{(/repos/[^/]+/[^/]+/(zip|tar)ball)(?:/.+)?$}i', '$1/'.$ref, $url);
         } elseif (in_array($host, $config->get('gitlab-domains'), true)) {
-            $url = preg_replace('{(/api/v[34]/projects/[^/]+/repository/archive\.(?:zip|tar\.gz|tar\.bz2|tar)\?sha=).+$}i', '$1'.$ref, $url);
+            $url = preg_replace('{(/api/v[34]/projects/[^/]+/repository/archive\.(?:zip|tar\.gz|tar\.bz2|tar)\?sha=).+$}i', '${1}'.$ref, $url);
         }
 
         return $url;

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -21,12 +21,12 @@ class UrlTest extends TestCase
     /**
      * @dataProvider distRefsProvider
      */
-    public function testUpdateDistReference($url, $expectedUrl, $conf = array())
+    public function testUpdateDistReference($url, $expectedUrl, $conf = array(), $ref = 'newref')
     {
         $config = new Config();
         $config->merge(array('config' => $conf));
 
-        $this->assertSame($expectedUrl, Url::updateDistReference($config, $url, 'newref'));
+        $this->assertSame($expectedUrl, Url::updateDistReference($config, $url, $ref));
     }
 
     public static function distRefsProvider()
@@ -55,6 +55,7 @@ class UrlTest extends TestCase
             // gitlab enterprise
             array('https://mygitlab.com/api/v4/projects/foo%2Fbar/repository/archive.tar.gz?sha=abcd',  'https://mygitlab.com/api/v4/projects/foo%2Fbar/repository/archive.tar.gz?sha=newref', array('gitlab-domains' => array('mygitlab.com'))),
             array('https://mygitlab.com/api/v3/projects/foo%2Fbar/repository/archive.tar.bz2?sha=abcd', 'https://mygitlab.com/api/v3/projects/foo%2Fbar/repository/archive.tar.bz2?sha=newref', array('gitlab-domains' => array('mygitlab.com'))),
+	        array('https://mygitlab.com/api/v3/projects/foo%2Fbar/repository/archive.tar.bz2?sha=abcd', 'https://mygitlab.com/api/v3/projects/foo%2Fbar/repository/archive.tar.bz2?sha=65', array('gitlab-domains' => array('mygitlab.com')), '65'),
         );
     }
 }


### PR DESCRIPTION
Added a encapsulated group to the replacement parameter of the `preg_replace` for GitLab in `\Composer\Util\Url::updateDistReference()`. This fixes #6994.