### PR TITLE
Generate same package mutual exclusion ("spme") rules on-demand to reduce memory.

### DIFF
--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -225,9 +225,6 @@ class RuleSetGenerator
 
                 if (($package instanceof AliasPackage) && $package->getAliasOf() === $provider) {
                     $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRequireRule($package, array($provider), Rule::RULE_PACKAGE_ALIAS, $package));
-                } elseif (!$this->obsoleteImpossibleForAlias($package, $provider)) {
-                    $reason = ($packageName == $provider->getName()) ? Rule::RULE_PACKAGE_SAME_NAME : Rule::RULE_PACKAGE_IMPLICIT_OBSOLETES;
-                    $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRule2Literals($package, $provider, $reason, $package));
                 }
             }
         }
@@ -276,7 +273,7 @@ class RuleSetGenerator
         }
     }
 
-    protected function obsoleteImpossibleForAlias($package, $provider)
+    public static function obsoleteImpossibleForAlias($package, $provider)
     {
         $packageIsAlias = $package instanceof AliasPackage;
         $providerIsAlias = $provider instanceof AliasPackage;

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -217,7 +217,7 @@ class Solver
         $this->rules = $this->ruleSetGenerator->getRulesFor($this->jobs, $this->installedMap, $ignorePlatformReqs);
         $this->checkForRootRequireProblems($ignorePlatformReqs);
         $this->decisions = new Decisions($this->pool);
-        $this->watchGraph = new RuleWatchGraph;
+        $this->watchGraph = new RuleWatchGraph($this->pool);
 
         foreach ($this->rules as $rule) {
             $this->watchGraph->insert(new RuleWatchNode($rule));

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -758,7 +758,11 @@ class SolverTest extends TestCase
             $msg .= "    - Can only install one of: B[0.9, 1.0].\n";
             $msg .= "    - A 1.0 requires b >= 1.0 -> satisfiable by B[1.0].\n";
             $msg .= "    - Installation request for a -> satisfiable by A[1.0].\n";
-            $this->assertEquals($msg, $e->getMessage());
+            // Accept problem details ordered differently.
+            $this->assertCount(
+                0,
+                array_diff(explode("\n", $msg), explode("\n", $e->getMessage()))
+            );
         }
     }
 


### PR DESCRIPTION
The vast majority of the total objects Composer previously generated express the
idea that package A 1.0 conflicts with package A 1.1, and 1.2, and ...
Since the number of these rules expands as n*n for the number of available
versions of each package, in many real-world evaluations these rule objects may
dominate Composer's total memory utilization.

Instead of doing that, this modification to the solver only instantiates those
rules as needed while propagating decisions. Intuitively, when we decide A 1.0,
all other packages providing A can be decided against. That's essentially what
this does by newing up conflict unit rules for the other providers of A into
RuleWatchGraph::propagateLiteral() through the RuleWatchChain iterator that
propagateLiteral() pumps from. The decision is made and the SPME rule has served
its purpose; its refcount drops to zero and the memory is reclaimed.

A side-effect of not generating the full compliment of rules upfront is that
watch chains that would only contain SPME rules are not added to the RuleWatchGraph
at all, since the watch graph is built based on the contents of the RuleSet.
This is compensated for by creating that too on demand in propagateLiteral() when
necessary.

In practice, using `--profile`, this saves 50% of peak memory utilization (~600MB down from
~1200MB) when evaluating https://github.com/drupal-composer/drupal-project, for example.

The RuleWatchChain iterator is a bit finnicky and certainly calls for unit testing, but I'd like to
gauge the maintainer's temperature on the change at this stage and...iterate 🤦‍♂️ on the PR from here.