### PR TITLE
Fix: Bitbucket getChangeDate throws exception for branches containing a slash

### DIFF
--- a/src/Composer/Repository/Vcs/BitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/BitbucketDriver.php
@@ -189,6 +189,13 @@ abstract class BitbucketDriver extends VcsDriver
             return $this->fallbackDriver->getFileContent($file, $identifier);
         }
 
+        if (strpos($identifier, '/') !== false) {
+            $branches = $this->getBranches();
+            if (isset($branches[$identifier])) {
+                $identifier = $branches[$identifier];
+            }
+        }
+
         $resource = sprintf(
             'https://api.bitbucket.org/1.0/repositories/%s/%s/raw/%s/%s',
             $this->owner,


### PR DESCRIPTION
Calling the `getChangeDate` method in the `BitbucketDriver` with an identifier containing a slash always throws an error

See: https://api.bitbucket.org/2.0/repositories/pcomtest/a1/commit/t/test?fields=date

This works fine for branches without slash or if you directly use the commit hash, see:
https://api.bitbucket.org/2.0/repositories/pcomtest/a1/commit/test?fields=date
https://api.bitbucket.org/2.0/repositories/pcomtest/a1/commit/a55e5e623678907fbd63f63ce37b873f57eec7b1?fields=date

Encoding the identifier doesn't help.

Note: this is only an issue while using the VcsRepositories directly outside of a regular composer install or update. For instance to check if a vcs repository contains a composer file.