### PR TITLE
Fix: Remove empty node

### DIFF
--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -193,6 +193,10 @@ class JsonConfigSource implements ConfigSourceInterface
     {
         $this->manipulateJson('removeSubNode', $type, $name, function (&$config, $type, $name) {
             unset($config[$type][$name]);
+
+            if (0 === count($config[$type])) {
+                unset($config[$type]);
+            }
         });
     }
 


### PR DESCRIPTION
This PR

* [x] adjusts `JsonConfigSource::removeLink()` to remove an empty node