### PR TITLE
Warning about the UNIX permissions lost if unzip command is not installed

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -69,7 +69,8 @@ class ZipDownloader extends ArchiveDownloader
 
             if (!self::$isWindows && !self::$hasSystemUnzip) {
                 $this->io->writeError("<warning>As there is no 'unzip' command installed zip files are being unpacked using the PHP zip extension.</warning>");
-                $this->io->writeError("<warning>This may cause invalid reports of corrupted archives. Installing 'unzip' may remediate them.</warning>");
+                $this->io->writeError("<warning>This may cause invalid reports of corrupted archives. Besides, any UNIX permissions (e.g. executable) defined in the archives will be lost.</warning>");
+                $this->io->writeError("<warning>Installing 'unzip' may remediate them.</warning>");
             }
         }
 


### PR DESCRIPTION
This pull request updates the warning about the `unzip` command not available to put in the spotlight, the fact that UNIX permissions will not be kept. This is especially important for the packages such as [Symfony Panther](https://github.com/symfony/panther) or [Laravel Dusk](https://github.com/laravel/dusk), which provide some binary files that should have the executable permission.

This issue is due to PHP's ZIP extension not handling UNIX permissions, which are a an extension to Microsoft's standard by the open-source software's community.

As using PHP's Unzip extension may lead to some strange issues, I'd like to propose to ask the user if they really want to continue that way. What do you think?