### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,14 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 matrix:
   include:
     - php: 5.3
       dist: precise
-    - php: 7.2
+    - php: 7.3
       env: deps=high
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and builds haven't been tested against PHP 7.3 for months now.

As of this week, Travis has (finally) made a PHP 7.3 alias available now RC3 is out, so I've added PHP 7.3 to the matrix.