### PR TITLE
composer/composer#7384: add chat to support options

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -243,7 +243,7 @@ Support information includes the following:
 * **source:** URL to browse or download the sources.
 * **docs:** URL to the documentation.
 * **rss:** URL to the RSS feed.
-* **chat:** URL to chat server.
+* **chat:** URL to the chat channel.
 
 An example:
 

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -243,6 +243,7 @@ Support information includes the following:
 * **source:** URL to browse or download the sources.
 * **docs:** URL to the documentation.
 * **rss:** URL to the RSS feed.
+* **chat:** URL to chat server.
 
 An example:
 

--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -161,7 +161,7 @@ class ValidatingArrayLoader implements LoaderInterface
         }
 
         if ($this->validateArray('support') && !empty($this->config['support'])) {
-            foreach (array('issues', 'forum', 'wiki', 'source', 'email', 'irc', 'docs', 'rss') as $key) {
+            foreach (array('issues', 'forum', 'wiki', 'source', 'email', 'irc', 'docs', 'rss', 'chat') as $key) {
                 if (isset($this->config['support'][$key]) && !is_string($this->config['support'][$key])) {
                     $this->errors[] = 'support.'.$key.' : invalid value, must be a string';
                     unset($this->config['support'][$key]);
@@ -178,7 +178,7 @@ class ValidatingArrayLoader implements LoaderInterface
                 unset($this->config['support']['irc']);
             }
 
-            foreach (array('issues', 'forum', 'wiki', 'source', 'docs') as $key) {
+            foreach (array('issues', 'forum', 'wiki', 'source', 'docs', 'chat') as $key) {
                 if (isset($this->config['support'][$key]) && !$this->filterUrl($this->config['support'][$key])) {
                     $this->warnings[] = 'support.'.$key.' : invalid value ('.$this->config['support'][$key].'), must be an http/https URL';
                     unset($this->config['support'][$key]);

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -71,6 +71,7 @@ class ValidatingArrayLoaderTest extends TestCase
                         'source' => 'http://example.org/',
                         'irc' => 'irc://example.org/example',
                         'rss' => 'http://example.org/rss',
+                        'chat' => 'http://example.org/chat',
                     ),
                     'require' => array(
                         'a/b' => '1.*',
@@ -305,6 +306,7 @@ class ValidatingArrayLoaderTest extends TestCase
                         'forum' => 'foo:bar',
                         'issues' => 'foo:bar',
                         'wiki' => 'foo:bar',
+                        'chat' => 'foo:bar',
                     ),
                 ),
                 array(
@@ -312,6 +314,7 @@ class ValidatingArrayLoaderTest extends TestCase
                     'support.forum : invalid value (foo:bar), must be an http/https URL',
                     'support.issues : invalid value (foo:bar), must be an http/https URL',
                     'support.wiki : invalid value (foo:bar), must be an http/https URL',
+                    'support.chat : invalid value (foo:bar), must be an http/https URL',
                 ),
             ),
             array(


### PR DESCRIPTION
 - update schema documents to note that chat is allowed,
 - validate that chat must be a string and a url similar to forum options

Is there anything else that should be changed? As far as I can see most chat options like slack and discord take a url to register users.