### PR TITLE
Fix 'Undefined variable: nameMatchesRequiredPackage' on macOS Mojave PHP

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1320,6 +1320,7 @@ class Installer
 
             $depPackages = $pool->whatProvides($packageName);
             $matchesByPattern = array();
+            $nameMatchesRequiredPackage = false;
             // check if the name is a glob pattern that did not match directly
             if (empty($depPackages)) {
                 // add any installed package matching the whitelisted name/pattern


### PR DESCRIPTION
Using the version of PHP Apple distribute with macOS 10.14.2:

```
$ php --version
PHP 7.1.19 (cli) (built: Aug 17 2018 20:10:18) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies
```

```
$ php ~/code/composer/bin/composer update
Deprecation warning: require.composer-plugin-api is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*". Make sure you fix this as Composer 2.0 will error.

  [ErrorException]
  Undefined variable: nameMatchesRequiredPackage
```