### PR TITLE
Lock _readme: remove outdated hashtag link part

### DIFF
--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -289,7 +289,7 @@ class Locker
     {
         $lock = array(
             '_readme' => array('This file locks the dependencies of your project to a known state',
-                               'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file',
+                               'Read more about it at https://getcomposer.org/doc/01-basic-usage.md',
                                'This file is @gener'.'ated automatically', ),
             'content-hash' => $this->contentHash,
             'packages' => null,

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -133,7 +133,7 @@ class LockerTest extends TestCase
             ->method('write')
             ->with(array(
                 '_readme' => array('This file locks the dependencies of your project to a known state',
-                                   'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file',
+                                   'Read more about it at https://getcomposer.org/doc/01-basic-usage.md',
                                    'This file is @gener'.'ated automatically', ),
                 'content-hash' => $contentHash,
                 'packages' => array(


### PR DESCRIPTION
`#composer-lock-the-lock-file` doesn't exist anymore in https://getcomposer.org/doc/01-basic-usage.md

I propose to get rid of the hastag part to ease the maintenance of the link.