### PR TITLE
Use target directory instead of CWD for hg pull with auth.json

### DIFF
--- a/src/Composer/Util/Hg.php
+++ b/src/Composer/Util/Hg.php
@@ -60,7 +60,7 @@ class Hg
 
             $command = call_user_func($commandCallable, $authenticatedUrl);
 
-            if (0 === $this->process->execute($command)) {
+            if (0 === $this->process->execute($command, $ignoredOutput, $cwd)) {
                 return;
             }
 


### PR DESCRIPTION
There are 2 missing parameters in the second try of the process-execution. (in case of authentication / use of auth.json)
If a package is updated, the `composer update` results in a `abort: repository is unrelated` because it is executed in the current working directory (CWD) instead of the install-dir.

I've added these 2 parameters to the `process->execute()` call.