### PR TITLE
add lib-imagick to composer show -p output

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -157,6 +157,18 @@ class PlatformRepository extends ArrayRepository
 
                     break;
 
+                case 'imagick':
+                    $reflector = new \ReflectionExtension('imagick');
+
+                    ob_start();
+                    $reflector->info();
+                    $output = ob_get_clean();
+
+                    preg_match('/^Imagick using ImageMagick library version => ImageMagick ([\d.]+)-(\d+)/m', $output, $matches);
+                    $prettyVersion = "{$matches[1]}.{$matches[2]}";
+
+                    break;
+
                 case 'libxml':
                     $prettyVersion = LIBXML_DOTTED_VERSION;
                     break;


### PR DESCRIPTION
Most of the imagick pecl extension functionality cames from underlying ImageMagick library version: http://php.net/manual/en/imagick.constants.php (see descriptions like `This constant is available if Imagick has been compiled against ImageMagick version 6.4.0 or higher.`)

# before
```
$ composer.phar show -p|grep -i imagick
ext-imagick          3.4.3     The imagick PHP extension
```

# after

```
$ ./bin/composer show -p|grep imagick
ext-imagick          3.4.3     The imagick PHP extension
lib-imagick          7.0.8.14  The imagick PHP library
```

Sadly there's no constant in the extension, so the version information is extracted from extension info, like `intl` extension.

There's two versions available, version from compile time and from runtime. Wasn't sure which one to pick, so I choose runtime version.

```
$ php -r '(new \ReflectionExtension("imagick"))->info();'|grep version
imagick module version => 3.4.3
Imagick compiled with ImageMagick version => ImageMagick 7.0.8-7 Q16 x86_64 2018-07-18 https://www.imagemagick.org
Imagick using ImageMagick library version => ImageMagick 7.0.8-14 Q16 x86_64 2018-10-25 https://imagemagick.org
imagick.skip_version_check => 0 => 0
```