### PR TITLE
add compile script call to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,12 @@
         "bin/composer"
     ],
     "scripts": {
+        "compile": "@php -dphar.readonly=0 bin/compile",
         "test": "phpunit"
+    },
+    "scripts-descriptions": {
+        "compile": "Compile composer.phar",
+        "test": "Run all tests"
     },
     "support": {
         "issues": "https://github.com/composer/composer/issues",


### PR DESCRIPTION
expose call for compiling `composer.phar` in composer json, along with description