### PR TITLE
Fix for UNC Windows paths

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -440,7 +440,7 @@ class Filesystem
      */
     public function isAbsolutePath($path)
     {
-        return substr($path, 0, 1) === '/' || substr($path, 1, 1) === ':' || substr($path,0,2) === '\\';
+        return substr($path, 0, 1) === '/' || substr($path, 1, 1) === ':' || substr($path, 0, 2) === '\\\\';
     }
 
     /**

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -440,7 +440,7 @@ class Filesystem
      */
     public function isAbsolutePath($path)
     {
-        return substr($path, 0, 1) === '/' || substr($path, 1, 1) === ':';
+        return substr($path, 0, 1) === '/' || substr($path, 1, 1) === ':' || substr($path,0,2) === '\\';
     }
 
     /**


### PR DESCRIPTION
Made isAbsolutePath recognize Windows UNC-style absolute paths starting with \\