### PR TITLE
Soften hard exit after revert of composer file

### DIFF
--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -195,7 +195,7 @@ EOT
 
         $status = $install->run();
         if ($status !== 0) {
-            $this->revertComposerFile();
+            $this->revertComposerFile(false);
         }
 
         return $status;
@@ -226,7 +226,7 @@ EOT
         return;
     }
 
-    public function revertComposerFile()
+    public function revertComposerFile($hardExit = true)
     {
         $io = $this->getIO();
 
@@ -238,6 +238,8 @@ EOT
             file_put_contents($this->json->getPath(), $this->composerBackup);
         }
 
-        exit(1);
+        if ($hardExit) {
+            exit(1);
+        }
     }
 }


### PR DESCRIPTION
Introduced with https://github.com/composer/composer/pull/7555 the composer file gets reverted in an own method in an error case. The problem is the former hard exit in this method.
Supposing `$install->run()` returns an error code, the require command is not terminated correctly.
This PR makes sure, that the hard exit only happens if `pcntl_signal()` is called. 