### PR TITLE
Wording:Use Downgrading instead of Updating

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -214,7 +214,8 @@ class FileDownloader implements DownloaderInterface
         $from = $initial->getPrettyVersion();
         $to = $target->getPrettyVersion();
 
-        $this->io->writeError("  - Updating <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>): ", false);
+        $actionName = version_compare($from, $to, '<') ? 'Updating' : 'Downgrading';
+        $this->io->writeError("  - " . $actionName . " <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>): ", false);
 
         $this->remove($initial, $path, false);
         $this->download($target, $path, false);

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -130,7 +130,8 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
             $to = $target->getFullPrettyVersion();
         }
 
-        $this->io->writeError("  - Updating <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>): ", false);
+        $actionName = $this->packageCompare($initial, $target, '>') ? 'Downgrading' : 'Updating';
+        $this->io->writeError("  - " . $actionName . " <info>" . $name . "</info> (<comment>" . $from . "</comment> => <comment>" . $to . "</comment>): ", false);
 
         $this->cleanChanges($initial, $path, true);
         $urls = $target->getSourceUrls();
@@ -240,6 +241,23 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
         if (null !== $this->getLocalChanges($package, $path)) {
             throw new \RuntimeException('Source directory ' . $path . ' has uncommitted changes.');
         }
+    }
+
+    /**
+     * Compare two packages. Always false if both versions are references
+     *
+     * @param  PackageInterface $initial
+     * @param  PackageInterface $target
+     * @param  string           $operation
+     * @return bool
+     */
+    protected function packageCompare(PackageInterface $initial, PackageInterface $target, $operation = '<')
+    {
+        if ($initial->getPrettyVersion() == $target->getPrettyVersion()) {
+            return false;
+        }
+
+        return version_compare($initial->getFullPrettyVersion(), $target->getFullPrettyVersion(), $operation);
     }
 
     /**


### PR DESCRIPTION
Add logic for choosing correct word for the action performed on a package (update/downgrade). 
Related to #7085.

Should work with both packages that use tags and those which does not