### PR TITLE
VcsRepository: fix undefined index notice in preProcess

### DIFF
--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -295,7 +295,8 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
     protected function preProcess(VcsDriverInterface $driver, array $data, $identifier)
     {
         // keep the name of the main identifier for all packages
-        $data['name'] = $this->packageName ?: $data['name'];
+        $dataPackageName = isset($data['name']) ? $data['name'] : null;
+        $data['name'] = $this->packageName ?: $dataPackageName;
 
         if (!isset($data['dist'])) {
             $data['dist'] = $driver->getDist($identifier);


### PR DESCRIPTION
Requiring a VcsRepository that doesn't have a composer.json in the rootIdentifier branch and that has tags and/or branches where the composer.json is missing the name attribute results in PHP notices.

`$this->packageName` is `null` if there is no composer.json in the rootIdentifier branch.

`Notice: Undefined index: name {"exception":"[object] (ErrorException(code: 0): Notice: Undefined index: name at /path/to/vendor/composer/composer/src/Composer/Repository/VcsRepository.php:298`