### PR TITLE
added blackfire captured metrics for subprocesses

### DIFF
--- a/.blackfire.yml
+++ b/.blackfire.yml
@@ -1,0 +1,8 @@
+metrics:
+  composer.processes: # metric name
+    label: "composer subprocesses"
+    matching_calls:
+      php:
+        - callee:
+            selector: '=Composer\Util\ProcessExecutor::execute' # aggregate the costs of all Cache::write calls
+            argument: { 1: "^" }  # but create separate nodes by the first argument value


### PR DESCRIPTION
utilize [metrics argument capturing](https://blackfire.io/docs/reference-guide/metrics#metrics-capturing-arguments) to get a better understanding of which cli commands are actually slow.

so with this change one can get a better picture of what is going..

before this patch
![grafik](https://user-images.githubusercontent.com/120441/37163983-6b821114-22f9-11e8-9812-140b88abe49c.png)


after this patch
![grafik](https://user-images.githubusercontent.com/120441/37163989-70c5251c-22f9-11e8-9bfb-d75db9bc950a.png)
