### PR TITLE
Avoid using 'just' in documentation

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -57,16 +57,15 @@ project, or globally as a system wide executable.
 
 #### Locally
 
-Installing Composer locally is a matter of just running the installer in your
-project directory. See [the Download page](https://getcomposer.org/download/)
-for instructions.
+To install Composer locally, run the installer in your project directory. See 
+[the Download page](https://getcomposer.org/download/) for instructions.
 
-The installer will just check a few PHP settings and then download
-`composer.phar` to your working directory. This file is the Composer binary. It
-is a PHAR (PHP archive), which is an archive format for PHP which can be run on
+The installer will check a few PHP settings and then download `composer.phar`
+to your working directory. This file is the Composer binary. It is a PHAR
+(PHP archive), which is an archive format for PHP which can be run on
 the command line, amongst other things.
 
-Now just run `php composer.phar` in order to run Composer.
+Now run `php composer.phar` in order to run Composer.
 
 You can install Composer to a specific directory by using the `--install-dir`
 option and additionally (re)name it as well using the `--filename` option. When
@@ -78,7 +77,7 @@ following parameters:
 php composer-setup.php --install-dir=bin --filename=composer
 ```
 
-Now just run `php bin/composer` in order to run Composer.
+Now run `php bin/composer` in order to run Composer.
 
 #### Globally
 
@@ -105,7 +104,7 @@ mv composer.phar /usr/local/bin/composer
 > **Note:** For information on changing your PATH, please read the
 > [Wikipedia article](https://en.wikipedia.org/wiki/PATH_(variable)) and/or use Google.
 
-Now just run `composer` in order to run Composer instead of `php composer.phar`.
+Now run `composer` in order to run Composer instead of `php composer.phar`.
 
 ## Installation - Windows
 
@@ -115,7 +114,7 @@ This is the easiest way to get Composer set up on your machine.
 
 Download and run
 [Composer-Setup.exe](https://getcomposer.org/Composer-Setup.exe). It will
-install the latest Composer version and set up your PATH so that you can just
+install the latest Composer version and set up your PATH so that you can
 call `composer` from any directory in your command line.
 
 > **Note:** Close your current terminal. Test usage with a new terminal: This is

--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -44,7 +44,7 @@ about Packagist [below](#packagist), or read more about repositories
 ### Package Names
 
 The package name consists of a vendor name and the project's name. Often these
-will be identical - the vendor name just exists to prevent naming clashes. For
+will be identical - the vendor name only exists to prevent naming clashes. For
 example, it would allow two different people to create a library named `json`.
 One might be named `igorw/json` while the other might be `seldaek/json`.
 
@@ -86,7 +86,7 @@ versions, how versions relate to each other, and on version constraints.
 
 ## Installing Dependencies
 
-To install the defined dependencies for your project, just run the
+To install the defined dependencies for your project, run the
 [`install`](03-cli.md#install) command.
 
 ```sh
@@ -196,7 +196,7 @@ includes PHP itself, PHP extensions and some system libraries.
 
 * `ext-<name>` allows you to require PHP extensions (includes core
   extensions). Versioning can be quite inconsistent here, so it's often
-  a good idea to just set the constraint to `*`.  An example of an extension
+  a good idea to set the constraint to `*`.  An example of an extension
   package name is `ext-gd`.
 
 * `lib-<name>` allows constraints to be made on versions of libraries used by
@@ -258,7 +258,7 @@ more information.
 See also the docs on [optimizing the autoloader](articles/autoloader-optimization.md).
 
 > **Note:** Composer provides its own autoloader. If you don't want to use that
-> one, you can just include `vendor/composer/autoload_*.php` files, which return
+> one, you can include `vendor/composer/autoload_*.php` files, which return
 > associative arrays allowing you to configure your own autoloader.
 
 &larr; [Intro](00-intro.md)  |  [Libraries](02-libraries.md) &rarr;

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -129,7 +129,7 @@ php composer.phar update
 This will resolve all dependencies of the project and write the exact versions
 into `composer.lock`.
 
-If you just want to update a few packages and not all, you can list them as such:
+If you only want to update a few packages and not all, you can list them as such:
 
 ```sh
 php composer.phar update vendor/package vendor/package2
@@ -184,7 +184,7 @@ php composer.phar require
 After adding/changing the requirements, the modified requirements will be
 installed or updated.
 
-If you do not want to choose requirements interactively, you can just pass them
+If you do not want to choose requirements interactively, you can pass them
 to the command.
 
 ```sh
@@ -272,7 +272,7 @@ This can be used to install CLI utilities globally. Here is an example:
 php composer.phar global require friendsofphp/php-cs-fixer
 ```
 
-Now the `php-cs-fixer` binary is available globally. Just make sure your global
+Now the `php-cs-fixer` binary is available globally. Make sure your global
 [vendor binaries](articles/vendor-binaries.md) directory is in your `$PATH`
 environment variable, you can get its location with the following command :
 
@@ -280,7 +280,7 @@ environment variable, you can get its location with the following command :
 php composer.phar global config bin-dir --absolute
 ```
 
-If you wish to update the binary later on you can just run a global update:
+If you wish to update the binary later on you can run a global update:
 
 ```sh
 php composer.phar global update
@@ -289,7 +289,7 @@ php composer.phar global update
 ## search
 
 The search command allows you to search through the current project's package
-repositories. Usually this will be just packagist. You simply pass it the
+repositories. Usually this will be packagist. You simply pass it the
 terms you want to search for.
 
 ```sh
@@ -520,7 +520,7 @@ vendor/seld/jsonlint:
 
 ## self-update (selfupdate)
 
-To update Composer itself to the latest version, just run the `self-update`
+To update Composer itself to the latest version, run the `self-update`
 command. It will replace your `composer.phar` with the latest version.
 
 ```sh
@@ -721,7 +721,7 @@ Lists the name, version and license of every package installed. Use
 * **--list (-l):** List user defined scripts.
 
 To run [scripts](articles/scripts.md) manually you can use this command,
-just give it the script name and optionally any required arguments.
+give it the script name and optionally any required arguments.
 
 ## exec
 
@@ -762,7 +762,7 @@ php composer.phar archive vendor/package 2.0.21 --format=zip
 
 ## help
 
-To get more information about a certain command, just use `help`.
+To get more information about a certain command, you can use `help`.
 
 ```sh
 php composer.phar help install

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -43,7 +43,7 @@ Required for published packages (libraries).
 
 ### description
 
-A short description of the package. Usually this is just one line long.
+A short description of the package. Usually this is one line long.
 
 Required for published packages (libraries).
 
@@ -104,7 +104,7 @@ Out of the box, Composer supports four types:
   [dedicated article](articles/custom-installers.md).
 
 Only use a custom type if you need custom logic during installation. It is
-recommended to omit this field and have it just default to `library`.
+recommended to omit this field and have it default to `library`.
 
 ### keywords
 
@@ -272,7 +272,7 @@ All links are optional fields.
 `require` and `require-dev` additionally support stability flags ([root-only](04-schema.md#root-package)).
 These allow you to further restrict or expand the stability of a package beyond
 the scope of the [minimum-stability](#minimum-stability) setting. You can apply
-them to a constraint, or just apply them to an empty constraint if you want to
+them to a constraint, or apply them to an empty constraint if you want to
 allow unstable packages of a dependency for example.
 
 Example:
@@ -406,7 +406,7 @@ simply list it in `provide`.
 #### suggest
 
 Suggested packages that can enhance or work well with this package. These are
-just informational and are displayed after the package is installed, to give
+informational and are displayed after the package is installed, to give
 your users a hint that they could add more packages, even though they are not
 strictly required.
 
@@ -711,7 +711,7 @@ Use `"prefer-stable": true` to enable.
 
 Custom package repositories to use.
 
-By default Composer just uses the packagist repository. By specifying
+By default Composer only uses the packagist repository. By specifying
 repositories you can get packages from elsewhere.
 
 Repositories are not resolved recursively. You can only add them to your main
@@ -731,7 +731,7 @@ The following repository types are supported:
   project.
 * **package:** If you depend on a project that does not have any support for
   composer whatsoever you can define the package inline using a `package`
-  repository. You basically just inline the `composer.json` object.
+  repository. You basically inline the `composer.json` object.
 
 For more information on any of these, see [Repositories](05-repositories.md).
 

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -11,7 +11,7 @@ understand some of the basic concepts that Composer is built on.
 ### Package
 
 Composer is a dependency manager. It installs packages locally. A package is
-essentially just a directory containing something. In this case it is PHP
+essentially a directory containing something. In this case it is PHP
 code, but in theory it could be anything. And it contains a package
 description which has a name and a version. The name and the version are used
 to identify the package.
@@ -57,7 +57,7 @@ The main repository type is the `composer` repository. It uses a single
 `packages.json` file that contains all of the package metadata.
 
 This is also the repository type that packagist uses. To reference a
-`composer` repository, just supply the path before the `packages.json` file.
+`composer` repository, supply the path before the `packages.json` file.
 In the case of packagist, that file is located at `/packages.json`, so the URL of
 the repository would be `packagist.org`. For `example.org/packages.json` the
 repository URL would be `example.org`.
@@ -177,7 +177,7 @@ integrity, for example:
 The file above declares that acme/foo and acme/bar can be found in this
 repository, by loading the file referenced by `providers-url`, replacing
 `%package%` by the vendor namespaced package name and `%hash%` by the
-sha256 field. Those files themselves just contain package definitions as
+sha256 field. Those files themselves contain package definitions as
 described [above](#packages).
 
 These fields are optional. You probably don't need them for your own custom
@@ -606,7 +606,7 @@ private packages:
 }
 ```
 
-Each zip artifact is just a ZIP archive with `composer.json` in root folder:
+Each zip artifact is a ZIP archive with `composer.json` in root folder:
 
 ```sh
 unzip -l acme-corp-parser-10.3.5.zip

--- a/doc/articles/aliases.md
+++ b/doc/articles/aliases.md
@@ -60,7 +60,7 @@ Branch aliases are great for aliasing main development lines. But in order to
 use them you need to have control over the source repository, and you need to
 commit changes to version control.
 
-This is not really fun when you just want to try a bugfix of some library that
+This is not really fun when you want to try a bugfix of some library that
 is a dependency of your local project.
 
 For this reason, you can alias packages in your `require` and `require-dev`
@@ -72,7 +72,7 @@ local project.
 You are using `symfony/monolog-bundle` which requires `monolog/monolog` version
 `1.*`. So you need your `dev-bugfix` to match that constraint.
 
-Just add this to your project's root `composer.json`:
+Add this to your project's root `composer.json`:
 
 ```json
 {

--- a/doc/articles/handling-private-packages-with-satis.md
+++ b/doc/articles/handling-private-packages-with-satis.md
@@ -77,7 +77,7 @@ or another constraint if you want really specific versions.
 }
 ```
 
-Once you've done this, you just run:
+Once you've done this, you run:
 
     php bin/satis build <configuration file> <build dir>
 
@@ -306,7 +306,7 @@ be marked abandoned as well.
 
 It is possible to make satis automatically resolve and add all dependencies for
 your projects. This can be used with the Downloads functionality to have a
-complete local mirror of packages. Just add the following to your `satis.json`:
+complete local mirror of packages. Add the following to your `satis.json`:
 
 ```json
 {

--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -163,7 +163,7 @@ please report this [issue](https://github.com/composer/composer/issues).
 2. Search for an `AutoRun` key inside `HKEY_LOCAL_MACHINE\Software\Microsoft\Command Processor`,
    `HKEY_CURRENT_USER\Software\Microsoft\Command Processor`
    or `HKEY_LOCAL_MACHINE\Software\Wow6432Node\Microsoft\Command Processor`.
-3. Check if it contains any path to non-existent file, if it's the case, just remove them.
+3. Check if it contains any path to non-existent file, if it's the case, remove them.
 
 ## API rate limit and OAuth tokens
 
@@ -281,7 +281,7 @@ for everyone.
 ## Composer hangs with SSH ControlMaster
 
 When you try to install packages from a Git repository and you use the `ControlMaster`
-setting for your SSH connection, Composer might just hang endlessly and you see a `sh`
+setting for your SSH connection, Composer might hang endlessly and you see a `sh`
 process in the `defunct` state in your process list.
 
 The reason for this is a SSH Bug: https://bugzilla.mindrot.org/show_bug.cgi?id=1988

--- a/doc/articles/versions.md
+++ b/doc/articles/versions.md
@@ -74,11 +74,11 @@ correct location in your `vendor` directory.
 
 ### Branches
 
-If you want Composer to check out a branch instead of a tag, you need to point it to the branch using the special `dev-*` prefix (or sometimes suffix; see below). If you're checking out a branch, it's assumed that you want to *work* on the branch and Composer actually clones the repo into the correct place in your `vendor` directory. For tags, it just copies the right files without actually cloning the repo. (You can modify this behavior with --prefer-source and --prefer-dist, see [install options](../03-cli.md#install).)
+If you want Composer to check out a branch instead of a tag, you need to point it to the branch using the special `dev-*` prefix (or sometimes suffix; see below). If you're checking out a branch, it's assumed that you want to *work* on the branch and Composer actually clones the repo into the correct place in your `vendor` directory. For tags, it copies the right files without actually cloning the repo. (You can modify this behavior with --prefer-source and --prefer-dist, see [install options](../03-cli.md#install).)
 
 In the above example, if you wanted to check out the `my-feature` branch, you would specify `dev-my-feature` as the version constraint in your `require` clause. This would result in Composer cloning the `my-library` repository into my `vendor` directory and checking out the `my-feature` branch.
 
-When branch names look like versions, we have to clarify for composer that we're trying to check out a branch and not a tag. In the above example, we have two version branches: `v1` and `v2`. To get Composer to check out one of these branches, you must specify a version constraint that looks like this: `v1.x-dev`. The `.x` is an arbitrary string that Composer requires to tell it that we're talking about the `v1` branch and not a `v1` tag (alternatively, you can just name the branch `v1.x` instead of `v1`). In the case of a branch with a version-like name (`v1`, in this case), you append `-dev` as a suffix, rather than using `dev-` as a prefix.
+When branch names look like versions, we have to clarify for composer that we're trying to check out a branch and not a tag. In the above example, we have two version branches: `v1` and `v2`. To get Composer to check out one of these branches, you must specify a version constraint that looks like this: `v1.x-dev`. The `.x` is an arbitrary string that Composer requires to tell it that we're talking about the `v1` branch and not a `v1` tag (alternatively, you can name the branch `v1.x` instead of `v1`). In the case of a branch with a version-like name (`v1`, in this case), you append `-dev` as a suffix, rather than using `dev-` as a prefix.
 
 ### Minimum Stability
 

--- a/doc/faqs/why-are-version-constraints-combining-comparisons-and-wildcards-a-bad-idea.md
+++ b/doc/faqs/why-are-version-constraints-combining-comparisons-and-wildcards-a-bad-idea.md
@@ -16,6 +16,6 @@ but it is not possible to determine if when you wrote that you were thinking
 of a package in version 3.0.0 or not. Should it match because you asked for
 `>=2` or should it not match because you asked for a `2.*`?
 
-For this reason, Composer just throws an error and says that this is invalid.
+For this reason, Composer throws an error and says that this is invalid.
 The easy way to fix it is to think about what you really mean, and use only
 one of those rules.


### PR DESCRIPTION
The word "just" can often be dropped in writing. 

- https://dev.to/marcuscreo/the-4-letter-word-word-that-makes-my-blood-boil
- https://www.glamour.com/story/why-i-quit-using-the-word-just-in-my-emails

**Edit:** I'd've edited the "Just fork it" at the bottom of the pages as well but it looks like that's part of the website, and isn't in the markdown files here. 

![footer](https://i.imgur.com/DYeU7Nz.png)