### PR TITLE
Show reason for php version package mismatch due to config.platform

### DIFF
--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -11,6 +11,7 @@
  */
 
 namespace Composer\DependencyResolver;
+use Composer\Package\CompletePackageInterface;
 
 /**
  * Represents a problem detected while solving dependencies
@@ -91,7 +92,13 @@ class Problem
                 // handle php/hhvm
                 if ($job['packageName'] === 'php' || $job['packageName'] === 'php-64bit' || $job['packageName'] === 'hhvm') {
                     $available = $this->pool->whatProvides($job['packageName']);
-                    $version = count($available) ? $available[0]->getPrettyVersion() : phpversion();
+                    $firstAvailable = reset($available);
+
+                    $version = count($available) ? $firstAvailable->getPrettyVersion() : phpversion();
+                    if (count($available) && $firstAvailable instanceof CompletePackageInterface) {
+                        $version .= '; ' . $firstAvailable->getDescription();
+                    }
+
 
                     $msg = "\n    - This package requires ".$job['packageName'].$this->constraintToText($job['constraint']).' but ';
 


### PR DESCRIPTION
A couple of times I've run into a frustrating situation where a config.platform generated by the Symfony installer has specified a php 5 version and I've changed my require to php 7 without realizing the config.platform issue. That leaves me hunting for a version of php that isn't installed anywhere on my system. Using verbose or even very very verbose doesn't seem to help. 

I used xdebug to track it down and saw that the package knew what the problem really was in its description but it wasn't revealing this to the user. This patch exposes that information. The nested parens aren't pretty, but I think developers will be able to parse it.

The patch starts by determining the version in the same way it used to. Then it double checks that we have a package, and that it is a CompletePackage so that it has a description. If so it appends the description to the version information.

I double checked it with phpcs and it complained about line lengths, but it also did this for much of the rest of the file.

The output looks like this:

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - This package requires php >=7.0.0 but your PHP version (5.6.0; Package overridden via config.platform (actual: 7.0.22)) does not satisfy that requirement.
```