### PR TITLE
provide fix for issue #7025

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -665,7 +665,7 @@ class Filesystem
          * Stat cache should be cleared before to avoid accidentally reading wrong information from previous installs.
          */
         clearstatcache(true, $junction);
-        // clearstatcache(false);
+        clearstatcache(false);
         $stat = lstat($junction);
 
         return !($stat['mode'] & 0xC000);

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -664,7 +664,8 @@ class Filesystem
          *
          * Stat cache should be cleared before to avoid accidentally reading wrong information from previous installs.
          */
-        clearstatcache(false);
+        clearstatcache(true, $junction);
+        // clearstatcache(false);
         $stat = lstat($junction);
 
         return !($stat['mode'] & 0xC000);

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -663,9 +663,6 @@ class Filesystem
          * #define	_S_IFREG	0x8000
          *
          * Stat cache should be cleared before to avoid accidentally reading wrong information from previous installs.
-         
-         * n.b. now clearing the entire stat cache, for its troubles in php7.1-windows, appearing and
-         * diagnosed in composer github issue #7025 -- @narrationsd 22 Jan 2018
          */
         clearstatcache(false);
         $stat = lstat($junction);

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -663,8 +663,11 @@ class Filesystem
          * #define	_S_IFREG	0x8000
          *
          * Stat cache should be cleared before to avoid accidentally reading wrong information from previous installs.
+         
+         * n.b. now clearing the entire stat cache, for its troubles in php7.1-windows, appearing and
+         * diagnosed in composer github issue #7025 -- @narrationsd 22 Jan 2018
          */
-        clearstatcache(true, $junction);
+        clearstatcache(false);
         $stat = lstat($junction);
 
         return !($stat['mode'] & 0xC000);


### PR DESCRIPTION
This small change means consistent values will be returned for lstat modes on repositories 'symlinked' by composer require.  In truth these are linked by junctions when on Windows. 

With the prior statcacheclear according to file only, lstat() will return arbitrary values from other files or folders. With this general clear, php-windows will return a consistent zero, which although incorrect, suffices for Composer to determine it is indeed a junction, and use its correct handling.

The issues with php-windows lstat are known to the Composer team, and the serious problem from them in #7025 shows up at least on a fast multicore Windows machine, running php7.1-windows.  This patch appears to relieve this problem consistently.