### PR TITLE
Use variable to call count() less often

### DIFF
--- a/src/Composer/DependencyResolver/RuleWatchNode.php
+++ b/src/Composer/DependencyResolver/RuleWatchNode.php
@@ -37,8 +37,9 @@ class RuleWatchNode
 
         $literals = $rule->getLiterals();
 
-        $this->watch1 = count($literals) > 0 ? $literals[0] : 0;
-        $this->watch2 = count($literals) > 1 ? $literals[1] : 0;
+        $literalCount = count($literals);
+        $this->watch1 = $literalCount > 0 ? $literals[0] : 0;
+        $this->watch2 = $literalCount > 1 ? $literals[1] : 0;
     }
 
     /**


### PR DESCRIPTION
`count()` is called hundred thousands of times. using a single variable in this single spot (most calling code-site) reduced it by ~130.000x even in a small project.

![image](https://user-images.githubusercontent.com/120441/42653083-a2fefc28-8614-11e8-9943-70645fc2d1a2.png)
