### PR TITLE
Fix htaccess-protect problems

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -216,7 +216,6 @@ class Config
             case 'cache-vcs-dir':
             case 'cafile':
             case 'capath':
-            case 'htaccess-protect':
                 // convert foo-bar to COMPOSER_FOO_BAR and check if it exists since it overrides the local config
                 $env = 'COMPOSER_' . strtoupper(strtr($key, '-', '_'));
 
@@ -229,6 +228,13 @@ class Config
                 }
 
                 return (($flags & self::RELATIVE_PATHS) == self::RELATIVE_PATHS) ? $val : $this->realpath($val);
+
+            case 'htaccess-protect':
+                $value = $this->getComposerEnv('COMPOSER_HTACCESS_PROTECT');
+                if (false === $value) {
+                    $value = $this->config[$key];
+                }
+                return $value !== 'false' && (bool) $value;
 
             case 'cache-ttl':
                 return (int) $this->config[$key];

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -164,6 +164,16 @@ class Factory
             'data-dir' => self::getDataDir($home),
         )));
 
+        // load global config
+        $file = new JsonFile($config->get('home').'/config.json');
+        if ($file->exists()) {
+            if ($io && $io->isDebug()) {
+                $io->writeError('Loading config file ' . $file->getPath());
+            }
+            $config->merge($file->read());
+        }
+        $config->setConfigSource(new JsonConfigSource($file));
+
         $htaccessProtect = (bool) $config->get('htaccess-protect');
         if ($htaccessProtect) {
             // Protect directory against web access. Since HOME could be
@@ -179,16 +189,6 @@ class Factory
                 }
             }
         }
-
-        // load global config
-        $file = new JsonFile($config->get('home').'/config.json');
-        if ($file->exists()) {
-            if ($io && $io->isDebug()) {
-                $io->writeError('Loading config file ' . $file->getPath());
-            }
-            $config->merge($file->read());
-        }
-        $config->setConfigSource(new JsonConfigSource($file));
 
         // load global auth file
         $file = new JsonFile($config->get('home').'/auth.json');


### PR DESCRIPTION
htaccess-protect doesn't work in global config because the option is checked before the config is read.

This also fixes the parsing for htaccess-protect. It's parsed as a string but should be parsed as a bool.