### PR TITLE
Fix: Keep rules sorted

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -24,12 +24,12 @@ return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
     ->setRules(array(
         '@PSR2' => true,
+        'array_syntax' => array('syntax' => 'long'),
         'binary_operator_spaces' => true,
         'blank_line_before_return' => true,
         'cast_spaces' => true,
         'header_comment' => array('header' => $header),
         'include' => true,
-        'array_syntax' => array('syntax' => 'long'),
         'method_separation' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
@@ -51,8 +51,8 @@ return PhpCsFixer\Config::create()
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
         'psr0' => true,
-        'single_blank_line_before_namespace' => true,
         'short_scalar_cast' => true,
+        'single_blank_line_before_namespace' => true,
         'standardize_not_equals' => true,
         'ternary_operator_spaces' => true,
         'trailing_comma_in_multiline_array' => true,


### PR DESCRIPTION
This PR

* [x] keeps rules in `php_cs` sorted

💁‍♂️ Makes it easier to find, and to determine where to add a new rule.