### PR TITLE
Parallel downloads 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "symfony/filesystem": "^2.7 || ^3.0 || ^4.0",
         "symfony/finder": "^2.7 || ^3.0 || ^4.0",
         "symfony/process": "^2.7 || ^3.0 || ^4.0",
-        "react/promise": "^1.2"
+        "react/promise": "^1.2 || ^2.7"
     },
     "conflict": {
         "symfony/console": "2.8.38"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "symfony/console": "^2.7 || ^3.0 || ^4.0",
         "symfony/filesystem": "^2.7 || ^3.0 || ^4.0",
         "symfony/finder": "^2.7 || ^3.0 || ^4.0",
-        "symfony/process": "^2.7 || ^3.0 || ^4.0"
+        "symfony/process": "^2.7 || ^3.0 || ^4.0",
+        "react/promise": "^1.2"
     },
     "conflict": {
         "symfony/console": "2.8.38"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3243ce6f26231df34d1bceab1a148803",
+    "content-hash": "b078b12b2912d599e0c6904f64def484",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e46280c4cfd37bf3ec8be36095feb20e",
+    "content-hash": "d356b92e869790db1e9d2c0f4b10935e",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -341,6 +341,50 @@
                 "psr-3"
             ],
             "time": "2018-11-20T15:27:04+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "eefff597e67ff66b719f8171480add3c91474a1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/eefff597e67ff66b719f8171480add3c91474a1e",
+                "reference": "eefff597e67ff66b719f8171480add3c91474a1e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "React\\Promise": "src/"
+                },
+                "files": [
+                    "src/React/Promise/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "time": "2016-03-07T13:46:50+00:00"
         },
         {
             "name": "seld/jsonlint",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d356b92e869790db1e9d2c0f4b10935e",
+    "content-hash": "3243ce6f26231df34d1bceab1a148803",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -928,4 +928,9 @@ repository options.
 Defaults to `1`. If set to `0`, Composer will not create `.htaccess` files in the
 composer home, cache, and data directories.
 
+### COMPOSER_DISABLE_NETWORK
+
+If set to `1`, disables network access (best effort). This can be used for debugging or
+to run Composer on a plane or a starship with poor connectivity.
+
 &larr; [Libraries](02-libraries.md)  |  [Schema](04-schema.md) &rarr;

--- a/doc/articles/plugins.md
+++ b/doc/articles/plugins.md
@@ -176,7 +176,7 @@ class AwsPlugin implements PluginInterface, EventSubscriberInterface
 
         if ($protocol === 's3') {
             $awsClient = new AwsClient($this->io, $this->composer->getConfig());
-            $s3Downloader = new S3Downloader($this->io, $event->getRemoteFilesystem()->getOptions(), $awsClient);
+            $s3Downloader = new S3Downloader($this->io, $event->getHttpDownloader()->getOptions(), $awsClient);
             $event->setHttpdownloader($s3Downloader);
         }
     }

--- a/doc/articles/plugins.md
+++ b/doc/articles/plugins.md
@@ -176,8 +176,8 @@ class AwsPlugin implements PluginInterface, EventSubscriberInterface
 
         if ($protocol === 's3') {
             $awsClient = new AwsClient($this->io, $this->composer->getConfig());
-            $s3RemoteFilesystem = new S3RemoteFilesystem($this->io, $event->getRemoteFilesystem()->getOptions(), $awsClient);
-            $event->setRemoteFilesystem($s3RemoteFilesystem);
+            $s3Downloader = new S3Downloader($this->io, $event->getRemoteFilesystem()->getOptions(), $awsClient);
+            $event->setHttpdownloader($s3Downloader);
         }
     }
 }

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -61,7 +61,7 @@ Composer fires the following named events during its execution process:
 - **command**: occurs before any Composer Command is executed on the CLI. It
   provides you with access to the input and output objects of the program.
 - **pre-file-download**: occurs before files are downloaded and allows
-  you to manipulate the `RemoteFilesystem` object prior to downloading files
+  you to manipulate the `HttpDownloader` object prior to downloading files
   based on the URL to be downloaded.
 - **pre-command-run**: occurs before a command is executed and allows you to
   manipulate the `InputInterface` object's options and arguments to tweak

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -22,6 +22,7 @@ use Composer\Script\ScriptEvents;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Composer\Util\Filesystem;
+use Composer\Util\Loop;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -104,8 +105,9 @@ EOT
             $archiveManager = $composer->getArchiveManager();
         } else {
             $factory = new Factory;
-            $downloadManager = $factory->createDownloadManager($io, $config, $factory->createHttpDownloader($io, $config));
-            $archiveManager = $factory->createArchiveManager($config, $downloadManager);
+            $httpDownloader = $factory->createHttpDownloader($io, $config);
+            $downloadManager = $factory->createDownloadManager($io, $config, $httpDownloader);
+            $archiveManager = $factory->createArchiveManager($config, $downloadManager, new Loop($httpDownloader));
         }
 
         if ($packageName) {

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -104,7 +104,7 @@ EOT
             $archiveManager = $composer->getArchiveManager();
         } else {
             $factory = new Factory;
-            $downloadManager = $factory->createDownloadManager($io, $config);
+            $downloadManager = $factory->createDownloadManager($io, $config, $factory->createHttpDownloader($io, $config));
             $archiveManager = $factory->createArchiveManager($config, $downloadManager);
         }
 

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -374,7 +374,7 @@ EOT
     {
         $factory = new Factory();
 
-        return $factory->createDownloadManager($io, $config);
+        return $factory->createDownloadManager($io, $config, $factory->createHttpDownloader($io, $config));
     }
 
     protected function createInstallationManager()

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -162,7 +162,6 @@ EOT
         }
 
         $composer = Factory::create($io, null, $disablePlugins);
-        $composer->getDownloadManager()->setOutputProgress(!$noProgress);
 
         $fs = new Filesystem();
 
@@ -351,8 +350,7 @@ EOT
         $httpDownloader = $factory->createHttpDownloader($io, $config);
         $dm = $factory->createDownloadManager($io, $config, $httpDownloader);
         $dm->setPreferSource($preferSource)
-            ->setPreferDist($preferDist)
-            ->setOutputProgress(!$noProgress);
+            ->setPreferDist($preferDist);
 
         $projectInstaller = new ProjectInstaller($directory, $dm);
         $im = $factory->createInstallationManager(new Loop($httpDownloader));

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -38,6 +38,7 @@ use Symfony\Component\Finder\Finder;
 use Composer\Json\JsonFile;
 use Composer\Config\JsonConfigSource;
 use Composer\Util\Filesystem;
+use Composer\Util\Loop;
 use Composer\Package\Version\VersionParser;
 
 /**
@@ -345,15 +346,18 @@ EOT
             $package = $package->getAliasOf();
         }
 
-        $dm = $this->createDownloadManager($io, $config);
+        $factory = new Factory();
+
+        $httpDownloader = $factory->createHttpDownloader($io, $config);
+        $dm = $factory->createDownloadManager($io, $config, $httpDownloader);
         $dm->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
             ->setOutputProgress(!$noProgress);
 
         $projectInstaller = new ProjectInstaller($directory, $dm);
-        $im = $this->createInstallationManager();
+        $im = $factory->createInstallationManager(new Loop($httpDownloader));
         $im->addInstaller($projectInstaller);
-        $im->install(new InstalledFilesystemRepository(new JsonFile('php://memory')), new InstallOperation($package));
+        $im->execute(new InstalledFilesystemRepository(new JsonFile('php://memory')), new InstallOperation($package));
         $im->notifyInstalls($io);
 
         // collect suggestions
@@ -368,17 +372,5 @@ EOT
         putenv('COMPOSER_ROOT_VERSION='.$_SERVER['COMPOSER_ROOT_VERSION']);
 
         return $installedFromVcs;
-    }
-
-    protected function createDownloadManager(IOInterface $io, Config $config)
-    {
-        $factory = new Factory();
-
-        return $factory->createDownloadManager($io, $config, $factory->createHttpDownloader($io, $config));
-    }
-
-    protected function createInstallationManager()
-    {
-        return new InstallationManager();
     }
 }

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -85,7 +85,6 @@ EOT
         }
 
         $composer = $this->getComposer(true, $input->getOption('no-plugins'));
-        $composer->getDownloadManager()->setOutputProgress(!$input->getOption('no-progress'));
 
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'install', $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -126,7 +126,6 @@ EOT
         // Update packages
         $this->resetComposer();
         $composer = $this->getComposer(true, $input->getOption('no-plugins'));
-        $composer->getDownloadManager()->setOutputProgress(!$input->getOption('no-progress'));
 
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'remove', $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -167,7 +167,6 @@ EOT
         // Update packages
         $this->resetComposer();
         $composer = $this->getComposer(true, $input->getOption('no-plugins'));
-        $composer->getDownloadManager()->setOutputProgress(!$input->getOption('no-progress'));
 
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'require', $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -76,9 +76,9 @@ EOT
         }
 
         $io = $this->getIO();
-        $remoteFilesystem = Factory::createRemoteFilesystem($io, $config);
+        $httpDownloader = Factory::createHttpDownloader($io, $config);
 
-        $versionsUtil = new Versions($config, $remoteFilesystem);
+        $versionsUtil = new Versions($config, $httpDownloader);
 
         // switch channel if requested
         foreach (array('stable', 'preview', 'snapshot') as $channel) {
@@ -155,9 +155,9 @@ EOT
 
         $io->write(sprintf("Updating to version <info>%s</info> (%s channel).", $updateVersion, $versionsUtil->getChannel()));
         $remoteFilename = $baseUrl . ($updatingToTag ? "/download/{$updateVersion}/composer.phar" : '/composer.phar');
-        $signature = $remoteFilesystem->getContents(self::HOMEPAGE, $remoteFilename.'.sig', false);
+        $signature = $httpDownloader->get($remoteFilename.'.sig')->getBody();
         $io->writeError('   ', false);
-        $remoteFilesystem->copy(self::HOMEPAGE, $remoteFilename, $tempFilename, !$input->getOption('no-progress'));
+        $httpDownloader->copy($remoteFilename, $tempFilename);
         $io->writeError('');
 
         if (!file_exists($tempFilename) || !$signature) {

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -317,8 +317,8 @@ EOT
             } else {
                 $type = 'available';
             }
-            if ($repo instanceof ComposerRepository && $repo->hasProviders()) {
-                foreach ($repo->getProviderNames() as $name) {
+            if ($repo instanceof ComposerRepository) {
+                foreach ($repo->getPackageNames() as $name) {
                     if (!$packageFilter || preg_match($packageFilter, $name)) {
                         $packages[$type][$name] = $name;
                     }

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -553,7 +553,7 @@ EOT
             $matches[$index] = $package->getId();
         }
 
-        $pool = $repositorySet->createPool();
+        $pool = $repositorySet->createPoolForPackage($package->getName());
 
         // select preferred package according to policy rules
         if (!$matchedPackage && $matches && $preferred = $policy->selectPreferredPackages($pool, array(), $matches)) {

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -89,7 +89,7 @@ EOT
 
         // list packages
         foreach ($installedRepo->getCanonicalPackages() as $package) {
-            $downloader = $dm->getDownloaderForInstalledPackage($package);
+            $downloader = $dm->getDownloaderForPackage($package);
             $targetDir = $im->getInstallPath($package);
 
             if ($downloader instanceof ChangeReportInterface) {

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -120,8 +120,6 @@ EOT
             }
         }
 
-        $composer->getDownloadManager()->setOutputProgress(!$input->getOption('no-progress'));
-
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'update', $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
 

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -123,6 +123,7 @@ class Compiler
             ->in(__DIR__.'/../../vendor/composer/ca-bundle/')
             ->in(__DIR__.'/../../vendor/composer/xdebug-handler/')
             ->in(__DIR__.'/../../vendor/psr/')
+            ->in(__DIR__.'/../../vendor/react/')
             ->sort($finderSort)
         ;
 

--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -32,6 +32,7 @@ class Composer
     const VERSION = '@package_version@';
     const BRANCH_ALIAS_VERSION = '@package_branch_alias_version@';
     const RELEASE_DATE = '@release_date@';
+    const SOURCE_VERSION = '2.0-source';
 
     /**
      * @var Package\RootPackageInterface

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -217,6 +217,7 @@ class Solver
 
         $this->setupInstalledMap();
 
+        $this->io->writeError('Generating rules', true, IOInterface::DEBUG);
         $this->ruleSetGenerator = new RuleSetGenerator($this->policy, $this->pool);
         $this->rules = $this->ruleSetGenerator->getRulesFor($this->jobs, $this->installedMap, $ignorePlatformReqs);
         $this->checkForRootRequireProblems($ignorePlatformReqs);

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -15,6 +15,7 @@ namespace Composer\Downloader;
 use Composer\Package\PackageInterface;
 use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
+use React\Promise\PromiseInterface;
 
 /**
  * Downloaders manager.
@@ -24,6 +25,7 @@ use Composer\Util\Filesystem;
 class DownloadManager
 {
     private $io;
+    private $httpDownloader;
     private $preferDist = false;
     private $preferSource = false;
     private $packagePreferences = array();
@@ -33,9 +35,9 @@ class DownloadManager
     /**
      * Initializes download manager.
      *
-     * @param IOInterface     $io           The Input Output Interface
-     * @param bool            $preferSource prefer downloading from source
-     * @param Filesystem|null $filesystem   custom Filesystem object
+     * @param IOInterface     $io             The Input Output Interface
+     * @param bool            $preferSource   prefer downloading from source
+     * @param Filesystem|null $filesystem     custom Filesystem object
      */
     public function __construct(IOInterface $io, $preferSource = false, Filesystem $filesystem = null)
     {
@@ -140,7 +142,7 @@ class DownloadManager
      *                                           wrong type
      * @return DownloaderInterface|null
      */
-    public function getDownloaderForInstalledPackage(PackageInterface $package)
+    public function getDownloaderForPackage(PackageInterface $package)
     {
         $installationSource = $package->getInstallationSource();
 
@@ -154,7 +156,7 @@ class DownloadManager
             $downloader = $this->getDownloader($package->getSourceType());
         } else {
             throw new \InvalidArgumentException(
-                'Package '.$package.' seems not been installed properly'
+                'Package '.$package.' does not have an installation source set'
             );
         }
 
@@ -171,63 +173,95 @@ class DownloadManager
         return $downloader;
     }
 
+    public function getDownloaderType(DownloaderInterface $downloader)
+    {
+        return array_search($downloader, $this->downloaders);
+    }
+
     /**
      * Downloads package into target dir.
      *
      * @param PackageInterface $package      package instance
      * @param string           $targetDir    target dir
-     * @param bool             $preferSource prefer installation from source
+     * @param PackageInterface $prevPackage  previous package instance in case of updates
+     *
+     * @return PromiseInterface
+     * @throws \InvalidArgumentException if package have no urls to download from
+     * @throws \RuntimeException
+     */
+    public function download(PackageInterface $package, $targetDir, PackageInterface $prevPackage = null)
+    {
+        $this->filesystem->ensureDirectoryExists(dirname($targetDir));
+
+        $sources = $this->getAvailableSources($package, $prevPackage);
+
+        $io = $this->io;
+        $self = $this;
+
+        $download = function ($retry = false) use (&$sources, $io, $package, $self, $targetDir, &$download) {
+            $source = array_shift($sources);
+            if ($retry) {
+                $io->writeError('    <warning>Now trying to download from ' . $source . '</warning>');
+            }
+            $package->setInstallationSource($source);
+
+            $downloader = $self->getDownloaderForPackage($package);
+            if (!$downloader) {
+                return \React\Promise\resolve();
+            }
+
+            $handleError = function ($e) use ($sources, $source, $package, $io, $download) {
+                if ($e instanceof \RuntimeException) {
+                    if (!$sources) {
+                        throw $e;
+                    }
+
+                    $io->writeError(
+                        '    <warning>Failed to download '.
+                        $package->getPrettyName().
+                        ' from ' . $source . ': '.
+                        $e->getMessage().'</warning>'
+                    );
+
+                    return $download(true);
+                }
+
+                throw $e;
+            };
+
+            try {
+                $result = $downloader->download($package, $targetDir);
+            } catch (\Exception $e) {
+                return $handleError($e);
+            }
+            if (!$result instanceof PromiseInterface) {
+                return \React\Promise\resolve($result);
+            }
+
+            $res = $result->then(function ($res) {
+                return $res;
+            }, $handleError);
+
+            return $res;
+        };
+
+        return $download();
+    }
+
+    /**
+     * Installs package into target dir.
+     *
+     * @param PackageInterface $package      package instance
+     * @param string           $targetDir    target dir
      *
      * @throws \InvalidArgumentException if package have no urls to download from
      * @throws \RuntimeException
      */
-    public function download(PackageInterface $package, $targetDir, $preferSource = null)
+    public function install(PackageInterface $package, $targetDir)
     {
-        $preferSource = null !== $preferSource ? $preferSource : $this->preferSource;
-        $sourceType = $package->getSourceType();
-        $distType = $package->getDistType();
-
-        $sources = array();
-        if ($sourceType) {
-            $sources[] = 'source';
-        }
-        if ($distType) {
-            $sources[] = 'dist';
-        }
-
-        if (empty($sources)) {
-            throw new \InvalidArgumentException('Package '.$package.' must have a source or dist specified');
-        }
-
-        if (!$preferSource && ($this->preferDist || 'dist' === $this->resolvePackageInstallPreference($package))) {
-            $sources = array_reverse($sources);
-        }
-
-        $this->filesystem->ensureDirectoryExists($targetDir);
-
-        foreach ($sources as $i => $source) {
-            if (isset($e)) {
-                $this->io->writeError('    <warning>Now trying to download from ' . $source . '</warning>');
-            }
-            $package->setInstallationSource($source);
-            try {
-                $downloader = $this->getDownloaderForInstalledPackage($package);
-                if ($downloader) {
-                    $downloader->download($package, $targetDir);
-                }
-                break;
-            } catch (\RuntimeException $e) {
-                if ($i === count($sources) - 1) {
-                    throw $e;
-                }
-
-                $this->io->writeError(
-                    '    <warning>Failed to download '.
-                    $package->getPrettyName().
-                    ' from ' . $source . ': '.
-                    $e->getMessage().'</warning>'
-                );
-            }
+        $downloader = $this->getDownloaderForPackage($package);
+        if ($downloader) {
+            $downloader->install($package, $targetDir);
         }
     }
 
@@ -242,31 +276,23 @@ class DownloadManager
      */
     public function update(PackageInterface $initial, PackageInterface $target, $targetDir)
     {
-        $downloader = $this->getDownloaderForInstalledPackage($initial);
+        $downloader = $this->getDownloaderForPackage($target);
+        $initialDownloader = $this->getDownloaderForPackage($initial);
+
+        // no downloaders present means update from metapackage to metapackage, nothing to do
+        if (!$initialDownloader && !$downloader) {
+            return;
+        }
+
+        // if we have a downloader present before, but not after, the package became a metapackage and its files should be removed
         if (!$downloader) {
+            $initialDownloader->remove($initial, $targetDir);
             return;
         }
 
-        $installationSource = $initial->getInstallationSource();
-
-        if ('dist' === $installationSource) {
-            $initialType = $initial->getDistType();
-            $targetType = $target->getDistType();
-        } else {
-            $initialType = $initial->getSourceType();
-            $targetType = $target->getSourceType();
-        }
-
-        // upgrading from a dist stable package to a dev package, force source reinstall
-        if ($target->isDev() && 'dist' === $installationSource) {
-            $downloader->remove($initial, $targetDir);
-            $this->download($target, $targetDir);
-
-            return;
-        }
-
+        $initialType = $this->getDownloaderType($initialDownloader);
+        $targetType = $this->getDownloaderType($downloader);
         if ($initialType === $targetType) {
-            $target->setInstallationSource($installationSource);
             try {
                 $downloader->update($initial, $target, $targetDir);
 
@@ -282,8 +308,12 @@ class DownloadManager
             }
         }
 
-        $downloader->remove($initial, $targetDir);
-        $this->download($target, $targetDir, 'source' === $installationSource);
+        // if downloader type changed, or update failed and user asks for reinstall,
+        // we wipe the dir and do a new install instead of updating it
+        if ($initialDownloader) {
+            $initialDownloader->remove($initial, $targetDir);
+        }
+        $this->install($target, $targetDir);
     }
 
     /**
@@ -294,7 +324,7 @@ class DownloadManager
      */
     public function remove(PackageInterface $package, $targetDir)
     {
-        $downloader = $this->getDownloaderForInstalledPackage($package);
+        $downloader = $this->getDownloaderForPackage($package);
         if ($downloader) {
             $downloader->remove($package, $targetDir);
         }
@@ -321,5 +351,49 @@ class DownloadManager
         }
 
         return $package->isDev() ? 'source' : 'dist';
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAvailableSources(PackageInterface $package, PackageInterface $prevPackage = null)
+    {
+        $sourceType = $package->getSourceType();
+        $distType = $package->getDistType();
+
+        // add source before dist by default
+        $sources = array();
+        if ($sourceType) {
+            $sources[] = 'source';
+        }
+        if ($distType) {
+            $sources[] = 'dist';
+        }
+
+        if (empty($sources)) {
+            throw new \InvalidArgumentException('Package '.$package.' must have a source or dist specified');
+        }
+
+        if (
+            $prevPackage
+            // if we are updating, we want to keep the same source as the previously installed package (if available in the new one)
+            && in_array($prevPackage->getInstallationSource(), $sources, true)
+            // unless the previous package was stable dist (by default) and the new package is dev, then we allow the new default to take over
+            && !(!$prevPackage->isDev() && $prevPackage->getInstallationSource() === 'dist' && $package->isDev())
+        ) {
+            $prevSource = $prevPackage->getInstallationSource();
+            usort($sources, function ($a, $b) use ($prevSource) {
+                return $a === $prevSource ? -1 : 1;
+            });
+
+            return $sources;
+        }
+
+        // reverse sources in case dist is the preferred source for this package
+        if (!$this->preferSource && ($this->preferDist || 'dist' === $this->resolvePackageInstallPreference($package))) {
+            $sources = array_reverse($sources);
+        }
+
+        return $sources;
     }
 }

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -86,22 +86,6 @@ class DownloadManager
     }
 
     /**
-     * Sets whether to output download progress information for all registered
-     * downloaders
-     *
-     * @param  bool            $outputProgress
-     * @return DownloadManager
-     */
-    public function setOutputProgress($outputProgress)
-    {
-        foreach ($this->downloaders as $downloader) {
-            $downloader->setOutputProgress($outputProgress);
-        }
-
-        return $this;
-    }
-
-    /**
      * Sets installer downloader for a specific installation type.
      *
      * @param  string              $type       installation type

--- a/src/Composer/Downloader/DownloaderInterface.php
+++ b/src/Composer/Downloader/DownloaderInterface.php
@@ -61,12 +61,4 @@ interface DownloaderInterface
      * @param string           $path    download path
      */
     public function remove(PackageInterface $package, $path);
-
-    /**
-     * Sets whether to output download progress information or not
-     *
-     * @param  bool                $outputProgress
-     * @return DownloaderInterface
-     */
-    public function setOutputProgress($outputProgress);
 }

--- a/src/Composer/Downloader/DownloaderInterface.php
+++ b/src/Composer/Downloader/DownloaderInterface.php
@@ -13,6 +13,7 @@
 namespace Composer\Downloader;
 
 use Composer\Package\PackageInterface;
+use React\Promise\PromiseInterface;
 
 /**
  * Downloader interface.
@@ -30,12 +31,19 @@ interface DownloaderInterface
     public function getInstallationSource();
 
     /**
+     * This should do any network-related tasks to prepare for install/update
+     *
+     * @return PromiseInterface|null
+     */
+    public function download(PackageInterface $package, $path);
+
+    /**
      * Downloads specific package into specific folder.
      *
      * @param PackageInterface $package package instance
      * @param string           $path    download path
      */
