### PR TITLE
Do not dump source and dist for metapackages

### DIFF
--- a/src/Composer/Package/Dumper/ArrayDumper.php
+++ b/src/Composer/Package/Dumper/ArrayDumper.php
@@ -45,7 +45,7 @@ class ArrayDumper
             $data['target-dir'] = $package->getTargetDir();
         }
 
-        if ($package->getSourceType()) {
+        if ($package->getSourceType() && $package->getType() !== 'metapackage') {
             $data['source']['type'] = $package->getSourceType();
             $data['source']['url'] = $package->getSourceUrl();
             $data['source']['reference'] = $package->getSourceReference();
@@ -54,7 +54,7 @@ class ArrayDumper
             }
         }
 
-        if ($package->getDistType()) {
+        if ($package->getDistType() && $package->getType() !== 'metapackage') {
             $data['dist']['type'] = $package->getDistType();
             $data['dist']['url'] = $package->getDistUrl();
             $data['dist']['reference'] = $package->getDistReference();

--- a/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
+++ b/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
@@ -106,6 +106,57 @@ class ArrayDumperTest extends TestCase
         $this->assertSame($expectedValue ?: $value, $config[$key]);
     }
 
+    public function testMetapackageShouldNotHaveSourceEntries()
+    {
+        $this
+            ->packageExpects('getPrettyName', 'foo')
+            ->packageExpects('getPrettyVersion', '1.0')
+            ->packageExpects('getVersion', '1.0.0.0')
+            ->packageExpects('getType', 'metapackage')
+            ->packageExpects('getSourceType', 'composer')
+            ->packageExpects('getSourceUrl', 'https://packagist.org')
+            ->packageExpects('getSourceReference', 'packagist')
+        ;
+
+        $config = $this->dumper->dump($this->package);
+
+        $this->assertEquals(
+            array(
+                'name' => 'foo',
+                'version' => '1.0',
+                'version_normalized' => '1.0.0.0',
+                'type' => 'metapackage',
+            ),
+            $config
+        );
+    }
+
+    public function testMetapackageShouldNotHaveDistEntries()
+    {
+        $this
+            ->packageExpects('getPrettyName', 'foo')
+            ->packageExpects('getPrettyVersion', '1.0')
+            ->packageExpects('getVersion', '1.0.0.0')
+            ->packageExpects('getType', 'metapackage')
+            ->packageExpects('getDistType', 'composer')
+            ->packageExpects('getDistUrl', 'https://packagist.org')
+            ->packageExpects('getDistReference', 'packagist')
+            ->packageExpects('getDistSha1Checksum', 'packagist')
+        ;
+
+        $config = $this->dumper->dump($this->package);
+
+        $this->assertEquals(
+            array(
+                'name' => 'foo',
+                'version' => '1.0',
+                'version_normalized' => '1.0.0.0',
+                'type' => 'metapackage',
+            ),
+            $config
+        );
+    }
+
     public function getKeys()
     {
         return array(


### PR DESCRIPTION
I stumbled upon composer/satis#439, did some tests and it looks like nothing breaks when removing `source` and `dist`. Anything else that this could go wrong?