### PR TITLE
Fixed Typo: Wrong folder name for Unix Systems

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -149,7 +149,7 @@ versions. See also [COMPOSER_HOME](03-cli.md#composer-home).
 
 Defaults to `C:\Users\<user>\AppData\Local\Composer` on Windows,
 `$XDG_CACHE_HOME/composer` on unix systems that follow the XDG Base Directory
-Specifications, and `$home/cache` on other unix systems. Stores all the caches
+Specifications, and `$home/.cache` on other unix systems. Stores all the caches
 used by Composer. See also [COMPOSER_HOME](03-cli.md#composer-home).
 
 ## cache-files-dir


### PR DESCRIPTION
The documentation says, the cache folder for unix systems is `$home/cache` but the correct path is `$home/.cache`.