### PR TITLE
Fix: Consistently indent with 2 spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,33 +37,33 @@ matrix:
     - php: nightly
 
 before_install:
-    # disable xdebug if available
-    - phpenv config-rm xdebug.ini || echo "xdebug not available"
-    # disable default memory limit
-    - export INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-    - echo memory_limit = -1 >> $INI
+  # disable xdebug if available
+  - phpenv config-rm xdebug.ini || echo "xdebug not available"
+  # disable default memory limit
+  - export INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo memory_limit = -1 >> $INI
 
 install:
-    # flags to pass to install
-    - flags="--ansi --prefer-dist --no-interaction --optimize-autoloader --no-suggest --no-progress"
-    # update deps to latest in case of high deps build
-    - if [ "$deps" == "high" ]; then composer config platform.php 7.2.4; composer update $flags; fi
-    # install dependencies using system provided composer binary
-    - composer install $flags
-    # install dependencies using composer from source
-    - bin/composer install $flags
+  # flags to pass to install
+  - flags="--ansi --prefer-dist --no-interaction --optimize-autoloader --no-suggest --no-progress"
+  # update deps to latest in case of high deps build
+  - if [ "$deps" == "high" ]; then composer config platform.php 7.2.4; composer update $flags; fi
+  # install dependencies using system provided composer binary
+  - composer install $flags
+  # install dependencies using composer from source
+  - bin/composer install $flags
 
 before_script:
-    # make sure git tests do not complain about user/email not being set
-    - git config --global user.name travis-ci
-    - git config --global user.email travis@example.com
+  # make sure git tests do not complain about user/email not being set
+  - git config --global user.name travis-ci
+  - git config --global user.email travis@example.com
 
 script:
-    # run test suite directories in parallel using GNU parallel
-    - ls -d tests/Composer/Test/* | grep -v TestCase.php | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/complete.phpunit.xml --colors=always {} || (echo -e "\e[41mFAILED\e[0m {}" && exit 1);'
+  # run test suite directories in parallel using GNU parallel
+  - ls -d tests/Composer/Test/* | grep -v TestCase.php | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/complete.phpunit.xml --colors=always {} || (echo -e "\e[41mFAILED\e[0m {}" && exit 1);'
 
 before_deploy:
-    - php -d phar.readonly=0 bin/compile
+  - php -d phar.readonly=0 bin/compile
 
 deploy:
   provider: releases


### PR DESCRIPTION
This PR

* [x] consistently indents `.travis.yml` with 2 spaces

💁‍♂️ Also see #7861.