### PR TITLE
Make sure we properly usleep() on windows rmdir/unlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### [1.8.4] 2019-02-11
+
+  * Fixed long standing solver bug leading to odd solving issues in edge cases, see #7946
+  * Fixed HHVM support for upcoming releases
+  * Fixed unix proxy for binaries to be POSIX compatible instead of breaking some shells
+  * Fixed invalid deprecation warning for composer-plugin-api
+  * Fixed edge case issues with Windows junctions when working with path repositories
+
 ### [1.8.3] 2019-01-30
 
   * Fixed regression when executing partial updates
@@ -729,6 +737,10 @@
 
   * Initial release
 
+[1.8.4]: https://github.com/composer/composer/compare/1.8.3...1.8.4
+[1.8.3]: https://github.com/composer/composer/compare/1.8.2...1.8.3
+[1.8.2]: https://github.com/composer/composer/compare/1.8.1...1.8.2
+[1.8.1]: https://github.com/composer/composer/compare/1.8.0...1.8.1
 [1.8.0]: https://github.com/composer/composer/compare/1.7.3...1.8.0
 [1.7.3]: https://github.com/composer/composer/compare/1.7.2...1.7.3
 [1.7.2]: https://github.com/composer/composer/compare/1.7.1...1.7.2

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -57,6 +57,9 @@ class Solver
     /** @var array */
     protected $learnedWhy = array();
 
+    /** @var bool */
+    public $testFlagLearnedPositiveLiteral = false;
+
     /** @var IOInterface */
     protected $io;
 
@@ -470,6 +473,9 @@ class Solver
                 unset($seen[abs($literal)]);
 
                 if ($num && 0 === --$num) {
+                    if ($literal < 0) {
+                        $this->testFlagLearnedPositiveLiteral = true;
+                    }
                     $learnedLiterals[0] = -$literal;
 
                     if (!$l1num) {

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -199,9 +199,15 @@ class Filesystem
      */
     public function unlink($path)
     {
-        if (!@$this->unlinkImplementation($path)) {
+        $unlinked = @$this->unlinkImplementation($path);
+        if (!$unlinked) {
             // retry after a bit on windows since it tends to be touchy with mass removals
-            if (!Platform::isWindows() || (usleep(350000) && !@$this->unlinkImplementation($path))) {
+            if (Platform::isWindows()) {
+                usleep(350000);
+                $unlinked = @$this->unlinkImplementation($path);
+            }
+            
+            if (!$unlinked) {
                 $error = error_get_last();
                 $message = 'Could not delete '.$path.': ' . @$error['message'];
                 if (Platform::isWindows()) {
@@ -224,9 +230,15 @@ class Filesystem
      */
     public function rmdir($path)
     {
-        if (!@rmdir($path)) {
+        $deleted = @rmdir($path);
+        if (!$deleted) {
             // retry after a bit on windows since it tends to be touchy with mass removals
-            if (!Platform::isWindows() || (usleep(350000) && !@rmdir($path))) {
+            if (Platform::isWindows()) {
+                usleep(350000);
+                $deleted = !@rmdir($path);
+            }
+            
+            if (!$deleted) {
                 $error = error_get_last();
                 $message = 'Could not delete '.$path.': ' . @$error['message'];
                 if (Platform::isWindows()) {

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -891,6 +891,9 @@ class SolverTest extends TestCase
 
         $this->request->install('A');
 
+        // check correct setup for assertion later
+        $this->assertFalse($this->solver->testFlagLearnedPositiveLiteral);
+
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageF1),
             array('job' => 'install', 'package' => $packageD),
@@ -900,6 +903,10 @@ class SolverTest extends TestCase
             array('job' => 'install', 'package' => $packageB),
             array('job' => 'install', 'package' => $packageA),
         ));
+
+        // verify that the code path leading to a negative literal resulting in a positive learned literal is actually
+        // executed
+        $this->assertTrue($this->solver->testFlagLearnedPositiveLiteral);
     }
 
     protected function reposComplete()


### PR DESCRIPTION
phpstan reports (line-numbers based on revision c5d8409599d4efc4e6fbc89fbeaa156a7d5bdd94)

```
 ------ ------------------------------------------- 
  Line   src/Composer/Util/Filesystem.php           
 ------ ------------------------------------------- 
  205    Result of function usleep (void) is used.  
  230    Result of function usleep (void) is used.  
 ------ ------------------------------------------- 
```

I guess this means that `!@unlink($path)` is effectively dead code since `usleep()` will never return a `true`-ish result (at least per php-src-docs)