### PR TITLE
using emptyDirectory instead of remove for clearing the cache

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -189,7 +189,8 @@ class Cache
     public function clear()
     {
         if ($this->enabled) {
-            return $this->filesystem->removeDirectory($this->root);
+            $this->filesystem->emptyDirectory($this->root);
+            return true;
         }
 
         return false;


### PR DESCRIPTION
Using composer with docker it can be useful to put the cache in its own data volume.
Doing this will result in problems clearing the cache because composer relies on removing the cache-root directory.
Therefore I want to suggest using emptyDirectory instead of removeDirectory here. 