### PR TITLE
Make unixy proxy code POSIX compatible

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -196,9 +196,13 @@ class BinaryInstaller
 
 dir=\$(cd "\${0%[/\\\\]*}" > /dev/null; cd $binDir && pwd)
 
-if [ -d /proc/cygdrive ] && [[ \$(which php) == \$(readlink -n /proc/cygdrive)/* ]]; then
-   # We are in Cgywin using Windows php, so the path must be translated
-   dir=\$(cygpath -m "\$dir");
+if [ -d /proc/cygdrive ]; then
+    case \$(which php) in
+        \$(readlink -n /proc/cygdrive)/*)
+            # We are in Cygwin using Windows php, so the path must be translated
+            dir=\$(cygpath -m "\$dir");
+            ;;
+    esac
 fi
 
 "\${dir}/$binFile" "\$@"


### PR DESCRIPTION
The `[[` keyword is not compatible with all shells that `/bin/sh` can represent. This non-portablity is a problem when calling Composer, or stuff installed by Composer, from Ubuntu on WSL. 

See: https://github.com/composer/windows-setup/pull/90