### PR TITLE
Choose correct url on saving credentials after redirects

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -504,7 +504,8 @@ class RemoteFilesystem
 
             if ($this->storeAuth && $this->config) {
                 $authHelper = new AuthHelper($this->io, $this->config);
-                $authHelper->storeAuth($this->originUrl, $this->storeAuth);
+                $originUrl = $this->io->hasAuthentication($this->originUrl) ? $this->originUrl : $originUrl;
+                $authHelper->storeAuth($originUrl, $this->storeAuth);
                 $this->storeAuth = false;
             }
 

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -504,8 +504,8 @@ class RemoteFilesystem
 
             if ($this->storeAuth && $this->config) {
                 $authHelper = new AuthHelper($this->io, $this->config);
-                $originUrl = $this->io->hasAuthentication($this->originUrl) ? $this->originUrl : $originUrl;
-                $authHelper->storeAuth($originUrl, $this->storeAuth);
+                $authUrl = $this->io->hasAuthentication($this->originUrl) ? $this->originUrl : $originUrl;
+                $authHelper->storeAuth($authUrl, $this->storeAuth);
                 $this->storeAuth = false;
             }
 


### PR DESCRIPTION
Problem with storing credentials after redirects

What Composer does today:
- User requests package from hostname/foo/1.0.0.zip
- `hostname` does authorization 
- `hostname` redirects to location otherhost/foo/1.0.0.zip
- `other-host` download the package
- tries to save credentials for `other-host`

Problem is that there are no credentials for the `other-host` but are for `hostname`.

Solution:
Check if there exists credentials for the  `other-host` and if yes then store them.
Otherwise try to store credentials for `hostname`.