### PR TITLE
Allow Composer to be used without running the application

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Console;
 
+use Composer\IO\NullIO;
 use Composer\Util\Platform;
 use Composer\Util\Silencer;
 use Symfony\Component\Console\Application as BaseApplication;
@@ -84,6 +85,8 @@ class Application extends BaseApplication
                 }
             });
         }
+
+        $this->io = new NullIO();
 
         parent::__construct('Composer', Composer::VERSION);
     }


### PR DESCRIPTION
For [Humbug Box](https://github.com/humbug/box/blob/master/src/Composer/ComposerOrchestrator.php#L30) we are using Composer to dump the autoload. To do so I'm using the `Composer` class from the application:

```php
$composer = (new ComposerApplication())->getComposer();
```

If you do so however this is going to fail because `Application#io` is `null` instead of being a `IOInterface` instance. Indeed it is initialised only when the application is run. So one solution
is to initialised it with a dummy IO and the right IO object will be set when the application is run
as usual.