### PR TITLE
Force "C" locale to prevent issue with Turkish "I"

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -5,6 +5,7 @@ if (PHP_SAPI !== 'cli') {
     echo 'Warning: Composer should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
 }
 
+setlocale(LC_ALL, 'C');
 require __DIR__.'/../src/bootstrap.php';
 
 use Composer\Factory;


### PR DESCRIPTION
Fixes https://github.com/symfony/flex/issues/362
Forces case insensitive operations and lowercasing to consider `I` <=> `i`, ignoring the dot-less Turkish "i".