### PR TITLE
perf improvement: refactored "svn --version" calls into a single place

### DIFF
--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -57,11 +57,10 @@ class SvnDownloader extends VcsDownloader
             throw new \RuntimeException('The .svn directory is missing from '.$path.', see https://getcomposer.org/commit-deps for more information');
         }
 
+        $util = new SvnUtil($url, $this->io, $this->config);
         $flags = "";
-        if (0 === $this->process->execute('svn --version', $output)) {
-            if (preg_match('{(\d+(?:\.\d+)+)}', $output, $match) && version_compare($match[1], '1.7.0', '>=')) {
-                $flags .= ' --ignore-ancestry';
-            }
+        if (version_compare($util->binaryVersion(), '1.7.0', '>=')) {
+            $flags .= ' --ignore-ancestry';
         }
 
         $this->io->writeError(" Checking out " . $ref);

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -353,7 +353,7 @@ class SvnDriver extends VcsDriver
         try {
             return $this->util->execute($command, $url);
         } catch (\RuntimeException $e) {
-            if (!$this->util->binaryVersion()) {
+            if (null === $this->util->binaryVersion()) {
                 throw new \RuntimeException('Failed to load '.$this->url.', svn was not found, check that it is installed and in your PATH env.' . "\n\n" . $this->process->getErrorOutput());
             }
 

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -353,7 +353,7 @@ class SvnDriver extends VcsDriver
         try {
             return $this->util->execute($command, $url);
         } catch (\RuntimeException $e) {
-            if (0 !== $this->process->execute('svn --version', $ignoredOutput)) {
+            if (!$this->util->binaryVersion()) {
                 throw new \RuntimeException('Failed to load '.$this->url.', svn was not found, check that it is installed and in your PATH env.' . "\n\n" . $this->process->getErrorOutput());
             }
 

--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -62,6 +62,11 @@ class Svn
      * @var \Composer\Config
      */
     protected $config;
+    
+    /**
+     * @var string|null
+     */
+    static private $version;
 
     /**
      * @param string                   $url
@@ -359,18 +364,21 @@ class Svn
 
         return $this->hasAuth = true;
     }
-
+    
+    /**
+     * Returns the version of the svn binary contained in PATH
+     *
+     * @return string|null
+     */
     public function binaryVersion() {
-        static $version = null;
-
-        if (!$version) {
+        if (!self::$version) {
             if (0 === $this->process->execute('svn --version', $output)) {
                 if (preg_match('{(\d+(?:\.\d+)+)}', $output, $match)) {
-                    $version = $match[1];
+                    self::$version = $match[1];
                 }
             }
         }
 
-        return $version;
+        return self::$version;
     }
 }

--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -359,4 +359,18 @@ class Svn
 
         return $this->hasAuth = true;
     }
+
+    public function binaryVersion() {
+        static $version = null;
+
+        if (!$version) {
+            if (0 === $this->process->execute('svn --version', $output)) {
+                if (preg_match('{(\d+(?:\.\d+)+)}', $output, $match)) {
+                    $version = $match[1];
+                }
+            }
+        }
+
+        return $version;
+    }
 }


### PR DESCRIPTION
this saves a lot of process-spawning as we re-use the result of a process started once.

with this changes the overall number of processes spawned by composer dropped from 156 to 89 in my real world test case (same scenario/config we use in production with satis).

this reduces wall time by 2 seconds.