### PR TITLE
Fix run-script -l

### DIFF
--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -15,6 +15,7 @@ namespace Composer\Command;
 use Composer\Script\Event as ScriptEvent;
 use Composer\Script\ScriptEvents;
 use Composer\Util\ProcessExecutor;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -114,10 +115,14 @@ EOT
         $io->writeError('<info>scripts:</info>');
         $table = array();
         foreach ($scripts as $name => $script) {
-            $cmd = $this->getApplication()->find($name);
             $description = '';
-            if ($cmd instanceof ScriptAliasCommand) {
-                $description = $cmd->getDescription();
+            try {
+                $cmd = $this->getApplication()->find($name);
+                if ($cmd instanceof ScriptAliasCommand) {
+                    $description = $cmd->getDescription();
+                }
+            } catch (CommandNotFoundException $e) {
+                // script is not known by Composer
             }
             $table[] = array('  '.$name, $description);
         }


### PR DESCRIPTION
My `composer.json`:

```json
{
    "scripts": {
        "auto-scripts": {
        },
        "post-install-cmd": [
            "@auto-scripts"
        ],
        "post-update-cmd": [
            "@auto-scripts"
        ]
    }
}
```

Output of `composer diagnose`:

```
Checking composer.json: WARNING
No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
Checking platform settings: OK
Checking git settings: OK
Checking http connectivity to packagist: OK
Checking https connectivity to packagist: OK
Checking github.com oauth access: OK
Checking disk free space: OK
Checking pubkeys:
Tags Public Key Fingerprint: 57815BA2 7E54DC31 7ECC7CC5 573090D0  87719BA6 8F3BB723 4E5D42D0 84A14642
Dev Public Key Fingerprint: 4AC45767 E5EC2265 2F0C1167 CBBB8A2B  0C708369 153E328C AD90147D AFE50952
OK
Checking composer version: WARNING
You are not running the latest snapshot version, run `composer self-update` to update (f31e2552be7fb8f165af001b912c2bcfc2459245 => 4d8b9be5b6a0bda0a3d24c0a6ff89d7ccb26f715)
Composer version: f31e2552be7fb8f165af001b912c2bcfc2459245
PHP version: 7.2.3
PHP binary path: /Users/fabien/.symfony/bin/php
```

When I run this command:

```
composer run-script -l
```

I get the following output:

```
scripts:


  [Symfony\Component\Console\Exception\CommandNotFoundException]
  Command "post-install-cmd" is not defined.


run-script [--timeout TIMEOUT] [--dev] [--no-dev] [-l|--list] [--] [<script>] [<args>]...
```

And I expected this to happen:

```
scripts:
  auto-scripts      Runs the auto-scripts script as defined in composer.json.
  post-install-cmd
  post-update-cmd
```

This bug was introduced by 1a6e3ee.
