### PR TITLE
prevent preg_replace() calls when cache is not enabled

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -71,11 +71,13 @@ class Cache
 
     public function read($file)
     {
-        $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
-        if ($this->enabled && file_exists($this->root . $file)) {
-            $this->io->writeError('Reading '.$this->root . $file.' from cache', true, IOInterface::DEBUG);
+        if ($this->enabled) {
+            $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
+            if (file_exists($this->root . $file)) {
+                $this->io->writeError('Reading '.$this->root . $file.' from cache', true, IOInterface::DEBUG);
 
-            return file_get_contents($this->root . $file);
+                return file_get_contents($this->root . $file);
+            }
         }
 
         return false;
@@ -142,19 +144,21 @@ class Cache
      */
     public function copyTo($file, $target)
     {
-        $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
-        if ($this->enabled && file_exists($this->root . $file)) {
-            try {
-                touch($this->root . $file, filemtime($this->root . $file), time());
-            } catch (\ErrorException $e) {
-                // fallback in case the above failed due to incorrect ownership
-                // see https://github.com/composer/composer/issues/4070
-                Silencer::call('touch', $this->root . $file);
+        if ($this->enabled) {
+            $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
+            if (file_exists($this->root . $file)) {
+                try {
+                    touch($this->root . $file, filemtime($this->root . $file), time());
+                } catch (\ErrorException $e) {
+                    // fallback in case the above failed due to incorrect ownership
+                    // see https://github.com/composer/composer/issues/4070
+                    Silencer::call('touch', $this->root . $file);
+                }
+
+                $this->io->writeError('Reading '.$this->root . $file.' from cache', true, IOInterface::DEBUG);
+
+                return copy($this->root . $file, $target);
             }
-
-            $this->io->writeError('Reading '.$this->root . $file.' from cache', true, IOInterface::DEBUG);
-
-            return copy($this->root . $file, $target);
         }
 
         return false;
@@ -167,9 +171,11 @@ class Cache
 
     public function remove($file)
     {
-        $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
-        if ($this->enabled && file_exists($this->root . $file)) {
-            return $this->filesystem->unlink($this->root . $file);
+        if ($this->enabled) {
+            $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
+            if (file_exists($this->root . $file)) {
+                return $this->filesystem->unlink($this->root . $file);
+            }
         }
 
         return false;
@@ -216,9 +222,11 @@ class Cache
 
     public function sha1($file)
     {
-        $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
-        if ($this->enabled && file_exists($this->root . $file)) {
-            return sha1_file($this->root . $file);
+        if ($this->enabled) {
+            $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
+            if (file_exists($this->root . $file)) {
+                return sha1_file($this->root . $file);
+            }
         }
 
         return false;
@@ -226,9 +234,11 @@ class Cache
 
     public function sha256($file)
     {
-        $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
-        if ($this->enabled && file_exists($this->root . $file)) {
-            return hash_file('sha256', $this->root . $file);
+        if ($this->enabled) {
+            $file = preg_replace('{[^'.$this->whitelist.']}i', '-', $file);
+            if (file_exists($this->root . $file)) {
+                return hash_file('sha256', $this->root . $file);
+            }
         }
 
         return false;


### PR DESCRIPTION
before this change the whitelist-replacement was invoked, even when the variable wasn't used.