### PR TITLE
Feature/no api config

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -236,11 +236,11 @@ This is used if you use the `gitlab` repository type.
 
 ## use-github-api
 
-Defaults to `true`.  Similar to the `no-api` key on a specific repository, setting `use-github-api` to `false` will define the global behavior for all GitHub repositories to clone the
-repository as it would with any other git repository instead of using the
-GitHub API. But unlike using the `git` driver directly, Composer will still
-attempt to use github's zip files.
-
+Defaults to `true`.  Similar to the `no-api` key on a specific repository,
+setting `use-github-api` to `false` will define the global behavior for all
+GitHub repositories to clone the repository as it would with any other git
+repository instead of using the GitHub API. But unlike using the `git`
+driver directly, Composer will still attempt to use GitHub's zip files.
 
 ## notify-on-install
 

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -234,6 +234,14 @@ github API will have a date instead of the machine hostname.
 Defaults to `["gitlab.com"]`. A list of domains of GitLab servers.
 This is used if you use the `gitlab` repository type.
 
+## use-github-api
+
+Defaults to `true`.  Similar to the `no-api` key on a specific repository, setting `use-github-api` to `false` will define the global behavior for all GitHub repositories to clone the
+repository as it would with any other git repository instead of using the
+GitHub API. But unlike using the `git` driver directly, Composer will still
+attempt to use github's zip files.
+
+
 ## notify-on-install
 
 Defaults to `true`. Composer allows repositories to define a notification URL,

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -271,6 +271,10 @@
                         "type": "string"
                     }
                 },
+                "use-github-api": {
+                    "type": "boolean",
+                    "description": "Defaults to true.  If set to false, globally disables the use of the GitHub API for all GitHub repositories and clones the repository as it would for any other repository."
+                },
                 "archive-format": {
                     "type": "string",
                     "description": "The default archiving format when not provided on cli, defaults to \"tar\"."

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -302,7 +302,7 @@ EOT
         $uniqueConfigValues = array(
             'process-timeout' => array('is_numeric', 'intval'),
             'use-include-path' => array($booleanValidator, $booleanNormalizer),
-            'no-api' => array($booleanValidator, $booleanNormalizer),
+            'use-github-api' => array($booleanValidator, $booleanNormalizer),
             'preferred-install' => array(
                 function ($val) {
                     return in_array($val, array('auto', 'source', 'dist'), true);

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -302,6 +302,7 @@ EOT
         $uniqueConfigValues = array(
             'process-timeout' => array('is_numeric', 'intval'),
             'use-include-path' => array($booleanValidator, $booleanNormalizer),
+            'no-api' => array($booleanValidator, $booleanNormalizer),
             'preferred-install' => array(
                 function ($val) {
                     return in_array($val, array('auto', 'source', 'dist'), true);

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -61,7 +61,7 @@ class Config
         'archive-format' => 'tar',
         'archive-dir' => '.',
         'htaccess-protect' => true,
-        'no-api' => false,
+        'use-github-api' => true,
         // valid keys without defaults (auth config stuff):
         // bitbucket-oauth
         // github-oauth
@@ -320,7 +320,7 @@ class Config
                 return $this->config[$key] !== 'false' && (bool) $this->config[$key];
             case 'secure-http':
                 return $this->config[$key] !== 'false' && (bool) $this->config[$key];
-            case 'no-api':
+            case 'use-github-api':
                 return $this->config[$key] !== 'false' && (bool) $this->config[$key];
             default:
                 if (!isset($this->config[$key])) {

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -61,6 +61,7 @@ class Config
         'archive-format' => 'tar',
         'archive-dir' => '.',
         'htaccess-protect' => true,
+        'no-api' => false,
         // valid keys without defaults (auth config stuff):
         // bitbucket-oauth
         // github-oauth
@@ -317,10 +318,10 @@ class Config
 
             case 'disable-tls':
                 return $this->config[$key] !== 'false' && (bool) $this->config[$key];
-
             case 'secure-http':
                 return $this->config[$key] !== 'false' && (bool) $this->config[$key];
-
+            case 'no-api':
+                return $this->config[$key] !== 'false' && (bool) $this->config[$key];
             default:
                 if (!isset($this->config[$key])) {
                     return null;

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -56,7 +56,7 @@ class GitHubDriver extends VcsDriver
         }
         $this->cache = new Cache($this->io, $this->config->get('cache-repo-dir').'/'.$this->originUrl.'/'.$this->owner.'/'.$this->repository);
 
-        if ( $this->config->get('no-api') === true || (isset($this->repoConfig['no-api']) && $this->repoConfig['no-api'] ) ){
+        if ( $this->config->get('use-github-api') === false || (isset($this->repoConfig['no-api']) && $this->repoConfig['no-api'] ) ){
             $this->setupGitDriver($this->url);
 
             return;

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -56,7 +56,7 @@ class GitHubDriver extends VcsDriver
         }
         $this->cache = new Cache($this->io, $this->config->get('cache-repo-dir').'/'.$this->originUrl.'/'.$this->owner.'/'.$this->repository);
 
-        if (isset($this->repoConfig['no-api']) && $this->repoConfig['no-api']) {
+        if ( $this->config->get('no-api') === true || (isset($this->repoConfig['no-api']) && $this->repoConfig['no-api'] ) ){
             $this->setupGitDriver($this->url);
 
             return;


### PR DESCRIPTION
Allowing for the no-api flag to be used as a config value for all Github repos, not just on a repo by repo basis.