-    public function download(PackageInterface $package, $path);
+    public function install(PackageInterface $package, $path);
 
     /**
      * Updates specific package in specific folder from initial to target version.

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -51,12 +51,12 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
      *
      * @param IOInterface      $io              The IO instance
      * @param Config           $config          The config
+     * @param HttpDownloader   $httpDownloader  The remote filesystem
      * @param EventDispatcher  $eventDispatcher The event dispatcher
      * @param Cache            $cache           Cache instance
-     * @param HttpDownloader   $httpDownloader  The remote filesystem
      * @param Filesystem       $filesystem      The filesystem
      */
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher, Cache $cache, HttpDownloader $httpDownloader, Filesystem $filesystem = null)
+    public function __construct(IOInterface $io, Config $config, HttpDownloader $httpDownloader, EventDispatcher $eventDispatcher = null, Cache $cache = null, Filesystem $filesystem = null)
     {
         $this->io = $io;
         $this->config = $config;

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -106,21 +106,19 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
 
         $io = $this->io;
         $cache = $this->cache;
-        $originalHttpDownloader = $this->httpDownloader;
+        $httpDownloader = $this->httpDownloader;
         $eventDispatcher = $this->eventDispatcher;
         $filesystem = $this->filesystem;
         $self = $this;
 
         $accept = null;
         $reject = null;
-        $download = function () use ($io, $output, $originalHttpDownloader, $cache, $eventDispatcher, $package, $fileName, $path, &$urls, &$accept, &$reject) {
+        $download = function () use ($io, $output, $httpDownloader, $cache, $eventDispatcher, $package, $fileName, $path, &$urls, &$accept, &$reject) {
             $url = reset($urls);
 
-            $httpDownloader = $originalHttpDownloader;
             if ($eventDispatcher) {
                 $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $httpDownloader, $url['processed']);
                 $eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
-                $httpDownloader = $preFileDownloadEvent->getHttpDownloader();
             }
 
             $checksum = $package->getDistSha1Checksum();

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -43,7 +43,6 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
     protected $httpDownloader;
     protected $filesystem;
     protected $cache;
-    protected $outputProgress = true;
     /**
      * @private this is only public for php 5.3 support in closures
      */
@@ -237,16 +236,6 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function setOutputProgress($outputProgress)
-    {
-        $this->outputProgress = $outputProgress;
-
-        return $this;
-    }
-
-    /**
      * TODO mark private in v3
      * @protected This is public due to PHP 5.3
      */
@@ -340,11 +329,9 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
     public function getLocalChanges(PackageInterface $package, $targetDir)
     {
         $prevIO = $this->io;
-        $prevProgress = $this->outputProgress;
 
         $this->io = new NullIO;
         $this->io->loadConfiguration($this->config);
-        $this->outputProgress = false;
         $e = null;
 
         try {
@@ -362,7 +349,6 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
         }
 
         $this->io = $prevIO;
-        $this->outputProgress = $prevProgress;
 
         if ($e) {
             throw $e;

--- a/src/Composer/Downloader/FossilDownloader.php
+++ b/src/Composer/Downloader/FossilDownloader.php
@@ -23,7 +23,7 @@ class FossilDownloader extends VcsDownloader
     /**
      * {@inheritDoc}
      */
-    public function doDownload(PackageInterface $package, $path, $url)
+    public function doInstall(PackageInterface $package, $path, $url)
     {
         // Ensure we are allowed to use this URL by config
         $this->config->prohibitUrlByConfig($url, $this->io);

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -38,7 +38,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
     /**
      * {@inheritDoc}
      */
-    public function doDownload(PackageInterface $package, $path, $url)
+    public function doInstall(PackageInterface $package, $path, $url)
     {
         GitUtil::cleanEnv();
         $path = $this->normalizePath($path);

--- a/src/Composer/Downloader/GzipDownloader.php
+++ b/src/Composer/Downloader/GzipDownloader.php
@@ -18,7 +18,7 @@ use Composer\EventDispatcher\EventDispatcher;
 use Composer\Package\PackageInterface;
 use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 use Composer\IO\IOInterface;
 
 /**
@@ -30,10 +30,10 @@ class GzipDownloader extends ArchiveDownloader
 {
     protected $process;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, RemoteFilesystem $rfs = null)
+    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, HttpDownloader $downloader = null)
     {
         $this->process = $process ?: new ProcessExecutor($io);
-        parent::__construct($io, $config, $eventDispatcher, $cache, $rfs);
+        parent::__construct($io, $config, $eventDispatcher, $cache, $downloader);
     }
 
     protected function extract($file, $path)

--- a/src/Composer/Downloader/GzipDownloader.php
+++ b/src/Composer/Downloader/GzipDownloader.php
@@ -36,9 +36,10 @@ class GzipDownloader extends ArchiveDownloader
         parent::__construct($io, $config, $downloader, $eventDispatcher, $cache);
     }
 
-    protected function extract($file, $path)
+    protected function extract(PackageInterface $package, $file, $path)
     {
-        $targetFilepath = $path . DIRECTORY_SEPARATOR . basename(substr($file, 0, -3));
+        $filename = pathinfo(parse_url($package->getDistUrl(), PHP_URL_PATH), PATHINFO_FILENAME);
+        $targetFilepath = $path . DIRECTORY_SEPARATOR . $filename;
 
         // Try to use gunzip on *nix
         if (!Platform::isWindows()) {
@@ -61,14 +62,6 @@ class GzipDownloader extends ArchiveDownloader
 
         // Windows version of PHP has built-in support of gzip functions
         $this->extractUsingExt($file, $targetFilepath);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFileName(PackageInterface $package, $path)
-    {
-        return $path.'/'.pathinfo(parse_url($package->getDistUrl(), PHP_URL_PATH), PATHINFO_BASENAME);
     }
 
     private function extractUsingExt($file, $targetFilepath)

--- a/src/Composer/Downloader/GzipDownloader.php
+++ b/src/Composer/Downloader/GzipDownloader.php
@@ -30,10 +30,10 @@ class GzipDownloader extends ArchiveDownloader
 {
     protected $process;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, HttpDownloader $downloader = null)
+    public function __construct(IOInterface $io, Config $config, HttpDownloader $downloader, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null)
     {
         $this->process = $process ?: new ProcessExecutor($io);
-        parent::__construct($io, $config, $eventDispatcher, $cache, $downloader);
+        parent::__construct($io, $config, $downloader, $eventDispatcher, $cache);
     }
 
     protected function extract($file, $path)

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -24,7 +24,7 @@ class HgDownloader extends VcsDownloader
     /**
      * {@inheritDoc}
      */
-    public function doDownload(PackageInterface $package, $path, $url)
+    public function doInstall(PackageInterface $package, $path, $url)
     {
         $hgUtils = new HgUtils($this->io, $this->config, $this->process);
 

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -61,6 +61,15 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
                 $realUrl
             ));
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function install(PackageInterface $package, $path, $output = true)
+    {
+        $url = $package->getDistUrl();
+        $realUrl = realpath($url);
 
         // Get the transport options with default values
         $transportOptions = $package->getTransportOptions() + array('symlink' => null);

--- a/src/Composer/Downloader/PerforceDownloader.php
+++ b/src/Composer/Downloader/PerforceDownloader.php
@@ -27,7 +27,7 @@ class PerforceDownloader extends VcsDownloader
     /**
      * {@inheritDoc}
      */
-    public function doDownload(PackageInterface $package, $path, $url)
+    public function doInstall(PackageInterface $package, $path, $url)
     {
         $ref = $package->getSourceReference();
         $label = $this->getLabelFromSourceReference($ref);

--- a/src/Composer/Downloader/PharDownloader.php
+++ b/src/Composer/Downloader/PharDownloader.php
@@ -12,6 +12,8 @@
 
 namespace Composer\Downloader;
 
+use Composer\Package\PackageInterface;
+
 /**
  * Downloader for phar files
  *
@@ -22,7 +24,7 @@ class PharDownloader extends ArchiveDownloader
     /**
      * {@inheritDoc}
      */
-    protected function extract($file, $path)
+    protected function extract(PackageInterface $package, $file, $path)
     {
         // Can throw an UnexpectedValueException
         $archive = new \Phar($file);

--- a/src/Composer/Downloader/RarDownloader.php
+++ b/src/Composer/Downloader/RarDownloader.php
@@ -18,7 +18,7 @@ use Composer\EventDispatcher\EventDispatcher;
 use Composer\Util\IniHelper;
 use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 use Composer\IO\IOInterface;
 use RarArchive;
 
@@ -33,10 +33,10 @@ class RarDownloader extends ArchiveDownloader
 {
     protected $process;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, RemoteFilesystem $rfs = null)
+    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, HttpDownloader $downloader = null)
     {
         $this->process = $process ?: new ProcessExecutor($io);
-        parent::__construct($io, $config, $eventDispatcher, $cache, $rfs);
+        parent::__construct($io, $config, $eventDispatcher, $cache, $downloader);
     }
 
     protected function extract($file, $path)

--- a/src/Composer/Downloader/RarDownloader.php
+++ b/src/Composer/Downloader/RarDownloader.php
@@ -33,10 +33,10 @@ class RarDownloader extends ArchiveDownloader
 {
     protected $process;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, HttpDownloader $downloader = null)
+    public function __construct(IOInterface $io, Config $config, HttpDownloader $downloader, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null)
     {
         $this->process = $process ?: new ProcessExecutor($io);
-        parent::__construct($io, $config, $eventDispatcher, $cache, $downloader);
+        parent::__construct($io, $config, $downloader, $eventDispatcher, $cache);
     }
 
     protected function extract($file, $path)

--- a/src/Composer/Downloader/RarDownloader.php
+++ b/src/Composer/Downloader/RarDownloader.php
@@ -20,6 +20,7 @@ use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\HttpDownloader;
 use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
 use RarArchive;
 
 /**
@@ -39,7 +40,7 @@ class RarDownloader extends ArchiveDownloader
         parent::__construct($io, $config, $downloader, $eventDispatcher, $cache);
     }
 
-    protected function extract($file, $path)
+    protected function extract(PackageInterface $package, $file, $path)
     {
         $processError = null;
 

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -28,7 +28,7 @@ class SvnDownloader extends VcsDownloader
     /**
      * {@inheritDoc}
      */
-    public function doDownload(PackageInterface $package, $path, $url)
+    public function doInstall(PackageInterface $package, $path, $url)
     {
         SvnUtil::cleanEnv();
         $ref = $package->getSourceReference();

--- a/src/Composer/Downloader/TarDownloader.php
+++ b/src/Composer/Downloader/TarDownloader.php
@@ -12,6 +12,8 @@
 
 namespace Composer\Downloader;
 
+use Composer\Package\PackageInterface;
+
 /**
  * Downloader for tar files: tar, tar.gz or tar.bz2
  *
@@ -22,7 +24,7 @@ class TarDownloader extends ArchiveDownloader
     /**
      * {@inheritDoc}
      */
-    protected function extract($file, $path)
+    protected function extract(PackageInterface $package, $file, $path)
     {
         // Can throw an UnexpectedValueException
         $archive = new \PharData($file);

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -211,15 +211,6 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     }
 
     /**
-     * Download progress information is not available for all VCS downloaders.
-     * {@inheritDoc}
-     */
-    public function setOutputProgress($outputProgress)
-    {
-        return $this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function getVcsReference(PackageInterface $package, $path)

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -56,6 +56,14 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
      */
     public function download(PackageInterface $package, $path)
     {
+        // noop for now, ideally we would do a git fetch already here, or make sure the cached git repo is synced, etc.
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function install(PackageInterface $package, $path)
+    {
         if (!$package->getSourceReference()) {
             throw new \InvalidArgumentException('Package '.$package->getPrettyName().' is missing reference information');
         }
@@ -87,7 +95,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
                         $url = $needle . $url;
                     }
                 }
-                $this->doDownload($package, $path, $url);
+                $this->doInstall($package, $path, $url);
                 break;
             } catch (\Exception $e) {
                 // rethrow phpunit exceptions to avoid hard to debug bug failures
@@ -260,7 +268,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
      * @param string           $path    download path
      * @param string           $url     package url
      */
-    abstract protected function doDownload(PackageInterface $package, $path, $url);
+    abstract protected function doInstall(PackageInterface $package, $path, $url);
 
     /**
      * Updates specific package in specific folder from initial to target version.

--- a/src/Composer/Downloader/XzDownloader.php
+++ b/src/Composer/Downloader/XzDownloader.php
@@ -37,7 +37,7 @@ class XzDownloader extends ArchiveDownloader
         parent::__construct($io, $config, $downloader, $eventDispatcher, $cache);
     }
 
-    protected function extract($file, $path)
+    protected function extract(PackageInterface $package, $file, $path)
     {
         $command = 'tar -xJf ' . ProcessExecutor::escape($file) . ' -C ' . ProcessExecutor::escape($path);
 
@@ -48,13 +48,5 @@ class XzDownloader extends ArchiveDownloader
         $processError = 'Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput();
 
         throw new \RuntimeException($processError);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFileName(PackageInterface $package, $path)
-    {
-        return $path.'/'.pathinfo(parse_url($package->getDistUrl(), PHP_URL_PATH), PATHINFO_BASENAME);
     }
 }

--- a/src/Composer/Downloader/XzDownloader.php
+++ b/src/Composer/Downloader/XzDownloader.php
@@ -30,11 +30,11 @@ class XzDownloader extends ArchiveDownloader
 {
     protected $process;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, HttpDownloader $downloader = null)
+    public function __construct(IOInterface $io, Config $config, HttpDownloader $downloader, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null)
     {
         $this->process = $process ?: new ProcessExecutor($io);
 
-        parent::__construct($io, $config, $eventDispatcher, $cache, $downloader);
+        parent::__construct($io, $config, $downloader, $eventDispatcher, $cache);
     }
 
     protected function extract($file, $path)

--- a/src/Composer/Downloader/XzDownloader.php
+++ b/src/Composer/Downloader/XzDownloader.php
@@ -17,7 +17,7 @@ use Composer\Cache;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\Package\PackageInterface;
 use Composer\Util\ProcessExecutor;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 use Composer\IO\IOInterface;
 
 /**
@@ -30,11 +30,11 @@ class XzDownloader extends ArchiveDownloader
 {
     protected $process;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, RemoteFilesystem $rfs = null)
+    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, HttpDownloader $downloader = null)
     {
         $this->process = $process ?: new ProcessExecutor($io);
 
-        parent::__construct($io, $config, $eventDispatcher, $cache, $rfs);
+        parent::__construct($io, $config, $eventDispatcher, $cache, $downloader);
     }
 
     protected function extract($file, $path)

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -185,7 +185,7 @@ class ZipDownloader extends ArchiveDownloader
      * @param string $file File to extract
      * @param string $path Path where to extract file
      */
-    public function extract($file, $path)
+    public function extract(PackageInterface $package, $file, $path)
     {
         // Each extract calls its alternative if not available or fails
         if (self::$isWindows) {

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -36,10 +36,10 @@ class ZipDownloader extends ArchiveDownloader
     protected $process;
     private $zipArchiveObject;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, HttpDownloader $downloader = null)
+    public function __construct(IOInterface $io, Config $config, HttpDownloader $downloader, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null)
     {
         $this->process = $process ?: new ProcessExecutor($io);
-        parent::__construct($io, $config, $eventDispatcher, $cache, $downloader);
+        parent::__construct($io, $config, $downloader, $eventDispatcher, $cache);
     }
 
     /**

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -19,7 +19,7 @@ use Composer\Package\PackageInterface;
 use Composer\Util\IniHelper;
 use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 use Composer\IO\IOInterface;
 use Symfony\Component\Process\ExecutableFinder;
 use ZipArchive;
@@ -36,10 +36,10 @@ class ZipDownloader extends ArchiveDownloader
     protected $process;
     private $zipArchiveObject;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, RemoteFilesystem $rfs = null)
+    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, Cache $cache = null, ProcessExecutor $process = null, HttpDownloader $downloader = null)
     {
         $this->process = $process ?: new ProcessExecutor($io);
-        parent::__construct($io, $config, $eventDispatcher, $cache, $rfs);
+        parent::__construct($io, $config, $eventDispatcher, $cache, $downloader);
     }
 
     /**

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -590,18 +590,18 @@ class Factory
             throw new Exception\NoSslException('The openssl extension is required for SSL/TLS protection but is not available. '
                 . 'If you can not enable the openssl extension, you can disable this error, at your own risk, by setting the \'disable-tls\' option to true.');
         }
-        $remoteFilesystemOptions = array();
+        $httpDownloaderOptions = array();
         if ($disableTls === false) {
             if ($config && $config->get('cafile')) {
-                $remoteFilesystemOptions['ssl']['cafile'] = $config->get('cafile');
+                $httpDownloaderOptions['ssl']['cafile'] = $config->get('cafile');
             }
             if ($config && $config->get('capath')) {
-                $remoteFilesystemOptions['ssl']['capath'] = $config->get('capath');
+                $httpDownloaderOptions['ssl']['capath'] = $config->get('capath');
             }
-            $remoteFilesystemOptions = array_replace_recursive($remoteFilesystemOptions, $options);
+            $httpDownloaderOptions = array_replace_recursive($httpDownloaderOptions, $options);
         }
         try {
-            $remoteFilesystem = new HttpDownloader($io, $config, $remoteFilesystemOptions, $disableTls);
+            $httpDownloader = new HttpDownloader($io, $config, $httpDownloaderOptions, $disableTls);
         } catch (TransportException $e) {
             if (false !== strpos($e->getMessage(), 'cafile')) {
                 $io->write('<error>Unable to locate a valid CA certificate file. You must set a valid \'cafile\' option.</error>');
@@ -614,7 +614,7 @@ class Factory
             throw $e;
         }
 
-        return $remoteFilesystem;
+        return $httpDownloader;
     }
 
     /**

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -23,7 +23,7 @@ use Composer\Repository\WritableRepositoryInterface;
 use Composer\Util\Filesystem;
 use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 use Composer\Util\Silencer;
 use Composer\Plugin\PluginEvents;
 use Composer\EventDispatcher\Event;
@@ -325,7 +325,7 @@ class Factory
             $io->loadConfiguration($config);
         }
 
-        $rfs = self::createRemoteFilesystem($io, $config);
+        $rfs = self::createHttpDownloader($io, $config);
 
         // initialize event dispatcher
         $dispatcher = new EventDispatcher($composer, $io);
@@ -451,7 +451,7 @@ class Factory
      * @param  EventDispatcher            $eventDispatcher
      * @return Downloader\DownloadManager
      */
-    public function createDownloadManager(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, RemoteFilesystem $rfs = null)
+    public function createDownloadManager(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, HttpDownloader $rfs = null)
     {
         $cache = null;
         if ($config->get('cache-files-ttl') > 0) {
@@ -579,10 +579,10 @@ class Factory
     /**
      * @param  IOInterface      $io      IO instance
      * @param  Config           $config  Config instance
-     * @param  array            $options Array of options passed directly to RemoteFilesystem constructor
-     * @return RemoteFilesystem
+     * @param  array            $options Array of options passed directly to HttpDownloader constructor
+     * @return HttpDownloader
      */
-    public static function createRemoteFilesystem(IOInterface $io, Config $config = null, $options = array())
+    public static function createHttpDownloader(IOInterface $io, Config $config = null, $options = array())
     {
         static $warned = false;
         $disableTls = false;
@@ -607,7 +607,7 @@ class Factory
             $remoteFilesystemOptions = array_replace_recursive($remoteFilesystemOptions, $options);
         }
         try {
-            $remoteFilesystem = new RemoteFilesystem($io, $config, $remoteFilesystemOptions, $disableTls);
+            $remoteFilesystem = new HttpDownloader($io, $config, $remoteFilesystemOptions, $disableTls);
         } catch (TransportException $e) {
             if (false !== strpos($e->getMessage(), 'cafile')) {
                 $io->write('<error>Unable to locate a valid CA certificate file. You must set a valid \'cafile\' option.</error>');

--- a/src/Composer/Installer/InstallerInterface.php
+++ b/src/Composer/Installer/InstallerInterface.php
@@ -15,6 +15,7 @@ namespace Composer\Installer;
 use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use InvalidArgumentException;
+use React\Promise\PromiseInterface;
 
 /**
  * Interface for the package installation manager.
@@ -41,6 +42,15 @@ interface InstallerInterface
      * @return bool
      */
     public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package);
+
+    /**
+     * Downloads the files needed to later install the given package.
+     *
+     * @param  PackageInterface $package     package instance
+     * @param  PackageInterface $prevPackage previous package instance in case of an update
+     * @return PromiseInterface
+     */
+    public function download(PackageInterface $package, PackageInterface $prevPackage = null);
 
     /**
      * Installs specific package.

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -85,6 +85,14 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
         return (Platform::isWindows() && $this->filesystem->isJunction($installPath)) || is_link($installPath);
     }
 
+    public function download(PackageInterface $package, PackageInterface $prevPackage = null)
+    {
+        $this->initializeVendorDir();
+        $downloadPath = $this->getInstallPath($package);
+
+        return $this->downloadManager->download($package, $downloadPath, $prevPackage);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -194,7 +202,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
     protected function installCode(PackageInterface $package)
     {
         $downloadPath = $this->getInstallPath($package);
-        $this->downloadManager->download($package, $downloadPath);
+        $this->downloadManager->install($package, $downloadPath);
     }
 
     protected function updateCode(PackageInterface $initial, PackageInterface $target)

--- a/src/Composer/Installer/MetapackageInstaller.php
+++ b/src/Composer/Installer/MetapackageInstaller.php
@@ -41,6 +41,14 @@ class MetapackageInstaller implements InstallerInterface
     /**
      * {@inheritDoc}
      */
+    public function download(PackageInterface $package, PackageInterface $prevPackage = null)
+    {
+        // noop
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
         $repo->addPackage(clone $package);

--- a/src/Composer/Installer/NoopInstaller.php
+++ b/src/Composer/Installer/NoopInstaller.php
@@ -43,6 +43,13 @@ class NoopInstaller implements InstallerInterface
     /**
      * {@inheritDoc}
      */
+    public function download(PackageInterface $package, PackageInterface $prevPackage = null)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
         if (!$repo->hasPackage($package)) {

--- a/src/Composer/Installer/PluginInstaller.php
+++ b/src/Composer/Installer/PluginInstaller.php
@@ -50,13 +50,21 @@ class PluginInstaller extends LibraryInstaller
     /**
      * {@inheritDoc}
      */
-    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    public function download(PackageInterface $package, PackageInterface $prevPackage = null)
     {
         $extra = $package->getExtra();
         if (empty($extra['class'])) {
             throw new \UnexpectedValueException('Error while installing '.$package->getPrettyName().', composer-plugin packages should have a class defined in their extra key to be usable.');
         }
 
+        return parent::download($package, $prevPackage);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    {
         parent::install($repo, $package);
         try {
             $this->composer->getPluginManager()->registerPackage($package, true);

--- a/src/Composer/Installer/ProjectInstaller.php
+++ b/src/Composer/Installer/ProjectInstaller.php
@@ -58,7 +58,7 @@ class ProjectInstaller implements InstallerInterface
     /**
      * {@inheritDoc}
      */
-    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    public function download(PackageInterface $package, PackageInterface $prevPackage = null)
     {
         $installPath = $this->installPath;
         if (file_exists($installPath) && !$this->filesystem->isDirEmpty($installPath)) {
@@ -67,7 +67,16 @@ class ProjectInstaller implements InstallerInterface
         if (!is_dir($installPath)) {
             mkdir($installPath, 0777, true);
         }
-        $this->downloadManager->download($package, $installPath);
+
+        return $this->downloadManager->download($package, $installPath, $prevPackage);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    {
+        $this->downloadManager->install($package, $this->installPath);
     }
 
     /**

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -15,7 +15,7 @@ namespace Composer\Json;
 use JsonSchema\Validator;
 use Seld\JsonLint\JsonParser;
 use Seld\JsonLint\ParsingException;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 use Composer\IO\IOInterface;
 use Composer\Downloader\TransportException;
 
@@ -35,25 +35,25 @@ class JsonFile
     const JSON_UNESCAPED_UNICODE = 256;
 
     private $path;
-    private $rfs;
+    private $httpDownloader;
     private $io;
 
     /**
      * Initializes json file reader/parser.
      *
-     * @param  string                    $path path to a lockfile
-     * @param  RemoteFilesystem          $rfs  required for loading http/https json files
+     * @param  string                    $path           path to a lockfile
+     * @param  HttpDownloader            $httpDownloader required for loading http/https json files
      * @param  IOInterface               $io
      * @throws \InvalidArgumentException
      */
-    public function __construct($path, RemoteFilesystem $rfs = null, IOInterface $io = null)
+    public function __construct($path, HttpDownloader $httpDownloader = null, IOInterface $io = null)
     {
         $this->path = $path;
 
-        if (null === $rfs && preg_match('{^https?://}i', $path)) {
-            throw new \InvalidArgumentException('http urls require a RemoteFilesystem instance to be passed');
+        if (null === $httpDownloader && preg_match('{^https?://}i', $path)) {
+            throw new \InvalidArgumentException('http urls require a HttpDownloader instance to be passed');
         }
-        $this->rfs = $rfs;
+        $this->httpDownloader = $httpDownloader;
         $this->io = $io;
     }
 
@@ -84,8 +84,8 @@ class JsonFile
     public function read()
     {
         try {
-            if ($this->rfs) {
-                $json = $this->rfs->getContents($this->path, $this->path, false);
+            if ($this->httpDownloader) {
+                $json = $this->httpDownloader->get($this->path)->getBody();
             } else {
                 if ($this->io && $this->io->isDebug()) {
                     $this->io->writeError('Reading ' . $this->path);

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -18,7 +18,6 @@ use Composer\Package\Link;
 use Composer\Package\RootAliasPackage;
 use Composer\Package\RootPackageInterface;
 use Composer\Package\Version\VersionParser;
-use Composer\Semver\VersionParser as SemverVersionParser;
 
 /**
  * @author Konstantin Kudryashiv <ever.zet@gmail.com>
@@ -29,7 +28,7 @@ class ArrayLoader implements LoaderInterface
     protected $versionParser;
     protected $loadOptions;
 
-    public function __construct(SemverVersionParser $parser = null, $loadOptions = false)
+    public function __construct(VersionParser $parser = null, $loadOptions = false)
     {
         if (!$parser) {
             $parser = new VersionParser;

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -39,6 +39,70 @@ class ArrayLoader implements LoaderInterface
 
     public function load(array $config, $class = 'Composer\Package\CompletePackage')
     {
+        $package = $this->createObject($config, $class);
+
+        foreach (Package\BasePackage::$supportedLinkTypes as $type => $opts) {
+            if (isset($config[$type])) {
+                $method = 'set'.ucfirst($opts['method']);
+                $package->{$method}(
+                    $this->parseLinks(
+                        $package->getName(),
+                        $package->getPrettyVersion(),
+                        $opts['description'],
+                        $config[$type]
+                    )
+                );
+            }
+        }
+
+        $package = $this->configureObject($package, $config);
+
+        return $package;
+    }
+
+    public function loadPackages(array $versions, $class)
+    {
+        static $uniqKeys = array('version', 'version_normalized', 'source', 'dist', 'time');
+
+        $packages = array();
+        $linkCache = array();
+
+        foreach ($versions as $version) {
+            if (isset($version['versions'])) {
+                $baseVersion = $version;
+                foreach ($uniqKeys as $key) {
+                    unset($baseVersion[$key.'s']);
+                }
+
+                foreach ($version['versions'] as $index => $dummy) {
+                    $unpackedVersion = $baseVersion;
+                    foreach ($uniqKeys as $key) {
+                        $unpackedVersion[$key] = $version[$key.'s'][$index];
+                    }
+
+                    $package = $this->createObject($unpackedVersion, $class);
+
+                    $this->configureCachedLinks($linkCache, $package, $unpackedVersion);
+                    $package = $this->configureObject($package, $unpackedVersion);
+
+                    $packages[] = $package;
+                }
+            } else {
+                $package = $this->createObject($version, $class);
+
+                $this->configureCachedLinks($linkCache, $package, $version);
+                $package = $this->configureObject($package, $version);
+
+                $packages[] = $package;
+            }
+
+        }
+
+        return $packages;
+    }
+
+    private function createObject(array $config, $class)
+    {
         if (!isset($config['name'])) {
             throw new \UnexpectedValueException('Unknown package has no name defined ('.json_encode($config).').');
         }
@@ -52,7 +116,12 @@ class ArrayLoader implements LoaderInterface
         } else {
             $version = $this->versionParser->normalize($config['version']);
         }
-        $package = new $class($config['name'], $version, $config['version']);
+
+        return new $class($config['name'], $version, $config['version']);
+    }
+
+    private function configureObject($package, array $config)
+    {
         $package->setType(isset($config['type']) ? strtolower($config['type']) : 'library');
 
         if (isset($config['target-dir'])) {
@@ -106,20 +175,6 @@ class ArrayLoader implements LoaderInterface
             $package->setDistSha1Checksum(isset($config['dist']['shasum']) ? $config['dist']['shasum'] : null);
             if (isset($config['dist']['mirrors'])) {
                 $package->setDistMirrors($config['dist']['mirrors']);
-            }
-        }
-
-        foreach (Package\BasePackage::$supportedLinkTypes as $type => $opts) {
-            if (isset($config[$type])) {
-                $method = 'set'.ucfirst($opts['method']);
-                $package->{$method}(
-                    $this->parseLinks(
-                        $package->getName(),
-                        $package->getPrettyVersion(),
-                        $opts['description'],
-                        $config[$type]
-                    )
-                );
             }
         }
 
@@ -202,19 +257,48 @@ class ArrayLoader implements LoaderInterface
             }
         }
 
-        if ($aliasNormalized = $this->getBranchAlias($config)) {
-            if ($package instanceof RootPackageInterface) {
-                $package = new RootAliasPackage($package, $aliasNormalized, preg_replace('{(\.9{7})+}', '.x', $aliasNormalized));
-            } else {
-                $package = new AliasPackage($package, $aliasNormalized, preg_replace('{(\.9{7})+}', '.x', $aliasNormalized));
-            }
-        }
-
         if ($this->loadOptions && isset($config['transport-options'])) {
             $package->setTransportOptions($config['transport-options']);
         }
 
+        if ($aliasNormalized = $this->getBranchAlias($config)) {
+            if ($package instanceof RootPackageInterface) {
+                return new RootAliasPackage($package, $aliasNormalized, preg_replace('{(\.9{7})+}', '.x', $aliasNormalized));
+            }
+
+            return new AliasPackage($package, $aliasNormalized, preg_replace('{(\.9{7})+}', '.x', $aliasNormalized));
+        }
+
         return $package;
+    }
+
+    private function configureCachedLinks(&$linkCache, $package, array $config)
+    {
+        $name = $package->getName();
+        $prettyVersion = $package->getPrettyVersion();
+
+        foreach (Package\BasePackage::$supportedLinkTypes as $type => $opts) {
+            if (isset($config[$type])) {
+                $method = 'set'.ucfirst($opts['method']);
+
+                $links = array();
+                foreach ($config[$type] as $prettyTarget => $constraint) {
+                    $target = strtolower($prettyTarget);
+                    if ($constraint === 'self.version') {
+                        $links[$target] = $this->createLink($name, $prettyVersion, $opts['description'], $target, $constraint);
+                    } else {
+                        if (!isset($linkCache[$name][$type][$target][$constraint])) {
+                            $linkCache[$name][$type][$target][$constraint] = array($target, $this->createLink($name, $prettyVersion, $opts['description'], $target, $constraint));
+                        }
+
+                        list($target, $link) = $linkCache[$name][$type][$target][$constraint];
+                        $links[$target] = $link;
+                    }
+                }
+
+                $package->{$method}($links);
+            }
+        }
     }
 
     /**
@@ -228,19 +312,24 @@ class ArrayLoader implements LoaderInterface
     {
         $res = array();
         foreach ($links as $target => $constraint) {
-            if (!is_string($constraint)) {
-                throw new \UnexpectedValueException('Link constraint in '.$source.' '.$description.' > '.$target.' should be a string, got '.gettype($constraint) . ' (' . var_export($constraint, true) . ')');
-            }
-            if ('self.version' === $constraint) {
-                $parsedConstraint = $this->versionParser->parseConstraints($sourceVersion);
-            } else {
-                $parsedConstraint = $this->versionParser->parseConstraints($constraint);
-            }
-
-            $res[strtolower($target)] = new Link($source, $target, $parsedConstraint, $description, $constraint);
+            $res[strtolower($target)] = $this->createLink($source, $sourceVersion, $description, $target, $constraint);
         }
 
         return $res;
+    }
+
+    private function createLink($source, $sourceVersion, $description, $target, $prettyConstraint)
+    {
+        if (!is_string($prettyConstraint)) {
+            throw new \UnexpectedValueException('Link constraint in '.$source.' '.$description.' > '.$target.' should be a string, got '.gettype($prettyConstraint) . ' (' . var_export($prettyConstraint, true) . ')');
+        }
+        if ('self.version' === $prettyConstraint) {
+            $parsedConstraint = $this->versionParser->parseConstraints($sourceVersion);
+        } else {
+            $parsedConstraint = $this->versionParser->parseConstraints($prettyConstraint);
+        }
+
+        return new Link($source, $target, $parsedConstraint, $description, $prettyConstraint);
     }
 
     /**

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -95,7 +95,6 @@ class ArrayLoader implements LoaderInterface
 
                 $packages[] = $package;
             }
-
         }
 
         return $packages;

--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -192,7 +192,8 @@ class VersionGuesser
             }
 
             // re-use the HgDriver to fetch branches (this properly includes bookmarks)
-            $driver = new HgDriver(array('url' => $path), new NullIO(), $this->config, $this->process);
+            $io = new NullIO();
+            $driver = new HgDriver(array('url' => $path), $io, $this->config, new HttpDownloader($io, $this->config), $this->process);
             $branches = array_keys($driver->getBranches());
 
             // try to find the best (nearest) version branch to assume this feature's version

--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -25,7 +25,7 @@ class PreFileDownloadEvent extends Event
     /**
      * @var HttpDownloader
      */
-    private $rfs;
+    private $httpDownloader;
 
     /**
      * @var string
@@ -36,13 +36,13 @@ class PreFileDownloadEvent extends Event
      * Constructor.
      *
      * @param string           $name         The event name
-     * @param HttpDownloader $rfs
+     * @param HttpDownloader $httpDownloader
      * @param string           $processedUrl
      */
-    public function __construct($name, HttpDownloader $rfs, $processedUrl)
+    public function __construct($name, HttpDownloader $httpDownloader, $processedUrl)
     {
         parent::__construct($name);
-        $this->rfs = $rfs;
+        $this->httpDownloader = $httpDownloader;
         $this->processedUrl = $processedUrl;
     }
 
@@ -51,15 +51,7 @@ class PreFileDownloadEvent extends Event
      */
     public function getHttpDownloader()
     {
-        return $this->rfs;
-    }
-
-    /**
-     * @param HttpDownloader $rfs
-     */
-    public function setHttpDownloader(HttpDownloader $rfs)
-    {
-        $this->rfs = $rfs;
+        return $this->httpDownloader;
     }
 
     /**

--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -13,7 +13,7 @@
 namespace Composer\Plugin;
 
 use Composer\EventDispatcher\Event;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 
 /**
  * The pre file download event.
@@ -23,7 +23,7 @@ use Composer\Util\RemoteFilesystem;
 class PreFileDownloadEvent extends Event
 {
     /**
-     * @var RemoteFilesystem
+     * @var HttpDownloader
      */
     private $rfs;
 
@@ -36,10 +36,10 @@ class PreFileDownloadEvent extends Event
      * Constructor.
      *
      * @param string           $name         The event name
-     * @param RemoteFilesystem $rfs
+     * @param HttpDownloader $rfs
      * @param string           $processedUrl
      */
-    public function __construct($name, RemoteFilesystem $rfs, $processedUrl)
+    public function __construct($name, HttpDownloader $rfs, $processedUrl)
     {
         parent::__construct($name);
         $this->rfs = $rfs;
@@ -47,21 +47,17 @@ class PreFileDownloadEvent extends Event
     }
 
     /**
-     * Returns the remote filesystem
-     *
-     * @return RemoteFilesystem
+     * @return HttpDownloader
      */
-    public function getRemoteFilesystem()
+    public function getHttpDownloader()
     {
         return $this->rfs;
     }
 
     /**
-     * Sets the remote filesystem
-     *
-     * @param RemoteFilesystem $rfs
+     * @param HttpDownloader $rfs
      */
-    public function setRemoteFilesystem(RemoteFilesystem $rfs)
+    public function setHttpDownloader(HttpDownloader $rfs)
     {
         $this->rfs = $rfs;
     }

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -527,6 +527,8 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         // TODO what if not, then throw?
         if ($this->lazyProvidersUrl) {
             foreach ($packageNames as $name => $constraint) {
+                $name = strtolower($name);
+
                 // skip platform packages, root package and composer-plugin-api
                 if (preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $name) || '__root__' === $name || 'composer-plugin-api' === $name) {
                     continue;

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -898,15 +898,12 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         $retries = 3;
         while ($retries--) {
             try {
-                $httpDownloader = $this->httpDownloader;
-
                 if ($this->eventDispatcher) {
                     $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename);
                     $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
-                    $httpDownloader = $preFileDownloadEvent->getHttpDownloader();
                 }
 
-                $response = $httpDownloader->get($filename, $this->options);
+                $response = $this->httpDownloader->get($filename, $this->options);
                 $json = $response->getBody();
                 if ($sha256 && $sha256 !== hash('sha256', $json)) {
                     // undo downgrade before trying again if http seems to be hijacked or modifying content somehow
@@ -989,12 +986,9 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         $retries = 3;
         while ($retries--) {
             try {
-                $httpDownloader = $this->httpDownloader;
-
                 if ($this->eventDispatcher) {
                     $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename);
                     $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
-                    $httpDownloader = $preFileDownloadEvent->getHttpDownloader();
                 }
 
                 $options = $this->options;
@@ -1002,7 +996,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     $options['http']['header'] = (array) $options['http']['header'];
                 }
                 $options['http']['header'][] = array('If-Modified-Since: '.$lastModifiedTime);
-                $response = $httpDownloader->get($filename, $options);
+                $response = $this->httpDownloader->get($filename, $options);
                 $json = $response->getBody();
                 if ($json === '' && $response->getStatusCode() === 304) {
                     return true;
@@ -1053,12 +1047,11 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     private function asyncFetchFile($filename, $cacheKey, $lastModifiedTime = null)
     {
         $retries = 3;
-        $httpDownloader = $this->httpDownloader;
 
+        $httpDownloader = $this->httpDownloader;
         if ($this->eventDispatcher) {
             $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename);
             $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
-            $httpDownloader = $preFileDownloadEvent->getHttpDownloader();
         }
 
         $options = $lastModifiedTime ? array('http' => array('header' => array('If-Modified-Since: '.$lastModifiedTime))) : array();

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1044,7 +1044,12 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 return false;
             }
 
-            if (--$retries) {
+            // special error code returned when network is being artificially disabled
+            if ($e instanceof TransportException && $e->getStatusCode() === 499) {
+                $retries = 0;
+            }
+
+            if (--$retries > 0) {
                 usleep(100000);
 
                 return $httpDownloader->add($filename, $options)->then($accept, $reject);

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -185,17 +185,25 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
     private function filterPackages(array $packages, $constraint = null, $returnFirstMatch = false)
     {
-        $packages = array();
+        if (null === $constraint) {
+            if ($returnFirstMatch) {
+                return reset($packages);
+            }
+
+            return $packages;
+        }
+
+        $filteredPackages = array();
 
         foreach ($packages as $package) {
-
             $pkgConstraint = new Constraint('==', $package->getVersion());
-            if (null === $constraint || $constraint->matches($pkgConstraint)) {
+
+            if ($constraint->matches($pkgConstraint)) {
                 if ($returnFirstMatch) {
                     return $package;
                 }
 
-                $packages[] = $package;
+                $filteredPackages[] = $package;
             }
         }
 
@@ -203,7 +211,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             return null;
         }
 
-        return $packages;
+        return $filteredPackages;
     }
 
     public function getPackages()

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -588,9 +588,9 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                             }
                         }
 
-                        $loadedPackages = $this->createPackages($versionsToLoad, 'Composer\Package\CompletePackage');
+                        $loadedPackages = $repo->createPackages($versionsToLoad, 'Composer\Package\CompletePackage');
                         foreach ($loadedPackages as $package) {
-                            $package->setRepository($this);
+                            $package->setRepository($repo);
 
                             $packages[spl_object_hash($package)] = $package;
                             if ($package instanceof AliasPackage && !isset($packages[spl_object_hash($package->getAliasOf())])) {

--- a/src/Composer/Repository/Pear/BaseChannelReader.php
+++ b/src/Composer/Repository/Pear/BaseChannelReader.php
@@ -12,7 +12,7 @@
 
 namespace Composer\Repository\Pear;
 
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 
 /**
  * Base PEAR Channel reader.
@@ -33,12 +33,12 @@ abstract class BaseChannelReader
     const ALL_RELEASES_NS = 'http://pear.php.net/dtd/rest.allreleases';
     const PACKAGE_INFO_NS = 'http://pear.php.net/dtd/rest.package';
 
-    /** @var RemoteFilesystem */
-    private $rfs;
+    /** @var HttpDownloader */
+    private $httpDownloader;
 
-    protected function __construct(RemoteFilesystem $rfs)
+    protected function __construct(HttpDownloader $httpDownloader)
     {
-        $this->rfs = $rfs;
+        $this->httpDownloader = $httpDownloader;
     }
 
     /**
@@ -52,7 +52,11 @@ abstract class BaseChannelReader
     protected function requestContent($origin, $path)
     {
         $url = rtrim($origin, '/') . '/' . ltrim($path, '/');
-        $content = $this->rfs->getContents($origin, $url, false);
+        try {
+            $content = $this->httpDownloader->get($url)->getBody();
+        } catch (\Exception $e) {
+            throw new \UnexpectedValueException('The PEAR channel at ' . $url . ' did not respond.', 0, $e);
+        }
         if (!$content) {
             throw new \UnexpectedValueException('The PEAR channel at ' . $url . ' did not respond.');
         }

--- a/src/Composer/Repository/Pear/ChannelReader.php
+++ b/src/Composer/Repository/Pear/ChannelReader.php
@@ -12,7 +12,7 @@
 
 namespace Composer\Repository\Pear;
 
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 
 /**
  * PEAR Channel package reader.
@@ -26,12 +26,12 @@ class ChannelReader extends BaseChannelReader
     /** @var array of ('xpath test' => 'rest implementation') */
     private $readerMap;
 
-    public function __construct(RemoteFilesystem $rfs)
+    public function __construct(HttpDownloader $httpDownloader)
     {
-        parent::__construct($rfs);
+        parent::__construct($httpDownloader);
 
-        $rest10reader = new ChannelRest10Reader($rfs);
-        $rest11reader = new ChannelRest11Reader($rfs);
+        $rest10reader = new ChannelRest10Reader($httpDownloader);
+        $rest11reader = new ChannelRest11Reader($httpDownloader);
 
         $this->readerMap = array(
             'REST1.3' => $rest11reader,

--- a/src/Composer/Repository/Pear/ChannelRest10Reader.php
+++ b/src/Composer/Repository/Pear/ChannelRest10Reader.php
@@ -13,6 +13,7 @@
 namespace Composer\Repository\Pear;
 
 use Composer\Downloader\TransportException;
+use Composer\Util\HttpDownloader;
 
 /**
  * Read PEAR packages using REST 1.0 interface
@@ -29,9 +30,9 @@ class ChannelRest10Reader extends BaseChannelReader
 {
     private $dependencyReader;
 
-    public function __construct($rfs)
+    public function __construct(HttpDownloader $httpDownloader)
     {
-        parent::__construct($rfs);
+        parent::__construct($httpDownloader);
 
         $this->dependencyReader = new PackageDependencyParser();
     }

--- a/src/Composer/Repository/Pear/ChannelRest11Reader.php
+++ b/src/Composer/Repository/Pear/ChannelRest11Reader.php
@@ -12,6 +12,8 @@
 
 namespace Composer\Repository\Pear;
 
+use Composer\Util\HttpDownloader;
+
 /**
  * Read PEAR packages using REST 1.1 interface
  *
@@ -25,9 +27,9 @@ class ChannelRest11Reader extends BaseChannelReader
 {
     private $dependencyReader;
 
-    public function __construct($rfs)
+    public function __construct(HttpDownloader $httpDownloader)
     {
-        parent::__construct($rfs);
+        parent::__construct($httpDownloader);
 
         $this->dependencyReader = new PackageDependencyParser();
     }

--- a/src/Composer/Repository/PearRepository.php
+++ b/src/Composer/Repository/PearRepository.php
@@ -47,7 +47,7 @@ class PearRepository extends ArrayRepository implements ConfigurableRepositoryIn
      */
     private $vendorAlias;
 
-    public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $dispatcher, HttpDownloader $httpDownloader)
+    public function __construct(array $repoConfig, IOInterface $io, Config $config, HttpDownloader $httpDownloader, EventDispatcher $dispatcher = null)
     {
         parent::__construct();
         if (!preg_match('{^https?://}', $repoConfig['url'])) {

--- a/src/Composer/Repository/PearRepository.php
+++ b/src/Composer/Repository/PearRepository.php
@@ -21,7 +21,7 @@ use Composer\Repository\Pear\ChannelInfo;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\Package\Link;
 use Composer\Semver\Constraint\Constraint;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 use Composer\Config;
 use Composer\Factory;
 
@@ -38,7 +38,7 @@ class PearRepository extends ArrayRepository implements ConfigurableRepositoryIn
 {
     private $url;
     private $io;
-    private $rfs;
+    private $httpDownloader;
     private $versionParser;
     private $repoConfig;
 
@@ -47,7 +47,7 @@ class PearRepository extends ArrayRepository implements ConfigurableRepositoryIn
      */
     private $vendorAlias;
 
-    public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $dispatcher = null, RemoteFilesystem $rfs = null)
+    public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $dispatcher, HttpDownloader $httpDownloader)
     {
         parent::__construct();
         if (!preg_match('{^https?://}', $repoConfig['url'])) {
@@ -61,7 +61,7 @@ class PearRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
         $this->url = rtrim($repoConfig['url'], '/');
         $this->io = $io;
-        $this->rfs = $rfs ?: Factory::createRemoteFilesystem($this->io, $config);
+        $this->httpDownloader = $httpDownloader;
         $this->vendorAlias = isset($repoConfig['vendor-alias']) ? $repoConfig['vendor-alias'] : null;
         $this->versionParser = new VersionParser();
         $this->repoConfig = $repoConfig;
@@ -78,7 +78,7 @@ class PearRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
         $this->io->writeError('Initializing PEAR repository '.$this->url);
 
-        $reader = new ChannelReader($this->rfs);
+        $reader = new ChannelReader($this->httpDownloader);
         try {
             $channelInfo = $reader->read($this->url);
         } catch (\Exception $e) {

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -308,6 +308,10 @@ class PlatformRepository extends ArrayRepository
         $this->addPackage($ext);
     }
 
+    /**
+     * @param string $name
+     * @return string
+     */
     private function buildPackageName($name)
     {
         return 'ext-' . str_replace(' ', '-', $name);

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -16,7 +16,7 @@ use Composer\Factory;
 use Composer\IO\IOInterface;
 use Composer\Config;
 use Composer\EventDispatcher\EventDispatcher;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 use Composer\Json\JsonFile;
 
 /**
@@ -108,10 +108,10 @@ class RepositoryFactory
      * @param  IOInterface       $io
      * @param  Config            $config
      * @param  EventDispatcher   $eventDispatcher
-     * @param  RemoteFilesystem  $rfs
+     * @param  HttpDownloader  $rfs
      * @return RepositoryManager
      */
-    public static function manager(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, RemoteFilesystem $rfs = null)
+    public static function manager(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, HttpDownloader $rfs = null)
     {
         $rm = new RepositoryManager($io, $config, $eventDispatcher, $rfs);
         $rm->setRepositoryClass('composer', 'Composer\Repository\ComposerRepository');

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -36,7 +36,7 @@ class RepositoryFactory
         if (0 === strpos($repository, 'http')) {
             $repoConfig = array('type' => 'composer', 'url' => $repository);
         } elseif ("json" === pathinfo($repository, PATHINFO_EXTENSION)) {
-            $json = new JsonFile($repository, Factory::createRemoteFilesystem($io, $config));
+            $json = new JsonFile($repository, Factory::createHttpDownloader($io, $config));
             $data = $json->read();
             if (!empty($data['packages']) || !empty($data['includes']) || !empty($data['provider-includes'])) {
                 $repoConfig = array('type' => 'composer', 'url' => 'file://' . strtr(realpath($repository), '\\', '/'));
@@ -77,7 +77,7 @@ class RepositoryFactory
      */
     public static function createRepo(IOInterface $io, Config $config, array $repoConfig)
     {
-        $rm = static::manager($io, $config, null, Factory::createRemoteFilesystem($io, $config));
+        $rm = static::manager($io, $config, Factory::createHttpDownloader($io, $config));
         $repos = static::createRepos($rm, array($repoConfig));
 
         return reset($repos);
@@ -98,7 +98,7 @@ class RepositoryFactory
             if (!$io) {
                 throw new \InvalidArgumentException('This function requires either an IOInterface or a RepositoryManager');
             }
-            $rm = static::manager($io, $config, null, Factory::createRemoteFilesystem($io, $config));
+            $rm = static::manager($io, $config, Factory::createHttpDownloader($io, $config));
         }
 
         return static::createRepos($rm, $config->getRepositories());
@@ -113,7 +113,7 @@ class RepositoryFactory
      */
     public static function manager(IOInterface $io, Config $config, HttpDownloader $httpDownloader, EventDispatcher $eventDispatcher = null)
     {
-        $rm = new RepositoryManager($io, $config, $eventDispatcher, $httpDownloader);
+        $rm = new RepositoryManager($io, $config, $httpDownloader, $eventDispatcher);
         $rm->setRepositoryClass('composer', 'Composer\Repository\ComposerRepository');
         $rm->setRepositoryClass('vcs', 'Composer\Repository\VcsRepository');
         $rm->setRepositoryClass('package', 'Composer\Repository\PackageRepository');

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -108,12 +108,12 @@ class RepositoryFactory
      * @param  IOInterface       $io
      * @param  Config            $config
      * @param  EventDispatcher   $eventDispatcher
-     * @param  HttpDownloader  $rfs
+     * @param  HttpDownloader    $httpDownloader
      * @return RepositoryManager
      */
-    public static function manager(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, HttpDownloader $rfs = null)
+    public static function manager(IOInterface $io, Config $config, HttpDownloader $httpDownloader, EventDispatcher $eventDispatcher = null)
     {
-        $rm = new RepositoryManager($io, $config, $eventDispatcher, $rfs);
+        $rm = new RepositoryManager($io, $config, $eventDispatcher, $httpDownloader);
         $rm->setRepositoryClass('composer', 'Composer\Repository\ComposerRepository');
         $rm->setRepositoryClass('vcs', 'Composer\Repository\VcsRepository');
         $rm->setRepositoryClass('package', 'Composer\Repository\PackageRepository');

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -13,6 +13,7 @@
 namespace Composer\Repository;
 
 use Composer\Package\PackageInterface;
+use Composer\Semver\Constraint\ConstraintInterface;
 
 /**
  * Repository interface.
@@ -38,8 +39,8 @@ interface RepositoryInterface extends \Countable
     /**
      * Searches for the first match of a package by name and version.
      *
-     * @param string                                                 $name       package name
-     * @param string|\Composer\Semver\Constraint\ConstraintInterface $constraint package version or version constraint to match against
+     * @param string                     $name       package name
+     * @param string|ConstraintInterface $constraint package version or version constraint to match against
      *
      * @return PackageInterface|null
      */
@@ -48,8 +49,8 @@ interface RepositoryInterface extends \Countable
     /**
      * Searches for all packages matching a name and optionally a version.
      *
-     * @param string                                                 $name       package name
-     * @param string|\Composer\Semver\Constraint\ConstraintInterface $constraint package version or version constraint to match against
+     * @param string                     $name       package name
+     * @param string|ConstraintInterface $constraint package version or version constraint to match against
      *
      * @return PackageInterface[]
      */
@@ -66,7 +67,7 @@ interface RepositoryInterface extends \Countable
     /**
      * Returns list of registered packages with the supplied name
      *
-     * @param bool[] $packageNameMap
+     * @param ConstraintInterface[] $packageNameMap package names pointing to constraints
      * @param $isPackageAcceptableCallable
      * @return PackageInterface[]
      */

--- a/src/Composer/Repository/RepositoryManager.php
+++ b/src/Composer/Repository/RepositoryManager.php
@@ -33,14 +33,14 @@ class RepositoryManager
     private $io;
     private $config;
     private $eventDispatcher;
-    private $rfs;
+    private $httpDownloader;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, HttpDownloader $rfs = null)
+    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher, HttpDownloader $httpDownloader)
     {
         $this->io = $io;
         $this->config = $config;
         $this->eventDispatcher = $eventDispatcher;
-        $this->rfs = $rfs;
+        $this->httpDownloader = $httpDownloader;
     }
 
     /**
@@ -128,7 +128,7 @@ class RepositoryManager
         $reflMethod = new \ReflectionMethod($class, '__construct');
         $params = $reflMethod->getParameters();
         if (isset($params[4]) && $params[4]->getClass() && $params[4]->getClass()->getName() === 'Composer\Util\HttpDownloader') {
-            return new $class($config, $this->io, $this->config, $this->eventDispatcher, $this->rfs);
+            return new $class($config, $this->io, $this->config, $this->eventDispatcher, $this->httpDownloader);
         }
 
         return new $class($config, $this->io, $this->config, $this->eventDispatcher);

--- a/src/Composer/Repository/RepositoryManager.php
+++ b/src/Composer/Repository/RepositoryManager.php
@@ -16,7 +16,7 @@ use Composer\IO\IOInterface;
 use Composer\Config;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\Package\PackageInterface;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 
 /**
  * Repositories manager.
@@ -35,7 +35,7 @@ class RepositoryManager
     private $eventDispatcher;
     private $rfs;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, RemoteFilesystem $rfs = null)
+    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, HttpDownloader $rfs = null)
     {
         $this->io = $io;
         $this->config = $config;
@@ -127,7 +127,7 @@ class RepositoryManager
 
         $reflMethod = new \ReflectionMethod($class, '__construct');
         $params = $reflMethod->getParameters();
-        if (isset($params[4]) && $params[4]->getClass() && $params[4]->getClass()->getName() === 'Composer\Util\RemoteFilesystem') {
+        if (isset($params[4]) && $params[4]->getClass() && $params[4]->getClass()->getName() === 'Composer\Util\HttpDownloader') {
             return new $class($config, $this->io, $this->config, $this->eventDispatcher, $this->rfs);
         }
 

--- a/src/Composer/Repository/RepositoryManager.php
+++ b/src/Composer/Repository/RepositoryManager.php
@@ -35,12 +35,12 @@ class RepositoryManager
     private $eventDispatcher;
     private $httpDownloader;
 
-    public function __construct(IOInterface $io, Config $config, EventDispatcher $eventDispatcher, HttpDownloader $httpDownloader)
+    public function __construct(IOInterface $io, Config $config, HttpDownloader $httpDownloader, EventDispatcher $eventDispatcher = null)
     {
         $this->io = $io;
         $this->config = $config;
-        $this->eventDispatcher = $eventDispatcher;
         $this->httpDownloader = $httpDownloader;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -127,8 +127,8 @@ class RepositoryManager
 
         $reflMethod = new \ReflectionMethod($class, '__construct');
         $params = $reflMethod->getParameters();
-        if (isset($params[4]) && $params[4]->getClass() && $params[4]->getClass()->getName() === 'Composer\Util\HttpDownloader') {
-            return new $class($config, $this->io, $this->config, $this->eventDispatcher, $this->httpDownloader);
+        if (isset($params[3]) && $params[3]->getClass() && $params[3]->getClass()->getName() === 'Composer\Util\HttpDownloader') {
+            return new $class($config, $this->io, $this->config, $this->httpDownloader, $this->eventDispatcher);
         }
 
         return new $class($config, $this->io, $this->config, $this->eventDispatcher);

--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -75,8 +75,8 @@ class GitBitbucketDriver extends BitbucketDriver
             array('url' => $url),
             $this->io,
             $this->config,
-            $this->process,
-            $this->httpDownloader
+            $this->httpDownloader,
+            $this->process
         );
         $this->fallbackDriver->initialize();
     }

--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -76,7 +76,7 @@ class GitBitbucketDriver extends BitbucketDriver
             $this->io,
             $this->config,
             $this->process,
-            $this->remoteFilesystem
+            $this->httpDownloader
         );
         $this->fallbackDriver->initialize();
     }

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -18,6 +18,8 @@ use Composer\Json\JsonFile;
 use Composer\Cache;
 use Composer\IO\IOInterface;
 use Composer\Util\GitHub;
+use Composer\Util\Http\Response;
+use Composer\Util\RemoteFilesystem;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -184,7 +186,7 @@ class GitHubDriver extends VcsDriver
         }
 
         $resource = $this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/contents/' . $file . '?ref='.urlencode($identifier);
-        $resource = JsonFile::parseJson($this->getContents($resource));
+        $resource = $this->getContents($resource)->decodeJson();
         if (empty($resource['content']) || $resource['encoding'] !== 'base64' || !($content = base64_decode($resource['content']))) {
             throw new \RuntimeException('Could not retrieve ' . $file . ' for '.$identifier);
         }
@@ -202,7 +204,7 @@ class GitHubDriver extends VcsDriver
         }
 
         $resource = $this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/commits/'.urlencode($identifier);
-        $commit = JsonFile::parseJson($this->getContents($resource), $resource);
+        $commit = $this->getContents($resource)->decodeJson();
 
         return new \DateTime($commit['commit']['committer']['date']);
     }
@@ -220,12 +222,13 @@ class GitHubDriver extends VcsDriver
             $resource = $this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/tags?per_page=100';
 
             do {
-                $tagsData = JsonFile::parseJson($this->getContents($resource), $resource);
+                $response = $this->getContents($resource);
+                $tagsData = $response->decodeJson();
                 foreach ($tagsData as $tag) {
                     $this->tags[$tag['name']] = $tag['commit']['sha'];
                 }
 
-                $resource = $this->getNextPage();
+                $resource = $this->getNextPage($response);
             } while ($resource);
         }
 
@@ -247,7 +250,8 @@ class GitHubDriver extends VcsDriver
             $branchBlacklist = array('gh-pages');
 
             do {
-                $branchData = JsonFile::parseJson($this->getContents($resource), $resource);
+                $response = $this->getContents($resource);
+                $branchData = $response->decodeJson();
                 foreach ($branchData as $branch) {
                     $name = substr($branch['ref'], 11);
                     if (!in_array($name, $branchBlacklist)) {
@@ -255,7 +259,7 @@ class GitHubDriver extends VcsDriver
                     }
                 }
 
-                $resource = $this->getNextPage();
+                $resource = $this->getNextPage($response);
             } while ($resource);
         }
 
@@ -315,7 +319,7 @@ class GitHubDriver extends VcsDriver
         try {
             return parent::getContents($url);
         } catch (TransportException $e) {
-            $gitHubUtil = new GitHub($this->io, $this->config, $this->process, $this->remoteFilesystem);
+            $gitHubUtil = new GitHub($this->io, $this->config, $this->process, $this->httpDownloader);
 
             switch ($e->getCode()) {
                 case 401:
@@ -330,16 +334,18 @@ class GitHubDriver extends VcsDriver
                     }
 
                     if (!$this->io->isInteractive()) {
-                        return $this->attemptCloneFallback();
+                        if ($this->attemptCloneFallback()) {
+                            return new Response(array('url' => 'dummy'), 200, array(), 'null');
+                        }
                     }
 
                     $scopesIssued = array();
                     $scopesNeeded = array();
                     if ($headers = $e->getHeaders()) {
-                        if ($scopes = $this->remoteFilesystem->findHeaderValue($headers, 'X-OAuth-Scopes')) {
+                        if ($scopes = RemoteFilesystem::findHeaderValue($headers, 'X-OAuth-Scopes')) {
                             $scopesIssued = explode(' ', $scopes);
                         }
-                        if ($scopes = $this->remoteFilesystem->findHeaderValue($headers, 'X-Accepted-OAuth-Scopes')) {
+                        if ($scopes = RemoteFilesystem::findHeaderValue($headers, 'X-Accepted-OAuth-Scopes')) {
                             $scopesNeeded = explode(' ', $scopes);
                         }
                     }
@@ -358,7 +364,9 @@ class GitHubDriver extends VcsDriver
                     }
 
                     if (!$this->io->isInteractive() && $fetchingRepoData) {
-                        return $this->attemptCloneFallback();
+                        if ($this->attemptCloneFallback()) {
+                            return new Response(array('url' => 'dummy'), 200, array(), 'null');
+                        }
                     }
 
                     $rateLimited = $gitHubUtil->isRateLimited($e->getHeaders());
@@ -404,7 +412,7 @@ class GitHubDriver extends VcsDriver
 
         $repoDataUrl = $this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository;
 
-        $this->repoData = JsonFile::parseJson($this->getContents($repoDataUrl, true), $repoDataUrl);
+        $this->repoData = $this->getContents($repoDataUrl, true)->decodeJson();
         if (null === $this->repoData && null !== $this->gitDriver) {
             return;
         }
@@ -434,7 +442,7 @@ class GitHubDriver extends VcsDriver
             // are not interactive) then we fallback to GitDriver.
             $this->setupGitDriver($this->generateSshUrl());
 
-            return;
+            return true;
         } catch (\RuntimeException $e) {
             $this->gitDriver = null;
 
@@ -450,22 +458,19 @@ class GitHubDriver extends VcsDriver
             $this->io,
             $this->config,
             $this->process,
-            $this->remoteFilesystem
+            $this->httpDownloader
         );
         $this->gitDriver->initialize();
     }
 
-    protected function getNextPage()
+    protected function getNextPage(Response $response)
     {
-        $headers = $this->remoteFilesystem->getLastHeaders();
-        foreach ($headers as $header) {
-            if (preg_match('{^link:\s*(.+?)\s*$}i', $header, $match)) {
-                $links = explode(',', $match[1]);
-                foreach ($links as $link) {
-                    if (preg_match('{<(.+?)>; *rel="next"}', $link, $match)) {
-                        return $match[1];
-                    }
-                }
+        $header = $response->getHeader('link');
+
+        $links = explode(',', $header);
+        foreach ($links as $link) {
+            if (preg_match('{<(.+?)>; *rel="next"}', $link, $match)) {
+                return $match[1];
             }
         }
     }

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -457,8 +457,8 @@ class GitHubDriver extends VcsDriver
             array('url' => $url),
             $this->io,
             $this->config,
-            $this->process,
-            $this->httpDownloader
+            $this->httpDownloader,
+            $this->process
         );
         $this->gitDriver->initialize();
     }

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -376,8 +376,8 @@ class GitLabDriver extends VcsDriver
             array('url' => $url),
             $this->io,
             $this->config,
-            $this->process,
-            $this->httpDownloader
+            $this->httpDownloader,
+            $this->process
         );
         $this->gitDriver->initialize();
     }

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -17,8 +17,9 @@ use Composer\Cache;
 use Composer\IO\IOInterface;
 use Composer\Json\JsonFile;
 use Composer\Downloader\TransportException;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 use Composer\Util\GitLab;
+use Composer\Util\Http\Response;
 
 /**
  * Driver for GitLab API, use the Git driver for local checkouts.
@@ -110,14 +111,14 @@ class GitLabDriver extends VcsDriver
     }
 
     /**
-     * Updates the RemoteFilesystem instance.
+     * Updates the HttpDownloader instance.
      * Mainly useful for tests.
      *
      * @internal
      */
-    public function setRemoteFilesystem(RemoteFilesystem $remoteFilesystem)
+    public function setHttpDownloader(HttpDownloader $httpDownloader)
     {
-        $this->remoteFilesystem = $remoteFilesystem;
+        $this->httpDownloader = $httpDownloader;
     }
 
     /**
@@ -140,7 +141,7 @@ class GitLabDriver extends VcsDriver
         $resource = $this->getApiUrl().'/repository/files/'.$this->urlEncodeAll($file).'/raw?ref='.$identifier;
 
         try {
-            $content = $this->getContents($resource);
+            $content = $this->getContents($resource)->getBody();
         } catch (TransportException $e) {
             if ($e->getCode() !== 404) {
                 throw $e;
@@ -297,7 +298,8 @@ class GitLabDriver extends VcsDriver
 
         $references = array();
         do {
-            $data = JsonFile::parseJson($this->getContents($resource), $resource);
+            $response = $this->getContents($resource);
+            $data = $response->decodeJson();
 
             foreach ($data as $datum) {
                 $references[$datum['name']] = $datum['commit']['id'];
@@ -308,7 +310,7 @@ class GitLabDriver extends VcsDriver
             }
 
             if (count($data) >= $perPage) {
-                $resource = $this->getNextPage();
+                $resource = $this->getNextPage($response);
             } else {
                 $resource = false;
             }
@@ -321,7 +323,7 @@ class GitLabDriver extends VcsDriver
     {
         // we need to fetch the default branch from the api
         $resource = $this->getApiUrl();
-        $this->project = JsonFile::parseJson($this->getContents($resource, true), $resource);
+        $this->project = $this->getContents($resource, true)->decodeJson();
         if (isset($this->project['visibility'])) {
             $this->isPrivate = $this->project['visibility'] !== 'public';
         } else {
@@ -344,7 +346,7 @@ class GitLabDriver extends VcsDriver
             // are not interactive) then we fallback to GitDriver.
             $this->setupGitDriver($url);
 
-            return;
+            return true;
         } catch (\RuntimeException $e) {
             $this->gitDriver = null;
 
@@ -375,7 +377,7 @@ class GitLabDriver extends VcsDriver
             $this->io,
             $this->config,
             $this->process,
-            $this->remoteFilesystem
+            $this->httpDownloader
         );
         $this->gitDriver->initialize();
     }
@@ -386,10 +388,10 @@ class GitLabDriver extends VcsDriver
     protected function getContents($url, $fetchingRepoData = false)
     {
         try {
-            $res = parent::getContents($url);
+            $response = parent::getContents($url);
 
             if ($fetchingRepoData) {
-                $json = JsonFile::parseJson($res, $url);
+                $json = $response->decodeJson();
 
                 // force auth as the unauthenticated version of the API is broken
                 if (!isset($json['default_branch'])) {
@@ -401,9 +403,9 @@ class GitLabDriver extends VcsDriver
                 }
             }
 
-            return $res;
+            return $response;
         } catch (TransportException $e) {
-            $gitLabUtil = new GitLab($this->io, $this->config, $this->process, $this->remoteFilesystem);
+            $gitLabUtil = new GitLab($this->io, $this->config, $this->process, $this->httpDownloader);
 
             switch ($e->getCode()) {
                 case 401:
@@ -418,7 +420,9 @@ class GitLabDriver extends VcsDriver
                     }
 
                     if (!$this->io->isInteractive()) {
-                        return $this->attemptCloneFallback();
+                        if ($this->attemptCloneFallback()) {
+                            return new Response(array('url' => 'dummy'), 200, array(), 'null');
+                        }
                     }
                     $this->io->writeError('<warning>Failed to download ' . $this->namespace . '/' . $this->repository . ':' . $e->getMessage() . '</warning>');
                     $gitLabUtil->authorizeOAuthInteractively($this->scheme, $this->originUrl, 'Your credentials are required to fetch private repository metadata (<info>'.$this->url.'</info>)');
@@ -431,7 +435,9 @@ class GitLabDriver extends VcsDriver
                     }
 
                     if (!$this->io->isInteractive() && $fetchingRepoData) {
-                        return $this->attemptCloneFallback();
+                        if ($this->attemptCloneFallback()) {
+                            return new Response(array('url' => 'dummy'), 200, array(), 'null');
+                        }
                     }
 
                     throw $e;
@@ -471,17 +477,14 @@ class GitLabDriver extends VcsDriver
         return true;
     }
 
-    private function getNextPage()
+    protected function getNextPage(Response $response)
     {
-        $headers = $this->remoteFilesystem->getLastHeaders();
-        foreach ($headers as $header) {
-            if (preg_match('{^link:\s*(.+?)\s*$}i', $header, $match)) {
-                $links = explode(',', $match[1]);
-                foreach ($links as $link) {
-                    if (preg_match('{<(.+?)>; *rel="next"}', $link, $match)) {
-                        return $match[1];
-                    }
-                }
+        $header = $response->getHeader('link');
+
+        $links = explode(',', $header);
+        foreach ($links as $link) {
+            if (preg_match('{<(.+?)>; *rel="next"}', $link, $match)) {
+                return $match[1];
             }
         }
     }

--- a/src/Composer/Repository/Vcs/HgBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/HgBitbucketDriver.php
@@ -76,7 +76,7 @@ class HgBitbucketDriver extends BitbucketDriver
             $this->io,
             $this->config,
             $this->process,
-            $this->remoteFilesystem
+            $this->httpDownloader
         );
         $this->fallbackDriver->initialize();
     }

--- a/src/Composer/Repository/Vcs/HgBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/HgBitbucketDriver.php
@@ -75,8 +75,8 @@ class HgBitbucketDriver extends BitbucketDriver
             array('url' => $url),
             $this->io,
             $this->config,
-            $this->process,
-            $this->httpDownloader
+            $this->httpDownloader,
+            $this->process
         );
         $this->fallbackDriver->initialize();
     }

--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -55,10 +55,10 @@ abstract class VcsDriver implements VcsDriverInterface
      * @param array            $repoConfig       The repository configuration
      * @param IOInterface      $io               The IO instance
      * @param Config           $config           The composer configuration
+     * @param HttpDownloader   $httpDownloader   Remote Filesystem, injectable for mocking
      * @param ProcessExecutor  $process          Process instance, injectable for mocking
-     * @param HttpDownloader $httpDownloader Remote Filesystem, injectable for mocking
      */
-    final public function __construct(array $repoConfig, IOInterface $io, Config $config, ProcessExecutor $process = null, HttpDownloader $httpDownloader = null)
+    final public function __construct(array $repoConfig, IOInterface $io, Config $config, HttpDownloader $httpDownloader, ProcessExecutor $process)
     {
         if (Filesystem::isLocalPath($repoConfig['url'])) {
             $repoConfig['url'] = Filesystem::getPlatformPath($repoConfig['url']);
@@ -69,8 +69,8 @@ abstract class VcsDriver implements VcsDriverInterface
         $this->repoConfig = $repoConfig;
         $this->io = $io;
         $this->config = $config;
-        $this->process = $process ?: new ProcessExecutor($io);
-        $this->httpDownloader = $httpDownloader ?: Factory::createHttpDownloader($this->io, $config);
+        $this->httpDownloader = $httpDownloader;
+        $this->process = $process;
     }
 
     /**

--- a/src/Composer/SelfUpdate/Versions.php
+++ b/src/Composer/SelfUpdate/Versions.php
@@ -12,7 +12,7 @@
 
 namespace Composer\SelfUpdate;
 
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 use Composer\Config;
 use Composer\Json\JsonFile;
 
@@ -21,13 +21,13 @@ use Composer\Json\JsonFile;
  */
 class Versions
 {
-    private $rfs;
+    private $httpDownloader;
     private $config;
     private $channel;
 
-    public function __construct(Config $config, RemoteFilesystem $rfs)
+    public function __construct(Config $config, HttpDownloader $httpDownloader)
     {
-        $this->rfs = $rfs;
+        $this->httpDownloader = $httpDownloader;
         $this->config = $config;
     }
 
@@ -62,7 +62,7 @@ class Versions
     public function getLatest()
     {
         $protocol = extension_loaded('openssl') ? 'https' : 'http';
-        $versions = JsonFile::parseJson($this->rfs->getContents('getcomposer.org', $protocol . '://getcomposer.org/versions', false));
+        $versions = $this->httpDownloader->get($protocol . '://getcomposer.org/versions')->decodeJson();
 
         foreach ($versions[$this->getChannel()] as $version) {
             if ($version['min-php'] <= PHP_VERSION_ID) {

--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -14,6 +14,7 @@ namespace Composer\Util;
 
 use Composer\Config;
 use Composer\IO\IOInterface;
+use Composer\Downloader\TransportException;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -59,5 +60,173 @@ class AuthHelper
                 $this->io->getAuthentication($originUrl)
             );
         }
+    }
+
+
+    public function promptAuthIfNeeded($url, $origin, $httpStatus, $reason = null, $warning = null, $headers = array())
+    {
+        $storeAuth = false;
+        $retry = false;
+
+        if (in_array($origin, $this->config->get('github-domains'), true)) {
+            $gitHubUtil = new GitHub($this->io, $this->config, null);
+            $message = "\n";
+
+            $rateLimited = $gitHubUtil->isRateLimited($headers);
+            if ($rateLimited) {
+                $rateLimit = $gitHubUtil->getRateLimit($headers);
+                if ($this->io->hasAuthentication($origin)) {
+                    $message = 'Review your configured GitHub OAuth token or enter a new one to go over the API rate limit.';
+                } else {
+                    $message = 'Create a GitHub OAuth token to go over the API rate limit.';
+                }
+
+                $message = sprintf(
+                    'GitHub API limit (%d calls/hr) is exhausted, could not fetch '.$url.'. '.$message.' You can also wait until %s for the rate limit to reset.',
+                    $rateLimit['limit'],
+                    $rateLimit['reset']
+                )."\n";
+            } else {
+                $message .= 'Could not fetch '.$url.', please ';
+                if ($this->io->hasAuthentication($origin)) {
+                    $message .= 'review your configured GitHub OAuth token or enter a new one to access private repos';
+                } else {
+                    $message .= 'create a GitHub OAuth token to access private repos';
+                }
+            }
+
+            if (!$gitHubUtil->authorizeOAuth($origin)
+                && (!$this->io->isInteractive() || !$gitHubUtil->authorizeOAuthInteractively($origin, $message))
+            ) {
+                throw new TransportException('Could not authenticate against '.$origin, 401);
+            }
+        } elseif (in_array($origin, $this->config->get('gitlab-domains'), true)) {
+            $message = "\n".'Could not fetch '.$url.', enter your ' . $origin . ' credentials ' .($httpStatus === 401 ? 'to access private repos' : 'to go over the API rate limit');
+            $gitLabUtil = new GitLab($this->io, $this->config, null);
+
+            if ($this->io->hasAuthentication($origin) && ($auth = $this->io->getAuthentication($origin)) && $auth['password'] === 'private-token') {
+                throw new TransportException("Invalid credentials for '" . $url . "', aborting.", $httpStatus);
+            }
+
+            if (!$gitLabUtil->authorizeOAuth($origin)
+                && (!$this->io->isInteractive() || !$gitLabUtil->authorizeOAuthInteractively(parse_url($url, PHP_URL_SCHEME), $origin, $message))
+            ) {
+                throw new TransportException('Could not authenticate against '.$origin, 401);
+            }
+        } elseif ($origin === 'bitbucket.org') {
+            $askForOAuthToken = true;
+            if ($this->io->hasAuthentication($origin)) {
+                $auth = $this->io->getAuthentication($origin);
+                if ($auth['username'] !== 'x-token-auth') {
+                    $bitbucketUtil = new Bitbucket($this->io, $this->config);
+                    $accessToken = $bitbucketUtil->requestToken($origin, $auth['username'], $auth['password']);
+                    if (!empty($accessToken)) {
+                        $this->io->setAuthentication($origin, 'x-token-auth', $accessToken);
+                        $askForOAuthToken = false;
+                    }
+                } else {
+                    throw new TransportException('Could not authenticate against ' . $origin, 401);
+                }
+            }
+
+            if ($askForOAuthToken) {
+                $message = "\n".'Could not fetch ' . $url . ', please create a bitbucket OAuth token to ' . (($httpStatus === 401 || $httpStatus === 403) ? 'access private repos' : 'go over the API rate limit');
+                $bitBucketUtil = new Bitbucket($this->io, $this->config);
+                if (! $bitBucketUtil->authorizeOAuth($origin)
+                    && (! $this->io->isInteractive() || !$bitBucketUtil->authorizeOAuthInteractively($origin, $message))
+                ) {
+                    throw new TransportException('Could not authenticate against ' . $origin, 401);
+                }
+            }
+        } else {
+            // 404s are only handled for github
+            if ($httpStatus === 404) {
+                return;
+            }
+
+            // fail if the console is not interactive
+            if (!$this->io->isInteractive()) {
+                if ($httpStatus === 401) {
+                    $message = "The '" . $url . "' URL required authentication.\nYou must be using the interactive console to authenticate";
+                }
+                if ($httpStatus === 403) {
+                    $message = "The '" . $url . "' URL could not be accessed: " . $reason;
+                }
+
+                throw new TransportException($message, $httpStatus);
+            }
+            // fail if we already have auth
+            if ($this->io->hasAuthentication($origin)) {
+                throw new TransportException("Invalid credentials for '" . $url . "', aborting.", $httpStatus);
+            }
+
+            $this->io->overwriteError('');
+            if ($warning) {
+                $this->io->writeError('    <warning>'.$warning.'</warning>');
+            }
+            $this->io->writeError('    Authentication required (<info>'.parse_url($url, PHP_URL_HOST).'</info>):');
+            $username = $this->io->ask('      Username: ');
+            $password = $this->io->askAndHideAnswer('      Password: ');
+            $this->io->setAuthentication($origin, $username, $password);
+            $storeAuth = $this->config->get('store-auths');
+        }
+
+        $retry = true;
+
+        return array('retry' => $retry, 'storeAuth' => $storeAuth);
+    }
+
+    public function addAuthenticationHeader(array $headers, $origin, $url)
+    {
+        if ($this->io->hasAuthentication($origin)) {
+            $auth = $this->io->getAuthentication($origin);
+            if ('github.com' === $origin && 'x-oauth-basic' === $auth['password']) {
+                $headers[] = 'Authorization: token '.$auth['username'];
+            } elseif (in_array($origin, $this->config->get('gitlab-domains'), true)) {
+                if ($auth['password'] === 'oauth2') {
+                    $headers[] = 'Authorization: Bearer '.$auth['username'];
+                } elseif ($auth['password'] === 'private-token') {
+                    $headers[] = 'PRIVATE-TOKEN: '.$auth['username'];
+                }
+            } elseif (
+                'bitbucket.org' === $origin
+                && $url !== Bitbucket::OAUTH2_ACCESS_TOKEN_URL
+                && 'x-token-auth' === $auth['username']
+            ) {
+                if (!$this->isPublicBitBucketDownload($url)) {
+                    $headers[] = 'Authorization: Bearer ' . $auth['password'];
+                }
+            } else {
+                $authStr = base64_encode($auth['username'] . ':' . $auth['password']);
+                $headers[] = 'Authorization: Basic '.$authStr;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @link https://github.com/composer/composer/issues/5584
+     *
+     * @param string $urlToBitBucketFile URL to a file at bitbucket.org.
+     *
+     * @return bool Whether the given URL is a public BitBucket download which requires no authentication.
+     */
+    public function isPublicBitBucketDownload($urlToBitBucketFile)
+    {
+        $domain = parse_url($urlToBitBucketFile, PHP_URL_HOST);
+        if (strpos($domain, 'bitbucket.org') === false) {
+            // Bitbucket downloads are hosted on amazonaws.
+            // We do not need to authenticate there at all
+            return true;
+        }
+
+        $path = parse_url($urlToBitBucketFile, PHP_URL_PATH);
+
+        // Path for a public download follows this pattern /{user}/{repo}/downloads/{whatever}
+        // {@link https://blog.bitbucket.org/2009/04/12/new-feature-downloads/}
+        $pathParts = explode('/', $path);
+
+        return count($pathParts) >= 4 && $pathParts[3] == 'downloads';
     }
 }

--- a/src/Composer/Util/Bitbucket.php
+++ b/src/Composer/Util/Bitbucket.php
@@ -25,7 +25,7 @@ class Bitbucket
     private $io;
     private $config;
     private $process;
-    private $remoteFilesystem;
+    private $httpDownloader;
     private $token = array();
     private $time;
 
@@ -37,15 +37,15 @@ class Bitbucket
      * @param IOInterface      $io               The IO instance
      * @param Config           $config           The composer configuration
      * @param ProcessExecutor  $process          Process instance, injectable for mocking
-     * @param RemoteFilesystem $remoteFilesystem Remote Filesystem, injectable for mocking
+     * @param HttpDownloader $httpDownloader Remote Filesystem, injectable for mocking
      * @param int              $time             Timestamp, injectable for mocking
      */
-    public function __construct(IOInterface $io, Config $config, ProcessExecutor $process = null, RemoteFilesystem $remoteFilesystem = null, $time = null)
+    public function __construct(IOInterface $io, Config $config, ProcessExecutor $process = null, HttpDownloader $httpDownloader = null, $time = null)
     {
         $this->io = $io;
         $this->config = $config;
         $this->process = $process ?: new ProcessExecutor($io);
-        $this->remoteFilesystem = $remoteFilesystem ?: Factory::createRemoteFilesystem($this->io, $config);
+        $this->httpDownloader = $httpDownloader ?: Factory::createHttpDownloader($this->io, $config);
         $this->time = $time;
     }
 
@@ -90,7 +90,7 @@ class Bitbucket
     private function requestAccessToken($originUrl)
     {
         try {
-            $json = $this->remoteFilesystem->getContents($originUrl, self::OAUTH2_ACCESS_TOKEN_URL, false, array(
+            $response = $this->httpDownloader->get(self::OAUTH2_ACCESS_TOKEN_URL, array(
                 'retry-auth-failure' => false,
                 'http' => array(
                     'method' => 'POST',
@@ -98,7 +98,7 @@ class Bitbucket
                 ),
             ));
 
-            $this->token = json_decode($json, true);
+            $this->token = $response->decodeJson();
         } catch (TransportException $e) {
             if ($e->getCode() === 400) {
                 $this->io->writeError('<error>Invalid OAuth consumer provided.</error>');

--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -25,7 +25,7 @@ class GitHub
     protected $io;
     protected $config;
     protected $process;
-    protected $remoteFilesystem;
+    protected $httpDownloader;
 
     /**
      * Constructor.
@@ -33,14 +33,14 @@ class GitHub
      * @param IOInterface      $io               The IO instance
      * @param Config           $config           The composer configuration
      * @param ProcessExecutor  $process          Process instance, injectable for mocking
-     * @param RemoteFilesystem $remoteFilesystem Remote Filesystem, injectable for mocking
+     * @param HttpDownloader $httpDownloader Remote Filesystem, injectable for mocking
      */
-    public function __construct(IOInterface $io, Config $config, ProcessExecutor $process = null, RemoteFilesystem $remoteFilesystem = null)
+    public function __construct(IOInterface $io, Config $config, ProcessExecutor $process = null, HttpDownloader $httpDownloader = null)
     {
         $this->io = $io;
         $this->config = $config;
         $this->process = $process ?: new ProcessExecutor($io);
-        $this->remoteFilesystem = $remoteFilesystem ?: Factory::createRemoteFilesystem($this->io, $config);
+        $this->httpDownloader = $httpDownloader ?: Factory::createHttpDownloader($this->io, $config);
     }
 
     /**
@@ -104,7 +104,7 @@ class GitHub
         try {
             $apiUrl = ('github.com' === $originUrl) ? 'api.github.com/' : $originUrl . '/api/v3/';
 
-            $this->remoteFilesystem->getContents($originUrl, 'https://'. $apiUrl, false, array(
+            $this->httpDownloader->get('https://'. $apiUrl, array(
                 'retry-auth-failure' => false,
             ));
         } catch (TransportException $e) {

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -26,7 +26,7 @@ class GitLab
     protected $io;
     protected $config;
     protected $process;
-    protected $remoteFilesystem;
+    protected $httpDownloader;
 
     /**
      * Constructor.
@@ -34,14 +34,14 @@ class GitLab
      * @param IOInterface      $io               The IO instance
      * @param Config           $config           The composer configuration
      * @param ProcessExecutor  $process          Process instance, injectable for mocking
-     * @param RemoteFilesystem $remoteFilesystem Remote Filesystem, injectable for mocking
+     * @param HttpDownloader $httpDownloader Remote Filesystem, injectable for mocking
      */
-    public function __construct(IOInterface $io, Config $config, ProcessExecutor $process = null, RemoteFilesystem $remoteFilesystem = null)
+    public function __construct(IOInterface $io, Config $config, ProcessExecutor $process = null, HttpDownloader $httpDownloader = null)
     {
         $this->io = $io;
         $this->config = $config;
         $this->process = $process ?: new ProcessExecutor($io);
-        $this->remoteFilesystem = $remoteFilesystem ?: Factory::createRemoteFilesystem($this->io, $config);
+        $this->httpDownloader = $httpDownloader ?: Factory::createHttpDownloader($this->io, $config);
     }
 
     /**
@@ -154,10 +154,10 @@ class GitLab
             ),
         );
 
-        $json = $this->remoteFilesystem->getContents($originUrl, $scheme.'://'.$apiUrl.'/oauth/token', false, $options);
+        $token = $this->httpDownloader->get($scheme.'://'.$apiUrl.'/oauth/token', $options)->decodeJson();
 
         $this->io->writeError('Token successfully created');
 
-        return JsonFile::parseJson($json);
+        return $token;
     }
 }

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -1,0 +1,282 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Util\Http;
+
+use Composer\Config;
+use Composer\IO\IOInterface;
+use Composer\Downloader\TransportException;
+use Composer\CaBundle\CaBundle;
+use Psr\Log\LoggerInterface;
+use React\Promise\Promise;
+
+/**
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class CurlDownloader
+{
+    private $multiHandle;
+    private $shareHandle;
+    private $jobs = array();
+    private $io;
+    private $selectTimeout = 5.0;
+    protected $multiErrors = array(
+        CURLM_BAD_HANDLE      => array('CURLM_BAD_HANDLE', 'The passed-in handle is not a valid CURLM handle.'),
+        CURLM_BAD_EASY_HANDLE => array('CURLM_BAD_EASY_HANDLE', "An easy handle was not good/valid. It could mean that it isn't an easy handle at all, or possibly that the handle already is in used by this or another multi handle."),
+        CURLM_OUT_OF_MEMORY   => array('CURLM_OUT_OF_MEMORY', 'You are doomed.'),
+        CURLM_INTERNAL_ERROR  => array('CURLM_INTERNAL_ERROR', 'This can only be returned if libcurl bugs. Please report it to us!')
+    );
+
+    private static $options = array(
+        'http' => array(
+            'method' => CURLOPT_CUSTOMREQUEST,
+            'content' => CURLOPT_POSTFIELDS,
+            'proxy' => CURLOPT_PROXY,
+        ),
+        'ssl' => array(
+            'ciphers' => CURLOPT_SSL_CIPHER_LIST,
+            'cafile' => CURLOPT_CAINFO,
+            'capath' => CURLOPT_CAPATH,
+        ),
+    );
+
+    private static $timeInfo = array(
+        'total_time' => true,
+        'namelookup_time' => true,
+        'connect_time' => true,
+        'pretransfer_time' => true,
+        'starttransfer_time' => true,
+        'redirect_time' => true,
+    );
+
+    public function __construct(IOInterface $io, Config $config, array $options = array(), $disableTls = false)
+    {
+        $this->io = $io;
+
+        $this->multiHandle = $mh = curl_multi_init();
+        if (function_exists('curl_multi_setopt')) {
+            curl_multi_setopt($mh, CURLMOPT_PIPELINING, /*CURLPIPE_HTTP1 | CURLPIPE_MULTIPLEX*/ 3);
+            if (defined('CURLMOPT_MAX_HOST_CONNECTIONS')) {
+                curl_multi_setopt($mh, CURLMOPT_MAX_HOST_CONNECTIONS, 8);
+            }
+        }
+
+        if (function_exists('curl_share_init')) {
+            $this->shareHandle = $sh = curl_share_init();
+            curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
+            curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+            curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+        }
+    }
+
+    public function download($resolve, $reject, $origin, $url, $options, $copyTo = null)
+    {
+        $ch = curl_init();
+        $hd = fopen('php://temp/maxmemory:32768', 'w+b');
+
+        // TODO auth & other context
+        // TODO cleanup
+
+        if ($copyTo && !$fd = @fopen($copyTo.'~', 'w+b')) {
+            // TODO throw here probably?
+            $copyTo = null;
+        }
+        if (!$copyTo) {
+            $fd = @fopen('php://temp/maxmemory:524288', 'w+b');
+        }
+
+        if (!isset($options['http']['header'])) {
+            $options['http']['header'] = array();
+        }
+
+        $headers = array_diff($options['http']['header'], array('Connection: close'));
+
+        // TODO
+        $degradedMode = false;
+        if ($degradedMode) {
+            curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+        } else {
+            $headers[] = 'Connection: keep-alive';
+            $version = curl_version();
+            $features = $version['features'];
+            if (0 === strpos($url, 'https://') && \defined('CURL_VERSION_HTTP2') && \defined('CURL_HTTP_VERSION_2_0') && (CURL_VERSION_HTTP2 & $features)) {
+                curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+            }
+        }
+
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        //curl_setopt($ch, CURLOPT_DNS_USE_GLOBAL_CACHE, false);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 10); // TODO increase
+        curl_setopt($ch, CURLOPT_WRITEHEADER, $hd);
+        curl_setopt($ch, CURLOPT_FILE, $fd);
+        if (function_exists('curl_share_init')) {
+            curl_setopt($ch, CURLOPT_SHARE, $this->shareHandle);
+        }
+
+        foreach (self::$options as $type => $curlOptions) {
+            foreach ($curlOptions as $name => $curlOption) {
+                if (isset($options[$type][$name])) {
+                    curl_setopt($ch, $curlOption, $options[$type][$name]);
+                }
+            }
+        }
+
+        $progress = array_diff_key(curl_getinfo($ch), self::$timeInfo);
+
+        $this->jobs[(int) $ch] = array(
+            'progress' => $progress,
+            'ch' => $ch,
+            //'callback' => $params['notification'],
+            'file' => $copyTo,
+            'hd' => $hd,
+            'fd' => $fd,
+            'resolve' => $resolve,
+            'reject' => $reject,
+        );
+
+        $this->io->write('Downloading '.$url, true, IOInterface::DEBUG);
+
+        $this->checkCurlResult(curl_multi_add_handle($this->multiHandle, $ch));
+        //$params['notification'](STREAM_NOTIFY_RESOLVE, STREAM_NOTIFY_SEVERITY_INFO, '', 0, 0, 0, false);
+    }
+
+    public function tick()
+    {
+        // TODO check we have active handles before doing this
+        if (!$this->jobs) {
+            return;
+        }
+
+        $active = true;
+        try {
+            $this->checkCurlResult(curl_multi_exec($this->multiHandle, $active));
+            if (-1 === curl_multi_select($this->multiHandle, $this->selectTimeout)) {
+                // sleep in case select returns -1 as it can happen on old php versions or some platforms where curl does not manage to do the select
+                usleep(150);
+            }
+
+            while ($progress = curl_multi_info_read($this->multiHandle)) {
+                $h = $progress['handle'];
+                $i = (int) $h;
+                if (!isset($this->jobs[$i])) {
+                    continue;
+                }
+                $progress = array_diff_key(curl_getinfo($h), self::$timeInfo);
+                $job = $this->jobs[$i];
+                unset($this->jobs[$i]);
+                curl_multi_remove_handle($this->multiHandle, $h);
+                $error = curl_error($h);
+                $errno = curl_errno($h);
+                curl_close($h);
+
+                try {
+                    //$this->onProgress($h, $job['callback'], $progress, $job['progress']);
+                    if ('' !== $error) {
+                        throw new TransportException(curl_error($h));
+                    }
+
+                    if ($job['file']) {
+                        if (CURLE_OK === $errno) {
+                            fclose($job['fd']);
+                            rename($job['file'].'~', $job['file']);
+                            call_user_func($job['resolve'], true);
+                        }
+                        // TODO otherwise show error?
+                    } else {
+                        rewind($job['hd']);
+                        $headers = explode("\r\n", rtrim(stream_get_contents($job['hd'])));
+                        fclose($job['hd']);
+                        rewind($job['fd']);
+                        $contents = stream_get_contents($job['fd']);
+                        fclose($job['fd']);
+                        $this->io->writeError('['.$progress['http_code'].'] '.$progress['url'], true, IOInterface::DEBUG);
+                        call_user_func($job['resolve'], new Response(array('url' => $progress['url']), $progress['http_code'], $headers, $contents));
+                    }
+                } catch (TransportException $e) {
+                    fclose($job['hd']);
+                    fclose($job['fd']);
+                    if ($job['file']) {
+                        @unlink($job['file'].'~');
+                    }
+                    call_user_func($job['reject'], $e);
+                }
+            }
+
+            foreach ($this->jobs as $i => $h) {
+                if (!isset($this->jobs[$i])) {
+                    continue;
+                }
+                $h = $this->jobs[$i]['ch'];
+                $progress = array_diff_key(curl_getinfo($h), self::$timeInfo);
+
+                if ($this->jobs[$i]['progress'] !== $progress) {
+                    $previousProgress = $this->jobs[$i]['progress'];
+                    $this->jobs[$i]['progress'] = $progress;
+                    try {
+                        //$this->onProgress($h, $this->jobs[$i]['callback'], $progress, $previousProgress);
+                    } catch (TransportException $e) {
+                        var_dump('Caught '.$e->getMessage());die;
+                        unset($this->jobs[$i]);
+                        curl_multi_remove_handle($this->multiHandle, $h);
+                        curl_close($h);
+
+                        fclose($job['hd']);
+                        fclose($job['fd']);
+                        if ($job['file']) {
+                            @unlink($job['file'].'~');
+                        }
+                        call_user_func($job['reject'], $e);
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+            var_dump('Caught2', get_class($e), $e->getMessage(), $e);die;
+        }
+
+// TODO finalize / resolve
+//            if ($copyTo && !isset($this->exceptions[(int) $ch])) {
+//                $fd = fopen($copyTo, 'rb');
+//            }
+//
+    }
+
+    private function onProgress($ch, callable $notify, array $progress, array $previousProgress)
+    {
+        if (300 <= $progress['http_code'] && $progress['http_code'] < 400) {
+            return;
+        }
+        if (!$previousProgress['http_code'] && $progress['http_code'] && $progress['http_code'] < 200 || 400 <= $progress['http_code']) {
+            $code = 403 === $progress['http_code'] ? STREAM_NOTIFY_AUTH_RESULT : STREAM_NOTIFY_FAILURE;
+            $notify($code, STREAM_NOTIFY_SEVERITY_ERR, curl_error($ch), $progress['http_code'], 0, 0, false);
+        }
+        if ($previousProgress['download_content_length'] < $progress['download_content_length']) {
+            $notify(STREAM_NOTIFY_FILE_SIZE_IS, STREAM_NOTIFY_SEVERITY_INFO, '', 0, 0, (int) $progress['download_content_length'], false);
+        }
+        if ($previousProgress['size_download'] < $progress['size_download']) {
+            $notify(STREAM_NOTIFY_PROGRESS, STREAM_NOTIFY_SEVERITY_INFO, '', 0, (int) $progress['size_download'], (int) $progress['download_content_length'], false);
+        }
+    }
+
+    private function checkCurlResult($code)
+    {
+        if ($code != CURLM_OK && $code != CURLM_CALL_MULTI_PERFORM) {
+            throw new \RuntimeException(isset($this->multiErrors[$code])
+                ? "cURL error: {$code} ({$this->multiErrors[$code][0]}): cURL message: {$this->multiErrors[$code][1]}"
+                : 'Unexpected cURL error: ' . $code
+            );
+        }
+    }
+}

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -225,6 +225,7 @@ class CurlDownloader
             if (!isset($this->jobs[$i])) {
                 continue;
             }
+
             $progress = array_diff_key(curl_getinfo($curlHandle), self::$timeInfo);
             $job = $this->jobs[$i];
             unset($this->jobs[$i]);
@@ -239,7 +240,7 @@ class CurlDownloader
             try {
 // TODO progress
                 //$this->onProgress($curlHandle, $job['callback'], $progress, $job['progress']);
-                if (CURLE_OK !== $errno) {
+                if (CURLE_OK !== $errno || $error) {
                     throw new TransportException($error);
                 }
 

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -114,8 +114,10 @@ class CurlDownloader
 
         $originalOptions = $options;
 
-        // check URL can be accessed (i.e. is not insecure)
-        $this->config->prohibitUrlByConfig($url, $this->io);
+        // check URL can be accessed (i.e. is not insecure), but allow insecure Packagist calls to $hashed providers as file integrity is verified with sha256
+        if (!preg_match('{^http://(repo\.)?packagist\.org/p/}', $url) || (false === strpos($url, '$') && false === strpos($url, '%24'))) {
+            $this->config->prohibitUrlByConfig($url, $this->io);
+        }
 
         $curlHandle = curl_init();
         $headerHandle = fopen('php://temp/maxmemory:32768', 'w+b');

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -295,7 +295,7 @@ class CurlDownloader
                 // resolve promise
                 if ($job['filename']) {
                     rename($job['filename'].'~', $job['filename']);
-                    call_user_func($job['resolve'], true);
+                    call_user_func($job['resolve'], $response);
                 } else {
                     call_user_func($job['resolve'], $response);
                 }

--- a/src/Composer/Util/Http/Response.php
+++ b/src/Composer/Util/Http/Response.php
@@ -27,7 +27,7 @@ class Response
             throw new \LogicException('url key missing from request array');
         }
         $this->request = $request;
-        $this->code = $code;
+        $this->code = (int) $code;
         $this->headers = $headers;
         $this->body = $body;
     }
@@ -35,6 +35,23 @@ class Response
     public function getStatusCode()
     {
         return $this->code;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStatusMessage()
+    {
+        $value = null;
+        foreach ($this->headers as $header) {
+            if (preg_match('{^HTTP/\S+ \d+}i', $header)) {
+                // In case of redirects, headers contain the headers of all responses
+                // so we can not return directly and need to keep iterating
+                $value = $header;
+            }
+        }
+
+        return $value;
     }
 
     public function getHeaders()
@@ -51,7 +68,7 @@ class Response
             } elseif (preg_match('{^HTTP/}i', $header)) {
                 // TODO ideally redirects would be handled in CurlDownloader/RemoteFilesystem and this becomes unnecessary
                 //
-                // In case of redirects, http_response_headers contains the headers of all responses
+                // In case of redirects, headers contains the headers of all responses
                 // so we reset the flag when a new response is being parsed as we are only interested in the last response
                 $value = null;
             }
@@ -59,7 +76,6 @@ class Response
 
         return $value;
     }
-
 
     public function getBody()
     {

--- a/src/Composer/Util/Http/Response.php
+++ b/src/Composer/Util/Http/Response.php
@@ -23,6 +23,9 @@ class Response
 
     public function __construct(array $request, $code, array $headers, $body)
     {
+        if (!isset($request['url'])) {
+            throw new \LogicException('url key missing from request array');
+        }
         $this->request = $request;
         $this->code = $code;
         $this->headers = $headers;

--- a/src/Composer/Util/Http/Response.php
+++ b/src/Composer/Util/Http/Response.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Util\Http;
+
+use Composer\Json\JsonFile;
+
+class Response
+{
+    private $request;
+    private $code;
+    private $headers;
+    private $body;
+
+    public function __construct(array $request, $code, array $headers, $body)
+    {
+        $this->request = $request;
+        $this->code = $code;
+        $this->headers = $headers;
+        $this->body = $body;
+    }
+
+    public function getStatusCode()
+    {
+        return $this->code;
+    }
+
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    public function getHeader($name)
+    {
+        $value = null;
+        foreach ($this->headers as $header) {
+            if (preg_match('{^'.$name.':\s*(.+?)\s*$}i', $header, $match)) {
+                $value = $match[1];
+            } elseif (preg_match('{^HTTP/}i', $header)) {
+                // TODO ideally redirects would be handled in CurlDownloader/RemoteFilesystem and this becomes unnecessary
+                //
+                // In case of redirects, http_response_headers contains the headers of all responses
+                // so we reset the flag when a new response is being parsed as we are only interested in the last response
+                $value = null;
+            }
+        }
+
+        return $value;
+    }
+
+
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    public function decodeJson()
+    {
+        return JsonFile::parseJson($this->body, $this->request['url']);
+    }
+
+    public function collect()
+    {
+        $this->request = $this->code = $this->headers = $this->body = null;
+    }
+}

--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -117,8 +117,8 @@ class HttpDownloader
 
         $origin = $this->getOrigin($job['request']['url']);
 
-        // TODO only send http/https through curl
-        if ($curl) {
+        // TODO experiment with allowing file:// through curl too
+        if ($curl && preg_match('{^https?://}i', $job['request']['url'])) {
             $resolver = function ($resolve, $reject) use (&$job, $curl, $origin) {
                 // start job
                 $url = $job['request']['url'];
@@ -141,11 +141,7 @@ class HttpDownloader
                 $job['status'] = HttpDownloader::STATUS_STARTED;
 
                 if ($job['request']['copyTo']) {
-                    if ($curl) {
-                        $result = $curl->download($origin, $url, $options, $job['request']['copyTo']);
-                    } else {
-                        $result = $rfs->copy($origin, $url, $job['request']['copyTo'], false /* TODO progress */, $options);
-                    }
+                    $result = $rfs->copy($origin, $url, $job['request']['copyTo'], false /* TODO progress */, $options);
 
                     $resolve($result);
                 } else {

--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -102,6 +102,26 @@ class HttpDownloader
         return $promise;
     }
 
+    /**
+     * Retrieve the options set in the constructor
+     *
+     * @return array Options
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Merges new options
+     *
+     * @return array $options
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = array_replace_recursive($this->options, $options);
+    }
+
     private function addJob($request, $sync = false)
     {
         $job = array(

--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -32,6 +32,7 @@ class HttpDownloader
     private $io;
     private $config;
     private $jobs = array();
+    private $options = array();
     private $index;
     private $progress;
     private $lastProgress;

--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -160,7 +160,10 @@ class HttpDownloader
                 if ($job['request']['copyTo']) {
                     $result = $rfs->copy($job['origin'], $url, $job['request']['copyTo'], false /* TODO progress */, $options);
 
-                    $resolve($result);
+                    $headers = $rfs->getLastHeaders();
+                    $response = new Http\Response($job['request'], $rfs->findStatusCode($headers), $headers, $job['request']['copyTo'].'~');
+
+                    $resolve($response);
                 } else {
                     $body = $rfs->getContents($job['origin'], $url, false /* TODO progress */, $options);
                     $headers = $rfs->getLastHeaders();
@@ -191,6 +194,7 @@ class HttpDownloader
             $job['exception'] = $e;
 
             $downloader->markJobDone();
+            $downloader->scheduleNextJob();
 
             throw $e;
         });

--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -1,0 +1,246 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Util;
+
+use Composer\Config;
+use Composer\IO\IOInterface;
+use Composer\Downloader\TransportException;
+use Composer\CaBundle\CaBundle;
+use Psr\Log\LoggerInterface;
+use React\Promise\Promise;
+
+/**
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class HttpDownloader
+{
+    const STATUS_QUEUED = 1;
+    const STATUS_STARTED = 2;
+    const STATUS_COMPLETED = 3;
+    const STATUS_FAILED = 4;
+
+    private $io;
+    private $config;
+    private $jobs = array();
+    private $index;
+    private $progress;
+    private $lastProgress;
+    private $disableTls = false;
+    private $curl;
+    private $rfs;
+    private $idGen = 0;
+
+    /**
+     * Constructor.
+     *
+     * @param IOInterface $io         The IO instance
+     * @param Config      $config     The config
+     * @param array       $options    The options
+     * @param bool        $disableTls
+     */
+    public function __construct(IOInterface $io, Config $config, array $options = array(), $disableTls = false)
+    {
+        $this->io = $io;
+
+        // Setup TLS options
+        // The cafile option can be set via config.json
+        if ($disableTls === false) {
+            $logger = $io instanceof LoggerInterface ? $io : null;
+            $this->options = StreamContextFactory::getTlsDefaults($options, $logger);
+        } else {
+            $this->disableTls = true;
+        }
+
+        // handle the other externally set options normally.
+        $this->options = array_replace_recursive($this->options, $options);
+        $this->config = $config;
+
+        if (extension_loaded('curl')) {
+            $this->curl = new Http\CurlDownloader($io, $config, $options, $disableTls);
+        }
+
+        $this->rfs = new RemoteFilesystem($io, $config, $options, $disableTls);
+    }
+
+    public function get($url, $options = array())
+    {
+        list($job, $promise) = $this->addJob(array('url' => $url, 'options' => $options, 'copyTo' => false), true);
+        $this->wait($job['id']);
+
+        return $this->getResponse($job['id']);
+    }
+
+    public function add($url, $options = array())
+    {
+        list($job, $promise) = $this->addJob(array('url' => $url, 'options' => $options, 'copyTo' => false));
+
+        return $promise;
+    }
+
+    public function copy($url, $to, $options = array())
+    {
+        list($job, $promise) = $this->addJob(array('url' => $url, 'options' => $options, 'copyTo' => $to), true);
+        $this->wait($job['id']);
+
+        return $this->getResponse($job['id']);
+    }
+
+    public function addCopy($url, $to, $options = array())
+    {
+        list($job, $promise) = $this->addJob(array('url' => $url, 'options' => $options, 'copyTo' => $to));
+
+        return $promise;
+    }
+
+    private function addJob($request, $sync = false)
+    {
+        $job = array(
+            'id' => $this->idGen++,
+            'status' => self::STATUS_QUEUED,
+            'request' => $request,
+            'sync' => $sync,
+        );
+
+        $curl = $this->curl;
+        $rfs = $this->rfs;
+        $io = $this->io;
+
+        $origin = $this->getOrigin($job['request']['url']);
+
+        // TODO only send http/https through curl
+        if ($curl) {
+            $resolver = function ($resolve, $reject) use (&$job, $curl, $origin) {
+                // start job
+                $url = $job['request']['url'];
+                $options = $job['request']['options'];
+
+                $job['status'] = HttpDownloader::STATUS_STARTED;
+
+                if ($job['request']['copyTo']) {
+                    $curl->download($resolve, $reject, $origin, $url, $options, $job['request']['copyTo']);
+                } else {
+                    $curl->download($resolve, $reject, $origin, $url, $options);
+                }
+            };
+        } else {
+            $resolver = function ($resolve, $reject) use (&$job, $rfs, $curl, $origin) {
+                // start job
+                $url = $job['request']['url'];
+                $options = $job['request']['options'];
+
+                $job['status'] = HttpDownloader::STATUS_STARTED;
+
+                if ($job['request']['copyTo']) {
+                    if ($curl) {
+                        $result = $curl->download($origin, $url, $options, $job['request']['copyTo']);
+                    } else {
+                        $result = $rfs->copy($origin, $url, $job['request']['copyTo'], false /* TODO progress */, $options);
+                    }
+
+                    $resolve($result);
+                } else {
+                    $body = $rfs->getContents($origin, $url, false /* TODO progress */, $options);
+                    $headers = $rfs->getLastHeaders();
+                    $response = new Http\Response($job['request'], $rfs->findStatusCode($headers), $headers, $body);
+
+                    $resolve($response);
+                }
+            };
+        }
+
+        $canceler = function () {};
+
+        $promise = new Promise($resolver, $canceler);
+        $promise->then(function ($response) use (&$job) {
+            $job['status'] = HttpDownloader::STATUS_COMPLETED;
+            $job['response'] = $response;
+            // TODO look for more jobs to start once we throttle to max X jobs
+        }, function ($e) use ($io, &$job) {
+            var_dump(__CLASS__ . __LINE__);
+            var_dump(gettype($e));
+            var_dump($e->getMessage());
+            die;
+            $job['status'] = HttpDownloader::STATUS_FAILED;
+            $job['exception'] = $e;
+        });
+        $this->jobs[$job['id']] =& $job;
+
+        return array($job, $promise);
+    }
+
+    public function wait($index = null, $progress = false)
+    {
+        while (true) {
+            if ($this->curl) {
+                $this->curl->tick();
+            }
+
+            if (null !== $index) {
+                if ($this->jobs[$index]['status'] === self::STATUS_COMPLETED || $this->jobs[$index]['status'] === self::STATUS_FAILED) {
+                    return;
+                }
+            } else {
+                $done = true;
+                foreach ($this->jobs as $job) {
+                    if (!in_array($job['status'], array(self::STATUS_COMPLETED, self::STATUS_FAILED), true)) {
+                        $done = false;
+                        break;
+                    } elseif (!$job['sync']) {
+                        unset($this->jobs[$job['id']]);
+                    }
+                }
+                if ($done) {
+                    return;
+                }
+            }
+
+            usleep(1000);
+        }
+    }
+
+    private function getResponse($index)
+    {
+        if (!isset($this->jobs[$index])) {
+            throw new \LogicException('Invalid request id');
+        }
+
+        if ($this->jobs[$index]['status'] === self::STATUS_FAILED) {
+            throw $this->jobs[$index]['exception'];
+        }
+
+        if (!isset($this->jobs[$index]['response'])) {
+            throw new \LogicException('Response not available yet, call wait() first');
+        }
+
+        $resp = $this->jobs[$index]['response'];
+
+        unset($this->jobs[$index]);
+
+        return $resp;
+    }
+
+    private function getOrigin($url)
+    {
+        $origin = parse_url($url, PHP_URL_HOST);
+
+        if ($origin === 'api.github.com') {
+            return 'github.com';
+        }
+
+        if ($origin === 'repo.packagist.org') {
+            return 'packagist.org';
+        }
+
+        return $origin ?: $url;
+    }
+}

--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -142,7 +142,7 @@ class HttpDownloader
         $rfs = $this->rfs;
         $io = $this->io;
 
-        $origin = $this->getOrigin($job['request']['url']);
+        $origin = Url::getOrigin($this->config, $job['request']['url']);
 
         if ($curl && preg_match('{^https?://}i', $job['request']['url'])) {
             $resolver = function ($resolve, $reject) use (&$job, $curl, $origin) {
@@ -249,38 +249,5 @@ class HttpDownloader
         unset($this->jobs[$index]);
 
         return $resp;
-    }
-
-    private function getOrigin($url)
-    {
-        if (0 === strpos($url, 'file://')) {
-            return $url;
-        }
-
-        $origin = parse_url($url, PHP_URL_HOST);
-
-        if (strpos($origin, '.github.com') === (strlen($origin) - 11)) {
-            return 'github.com';
-        }
-
-        if ($origin === 'repo.packagist.org') {
-            return 'packagist.org';
-        }
-
-        // Gitlab can be installed in a non-root context (i.e. gitlab.com/foo). When downloading archives the originUrl
-        // is the host without the path, so we look for the registered gitlab-domains matching the host here
-        if (
-            is_array($this->config->get('gitlab-domains'))
-            && false === strpos($origin, '/')
-            && !in_array($origin, $this->config->get('gitlab-domains'))
-        ) {
-            foreach ($this->config->get('gitlab-domains') as $gitlabDomain) {
-                if (0 === strpos($gitlabDomain, $origin)) {
-                    return $gitlabDomain;
-                }
-            }
-        }
-
-        return $origin ?: $url;
     }
 }

--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -126,11 +126,6 @@ class HttpDownloader
 
     private function addJob($request, $sync = false)
     {
-        // capture username/password from URL if there is one
-        if (preg_match('{^https?://([^:/]+):([^@/]+)@([^/]+)}i', $request['url'], $match)) {
-            $this->io->setAuthentication($originUrl, rawurldecode($match[1]), rawurldecode($match[2]));
-        }
-
         $job = array(
             'id' => $this->idGen++,
             'status' => self::STATUS_QUEUED,
@@ -138,11 +133,16 @@ class HttpDownloader
             'sync' => $sync,
         );
 
+        $origin = Url::getOrigin($this->config, $job['request']['url']);
+
+        // capture username/password from URL if there is one
+        if (preg_match('{^https?://([^:/]+):([^@/]+)@([^/]+)}i', $request['url'], $match)) {
+            $this->io->setAuthentication($origin, rawurldecode($match[1]), rawurldecode($match[2]));
+        }
+
         $curl = $this->curl;
         $rfs = $this->rfs;
         $io = $this->io;
-
-        $origin = Url::getOrigin($this->config, $job['request']['url']);
 
         if ($curl && preg_match('{^https?://}i', $job['request']['url'])) {
             $resolver = function ($resolve, $reject) use (&$job, $curl, $origin) {

--- a/src/Composer/Util/Loop.php
+++ b/src/Composer/Util/Loop.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Util;
+
+use Composer\Util\HttpDownloader;
+use React\Promise\Promise;
+
+/**
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class Loop
+{
+    private $io;
+
+    public function __construct(HttpDownloader $httpDownloader)
+    {
+        $this->httpDownloader = $httpDownloader;
+    }
+
+    public function wait(array $promises)
+    {
+        $uncaught = null;
+
+        \React\Promise\all($promises)->then(
+            function () { },
+            function ($e) use (&$uncaught) {
+                $uncaught = $e;
+            }
+        );
+
+        $this->httpDownloader->wait();
+
+        if ($uncaught) {
+            throw $uncaught;
+        }
+    }
+}

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -41,6 +41,7 @@ class RemoteFilesystem
     private $retryAuthFailure;
     private $lastHeaders;
     private $storeAuth;
+    private $authHelper;
     private $degradedMode = false;
     private $redirects;
     private $maxRedirects = 20;
@@ -53,7 +54,7 @@ class RemoteFilesystem
      * @param array       $options    The options
      * @param bool        $disableTls
      */
-    public function __construct(IOInterface $io, Config $config = null, array $options = array(), $disableTls = false)
+    public function __construct(IOInterface $io, Config $config, array $options = array(), $disableTls = false)
     {
         $this->io = $io;
 
@@ -69,6 +70,7 @@ class RemoteFilesystem
         // handle the other externally set options normally.
         $this->options = array_replace_recursive($this->options, $options);
         $this->config = $config;
+        $this->authHelper = new AuthHelper($io, $config);
     }
 
     /**
@@ -215,27 +217,6 @@ class RemoteFilesystem
      */
     protected function get($originUrl, $fileUrl, $additionalOptions = array(), $fileName = null, $progress = true)
     {
-        if (strpos($originUrl, '.github.com') === (strlen($originUrl) - 11)) {
-            $originUrl = 'github.com';
-        }
-
-        // Gitlab can be installed in a non-root context (i.e. gitlab.com/foo). When downloading archives the originUrl
-        // is the host without the path, so we look for the registered gitlab-domains matching the host here
-        if (
-            $this->config
-            && is_array($this->config->get('gitlab-domains'))
-            && false === strpos($originUrl, '/')
-            && !in_array($originUrl, $this->config->get('gitlab-domains'))
-        ) {
-            foreach ($this->config->get('gitlab-domains') as $gitlabDomain) {
-                if (0 === strpos($gitlabDomain, $originUrl)) {
-                    $originUrl = $gitlabDomain;
-                    break;
-                }
-            }
-            unset($gitlabDomain);
-        }
-
         $this->scheme = parse_url($fileUrl, PHP_URL_SCHEME);
         $this->bytesMax = 0;
         $this->originUrl = $originUrl;
@@ -246,11 +227,6 @@ class RemoteFilesystem
         $this->retryAuthFailure = true;
         $this->lastHeaders = array();
         $this->redirects = 1; // The first request counts.
-
-        // capture username/password from URL if there is one
-        if (preg_match('{^https?://([^:/]+):([^@/]+)@([^/]+)}i', $fileUrl, $match)) {
-            $this->io->setAuthentication($originUrl, rawurldecode($match[1]), rawurldecode($match[2]));
-        }
 
         $tempAdditionalOptions = $additionalOptions;
         if (isset($tempAdditionalOptions['retry-auth-failure'])) {
@@ -271,14 +247,6 @@ class RemoteFilesystem
         unset($tempAdditionalOptions);
 
         $origFileUrl = $fileUrl;
-
-        if (isset($options['github-token'])) {
-            // only add the access_token if it is actually a github URL (in case we were redirected to S3)
-            if (preg_match('{^https?://([a-z0-9-]+\.)*github\.com/}', $fileUrl)) {
-                $fileUrl .= (false === strpos($fileUrl, '?') ? '?' : '&') . 'access_token='.$options['github-token'];
-            }
-            unset($options['github-token']);
-        }
 
         if (isset($options['gitlab-token'])) {
             $fileUrl .= (false === strpos($fileUrl, '?') ? '?' : '&') . 'access_token='.$options['gitlab-token'];
@@ -400,7 +368,7 @@ class RemoteFilesystem
 
         // check for bitbucket login page asking to authenticate
         if ($originUrl === 'bitbucket.org'
-            && !$this->isPublicBitBucketDownload($fileUrl)
+            && !$this->authHelper->isPublicBitBucketDownload($fileUrl)
             && substr($fileUrl, -4) === '.zip'
             && (!$locationHeader || substr($locationHeader, -4) !== '.zip')
             && $contentType && preg_match('{^text/html\b}i', $contentType)
@@ -544,8 +512,7 @@ class RemoteFilesystem
             $result = $this->get($this->originUrl, $this->fileUrl, $additionalOptions, $this->fileName, $this->progress);
 
             if ($this->storeAuth && $this->config) {
-                $authHelper = new AuthHelper($this->io, $this->config);
-                $authHelper->storeAuth($this->originUrl, $this->storeAuth);
+                $this->authHelper->storeAuth($this->originUrl, $this->storeAuth);
                 $this->storeAuth = false;
             }
 
@@ -650,111 +617,14 @@ class RemoteFilesystem
 
     protected function promptAuthAndRetry($httpStatus, $reason = null, $warning = null, $headers = array())
     {
-        if ($this->config && in_array($this->originUrl, $this->config->get('github-domains'), true)) {
-            $gitHubUtil = new GitHub($this->io, $this->config, null);
-            $message = "\n";
+        $result = $this->authHelper->promptAuthIfNeeded($this->fileUrl, $this->originUrl, $httpStatus, $reason, $warning, $headers);
 
-            $rateLimited = $gitHubUtil->isRateLimited($headers);
-            if ($rateLimited) {
-                $rateLimit = $gitHubUtil->getRateLimit($headers);
-                if ($this->io->hasAuthentication($this->originUrl)) {
-                    $message = 'Review your configured GitHub OAuth token or enter a new one to go over the API rate limit.';
-                } else {
-                    $message = 'Create a GitHub OAuth token to go over the API rate limit.';
-                }
+        $this->storeAuth = $result['storeAuth'];
+        $this->retry = $result['retry'];
 
-                $message = sprintf(
-                    'GitHub API limit (%d calls/hr) is exhausted, could not fetch '.$this->fileUrl.'. '.$message.' You can also wait until %s for the rate limit to reset.',
-                    $rateLimit['limit'],
-                    $rateLimit['reset']
-                )."\n";
-            } else {
-                $message .= 'Could not fetch '.$this->fileUrl.', please ';
-                if ($this->io->hasAuthentication($this->originUrl)) {
-                    $message .= 'review your configured GitHub OAuth token or enter a new one to access private repos';
-                } else {
-                    $message .= 'create a GitHub OAuth token to access private repos';
-                }
-            }
-
-            if (!$gitHubUtil->authorizeOAuth($this->originUrl)
-                && (!$this->io->isInteractive() || !$gitHubUtil->authorizeOAuthInteractively($this->originUrl, $message))
-            ) {
-                throw new TransportException('Could not authenticate against '.$this->originUrl, 401);
-            }
-        } elseif ($this->config && in_array($this->originUrl, $this->config->get('gitlab-domains'), true)) {
-            $message = "\n".'Could not fetch '.$this->fileUrl.', enter your ' . $this->originUrl . ' credentials ' .($httpStatus === 401 ? 'to access private repos' : 'to go over the API rate limit');
-            $gitLabUtil = new GitLab($this->io, $this->config, null);
-
-            if ($this->io->hasAuthentication($this->originUrl) && ($auth = $this->io->getAuthentication($this->originUrl)) && $auth['password'] === 'private-token') {
-                throw new TransportException("Invalid credentials for '" . $this->fileUrl . "', aborting.", $httpStatus);
-            }
-
-            if (!$gitLabUtil->authorizeOAuth($this->originUrl)
-                && (!$this->io->isInteractive() || !$gitLabUtil->authorizeOAuthInteractively($this->scheme, $this->originUrl, $message))
-            ) {
-                throw new TransportException('Could not authenticate against '.$this->originUrl, 401);
-            }
-        } elseif ($this->config && $this->originUrl === 'bitbucket.org') {
-            $askForOAuthToken = true;
-            if ($this->io->hasAuthentication($this->originUrl)) {
-                $auth = $this->io->getAuthentication($this->originUrl);
-                if ($auth['username'] !== 'x-token-auth') {
-                    $bitbucketUtil = new Bitbucket($this->io, $this->config);
-                    $accessToken = $bitbucketUtil->requestToken($this->originUrl, $auth['username'], $auth['password']);
-                    if (!empty($accessToken)) {
-                        $this->io->setAuthentication($this->originUrl, 'x-token-auth', $accessToken);
-                        $askForOAuthToken = false;
-                    }
-                } else {
-                    throw new TransportException('Could not authenticate against ' . $this->originUrl, 401);
-                }
-            }
-
-            if ($askForOAuthToken) {
-                $message = "\n".'Could not fetch ' . $this->fileUrl . ', please create a bitbucket OAuth token to ' . (($httpStatus === 401 || $httpStatus === 403) ? 'access private repos' : 'go over the API rate limit');
-                $bitBucketUtil = new Bitbucket($this->io, $this->config);
-                if (! $bitBucketUtil->authorizeOAuth($this->originUrl)
-                    && (! $this->io->isInteractive() || !$bitBucketUtil->authorizeOAuthInteractively($this->originUrl, $message))
-                ) {
-                    throw new TransportException('Could not authenticate against ' . $this->originUrl, 401);
-                }
-            }
-        } else {
-            // 404s are only handled for github
-            if ($httpStatus === 404) {
-                return;
-            }
-
-            // fail if the console is not interactive
-            if (!$this->io->isInteractive()) {
-                if ($httpStatus === 401) {
-                    $message = "The '" . $this->fileUrl . "' URL required authentication.\nYou must be using the interactive console to authenticate";
-                }
-                if ($httpStatus === 403) {
-                    $message = "The '" . $this->fileUrl . "' URL could not be accessed: " . $reason;
-                }
-
-                throw new TransportException($message, $httpStatus);
-            }
-            // fail if we already have auth
-            if ($this->io->hasAuthentication($this->originUrl)) {
-                throw new TransportException("Invalid credentials for '" . $this->fileUrl . "', aborting.", $httpStatus);
-            }
-
-            $this->io->overwriteError('');
-            if ($warning) {
-                $this->io->writeError('    <warning>'.$warning.'</warning>');
-            }
-            $this->io->writeError('    Authentication required (<info>'.parse_url($this->fileUrl, PHP_URL_HOST).'</info>):');
-            $username = $this->io->ask('      Username: ');
-            $password = $this->io->askAndHideAnswer('      Password: ');
-            $this->io->setAuthentication($this->originUrl, $username, $password);
-            $this->storeAuth = $this->config->get('store-auths');
+        if ($this->retry) {
+            throw new TransportException('RETRY');
         }
-
-        $this->retry = true;
-        throw new TransportException('RETRY');
     }
 
     protected function getOptionsForUrl($originUrl, $additionalOptions)
@@ -814,27 +684,7 @@ class RemoteFilesystem
             $headers[] = 'Connection: close';
         }
 
-        if ($this->io->hasAuthentication($originUrl)) {
-            $auth = $this->io->getAuthentication($originUrl);
-            if ('github.com' === $originUrl && 'x-oauth-basic' === $auth['password']) {
-                $options['github-token'] = $auth['username'];
-            } elseif ($this->config && in_array($originUrl, $this->config->get('gitlab-domains'), true)) {
-                if ($auth['password'] === 'oauth2') {
-                    $headers[] = 'Authorization: Bearer '.$auth['username'];
-                } elseif ($auth['password'] === 'private-token') {
-                    $headers[] = 'PRIVATE-TOKEN: '.$auth['username'];
-                }
-            } elseif ('bitbucket.org' === $originUrl
-                && $this->fileUrl !== Bitbucket::OAUTH2_ACCESS_TOKEN_URL && 'x-token-auth' === $auth['username']
-            ) {
-                if (!$this->isPublicBitBucketDownload($this->fileUrl)) {
-                    $headers[] = 'Authorization: Bearer ' . $auth['password'];
-                }
-            } else {
-                $authStr = base64_encode($auth['username'] . ':' . $auth['password']);
-                $headers[] = 'Authorization: Basic '.$authStr;
-            }
-        }
+        $headers = $this->authHelper->addAuthenticationHeader($headers, $originUrl, $this->fileUrl);
 
         $options['http']['follow_location'] = 0;
 
@@ -960,30 +810,5 @@ class RemoteFilesystem
         $port = parse_url($url, PHP_URL_PORT) ?: $defaultPort;
 
         return parse_url($url, PHP_URL_HOST).':'.$port;
-    }
-
-    /**
-     * @link https://github.com/composer/composer/issues/5584
-     *
-     * @param string $urlToBitBucketFile URL to a file at bitbucket.org.
-     *
-     * @return bool Whether the given URL is a public BitBucket download which requires no authentication.
-     */
-    private function isPublicBitBucketDownload($urlToBitBucketFile)
-    {
-        $domain = parse_url($urlToBitBucketFile, PHP_URL_HOST);
-        if (strpos($domain, 'bitbucket.org') === false) {
-            // Bitbucket downloads are hosted on amazonaws.
-            // We do not need to authenticate there at all
-            return true;
-        }
-
-        $path = parse_url($urlToBitBucketFile, PHP_URL_PATH);
-
-        // Path for a public download follows this pattern /{user}/{repo}/downloads/{whatever}
-        // {@link https://blog.bitbucket.org/2009/04/12/new-feature-downloads/}
-        $pathParts = explode('/', $path);
-
-        return count($pathParts) >= 4 && $pathParts[3] == 'downloads';
     }
 }

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -147,7 +147,7 @@ class RemoteFilesystem
      * @param  string      $name    header name (case insensitive)
      * @return string|null
      */
-    public function findHeaderValue(array $headers, $name)
+    public static function findHeaderValue(array $headers, $name)
     {
         $value = null;
         foreach ($headers as $header) {
@@ -167,7 +167,7 @@ class RemoteFilesystem
      * @param  array    $headers array of returned headers like from getLastHeaders()
      * @return int|null
      */
-    public function findStatusCode(array $headers)
+    public static function findStatusCode(array $headers)
     {
         $value = null;
         foreach ($headers as $header) {

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -13,6 +13,8 @@
 namespace Composer\Util;
 
 use Composer\Composer;
+use Composer\CaBundle\CaBundle;
+use Psr\Log\LoggerInterface;
 
 /**
  * Allows the creation of a basic context supporting http proxy
@@ -151,6 +153,109 @@ final class StreamContextFactory
         }
 
         return stream_context_create($options, $defaultParams);
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    public static function getTlsDefaults(array $options, LoggerInterface $logger = null)
+    {
+        $ciphers = implode(':', array(
+            'ECDHE-RSA-AES128-GCM-SHA256',
+            'ECDHE-ECDSA-AES128-GCM-SHA256',
+            'ECDHE-RSA-AES256-GCM-SHA384',
+            'ECDHE-ECDSA-AES256-GCM-SHA384',
+            'DHE-RSA-AES128-GCM-SHA256',
+            'DHE-DSS-AES128-GCM-SHA256',
+            'kEDH+AESGCM',
+            'ECDHE-RSA-AES128-SHA256',
+            'ECDHE-ECDSA-AES128-SHA256',
+            'ECDHE-RSA-AES128-SHA',
+            'ECDHE-ECDSA-AES128-SHA',
+            'ECDHE-RSA-AES256-SHA384',
+            'ECDHE-ECDSA-AES256-SHA384',
+            'ECDHE-RSA-AES256-SHA',
+            'ECDHE-ECDSA-AES256-SHA',
+            'DHE-RSA-AES128-SHA256',
+            'DHE-RSA-AES128-SHA',
+            'DHE-DSS-AES128-SHA256',
+            'DHE-RSA-AES256-SHA256',
+            'DHE-DSS-AES256-SHA',
+            'DHE-RSA-AES256-SHA',
+            'AES128-GCM-SHA256',
+            'AES256-GCM-SHA384',
+            'AES128-SHA256',
+            'AES256-SHA256',
+            'AES128-SHA',
+            'AES256-SHA',
+            'AES',
+            'CAMELLIA',
+            'DES-CBC3-SHA',
+            '!aNULL',
+            '!eNULL',
+            '!EXPORT',
+            '!DES',
+            '!RC4',
+            '!MD5',
+            '!PSK',
+            '!aECDH',
+            '!EDH-DSS-DES-CBC3-SHA',
+            '!EDH-RSA-DES-CBC3-SHA',
+            '!KRB5-DES-CBC3-SHA',
+        ));
+
+        /**
+         * CN_match and SNI_server_name are only known once a URL is passed.
+         * They will be set in the getOptionsForUrl() method which receives a URL.
+         *
+         * cafile or capath can be overridden by passing in those options to constructor.
+         */
+        $defaults = array(
+            'ssl' => array(
+                'ciphers' => $ciphers,
+                'verify_peer' => true,
+                'verify_depth' => 7,
+                'SNI_enabled' => true,
+                'capture_peer_cert' => true,
+            ),
+        );
+
+        if (isset($options['ssl'])) {
+            $defaults['ssl'] = array_replace_recursive($defaults['ssl'], $options['ssl']);
+        }
+
+        /**
+         * Attempt to find a local cafile or throw an exception if none pre-set
+         * The user may go download one if this occurs.
+         */
+        if (!isset($defaults['ssl']['cafile']) && !isset($defaults['ssl']['capath'])) {
+            $result = CaBundle::getSystemCaRootBundlePath($logger);
+
+            if (is_dir($result)) {
+                $defaults['ssl']['capath'] = $result;
+            } else {
+                $defaults['ssl']['cafile'] = $result;
+            }
+        }
+
+        if (isset($defaults['ssl']['cafile']) && (!is_readable($defaults['ssl']['cafile']) || !CaBundle::validateCaFile($defaults['ssl']['cafile'], $logger))) {
+            throw new TransportException('The configured cafile was not valid or could not be read.');
+        }
+
+        if (isset($defaults['ssl']['capath']) && (!is_dir($defaults['ssl']['capath']) || !is_readable($defaults['ssl']['capath']))) {
+            throw new TransportException('The configured capath was not valid or could not be read.');
+        }
+
+        /**
+         * Disable TLS compression to prevent CRIME attacks where supported.
+         */
+        if (PHP_VERSION_ID >= 50413) {
+            $defaults['ssl']['disable_compression'] = true;
+        }
+
+        return $defaults;
     }
 
     /**

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -87,15 +87,15 @@ final class StreamContextFactory
 
             // enabled request_fulluri unless it is explicitly disabled
             switch (parse_url($url, PHP_URL_SCHEME)) {
-                case 'http': // default request_fulluri to true
+                case 'http': // default request_fulluri to true for HTTP
                     $reqFullUriEnv = getenv('HTTP_PROXY_REQUEST_FULLURI');
                     if ($reqFullUriEnv === false || $reqFullUriEnv === '' || (strtolower($reqFullUriEnv) !== 'false' && (bool) $reqFullUriEnv)) {
                         $options['http']['request_fulluri'] = true;
                     }
                     break;
-                case 'https': // default request_fulluri to true
+                case 'https': // default request_fulluri to false for HTTPS
                     $reqFullUriEnv = getenv('HTTPS_PROXY_REQUEST_FULLURI');
-                    if ($reqFullUriEnv === false || $reqFullUriEnv === '' || (strtolower($reqFullUriEnv) !== 'false' && (bool) $reqFullUriEnv)) {
+                    if (strtolower($reqFullUriEnv) !== 'false' && (bool) $reqFullUriEnv) {
                         $options['http']['request_fulluri'] = true;
                     }
                     break;

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -59,7 +59,7 @@ class Url
             return $url;
         }
 
-        $origin = parse_url($url, PHP_URL_HOST);
+        $origin = (string) parse_url($url, PHP_URL_HOST);
 
         if (strpos($origin, '.github.com') === (strlen($origin) - 11)) {
             return 'github.com';
@@ -67,6 +67,10 @@ class Url
 
         if ($origin === 'repo.packagist.org') {
             return 'packagist.org';
+        }
+
+        if ($origin === '') {
+            $origin = $url;
         }
 
         // Gitlab can be installed in a non-root context (i.e. gitlab.com/foo). When downloading archives the originUrl
@@ -83,7 +87,7 @@ class Url
             }
         }
 
-        return $origin ?: $url;
+        return $origin;
     }
 
 }

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -52,4 +52,38 @@ class Url
 
         return $url;
     }
+
+    public static function getOrigin(Config $config, $url)
+    {
+        if (0 === strpos($url, 'file://')) {
+            return $url;
+        }
+
+        $origin = parse_url($url, PHP_URL_HOST);
+
+        if (strpos($origin, '.github.com') === (strlen($origin) - 11)) {
+            return 'github.com';
+        }
+
+        if ($origin === 'repo.packagist.org') {
+            return 'packagist.org';
+        }
+
+        // Gitlab can be installed in a non-root context (i.e. gitlab.com/foo). When downloading archives the originUrl
+        // is the host without the path, so we look for the registered gitlab-domains matching the host here
+        if (
+            is_array($config->get('gitlab-domains'))
+            && false === strpos($origin, '/')
+            && !in_array($origin, $config->get('gitlab-domains'))
+        ) {
+            foreach ($config->get('gitlab-domains') as $gitlabDomain) {
+                if (0 === strpos($gitlabDomain, $origin)) {
+                    return $gitlabDomain;
+                }
+            }
+        }
+
+        return $origin ?: $url;
+    }
+
 }

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -19,6 +19,12 @@ use Composer\Config;
  */
 class Url
 {
+    /**
+     * @param Config $config
+     * @param string $url
+     * @param string $ref
+     * @return string the updated URL
+     */
     public static function updateDistReference(Config $config, $url, $ref)
     {
         $host = parse_url($url, PHP_URL_HOST);
@@ -53,6 +59,10 @@ class Url
         return $url;
     }
 
+    /**
+     * @param string $url
+     * @return string
+     */
     public static function getOrigin(Config $config, $url)
     {
         if (0 === strpos($url, 'file://')) {
@@ -89,5 +99,4 @@ class Url
 
         return $origin;
     }
-
 }

--- a/tests/Composer/Test/ComposerTest.php
+++ b/tests/Composer/Test/ComposerTest.php
@@ -57,7 +57,7 @@ class ComposerTest extends TestCase
     public function testSetGetInstallationManager()
     {
         $composer = new Composer();
-        $manager = $this->getMockBuilder('Composer\Installer\InstallationManager')->getMock();
+        $manager = $this->getMockBuilder('Composer\Installer\InstallationManager')->disableOriginalConstructor()->getMock();
         $composer->setInstallationManager($manager);
 
         $this->assertSame($manager, $composer->getInstallationManager());

--- a/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
@@ -156,7 +156,11 @@ class ArchiveDownloaderTest extends TestCase
     {
         return $this->getMockForAbstractClass(
             'Composer\Downloader\ArchiveDownloader',
-            array($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getMockBuilder('Composer\Config')->getMock())
+            array(
+                $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+                $config = $this->getMockBuilder('Composer\Config')->getMock(),
+                new \Composer\Util\HttpDownloader($io, $config),
+            )
         );
     }
 }

--- a/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
@@ -29,7 +29,7 @@ class ArchiveDownloaderTest extends TestCase
         $method->setAccessible(true);
 
         $first = $method->invoke($downloader, $packageMock, '/path');
-        $this->assertRegExp('#/path/[a-z0-9]+\.js#', $first);
+        $this->assertRegExp('#/path_[a-z0-9]+\.js#', $first);
         $this->assertSame($first, $method->invoke($downloader, $packageMock, '/path'));
     }
 

--- a/tests/Composer/Test/Downloader/DownloadManagerTest.php
+++ b/tests/Composer/Test/Downloader/DownloadManagerTest.php
@@ -50,7 +50,7 @@ class DownloadManagerTest extends TestCase
 
         $this->setExpectedException('InvalidArgumentException');
 
-        $manager->getDownloaderForInstalledPackage($package);
+        $manager->getDownloaderForPackage($package);
     }
 
     public function testGetDownloaderForCorrectlyInstalledDistPackage()
@@ -82,7 +82,7 @@ class DownloadManagerTest extends TestCase
             ->with('pear')
             ->will($this->returnValue($downloader));
 
-        $this->assertSame($downloader, $manager->getDownloaderForInstalledPackage($package));
+        $this->assertSame($downloader, $manager->getDownloaderForPackage($package));
     }
 
     public function testGetDownloaderForIncorrectlyInstalledDistPackage()
@@ -116,7 +116,7 @@ class DownloadManagerTest extends TestCase
 
         $this->setExpectedException('LogicException');
 
-        $manager->getDownloaderForInstalledPackage($package);
+        $manager->getDownloaderForPackage($package);
     }
 
     public function testGetDownloaderForCorrectlyInstalledSourcePackage()
@@ -148,7 +148,7 @@ class DownloadManagerTest extends TestCase
             ->with('git')
             ->will($this->returnValue($downloader));
 
-        $this->assertSame($downloader, $manager->getDownloaderForInstalledPackage($package));
+        $this->assertSame($downloader, $manager->getDownloaderForPackage($package));
     }
 
     public function testGetDownloaderForIncorrectlyInstalledSourcePackage()
@@ -182,7 +182,7 @@ class DownloadManagerTest extends TestCase
 
         $this->setExpectedException('LogicException');
 
-        $manager->getDownloaderForInstalledPackage($package);
+        $manager->getDownloaderForPackage($package);
     }
 
     public function testGetDownloaderForMetapackage()
@@ -195,7 +195,7 @@ class DownloadManagerTest extends TestCase
 
         $manager = new DownloadManager($this->io, false, $this->filesystem);
 
-        $this->assertNull($manager->getDownloaderForInstalledPackage($package));
+        $this->assertNull($manager->getDownloaderForPackage($package));
     }
 
     public function testFullPackageDownload()
@@ -223,11 +223,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
 
@@ -274,16 +274,16 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->at(0))
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloaderFail));
         $manager
             ->expects($this->at(1))
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloaderSuccess));
 
@@ -333,11 +333,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
 
@@ -369,11 +369,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
 
@@ -399,11 +399,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
           ->setConstructorArgs(array($this->io, false, $this->filesystem))
-          ->setMethods(array('getDownloaderForInstalledPackage'))
+          ->setMethods(array('getDownloaderForPackage'))
           ->getMock();
         $manager
           ->expects($this->once())
-          ->method('getDownloaderForInstalledPackage')
+          ->method('getDownloaderForPackage')
           ->with($package)
           ->will($this->returnValue(null)); // There is no downloader for Metapackages.
 
@@ -435,11 +435,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
 
@@ -472,11 +472,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
 
@@ -509,11 +509,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
 
@@ -550,33 +550,30 @@ class DownloadManagerTest extends TestCase
         $initial
             ->expects($this->once())
             ->method('getDistType')
-            ->will($this->returnValue('pear'));
+            ->will($this->returnValue('zip'));
 
         $target = $this->createPackageMock();
         $target
             ->expects($this->once())
-            ->method('getDistType')
-            ->will($this->returnValue('pear'));
+            ->method('getInstallationSource')
+            ->will($this->returnValue('dist'));
         $target
             ->expects($this->once())
-            ->method('setInstallationSource')
-            ->with('dist');
+            ->method('getDistType')
+            ->will($this->returnValue('zip'));
 
-        $pearDownloader = $this->createDownloaderMock();
-        $pearDownloader
+        $zipDownloader = $this->createDownloaderMock();
+        $zipDownloader
             ->expects($this->once())
             ->method('update')
             ->with($initial, $target, 'vendor/bundles/FOS/UserBundle');
+        $zipDownloader
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('dist'));
 
-        $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
-            ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
-            ->getMock();
-        $manager
-            ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
-            ->with($initial)
-            ->will($this->returnValue($pearDownloader));
+        $manager = new DownloadManager($this->io, false, $this->filesystem);
+        $manager->setDownloader('zip', $zipDownloader);
 
         $manager->update($initial, $target, 'vendor/bundles/FOS/UserBundle');
     }
@@ -591,113 +588,89 @@ class DownloadManagerTest extends TestCase
         $initial
             ->expects($this->once())
             ->method('getDistType')
-            ->will($this->returnValue('pear'));
+            ->will($this->returnValue('xz'));
 
         $target = $this->createPackageMock();
         $target
-            ->expects($this->once())
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('dist'));
+        $target
+            ->expects($this->any())
             ->method('getDistType')
-            ->will($this->returnValue('composer'));
+            ->will($this->returnValue('zip'));
 
-        $pearDownloader = $this->createDownloaderMock();
-        $pearDownloader
+        $xzDownloader = $this->createDownloaderMock();
+        $xzDownloader
             ->expects($this->once())
             ->method('remove')
             ->with($initial, 'vendor/bundles/FOS/UserBundle');
+        $xzDownloader
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('dist'));
 
-        $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
-            ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage', 'download'))
-            ->getMock();
-        $manager
+        $zipDownloader = $this->createDownloaderMock();
+        $zipDownloader
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
-            ->with($initial)
-            ->will($this->returnValue($pearDownloader));
-        $manager
-            ->expects($this->once())
-            ->method('download')
-            ->with($target, 'vendor/bundles/FOS/UserBundle', false);
+            ->method('install')
+            ->with($target, 'vendor/bundles/FOS/UserBundle');
+        $zipDownloader
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('dist'));
+
+        $manager = new DownloadManager($this->io, false, $this->filesystem);
+        $manager->setDownloader('xz', $xzDownloader);
+        $manager->setDownloader('zip', $zipDownloader);
 
         $manager->update($initial, $target, 'vendor/bundles/FOS/UserBundle');
     }
 
-    public function testUpdateSourceWithEqualTypes()
+    /**
+     * @dataProvider updatesProvider
+     */
+    public function testGetAvailableSourcesUpdateSticksToSameSource($prevPkgSource, $prevPkgIsDev, $targetAvailable, $targetIsDev, $expected)
     {
-        $initial = $this->createPackageMock();
-        $initial
-            ->expects($this->once())
-            ->method('getInstallationSource')
-            ->will($this->returnValue('source'));
-        $initial
-            ->expects($this->once())
-            ->method('getSourceType')
-            ->will($this->returnValue('svn'));
+        $initial = null;
+        if ($prevPkgSource) {
+            $initial = $this->prophesize('Composer\Package\PackageInterface');
+            $initial->getInstallationSource()->willReturn($prevPkgSource);
+            $initial->isDev()->willReturn($prevPkgIsDev);
+        }
 
-        $target = $this->createPackageMock();
-        $target
-            ->expects($this->once())
-            ->method('getSourceType')
-            ->will($this->returnValue('svn'));
+        $target = $this->prophesize('Composer\Package\PackageInterface');
+        $target->getSourceType()->willReturn(in_array('source', $targetAvailable, true) ? 'git' : null);
+        $target->getDistType()->willReturn(in_array('dist', $targetAvailable, true) ? 'zip' : null);
+        $target->isDev()->willReturn($targetIsDev);
 
-        $svnDownloader = $this->createDownloaderMock();
-        $svnDownloader
-            ->expects($this->once())
-            ->method('update')
-            ->with($initial, $target, 'vendor/pkg');
-
-        $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
-            ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage', 'download'))
-            ->getMock();
-        $manager
-            ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
-            ->with($initial)
-            ->will($this->returnValue($svnDownloader));
-
-        $manager->update($initial, $target, 'vendor/pkg');
+        $manager = new DownloadManager($this->io, false, $this->filesystem);
+        $method = new \ReflectionMethod($manager, 'getAvailableSources');
+        $method->setAccessible(true);
+        $this->assertEquals($expected, $method->invoke($manager, $target->reveal(), $initial ? $initial->reveal() : null));
     }
 
-    public function testUpdateSourceWithNotEqualTypes()
+    public static function updatesProvider()
     {
-        $initial = $this->createPackageMock();
-        $initial
-            ->expects($this->once())
-            ->method('getInstallationSource')
-            ->will($this->returnValue('source'));
-        $initial
-            ->expects($this->once())
-            ->method('getSourceType')
-            ->will($this->returnValue('svn'));
-
-        $target = $this->createPackageMock();
-        $target
-            ->expects($this->once())
-            ->method('getSourceType')
-            ->will($this->returnValue('git'));
-
-        $svnDownloader = $this->createDownloaderMock();
-        $svnDownloader
-            ->expects($this->once())
-            ->method('remove')
-            ->with($initial, 'vendor/pkg');
-
-        $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
-            ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage', 'download'))
-            ->getMock();
-        $manager
-            ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
-            ->with($initial)
-            ->will($this->returnValue($svnDownloader));
-        $manager
-            ->expects($this->once())
-            ->method('download')
-            ->with($target, 'vendor/pkg', true);
-
-        $manager->update($initial, $target, 'vendor/pkg');
+        return array(
+            //    prevPkg source,  prevPkg isDev, pkg available,           pkg isDev,  expected
+            // updates keep previous source as preference
+            array('source',        false,         array('source', 'dist'), false,      array('source', 'dist')),
+            array('dist',          false,         array('source', 'dist'), false,      array('dist', 'source')),
+            // updates do not keep previous source if target package does not have it
+            array('source',        false,         array('dist'),           false,      array('dist')),
+            array('dist',          false,         array('source'),         false,      array('source')),
+            // updates do not keep previous source if target is dev and prev wasn't dev and installed from dist
+            array('source',        false,         array('source', 'dist'), true,       array('source', 'dist')),
+            array('dist',          false,         array('source', 'dist'), true,       array('source', 'dist')),
+            // install picks the right default
+            array(null,            null,          array('source', 'dist'), true,       array('source', 'dist')),
+            array(null,            null,          array('dist'),           true,       array('dist')),
+            array(null,            null,          array('source'),         true,       array('source')),
+            array(null,            null,          array('source', 'dist'), false,      array('dist', 'source')),
+            array(null,            null,          array('dist'),           false,      array('dist')),
+            array(null,            null,          array('source'),         false,      array('source')),
+        );
     }
 
     public function testUpdateMetapackage()
@@ -707,11 +680,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
           ->setConstructorArgs(array($this->io, false, $this->filesystem))
-          ->setMethods(array('getDownloaderForInstalledPackage'))
+          ->setMethods(array('getDownloaderForPackage'))
           ->getMock();
         $manager
-          ->expects($this->once())
-          ->method('getDownloaderForInstalledPackage')
+          ->expects($this->exactly(2))
+          ->method('getDownloaderForPackage')
           ->with($initial)
           ->will($this->returnValue(null)); // There is no downloader for metapackages.
 
@@ -730,11 +703,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($pearDownloader));
 
@@ -747,11 +720,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
           ->setConstructorArgs(array($this->io, false, $this->filesystem))
-          ->setMethods(array('getDownloaderForInstalledPackage'))
+          ->setMethods(array('getDownloaderForPackage'))
           ->getMock();
         $manager
           ->expects($this->once())
-          ->method('getDownloaderForInstalledPackage')
+          ->method('getDownloaderForPackage')
           ->with($package)
           ->will($this->returnValue(null)); // There is no downloader for metapackages.
 
@@ -790,11 +763,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
 
@@ -833,11 +806,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
 
@@ -879,11 +852,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
         $manager->setPreferences(array('foo/*' => 'source'));
@@ -926,11 +899,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
         $manager->setPreferences(array('foo/*' => 'source'));
@@ -973,11 +946,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
         $manager->setPreferences(array('foo/*' => 'auto'));
@@ -1020,11 +993,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
         $manager->setPreferences(array('foo/*' => 'auto'));
@@ -1063,11 +1036,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
         $manager->setPreferences(array('foo/*' => 'source'));
@@ -1106,11 +1079,11 @@ class DownloadManagerTest extends TestCase
 
         $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->setConstructorArgs(array($this->io, false, $this->filesystem))
-            ->setMethods(array('getDownloaderForInstalledPackage'))
+            ->setMethods(array('getDownloaderForPackage'))
             ->getMock();
         $manager
             ->expects($this->once())
-            ->method('getDownloaderForInstalledPackage')
+            ->method('getDownloaderForPackage')
             ->with($package)
             ->will($this->returnValue($downloader));
         $manager->setPreferences(array('foo/*' => 'dist'));

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -18,13 +18,13 @@ use Composer\Util\Filesystem;
 
 class FileDownloaderTest extends TestCase
 {
-    protected function getDownloader($io = null, $config = null, $eventDispatcher = null, $cache = null, $rfs = null, $filesystem = null)
+    protected function getDownloader($io = null, $config = null, $eventDispatcher = null, $cache = null, $httpDownloader = null, $filesystem = null)
     {
         $io = $io ?: $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $config = $config ?: $this->getMockBuilder('Composer\Config')->getMock();
-        $rfs = $rfs ?: $this->getMockBuilder('Composer\Util\RemoteFilesystem')->disableOriginalConstructor()->getMock();
+        $httpDownloader = $httpDownloader ?: $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock();
 
-        return new FileDownloader($io, $config, $eventDispatcher, $cache, $rfs, $filesystem);
+        return new FileDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $filesystem);
     }
 
     /**

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -15,6 +15,8 @@ namespace Composer\Test\Downloader;
 use Composer\Downloader\FileDownloader;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
+use Composer\Util\Http\Response;
+use Composer\Util\Loop;
 
 class FileDownloaderTest extends TestCase
 {
@@ -23,6 +25,11 @@ class FileDownloaderTest extends TestCase
         $io = $io ?: $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $config = $config ?: $this->getMockBuilder('Composer\Config')->getMock();
         $httpDownloader = $httpDownloader ?: $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock();
+        $httpDownloader
+            ->expects($this->any())
+            ->method('addCopy')
+            ->will($this->returnValue(\React\Promise\resolve(new Response(array('url' => 'http://example.org/'), 200, array(), 'file~'))));
+        $this->httpDownloader = $httpDownloader;
 
         return new FileDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $filesystem);
     }
@@ -84,7 +91,7 @@ class FileDownloaderTest extends TestCase
         $method = new \ReflectionMethod($downloader, 'getFileName');
         $method->setAccessible(true);
 
-        $this->assertEquals('/path/script.js', $method->invoke($downloader, $packageMock, '/path'));
+        $this->assertEquals('/path_script.js', $method->invoke($downloader, $packageMock, '/path'));
     }
 
     public function testDownloadButFileIsUnsaved()
@@ -118,8 +125,11 @@ class FileDownloaderTest extends TestCase
 
         $downloader = $this->getDownloader($ioMock);
         try {
-            $downloader->download($packageMock, $path);
-            $this->fail();
+            $promise = $downloader->download($packageMock, $path);
+            $loop = new Loop($this->httpDownloader);
+            $loop->wait(array($promise));
+
+            $this->fail('Download was expected to throw');
         } catch (\Exception $e) {
             if (is_dir($path)) {
                 $fs = new Filesystem();
@@ -128,7 +138,7 @@ class FileDownloaderTest extends TestCase
                 unlink($path);
             }
 
-            $this->assertInstanceOf('UnexpectedValueException', $e);
+            $this->assertInstanceOf('UnexpectedValueException', $e, $e->getMessage());
             $this->assertContains('could not be saved to', $e->getMessage());
         }
     }
@@ -188,11 +198,14 @@ class FileDownloaderTest extends TestCase
         $path = $this->getUniqueTmpDirectory();
         $downloader = $this->getDownloader(null, null, null, null, null, $filesystem);
         // make sure the file expected to be downloaded is on disk already
-        touch($path.'/script.js');
+        touch($path.'_script.js');
 
         try {
-            $downloader->download($packageMock, $path);
-            $this->fail();
+            $promise = $downloader->download($packageMock, $path);
+            $loop = new Loop($this->httpDownloader);
+            $loop->wait(array($promise));
+
+            $this->fail('Download was expected to throw');
         } catch (\Exception $e) {
             if (is_dir($path)) {
                 $fs = new Filesystem();
@@ -201,7 +214,7 @@ class FileDownloaderTest extends TestCase
                 unlink($path);
             }
 
-            $this->assertInstanceOf('UnexpectedValueException', $e);
+            $this->assertInstanceOf('UnexpectedValueException', $e, $e->getMessage());
             $this->assertContains('checksum verification', $e->getMessage());
         }
     }
@@ -233,16 +246,24 @@ class FileDownloaderTest extends TestCase
         $ioMock = $this->getMock('Composer\IO\IOInterface');
         $ioMock->expects($this->at(0))
             ->method('writeError')
+            ->with($this->stringContains('Downloading'));
+
+        $ioMock->expects($this->at(1))
+            ->method('writeError')
             ->with($this->stringContains('Downgrading'));
 
         $path = $this->getUniqueTmpDirectory();
-        touch($path.'/script.js');
+        touch($path.'_script.js');
         $filesystem = $this->getMock('Composer\Util\Filesystem');
         $filesystem->expects($this->once())
             ->method('removeDirectory')
             ->will($this->returnValue(true));
 
         $downloader = $this->getDownloader($ioMock, null, null, null, null, $filesystem);
+        $promise = $downloader->download($newPackage, $path, $oldPackage);
+        $loop = new Loop($this->httpDownloader);
+        $loop->wait(array($promise));
+
         $downloader->update($oldPackage, $newPackage, $path);
     }
 }

--- a/tests/Composer/Test/Downloader/FossilDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FossilDownloaderTest.php
@@ -56,7 +56,7 @@ class FossilDownloaderTest extends TestCase
             ->will($this->returnValue(null));
 
         $downloader = $this->getDownloaderMock();
-        $downloader->download($packageMock, '/path');
+        $downloader->install($packageMock, '/path');
     }
 
     public function testDownload()
@@ -89,7 +89,7 @@ class FossilDownloaderTest extends TestCase
             ->will($this->returnValue(0));
 
         $downloader = $this->getDownloaderMock(null, null, $processExecutor);
-        $downloader->download($packageMock, 'repo');
+        $downloader->install($packageMock, 'repo');
     }
 
     /**

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -79,7 +79,7 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue(null));
 
         $downloader = $this->getDownloaderMock();
-        $downloader->download($packageMock, '/path');
+        $downloader->install($packageMock, '/path');
     }
 
     public function testDownload()
@@ -130,7 +130,7 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue(0));
 
         $downloader = $this->getDownloaderMock(null, null, $processExecutor);
-        $downloader->download($packageMock, 'composerPath');
+        $downloader->install($packageMock, 'composerPath');
     }
 
     public function testDownloadWithCache()
@@ -195,7 +195,7 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue(0));
 
         $downloader = $this->getDownloaderMock(null, $config, $processExecutor);
-        $downloader->download($packageMock, 'composerPath');
+        $downloader->install($packageMock, 'composerPath');
         @rmdir($cachePath);
     }
 
@@ -265,7 +265,7 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue(0));
 
         $downloader = $this->getDownloaderMock(null, new Config(), $processExecutor);
-        $downloader->download($packageMock, 'composerPath');
+        $downloader->install($packageMock, 'composerPath');
     }
 
     public function pushUrlProvider()
@@ -329,7 +329,7 @@ class GitDownloaderTest extends TestCase
         $config->merge(array('config' => array('github-protocols' => $protocols)));
 
         $downloader = $this->getDownloaderMock(null, $config, $processExecutor);
-        $downloader->download($packageMock, 'composerPath');
+        $downloader->install($packageMock, 'composerPath');
     }
 
     /**
@@ -360,7 +360,7 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue(1));
 
         $downloader = $this->getDownloaderMock(null, null, $processExecutor);
-        $downloader->download($packageMock, 'composerPath');
+        $downloader->install($packageMock, 'composerPath');
     }
 
     /**

--- a/tests/Composer/Test/Downloader/HgDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/HgDownloaderTest.php
@@ -56,7 +56,7 @@ class HgDownloaderTest extends TestCase
             ->will($this->returnValue(null));
 
         $downloader = $this->getDownloaderMock();
-        $downloader->download($packageMock, '/path');
+        $downloader->install($packageMock, '/path');
     }
 
     public function testDownload()
@@ -83,7 +83,7 @@ class HgDownloaderTest extends TestCase
             ->will($this->returnValue(0));
 
         $downloader = $this->getDownloaderMock(null, null, $processExecutor);
-        $downloader->download($packageMock, 'composerPath');
+        $downloader->install($packageMock, 'composerPath');
     }
 
     /**

--- a/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
@@ -138,7 +138,7 @@ class PerforceDownloaderTest extends TestCase
         $perforce->expects($this->at(5))->method('syncCodeBase')->with($label);
         $perforce->expects($this->at(6))->method('cleanupClientSpec');
         $this->downloader->setPerforce($perforce);
-        $this->downloader->doDownload($this->package, $this->testPath, 'url');
+        $this->downloader->doInstall($this->package, $this->testPath, 'url');
     }
 
     /**
@@ -161,6 +161,6 @@ class PerforceDownloaderTest extends TestCase
         $perforce->expects($this->at(5))->method('syncCodeBase')->with($label);
         $perforce->expects($this->at(6))->method('cleanupClientSpec');
         $this->downloader->setPerforce($perforce);
-        $this->downloader->doDownload($this->package, $this->testPath, 'url');
+        $this->downloader->doInstall($this->package, $this->testPath, 'url');
     }
 }

--- a/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
@@ -17,6 +17,7 @@ use Composer\Config;
 use Composer\Repository\VcsRepository;
 use Composer\IO\IOInterface;
 use Composer\Test\TestCase;
+use Composer\Factory;
 use Composer\Util\Filesystem;
 
 /**
@@ -96,7 +97,7 @@ class PerforceDownloaderTest extends TestCase
     {
         $repository = $this->getMockBuilder('Composer\Repository\VcsRepository')
             ->setMethods(array('getRepoConfig'))
-            ->setConstructorArgs(array($repoConfig, $io, $config))
+            ->setConstructorArgs(array($repoConfig, $io, $config, Factory::createHttpDownloader($io, $config)))
             ->getMock();
         $repository->expects($this->any())->method('getRepoConfig')->will($this->returnValue($repoConfig));
 

--- a/tests/Composer/Test/Downloader/XzDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/XzDownloaderTest.php
@@ -16,7 +16,7 @@ use Composer\Downloader\XzDownloader;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Util\Platform;
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
 
 class XzDownloaderTest extends TestCase
 {
@@ -66,7 +66,7 @@ class XzDownloaderTest extends TestCase
             ->method('get')
             ->with('vendor-dir')
             ->will($this->returnValue($this->testDir));
-        $downloader = new XzDownloader($io, $config, null, null, null, new RemoteFilesystem($io));
+        $downloader = new XzDownloader($io, $config, new HttpDownloader($io, $this->getMockBuilder('Composer\Config')->getMock()), null, null, null);
 
         try {
             $downloader->download($packageMock, $this->getUniqueTmpDirectory());

--- a/tests/Composer/Test/Downloader/ZipDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ZipDownloaderTest.php
@@ -16,6 +16,7 @@ use Composer\Downloader\ZipDownloader;
 use Composer\Package\PackageInterface;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
+use Composer\Util\HttpDownloader;
 
 class ZipDownloaderTest extends TestCase
 {
@@ -32,6 +33,8 @@ class ZipDownloaderTest extends TestCase
         $this->testDir = $this->getUniqueTmpDirectory();
         $this->io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $this->config = $this->getMockBuilder('Composer\Config')->getMock();
+        $dlConfig = $this->getMockBuilder('Composer\Config')->getMock();
+        $this->httpDownloader = new HttpDownloader($this->io, $dlConfig);
     }
 
     public function tearDown()
@@ -65,18 +68,6 @@ class ZipDownloaderTest extends TestCase
 
         $this->config->expects($this->at(0))
             ->method('get')
-            ->with('disable-tls')
-            ->will($this->returnValue(false));
-        $this->config->expects($this->at(1))
-            ->method('get')
-            ->with('cafile')
-            ->will($this->returnValue(null));
-        $this->config->expects($this->at(2))
-            ->method('get')
-            ->with('capath')
-            ->will($this->returnValue(null));
-        $this->config->expects($this->at(3))
-            ->method('get')
             ->with('vendor-dir')
             ->will($this->returnValue($this->testDir));
 
@@ -94,7 +85,7 @@ class ZipDownloaderTest extends TestCase
             ->will($this->returnValue(array()))
         ;
 
-        $downloader = new ZipDownloader($this->io, $this->config);
+        $downloader = new ZipDownloader($this->io, $this->config, $this->httpDownloader);
 
         $this->setPrivateProperty('hasSystemUnzip', false);
 
@@ -118,8 +109,7 @@ class ZipDownloaderTest extends TestCase
 
         $this->setPrivateProperty('hasSystemUnzip', false);
         $this->setPrivateProperty('hasZipArchive', true);
-        $downloader = new MockedZipDownloader($this->io, $this->config);
-
+        $downloader = new MockedZipDownloader($this->io, $this->config, $this->httpDownloader);
         $zipArchive = $this->getMockBuilder('ZipArchive')->getMock();
         $zipArchive->expects($this->at(0))
             ->method('open')
@@ -144,8 +134,7 @@ class ZipDownloaderTest extends TestCase
 
         $this->setPrivateProperty('hasSystemUnzip', false);
         $this->setPrivateProperty('hasZipArchive', true);
-        $downloader = new MockedZipDownloader($this->io, $this->config);
-
+        $downloader = new MockedZipDownloader($this->io, $this->config, $this->httpDownloader);
         $zipArchive = $this->getMockBuilder('ZipArchive')->getMock();
         $zipArchive->expects($this->at(0))
             ->method('open')
@@ -169,8 +158,7 @@ class ZipDownloaderTest extends TestCase
 
         $this->setPrivateProperty('hasSystemUnzip', false);
         $this->setPrivateProperty('hasZipArchive', true);
-        $downloader = new MockedZipDownloader($this->io, $this->config);
-
+        $downloader = new MockedZipDownloader($this->io, $this->config, $this->httpDownloader);
         $zipArchive = $this->getMockBuilder('ZipArchive')->getMock();
         $zipArchive->expects($this->at(0))
             ->method('open')
@@ -200,7 +188,7 @@ class ZipDownloaderTest extends TestCase
             ->method('execute')
             ->will($this->returnValue(1));
 
-        $downloader = new MockedZipDownloader($this->io, $this->config, null, null, $processExecutor);
+        $downloader = new MockedZipDownloader($this->io, $this->config, $this->httpDownloader, null, null, $processExecutor);
         $downloader->extract('testfile.zip', 'vendor/dir');
     }
 
@@ -217,7 +205,7 @@ class ZipDownloaderTest extends TestCase
             ->method('execute')
             ->will($this->returnValue(0));
 
-        $downloader = new MockedZipDownloader($this->io, $this->config, null, null, $processExecutor);
+        $downloader = new MockedZipDownloader($this->io, $this->config, $this->httpDownloader, null, null, $processExecutor);
         $downloader->extract('testfile.zip', 'vendor/dir');
     }
 
@@ -244,7 +232,7 @@ class ZipDownloaderTest extends TestCase
             ->method('extractTo')
             ->will($this->returnValue(true));
 
-        $downloader = new MockedZipDownloader($this->io, $this->config, null, null, $processExecutor);
+        $downloader = new MockedZipDownloader($this->io, $this->config, $this->httpDownloader, null, null, $processExecutor);
         $this->setPrivateProperty('zipArchiveObject', $zipArchive, $downloader);
         $downloader->extract('testfile.zip', 'vendor/dir');
     }
@@ -276,7 +264,7 @@ class ZipDownloaderTest extends TestCase
           ->method('extractTo')
           ->will($this->returnValue(false));
 
-        $downloader = new MockedZipDownloader($this->io, $this->config, null, null, $processExecutor);
+        $downloader = new MockedZipDownloader($this->io, $this->config, $this->httpDownloader, null, null, $processExecutor);
         $this->setPrivateProperty('zipArchiveObject', $zipArchive, $downloader);
         $downloader->extract('testfile.zip', 'vendor/dir');
     }
@@ -304,7 +292,7 @@ class ZipDownloaderTest extends TestCase
             ->method('extractTo')
             ->will($this->returnValue(false));
 
-        $downloader = new MockedZipDownloader($this->io, $this->config, null, null, $processExecutor);
+        $downloader = new MockedZipDownloader($this->io, $this->config, $this->httpDownloader, null, null, $processExecutor);
         $this->setPrivateProperty('zipArchiveObject', $zipArchive, $downloader);
         $downloader->extract('testfile.zip', 'vendor/dir');
     }
@@ -336,7 +324,7 @@ class ZipDownloaderTest extends TestCase
           ->method('extractTo')
           ->will($this->returnValue(false));
 
-        $downloader = new MockedZipDownloader($this->io, $this->config, null, null, $processExecutor);
+        $downloader = new MockedZipDownloader($this->io, $this->config, $this->httpDownloader, null, null, $processExecutor);
         $this->setPrivateProperty('zipArchiveObject', $zipArchive, $downloader);
         $downloader->extract('testfile.zip', 'vendor/dir');
     }

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -101,7 +101,7 @@ class EventDispatcherTest extends TestCase
         $composer->setPackage($package);
 
         $composer->setRepositoryManager($this->getRepositoryManagerMockForDevModePassingTest());
-        $composer->setInstallationManager($this->getMockBuilder('Composer\Installer\InstallationManager')->getMock());
+        $composer->setInstallationManager($this->getMockBuilder('Composer\Installer\InstallationManager')->disableOriginalConstructor()->getMock());
 
         $dispatcher = new EventDispatcher(
             $composer,

--- a/tests/Composer/Test/FactoryTest.php
+++ b/tests/Composer/Test/FactoryTest.php
@@ -35,6 +35,6 @@ class FactoryTest extends TestCase
             ->with($this->equalTo('disable-tls'))
             ->will($this->returnValue(true));
 
-        Factory::createRemoteFilesystem($ioMock, $config);
+        Factory::createHttpDownloader($ioMock, $config);
     }
 }

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\Installer;
 
 use Composer\Installer\InstallationManager;
+use Composer\Installer\NoopInstaller;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
@@ -21,9 +22,11 @@ use PHPUnit\Framework\TestCase;
 class InstallationManagerTest extends TestCase
 {
     protected $repository;
+    protected $loop;
 
     public function setUp()
     {
+        $this->loop = $this->getMockBuilder('Composer\Util\Loop')->disableOriginalConstructor()->getMock();
         $this->repository = $this->getMockBuilder('Composer\Repository\InstalledRepositoryInterface')->getMock();
     }
 
@@ -38,7 +41,7 @@ class InstallationManagerTest extends TestCase
                 return $arg === 'vendor';
             }));
 
-        $manager = new InstallationManager();
+        $manager = new InstallationManager($this->loop);
 
         $manager->addInstaller($installer);
         $this->assertSame($installer, $manager->getInstaller('vendor'));
@@ -67,7 +70,7 @@ class InstallationManagerTest extends TestCase
                 return $arg === 'vendor';
             }));
 
-        $manager = new InstallationManager();
+        $manager = new InstallationManager($this->loop);
 
         $manager->addInstaller($installer);
         $this->assertSame($installer, $manager->getInstaller('vendor'));
@@ -80,15 +83,20 @@ class InstallationManagerTest extends TestCase
     public function testExecute()
     {
         $manager = $this->getMockBuilder('Composer\Installer\InstallationManager')
+            ->setConstructorArgs(array($this->loop))
             ->setMethods(array('install', 'update', 'uninstall'))
             ->getMock();
 
-        $installOperation = new InstallOperation($this->createPackageMock());
-        $removeOperation = new UninstallOperation($this->createPackageMock());
+        $installOperation = new InstallOperation($package = $this->createPackageMock());
+        $removeOperation = new UninstallOperation($package);
         $updateOperation = new UpdateOperation(
-            $this->createPackageMock(),
-            $this->createPackageMock()
+            $package,
+            $package
         );
+
+        $package->expects($this->any())
+            ->method('getType')
+            ->will($this->returnValue('library'));
 
         $manager
             ->expects($this->once())
@@ -103,6 +111,7 @@ class InstallationManagerTest extends TestCase
             ->method('update')
             ->with($this->repository, $updateOperation);
 
+        $manager->addInstaller(new NoopInstaller());
         $manager->execute($this->repository, $installOperation);
         $manager->execute($this->repository, $removeOperation);
         $manager->execute($this->repository, $updateOperation);
@@ -111,7 +120,7 @@ class InstallationManagerTest extends TestCase
     public function testInstall()
     {
         $installer = $this->createInstallerMock();
-        $manager = new InstallationManager();
+        $manager = new InstallationManager($this->loop);
         $manager->addInstaller($installer);
 
         $package = $this->createPackageMock();
@@ -139,7 +148,7 @@ class InstallationManagerTest extends TestCase
     public function testUpdateWithEqualTypes()
     {
         $installer = $this->createInstallerMock();
-        $manager = new InstallationManager();
+        $manager = new InstallationManager($this->loop);
         $manager->addInstaller($installer);
 
         $initial = $this->createPackageMock();
@@ -173,18 +182,17 @@ class InstallationManagerTest extends TestCase
     {
         $libInstaller = $this->createInstallerMock();
         $bundleInstaller = $this->createInstallerMock();
-        $manager = new InstallationManager();
+        $manager = new InstallationManager($this->loop);
         $manager->addInstaller($libInstaller);
         $manager->addInstaller($bundleInstaller);
 
         $initial = $this->createPackageMock();
-        $target = $this->createPackageMock();
-        $operation = new UpdateOperation($initial, $target, 'test');
-
         $initial
             ->expects($this->once())
             ->method('getType')
             ->will($this->returnValue('library'));
+
+        $target = $this->createPackageMock();
         $target
             ->expects($this->once())
             ->method('getType')
@@ -213,13 +221,14 @@ class InstallationManagerTest extends TestCase
             ->method('install')
             ->with($this->repository, $target);
 
+        $operation = new UpdateOperation($initial, $target, 'test');
         $manager->update($this->repository, $operation);
     }
 
     public function testUninstall()
     {
         $installer = $this->createInstallerMock();
-        $manager = new InstallationManager();
+        $manager = new InstallationManager($this->loop);
         $manager->addInstaller($installer);
 
         $package = $this->createPackageMock();
@@ -249,7 +258,7 @@ class InstallationManagerTest extends TestCase
         $installer = $this->getMockBuilder('Composer\Installer\LibraryInstaller')
             ->disableOriginalConstructor()
             ->getMock();
-        $manager = new InstallationManager();
+        $manager = new InstallationManager($this->loop);
         $manager->addInstaller($installer);
 
         $package = $this->createPackageMock();
@@ -281,7 +290,9 @@ class InstallationManagerTest extends TestCase
 
     private function createPackageMock()
     {
-        return $this->getMockBuilder('Composer\Package\PackageInterface')
+        $mock = $this->getMockBuilder('Composer\Package\PackageInterface')
             ->getMock();
+
+        return $mock;
     }
 }

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -113,7 +113,7 @@ class LibraryInstallerTest extends TestCase
 
         $this->dm
             ->expects($this->once())
-            ->method('download')
+            ->method('install')
             ->with($package, $this->vendorDir.'/some/package');
 
         $this->repository

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -65,7 +65,7 @@ class InstallerTest extends TestCase
 
         $eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
         $httpDownloader = $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock();
-        $repositoryManager = new RepositoryManager($io, $config, $eventDispatcher, $httpDownloader);
+        $repositoryManager = new RepositoryManager($io, $config, $httpDownloader, $eventDispatcher);
         $repositoryManager->setLocalRepository(new InstalledArrayRepository());
 
         if (!is_array($repositories)) {

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -63,7 +63,9 @@ class InstallerTest extends TestCase
             ->getMock();
         $config = $this->getMockBuilder('Composer\Config')->getMock();
 
-        $repositoryManager = new RepositoryManager($io, $config);
+        $eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
+        $httpDownloader = $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock();
+        $repositoryManager = new RepositoryManager($io, $config, $eventDispatcher, $httpDownloader);
         $repositoryManager->setLocalRepository(new InstalledArrayRepository());
 
         if (!is_array($repositories)) {
@@ -76,7 +78,6 @@ class InstallerTest extends TestCase
         $locker = $this->getMockBuilder('Composer\Package\Locker')->disableOriginalConstructor()->getMock();
         $installationManager = new InstallationManagerMock();
 
-        $eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
         $autoloadGenerator = $this->getMockBuilder('Composer\Autoload\AutoloadGenerator')->disableOriginalConstructor()->getMock();
 
         $installer = new Installer($io, $config, clone $rootPackage, $downloadManager, $repositoryManager, $locker, $installationManager, $eventDispatcher, $autoloadGenerator);

--- a/tests/Composer/Test/Mock/FactoryMock.php
+++ b/tests/Composer/Test/Mock/FactoryMock.php
@@ -20,6 +20,7 @@ use Composer\Repository\WritableRepositoryInterface;
 use Composer\Installer;
 use Composer\IO\IOInterface;
 use Composer\Test\TestCase;
+use Composer\Util\Loop;
 
 class FactoryMock extends Factory
 {
@@ -39,9 +40,9 @@ class FactoryMock extends Factory
     {
     }
 
-    protected function createInstallationManager()
+    public function createInstallationManager(Loop $loop)
     {
-        return new InstallationManagerMock;
+        return new InstallationManagerMock();
     }
 
     protected function createDefaultInstallers(Installer\InstallationManager $im, Composer $composer, IOInterface $io)

--- a/tests/Composer/Test/Mock/HttpDownloaderMock.php
+++ b/tests/Composer/Test/Mock/HttpDownloaderMock.php
@@ -12,13 +12,11 @@
 
 namespace Composer\Test\Mock;
 
-use Composer\Util\RemoteFilesystem;
+use Composer\Util\HttpDownloader;
+use Composer\Util\Http\Response;
 use Composer\Downloader\TransportException;
 
-/**
- * Remote filesystem mock
- */
-class RemoteFilesystemMock extends RemoteFilesystem
+class HttpDownloaderMock extends HttpDownloader
 {
     protected $contentMap;
 
@@ -30,10 +28,10 @@ class RemoteFilesystemMock extends RemoteFilesystem
         $this->contentMap = $contentMap;
     }
 
-    public function getContents($originUrl, $fileUrl, $progress = true, $options = array())
+    public function get($fileUrl, $options = array())
     {
         if (!empty($this->contentMap[$fileUrl])) {
-            return $this->contentMap[$fileUrl];
+            return new Response(array('url' => $fileUrl), 200, array(), $this->contentMap[$fileUrl]);
         }
 
         throw new TransportException('The "'.$fileUrl.'" file could not be downloaded (NOT FOUND)', 404);

--- a/tests/Composer/Test/Mock/InstallationManagerMock.php
+++ b/tests/Composer/Test/Mock/InstallationManagerMock.php
@@ -17,6 +17,7 @@ use Composer\Repository\RepositoryInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Package\PackageInterface;
 use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\MarkAliasInstalledOperation;
@@ -28,6 +29,18 @@ class InstallationManagerMock extends InstallationManager
     private $updated = array();
     private $uninstalled = array();
     private $trace = array();
+
+    public function __construct()
+    {
+
+    }
+
+    public function execute(RepositoryInterface $repo, OperationInterface $operation)
+    {
+        $method = $operation->getJobType();
+        // skipping download() step here for tests
+        $this->$method($repo, $operation);
+    }
 
     public function getInstallPath(PackageInterface $package)
     {

--- a/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
@@ -12,9 +12,11 @@
 
 namespace Composer\Test\Package\Archiver;
 
+use Composer\IO\NullIO;
 use Composer\Factory;
 use Composer\Package\Archiver\ArchiveManager;
 use Composer\Package\PackageInterface;
+use Composer\Test\Mock\FactoryMock;
 
 class ArchiveManagerTest extends ArchiverTest
 {
@@ -30,7 +32,12 @@ class ArchiveManagerTest extends ArchiverTest
         parent::setUp();
 
         $factory = new Factory();
-        $this->manager = $factory->createArchiveManager($factory->createConfig());
+        $dm = $factory->createDownloadManager(
+            $io = new NullIO,
+            $config = FactoryMock::createConfig(),
+            $factory->createHttpDownloader($io, $config)
+        );
+        $this->manager = $factory->createArchiveManager($factory->createConfig(), $dm);
         $this->targetDir = $this->testDir.'/composer_archiver_tests';
     }
 

--- a/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
@@ -16,6 +16,7 @@ use Composer\IO\NullIO;
 use Composer\Factory;
 use Composer\Package\Archiver\ArchiveManager;
 use Composer\Package\PackageInterface;
+use Composer\Util\Loop;
 use Composer\Test\Mock\FactoryMock;
 
 class ArchiveManagerTest extends ArchiverTest
@@ -35,9 +36,10 @@ class ArchiveManagerTest extends ArchiverTest
         $dm = $factory->createDownloadManager(
             $io = new NullIO,
             $config = FactoryMock::createConfig(),
-            $factory->createHttpDownloader($io, $config)
+            $httpDownloader = $factory->createHttpDownloader($io, $config)
         );
-        $this->manager = $factory->createArchiveManager($factory->createConfig(), $dm);
+        $loop = new Loop($httpDownloader);
+        $this->manager = $factory->createArchiveManager($factory->createConfig(), $dm, $loop);
         $this->targetDir = $this->testDir.'/composer_archiver_tests';
     }
 

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -89,7 +89,7 @@ class PluginInstallerTest extends TestCase
             ->method('getLocalRepository')
             ->will($this->returnValue($this->repository));
 
-        $im = $this->getMockBuilder('Composer\Installer\InstallationManager')->getMock();
+        $im = $this->getMockBuilder('Composer\Installer\InstallationManager')->disableOriginalConstructor()->getMock();
         $im->expects($this->any())
             ->method('getInstallPath')
             ->will($this->returnCallback(function ($package) {

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -153,7 +153,9 @@ class ComposerRepositoryTest extends TestCase
             ),
         ));
 
-        $packages = $repo->whatProvides('a', false, array($this, 'isPackageAcceptableReturnTrue'));
+        $reflMethod = new \ReflectionMethod($repo, 'whatProvides');
+        $reflMethod->setAccessible(true);
+        $packages = $reflMethod->invoke($repo, 'a', array($this, 'isPackageAcceptableReturnTrue'));
 
         $this->assertCount(7, $packages);
         $this->assertEquals(array('1', '1-alias', '2', '2-alias', '2-root', '3', '3-root'), array_keys($packages));

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -32,7 +32,7 @@ class ComposerRepositoryTest extends TestCase
         );
 
         $repository = $this->getMockBuilder('Composer\Repository\ComposerRepository')
-            ->setMethods(array('loadRootServerFile', 'createPackage'))
+            ->setMethods(array('loadRootServerFile', 'createPackages'))
             ->setConstructorArgs(array(
                 $repoConfig,
                 new NullIO,
@@ -47,15 +47,16 @@ class ComposerRepositoryTest extends TestCase
             ->method('loadRootServerFile')
             ->will($this->returnValue($repoPackages));
 
+        $stubs = array();
         foreach ($expected as $at => $arg) {
-            $stubPackage = $this->getPackage('stub/stub', '1.0.0');
-
-            $repository
-                ->expects($this->at($at + 2))
-                ->method('createPackage')
-                ->with($this->identicalTo($arg), $this->equalTo('Composer\Package\CompletePackage'))
-                ->will($this->returnValue($stubPackage));
+            $stubs[] = $this->getPackage('stub/stub', '1.0.0');
         }
+
+        $repository
+            ->expects($this->at(2))
+            ->method('createPackages')
+            ->with($this->identicalTo($expected), $this->equalTo('Composer\Package\CompletePackage'))
+            ->will($this->returnValue($stubs));
 
         // Triggers initialization
         $packages = $repository->getPackages();

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -146,21 +146,12 @@ class ComposerRepositoryTest extends TestCase
             )));
 
         $versionParser = new VersionParser();
-        $repo->setRootAliases(array(
-            'a' => array(
-                $versionParser->normalize('0.6') => array('alias' => 'dev-feature', 'alias_normalized' => $versionParser->normalize('dev-feature')),
-                $versionParser->normalize('1.1.x-dev') => array('alias' => '1.0', 'alias_normalized' => $versionParser->normalize('1.0')),
-            ),
-        ));
-
         $reflMethod = new \ReflectionMethod($repo, 'whatProvides');
         $reflMethod->setAccessible(true);
         $packages = $reflMethod->invoke($repo, 'a', array($this, 'isPackageAcceptableReturnTrue'));
 
-        $this->assertCount(7, $packages);
-        $this->assertEquals(array('1', '1-alias', '2', '2-alias', '2-root', '3', '3-root'), array_keys($packages));
-        $this->assertInstanceOf('Composer\Package\AliasPackage', $packages['2-root']);
-        $this->assertSame($packages['2'], $packages['2-root']->getAliasOf());
+        $this->assertCount(5, $packages);
+        $this->assertEquals(array('1', '1-alias', '2', '2-alias', '3'), array_keys($packages));
         $this->assertSame($packages['2'], $packages['2-alias']->getAliasOf());
     }
 

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -37,8 +37,8 @@ class ComposerRepositoryTest extends TestCase
                 $repoConfig,
                 new NullIO,
                 FactoryMock::createConfig(),
-                $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock(),
-                $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock()
+                $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock(),
+                $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock()
             ))
             ->getMock();
 
@@ -203,7 +203,7 @@ class ComposerRepositoryTest extends TestCase
             ->with($url = 'http://example.org/search.json?q=foo&type=library')
             ->willReturn(new \Composer\Util\Http\Response(array('url' => $url), 200, array(), json_encode(array())));
 
-        $repository = new ComposerRepository($repoConfig, new NullIO, FactoryMock::createConfig(), $eventDispatcher, $httpDownloader);
+        $repository = new ComposerRepository($repoConfig, new NullIO, FactoryMock::createConfig(), $httpDownloader, $eventDispatcher);
 
         $this->assertSame(
             array(array('name' => 'foo', 'description' => null)),

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -14,8 +14,8 @@ namespace Composer\Test\Repository;
 
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Repository\PathRepository;
-use Composer\Semver\VersionParser;
 use Composer\Test\TestCase;
+use Composer\Package\Version\VersionParser;
 
 class PathRepositoryTest extends TestCase
 {

--- a/tests/Composer/Test/Repository/Pear/ChannelReaderTest.php
+++ b/tests/Composer/Test/Repository/Pear/ChannelReaderTest.php
@@ -22,13 +22,13 @@ use Composer\Semver\VersionParser;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Package\Link;
 use Composer\Package\CompletePackage;
-use Composer\Test\Mock\RemoteFilesystemMock;
+use Composer\Test\Mock\HttpDownloaderMock;
 
 class ChannelReaderTest extends TestCase
 {
     public function testShouldBuildPackagesFromPearSchema()
     {
-        $rfs = new RemoteFilesystemMock(array(
+        $rfs = new HttpDownloaderMock(array(
             'http://pear.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
             'http://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
             'http://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),
@@ -50,11 +50,15 @@ class ChannelReaderTest extends TestCase
 
     public function testShouldSelectCorrectReader()
     {
-        $rfs = new RemoteFilesystemMock(array(
+        $rfs = new HttpDownloaderMock(array(
             'http://pear.1.0.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.0.xml'),
             'http://test.loc/rest10/p/packages.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/packages.xml'),
             'http://test.loc/rest10/p/http_client/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_info.xml'),
+            'http://test.loc/rest10/r/http_client/allreleases.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_allreleases.xml'),
+            'http://test.loc/rest10/r/http_client/deps.1.2.1.txt' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_deps.1.2.1.txt'),
             'http://test.loc/rest10/p/http_request/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_info.xml'),
+            'http://test.loc/rest10/r/http_request/allreleases.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_allreleases.xml'),
+            'http://test.loc/rest10/r/http_request/deps.1.4.0.txt' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_deps.1.4.0.txt'),
             'http://pear.1.1.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
             'http://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
             'http://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),

--- a/tests/Composer/Test/Repository/Pear/ChannelReaderTest.php
+++ b/tests/Composer/Test/Repository/Pear/ChannelReaderTest.php
@@ -28,13 +28,13 @@ class ChannelReaderTest extends TestCase
 {
     public function testShouldBuildPackagesFromPearSchema()
     {
-        $rfs = new HttpDownloaderMock(array(
+        $httpDownloader = new HttpDownloaderMock(array(
             'http://pear.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
             'http://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
             'http://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),
         ));
 
-        $reader = new \Composer\Repository\Pear\ChannelReader($rfs);
+        $reader = new \Composer\Repository\Pear\ChannelReader($httpDownloader);
 
         $channelInfo = $reader->read('http://pear.net/');
         $packages = $channelInfo->getPackages();
@@ -50,7 +50,7 @@ class ChannelReaderTest extends TestCase
 
     public function testShouldSelectCorrectReader()
     {
-        $rfs = new HttpDownloaderMock(array(
+        $httpDownloader = new HttpDownloaderMock(array(
             'http://pear.1.0.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.0.xml'),
             'http://test.loc/rest10/p/packages.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/packages.xml'),
             'http://test.loc/rest10/p/http_client/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_info.xml'),
@@ -64,7 +64,7 @@ class ChannelReaderTest extends TestCase
             'http://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),
         ));
 
-        $reader = new \Composer\Repository\Pear\ChannelReader($rfs);
+        $reader = new \Composer\Repository\Pear\ChannelReader($httpDownloader);
 
         $reader->read('http://pear.1.0.net/');
         $reader->read('http://pear.1.1.net/');

--- a/tests/Composer/Test/Repository/Pear/ChannelRest10ReaderTest.php
+++ b/tests/Composer/Test/Repository/Pear/ChannelRest10ReaderTest.php
@@ -13,13 +13,13 @@
 namespace Composer\Test\Repository\Pear;
 
 use Composer\Test\TestCase;
-use Composer\Test\Mock\RemoteFilesystemMock;
+use Composer\Test\Mock\HttpDownloaderMock;
 
 class ChannelRest10ReaderTest extends TestCase
 {
     public function testShouldBuildPackagesFromPearSchema()
     {
-        $rfs = new RemoteFilesystemMock(array(
+        $rfs = new HttpDownloaderMock(array(
             'http://test.loc/rest10/p/packages.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/packages.xml'),
             'http://test.loc/rest10/p/http_client/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_info.xml'),
             'http://test.loc/rest10/r/http_client/allreleases.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_allreleases.xml'),

--- a/tests/Composer/Test/Repository/Pear/ChannelRest10ReaderTest.php
+++ b/tests/Composer/Test/Repository/Pear/ChannelRest10ReaderTest.php
@@ -19,7 +19,7 @@ class ChannelRest10ReaderTest extends TestCase
 {
     public function testShouldBuildPackagesFromPearSchema()
     {
-        $rfs = new HttpDownloaderMock(array(
+        $httpDownloader = new HttpDownloaderMock(array(
             'http://test.loc/rest10/p/packages.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/packages.xml'),
             'http://test.loc/rest10/p/http_client/info.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_info.xml'),
             'http://test.loc/rest10/r/http_client/allreleases.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_client_allreleases.xml'),
@@ -29,7 +29,7 @@ class ChannelRest10ReaderTest extends TestCase
             'http://test.loc/rest10/r/http_request/deps.1.4.0.txt' => file_get_contents(__DIR__ . '/Fixtures/Rest1.0/http_request_deps.1.4.0.txt'),
         ));
 
-        $reader = new \Composer\Repository\Pear\ChannelRest10Reader($rfs);
+        $reader = new \Composer\Repository\Pear\ChannelRest10Reader($httpDownloader);
 
         /** @var \Composer\Package\PackageInterface[] $packages */
         $packages = $reader->read('http://test.loc/rest10');

--- a/tests/Composer/Test/Repository/Pear/ChannelRest11ReaderTest.php
+++ b/tests/Composer/Test/Repository/Pear/ChannelRest11ReaderTest.php
@@ -19,13 +19,13 @@ class ChannelRest11ReaderTest extends TestCase
 {
     public function testShouldBuildPackagesFromPearSchema()
     {
-        $rfs = new HttpDownloaderMock(array(
+        $httpDownloader = new HttpDownloaderMock(array(
             'http://pear.1.1.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
             'http://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
             'http://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),
         ));
 
-        $reader = new \Composer\Repository\Pear\ChannelRest11Reader($rfs);
+        $reader = new \Composer\Repository\Pear\ChannelRest11Reader($httpDownloader);
 
         /** @var \Composer\Package\PackageInterface[] $packages */
         $packages = $reader->read('http://test.loc/rest11');

--- a/tests/Composer/Test/Repository/Pear/ChannelRest11ReaderTest.php
+++ b/tests/Composer/Test/Repository/Pear/ChannelRest11ReaderTest.php
@@ -13,13 +13,13 @@
 namespace Composer\Test\Repository\Pear;
 
 use Composer\Test\TestCase;
-use Composer\Test\Mock\RemoteFilesystemMock;
+use Composer\Test\Mock\HttpDownloaderMock;
 
 class ChannelRest11ReaderTest extends TestCase
 {
     public function testShouldBuildPackagesFromPearSchema()
     {
-        $rfs = new RemoteFilesystemMock(array(
+        $rfs = new HttpDownloaderMock(array(
             'http://pear.1.1.net/channel.xml' => file_get_contents(__DIR__ . '/Fixtures/channel.1.1.xml'),
             'http://test.loc/rest11/c/categories.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/categories.xml'),
             'http://test.loc/rest11/c/Default/packagesinfo.xml' => file_get_contents(__DIR__ . '/Fixtures/Rest1.1/packagesinfo.xml'),

--- a/tests/Composer/Test/Repository/PearRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PearRepositoryTest.php
@@ -133,7 +133,7 @@ class PearRepositoryTest extends TestCase
 
         $config = new \Composer\Config();
 
-        $this->remoteFilesystem = $this->getMockBuilder('Composer\Util\RemoteFilesystem')
+        $this->httpDownloader = $this->getMockBuilder('Composer\Util\HttpDownloader')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -143,6 +143,6 @@ class PearRepositoryTest extends TestCase
     protected function tearDown()
     {
         $this->repository = null;
-        $this->remoteFilesystem = null;
+        $this->httpDownloader = null;
     }
 }

--- a/tests/Composer/Test/Repository/PearRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PearRepositoryTest.php
@@ -28,7 +28,7 @@ class PearRepositoryTest extends TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    private $remoteFilesystem;
+    private $httpDownloader;
 
     public function testComposerShouldSetIncludePath()
     {

--- a/tests/Composer/Test/Repository/RepositoryFactoryTest.php
+++ b/tests/Composer/Test/Repository/RepositoryFactoryTest.php
@@ -21,7 +21,9 @@ class RepositoryFactoryTest extends TestCase
     {
         $manager = RepositoryFactory::manager(
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
-            $this->getMockBuilder('Composer\Config')->getMock()
+            $this->getMockBuilder('Composer\Config')->getMock(),
+            $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock()
         );
 
         $ref = new \ReflectionProperty($manager, 'repositoryClasses');

--- a/tests/Composer/Test/Repository/RepositoryManagerTest.php
+++ b/tests/Composer/Test/Repository/RepositoryManagerTest.php
@@ -38,8 +38,8 @@ class RepositoryManagerTest extends TestCase
         $rm = new RepositoryManager(
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
             $this->getMockBuilder('Composer\Config')->getMock(),
-            $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock(),
-            $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock()
+            $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock()
         );
 
         $repository1 = $this->getMockBuilder('Composer\Repository\RepositoryInterface')->getMock();
@@ -62,8 +62,8 @@ class RepositoryManagerTest extends TestCase
         $rm = new RepositoryManager(
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
             $config = $this->getMockBuilder('Composer\Config')->setMethods(array('get'))->getMock(),
-            $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock(),
-            $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock()
+            $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock()
         );
 
         $tmpdir = $this->tmpdir;

--- a/tests/Composer/Test/Repository/RepositoryManagerTest.php
+++ b/tests/Composer/Test/Repository/RepositoryManagerTest.php
@@ -38,7 +38,8 @@ class RepositoryManagerTest extends TestCase
         $rm = new RepositoryManager(
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
             $this->getMockBuilder('Composer\Config')->getMock(),
-            $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock()
+            $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock()
         );
 
         $repository1 = $this->getMockBuilder('Composer\Repository\RepositoryInterface')->getMock();
@@ -61,7 +62,8 @@ class RepositoryManagerTest extends TestCase
         $rm = new RepositoryManager(
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
             $config = $this->getMockBuilder('Composer\Config')->setMethods(array('get'))->getMock(),
-            $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock()
+            $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock()
         );
 
         $tmpdir = $this->tmpdir;

--- a/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
@@ -16,6 +16,7 @@ use Composer\Config;
 use Composer\Repository\Vcs\GitBitbucketDriver;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
+use Composer\Util\Http\Response;
 
 /**
  * @group bitbucket
@@ -26,8 +27,8 @@ class GitBitbucketDriverTest extends TestCase
     private $io;
     /** @type \Composer\Config */
     private $config;
-    /** @type \Composer\Util\RemoteFilesystem|\PHPUnit_Framework_MockObject_MockObject */
-    private $rfs;
+    /** @type \Composer\Util\HttpDownloader|\PHPUnit_Framework_MockObject_MockObject */
+    private $httpDownloader;
     /** @type string */
     private $home;
     /** @type string */
@@ -46,7 +47,7 @@ class GitBitbucketDriverTest extends TestCase
             ),
         ));
 
-        $this->rfs = $this->getMockBuilder('Composer\Util\RemoteFilesystem')
+        $this->httpDownloader = $this->getMockBuilder('Composer\Util\HttpDownloader')
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -68,7 +69,7 @@ class GitBitbucketDriverTest extends TestCase
             $this->io,
             $this->config,
             null,
-            $this->rfs
+            $this->httpDownloader
         );
 
         $driver->initialize();
@@ -83,15 +84,14 @@ class GitBitbucketDriverTest extends TestCase
             'https://bitbucket.org/user/repo.git does not appear to be a git repository, use https://bitbucket.org/user/repo if this is a mercurial bitbucket repository'
         );
 
-        $this->rfs->expects($this->once())
-            ->method('getContents')
+        $this->httpDownloader->expects($this->once())
+            ->method('get')
             ->with(
-                $this->originUrl,
-                'https://api.bitbucket.org/2.0/repositories/user/repo?fields=-project%2C-owner',
-                false
+                $url = 'https://api.bitbucket.org/2.0/repositories/user/repo?fields=-project%2C-owner',
+                array()
             )
             ->willReturn(
-                '{"scm":"hg","website":"","has_wiki":false,"name":"repo","links":{"branches":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/branches"},"tags":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/tags"},"clone":[{"href":"https:\/\/user@bitbucket.org\/user\/repo","name":"https"},{"href":"ssh:\/\/hg@bitbucket.org\/user\/repo","name":"ssh"}],"html":{"href":"https:\/\/bitbucket.org\/user\/repo"}},"language":"php","created_on":"2015-02-18T16:22:24.688+00:00","updated_on":"2016-05-17T13:20:21.993+00:00","is_private":true,"has_issues":false}'
+                new Response(array('url' => $url), 200, array(), '{"scm":"hg","website":"","has_wiki":false,"name":"repo","links":{"branches":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/branches"},"tags":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/tags"},"clone":[{"href":"https:\/\/user@bitbucket.org\/user\/repo","name":"https"},{"href":"ssh:\/\/hg@bitbucket.org\/user\/repo","name":"ssh"}],"html":{"href":"https:\/\/bitbucket.org\/user\/repo"}},"language":"php","created_on":"2015-02-18T16:22:24.688+00:00","updated_on":"2016-05-17T13:20:21.993+00:00","is_private":true,"has_issues":false}')
             );
 
         $driver = $this->getDriver(array('url' => 'https://bitbucket.org/user/repo.git'));
@@ -103,47 +103,43 @@ class GitBitbucketDriverTest extends TestCase
     {
         $driver = $this->getDriver(array('url' => 'https://bitbucket.org/user/repo.git'));
 
-        $this->rfs->expects($this->any())
-            ->method('getContents')
+        $urls = array(
+            'https://api.bitbucket.org/2.0/repositories/user/repo?fields=-project%2C-owner',
+            'https://api.bitbucket.org/2.0/repositories/user/repo?fields=mainbranch',
+            'https://api.bitbucket.org/2.0/repositories/user/repo/refs/tags?pagelen=100&fields=values.name%2Cvalues.target.hash%2Cnext&sort=-target.date',
+            'https://api.bitbucket.org/2.0/repositories/user/repo/refs/branches?pagelen=100&fields=values.name%2Cvalues.target.hash%2Cvalues.heads%2Cnext&sort=-target.date',
+            'https://api.bitbucket.org/2.0/repositories/user/repo/src/master/composer.json',
+            'https://api.bitbucket.org/2.0/repositories/user/repo/commit/master?fields=date',
+        );
+        $this->httpDownloader->expects($this->any())
+            ->method('get')
             ->withConsecutive(
                 array(
-                    $this->originUrl,
-                    'https://api.bitbucket.org/2.0/repositories/user/repo?fields=-project%2C-owner',
-                    false,
+                    $urls[0], array()
                 ),
                 array(
-                    $this->originUrl,
-                    'https://api.bitbucket.org/2.0/repositories/user/repo?fields=mainbranch',
-                    false,
+                    $urls[1], array()
                 ),
                 array(
-                    $this->originUrl,
-                    'https://api.bitbucket.org/2.0/repositories/user/repo/refs/tags?pagelen=100&fields=values.name%2Cvalues.target.hash%2Cnext&sort=-target.date',
-                    false,
+                    $urls[2], array()
                 ),
                 array(
-                    $this->originUrl,
-                    'https://api.bitbucket.org/2.0/repositories/user/repo/refs/branches?pagelen=100&fields=values.name%2Cvalues.target.hash%2Cvalues.heads%2Cnext&sort=-target.date',
-                    false,
+                    $urls[3], array()
                 ),
                 array(
-                    $this->originUrl,
-                    'https://api.bitbucket.org/2.0/repositories/user/repo/src/master/composer.json',
-                    false,
+                    $urls[4], array()
                 ),
                 array(
-                    $this->originUrl,
-                    'https://api.bitbucket.org/2.0/repositories/user/repo/commit/master?fields=date',
-                    false,
+                    $urls[5], array()
                 )
             )
             ->willReturnOnConsecutiveCalls(
-                '{"scm":"git","website":"","has_wiki":false,"name":"repo","links":{"branches":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/branches"},"tags":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/tags"},"clone":[{"href":"https:\/\/user@bitbucket.org\/user\/repo.git","name":"https"},{"href":"ssh:\/\/git@bitbucket.org\/user\/repo.git","name":"ssh"}],"html":{"href":"https:\/\/bitbucket.org\/user\/repo"}},"language":"php","created_on":"2015-02-18T16:22:24.688+00:00","updated_on":"2016-05-17T13:20:21.993+00:00","is_private":true,"has_issues":false}',
-                '{"mainbranch": {"name": "master"}}',
-                '{"values":[{"name":"1.0.1","target":{"hash":"9b78a3932143497c519e49b8241083838c8ff8a1"}},{"name":"1.0.0","target":{"hash":"d3393d514318a9267d2f8ebbf463a9aaa389f8eb"}}]}',
-                '{"values":[{"name":"master","target":{"hash":"937992d19d72b5116c3e8c4a04f960e5fa270b22"}}]}',
-                '{"name": "user/repo","description": "test repo","license": "GPL","authors": [{"name": "Name","email": "local@domain.tld"}],"require": {"creator/package": "^1.0"},"require-dev": {"phpunit/phpunit": "~4.8"}}',
-                '{"date": "2016-05-17T13:19:52+00:00"}'
+                new Response(array('url' => $urls[0]), 200, array(), '{"scm":"git","website":"","has_wiki":false,"name":"repo","links":{"branches":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/branches"},"tags":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/tags"},"clone":[{"href":"https:\/\/user@bitbucket.org\/user\/repo.git","name":"https"},{"href":"ssh:\/\/git@bitbucket.org\/user\/repo.git","name":"ssh"}],"html":{"href":"https:\/\/bitbucket.org\/user\/repo"}},"language":"php","created_on":"2015-02-18T16:22:24.688+00:00","updated_on":"2016-05-17T13:20:21.993+00:00","is_private":true,"has_issues":false}'),
+                new Response(array('url' => $urls[1]), 200, array(), '{"mainbranch": {"name": "master"}}'),
+                new Response(array('url' => $urls[2]), 200, array(), '{"values":[{"name":"1.0.1","target":{"hash":"9b78a3932143497c519e49b8241083838c8ff8a1"}},{"name":"1.0.0","target":{"hash":"d3393d514318a9267d2f8ebbf463a9aaa389f8eb"}}]}'),
+                new Response(array('url' => $urls[3]), 200, array(), '{"values":[{"name":"master","target":{"hash":"937992d19d72b5116c3e8c4a04f960e5fa270b22"}}]}'),
+                new Response(array('url' => $urls[4]), 200, array(), '{"name": "user/repo","description": "test repo","license": "GPL","authors": [{"name": "Name","email": "local@domain.tld"}],"require": {"creator/package": "^1.0"},"require-dev": {"phpunit/phpunit": "~4.8"}}'),
+                new Response(array('url' => $urls[5]), 200, array(), '{"date": "2016-05-17T13:19:52+00:00"}')
             );
 
         $this->assertEquals(

--- a/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
@@ -16,6 +16,7 @@ use Composer\Config;
 use Composer\Repository\Vcs\GitBitbucketDriver;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
+use Composer\Util\ProcessExecutor;
 use Composer\Util\Http\Response;
 
 /**
@@ -68,8 +69,8 @@ class GitBitbucketDriverTest extends TestCase
             $repoConfig,
             $this->io,
             $this->config,
-            null,
-            $this->httpDownloader
+            $this->httpDownloader,
+            new ProcessExecutor($this->io)
         );
 
         $driver->initialize();

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -96,7 +96,7 @@ class GitHubDriverTest extends TestCase
             'url' => $repoUrl,
         );
 
-        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $process, $httpDownloader);
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $httpDownloader, $process);
         $gitHubDriver->initialize();
         $this->setAttribute($gitHubDriver, 'tags', array($identifier => $sha));
 
@@ -139,7 +139,11 @@ class GitHubDriverTest extends TestCase
         );
         $repoUrl = 'https://github.com/composer/packagist.git';
 
-        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, null, $httpDownloader);
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $httpDownloader, $process);
         $gitHubDriver->initialize();
         $this->setAttribute($gitHubDriver, 'tags', array($identifier => $sha));
 
@@ -192,7 +196,11 @@ class GitHubDriverTest extends TestCase
         );
         $repoUrl = 'https://github.com/composer/packagist.git';
 
-        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, null, $httpDownloader);
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config,$httpDownloader, $process);
         $gitHubDriver->initialize();
         $this->setAttribute($gitHubDriver, 'tags', array($identifier => $sha));
 
@@ -279,7 +287,7 @@ class GitHubDriverTest extends TestCase
             'url' => $repoUrl,
         );
 
-        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $process, $httpDownloader);
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $httpDownloader, $process);
         $gitHubDriver->initialize();
 
         $this->assertEquals('test_master', $gitHubDriver->getRootIdentifier());

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -16,6 +16,7 @@ use Composer\Downloader\TransportException;
 use Composer\Repository\Vcs\GitHubDriver;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
+use Composer\Util\Http\Response;
 use Composer\Config;
 
 class GitHubDriverTest extends TestCase
@@ -53,8 +54,8 @@ class GitHubDriverTest extends TestCase
             ->method('isInteractive')
             ->will($this->returnValue(true));
 
-        $remoteFilesystem = $this->getMockBuilder('Composer\Util\RemoteFilesystem')
-            ->setConstructorArgs(array($io))
+        $httpDownloader = $this->getMockBuilder('Composer\Util\HttpDownloader')
+            ->setConstructorArgs(array($io, $this->config))
             ->getMock();
 
         $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
@@ -62,9 +63,9 @@ class GitHubDriverTest extends TestCase
             ->method('execute')
             ->will($this->returnValue(1));
 
-        $remoteFilesystem->expects($this->at(0))
-            ->method('getContents')
-            ->with($this->equalTo('github.com'), $this->equalTo($repoApiUrl), $this->equalTo(false))
+        $httpDownloader->expects($this->at(0))
+            ->method('get')
+            ->with($this->equalTo($repoApiUrl))
             ->will($this->throwException(new TransportException('HTTP/1.1 404 Not Found', 404)));
 
         $io->expects($this->once())
@@ -76,15 +77,15 @@ class GitHubDriverTest extends TestCase
             ->method('setAuthentication')
             ->with($this->equalTo('github.com'), $this->matchesRegularExpression('{sometoken}'), $this->matchesRegularExpression('{x-oauth-basic}'));
 
-        $remoteFilesystem->expects($this->at(1))
-            ->method('getContents')
-            ->with($this->equalTo('github.com'), $this->equalTo('https://api.github.com/'), $this->equalTo(false))
-            ->will($this->returnValue('{}'));
+        $httpDownloader->expects($this->at(1))
+            ->method('get')
+            ->with($this->equalTo($url = 'https://api.github.com/'))
+            ->will($this->returnValue(new Response(array('url' => $url), 200, array(), '{}')));
 
-        $remoteFilesystem->expects($this->at(2))
-            ->method('getContents')
-            ->with($this->equalTo('github.com'), $this->equalTo($repoApiUrl), $this->equalTo(false))
-            ->will($this->returnValue('{"master_branch": "test_master", "private": true, "owner": {"login": "composer"}, "name": "packagist"}'));
+        $httpDownloader->expects($this->at(2))
+            ->method('get')
+            ->with($this->equalTo($url = $repoApiUrl))
+            ->will($this->returnValue(new Response(array('url' => $url), 200, array(), '{"master_branch": "test_master", "private": true, "owner": {"login": "composer"}, "name": "packagist"}')));
 
         $configSource = $this->getMockBuilder('Composer\Config\ConfigSourceInterface')->getMock();
         $authConfigSource = $this->getMockBuilder('Composer\Config\ConfigSourceInterface')->getMock();
@@ -95,7 +96,7 @@ class GitHubDriverTest extends TestCase
             'url' => $repoUrl,
         );
 
-        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $process, $remoteFilesystem);
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $process, $httpDownloader);
         $gitHubDriver->initialize();
         $this->setAttribute($gitHubDriver, 'tags', array($identifier => $sha));
 
@@ -124,21 +125,21 @@ class GitHubDriverTest extends TestCase
             ->method('isInteractive')
             ->will($this->returnValue(true));
 
-        $remoteFilesystem = $this->getMockBuilder('Composer\Util\RemoteFilesystem')
-            ->setConstructorArgs(array($io))
+        $httpDownloader = $this->getMockBuilder('Composer\Util\HttpDownloader')
+            ->setConstructorArgs(array($io, $this->config))
             ->getMock();
 
-        $remoteFilesystem->expects($this->at(0))
-            ->method('getContents')
-            ->with($this->equalTo('github.com'), $this->equalTo($repoApiUrl), $this->equalTo(false))
-            ->will($this->returnValue('{"master_branch": "test_master", "owner": {"login": "composer"}, "name": "packagist"}'));
+        $httpDownloader->expects($this->at(0))
+            ->method('get')
+            ->with($this->equalTo($repoApiUrl))
+            ->will($this->returnValue(new Response(array('url' => $repoApiUrl), 200, array(), '{"master_branch": "test_master", "owner": {"login": "composer"}, "name": "packagist"}')));
 
         $repoConfig = array(
             'url' => $repoUrl,
         );
         $repoUrl = 'https://github.com/composer/packagist.git';
 
-        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, null, $remoteFilesystem);
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, null, $httpDownloader);
         $gitHubDriver->initialize();
         $this->setAttribute($gitHubDriver, 'tags', array($identifier => $sha));
 
@@ -167,31 +168,31 @@ class GitHubDriverTest extends TestCase
             ->method('isInteractive')
             ->will($this->returnValue(true));
 
-        $remoteFilesystem = $this->getMockBuilder('Composer\Util\RemoteFilesystem')
-            ->setConstructorArgs(array($io))
+        $httpDownloader = $this->getMockBuilder('Composer\Util\HttpDownloader')
+            ->setConstructorArgs(array($io, $this->config))
             ->getMock();
 
-        $remoteFilesystem->expects($this->at(0))
-            ->method('getContents')
-            ->with($this->equalTo('github.com'), $this->equalTo($repoApiUrl), $this->equalTo(false))
-            ->will($this->returnValue('{"master_branch": "test_master", "owner": {"login": "composer"}, "name": "packagist"}'));
+        $httpDownloader->expects($this->at(0))
+            ->method('get')
+            ->with($this->equalTo($url = $repoApiUrl))
+            ->will($this->returnValue(new Response(array('url' => $url), 200, array(), '{"master_branch": "test_master", "owner": {"login": "composer"}, "name": "packagist"}')));
 
-        $remoteFilesystem->expects($this->at(1))
-            ->method('getContents')
-            ->with($this->equalTo('github.com'), $this->equalTo('https://api.github.com/repos/composer/packagist/contents/composer.json?ref=feature%2F3.2-foo'), $this->equalTo(false))
-            ->will($this->returnValue('{"encoding":"base64","content":"'.base64_encode('{"support": {"source": "'.$repoUrl.'" }}').'"}'));
+        $httpDownloader->expects($this->at(1))
+            ->method('get')
+            ->with($this->equalTo($url = 'https://api.github.com/repos/composer/packagist/contents/composer.json?ref=feature%2F3.2-foo'))
+            ->will($this->returnValue(new Response(array('url' => $url), 200, array(), '{"encoding":"base64","content":"'.base64_encode('{"support": {"source": "'.$repoUrl.'" }}').'"}')));
 
-        $remoteFilesystem->expects($this->at(2))
-            ->method('getContents')
-            ->with($this->equalTo('github.com'), $this->equalTo('https://api.github.com/repos/composer/packagist/commits/feature%2F3.2-foo'), $this->equalTo(false))
-            ->will($this->returnValue('{"commit": {"committer":{ "date": "2012-09-10"}}}'));
+        $httpDownloader->expects($this->at(2))
+            ->method('get')
+            ->with($this->equalTo($url = 'https://api.github.com/repos/composer/packagist/commits/feature%2F3.2-foo'))
+            ->will($this->returnValue(new Response(array('url' => $url), 200, array(), '{"commit": {"committer":{ "date": "2012-09-10"}}}')));
 
         $repoConfig = array(
             'url' => $repoUrl,
         );
         $repoUrl = 'https://github.com/composer/packagist.git';
 
-        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, null, $remoteFilesystem);
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, null, $httpDownloader);
         $gitHubDriver->initialize();
         $this->setAttribute($gitHubDriver, 'tags', array($identifier => $sha));
 
@@ -227,13 +228,13 @@ class GitHubDriverTest extends TestCase
             ->method('isInteractive')
             ->will($this->returnValue(false));
 
-        $remoteFilesystem = $this->getMockBuilder('Composer\Util\RemoteFilesystem')
-            ->setConstructorArgs(array($io))
+        $httpDownloader = $this->getMockBuilder('Composer\Util\HttpDownloader')
+            ->setConstructorArgs(array($io, $this->config))
             ->getMock();
 
-        $remoteFilesystem->expects($this->at(0))
-            ->method('getContents')
-            ->with($this->equalTo('github.com'), $this->equalTo($repoApiUrl), $this->equalTo(false))
+        $httpDownloader->expects($this->at(0))
+            ->method('get')
+            ->with($this->equalTo($repoApiUrl))
             ->will($this->throwException(new TransportException('HTTP/1.1 404 Not Found', 404)));
 
         // clean local clone if present
@@ -278,7 +279,7 @@ class GitHubDriverTest extends TestCase
             'url' => $repoUrl,
         );
 
-        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $process, $remoteFilesystem);
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $process, $httpDownloader);
         $gitHubDriver->initialize();
 
         $this->assertEquals('test_master', $gitHubDriver->getRootIdentifier());

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -92,7 +92,7 @@ JSON;
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->httpDownloader->reveal(), $this->process->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -129,7 +129,7 @@ JSON;
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->httpDownloader->reveal(), $this->process->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -165,7 +165,7 @@ JSON;
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->httpDownloader->reveal(), $this->process->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -204,7 +204,7 @@ JSON;
         $this->mockResponse($apiUrl, array(), sprintf($projectData, $domain, $port, $namespace))
             ->shouldBeCalledTimes(1);
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->httpDownloader->reveal(), $this->process->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -457,7 +457,7 @@ JSON;
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->httpDownloader->reveal(), $this->process->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -488,7 +488,7 @@ JSON;
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->httpDownloader->reveal(), $this->process->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -519,7 +519,7 @@ JSON;
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->httpDownloader->reveal(), $this->process->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -555,8 +555,8 @@ JSON;
             array('url' => 'https://gitlab.mycompany.local/mygroup/myproject', 'options' => $options),
             $this->io->reveal(),
             $this->config,
-            $this->process->reveal(),
-            $this->httpDownloader->reveal()
+            $this->httpDownloader->reveal(),
+            $this->process->reveal()
         );
         $driver->initialize();
     }

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -17,6 +17,7 @@ use Composer\Config;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
 use Prophecy\Argument;
+use Composer\Util\Http\Response;
 
 /**
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
@@ -27,7 +28,7 @@ class GitLabDriverTest extends TestCase
     private $config;
     private $io;
     private $process;
-    private $remoteFilesystem;
+    private $httpDownloader;
 
     public function setUp()
     {
@@ -47,7 +48,7 @@ class GitLabDriverTest extends TestCase
 
         $this->io = $this->prophesize('Composer\IO\IOInterface');
         $this->process = $this->prophesize('Composer\Util\ProcessExecutor');
-        $this->remoteFilesystem = $this->prophesize('Composer\Util\RemoteFilesystem');
+        $this->httpDownloader = $this->prophesize('Composer\Util\HttpDownloader');
     }
 
     public function tearDown()
@@ -87,13 +88,11 @@ class GitLabDriverTest extends TestCase
 }
 JSON;
 
-        $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false, array())
-            ->willReturn($projectData)
+        $this->mockResponse($apiUrl, array(), $projectData)
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->remoteFilesystem->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -126,13 +125,11 @@ JSON;
 }
 JSON;
 
-        $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false, array())
-            ->willReturn($projectData)
+        $this->mockResponse($apiUrl, array(), $projectData)
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->remoteFilesystem->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -164,13 +161,11 @@ JSON;
 }
 JSON;
 
-        $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false, array())
-            ->willReturn($projectData)
+        $this->mockResponse($apiUrl, array(), $projectData)
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->remoteFilesystem->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -206,12 +201,10 @@ JSON;
 }
 JSON;
 
-        $this->remoteFilesystem
-            ->getContents($domain, $apiUrl, false, array())
-            ->willReturn(sprintf($projectData, $domain, $port, $namespace))
+        $this->mockResponse($apiUrl, array(), sprintf($projectData, $domain, $port, $namespace))
             ->shouldBeCalledTimes(1);
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->remoteFilesystem->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -289,15 +282,11 @@ JSON;
 ]
 JSON;
 
-        $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false, array())
-            ->willReturn($tagData)
+        $this->mockResponse($apiUrl, array(), $tagData)
             ->shouldBeCalledTimes(1)
         ;
-        $this->remoteFilesystem->getLastHeaders()
-            ->willReturn(array());
 
-        $driver->setRemoteFilesystem($this->remoteFilesystem->reveal());
+        $driver->setHttpDownloader($this->httpDownloader->reveal());
 
         $expected = array(
             'v1.0.0' => '092ed2c762bbae331e3f51d4a17f67310bf99a81',
@@ -344,26 +333,20 @@ JSON;
 
         $branchData = json_encode($branchData);
 
-        $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false, array())
-            ->willReturn($branchData)
-            ->shouldBeCalledTimes(1)
-        ;
+        $headers = array('Link: <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=2&per_page=20>; rel="next", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=1&per_page=20>; rel="first", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=3&per_page=20>; rel="last"');
+        $this->httpDownloader
+            ->get($apiUrl, array())
+            ->willReturn(new Response(array('url' => $apiUrl), 200, $headers, $branchData))
+            ->shouldBeCalledTimes(1);
 
-        $this->remoteFilesystem
-            ->getContents('gitlab.com', "http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=2&per_page=20", false, array())
-            ->willReturn($branchData)
-            ->shouldBeCalledTimes(1)
-        ;
+        $apiUrl = "http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=2&per_page=20";
+        $headers = array('Link: <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=2&per_page=20>; rel="prev", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=1&per_page=20>; rel="first", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=3&per_page=20>; rel="last"');
+        $this->httpDownloader
+            ->get($apiUrl, array())
+            ->willReturn(new Response(array('url' => $apiUrl), 200, $headers, $branchData))
+            ->shouldBeCalledTimes(1);
 
-        $this->remoteFilesystem->getLastHeaders()
-            ->willReturn(
-                array('Link: <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=2&per_page=20>; rel="next", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=1&per_page=20>; rel="first", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=3&per_page=20>; rel="last"'),
-                array('Link: <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=2&per_page=20>; rel="prev", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=1&per_page=20>; rel="first", <http://gitlab.com/api/v4/projects/mygroup%2Fmyproject/repository/tags?id=mygroup%2Fmyproject&page=3&per_page=20>; rel="last"')
-            )
-            ->shouldBeCalledTimes(2);
-
-        $driver->setRemoteFilesystem($this->remoteFilesystem->reveal());
+        $driver->setHttpDownloader($this->httpDownloader->reveal());
 
         $expected = array(
             'mymaster' => '97eda36b5c1dd953a3792865c222d4e85e5f302e',
@@ -401,15 +384,11 @@ JSON;
 ]
 JSON;
 
-        $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false, array())
-            ->willReturn($branchData)
+        $this->mockResponse($apiUrl, array(), $branchData)
             ->shouldBeCalledTimes(1)
         ;
-        $this->remoteFilesystem->getLastHeaders()
-            ->willReturn(array());
 
-        $driver->setRemoteFilesystem($this->remoteFilesystem->reveal());
+        $driver->setHttpDownloader($this->httpDownloader->reveal());
 
         $expected = array(
             'mymaster' => '97eda36b5c1dd953a3792865c222d4e85e5f302e',
@@ -474,13 +453,11 @@ JSON;
 }
 JSON;
 
-        $this->remoteFilesystem
-            ->getContents('mycompany.com/gitlab', $apiUrl, false, array())
-            ->willReturn($projectData)
+        $this->mockResponse($apiUrl, array(), $projectData)
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->remoteFilesystem->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -507,13 +484,11 @@ JSON;
 }
 JSON;
 
-        $this->remoteFilesystem
-            ->getContents('gitlab.com', $apiUrl, false, array())
-            ->willReturn($projectData)
+        $this->mockResponse($apiUrl, array(), $projectData)
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->remoteFilesystem->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -540,13 +515,11 @@ JSON;
 }
 JSON;
 
-        $this->remoteFilesystem
-            ->getContents('mycompany.com/gitlab', $apiUrl, false, array())
-            ->willReturn($projectData)
+        $this->mockResponse($apiUrl, array(), $projectData)
             ->shouldBeCalledTimes(1)
         ;
 
-        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->remoteFilesystem->reveal());
+        $driver = new GitLabDriver(array('url' => $url), $this->io->reveal(), $this->config, $this->process->reveal(), $this->httpDownloader->reveal());
         $driver->initialize();
 
         $this->assertEquals($apiUrl, $driver->getApiUrl(), 'API URL is derived from the repository URL');
@@ -575,9 +548,7 @@ JSON;
 }
 JSON;
 
-        $this->remoteFilesystem
-            ->getContents(Argument::cetera(), $options)
-            ->willReturn($projectData)
+        $this->mockResponse(Argument::cetera(), $options, $projectData)
             ->shouldBeCalled();
 
         $driver = new GitLabDriver(
@@ -585,8 +556,15 @@ JSON;
             $this->io->reveal(),
             $this->config,
             $this->process->reveal(),
-            $this->remoteFilesystem->reveal()
+            $this->httpDownloader->reveal()
         );
         $driver->initialize();
+    }
+
+    private function mockResponse($url, $options, $return)
+    {
+        return $this->httpDownloader
+            ->get($url, $options)
+            ->willReturn(new Response(array('url' => $url), 200, array(), $return));
     }
 }

--- a/tests/Composer/Test/Repository/Vcs/PerforceDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/PerforceDriverTest.php
@@ -45,7 +45,7 @@ class PerforceDriverTest extends TestCase
         $this->process = $this->getMockProcessExecutor();
         $this->httpDownloader = $this->getMockHttpDownloader();
         $this->perforce = $this->getMockPerforce();
-        $this->driver = new PerforceDriver($this->repoConfig, $this->io, $this->config, $this->process, $this->httpDownloader);
+        $this->driver = new PerforceDriver($this->repoConfig, $this->io, $this->config, $this->httpDownloader, $this->process);
         $this->overrideDriverInternalPerforce($this->perforce);
     }
 
@@ -113,7 +113,7 @@ class PerforceDriverTest extends TestCase
 
     public function testInitializeCapturesVariablesFromRepoConfig()
     {
-        $driver = new PerforceDriver($this->repoConfig, $this->io, $this->config, $this->process, $this->httpDownloader);
+        $driver = new PerforceDriver($this->repoConfig, $this->io, $this->config, $this->httpDownloader, $this->process);
         $driver->initialize();
         $this->assertEquals(self::TEST_URL, $driver->getUrl());
         $this->assertEquals(self::TEST_DEPOT, $driver->getDepot());

--- a/tests/Composer/Test/Repository/Vcs/PerforceDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/PerforceDriverTest.php
@@ -26,7 +26,7 @@ class PerforceDriverTest extends TestCase
     protected $config;
     protected $io;
     protected $process;
-    protected $remoteFileSystem;
+    protected $httpDownloader;
     protected $testPath;
     protected $driver;
     protected $repoConfig;
@@ -43,9 +43,9 @@ class PerforceDriverTest extends TestCase
         $this->repoConfig = $this->getTestRepoConfig();
         $this->io = $this->getMockIOInterface();
         $this->process = $this->getMockProcessExecutor();
-        $this->remoteFileSystem = $this->getMockRemoteFilesystem();
+        $this->httpDownloader = $this->getMockHttpDownloader();
         $this->perforce = $this->getMockPerforce();
-        $this->driver = new PerforceDriver($this->repoConfig, $this->io, $this->config, $this->process, $this->remoteFileSystem);
+        $this->driver = new PerforceDriver($this->repoConfig, $this->io, $this->config, $this->process, $this->httpDownloader);
         $this->overrideDriverInternalPerforce($this->perforce);
     }
 
@@ -56,7 +56,7 @@ class PerforceDriverTest extends TestCase
         $fs->removeDirectory($this->testPath);
         $this->driver = null;
         $this->perforce = null;
-        $this->remoteFileSystem = null;
+        $this->httpDownloader = null;
         $this->process = null;
         $this->io = null;
         $this->repoConfig = null;
@@ -99,9 +99,9 @@ class PerforceDriverTest extends TestCase
         return $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
     }
 
-    protected function getMockRemoteFilesystem()
+    protected function getMockHttpDownloader()
     {
-        return $this->getMockBuilder('Composer\Util\RemoteFilesystem')->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock();
     }
 
     protected function getMockPerforce()
@@ -113,7 +113,7 @@ class PerforceDriverTest extends TestCase
 
     public function testInitializeCapturesVariablesFromRepoConfig()
     {
-        $driver = new PerforceDriver($this->repoConfig, $this->io, $this->config, $this->process, $this->remoteFileSystem);
+        $driver = new PerforceDriver($this->repoConfig, $this->io, $this->config, $this->process, $this->httpDownloader);
         $driver->initialize();
         $this->assertEquals(self::TEST_URL, $driver->getUrl());
         $this->assertEquals(self::TEST_DEPOT, $driver->getDepot());

--- a/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
@@ -46,6 +46,7 @@ class SvnDriverTest extends TestCase
     public function testWrongCredentialsInUrl()
     {
         $console = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $httpDownloader = $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock();
 
         $output = "svn: OPTIONS of 'https://corp.svn.local/repo':";
         $output .= " authorization failed: Could not authenticate to server:";
@@ -66,7 +67,7 @@ class SvnDriverTest extends TestCase
             'url' => 'https://till:secret@corp.svn.local/repo',
         );
 
-        $svn = new SvnDriver($repoConfig, $console, $this->config, $process);
+        $svn = new SvnDriver($repoConfig, $console, $this->config, $httpDownloader, $process);
         $svn->initialize();
     }
 

--- a/tests/Composer/Test/Util/BitbucketTest.php
+++ b/tests/Composer/Test/Util/BitbucketTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Bitbucket;
+use Composer\Util\Http\Response;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -30,8 +31,8 @@ class BitbucketTest extends TestCase
 
     /** @type \Composer\IO\ConsoleIO|\PHPUnit_Framework_MockObject_MockObject */
     private $io;
-    /** @type \Composer\Util\RemoteFilesystem|\PHPUnit_Framework_MockObject_MockObject */
-    private $rfs;
+    /** @type \Composer\Util\HttpDownloader|\PHPUnit_Framework_MockObject_MockObject */
+    private $httpDownloader;
     /** @type \Composer\Config|\PHPUnit_Framework_MockObject_MockObject */
     private $config;
     /** @type Bitbucket */
@@ -47,8 +48,8 @@ class BitbucketTest extends TestCase
             ->getMock()
         ;
 
-        $this->rfs = $this
-            ->getMockBuilder('Composer\Util\RemoteFilesystem')
+        $this->httpDownloader = $this
+            ->getMockBuilder('Composer\Util\HttpDownloader')
             ->disableOriginalConstructor()
             ->getMock()
         ;
@@ -57,7 +58,7 @@ class BitbucketTest extends TestCase
 
         $this->time = time();
 
-        $this->bitbucket = new Bitbucket($this->io, $this->config, null, $this->rfs, $this->time);
+        $this->bitbucket = new Bitbucket($this->io, $this->config, null, $this->httpDownloader, $this->time);
     }
 
     public function testRequestAccessTokenWithValidOAuthConsumer()
@@ -66,12 +67,10 @@ class BitbucketTest extends TestCase
             ->method('setAuthentication')
             ->with($this->origin, $this->consumer_key, $this->consumer_secret);
 
-        $this->rfs->expects($this->once())
-            ->method('getContents')
+        $this->httpDownloader->expects($this->once())
+            ->method('get')
             ->with(
-                $this->origin,
                 Bitbucket::OAUTH2_ACCESS_TOKEN_URL,
-                false,
                 array(
                     'retry-auth-failure' => false,
                     'http' => array(
@@ -81,9 +80,14 @@ class BitbucketTest extends TestCase
                 )
             )
             ->willReturn(
-                sprintf(
-                    '{"access_token": "%s", "scopes": "repository", "expires_in": 3600, "refresh_token": "refreshtoken", "token_type": "bearer"}',
-                    $this->token
+                new Response(
+                    array('url' => Bitbucket::OAUTH2_ACCESS_TOKEN_URL),
+                    200,
+                    array(),
+                    sprintf(
+                        '{"access_token": "%s", "scopes": "repository", "expires_in": 3600, "refresh_token": "refreshtoken", "token_type": "bearer"}',
+                        $this->token
+                    )
                 )
             );
 
@@ -142,12 +146,10 @@ class BitbucketTest extends TestCase
             ->method('setAuthentication')
             ->with($this->origin, $this->consumer_key, $this->consumer_secret);
 
-        $this->rfs->expects($this->once())
-            ->method('getContents')
+        $this->httpDownloader->expects($this->once())
+            ->method('get')
             ->with(
-                $this->origin,
                 Bitbucket::OAUTH2_ACCESS_TOKEN_URL,
-                false,
                 array(
                     'retry-auth-failure' => false,
                     'http' => array(
@@ -157,9 +159,14 @@ class BitbucketTest extends TestCase
                 )
             )
             ->willReturn(
-                sprintf(
-                    '{"access_token": "%s", "scopes": "repository", "expires_in": 3600, "refresh_token": "refreshtoken", "token_type": "bearer"}',
-                    $this->token
+                new Response(
+                    array('url' => Bitbucket::OAUTH2_ACCESS_TOKEN_URL),
+                    200,
+                    array(),
+                    sprintf(
+                        '{"access_token": "%s", "scopes": "repository", "expires_in": 3600, "refresh_token": "refreshtoken", "token_type": "bearer"}',
+                        $this->token
+                    )
                 )
             );
 
@@ -186,12 +193,10 @@ class BitbucketTest extends TestCase
                 array('2. You are using an OAuth consumer, but didn\'t configure a (dummy) callback url')
             );
 
-        $this->rfs->expects($this->once())
-            ->method('getContents')
+        $this->httpDownloader->expects($this->once())
+            ->method('get')
             ->with(
-                $this->origin,
                 Bitbucket::OAUTH2_ACCESS_TOKEN_URL,
-                false,
                 array(
                     'retry-auth-failure' => false,
                     'http' => array(
@@ -234,21 +239,24 @@ class BitbucketTest extends TestCase
             )
             ->willReturnOnConsecutiveCalls($this->consumer_key, $this->consumer_secret);
 
-        $this->rfs
+        $this->httpDownloader
             ->expects($this->once())
-            ->method('getContents')
+            ->method('get')
             ->with(
-                $this->equalTo($this->origin),
-                $this->equalTo(sprintf('https://%s/site/oauth2/access_token', $this->origin)),
-                $this->isFalse(),
+                $this->equalTo($url = sprintf('https://%s/site/oauth2/access_token', $this->origin)),
                 $this->anything()
             )
             ->willReturn(
-                sprintf(
-                    '{"access_token": "%s", "scopes": "repository", "expires_in": 3600, "refresh_token": "refresh_token", "token_type": "bearer"}',
-                    $this->token
+                new Response(
+                    array('url' => $url),
+                    200,
+                    array(),
+                    sprintf(
+                        '{"access_token": "%s", "scopes": "repository", "expires_in": 3600, "refresh_token": "refresh_token", "token_type": "bearer"}',
+                        $this->token
+                    )
                 )
-            )
+            );
         ;
 
         $this->setExpectationsForStoringAccessToken(true);

--- a/tests/Composer/Test/Util/GitHubTest.php
+++ b/tests/Composer/Test/Util/GitHubTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test\Util;
 
 use Composer\Downloader\TransportException;
 use Composer\Util\GitHub;
+use Composer\Util\Http\Response;
 use PHPUnit\Framework\TestCase;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
@@ -45,17 +46,15 @@ class GitHubTest extends TestCase
             ->willReturn($this->password)
         ;
 
-        $rfs = $this->getRemoteFilesystemMock();
-        $rfs
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader
             ->expects($this->once())
-            ->method('getContents')
+            ->method('get')
             ->with(
-                $this->equalTo($this->origin),
-                $this->equalTo(sprintf('https://api.%s/', $this->origin)),
-                $this->isFalse(),
+                $this->equalTo($url = sprintf('https://api.%s/', $this->origin)),
                 $this->anything()
             )
-            ->willReturn('{}')
+            ->willReturn(new Response(array('url' => $url), 200, array(), '{}'));
         ;
 
         $config = $this->getConfigMock();
@@ -70,7 +69,7 @@ class GitHubTest extends TestCase
             ->willReturn($this->getConfJsonMock())
         ;
 
-        $github = new GitHub($io, $config, null, $rfs);
+        $github = new GitHub($io, $config, null, $httpDownloader);
 
         $this->assertTrue($github->authorizeOAuthInteractively($this->origin, $this->message));
     }
@@ -85,10 +84,10 @@ class GitHubTest extends TestCase
             ->willReturn($this->password)
         ;
 
-        $rfs = $this->getRemoteFilesystemMock();
-        $rfs
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader
             ->expects($this->exactly(1))
-            ->method('getContents')
+            ->method('get')
             ->will($this->throwException(new TransportException('', 401)))
         ;
 
@@ -99,7 +98,7 @@ class GitHubTest extends TestCase
             ->willReturn($this->getAuthJsonMock())
         ;
 
-        $github = new GitHub($io, $config, null, $rfs);
+        $github = new GitHub($io, $config, null, $httpDownloader);
 
         $this->assertFalse($github->authorizeOAuthInteractively($this->origin));
     }
@@ -120,15 +119,15 @@ class GitHubTest extends TestCase
         return $this->getMockBuilder('Composer\Config')->getMock();
     }
 
-    private function getRemoteFilesystemMock()
+    private function getHttpDownloaderMock()
     {
-        $rfs = $this
-            ->getMockBuilder('Composer\Util\RemoteFilesystem')
+        $httpDownloader = $this
+            ->getMockBuilder('Composer\Util\HttpDownloader')
             ->disableOriginalConstructor()
             ->getMock()
         ;
 
-        return $rfs;
+        return $httpDownloader;
     }
 
     private function getAuthJsonMock()

--- a/tests/Composer/Test/Util/GitLabTest.php
+++ b/tests/Composer/Test/Util/GitLabTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test\Util;
 
 use Composer\Downloader\TransportException;
 use Composer\Util\GitLab;
+use Composer\Util\Http\Response;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -49,17 +50,15 @@ class GitLabTest extends TestCase
             ->willReturn($this->password)
         ;
 
-        $rfs = $this->getRemoteFilesystemMock();
-        $rfs
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader
             ->expects($this->once())
-            ->method('getContents')
+            ->method('get')
             ->with(
-                $this->equalTo($this->origin),
-                $this->equalTo(sprintf('http://%s/oauth/token', $this->origin)),
-                $this->isFalse(),
+                $this->equalTo($url = sprintf('http://%s/oauth/token', $this->origin)),
                 $this->anything()
             )
-            ->willReturn(sprintf('{"access_token": "%s", "token_type": "bearer", "expires_in": 7200}', $this->token))
+            ->willReturn(new Response(array('url' => $url), 200, array(), sprintf('{"access_token": "%s", "token_type": "bearer", "expires_in": 7200}', $this->token)));
         ;
 
         $config = $this->getConfigMock();
@@ -69,7 +68,7 @@ class GitLabTest extends TestCase
             ->willReturn($this->getAuthJsonMock())
         ;
 
-        $gitLab = new GitLab($io, $config, null, $rfs);
+        $gitLab = new GitLab($io, $config, null, $httpDownloader);
 
         $this->assertTrue($gitLab->authorizeOAuthInteractively('http', $this->origin, $this->message));
     }
@@ -94,10 +93,10 @@ class GitLabTest extends TestCase
             ->willReturn($this->password)
         ;
 
-        $rfs = $this->getRemoteFilesystemMock();
-        $rfs
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader
             ->expects($this->exactly(5))
-            ->method('getContents')
+            ->method('get')
             ->will($this->throwException(new TransportException('', 401)))
         ;
 
@@ -108,7 +107,7 @@ class GitLabTest extends TestCase
             ->willReturn($this->getAuthJsonMock())
         ;
 
-        $gitLab = new GitLab($io, $config, null, $rfs);
+        $gitLab = new GitLab($io, $config, null, $httpDownloader);
 
         $gitLab->authorizeOAuthInteractively('https', $this->origin);
     }
@@ -129,15 +128,15 @@ class GitLabTest extends TestCase
         return $this->getMockBuilder('Composer\Config')->getMock();
     }
 
-    private function getRemoteFilesystemMock()
+    private function getHttpDownloaderMock()
     {
-        $rfs = $this
-            ->getMockBuilder('Composer\Util\RemoteFilesystem')
+        $httpDownloader = $this
+            ->getMockBuilder('Composer\Util\HttpDownloader')
             ->disableOriginalConstructor()
             ->getMock()
         ;
 
-        return $rfs;
+        return $httpDownloader;
     }
 
     private function getAuthJsonMock()

--- a/tests/Composer/Test/Util/HttpDownloaderTest.php
+++ b/tests/Composer/Test/Util/HttpDownloaderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Util;
+
+use Composer\Util\HttpDownloader;
+use PHPUnit\Framework\TestCase;
+
+class HttpDownloaderTest extends TestCase
+{
+    private function getConfigMock()
+    {
+        $config = $this->getMockBuilder('Composer\Config')->getMock();
+        $config->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function ($key) {
+                if ($key === 'github-domains' || $key === 'gitlab-domains') {
+                    return array();
+                }
+            }));
+
+        return $config;
+    }
+
+    /**
+     * @group slow
+     */
+    public function testCaptureAuthenticationParamsFromUrl()
+    {
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $io->expects($this->once())
+            ->method('setAuthentication')
+            ->with($this->equalTo('github.com'), $this->equalTo('user'), $this->equalTo('pass'));
+
+        $fs = new HttpDownloader($io, $this->getConfigMock());
+        try {
+            $fs->get('https://user:pass@github.com/composer/composer/404');
+        } catch (\Composer\Downloader\TransportException $e) {
+            $this->assertNotEquals(200, $e->getCode());
+        }
+    }
+}

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -17,6 +17,20 @@ use PHPUnit\Framework\TestCase;
 
 class RemoteFilesystemTest extends TestCase
 {
+    private function getConfigMock()
+    {
+        $config = $this->getMockBuilder('Composer\Config')->getMock();
+        $config->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function ($key) {
+                if ($key === 'github-domains' || $key === 'gitlab-domains') {
+                    return array();
+                }
+            }));
+
+        return $config;
+    }
+
     public function testGetOptionsForUrl()
     {
         $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
@@ -101,7 +115,7 @@ class RemoteFilesystemTest extends TestCase
 
     public function testCallbackGetFileSize()
     {
-        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock());
+        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getConfigMock());
         $this->callCallbackGet($fs, STREAM_NOTIFY_FILE_SIZE_IS, 0, '', 0, 0, 20);
         $this->assertAttributeEquals(20, 'bytesMax', $fs);
     }
@@ -114,7 +128,7 @@ class RemoteFilesystemTest extends TestCase
             ->method('overwriteError')
         ;
 
-        $fs = new RemoteFilesystem($io);
+        $fs = new RemoteFilesystem($io, $this->getConfigMock());
         $this->setAttribute($fs, 'bytesMax', 20);
         $this->setAttribute($fs, 'progress', true);
 
@@ -124,7 +138,7 @@ class RemoteFilesystemTest extends TestCase
 
     public function testCallbackGetPassesThrough404()
     {
-        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock());
+        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getConfigMock());
 
         $this->assertNull($this->callCallbackGet($fs, STREAM_NOTIFY_FAILURE, 0, 'HTTP/1.1 404 Not Found', 404, 0, 0));
     }
@@ -139,7 +153,7 @@ class RemoteFilesystemTest extends TestCase
             ->method('setAuthentication')
             ->with($this->equalTo('github.com'), $this->equalTo('user'), $this->equalTo('pass'));
 
-        $fs = new RemoteFilesystem($io);
+        $fs = new RemoteFilesystem($io, $this->getConfigMock());
         try {
             $fs->getContents('github.com', 'https://user:pass@github.com/composer/composer/404');
         } catch (\Exception $e) {
@@ -150,14 +164,14 @@ class RemoteFilesystemTest extends TestCase
 
     public function testGetContents()
     {
-        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock());
+        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getConfigMock());
 
         $this->assertContains('testGetContents', $fs->getContents('http://example.org', 'file://'.__FILE__));
     }
 
     public function testCopy()
     {
-        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock());
+        $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getConfigMock());
 
         $file = tempnam(sys_get_temp_dir(), 'c');
         $this->assertTrue($fs->copy('http://example.org', 'file://'.__FILE__, $file));
@@ -218,7 +232,7 @@ class RemoteFilesystemTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $rfs = new RemoteFilesystem($io);
+        $rfs = new RemoteFilesystem($io, $this->getConfigMock());
         $hostname = parse_url($url, PHP_URL_HOST);
 
         $result = $rfs->getContents($hostname, $url, false);
@@ -240,14 +254,6 @@ class RemoteFilesystemTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $config = $this
-            ->getMockBuilder('Composer\Config')
-            ->getMock();
-        $config
-            ->method('get')
-            ->withAnyParameters()
-            ->willReturn(array());
-
         $domains = array();
         $io
             ->expects($this->any())
@@ -267,7 +273,7 @@ class RemoteFilesystemTest extends TestCase
                 'password' => '1A0yeK5Po3ZEeiiRiMWLivS0jirLdoGuaSGq9NvESFx1Fsdn493wUDXC8rz_1iKVRTl1GINHEUCsDxGh5lZ=',
             ));
 
-        $rfs = new RemoteFilesystem($io, $config);
+        $rfs = new RemoteFilesystem($io, $this->getConfigMock());
         $hostname = parse_url($url, PHP_URL_HOST);
 
         $result = $rfs->getContents($hostname, $url, false);
@@ -278,7 +284,7 @@ class RemoteFilesystemTest extends TestCase
 
     protected function callGetOptionsForUrl($io, array $args = array(), array $options = array(), $fileUrl = '')
     {
-        $fs = new RemoteFilesystem($io, null, $options);
+        $fs = new RemoteFilesystem($io, $this->getConfigMock(), $options);
         $ref = new \ReflectionMethod($fs, 'getOptionsForUrl');
         $prop = new \ReflectionProperty($fs, 'fileUrl');
         $ref->setAccessible(true);

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -143,25 +143,6 @@ class RemoteFilesystemTest extends TestCase
         $this->assertNull($this->callCallbackGet($fs, STREAM_NOTIFY_FAILURE, 0, 'HTTP/1.1 404 Not Found', 404, 0, 0));
     }
 
-    /**
-     * @group slow
-     */
-    public function testCaptureAuthenticationParamsFromUrl()
-    {
-        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
-        $io->expects($this->once())
-            ->method('setAuthentication')
-            ->with($this->equalTo('github.com'), $this->equalTo('user'), $this->equalTo('pass'));
-
-        $fs = new RemoteFilesystem($io, $this->getConfigMock());
-        try {
-            $fs->getContents('github.com', 'https://user:pass@github.com/composer/composer/404');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('Composer\Downloader\TransportException', $e);
-            $this->assertNotEquals(200, $e->getCode());
-        }
-    }
-
     public function testGetContents()
     {
         $fs = new RemoteFilesystem($this->getMockBuilder('Composer\IO\IOInterface')->getMock(), $this->getConfigMock());

--- a/tests/Composer/Test/Util/StreamContextFactoryTest.php
+++ b/tests/Composer/Test/Util/StreamContextFactoryTest.php
@@ -142,7 +142,6 @@ class StreamContextFactoryTest extends TestCase
         $expected = array(
             'http' => array(
                 'proxy' => 'tcp://proxyserver.net:80',
-                'request_fulluri' => true,
                 'method' => 'GET',
                 'header' => array('User-Agent: foo', "Proxy-Authorization: Basic " . base64_encode('username:password')),
                 'max_redirects' => 20,
@@ -173,7 +172,6 @@ class StreamContextFactoryTest extends TestCase
         $expected = array(
             'http' => array(
                 'proxy' => 'ssl://woopproxy.net:443',
-                'request_fulluri' => true,
                 'method' => 'GET',
                 'max_redirects' => 20,
                 'follow_location' => 1,


### PR DESCRIPTION
- Adds parallel downloads when ext-curl is present, including HTTP/2 and all niceties, much faster. (Closes https://github.com/composer/composer/pull/1628 https://github.com/composer/composer/pull/5293 https://github.com/composer/composer/pull/7197)
- Makes sure that all network operations are complete before the filesystem is touched, which should mean in theory we never end up with a borked vendor dir due to a failed download. Still need to follow up with https://github.com/composer/composer/issues/7903 tho. And also there is a dependency on another ongoing refactoring so packages are still done one by one now, but this will be fixed.
- Introduces new metadata format which is more compact on the wire and also reduces memory usage slightly thanks to interned strings (still in development, DO NOT RELY ON THIS UNTIL 2.0 stable) - further improvement might come with https://github.com/composer/composer/issues/6415 which I still have to look at but it sounds sensible to maximize cache hits. e.g. https://repo.packagist.org/p2/symfony/symfony.json is 23KB gzipped vs 37KB before (uncompressed size went from 1.3MB to 243KB)
- JSON package listings (provider-*) have been dropped as well which means more requests are done to verify cache integrity but most of them return a 304 Not Modified very quickly so hopefully this will be a net positive.
- Some memory optimization in the way packages are loaded, might save a few percent on large projects.