### PR TITLE
Specialize Rule2Literal->equals(Rule2Literal) for speedup

### DIFF
--- a/src/Composer/DependencyResolver/Rule2Literals.php
+++ b/src/Composer/DependencyResolver/Rule2Literals.php
@@ -65,6 +65,19 @@ class Rule2Literals extends Rule
      */
     public function equals(Rule $rule)
     {
+        // specialized fast-case
+        if ($rule instanceof self) {
+            if ($this->literal1 !== $rule->literal1) {
+                return false;
+            }
+
+            if ($this->literal2 !== $rule->literal2) {
+                return false;
+            }
+
+            return true;
+        }
+
         $literals = $rule->getLiterals();
         if (2 != count($literals)) {
             return false;


### PR DESCRIPTION
optimize Rule2Literal for a common case of the hot-path.

Reduces walltime by ~1.1 seconds on our typical workload:

https://blackfire.io/profiles/compare/5e2c1260-9186-4ad6-aef9-fd524ce46094/graph

![grafik](https://user-images.githubusercontent.com/120441/42523615-8161192c-846e-11e8-94e6-6c6bf0963234.png)


the actual speedup seems to happen because we need 23% less calls to `$rule->getLiterals()`
(+ the calling overhead + saving ~100.000 calls to `count`)

![grafik](https://user-images.githubusercontent.com/120441/42524394-a4b2f06a-8470-11e8-878e-5e56d2f3e5a7.png)
