### PR TITLE
Fix: undefined index name in VcsRepository

### DIFF
--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -188,7 +188,8 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
                     continue;
                 }
 
-                if ($existingPackage = $this->findPackage($data['name'], $data['version_normalized'])) {
+                $tagPackageName = isset($data['name']) ? $data['name'] : $this->packageName;
+                if ($existingPackage = $this->findPackage($tagPackageName, $data['version_normalized'])) {
                     if ($verbose) {
                         $this->io->writeError('<warning>Skipped tag '.$tag.', it conflicts with an another tag ('.$existingPackage->getPrettyVersion().') as both resolve to '.$data['version_normalized'].' internally</warning>');
                     }


### PR DESCRIPTION
Requiring a VcsRepository that has tags where the composer.json is missing the name attribute in certain tags results in PHP notices.

This is the error message if I force throwing exceptions on notices
`Notice: Undefined index: name {"exception":"[object] (ErrorException(code: 0): Notice: Undefined index: name at /path/to/vendor/composer/composer/src/Composer/Repository/VcsRepository.php:201)