### PR TITLE
Fix Git detection of authentication failure when no tty is attached to the process

### DIFF
--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -254,6 +254,7 @@ class Git
             'remote error: Invalid username or password.',
             'error: 401 Unauthorized',
             'fatal: unable to access',
+            'fatal: could not read Username',
         );
 
         foreach ($authFailures as $authFailure) {


### PR DESCRIPTION
Hi,
I am trying to run composer (well, satis to be precise) from a process that has no tty attached. Obviously, the underlying git process fails to get user input for username & password, but the error message was not taken into account by composer in the `isAuthenticationFailure` method of `Composer\Util\Git` class.
You can get this Git error message when trying the following command:
`setsid sh -c 'git clone http://private/repo/url' < /dev/null`
You will get something like the following:
`fatal: could not read Username for 'http://private/repo/url': No such device or address`
Setting `GIT_ASKPASS=echo` or `true` has no impact on this behavior.

Such error did not trigger the authentication mechanism, with this PR it does.

Thank you for your awesome work on composer! Best regards.