### PR TITLE
feat(buffer-io): add question helper to helper set

### DIFF
--- a/src/Composer/IO/BufferIO.php
+++ b/src/Composer/IO/BufferIO.php
@@ -12,6 +12,7 @@
 
 namespace Composer\IO;
 
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Input\StringInput;
@@ -34,7 +35,9 @@ class BufferIO extends ConsoleIO
 
         $output = new StreamOutput(fopen('php://memory', 'rw'), $verbosity, $formatter ? $formatter->isDecorated() : false, $formatter);
 
-        parent::__construct($input, $output, new HelperSet(array()));
+        parent::__construct($input, $output, new HelperSet(array(
+            new QuestionHelper(),
+        )));
     }
 
     public function getOutput()


### PR DESCRIPTION
Without the `QuestionHelper`, it is impossible to use the `BufferIO` class when your Composer command has an interactive question.
```
Symfony\Component\Console\Exception\InvalidArgumentException: The helper "question" is not defined.
```