### PR TITLE
Update example for auth.json in BitBucket config

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -305,12 +305,10 @@ After creating an OAuth consumer in the BitBucket control panel, you need to set
 the credentials like this (more info [here](https://getcomposer.org/doc/06-config.md#bitbucket-oauth)):
 ```json
 {
-    "config": {
-        "bitbucket-oauth": {
-            "bitbucket.org": {
-                "consumer-key": "myKey",
-                "consumer-secret": "mySecret"
-            }
+    "bitbucket-oauth": {
+        "bitbucket.org": {
+            "consumer-key": "myKey",
+            "consumer-secret": "mySecret"
         }
     }
 }


### PR DESCRIPTION
In the current context (the paragraph above relating to auth.json), the sample given would be incorrect as it references a `config` node which is for [root only](https://getcomposer.org/doc/04-schema.md#config). 