### PR TITLE
Don't unescape surrogate pairs in fallback JSON formatter

### DIFF
--- a/src/Composer/Json/JsonFormatter.php
+++ b/src/Composer/Json/JsonFormatter.php
@@ -69,6 +69,13 @@ class JsonFormatter
                         $l = strlen($match[1]);
 
                         if ($l % 2) {
+                            $code = hexdec($match[2]);
+                            // 0xD800..0xDFFF denotes UTF-16 surrogate pair which won't be unescaped
+                            // see https://github.com/composer/composer/issues/7510
+                            if (0xD800 <= $code && 0xDFFF >= $code) {
+                                return $match[0];
+                            }
+
                             return str_repeat('\\', $l - 1) . mb_convert_encoding(
                                 pack('H*', $match[2]),
                                 'UTF-8',

--- a/tests/Composer/Test/Json/JsonFormatterTest.php
+++ b/tests/Composer/Test/Json/JsonFormatterTest.php
@@ -34,6 +34,20 @@ class JsonFormatterTest extends TestCase
     }
 
     /**
+     * Surrogate pairs are intentionally skipped and not unescaped
+     * https://github.com/composer/composer/issues/7510
+     */
+    public function testUtf16SurrogatePair()
+    {
+        if (!extension_loaded('mbstring')) {
+            $this->markTestSkipped('Test requires the mbstring extension');
+        }
+
+        $escaped = '"\ud83d\ude00"';
+        $this->assertEquals($escaped, JsonFormatter::format($escaped, true, true));
+    }
+
+    /**
      * Convert string to character codes split by a plus sign
      * @param  string $string
      * @return string

--- a/tests/Composer/Test/Json/JsonFormatterTest.php
+++ b/tests/Composer/Test/Json/JsonFormatterTest.php
@@ -18,19 +18,18 @@ use PHPUnit\Framework\TestCase;
 class JsonFormatterTest extends TestCase
 {
     /**
-     * Test if \u0119 (196+153) will get correctly formatted
-     * See ticket #2613
+     * Test if \u0119 will get correctly formatted (unescaped)
+     * https://github.com/composer/composer/issues/2613
      */
     public function testUnicodeWithPrependedSlash()
     {
         if (!extension_loaded('mbstring')) {
             $this->markTestSkipped('Test requires the mbstring extension');
         }
-
-        $data = '"' . chr(92) . chr(92) . chr(92) . 'u0119"';
-        $encodedData = JsonFormatter::format($data, true, true);
-        $expected = '34+92+92+196+153+34';
-        $this->assertEquals($expected, $this->getCharacterCodes($encodedData));
+        $backslash = chr(92);
+        $data = '"' . $backslash . $backslash . $backslash . 'u0119"';
+        $expected = '"' . $backslash . $backslash . 'ę"';
+        $this->assertEquals($expected, JsonFormatter::format($data, true, true));
     }
 
     /**
@@ -45,20 +44,5 @@ class JsonFormatterTest extends TestCase
 
         $escaped = '"\ud83d\ude00"';
         $this->assertEquals($escaped, JsonFormatter::format($escaped, true, true));
-    }
-
-    /**
-     * Convert string to character codes split by a plus sign
-     * @param  string $string
-     * @return string
-     */
-    protected function getCharacterCodes($string)
-    {
-        $codes = array();
-        for ($i = 0; $i < strlen($string); $i++) {
-            $codes[] = ord($string[$i]);
-        }
-
-        return implode('+', $codes);
     }
 }


### PR DESCRIPTION
The proposed solution to having broken UTF-8 out of the fallback formatter is to skip surrogate pairs rather than trying to handle them correctly. If we were to implement "The Proper" solution, which is basically to port JSON unescaping to PHP and put into formatter, it would require at least looking ahead/behind (because a pair of 2 escape sequences in 0xD800..0xDFFF matters) and handling errors in case of unpaired surrogates; that seems to be an overkill for workaround for PHP 5.3 which is dead anyways.