### PR TITLE
Use a simpler hashing for the Rule2Literal case

### DIFF
--- a/src/Composer/DependencyResolver/Rule2Literals.php
+++ b/src/Composer/DependencyResolver/Rule2Literals.php
@@ -50,9 +50,7 @@ class Rule2Literals extends Rule
 
     public function getHash()
     {
-        $data = unpack('ihash', md5($this->literal1.','.$this->literal2, true));
-
-        return $data['hash'];
+        return $this->literal1.','.$this->literal2;
     }
 
     /**


### PR DESCRIPTION
this speeds up "composer update" by a second.

as discussed in https://github.com/composer/composer/issues/7449 lets use a simpler hashing to speedup the hot path.