### PR TITLE
Add repositories path glob

### DIFF
--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -177,6 +177,6 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
         // Ensure environment-specific path separators are normalized to URL separators
         return array_map(function ($val) {
             return rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $val), '/');
-        }, glob($this->url, GLOB_MARK | GLOB_ONLYDIR));
+        }, glob($this->url, GLOB_MARK | GLOB_ONLYDIR | GLOB_BRACE));
     }
 }


### PR DESCRIPTION
In the Composer document, it is stated that glob can be used, but only some functions can be used.
All functions are unnecessary, but I would like to use ``GLOB_BRACE``.

- [Repositories - Composer](https://getcomposer.org/doc/05-repositories.md#path "Repositories - Composer")
- [PHP: glob - Manual](http://php.net/manual/ja/function.glob.php "PHP: glob - Manual")

Since now ``GLOB_BRACE`` can not be used, it will be written as follows.

```
{
  "repositories": [{
    "type": "path",
    "url": "$HOME/Scripts/composer",
  } {,
    "type": "path",
    "url": "$HOME/Scripts/php-test",
  }, {
    "type": "path",
    "url": "$HOME/Scripts/php-unit",
  }]
}
```

If you can use ``GLOB_BRACE`` you can write more easily
```
{
  "repositories": [{
    "type": "path",
    "url": "$HOME/Scripts/{composer,php-*}"
  }]
}
```
