### PR TITLE
Temporary save the package-name into a variable

### DIFF
--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -232,7 +232,8 @@ class RuleSetGenerator
                 }
             }
 
-            $obsoleteProviders = $this->pool->whatProvides($package->getName(), null);
+            $packageName = $package->getName();
+            $obsoleteProviders = $this->pool->whatProvides($packageName, null);
 
             foreach ($obsoleteProviders as $provider) {
                 if ($provider === $package) {
@@ -242,7 +243,7 @@ class RuleSetGenerator
                 if (($package instanceof AliasPackage) && $package->getAliasOf() === $provider) {
                     $this->addRule(RuleSet::TYPE_PACKAGE, $rule = $this->createRequireRule($package, array($provider), Rule::RULE_PACKAGE_ALIAS, $package));
                 } elseif (!$this->obsoleteImpossibleForAlias($package, $provider)) {
-                    $reason = ($package->getName() == $provider->getName()) ? Rule::RULE_PACKAGE_SAME_NAME : Rule::RULE_PACKAGE_IMPLICIT_OBSOLETES;
+                    $reason = ($packageName == $provider->getName()) ? Rule::RULE_PACKAGE_SAME_NAME : Rule::RULE_PACKAGE_IMPLICIT_OBSOLETES;
                     $this->addRule(RuleSet::TYPE_PACKAGE, $rule = $this->createRule2Literals($package, $provider, $reason, $package));
                 }
             }


### PR DESCRIPTION
this reduces number of unnecessary function calls in the hot path of "composer update".

in my case this reduces "composer update" walltime (~45s) by 750ms .

![grafik](https://user-images.githubusercontent.com/120441/42449668-dbc19ff6-8381-11e8-9736-aa6e1fd2073c.png)
