### PR TITLE
Fix: Remove VersionEye badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Composer helps you declare, manage, and install dependencies of PHP projects.
 See [https://getcomposer.org/](https://getcomposer.org/) for more information and documentation.
 
 [![Build Status](https://travis-ci.org/composer/composer.svg?branch=master)](https://travis-ci.org/composer/composer)
-[![Dependency Status](https://www.versioneye.com/php/composer:composer/dev-master/badge.svg)](https://www.versioneye.com/php/composer:composer/dev-master)
-[![Reference Status](https://www.versioneye.com/php/composer:composer/reference_badge.svg?style=flat)](https://www.versioneye.com/php/composer:composer/references)
 
 Installation / Usage
 --------------------


### PR DESCRIPTION
This PR

* [x] removes the VersionEye badges

Follows #4019.

💁‍♂️ It's been shut down a while ago. For reference, also see https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/.