### PR TITLE
Archive: cleanup temp dir on download error

### DIFF
--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -147,8 +147,13 @@ class ArchiveManager
             $sourcePath = sys_get_temp_dir().'/composer_archive'.uniqid();
             $filesystem->ensureDirectoryExists($sourcePath);
 
-            // Download sources
-            $this->downloadManager->download($package, $sourcePath);
+            try {
+                // Download sources
+                $this->downloadManager->download($package, $sourcePath);
+            } catch (\Exception $e) {
+                $filesystem->removeDirectory($sourcePath);
+                throw  $e;
+            }
 
             // Check exclude from downloaded composer.json
             if (file_exists($composerJsonPath = $sourcePath.'/composer.json')) {


### PR DESCRIPTION
Composer will not cleanup the temporary directory created in case the archive manager throws an exception while downloading a version from a git repository e.g.
```
Failed to execute git checkout '18313f04cea0e078412a028c5361bd4e' -- && git reset --hard '18313f04cea0e078412a028c5361bd4e' --

fatal: invalid reference: 18313f04cea0e078412a028c5361bd4e
```

This starts consuming quite a lot of disk space if this happens while trying to install a 200MB repo like wordpress several times.