### PR TITLE
Fix for composer.json file

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -700,7 +700,7 @@ You can disable the default Packagist.org repository by adding this to your
 {
     "repositories": [
         {
-            "packagist.org": false
+            "packagist": false
         }
     ]
 }


### PR DESCRIPTION
The `composer config repo.packagist false` command will add the following to you composer.json file
```json
{
    "repositories": [
        {
            "packagist": false
        }
    ]
}
```

So I'm pretty sure that the json example given should be `packagist` instead of `packagist.org`