### PR TITLE
Allows the JsonFile class to be used for other json files than composer.json

### DIFF
--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -146,7 +146,7 @@ class JsonFile
      * Validates the schema of the current json file according to composer-schema.json rules
      *
      * @param  int                     $schema a JsonFile::*_SCHEMA constant
-     * @param  string                  $schemaFile a path to the schema file
+     * @param  string|null             $schemaFile a path to the schema file
      * @throws JsonValidationException
      * @return bool                    true on success
      */

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -34,7 +34,7 @@ class JsonFile
     const JSON_PRETTY_PRINT = 128;
     const JSON_UNESCAPED_UNICODE = 256;
 
-    const COMPOSER_SCHEMA_PATH = __DIR__ . '/../../../res/composer-schema.json';
+    const COMPOSER_SCHEMA_PATH = '/../../../res/composer-schema.json';
 
     private $path;
     private $rfs;
@@ -150,13 +150,17 @@ class JsonFile
      * @throws JsonValidationException
      * @return bool                    true on success
      */
-    public function validateSchema($schema = self::STRICT_SCHEMA, $schemaFile = self::COMPOSER_SCHEMA_PATH)
+    public function validateSchema($schema = self::STRICT_SCHEMA, $schemaFile = null)
     {
         $content = file_get_contents($this->path);
         $data = json_decode($content);
 
         if (null === $data && 'null' !== $content) {
             self::validateSyntax($content, $this->path);
+        }
+
+        if (null === $schemaFile) {
+            $schemaFile = __DIR__ . self::COMPOSER_SCHEMA_PATH;
         }
 
         // Prepend with file:// only when not using a special schema already (e.g. in the phar)

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -34,6 +34,8 @@ class JsonFile
     const JSON_PRETTY_PRINT = 128;
     const JSON_UNESCAPED_UNICODE = 256;
 
+    const COMPOSER_SCHEMA_PATH = __DIR__ . '/../../../res/composer-schema.json';
+
     private $path;
     private $rfs;
     private $io;
@@ -144,10 +146,11 @@ class JsonFile
      * Validates the schema of the current json file according to composer-schema.json rules
      *
      * @param  int                     $schema a JsonFile::*_SCHEMA constant
+     * @param  string                  $schemaFile a path to the schema file
      * @throws JsonValidationException
      * @return bool                    true on success
      */
-    public function validateSchema($schema = self::STRICT_SCHEMA)
+    public function validateSchema($schema = self::STRICT_SCHEMA, $schemaFile = self::COMPOSER_SCHEMA_PATH)
     {
         $content = file_get_contents($this->path);
         $data = json_decode($content);
@@ -155,8 +158,6 @@ class JsonFile
         if (null === $data && 'null' !== $content) {
             self::validateSyntax($content, $this->path);
         }
-
-        $schemaFile = __DIR__ . '/../../../res/composer-schema.json';
 
         // Prepend with file:// only when not using a special schema already (e.g. in the phar)
         if (false === strpos($schemaFile, '://')) {


### PR DESCRIPTION
Normally, there should be no side effects.
Unit tests work identically.
The goal is to allow the JsonFile class to be more easily used by any composer plugin.