### PR TITLE
Add interactive option to install dependencies after running init command

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -147,7 +147,7 @@ EOT
             }
         }
 
-        $question = 'Would you like to install dependencies now? [<comment>yes</comment>]? ';
+        $question = 'Would you like to install dependencies now [<comment>yes</comment>]? ';
         if ($input->isInteractive() && $this->hasDependencies($options) && $io->askConfirmation($question, true)) {
             $this->installDependencies($output);
         }

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -147,10 +147,8 @@ EOT
             }
         }
 
-
         $question = 'Would you like to install dependencies now? [<comment>yes</comment>]? ';
-
-        if ($input->isInteractive() && $io->askConfirmation($question, true)) {
+        if ($input->isInteractive() && $this->hasDependencies($options) && $io->askConfirmation($question, true)) {
             $this->installDependencies($output);
         }
 
@@ -787,5 +785,12 @@ EOT
             $this->getIO()->writeError("Couldn't install dependencies. You can install them later by running 'composer install'.");
         }
 
+    }
+
+    private function hasDependencies($options)
+    {
+        $requires = (array)$options['require'];
+        $devRequires = isset($options['require-dev']) ? (array)$options['require-dev'] : array();
+        return !empty($requires) || !empty($devRequires);
     }
 }

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -22,6 +22,7 @@ use Composer\Repository\CompositeRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryFactory;
 use Composer\Util\ProcessExecutor;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -145,6 +146,15 @@ EOT
                 }
             }
         }
+
+
+        $question = 'Would you like to install dependencies now? [<comment>yes</comment>]? ';
+
+        if ($input->isInteractive() && $io->askConfirmation($question, true)) {
+            $this->installDependencies($output);
+        }
+
+        $io->write('Done. Compose something awesome.');
     }
 
     /**
@@ -766,5 +776,16 @@ EOT
         asort($similarPackages);
 
         return array_keys(array_slice($similarPackages, 0, 5));
+    }
+
+    private function installDependencies($output)
+    {
+        try {
+            $installCommand = $this->getApplication()->find('install');
+            $installCommand->run(new ArrayInput(array()), $output);
+        } catch (\Exception $e) {
+            $this->getIO()->writeError("Couldn't install dependencies. You can install them later by running 'composer install'.");
+        }
+
     }
 }

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -151,8 +151,6 @@ EOT
         if ($input->isInteractive() && $this->hasDependencies($options) && $io->askConfirmation($question, true)) {
             $this->installDependencies($output);
         }
-
-        $io->write('Done. Compose something awesome.');
     }
 
     /**
@@ -782,15 +780,16 @@ EOT
             $installCommand = $this->getApplication()->find('install');
             $installCommand->run(new ArrayInput(array()), $output);
         } catch (\Exception $e) {
-            $this->getIO()->writeError("Couldn't install dependencies. You can install them later by running 'composer install'.");
+            $this->getIO()->writeError('Could not install dependencies. Run `composer install` to see more information.');
         }
 
     }
 
     private function hasDependencies($options)
     {
-        $requires = (array)$options['require'];
-        $devRequires = isset($options['require-dev']) ? (array)$options['require-dev'] : array();
+        $requires = (array) $options['require'];
+        $devRequires = isset($options['require-dev']) ? (array) $options['require-dev'] : array();
+
         return !empty($requires) || !empty($devRequires);
     }
 }


### PR DESCRIPTION
When the `init` command is run in interactive mode, the dev will be asked if they wish to install dependencies straightaway (only if they specified any dependencies). It's a minor improvement that makes life a tad easier. 😀 