### PR TITLE
Add --no-dev option to check-platform-reqs command (#7314)

### DIFF
--- a/src/Composer/Command/CheckPlatformReqsCommand.php
+++ b/src/Composer/Command/CheckPlatformReqsCommand.php
@@ -17,6 +17,7 @@ use Composer\Package\PackageInterface;
 use Composer\Semver\Constraint\Constraint;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Composer\Repository\PlatformRepository;
 
@@ -26,6 +27,9 @@ class CheckPlatformReqsCommand extends BaseCommand
     {
         $this->setName('check-platform-reqs')
             ->setDescription('Check that platform requirements are satisfied.')
+            ->setDefinition(array(
+                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables checking of require-dev packages requirements.'),
+            ))
             ->setHelp(
                 <<<EOT
 Checks that your PHP and extensions versions match the platform requirements of the installed packages.
@@ -40,22 +44,22 @@ EOT
     {
         $composer = $this->getComposer();
 
-        $repos = $composer->getRepositoryManager()->getLocalRepository();
-
-        $allPackages = array_merge(array($composer->getPackage()), $repos->getPackages());
-        $requires = $composer->getPackage()->getDevRequires();
+        $requires = $composer->getPackage()->getRequires();
+        if (!$input->getOption('no-dev')) {
+            $requires += $composer->getPackage()->getDevRequires();
+        }
         foreach ($requires as $require => $link) {
             $requires[$require] = array($link);
         }
 
-        /**
-         * @var PackageInterface $package
-         */
-        foreach ($allPackages as $package) {
+        $locker = $composer->getLocker()
+                           ->getLockedRepository(!$input->getOption('no-dev'));
+        foreach ($locker->getPackages() as $package) {
             foreach ($package->getRequires() as $require => $link) {
                 $requires[$require][] = $link;
             }
         }
+
         ksort($requires);
 
         $platformRepo = new PlatformRepository(array(), array());
@@ -74,7 +78,7 @@ EOT
         $exitCode = 0;
 
         /**
-         * @var Link $require
+         * @var Link[] $links
          */
         foreach ($requires as $require => $links) {
             if (preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $require)) {


### PR DESCRIPTION
This pull request covers https://github.com/composer/composer/issues/7314 issue.

It adds "--no-dev" option to "check-platform-reqs" command.

To do this it changes "check-platform-reqs" logic. Previous logic considered `installed.json` file to check platform reqs. Current logic considers `composer.lock` to perform such check.

Logic has been changed, because currently there is no easy way to check whether requirement is `required-dev` or not with `installed.json` file. On other hand, it's really easy to do with `composer.lock`.

`installed.json` file should be related to `composer.lock`, so there is no big deal at that point.

### Why it's ok to use `composer.lock`

On dev machines, both of files (`installed.json` and `composer.lock`) exist.

On prod (which may not contain `composer.lock`) such commands should not be executed (like you state [here](https://github.com/composer/composer/issues/7314#issuecomment-386985135) ) until this pull request, so it is not a big breaking change. 

Even more: `check-platform-reqs` command currently requires `composer.json` to exists and be valid. This means, that command can rely on dev-files, and `composer.lock` is just one of them, so its totally ok to use it.