### PR TITLE
Load autoload files for global package

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -177,6 +177,14 @@ class PluginManager
         $classLoader = $generator->createLoader($map);
         $classLoader->register();
 
+        foreach ($map['files'] as $fileIdentifier => $file) {
+            if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
+                require $file;
+
+                $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;
+            }
+        }
+
         foreach ($classes as $class) {
             if (class_exists($class, false)) {
                 $class = trim($class, '\\');


### PR DESCRIPTION
Actually only a class loader is created, as an example functions defined in global package are never loaded.

However i'm not sure if this is the right way to do that.