### PR TITLE
add hint for possible need of gitlab-domains option

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -65,13 +65,17 @@ an OAuth token for GitHub.
 
 A list of domain names and oauth keys. For example using `{"gitlab.com":
 "oauthtoken"}` as the value of this option will use `oauthtoken` to access
-private repositories on gitlab.
+private repositories on gitlab. Please note: If the package is not hosted at 
+gitlab.com the domain names must be also specified with the 
+[`gitlab-domains`](06-config.md#gitlab-domains) option.
 
 ## gitlab-token
 
 A list of domain names and private tokens. For example using `{"gitlab.com":
 "privatetoken"}` as the value of this option will use `privatetoken` to access
-private repositories on gitlab.
+private repositories on gitlab. Please note: If the package is not hosted at 
+gitlab.com the domain names must be also specified with the 
+[`gitlab-domains`](06-config.md#gitlab-domains) option.
 
 ## disable-tls
 


### PR DESCRIPTION
Took me quite some time to figure this out. If you are a) using self-hosted gitlab and b) tunneling on the gitlab-token without `ctrl+f`ing for the other `gitlab-`options you waste a lot of time. So I'm creating this PR to help others.
