### PR TITLE
Updated deploy php version to 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,4 +73,4 @@ deploy:
   on:
     tags: true
     repo: composer/composer
-    php:  '7.1'
+    php:  '7.2'


### PR DESCRIPTION
Actually not 100% sure this is correct, but I feel the php version used for deployment should be the latest stable