### PR TITLE
Update installer commit to fix SHA384 bug

### DIFF
--- a/doc/faqs/how-to-install-composer-programmatically.md
+++ b/doc/faqs/how-to-install-composer-programmatically.md
@@ -35,7 +35,7 @@ give it uniqueness and authenticity as long as you can trust the GitHub servers.
 For example:
 
 ```bash
-wget https://raw.githubusercontent.com/composer/getcomposer.org/1b137f8bf6db3e79a38a5bc45324414a6b1f9df2/web/installer -O - -q | php -- --quiet
+wget https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer -O - -q | php -- --quiet
 ```
 
 You may replace the commit hash by whatever the last commit hash is on


### PR DESCRIPTION
Installer that is listed in the documentation is affected by #7776.

The newest copy is no longer affected but have updated the link in the docs to prevent people trying to install a broken version.