### PR TITLE
Improve grammar in the programmatic Composer installation page

### DIFF
--- a/doc/faqs/how-to-install-composer-programmatically.md
+++ b/doc/faqs/how-to-install-composer-programmatically.md
@@ -2,9 +2,9 @@
 
 As noted on the download page, the installer script contains a
 signature which changes when the installer code changes and as such
-it should not be relied upon long term.
+it should not be relied upon in the long term.
 
-An alternative is to use this script which only works with unix utils:
+An alternative is to use this script which only works with UNIX utilities:
 
 ```bash
 #!/bin/sh
@@ -29,8 +29,8 @@ exit $RESULT
 The script will exit with 1 in case of failure, or 0 on success, and is quiet
 if no error occurs.
 
-Alternatively if you want to rely on an exact copy of the installer you can fetch
-a specific version from github's history. The commit hash should be enough to
+Alternatively, if you want to rely on an exact copy of the installer, you can fetch
+a specific version from GitHub's history. The commit hash should be enough to
 give it uniqueness and authenticity as long as you can trust the GitHub servers.
 For example:
 


### PR DESCRIPTION
This improves grammar and uses official casing for UNIX and GitHub.