### PR TITLE
Enhancement: Explicitly configure build matrix to maintain order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,22 +16,20 @@ addons:
     packages:
       - parallel
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - nightly
-
 matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
     - php: 7.3
       env: deps=high
+    - php: nightly
   fast_finish: true
   allow_failures:
     - php: nightly


### PR DESCRIPTION
This PR

* [x] explicitly configures the build matrix to maintain order of PHP versions

### Before

See https://travis-ci.org/composer/composer/builds/474430201:

<img width="1009" alt="screen shot 2019-01-02 at 15 48 13" src="https://user-images.githubusercontent.com/605483/50596865-d6581400-0ea5-11e9-92ed-7d329871f10f.png">


### After

See https://travis-ci.org/composer/composer/builds/474433629:

<img width="1008" alt="screen shot 2019-01-02 at 16 04 53" src="https://user-images.githubusercontent.com/605483/50597583-2932cb00-0ea8-11e9-9755-0952e9c7d53e.png">
