### PR TITLE
properly cache when a branch in a certain revision does not contain a…

### DIFF
--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -125,7 +125,16 @@ class SvnDriver extends VcsDriver
                 return $this->infoCache[$identifier] = JsonFile::parseJson($res);
             }
 
-            $composer = $this->getBaseComposerInformation($identifier);
+            try {
+                $composer = $this->getBaseComposerInformation($identifier);
+            } catch(TransportException $e) {
+                $message = $e->getMessage();
+                if (stripos($message, 'path not found') === false && stripos($message, 'svn: warning: W160013') === false) {
+                    throw $e;
+                }
+                // remember a not-existent composer.json
+                $composer = '';
+            }
 
             $this->cache->write($identifier.'.json', json_encode($composer));
 


### PR DESCRIPTION
… composer.json

this prevents requesting/trying to get the composer.json over and over again even if no commits happend.

blackfire diff of this change
https://blackfire.io/profiles/compare/4133c999-9ad5-4c38-af1d-d5c8f6497f16/graph

fixes https://github.com/composer/satis/issues/462