### PR TITLE
Fix RemoteFilesystem::getRemoteContents() on-failure behavior

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -551,7 +551,7 @@ class RemoteFilesystem
     {
         $contents = file_get_contents($fileUrl, false, $context);
 
-        return array($http_response_header, $contents);
+        return array(isset($http_response_header) ? $http_response_header : null, $contents);
     }
 
     /**


### PR DESCRIPTION
Instead of "Undefined variable $http_response_header" when network is off.