### PR TITLE
Add support for running composer with phpdbg

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-if (PHP_SAPI !== 'cli') {
+if (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') {
     echo 'Warning: Composer should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
 }
 

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -262,16 +262,17 @@ class EventDispatcher
     protected function getPhpExecCommand()
     {
         $finder = new PhpExecutableFinder();
-        $phpPath = $finder->find();
+        $phpPath = $finder->find(false);
         if (!$phpPath) {
             throw new \RuntimeException('Failed to locate PHP binary to execute '.$phpPath);
         }
-
+        $phpArgs = $finder->findArguments();
+        $phpArgs = $phpArgs ? ' ' . implode(' ', $phpArgs) : '';
         $allowUrlFOpenFlag = ' -d allow_url_fopen=' . ProcessExecutor::escape(ini_get('allow_url_fopen'));
         $disableFunctionsFlag = ' -d disable_functions=' . ProcessExecutor::escape(ini_get('disable_functions'));
         $memoryLimitFlag = ' -d memory_limit=' . ProcessExecutor::escape(ini_get('memory_limit'));
 
-        return ProcessExecutor::escape($phpPath) . $allowUrlFOpenFlag . $disableFunctionsFlag . $memoryLimitFlag;
+        return ProcessExecutor::escape($phpPath) . $phpArgs . $allowUrlFOpenFlag . $disableFunctionsFlag . $memoryLimitFlag;
     }
 
     /**

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -40,7 +40,7 @@ final class StreamContextFactory
         ));
 
         // Handle HTTP_PROXY/http_proxy on CLI only for security reasons
-        if (PHP_SAPI === 'cli' && (!empty($_SERVER['HTTP_PROXY']) || !empty($_SERVER['http_proxy']))) {
+        if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') && (!empty($_SERVER['HTTP_PROXY']) || !empty($_SERVER['http_proxy']))) {
             $proxy = parse_url(!empty($_SERVER['http_proxy']) ? $_SERVER['http_proxy'] : $_SERVER['HTTP_PROXY']);
         }
 


### PR DESCRIPTION
In order to run PHPUnit, it's very handy to add a section like this in composer.json:
```json
{
    "require-dev": {
        "phpunit/phpunit": "whatever"
    },
    "scripts": {
        "test": "phpunit"
    }
}
```

so that we can invoke PHPUnit simply by running

```sh
composer run-script test
```

This is currently working great.

We have one problem though: when we want to collect code coverage (`composer run-script test -- --coverage-clover=coverage.xml`), we can use xdebug or phpdbg.

Using xdebug works fine.

BTW using phpdbg doesn't work, since `PhpExecutableFinder::find()` returns `'/usr/bin/phpdbg -rrq'` (note the extra argument), and composer calls `ProcessExecutor::escape()` on it, so we'll try to execute the command `/usr/bin/phpdbg -qrr`, which does not exist (what exists is `/usr/bin/phpdbg`).

So, let's just escape `/usr/bin/phpdbg` (the result of `PhpExecutableFinder::find(false)`), and add optional php executable arguments ( `PhpExecutableFinder::findArguments()`) in a separate way.