### PR TITLE
Implementation of PECL Extension Installer

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -608,6 +608,7 @@
                 { "$ref": "#/definitions/path-repository" },
                 { "$ref": "#/definitions/artifact-repository" },
                 { "$ref": "#/definitions/pear-repository" },
+                { "$ref": "#/definitions/pecl-repository" },
                 { "$ref": "#/definitions/package-repository" }
             ]
         },
@@ -673,6 +674,15 @@
             "required": ["type", "url"],
             "properties": {
                 "type": { "type": "string", "enum": ["pear"] },
+                "url": { "type": "string" },
+                "vendor-alias": { "type": "string" }
+            }
+        },
+        "pecl-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["pecl"] },
                 "url": { "type": "string" },
                 "vendor-alias": { "type": "string" }
             }

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -547,6 +547,7 @@ class Factory
         $im->addInstaller(new Installer\PearInstaller($io, $composer, 'pear-library'));
         $im->addInstaller(new Installer\PluginInstaller($io, $composer));
         $im->addInstaller(new Installer\MetapackageInstaller($io));
+        $im->addInstaller(new Installer\ExtensionInstaller($io, $composer));
     }
 
     /**

--- a/src/Composer/Installer/ExtensionInstaller.php
+++ b/src/Composer/Installer/ExtensionInstaller.php
@@ -1,0 +1,85 @@
+<?php
+
+
+namespace Composer\Installer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Repository\InstalledRepositoryInterface;
+use Composer\Package\PackageInterface;
+use Composer\Util\Filesystem;
+use Composer\Util\Silencer;
+use Composer\Util\Platform;
+use InvalidArgumentException;
+
+class ExtensionInstaller implements InstallerInterface
+{
+    protected $composer;
+    protected $downloadManager;
+    protected $io;
+    protected $pickle = 'pickle';
+    protected $process;
+    protected $cacheDir;
+
+    public function __construct(IOInterface $io, Composer $composer)
+    {
+        $this->composer = $composer;
+        $this->downloadManager = $composer->getDownloadManager();
+        $this->io = $io;
+
+        $this->cacheDir = rtrim($composer->getConfig()->get('cache-file-dir'), '/');
+        if (($pickle = getenv('COMPOSER_PECL_PATH'))) {
+            $this->pickle = escapeshellcmd($pickle);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($packageType)
+    {
+        return $packageType === 'extension';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package)
+    {
+        // TODO: implement proper way to check extension status
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    {
+        $package;
+        // TODO: Implement install() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
+    {
+        // TODO: Implement update() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
+    {
+        // TODO: Implement uninstall() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInstallPath(PackageInterface $package)
+    {
+        // TODO: Implement getInstallPath() method.
+    }
+}

--- a/src/Composer/Repository/PeclRepository.php
+++ b/src/Composer/Repository/PeclRepository.php
@@ -1,0 +1,189 @@
+<?php
+
+
+namespace Composer\Repository;
+
+use Composer\IO\IOInterface;
+use Composer\Semver\VersionParser as SemverVersionParser;
+use Composer\Package\Version\VersionParser;
+use Composer\Repository\Pear\ChannelReader;
+use Composer\Package\CompletePackage;
+use Composer\Repository\Pear\ChannelInfo;
+use Composer\EventDispatcher\EventDispatcher;
+use Composer\Package\Link;
+use Composer\Semver\Constraint\Constraint;
+use Composer\Util\RemoteFilesystem;
+use Composer\Config;
+use Composer\Factory;
+
+/**
+ * Builds list of package from PECL repository.
+ *
+ * The package definition file package.xml description you can find in
+ * {@link https://web.archive.org/web/20160319120209/http://pear.php.net/manual/en/guide.developers.package2.php Developers Guide}
+ *
+ * @author  Dmitrijs Balabka <dmitry.balabka@gmail.com>
+ */
+class PeclRepository extends ArrayRepository implements ConfigurableRepositoryInterface
+{
+    private $url;
+    private $io;
+    private $rfs;
+    private $versionParser;
+    private $repoConfig;
+
+    /** @var string vendor makes additional alias for each channel as {prefix}/{packagename}. It allows smoother
+     * package transition to composer-like repositories.
+     */
+    private $vendorAlias;
+
+    public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $dispatcher = null, RemoteFilesystem $rfs = null)
+    {
+        parent::__construct();
+        if (!preg_match('{^https?://}', $repoConfig['url'])) {
+            $repoConfig['url'] = 'http://'.$repoConfig['url'];
+        }
+
+        $urlBits = parse_url($repoConfig['url']);
+        if (empty($urlBits['scheme']) || empty($urlBits['host'])) {
+            throw new \UnexpectedValueException('Invalid url given for PEAR repository: '.$repoConfig['url']);
+        }
+
+        $this->url = rtrim($repoConfig['url'], '/');
+        $this->io = $io;
+        $this->rfs = $rfs ?: Factory::createRemoteFilesystem($this->io, $config);
+        $this->vendorAlias = isset($repoConfig['vendor-alias']) ? $repoConfig['vendor-alias'] : null;
+        $this->versionParser = new VersionParser();
+        $this->repoConfig = $repoConfig;
+    }
+
+    public function getRepoConfig()
+    {
+        return $this->repoConfig;
+    }
+
+    protected function initialize()
+    {
+        parent::initialize();
+
+        $this->io->writeError('Initializing PECL repository '.$this->url);
+
+        $reader = new ChannelReader($this->rfs);
+        try {
+            $channelInfo = $reader->read($this->url);
+        } catch (\Exception $e) {
+            $this->io->writeError('<warning>PECL repository from '.$this->url.' could not be loaded. '.$e->getMessage().'</warning>');
+
+            return;
+        }
+        $packages = $this->buildComposerPackages($channelInfo, $this->versionParser);
+        foreach ($packages as $package) {
+            $this->addPackage($package);
+        }
+    }
+
+    /**
+     * Builds CompletePackages from PEAR package definition data.
+     *
+     * @param  ChannelInfo         $channelInfo
+     * @param  SemverVersionParser $versionParser
+     * @return CompletePackage
+     */
+    private function buildComposerPackages(ChannelInfo $channelInfo, SemverVersionParser $versionParser)
+    {
+        // TODO: need to implement
+        $result = array();
+        foreach ($channelInfo->getPackages() as $packageDefinition) {
+            foreach ($packageDefinition->getReleases() as $version => $releaseInfo) {
+                try {
+                    $normalizedVersion = $versionParser->normalize($version);
+                } catch (\UnexpectedValueException $e) {
+                    $this->io->writeError('Could not load '.$packageDefinition->getPackageName().' '.$version.': '.$e->getMessage(), true, IOInterface::VERBOSE);
+                    continue;
+                }
+
+                $composerPackageName = $this->buildComposerPackageName($packageDefinition->getChannelName(), $packageDefinition->getPackageName());
+
+                // distribution url must be read from /r/{packageName}/{version}.xml::/r/g:text()
+                // but this location is 'de-facto' standard
+                $urlBits = parse_url($this->url);
+                $scheme = (isset($urlBits['scheme']) && 'https' === $urlBits['scheme'] && extension_loaded('openssl')) ? 'https' : 'http';
+                $distUrl = "{$scheme}://{$packageDefinition->getChannelName()}/get/{$packageDefinition->getPackageName()}-{$version}.tgz";
+
+                $requires = array();
+                $suggests = array();
+                $conflicts = array();
+                $replaces = array();
+
+                // alias package only when its channel matches repository channel,
+                // cause we've know only repository channel alias
+                if ($channelInfo->getName() == $packageDefinition->getChannelName()) {
+                    $composerPackageAlias = $this->buildComposerPackageName($channelInfo->getAlias(), $packageDefinition->getPackageName());
+                    $aliasConstraint = new Constraint('==', $normalizedVersion);
+                    $replaces[] = new Link($composerPackageName, $composerPackageAlias, $aliasConstraint, 'replaces', (string) $aliasConstraint);
+                }
+
+                // alias package with user-specified prefix. it makes private pear channels looks like composer's.
+                if (!empty($this->vendorAlias)
+                    && ($this->vendorAlias != 'pear-'.$channelInfo->getAlias() || $channelInfo->getName() != $packageDefinition->getChannelName())
+                ) {
+                    $composerPackageAlias = "{$this->vendorAlias}/{$packageDefinition->getPackageName()}";
+                    $aliasConstraint = new Constraint('==', $normalizedVersion);
+                    $replaces[] = new Link($composerPackageName, $composerPackageAlias, $aliasConstraint, 'replaces', (string) $aliasConstraint);
+                }
+
+                foreach ($releaseInfo->getDependencyInfo()->getRequires() as $dependencyConstraint) {
+                    $dependencyPackageName = $this->buildComposerPackageName($dependencyConstraint->getChannelName(), $dependencyConstraint->getPackageName());
+                    $constraint = $versionParser->parseConstraints($dependencyConstraint->getConstraint());
+                    $link = new Link($composerPackageName, $dependencyPackageName, $constraint, $dependencyConstraint->getType(), $dependencyConstraint->getConstraint());
+                    switch ($dependencyConstraint->getType()) {
+                        case 'required':
+                            $requires[] = $link;
+                            break;
+                        case 'conflicts':
+                            $conflicts[] = $link;
+                            break;
+                        case 'replaces':
+                            $replaces[] = $link;
+                            break;
+                    }
+                }
+
+                foreach ($releaseInfo->getDependencyInfo()->getOptionals() as $group => $dependencyConstraints) {
+                    foreach ($dependencyConstraints as $dependencyConstraint) {
+                        $dependencyPackageName = $this->buildComposerPackageName($dependencyConstraint->getChannelName(), $dependencyConstraint->getPackageName());
+                        $suggests[$group.'-'.$dependencyPackageName] = $dependencyConstraint->getConstraint();
+                    }
+                }
+
+                $package = new CompletePackage($composerPackageName, $normalizedVersion, $version);
+                $package->setType('pear-library');
+                $package->setDescription($packageDefinition->getDescription());
+                $package->setLicense(array($packageDefinition->getLicense()));
+                $package->setDistType('file');
+                $package->setDistUrl($distUrl);
+                $package->setAutoload(array('classmap' => array('')));
+                $package->setIncludePaths(array('/'));
+                $package->setRequires($requires);
+                $package->setConflicts($conflicts);
+                $package->setSuggests($suggests);
+                $package->setReplaces($replaces);
+                $result[] = $package;
+            }
+        }
+
+        return $result;
+    }
+
+    private function buildComposerPackageName($channelName, $packageName)
+    {
+        if ('php' === $channelName) {
+            return "php";
+        }
+        if ('ext' === $channelName) {
+            return "ext-{$packageName}";
+        }
+
+        return "pear-{$channelName}/{$packageName}";
+    }
+}

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -121,6 +121,7 @@ class RepositoryFactory
         $rm->setRepositoryClass('vcs', 'Composer\Repository\VcsRepository');
         $rm->setRepositoryClass('package', 'Composer\Repository\PackageRepository');
         $rm->setRepositoryClass('pear', 'Composer\Repository\PearRepository');
