### PR TITLE
Fixes #8065: Load plugins in consistent and deterministic order.

### DIFF
--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -88,10 +88,6 @@ class FilesystemRepository extends WritableArrayRepository
             $data[] = $dumper->dump($package);
         }
 
-        usort($data, function ($a, $b) {
-            return strcmp($a['name'], $b['name']);
-        });
-
         $this->file->write($data);
     }
 }


### PR DESCRIPTION
Fixes #8065 

Composer currently loads plugins in a different order depending on operation and state.

During an update, or initial install, it will activate plugins according to their dependency tree, which is IMO the expected behavior. That way, if one plugin depends on another, the dependent plugin always gets loaded first.

During subsequent operations, Composer activates plugins in _alphabetical_ order as they are read from `installed.json`. This is bad because now dependencies are not necessarily available in time, causing a lot of issues for downstream projects, especially those depending on Composer Installers and starting with "A" or "B" :smile: https://github.com/acquia/blt/issues/3148

I think it's better that `installed.json` is ordered according to the dependency tree, so plugins are loaded in the correct order.

Of course this also reverts #6696 which isn't ideal. But I think avoiding race conditions is important. I'm surprised people are committing and reviewing file diffs for `installed.json` in the first place. That should really be done by a CI tool, I've never committed a vendor directory to Git.