### PR TITLE
Allow setting value for gitlab_domains via COMPOSER_AUTH

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -131,7 +131,7 @@ class Config
         // override defaults with given config
         if (!empty($config['config']) && is_array($config['config'])) {
             foreach ($config['config'] as $key => $val) {
-                if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic')) && isset($this->config[$key])) {
+                if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic', 'gitlab-domains')) && isset($this->config[$key])) {
                     $this->config[$key] = array_merge($this->config[$key], $val);
                 } elseif ('preferred-install' === $key && isset($this->config[$key])) {
                     if (is_array($val) || is_array($this->config[$key])) {


### PR DESCRIPTION
For self-hosted gitlab there's no point in allowing overriding `gitlab-token` via COMPOSER_AUTH without also specifying `gitlab-domains`.

Please, add `gitlab-domains` to the config whitelist.