### PR TITLE
fix regex for heredoc/nowdoc

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -162,7 +162,7 @@ class ClassMapGenerator
         }
 
         // strip heredocs/nowdocs
-        $contents = preg_replace('{<<<\s*(\'?)(\w+)\\1(?:\r\n|\n|\r)(?:.*?)(?:\r\n|\n|\r)\\2(?=\r\n|\n|\r|;)}s', 'null', $contents);
+        $contents = preg_replace('{<<<\s*([\'"]?)(\w+)\\1(?:\r\n|\n|\r)(?:.*?)(?:\r\n|\n|\r|\s*)\\2(?=\r\n|\n|\r|\s|;)}s', 'null', $contents);
         // strip strings
         $contents = preg_replace('{"[^"\\\\]*+(\\\\.[^"\\\\]*+)*+"|\'[^\'\\\\]*+(\\\\.[^\'\\\\]*+)*+\'}s', 'null', $contents);
         // strip leading non-php code if needed

--- a/tests/Composer/Test/Autoload/Fixtures/classmap/StripNoise.php
+++ b/tests/Composer/Test/Autoload/Fixtures/classmap/StripNoise.php
@@ -33,12 +33,18 @@ class Fail5
 
 }
 ANOTHER
-. <<<	'ONEMORE'
+. <<<	"ONEMORE"
 class Fail6
 {
 
 }
-ONEMORE;
+ONEMORE
+. <<<PHP73
+  class Heredoc
+  {
+
+  }
+  PHP73;
     }
 
     public function test2()


### PR DESCRIPTION
* take into account relaxed changes introduced in php 7.3
  * see: https://github.com/php/php-src/commit/4887357269107ed669463c4b95bd755fbbb52490
* allow " as well as ', which was introduced in php 5.3

closes #8080