### PR TITLE
Adds throws tags in PHPDocs

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -36,6 +36,7 @@ class Cache
      * @param string      $cacheDir   location of the cache
      * @param string      $whitelist  List of characters that are allowed in path names (used in a regex character class)
      * @param Filesystem  $filesystem optional filesystem instance
+     * @throws \Exception
      */
     public function __construct(IOInterface $io, $cacheDir, $whitelist = 'a-z0-9.', Filesystem $filesystem = null)
     {

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -149,6 +149,7 @@ class Factory
     /**
      * @param  IOInterface|null $io
      * @return Config
+     * @throws \Exception
      */
     public static function createConfig(IOInterface $io = null, $cwd = null)
     {

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -282,8 +282,8 @@ class Locker
      * @param bool   $preferStable
      * @param bool   $preferLowest
      * @param array  $platformOverrides
-     *
      * @return bool
+     * @throws \Exception
      */
     public function setLockData(array $packages, $devPackages, array $platformReqs, $platformDevReqs, array $aliases, $minimumStability, array $stabilityFlags, $preferStable, $preferLowest, array $platformOverrides)
     {

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -293,6 +293,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      * @param  string      $name          package name
      * @param  bool        $bypassFilters If set to true, this bypasses the stability filtering, and forces a recompute without cache
      * @return array|mixed
+     * @throws RepositorySecurityException
      */
     public function whatProvides(Pool $pool, $name, $bypassFilters = false)
     {

--- a/src/Composer/Repository/Pear/ChannelRest10Reader.php
+++ b/src/Composer/Repository/Pear/ChannelRest10Reader.php
@@ -78,6 +78,7 @@ class ChannelRest10Reader extends BaseChannelReader
      * @param $baseUrl      string
      * @param $packageName  string
      * @return PackageInfo
+     * @throws \Exception
      */
     private function readPackage($baseUrl, $packageName)
     {

--- a/src/Composer/Repository/RepositoryManager.php
+++ b/src/Composer/Repository/RepositoryManager.php
@@ -111,6 +111,7 @@ class RepositoryManager
      * @param  array                     $config repository configuration
      * @param  string                    $name   repository name
      * @throws \InvalidArgumentException if repository for provided type is not registered
+     * @throws \ReflectionException
      * @return RepositoryInterface
      */
     public function createRepository($type, $config, $name = null)


### PR DESCRIPTION
Looking some classes I saw that some methods there was no comment on what their exception was, this PR is meant to add the exception comment that the method can throw.