### PR TITLE
Fix for #7125: Allowing to use fossil dependency in a fossil repository

### DIFF
--- a/src/Composer/Downloader/FossilDownloader.php
+++ b/src/Composer/Downloader/FossilDownloader.php
@@ -36,7 +36,7 @@ class FossilDownloader extends VcsDownloader
         if (0 !== $this->process->execute($command, $ignoredOutput)) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
         }
-        $command = sprintf('fossil open %s', ProcessExecutor::escape($repoFile));
+        $command = sprintf('fossil open %s --nested', ProcessExecutor::escape($repoFile));
         if (0 !== $this->process->execute($command, $ignoredOutput, realpath($path))) {
             throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
         }

--- a/src/Composer/Repository/Vcs/FossilDriver.php
+++ b/src/Composer/Repository/Vcs/FossilDriver.php
@@ -96,7 +96,7 @@ class FossilDriver extends VcsDriver
                 throw new \RuntimeException('Failed to clone '.$this->url.' to repository ' . $this->repoFile . "\n\n" .$output);
             }
 
-            if (0 !== $this->process->execute(sprintf('fossil open %s', ProcessExecutor::escape($this->repoFile)), $output, $this->checkoutDir)) {
+            if (0 !== $this->process->execute(sprintf('fossil open %s --nested', ProcessExecutor::escape($this->repoFile)), $output, $this->checkoutDir)) {
                 $output = $this->process->getErrorOutput();
 
                 throw new \RuntimeException('Failed to open repository '.$this->repoFile.' in ' . $this->checkoutDir . "\n\n" .$output);

--- a/tests/Composer/Test/Downloader/FossilDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FossilDownloaderTest.php
@@ -76,7 +76,7 @@ class FossilDownloaderTest extends TestCase
             ->with($this->equalTo($expectedFossilCommand))
             ->will($this->returnValue(0));
 
-        $expectedFossilCommand = $this->getCmd('fossil open \'repo.fossil\'');
+        $expectedFossilCommand = $this->getCmd('fossil open \'repo.fossil\' --nested');
         $processExecutor->expects($this->at(1))
             ->method('execute')
             ->with($this->equalTo($expectedFossilCommand))


### PR DESCRIPTION
This fix the issue at https://github.com/composer/composer/issues/7125

Tested vs the following case

```
mkdir project;
cd project;
fossil clone http://chiselapp.com/user/edwrodrig/repository/composer_project r.fossil;
fossil open r.fossil;
composer update;
```