### PR TITLE
Fix solver problem exceptions with unexpected contradictory "Conclusions"

### DIFF
--- a/src/Composer/DependencyResolver/Decisions.php
+++ b/src/Composer/DependencyResolver/Decisions.php
@@ -196,4 +196,16 @@ class Decisions implements \Iterator, \Countable
             $this->decisionMap[$packageId] = -$level;
         }
     }
+
+    public function __toString()
+    {
+        $decisionMap = $this->decisionMap;
+        ksort($decisionMap);
+        $str = '[';
+        foreach ($decisionMap as $packageId => $level) {
+            $str .= $packageId.':'.$level.',';
+        }
+        $str .= ']';
+        return $str;
+    }
 }

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -470,7 +470,7 @@ class Solver
                 unset($seen[abs($literal)]);
 
                 if ($num && 0 === --$num) {
-                    $learnedLiterals[0] = -abs($literal);
+                    $learnedLiterals[0] = -$literal;
 
                     if (!$l1num) {
                         break 2;

--- a/tests/Composer/Test/Fixtures/installer/update-requiring-decision-reverts-and-learning-positive-literals.test
+++ b/tests/Composer/Test/Fixtures/installer/update-requiring-decision-reverts-and-learning-positive-literals.test
@@ -1,0 +1,100 @@
+--TEST--
+Update a project which requires decision reverts and learning a positive literal to arrive at a correct solution.
+
+Tests for solver regression in commit 451bab1c2cd58e05af6e21639b829408ad023463. See also SolverTest testLearnPositiveLiteral
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "spryker-feature/product",
+                    "require": {
+                        "spryker-feature/spryker-core": "1.0.0",
+                        "spryker-shop/product-search-widget": ">=1.0.0",
+                        "spryker/product-category-filter-gui": "1.0.0"
+                    },
+                    "version": "1.0.0"
+                },
+                {
+                    "name": "spryker-feature/spryker-core",
+                    "version": "1.0.0",
+                    "require": {
+                        "spryker/store": "1.0.0"
+                    }
+                },
+                {
+                    "name": "spryker/store",
+                    "version": "1.0.0",
+                    "require": {
+                        "spryker/kernel": "<=2.0.0"
+                    }
+                },
+                {
+                    "name": "spryker-shop/product-search-widget",
+                    "version": "1.0.0",
+                    "require": {
+                        "spryker/catalog": "1.0.0"
+                    }
+                },
+                {
+                    "name": "spryker-shop/product-search-widget",
+                    "version": "2.0.0",
+                    "require": {
+                        "spryker/catalog": "1.0.0",
+                        "spryker/kernel": ">=1.0.0"
+                    }
+                },
+                {
+                    "name": "spryker/product-category-filter-gui",
+                    "version": "1.0.0",
+                    "require": {
+                        "spryker/catalog": ">=1.0.0"
+                    }
+                },
+                {
+                    "name": "spryker/catalog",
+                    "version": "1.0.0",
+                    "require": { }
+                },
+                {
+                    "name": "spryker/catalog",
+                    "version": "2.0.0",
+                    "require": { }
+                },
+
+                {
+                    "name": "spryker/kernel",
+                    "version": "1.0.0",
+                    "require": { }
+                },
+                {
+                    "name": "spryker/kernel",
+                    "version": "2.0.0",
+                    "require": {
+                    }
+                },
+                {
+                    "name": "spryker/kernel",
+                    "version": "3.0.0",
+                    "require": { }
+                }
+            ]
+        }
+    ],
+    "require": {
+        "spryker-feature/product": "1.0.0"
+    }
+}
+--RUN--
+update
+--EXPECT--
+Installing spryker/catalog (1.0.0)
+Installing spryker/product-category-filter-gui (1.0.0)
+Installing spryker/kernel (2.0.0)
+Installing spryker-shop/product-search-widget (2.0.0)
+Installing spryker/store (1.0.0)
+Installing spryker-feature/spryker-core (1.0.0)
+Installing spryker-feature/product (1.0.0)
+


### PR DESCRIPTION
This 5 character fix comes with a solver test as well as a functional installer test essentially verifying the same thing. The solver test is more useful when working on the solver. But the functional test is less
likely to be accidentally modified incorrectly during refactoring, as every single package, version and link in the rather complex test scenario is essential, and a modified version of the test may very well still result in a successful installation but no longer verify the bug described below.

#### Background

In commit https://github.com/composer/composer/commit/451bab1c2cd58e05af6e21639b829408ad023463#diff-57acde011ed9b5a18bb373af9d616bf1L554 from May 19, 2012 I refactored literals from complex objects into pure integers to reduce memory consumption. The absolute value of an integer literal is the id of the package it refers to in the package pool. The sign indicates whether the package should be installed (positive) or removed (negative),

So a major part of the refactoring was swapping this call `$literal->getPackageId()` for this `abs($literal)`.

Unintentionally in line 554/523 I incorrectly applied this change to the line:

```
$this->literalFromId(-$literal->getPackageId());
```

It was converted to:

```
-abs($literal);
```

The function `literalFromId()` used to create a new literal object. By using the `abs()` function this change essentially forces the resulting literal to be negative, while the minus sign previously inverted the literal, so positive into negative and vice versa.

This particular line is in a function meant to analyze a conflicting decision during dependency resolution and to draw a conclusion from it, then revert the state of the solver to an earlier position, and attempt to solve the rest of the rules again with this new "learned" conclusion.

Because of this bug these conclusions could only ever occur in the negative, e.g. "don't install package X". This is by far the most likely scenario when the solver reaches this particular line, but there are
exceptions.

If you experienced a solver problem description that contained a statement like "Conclusion: don't install vendor/package 1.2.3" which directly contradicted other statements listed as part of the problem,
this could likely have been the cause.

The example, included in this PR as a functional installer test, used to throw this error when trying to run composer update:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for spryker-feature/product 1.0.0 -> satisfiable by spryker-feature/product[1.0.0].
    - spryker-feature/product 1.0.0 requires spryker-shop/product-search-widget >=1.0.0 -> satisfiable by spryker-shop/product-search-widget[1.0.0, 2.0.0].
    - spryker-shop/product-search-widget 1.0.0 requires spryker/catalog 1.0.0 -> satisfiable by spryker/catalog[1.0.0].
    - spryker-shop/product-search-widget 2.0.0 requires spryker/catalog 1.0.0 -> satisfiable by spryker/catalog[1.0.0].
    - Conclusion: don't install spryker/catalog 1.0.0
```