### PR TITLE
Fix defaultRepos fallback does not use auth config

### DIFF
--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -93,6 +93,7 @@ class RepositoryFactory
     {
         if (!$config) {
             $config = Factory::createConfig($io);
+            $io->loadConfiguration($config);
         }
         if (!$rm) {
             if (!$io) {

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -93,9 +93,9 @@ class RepositoryFactory
     {
         if (!$config) {
             $config = Factory::createConfig($io);
-            if ($io) {
-                $io->loadConfiguration($config);
-            }
+        }
+        if ($io) {
+            $io->loadConfiguration($config);
         }
         if (!$rm) {
             if (!$io) {

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -93,7 +93,9 @@ class RepositoryFactory
     {
         if (!$config) {
             $config = Factory::createConfig($io);
-            $io->loadConfiguration($config);
+            if ($io) {
+                $io->loadConfiguration($config);
+            }
         }
         if (!$rm) {
             if (!$io) {


### PR DESCRIPTION
When a full 'composer' cannot be constructed (because there is no local composer.json and no global composer.json), some commands (e.g. `show -a`) fall back to the default repositories from the `$COMPOSER_HOME/config.json` file. Without this fix, any auth configuration from `$COMPOSER_HOME/auth.json` is not used for these repositories in such a fallback scenario.

Steps to reproduce:

* Configure a password-protected composer repository in `$COMPOSER_HOME/config.json`.
* Configure valid credentials for that repository in `$COMPOSER_HOME/auth.json`.
* Make sure there is no file `$COMPOSER_HOME/composer.json`.
* Ensure the current working directory has no `composer.json`.
* Run `composer show -a some/package`.

Expected: Information about `some/package` is shown without needing to enter credentials.

Actual: A prompt "Authentication required" is shown for the private repository. When running the same command in a dir that has a `composer.json`, or when `$COMPOSER_HOME/composer.json` exists, things work as expected.