### PR TITLE
DX: .php_cs - drop commented option of v1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -20,7 +20,6 @@ $finder = PhpCsFixer\Finder::create()
 
 return PhpCsFixer\Config::create()
     ->setUsingCache(true)
-    //->setUsingLinter(false)
     ->setRiskyAllowed(true)
     ->setRules(array(
         '@PSR2' => true,


### PR DESCRIPTION
This option had been removed in v2.0, linter is enabled and can't be disabled. Don't worry - under PHP 7 it has no performance impact