### PR TITLE
Bitbucket: fix redirect behaviour for private repositories

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -385,15 +385,18 @@ class RemoteFilesystem
 
         $statusCode = null;
         $contentType = null;
+        $locationHeader = null;
         if (!empty($http_response_header[0])) {
             $statusCode = $this->findStatusCode($http_response_header);
             $contentType = $this->findHeaderValue($http_response_header, 'content-type');
+            $locationHeader = $this->findHeaderValue($http_response_header, 'location');
         }
 
         // check for bitbucket login page asking to authenticate
         if ($originUrl === 'bitbucket.org'
             && !$this->isPublicBitBucketDownload($fileUrl)
             && substr($fileUrl, -4) === '.zip'
+            && (!$locationHeader || substr($locationHeader, -4) !== '.zip')
             && $contentType && preg_match('{^text/html\b}i', $contentType)
         ) {
             $result = false;


### PR DESCRIPTION
If your Bitbucket user/team name contains upper case letters and composer tries to download the zip file with all lower case letters then Bitbucket will return a 302 Found with content-type "text/html" and the new location to the zip file.

Currently for private repositories this will try to setup oauth which is not necessary.

Below you find all the response headers that are returned by Bitbucket:
```
array (
  0 => 'HTTP/1.1 302 Found',
  1 => 'Content-Security-Policy-Report-Only:',
  2 => 'Server: nginx',
  3 => 'Vary: Accept-Language, Cookie',
  4 => 'Cache-Control: no-cache, no-store, must-revalidate, max-age=0',
  5 => 'Content-Type: text/html; charset=utf-8',
  6 => 'X-OAuth-Scopes: webhook, repository, team, account',
  7 => 'X-Usage-Output-Ops: 0',
  8 => 'Strict-Transport-Security: max-age=31536000; includeSubDomains; preload',
  9 => 'Date: Fri, 26 Oct 2018 XX:XX:XX GMT',
  10 => 'X-Usage-User-Time: ########',
  11 => 'X-Usage-System-Time: ########',
  12 => 'Location: /My-Bitbucket-Team/my-repository/get/XXXXXXXXXXXXXXXXXXXXX.zip',
  13 => 'bbuserid: ########',
  14 => 'X-Served-By: app-XXX',
  15 => 'Expires: Fri, 26 Oct 2018 XX:XX:XX GMT',
  16 => 'Content-Language: en',
  17 => 'X-View-Name: bitbucket.apps.archiving.views.download_repo',
  18 => 'ETag: "#############"',
  19 => 'X-Static-Version: XXXXXXX',
  20 => 'X-Content-Type-Options: nosniff',
  21 => 'X-Credential-Type: apppassword',
  22 => 'X-Render-Time: 0.034285068512',
  23 => 'Connection: close',
  24 => 'bbusername: #############',
  25 => 'X-Usage-Input-Ops: 0',
  26 => 'X-Request-Count: XXXX',
  27 => 'Last-Modified: Fri, 26 Oct 2018 XX:XX:XX GMT',
  28 => 'X-Version: XXXXXXX',
  29 => 'X-Frame-Options: SAMEORIGIN',
  30 => 'X-Cache-Info: not cacheable; response specified "Cache-Control: no-cache"',
  31 => 'Content-Length: 0',
)
```