### PR TITLE
Store dev mode in installed.json, fixes #3008

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   - ls -d tests/Composer/Test/* | grep -v TestCase.php | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/complete.phpunit.xml --colors=always {} || (echo -e "\e[41mFAILED\e[0m {}" && exit 1);'
   # Run PHPStan
   - if [[ $PHPSTAN == "1" ]]; then
-      composer require --dev phpstan/phpstan-shim:^0.11 --ignore-platform-reqs &&
+      bin/composer require --dev phpstan/phpstan-shim:^0.11 --ignore-platform-reqs &&
       vendor/bin/phpstan.phar analyse src tests --configuration=phpstan/config.neon --autoload-file=phpstan/autoload.php;
     fi
 

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -616,7 +616,7 @@ class Installer
             }
 
             if ($this->executeOperations || $this->writeLock) {
-                $localRepo->write();
+                $localRepo->write($this->devMode);
             }
 
             $event = 'Composer\Installer\PackageEvents::POST_PACKAGE_'.strtoupper($jobType);
@@ -628,7 +628,7 @@ class Installer
         if ($this->executeOperations) {
             // force source/dist urls to be updated for all packages
             $this->processPackageUrls($pool, $policy, $localRepo, $repositories);
-            $localRepo->write();
+            $localRepo->write($this->devMode);
         }
 
         return array(0, $devPackages);

--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -49,7 +49,12 @@ class FilesystemRepository extends WritableArrayRepository
         }
 
         try {
-            $packages = $this->file->read();
+            $data = $this->file->read();
+            if (isset($data['packages'])) {
+                $packages = $data['packages'];
+            } else {
+                $packages = $data;
+            }
 
             if (!is_array($packages)) {
                 throw new \UnexpectedValueException('Could not parse package list from the repository');
@@ -74,16 +79,16 @@ class FilesystemRepository extends WritableArrayRepository
     /**
      * Writes writable repository.
      */
-    public function write()
+    public function write($devMode)
     {
-        $data = array();
+        $data = array('packages' => array(), 'dev' => $devMode);
         $dumper = new ArrayDumper();
 
         foreach ($this->getCanonicalPackages() as $package) {
-            $data[] = $dumper->dump($package);
+            $data['packages'][] = $dumper->dump($package);
         }
 
-        usort($data, function ($a, $b) {
+        usort($data['packages'], function ($a, $b) {
             return strcmp($a['name'], $b['name']);
         });
 

--- a/src/Composer/Repository/WritableArrayRepository.php
+++ b/src/Composer/Repository/WritableArrayRepository.php
@@ -24,7 +24,7 @@ class WritableArrayRepository extends ArrayRepository implements WritableReposit
     /**
      * {@inheritDoc}
      */
-    public function write()
+    public function write($devMode)
     {
     }
 

--- a/src/Composer/Repository/WritableRepositoryInterface.php
+++ b/src/Composer/Repository/WritableRepositoryInterface.php
@@ -23,8 +23,10 @@ interface WritableRepositoryInterface extends RepositoryInterface
 {
     /**
      * Writes repository (f.e. to the disc).
+     *
+     * @param bool $devMode Whether dev requirements were included or not in this installation
      */
-    public function write();
+    public function write($devMode);
 
     /**
      * Adds package to the repository.

--- a/tests/Composer/Test/Mock/InstalledFilesystemRepositoryMock.php
+++ b/tests/Composer/Test/Mock/InstalledFilesystemRepositoryMock.php
@@ -20,7 +20,7 @@ class InstalledFilesystemRepositoryMock extends InstalledFilesystemRepository
     {
     }
 
-    public function write()
+    public function write($devMode)
     {
     }
 }

--- a/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
@@ -95,11 +95,12 @@ class FilesystemRepositoryTest extends TestCase
             ->expects($this->once())
             ->method('write')
             ->with(array(
-                array('name' => 'mypkg', 'type' => 'library', 'version' => '0.1.10', 'version_normalized' => '0.1.10.0'),
+                'packages' => array(array('name' => 'mypkg', 'type' => 'library', 'version' => '0.1.10', 'version_normalized' => '0.1.10.0')),
+                'dev' => true,
             ));
 
         $repository->addPackage($this->getPackage('mypkg', '0.1.10'));
-        $repository->write();
+        $repository->write(true);
     }
 
     private function createJsonFileMock()


### PR DESCRIPTION
This introduces a BC break in installed.json as the packages are now nested in a "packages" key, but it also brings it in line with the composer.lock format which isn't bad, and opens up for further improvements later. Any thoughts @gossi as you requested the feature?

Fixed #3008