### PR TITLE
Update all root dependencies matching given pattern

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.8-dev"
+            "dev-master": "1.9-dev"
         }
     },
     "autoload": {

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1332,8 +1332,8 @@ class Installer
                 $whitelistPatternRegexp = BasePackage::packageNameToRegexp($packageName);
                 foreach ($rootRequiredPackageNames as $rootRequiredPackageName) {
                     if (preg_match($whitelistPatternRegexp, $rootRequiredPackageName)) {
+                        $depPackages = array_merge($pool->whatProvides($rootRequiredPackageName));
                         $nameMatchesRequiredPackage = true;
-                        break;
                     }
                 }
             }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1323,7 +1323,7 @@ class Installer
         foreach ($this->updateWhitelist as $packageName => $void) {
             $packageQueue = new \SplQueue;
 
-            $depPackages = $pool->whatProvides($packageName);
+            $depPackages = [$pool->whatProvides($packageName)];
 
             $nameMatchesRequiredPackage = in_array($packageName, $requiredPackageNames, true);
 
@@ -1332,11 +1332,13 @@ class Installer
                 $whitelistPatternRegexp = BasePackage::packageNameToRegexp($packageName);
                 foreach ($rootRequiredPackageNames as $rootRequiredPackageName) {
                     if (preg_match($whitelistPatternRegexp, $rootRequiredPackageName)) {
-                        $depPackages = array_merge($pool->whatProvides($rootRequiredPackageName));
+                        $depPackages[] = $pool->whatProvides($rootRequiredPackageName);
                         $nameMatchesRequiredPackage = true;
                     }
                 }
             }
