### PR TITLE
Make it plainly clear that names should be lowercase

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -34,9 +34,10 @@ separated by `/`. Examples:
 * monolog/monolog
 * igorw/event-source
 
-The name can contain any character, including white spaces, and it's case
-insensitive (`foo/bar` and `Foo/Bar` are considered the same package). In order
-to simplify its installation, it's recommended to define a short and lowercase
+The name can contain any character, including white spaces, and should be all
+lowercase (Note, before Composer 2.0 it's case insensitive (`foo/bar` and `Foo/Bar`
+are considered the same package, but this is deprecated in in Composer 2.0 will error). 
+In order to simplify its installation, it's recommended to define a short and lowercase
 name that doesn't include non-alphanumeric characters or white spaces.
 
 Required for published packages (libraries).


### PR DESCRIPTION
Starting to see several projects with this error

> Deprecation warning: require.beberlei/DoctrineExtensions is invalid, it should not contain uppercase characters. Please use beberlei/doctrineextensions instead. Make sure you fix this as Composer 2.0 will error.

That developer then [pointed to the documentation ](https://github.com/beberlei/DoctrineExtensions/pull/315#issuecomment-460078007) which said (before this PR) that it was allowed to be case insensitive

So Im proposing that the documentation should spell out that there is a deprecated and legacy ways.