### PR TITLE
Report "same as actual" version if override package matches actual

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -236,7 +236,12 @@ class PlatformRepository extends ArrayRepository
         // Skip if overridden
         if (isset($this->overrides[$package->getName()])) {
             $overrider = $this->findPackage($package->getName(), '*');
-            $overrider->setDescription($overrider->getDescription().' (actual: '.$package->getPrettyVersion().')');
+            if ($package->getVersion() === $overrider->getVersion()) {
+                $actualText = 'same as actual';
+            } else {
+                $actualText = 'actual: '.$package->getPrettyVersion();
+            }
+            $overrider->setDescription($overrider->getDescription().' ('.$actualText.')');
 
             return;
         }
@@ -244,7 +249,12 @@ class PlatformRepository extends ArrayRepository
         // Skip if PHP is overridden and we are adding a php-* package
         if (isset($this->overrides['php']) && 0 === strpos($package->getName(), 'php-')) {
             $overrider = $this->addOverriddenPackage($this->overrides['php'], $package->getPrettyName());
-            $overrider->setDescription($overrider->getDescription().' (actual: '.$package->getPrettyVersion().')');
+            if ($package->getVersion() === $overrider->getVersion()) {
+                $actualText = 'same as actual';
+            } else {
+                $actualText = 'actual: '.$package->getPrettyVersion();
+            }
+            $overrider->setDescription($overrider->getDescription().' ('.$actualText.')');
 
             return;
         }


### PR DESCRIPTION
When running `composer show -p` and having defined overrides via config.platform, the corresponding lines currently will show as
```
php                 7.2.9    Package overridden via config.platform (actual: 7.2.9)
```
This isn't very practical if you want to determine discrepancies.
Therefor I propose changing it to the following if the version matches:
```
php                 7.2.9    Package overridden via config.platform (same as actual)
```
If the versions don't match, the same format as before is used:
```
lib-curl            7.47.0   Package overridden via config.platform (actual: 7.52.1)
```