### PR TITLE
Don't call Symfony ProcessUtils::escapeArgument

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -131,15 +131,11 @@ class ProcessExecutor
      */
     public static function escape($argument)
     {
-        if (method_exists('Symfony\Component\Process\ProcessUtils', 'escapeArgument')) {
-            return ProcessUtils::escapeArgument($argument);
-        }
-
         return self::escapeArgument($argument);
     }
 
     /**
-     * Copy of ProcessUtils::escapeArgument() that is removed in Symfony 4.
+     * Copy of ProcessUtils::escapeArgument() that is deprecated in Symfony 3.3 and removed in Symfony 4.
      *
      * @param string $argument
      *


### PR DESCRIPTION
We currently check if `Symfony\Component\Process\ProcessUtils` has the `escapeArgument` method in order to call it (it has been removed in Symfony 4).

BTW `ProcessUtils::escapeArgument` throws a `E_USER_DEPRECATED` warning for Symfony 3.3+.

So, what about avoid calling it?