### PR TITLE
Fix: Add type field to schema for inline-package

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -683,6 +683,7 @@
             }
         },
         "inline-package": {
+            "type": "object",
             "required": ["name", "version"],
             "properties": {
                 "name": {


### PR DESCRIPTION
This PR

* [x] adds a `type` field to the definition of an `inline-package`
