### PR TITLE
Metapackage: Don't rely on sourceReference property to avoid invalid comparison.

### DIFF
--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -212,7 +212,10 @@ abstract class BasePackage implements PackageInterface
      */
     public function getFullPrettyVersion($truncate = true)
     {
-        if (!$this->isDev() || !in_array($this->getSourceType(), array('hg', 'git'))) {
+        if (!$this->isDev() ||
+            !in_array($this->getSourceType(), array('hg', 'git')) ||
+            $this->getType() === 'metapackage'
+        ) {
             return $this->getPrettyVersion();
         }
 


### PR DESCRIPTION
Since the metapackage don't store `sourceReference` anymore in the `installed.json` file
we can't use it in the `getFullPrettyVersion` to compare version.

That particular method is used in the outdated comparison algorithm (see #7546 for more details).