### PR TITLE
Remove the word "just" from documentation

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -57,16 +57,16 @@ project, or globally as a system wide executable.
 
 #### Locally
 
-Installing Composer locally is a matter of just running the installer in your
+Installing Composer locally is a matter of running the installer in your
 project directory. See [the Download page](https://getcomposer.org/download/)
 for instructions.
 
-The installer will just check a few PHP settings and then download
+The installer will check a few PHP settings and then download
 `composer.phar` to your working directory. This file is the Composer binary. It
 is a PHAR (PHP archive), which is an archive format for PHP which can be run on
 the command line, amongst other things.
 
-Now just run `php composer.phar` in order to run Composer.
+Now run `php composer.phar` in order to run Composer.
 
 You can install Composer to a specific directory by using the `--install-dir`
 option and additionally (re)name it as well using the `--filename` option. When
@@ -78,7 +78,7 @@ following parameters:
 php composer-setup.php --install-dir=bin --filename=composer
 ```
 
-Now just run `php bin/composer` in order to run Composer.
+Now run `php bin/composer` in order to run Composer.
 
 #### Globally
 
@@ -105,7 +105,7 @@ mv composer.phar /usr/local/bin/composer
 > **Note:** For information on changing your PATH, please read the
 > [Wikipedia article](https://en.wikipedia.org/wiki/PATH_(variable)) and/or use Google.
 
-Now just run `composer` in order to run Composer instead of `php composer.phar`.
+Now run `composer` in order to run Composer instead of `php composer.phar`.
 
 ## Installation - Windows
 
@@ -115,7 +115,7 @@ This is the easiest way to get Composer set up on your machine.
 
 Download and run
 [Composer-Setup.exe](https://getcomposer.org/Composer-Setup.exe). It will
-install the latest Composer version and set up your PATH so that you can just
+install the latest Composer version and set up your PATH so that you can
 call `composer` from any directory in your command line.
 
 > **Note:** Close your current terminal. Test usage with a new terminal: This is

--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -44,7 +44,7 @@ about Packagist [below](#packagist), or read more about repositories
 ### Package Names
 
 The package name consists of a vendor name and the project's name. Often these
-will be identical - the vendor name just exists to prevent naming clashes. For
+will be identical - the vendor name exists to prevent naming clashes. For
 example, it would allow two different people to create a library named `json`.
 One might be named `igorw/json` while the other might be `seldaek/json`.
 
@@ -86,7 +86,7 @@ versions, how versions relate to each other, and on version constraints.
 
 ## Installing Dependencies
 
-To install the defined dependencies for your project, just run the
+To install the defined dependencies for your project, run the
 [`install`](03-cli.md#install) command.
 
 ```sh
@@ -196,7 +196,7 @@ includes PHP itself, PHP extensions and some system libraries.
 
 * `ext-<name>` allows you to require PHP extensions (includes core
   extensions). Versioning can be quite inconsistent here, so it's often
-  a good idea to just set the constraint to `*`.  An example of an extension
+  a good idea to set the constraint to `*`.  An example of an extension
   package name is `ext-gd`.
 
 * `lib-<name>` allows constraints to be made on versions of libraries used by
@@ -258,7 +258,7 @@ more information.
 See also the docs on [optimizing the autoloader](articles/autoloader-optimization.md).
 
 > **Note:** Composer provides its own autoloader. If you don't want to use that
-> one, you can just include `vendor/composer/autoload_*.php` files, which return
+> one, you can include `vendor/composer/autoload_*.php` files, which return
 > associative arrays allowing you to configure your own autoloader.
 
 &larr; [Intro](00-intro.md)  |  [Libraries](02-libraries.md) &rarr;


### PR DESCRIPTION
Although the word "just" is intended to convey simplicity, it can have the unintended side effect of make the reader feel disempowered:

http://bradfrost.com/blog/post/just/