+        $rm->setRepositoryClass('pecl', 'Composer\Repository\PeclRepository');
         $rm->setRepositoryClass('git', 'Composer\Repository\VcsRepository');
         $rm->setRepositoryClass('git-bitbucket', 'Composer\Repository\VcsRepository');
         $rm->setRepositoryClass('github', 'Composer\Repository\VcsRepository');


### PR DESCRIPTION
## Introduction
There were multiples PRs which were tried to address PECL extension installations:
1. https://github.com/composer/composer/pull/498/files
1. https://github.com/composer/composer/pull/2898/files
1. https://github.com/composer/composer/pull/3897/files

Now the situation is slightly different. The PEAR which includes PECL command code contains multiple PHP 8 compatibility issues:
1. https://github.com/pear/pear-core/pull/82
1. https://github.com/pear/pear-core/pull/85
1. https://github.com/pear/Console_Getopt/pull/3
1. ... and others

There is also an initiative to disable PEAR by default:
1. https://externals.io/message/103977
1. https://github.com/php/php-src/pull/3781

IMO the effort to support PECL in the long term will be more significant then reuse Composer code base with existing functionality. So I'm trying to to find a solution to replace PECL command with a same or similar convenient way for PHP developers to compile and install extensions.

## Scope
*Note!* Scope is topic of discussion, and it might be changed. It also depends on the required effort to implement the Extension Installer. So feature list might be cut to deliver a base implementation of Extension Installer faster.
1. Reuse [PEAR repository REST API client](https://github.com/composer/composer/tree/master/src/Composer/Repository/Pear) to communicate with PECL repositories.
1. Implement possibility to download PECL extensions source using existing Composer functionality
1. Implement extension compilation using `phpize` and `make` commands
1. Implement installation of a compiled extension
1. Download existing binaries and install extensions for Windows