### PR TITLE
Improve SAT resolving developer debug information

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -223,9 +223,10 @@ class Solver
         /* make decisions based on job/update assertions */
         $this->makeAssertionRuleDecisions();
 
-        $this->io->writeError('Resolving dependencies through SAT', true, IOInterface::DEBUG);
+        $this->io->writeError('Resolving dependencies through SAT', false, IOInterface::DEBUG);
         $before = microtime(true);
         $this->runSat(true);
+        $this->io->writeError('', true, IOInterface::DEBUG);
         $this->io->writeError(sprintf('Dependency resolution completed in %.3f seconds', microtime(true) - $before), true, IOInterface::VERBOSE);
 
         // decide to remove everything that's installed and undecided
@@ -762,6 +763,7 @@ class Solver
 
             for ($i = 0, $n = 0; $n < $rulesCount; $i++, $n++) {
                 if ($i == $rulesCount) {
+                    $this->io->writeError('.', false, IOInterface::DEBUG);
                     $i = 0;
                 }
 

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -223,7 +223,7 @@ class Solver
         /* make decisions based on job/update assertions */
         $this->makeAssertionRuleDecisions();
 
-        $this->io->writeError('Resolving dependencies through SAT', false, IOInterface::DEBUG);
+        $this->io->writeError('Resolving dependencies through SAT', true, IOInterface::DEBUG);
         $before = microtime(true);
         $this->runSat(true);
         $this->io->writeError('', true, IOInterface::DEBUG);
@@ -760,11 +760,19 @@ class Solver
             }
 
             $rulesCount = count($this->rules);
+            $pass = 1;
 
+            $this->io->writeError('Looking at all rules.', true, IOInterface::DEBUG);
             for ($i = 0, $n = 0; $n < $rulesCount; $i++, $n++) {
                 if ($i == $rulesCount) {
-                    $this->io->writeError('.', false, IOInterface::DEBUG);
+                    if (1 === $pass) {
+                        $this->io->writeError("Something's changed, looking at all rules again (pass #$pass)", false, IOInterface::DEBUG);
+                    } else {
+                        $this->io->overwriteError("Something's changed, looking at all rules again (pass #$pass)", false, null, IOInterface::DEBUG);
+                    }
+
                     $i = 0;
+                    $pass++;
                 }
 
                 $rule = $this->rules->ruleById[$i];


### PR DESCRIPTION
Currently, when you debug using `-vvv`, with rather complex dependencies, your CLI output is stuck at `Resolving dependencies through SAT` for 20+ seconds and you don't know if Composer is still doing anything or it crashed, so I tried to improve this.

Before it just prompts after 22 seconds:

![bildschirmfoto 2018-05-18 um 11 03 05](https://user-images.githubusercontent.com/481937/40226338-b4708468-5a8b-11e8-8f6d-75bab04b3735.png)

After:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/481937/40226357-c1e07c2a-5a8b-11e8-9d2e-447f9f83d0ec.gif)

