### PR TITLE
Improve path repository UX

### DIFF
--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -245,6 +245,7 @@ class Pool implements \Countable
 
                 case self::MATCH_NAME:
                     $nameMatch = true;
+                    $matches[] = $candidate;
                     break;
 
                 case self::MATCH:


### PR DESCRIPTION
When running "composer outdated" command and using local (path) repositories - result has always return code higher than 0 and local repository listed. This PR makes it also displays found new version, but I'm not sure if this is solution to this problem, since the result of "composer outdated" is still wrong. i think we should dropped version checking for path repositories, because:
1, when they are symlinks - they are always updated by default
2. when not - they are copied on `install` command anyway