### PR TITLE
Support identifying the HHVM version when not running with HHVM

### DIFF
--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -106,7 +106,7 @@ class Problem
 
                     $msg = "\n    - This package requires ".$job['packageName'].$this->constraintToText($job['constraint']).' but ';
 
-                    if (defined('HHVM_VERSION')) {
+                    if (defined('HHVM_VERSION') || count($available)) {
                         return $msg . 'your HHVM version does not satisfy that requirement.';
                     }
 

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -175,12 +175,17 @@ abstract class Rule
                             return $text . ' -> your HHVM version does not satisfy that requirement.';
                         }
 
-                        if ($targetName === 'hhvm') {
-                            return $text . ' -> you are running this with PHP and not HHVM.';
-                        }
-
                         $packages = $pool->whatProvides($targetName);
                         $package = count($packages) ? current($packages) : phpversion();
+
+                        if ($targetName === 'hhvm') {
+                            if ($package instanceof CompletePackage) {
+                                return $text . ' -> your HHVM version ('.$package->getPrettyVersion().') does not satisfy that requirement.';
+                            } else {
+                                return $text . ' -> you are running this with PHP and not HHVM.';
+                            }
+                        }
+
 
                         if (!($package instanceof CompletePackage)) {
                             return $text . ' -> your PHP version ('.phpversion().') does not satisfy that requirement.';

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -16,8 +16,11 @@ use Composer\Package\CompletePackage;
 use Composer\Package\PackageInterface;
 use Composer\Package\Version\VersionParser;
 use Composer\Plugin\PluginInterface;
+use Composer\Util\ProcessExecutor;
 use Composer\Util\Silencer;
+use Composer\Util\Platform;
 use Composer\XdebugHandler\XdebugHandler;
+use Symfony\Component\Process\ExecutableFinder;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -37,8 +40,11 @@ class PlatformRepository extends ArrayRepository
      */
     private $overrides = array();
 
-    public function __construct(array $packages = array(), array $overrides = array())
+    private $process;
+
+    public function __construct(array $packages = array(), array $overrides = array(), ProcessExecutor $process = null)
     {
+        $this->process = $process === null ? (new ProcessExecutor()) : $process;
         foreach ($overrides as $name => $version) {
             $this->overrides[strtolower($name)] = array('name' => $name, 'version' => $version);
         }
@@ -220,12 +226,27 @@ class PlatformRepository extends ArrayRepository
             $this->addPackage($lib);
         }
 
-        if (defined('HHVM_VERSION')) {
+        $hhvmVersion = defined('HHVM_VERSION') ? HHVM_VERSION : null;
+        if ($hhvmVersion === null && !Platform::isWindows()) {
+            $finder = new ExecutableFinder();
+            $hhvm = $finder->find('hhvm');
+            if ($hhvm !== null) {
+                $exitCode = $this->process->execute(
+                    ProcessExecutor::escape($hhvm).
+                    ' --php -d hhvm.jit=0 -r "echo HHVM_VERSION;" 2>/dev/null',
+                    $hhvmVersion
+                );
+                if ($exitCode !== 0) {
+                    $hhvmVersion = null;
+                }
+            }
+        }
+        if ($hhvmVersion) {
             try {
-                $prettyVersion = HHVM_VERSION;
+                $prettyVersion = $hhvmVersion;
                 $version = $this->versionParser->normalize($prettyVersion);
             } catch (\UnexpectedValueException $e) {
-                $prettyVersion = preg_replace('#^([^~+-]+).*$#', '$1', HHVM_VERSION);
+                $prettyVersion = preg_replace('#^([^~+-]+).*$#', '$1', $hhvmVersion);
                 $version = $this->versionParser->normalize($prettyVersion);
             }
 

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *         Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Repository;
+
+use Composer\Repository\PlatformRepository;
+use Composer\Test\TestCase;
+use Composer\Util\Platform;
+use Symfony\Component\Process\ExecutableFinder;
+
+class PlatformRepositoryTest extends TestCase {
+    public function testHHVMVersionWhenExecutingInHHVM() {
+        if (!defined('HHVM_VERSION_ID')) {
+            $this->markTestSkipped('Not running with HHVM');
+            return;
+        }
+        $repository = new PlatformRepository();
+        $package = $repository->findPackage('hhvm', '*');
+        $this->assertNotNull($package, 'failed to find HHVM package');
+        $this->assertSame(
+            sprintf('%d.%d.%d',
+                HHVM_VERSION_ID / 10000,
+                (HHVM_VERSION_ID / 100) % 100,
+                HHVM_VERSION_ID % 100
+            ),
+            $package->getPrettyVersion()
+        );
+    }
+
+    public function testHHVMVersionWhenExecutingInPHP() {
+        if (defined('HHVM_VERSION_ID')) {
+            $this->markTestSkipped('Running with HHVM');
+            return;
+        }
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('Test only works on PHP 5.4+');
+            return;
+        }
+        if (Platform::isWindows()) {
+            $this->markTestSkipped('Test does not run on Windows');
+            return;
+        }
+        $hhvm = (new ExecutableFinder())->find('hhvm');
+        if ($hhvm === null) {
+            $this->markTestSkipped('HHVM is not installed');
+        }
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $process->expects($this->once())->method('execute')->will($this->returnCallback(
+            function($command, &$out) {
+                $this->assertContains('HHVM_VERSION', $command);
+                $out = '4.0.1-dev';
+                return 0;
+            }
+        ));
+        $repository = new PlatformRepository(array(), array(), $process);
+        $package = $repository->findPackage('hhvm', '*');
+        $this->assertNotNull($package, 'failed to find HHVM package');
+        $this->assertSame('4.0.1.0-dev', $package->getVersion());
+    }
+}

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -49,7 +49,8 @@ class PlatformRepositoryTest extends TestCase {
             $this->markTestSkipped('Test does not run on Windows');
             return;
         }
-        $hhvm = (new ExecutableFinder())->find('hhvm');
+        $finder = new ExecutableFinder();
+        $hhvm = $finder->find('hhvm');
         if ($hhvm === null) {
             $this->markTestSkipped('HHVM is not installed');
         }


### PR DESCRIPTION
hhvm-nightly (and the next release) are no longer able to execute
Composer. Support executing Composer with PHP to install dependencies
for hack projects.

The goal is for this to be temporary, until Hack identifies a new
package manager, given that Composer does not aim to be a multi-language
package manager.

fixes #7734