### PR TITLE
Change status command help to make it clearer

### DIFF
--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -40,7 +40,7 @@ class StatusCommand extends BaseCommand
     {
         $this
             ->setName('status')
-            ->setDescription('Shows a list of locally modified packages.')
+            ->setDescription('Shows a list of locally modified packages. (Only for packages installed from source).')
             ->setDefinition(array(
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Show modified files for each directory that contains changes.'),
             ))


### PR DESCRIPTION
status help from `composer help` command is a little confusing because it doesn't explain that it will only work for packages installed from source. May be this little addition helps to make it clearer.

See:

https://github.com/composer/composer/issues/5500
https://stackoverflow.com/questions/49464164/
