### PR TITLE
Remove unnecessary abs() calls

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -796,10 +796,10 @@ class Solver
                             continue 2; // next rule
                         }
                     } else {
-                        if ($this->decisions->decidedInstall(abs($literal))) {
+                        if ($this->decisions->decidedInstall($literal)) {
                             continue 2; // next rule
                         }
-                        if ($this->decisions->undecided(abs($literal))) {
+                        if ($this->decisions->undecided($literal)) {
                             $decisionQueue[] = $literal;
                         }
                     }

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -792,7 +792,7 @@ class Solver
                 //
                 foreach ($literals as $literal) {
                     if ($literal <= 0) {
-                        if (!$this->decisions->decidedInstall(abs($literal))) {
+                        if (!$this->decisions->decidedInstall($literal)) {
                             continue 2; // next rule
                         }
                     } else {

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -100,7 +100,7 @@ class Solver
             $literals = $rule->getLiterals();
             $literal = $literals[0];
 
-            if (!$this->decisions->decided(abs($literal))) {
+            if (!$this->decisions->decided($literal)) {
                 $this->decisions->decide($literal, 1, $rule);
                 continue;
             }


### PR DESCRIPTION

`runSat` is at the hot path, every fn call saved counts.

https://github.com/composer/composer/blob/master/src/Composer/DependencyResolver/Decisions.php Calls abs() on the given arguments again, so no need to call it before calling methods on Decisions objects.

![8ff95a4f-67f8-4b46-a868-cbe4aa741333](https://user-images.githubusercontent.com/120441/42532375-00268d56-8487-11e8-8688-e16a388e4395.jpeg)
