### PR TITLE
fix(application): use precise helper set

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -17,6 +17,8 @@ use Composer\Util\Platform;
 use Composer\Util\Silencer;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -111,7 +113,9 @@ class Application extends BaseApplication
     {
         $this->disablePluginsByDefault = $input->hasParameterOption('--no-plugins');
 
-        $io = $this->io = new ConsoleIO($input, $output, $this->getHelperSet());
+        $io = $this->io = new ConsoleIO($input, $output, new HelperSet(array(
+            new QuestionHelper(),
+        )));
         ErrorHandler::register($io);
 
         // switch working dir


### PR DESCRIPTION
Currently, the Composer console Application relies on the default helper set of the Symfony Console Component. However, only one is used internally (the Question one).
I think it would be better to require it directly like this.
It is also better for the `BuffferIO` class (cf my next PR https://github.com/composer/composer/pull/7868)