### PR TITLE
Updates typo: nother-feature to another-feature

### DIFF
--- a/doc/articles/versions.md
+++ b/doc/articles/versions.md
@@ -32,7 +32,7 @@ repository:*
 v1
 v2
 my-feature
-nother-feature
+another-feature
 
 ~/my-library$ git tag
 v1.0


### PR DESCRIPTION
I assume the original author meant to type `another-feature` after `my-feature`.  This PR updates that.