### PR TITLE
Ensure that a missing SSL/TLS protection warning does not pollute STDOUT

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -588,7 +588,7 @@ class Factory
         $disableTls = false;
         if ($config && $config->get('disable-tls') === true) {
             if (!$warned) {
-                $io->write('<warning>You are running Composer with SSL/TLS protection disabled.</warning>');
+                $io->writeError('<warning>You are running Composer with SSL/TLS protection disabled.</warning>');
             }
             $warned = true;
             $disableTls = true;

--- a/tests/Composer/Test/FactoryTest.php
+++ b/tests/Composer/Test/FactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test;
+
+use PHPUnit\Framework\TestCase;
+use Composer\Factory;
+
+class FactoryTest extends TestCase
+{
+    /**
+     * @group TLS
+     */
+    public function testDefaultValuesAreAsExpected()
+    {
+        $ioMock = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+
+        $ioMock->expects($this->once())
+            ->method("writeError");
+
+        $config = $this
+            ->getMockBuilder('Composer\Config')
+            ->getMock();
+
+        $config->method('get')
+            ->with($this->equalTo('disable-tls'))
+            ->will($this->returnValue(true));
+
+        Factory::createRemoteFilesystem($ioMock, $config);
+    }
+}

--- a/tests/Composer/Test/FactoryTest.php
+++ b/tests/Composer/Test/FactoryTest.php
@@ -25,7 +25,8 @@ class FactoryTest extends TestCase
         $ioMock = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
 
         $ioMock->expects($this->once())
-            ->method("writeError");
+            ->method("writeError")
+            ->with($this->equalTo('<warning>You are running Composer with SSL/TLS protection disabled.</warning>'));
 
         $config = $this
             ->getMockBuilder('Composer\Config')


### PR DESCRIPTION
- [x] Fixes #7737
- [x] Covered by a test

There's a similar PR #7750 which I overlook, but it has no test coverage.