### PR TITLE
Remove junctions with PHP rather than system rmdir

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -692,9 +692,7 @@ class Filesystem
         if (!$this->isJunction($junction)) {
             throw new IOException(sprintf('%s is not a junction and thus cannot be removed as one', $junction));
         }
-        $cmd = sprintf('rmdir /S /Q %s', ProcessExecutor::escape($junction));
-        clearstatcache(true, $junction);
 
-        return ($this->getProcess()->execute($cmd, $output) === 0);
+        return $this->rmdir($junction);
     }
 }


### PR DESCRIPTION
PHP will happily remove junctions using its `rmdir` function (tested on versions back to 5.2.17). This saves invoking system `rmdir` through cmd.exe.

Note this is just a tweak (it is not crucial and is separate from the previous buggy junction issue).