+
+            $depPackages = array_merge(...$depPackages);
 
             if (count($depPackages) == 0 && !$nameMatchesRequiredPackage && !in_array($packageName, array('nothing', 'lock', 'mirrors'))) {
                 $this->io->writeError('<warning>Package "' . $packageName . '" listed for update is not installed. Ignoring.</warning>');

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1319,7 +1319,7 @@ class Installer
             $packageQueue = new \SplQueue;
 
             $depPackages = $pool->whatProvides($packageName);
-            $matchesByPattern = [];
+            $matchesByPattern = array();
             // check if the name is a glob pattern that did not match directly
             if (empty($depPackages)) {
                 $whitelistPatternSearchRegexp = BasePackage::packageNameToRegexp($packageName, '^%s$');
@@ -1336,7 +1336,7 @@ class Installer
             }
 
             if (!empty($matchesByPattern)) {
-                $depPackages = array_merge($depPackages, array_merge(...$matchesByPattern));
+                $depPackages = array_merge($depPackages, call_user_func_array('array_merge', $matchesByPattern));
             }
 
             if (count($depPackages) == 0 && !$nameMatchesRequiredPackage && !in_array($packageName, array('nothing', 'lock', 'mirrors'))) {

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -239,12 +239,13 @@ abstract class BasePackage implements PackageInterface
      * Build a regexp from a package name, expanding * globs as required
      *
      * @param  string $whiteListedPattern
+     * @param  bool $wrap Wrap the cleaned string by the given string
      * @return string
      */
-    public static function packageNameToRegexp($whiteListedPattern)
+    public static function packageNameToRegexp($whiteListedPattern, $wrap = '{^%s$}i')
     {
         $cleanedWhiteListedPattern = str_replace('\\*', '.*', preg_quote($whiteListedPattern));
 
-        return "{^" . $cleanedWhiteListedPattern . "$}i";
+        return sprintf($wrap, $cleanedWhiteListedPattern);
     }
 }

--- a/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns-with-all-dependencies.test
+++ b/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns-with-all-dependencies.test
@@ -1,0 +1,46 @@
+--TEST--
+Update with a package whitelist pattern and all-dependencies flag updates packages and their dependencies, even if defined as root dependency, matching the pattern
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "fixed", "version": "1.1.0" },
+                { "name": "fixed", "version": "1.0.0" },
+                { "name": "whitelisted-component1", "version": "1.1.0" },
+                { "name": "whitelisted-component1", "version": "1.0.0" },
+                { "name": "whitelisted-component2", "version": "1.1.0", "require": { "dependency": "1.*" } },
+                { "name": "whitelisted-component2", "version": "1.0.0", "require": { "dependency": "1.*" } },
+                { "name": "dependency", "version": "1.1.0" },
+                { "name": "dependency", "version": "1.0.0" },
+                { "name": "unrelated", "version": "1.1.0", "require": { "unrelated-dependency": "1.*" }  },
+                { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" }  },
+                { "name": "unrelated-dependency", "version": "1.1.0" },
+                { "name": "unrelated-dependency", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "fixed": "1.*",
+        "whitelisted-component1": "1.*",
+        "whitelisted-component2": "1.*",
+        "dependency": "1.*",
+        "unrelated": "1.*"
+    }
+}
+--INSTALLED--
+[
+    { "name": "fixed", "version": "1.0.0" },
+    { "name": "whitelisted-component1", "version": "1.0.0" },
+    { "name": "whitelisted-component2", "version": "1.0.0", "require": { "dependency": "1.0.0" } },
+    { "name": "dependency", "version": "1.0.0" },
+    { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" } },
+    { "name": "unrelated-dependency", "version": "1.0.0" }
+]
+--RUN--
+update whitelisted-* --with-all-dependencies
+--EXPECT--
+Updating whitelisted-component1 (1.0.0) to whitelisted-component1 (1.1.0)
+Updating dependency (1.0.0) to dependency (1.1.0)
+Updating whitelisted-component2 (1.0.0) to whitelisted-component2 (1.1.0)

--- a/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns-with-dependencies.test
+++ b/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns-with-dependencies.test
@@ -1,0 +1,49 @@
+--TEST--
+Update with a package whitelist only updates those packages and their dependencies matching the pattern but no dependencies defined as roo package
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "fixed", "version": "1.1.0" },
+                { "name": "fixed", "version": "1.0.0" },
+                { "name": "whitelisted-component1", "version": "1.1.0" },
+                { "name": "whitelisted-component1", "version": "1.0.0" },
+                { "name": "whitelisted-component2", "version": "1.1.0", "require": { "dependency": "1.*", "root-dependency": "1.*" } },
+                { "name": "whitelisted-component2", "version": "1.0.0", "require": { "dependency": "1.*", "root-dependency": "1.*" } },
+                { "name": "dependency", "version": "1.1.0" },
+                { "name": "dependency", "version": "1.0.0" },
+                { "name": "root-dependency", "version": "1.1.0" },
+                { "name": "root-dependency", "version": "1.0.0" },
+                { "name": "unrelated", "version": "1.1.0", "require": { "unrelated-dependency": "1.*" }  },
+                { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" }  },
+                { "name": "unrelated-dependency", "version": "1.1.0" },
+                { "name": "unrelated-dependency", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "fixed": "1.*",
+        "whitelisted-component1": "1.*",
+        "whitelisted-component2": "1.*",
+        "root-dependency": "1.*",
+        "unrelated": "1.*"
+    }
+}
+--INSTALLED--
+[
+    { "name": "fixed", "version": "1.0.0" },
+    { "name": "whitelisted-component1", "version": "1.0.0" },
+    { "name": "whitelisted-component2", "version": "1.0.0", "require": { "dependency": "1.0.0" } },
+    { "name": "root-dependency", "version": "1.0.0" },
+    { "name": "dependency", "version": "1.0.0" },
+    { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" } },
+    { "name": "unrelated-dependency", "version": "1.0.0" }
+]
+--RUN--
+update whitelisted-* --with-dependencies
+--EXPECT--
+Updating whitelisted-component1 (1.0.0) to whitelisted-component1 (1.1.0)
+Updating dependency (1.0.0) to dependency (1.1.0)
+Updating whitelisted-component2 (1.0.0) to whitelisted-component2 (1.1.0)

--- a/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns-with-root-dependencies.test
+++ b/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns-with-root-dependencies.test
@@ -1,0 +1,45 @@
+--TEST--
+Update with a package whitelist only updates those packages and their dependencies matching the pattern
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "fixed", "version": "1.1.0" },
+                { "name": "fixed", "version": "1.0.0" },
+                { "name": "whitelisted-component1", "version": "1.1.0", "require": { "whitelisted-component2": "1.1.0" } },
+                { "name": "whitelisted-component1", "version": "1.0.0", "require": { "whitelisted-component2": "1.0.0" } },
+                { "name": "whitelisted-component2", "version": "1.1.0", "require": { "dependency": "1.1.0" } },
+                { "name": "whitelisted-component2", "version": "1.0.0", "require": { "dependency": "1.0.0" } },
+                { "name": "dependency", "version": "1.1.0" },
+                { "name": "dependency", "version": "1.0.0" },
+                { "name": "unrelated", "version": "1.1.0", "require": { "unrelated-dependency": "1.*" }  },
+                { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" }  },
+                { "name": "unrelated-dependency", "version": "1.1.0" },
+                { "name": "unrelated-dependency", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "fixed": "1.*",
+        "whitelisted-component1": "1.*",
+        "whitelisted-component2": "1.*",
+        "unrelated": "1.*"
+    }
+}
+--INSTALLED--
+[
+    { "name": "fixed", "version": "1.0.0" },
+    { "name": "whitelisted-component1", "version": "1.0.0", "require": { "whitelisted-component2": "1.0.0" } },
+    { "name": "whitelisted-component2", "version": "1.0.0", "require": { "dependency": "1.0.0" } },
+    { "name": "dependency", "version": "1.0.0" },
+    { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" } },
+    { "name": "unrelated-dependency", "version": "1.0.0" }
+]
+--RUN--
+update whitelisted-* --with-dependencies
+--EXPECT--
+Updating dependency (1.0.0) to dependency (1.1.0)
+Updating whitelisted-component2 (1.0.0) to whitelisted-component2 (1.1.0)
+Updating whitelisted-component1 (1.0.0) to whitelisted-component1 (1.1.0)

--- a/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns-with-root-dependencies.test
+++ b/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns-with-root-dependencies.test
@@ -10,8 +10,14 @@ Update with a package whitelist only updates those packages and their dependenci
                 { "name": "fixed", "version": "1.0.0" },
                 { "name": "whitelisted-component1", "version": "1.1.0", "require": { "whitelisted-component2": "1.1.0" } },
                 { "name": "whitelisted-component1", "version": "1.0.0", "require": { "whitelisted-component2": "1.0.0" } },
-                { "name": "whitelisted-component2", "version": "1.1.0", "require": { "dependency": "1.1.0" } },
+                { "name": "whitelisted-component2", "version": "1.1.0", "require": { "dependency": "1.1.0", "whitelisted-component5": "1.0.0" } },
                 { "name": "whitelisted-component2", "version": "1.0.0", "require": { "dependency": "1.0.0" } },
+                { "name": "whitelisted-component3", "version": "1.1.0", "require": { "whitelisted-component4": "1.1.0" } },
+                { "name": "whitelisted-component3", "version": "1.0.0", "require": { "whitelisted-component4": "1.0.0" } },
+                { "name": "whitelisted-component4", "version": "1.1.0" },
+                { "name": "whitelisted-component4", "version": "1.0.0" },
+                { "name": "whitelisted-component5", "version": "1.1.0" },
+                { "name": "whitelisted-component5", "version": "1.0.0" },
                 { "name": "dependency", "version": "1.1.0" },
                 { "name": "dependency", "version": "1.0.0" },
                 { "name": "unrelated", "version": "1.1.0", "require": { "unrelated-dependency": "1.*" }  },
@@ -25,6 +31,7 @@ Update with a package whitelist only updates those packages and their dependenci
         "fixed": "1.*",
         "whitelisted-component1": "1.*",
         "whitelisted-component2": "1.*",
+        "whitelisted-component3": "1.0.0",
         "unrelated": "1.*"
     }
 }
