### PR TITLE
Generate Package Ids in pool only once all packages are defined

### DIFF
--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -68,7 +68,10 @@ class Pool implements \Countable
         $this->priorities = $priorities;
         $this->packages = $packages;
 
+        $id = 1;
+
         foreach ($this->packages as $package) {
+            $package->id = $id++;
             $names = $package->getNames();
             $this->packageByExactName[$package->getName()][$package->id] = $package;
 

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -32,7 +32,6 @@ class PoolBuilder
 
     private $loadedNames = array();
 
-    private $id = 1;
     private $packages = array();
     private $priorities = array();
 
@@ -54,14 +53,6 @@ class PoolBuilder
                 case 'install':
                     $loadNames[$job['packageName']] = true;
                     break;
-            }
-        }
-
-        foreach ($repositories as $repository) {
-            if ($repository instanceof ComposerRepository && $repository->hasProviders()) {
-                $this->providerRepos[] = $repository;
-                $repository->setRootAliases($this->rootAliases);
-                $repository->resetPackageIds();
             }
         }
 
@@ -117,9 +108,8 @@ class PoolBuilder
 
     private function loadPackage(PackageInterface $package, $repoIndex)
     {
-        $package->setId($this->id++);
         $this->packages[] = $package;
-        $this->priorities[$this->id - 2] = -$repoIndex;
+        $this->priorities[] = -$repoIndex;
 
         // handle root package aliases
         $name = $package->getName();
@@ -130,7 +120,6 @@ class PoolBuilder
             }
             $aliasPackage = new AliasPackage($package, $alias['alias_normalized'], $alias['alias']);
             $aliasPackage->setRootPackageAlias(true);
-            $aliasPackage->setId($this->id++);
 
             $package->getRepository()->addPackage($aliasPackage); // TODO do we need this?
             $this->packages[] = $aliasPackage;

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -297,16 +297,6 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         return $this->hasProviders;
     }
 
-    public function resetPackageIds()
-    {
-        foreach ($this->providersByUid as $package) {
-            if ($package instanceof AliasPackage) {
-                $package->getAliasOf()->setId(-1);
-            }
-            $package->setId(-1);
-        }
-    }
-
     /**
      * @param string $name package name
      * @param bool $bypassFilters If set to true, this bypasses the stability filtering, and forces a recompute without cache

--- a/tests/Composer/Test/DependencyResolver/RuleSetTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetTest.php
@@ -143,7 +143,6 @@ class RuleSetTest extends TestCase
         $pool->setPackages(array(
             $p = $this->getPackage('foo', '2.1'),
         ));
-        $p->setId(1);
 
         $ruleSet = new RuleSet;
         $literal = $p->getId();

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -98,8 +98,6 @@ class RuleTest extends TestCase
             $p1 = $this->getPackage('foo', '2.1'),
             $p2 = $this->getPackage('baz', '1.1'),
         ));
-        $p1->setId(1);
-        $p2->setId(2);
 
         $rule = new GenericRule(array($p1->getId(), -$p2->getId()), Rule::RULE_JOB_INSTALL, null);
 


### PR DESCRIPTION
Ids all get set in one place only and at a specific time when nothing else will possibly change them anymore.
Improves https://github.com/composer/composer/pull/7625