### PR TITLE
PoolBuilder:  prune impossible versions before pool creation

### DIFF
--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -58,12 +58,12 @@ class Pool implements \Countable
 
     public function setPackages(array $packages, array $priorities = array())
     {
-        $this->priorities = $priorities;
-        $this->packages = $packages;
-
         $id = 1;
 
-        foreach ($this->packages as $package) {
+        foreach ($packages as $i => $package) {
+            $this->packages[] = $package;
+            $this->priorities[] = isset($priorities[$i]) ? $priorities[$i] : 0;
+
             $package->id = $id++;
             $names = $package->getNames();
             $this->packageByExactName[$package->getName()][$package->id] = $package;


### PR DESCRIPTION
This still loads all package metadata by name but it collects all constraints for all names as it loads data. It then tries to prune all versions away which do not match a single constraint used for that package name, before the pool is created and before the solver creates rules.

Results:
Composer: 8MB peak saved, 14% rule reduction, 12% package object count reduction
Sylius: 22MB peak saved, 2.4% rule reduction, 14% package object count reduction

Applying this pruning to aliased packages seems unnecessarily complex for hardly any benefit that I could measure, so I may want to remove that part from this PR.

Alternatively we could still try to prune versions as part of data loading already. The only downside is that it's possible that a versions already pruned for a package may be needed if we later encounter a package with a different constraint for the same name that's wider than the previous constraints.