### PR TITLE
add removePackage() to RepositoryInterface

### DIFF
--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -71,4 +71,11 @@ interface RepositoryInterface extends \Countable
      * @return array[] an array of array('name' => '...', 'description' => '...')
      */
     public function search($query, $mode = 0);
+
+    /**
+     * Removes a package from the registered packages list.
+     *
+     * @param PackageInterface $package
+     */
+    public function removePackage(PackageInterface $package);
 }


### PR DESCRIPTION
This seems to be implemented by all repositories, but not part of any interface. Since both the `Installer` and `CompositeRepository` depend on it, it should probably be a part of the interface.