### PR TITLE
[docs] basic usage - promote safe version range

### DIFF
--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -190,11 +190,11 @@ installed on the system but are not actually installable by Composer. This
 includes PHP itself, PHP extensions and some system libraries.
 
 * `php` represents the PHP version of the user, allowing you to apply
-  constraints, e.g. `>=5.4.0`. To require a 64bit version of php, you can
+  constraints, e.g. `^7.1`. To require a 64bit version of php, you can
   require the `php-64bit` package.
 
 * `hhvm` represents the version of the HHVM runtime and allows you to apply
-  a constraint, e.g., `>=2.3.3`.
+  a constraint, e.g., `^2.3`.
 
 * `ext-<name>` allows you to require PHP extensions (includes core
   extensions). Versioning can be quite inconsistent here, so it's often


### PR DESCRIPTION
I'm aware this just an example, but it [leads readers to see it a best practise](https://github.com/Automattic/phpcs-neutron-standard/commit/40642df5ec9ea39871f1b99ada7fa34976169788#r29802440).

Having code with `"php": ">=5.4.0"` is pretty dangerous and will probably break with next major version. Such usage is nowhere to be seen apart docs and just a handful of php packages.

On the other hand: 

```json
{
    "require": {
        "php": "^5.4"
    }
}
```

or

```json
{
    "require": {
        "php": "^7.1"
    }
}
```

is much more safer. Promoting best and proven practise should from *Basic usage* helps people to use composer the best way they can.

What do you think?