### PR TITLE
Add `composer i` shorthand for `composer install`

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -115,7 +115,7 @@ resolution.
   requirements and force the installation even if the local machine does not
   fulfill these. See also the [`platform`](06-config.md#platform) config option.
 
-## update
+## update / u
 
 In order to get the latest versions of the dependencies and to update the
 `composer.lock` file, you should use the `update` command. This command is also

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -65,7 +65,7 @@ php composer.phar init
   to a `composer` repository or a JSON string which similar to what the
   [repositories](04-schema.md#repositories) key accepts.
 
-## install
+## install / i
 
 The `install` command reads the `composer.json` file from the current
 directory, resolves the dependencies, and installs them into `vendor`.

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -32,6 +32,7 @@ class InstallCommand extends BaseCommand
     {
         $this
             ->setName('install')
+            ->setAliases(array('i'))
             ->setDescription('Installs the project dependencies from the composer.lock file if present, or falls back on the composer.json.')
             ->setDefinition(array(
                 new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -34,7 +34,7 @@ class UpdateCommand extends BaseCommand
     {
         $this
             ->setName('update')
-            ->setAliases(array('upgrade'))
+            ->setAliases(array('u', 'upgrade'))
             ->setDescription('Upgrades your dependencies to the latest version according to composer.json, and updates the composer.lock file.')
             ->setDefinition(array(
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that should be updated, if not provided all packages are.'),


### PR DESCRIPTION
In npm I really like this shorthand `npm i`
So thought it may also be convenient in composer