### PR TITLE
composer/composer#7159: make the remove command do a lookup

### DIFF
--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -94,10 +94,23 @@ EOT
             if (isset($composer[$type][$package])) {
                 $json->removeLink($type, $composer[$type][$package]);
             } elseif (isset($composer[$altType][$package])) {
-                $io->writeError('<warning>'.$composer[$altType][$package].' could not be found in '.$type.' but it is present in '.$altType.'</warning>');
+                $io->writeError('<warning>' . $composer[$altType][$package] . ' could not be found in ' . $type . ' but it is present in ' . $altType . '</warning>');
                 if ($io->isInteractive()) {
-                    if ($io->askConfirmation('Do you want to remove it from '.$altType.' [<comment>yes</comment>]? ', true)) {
+                    if ($io->askConfirmation('Do you want to remove it from ' . $altType . ' [<comment>yes</comment>]? ', true)) {
                         $json->removeLink($altType, $composer[$altType][$package]);
+                    }
+                }
+            } elseif (isset($composer[$type]) && $matches = preg_grep('#^'.$package.'#', array_keys($composer[$type]))) {
+                foreach ($matches as $matchedPackage) {
+                    $json->removeLink($type, $matchedPackage);
+                }
+            } elseif (isset($composer[$altType]) && $matches = preg_grep('#^'.$package.'#', array_keys($composer[$altType]))) {
+                foreach ($matches as $matchedPackage) {
+                    $io->writeError('<warning>' . $matchedPackage . ' could not be found in ' . $type . ' but it is present in ' . $altType . '</warning>');
+                    if ($io->isInteractive()) {
+                        if ($io->askConfirmation('Do you want to remove it from ' . $altType . ' [<comment>yes</comment>]? ', true)) {
+                            $json->removeLink($altType, $matchedPackage);
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Make the remove command do a lookup for package name

 - if you have multiple vendor modules installed you should be able to do composer remove vendor/* to remove all
 - update remove and also remove from alternative type to also do a preg_grep for what the user has inputed

Fixes #7159 