### PR TITLE
Fix support for imagemagick <3.3

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -158,15 +158,10 @@ class PlatformRepository extends ArrayRepository
                     break;
 
                 case 'imagick':
-                    $reflector = new \ReflectionExtension('imagick');
-
-                    ob_start();
-                    $reflector->info();
-                    $output = ob_get_clean();
-
-                    preg_match('/^(Imagick using ImageMagick library version|ImageMagick version) => ImageMagick ([\d.]+)-(\d+)/m', $output, $matches);
+                    $imagick = new \Imagick();
+                    $imageMagickVersion = $imagick->getVersion();
+                    preg_match('/^ImageMagick ([\d.]+)-(\d+)/', $imageMagickVersion['versionString'], $matches);
                     $prettyVersion = "{$matches[1]}.{$matches[2]}";
-
                     break;
 
                 case 'libxml':


### PR DESCRIPTION
This PR is an alternative to https://github.com/composer/composer/commit/489e0d4b124905a26310c9026d83eb82eb0e57ce (which introduced another bug).
See #7762:

> This regex is not correct and breaks Composer with PHP Imagick < `3.3.0`:
> * Before `3.3.0`:
> ```C
> php_info_print_table_row(2, "ImageMagick version", MagickGetVersion(&version_number));
> ```
> * Since `3.3.0`:
> ```C
> php_info_print_table_row(2, "Imagick using ImageMagick library version", MagickGetVersion(&version_number));
> ```