### PR TITLE
how-to-install-composer-programmatically.md: quotes are seatbelts

### DIFF
--- a/doc/faqs/how-to-install-composer-programmatically.md
+++ b/doc/faqs/how-to-install-composer-programmatically.md
@@ -9,9 +9,9 @@ An alternative is to use this script which only works with unix utils:
 ```bash
 #!/bin/sh
 
-EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('SHA384', 'composer-setup.php');")"
 
 if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
 then


### PR DESCRIPTION
Not using quotes could end badly, because shell does not forgive when it comes to quotes.

If https://composer.github.io/installer.sig contains a shell command... well oops.

```bash
EXPECTED_SIGNATURE=foobar ; rm -rf /* # Catastrophic
EXPECTED_SIGNATURE="foobar ; rm -rf /*" # No harm done
```