### PR TITLE
Fix the doc markup

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -856,9 +856,9 @@ is a hidden, global (per-user on the machine) directory that is shared between
 all projects.
 
 By default it points to `C:\Users\<user>\AppData\Roaming\Composer` on Windows
-and `/Users/<user>/.composer` on OSX. On *nix systems that follow the [XDG Base
+and `/Users/<user>/.composer` on OSX. On \*nix systems that follow the [XDG Base
 Directory Specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html),
-it points to `$XDG_CONFIG_HOME/composer`. On other *nix systems, it points to
+it points to `$XDG_CONFIG_HOME/composer`. On other \*nix systems, it points to
 `/home/<user>/.composer`.
 
 #### COMPOSER_HOME/config.json


### PR DESCRIPTION
In `*nix`, the star needs to be part of the content, not of the markdown markup, and so it requires escaping.