### PR TITLE
Add alias of run-script command

### DIFF
--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -48,6 +48,7 @@ class RunScriptCommand extends BaseCommand
     {
         $this
             ->setName('run-script')
+            ->setAliases(array('run'))
             ->setDescription('Runs the scripts defined in composer.json.')
             ->setDefinition(array(
                 new InputArgument('script', InputArgument::OPTIONAL, 'Script name to run.'),


### PR DESCRIPTION
The `run` command looks like more pretty than `run-script` but it's still meaningful. Let me add an alias for the "run-script" command.

```bash
composer run post-root-package-install # instead of "composer run-script post-root-package-install"
composer run test # instead of "composer run-script test"
```