### PR TITLE
add readme to support fields in the schema docs

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -237,6 +237,7 @@ Support information includes the following:
 * **source:** URL to browse or download the sources.
 * **docs:** URL to the documentation.
 * **rss:** URL to the RSS feed.
+* **readme:** Relative path to the readme document.
 
 An example:
 


### PR DESCRIPTION
This change is related to https://github.com/composer/packagist/pull/750

It should also be added to the schema.json but I don't know where it is. Is it stored in this repo or generated? And where is the definition of it?