@@ -33,6 +40,9 @@ Update with a package whitelist only updates those packages and their dependenci
     { "name": "fixed", "version": "1.0.0" },
     { "name": "whitelisted-component1", "version": "1.0.0", "require": { "whitelisted-component2": "1.0.0" } },
     { "name": "whitelisted-component2", "version": "1.0.0", "require": { "dependency": "1.0.0" } },
+    { "name": "whitelisted-component3", "version": "1.0.0", "require": { "whitelisted-component4": "1.0.0" } },
+    { "name": "whitelisted-component4", "version": "1.0.0" },
+    { "name": "whitelisted-component5", "version": "1.0.0" },
     { "name": "dependency", "version": "1.0.0" },
     { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" } },
     { "name": "unrelated-dependency", "version": "1.0.0" }

--- a/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns-without-dependencies.test
+++ b/tests/Composer/Test/Fixtures/installer/update-whitelist-patterns-without-dependencies.test
@@ -1,0 +1,44 @@
+--TEST--
+Update with a package whitelist only updates those packages matching the pattern
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "fixed", "version": "1.1.0" },
+                { "name": "fixed", "version": "1.0.0" },
+                { "name": "whitelisted-component1", "version": "1.1.0" },
+                { "name": "whitelisted-component1", "version": "1.0.0" },
+                { "name": "whitelisted-component2", "version": "1.1.0", "require": { "dependency": "1.*" } },
+                { "name": "whitelisted-component2", "version": "1.0.0", "require": { "dependency": "1.*" } },
+                { "name": "dependency", "version": "1.1.0" },
+                { "name": "dependency", "version": "1.0.0" },
+                { "name": "unrelated", "version": "1.1.0", "require": { "unrelated-dependency": "1.*" }  },
+                { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" }  },
+                { "name": "unrelated-dependency", "version": "1.1.0" },
+                { "name": "unrelated-dependency", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "fixed": "1.*",
+        "whitelisted-component1": "1.*",
+        "whitelisted-component2": "1.*",
+        "unrelated": "1.*"
+    }
+}
+--INSTALLED--
+[
+    { "name": "fixed", "version": "1.0.0" },
+    { "name": "whitelisted-component1", "version": "1.0.0" },
+    { "name": "whitelisted-component2", "version": "1.0.0", "require": { "dependency": "1.0.0" } },
+    { "name": "dependency", "version": "1.0.0" },
+    { "name": "unrelated", "version": "1.0.0", "require": { "unrelated-dependency": "1.*" } },
+    { "name": "unrelated-dependency", "version": "1.0.0" }
+]
+--RUN--
+update whitelisted-*
+--EXPECT--
+Updating whitelisted-component1 (1.0.0) to whitelisted-component1 (1.1.0)
+Updating whitelisted-component2 (1.0.0) to whitelisted-component2 (1.1.0)


### PR DESCRIPTION
The update command can receive a pattern like `vendor/prefix-*`
to update all matching packages.
This has not worked if multiple packages, depending on each other,
where matched to the given pattern. No package has been updated
in this case as only the first package matching the pattern was
added to the whitelist.

Resolves #7261