### PR TITLE
Unify Composer concept

### DIFF
--- a/src/Composer/Command/AboutCommand.php
+++ b/src/Composer/Command/AboutCommand.php
@@ -37,7 +37,7 @@ EOT
     {
         $this->getIO()->write(
             <<<EOT
-<info>Composer - Package Management for PHP</info>
+<info>Composer - Dependency Manager for PHP</info>
 <comment>Composer is a dependency manager tracking local dependencies of your projects and libraries.
 See https://getcomposer.org/ for more information.</comment>
 EOT


### PR DESCRIPTION
Such as the concept that is showed on the page [introduction](https://getcomposer.org/doc/00-intro.md).

>Composer is not a package manager in the same sense as Yum or Apt are. Yes, it deals with "packages" or libraries, but it manages them on a per-project basis, installing them in a directory (e.g. vendor) inside your project. By default it does not install anything globally. Thus, it is a dependency manager. It does however support a "global" project for convenience via the global command

I think it's better to unify the Composer concept.

"Composer is a dependency manager or dependency management".