### PR TITLE
Pool Builder: don't add identical packages (same name, version, stability, require, provide, replace, conflict)

### DIFF
--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -106,6 +106,44 @@ abstract class BasePackage implements PackageInterface
         return array_keys($names);
     }
 
+    public function getIdentityHash()
+    {
+        return md5($this->getIdentityString());
+    }
+
+    public function isIdentical(BasePackage $package)
+    {
+        return $this->getIdentityString() == $package->getIdentityString();
+    }
+
+    protected function getIdentityString()
+    {
+        $str = $this->getName().';'.$this->getVersion().';'.$this->getStability().'@@@';
+
+        $links = array();
+        foreach ($this->getProvides() as $link) {
+            $links[] = $link->getTarget().';'.(string) $link->getConstraint();
+        }
+        sort($links);
+        $str .= implode('@@', $links).'@@@';
+
+        $links = array();
+        foreach ($this->getReplaces() as $link) {
+            $links[] = $link->getTarget().';'.(string) $link->getConstraint();
+        }
+        sort($links);
+        $str .= implode('@@', $links).'@@@';
+
+        $links = array();
+        foreach ($this->getConflicts() as $link) {
+            $links[] = $link->getTarget().';'.(string) $link->getConstraint();
+        }
+        sort($links);
+        $str .= '@@@';
+
+        return $str;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/tests/Composer/Test/DependencyResolver/DefaultPolicyTest.php
+++ b/tests/Composer/Test/DependencyResolver/DefaultPolicyTest.php
@@ -193,7 +193,7 @@ class DefaultPolicyTest extends TestCase
         $this->assertSame($expected, $selected);
     }
 
-    public function testSelectLocalReposFirst()
+    public function testSelectFirstPackageInSameRepo()
     {
         $repoImportant = new ArrayRepository;
 


### PR DESCRIPTION
For now this improves performance with present lock file and breaks tests which check if packages get updated to remote package. After further installer refactoring this will lead to correct updating behaviour (lock packages will always be lowest priority) and improve updates with lock file present.

Current improvement on a Sylius project with vendor directory present: 0.5% reduction in rules (= 15k rules), 185 package objects less analyzed (~= number of installed packages), 8MB memory reduced (=0.4%).

For now this breaks tests verifying installed packages get updated to newest metadata on remote end. After refactoring the installer to always pick remote packages as highest priority we can drop any special code to update installed packages and this patch will take care of ensuring the right package data is used.

