### PR TITLE
Fix #8080

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -162,7 +162,7 @@ class ClassMapGenerator
         }
 
         // strip heredocs/nowdocs
-        $contents = preg_replace('{<<<\s*([\'"]?)(\w+)\\1(?:\r\n|\n|\r)(?:.*?)(?:\r\n|\n|\r|\s*)\\2(?=\r\n|\n|\r|\s|;)}s', 'null', $contents);
+        $contents = preg_replace('{<<<[ \t]*([\'"]?)(\w+)\\1(?:\r\n|\n|\r)(?:.*?)(?:\s+)\\2(?=\s+|[;,.)])}s', 'null', $contents);
         // strip strings
         $contents = preg_replace('{"[^"\\\\]*+(\\\\.[^"\\\\]*+)*+"|\'[^\'\\\\]*+(\\\\.[^\'\\\\]*+)*+\'}s', 'null', $contents);
         // strip leading non-php code if needed

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -162,7 +162,7 @@ class ClassMapGenerator
         }
 
         // strip heredocs/nowdocs
-        $contents = preg_replace('{<<<[ \t]*([\'"]?)(\w+)\\1(?:\r\n|\n|\r)(?:.*?)(?:\s+)\\2(?=\s+|[;,.)])}s', 'null', $contents);
+        $contents = preg_replace('{<<<[ \t]*([\'"]?)(\w+)\\1(?:\r\n|\n|\r)(?:.*?)(?:\r\n|\n|\r)(?:\s*)\\2(?=\s+|[;,.)])}s', 'null', $contents);
         // strip strings
         $contents = preg_replace('{"[^"\\\\]*+(\\\\.[^"\\\\]*+)*+"|\'[^\'\\\\]*+(\\\\.[^\'\\\\]*+)*+\'}s', 'null', $contents);
         // strip leading non-php code if needed

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -162,7 +162,7 @@ class ClassMapGenerator
         }
 
         // strip heredocs/nowdocs
-        $contents = preg_replace('{<<<\s*(\'?)(\w+)\\1(?:\r\n|\n|\r)(?:.*?)(?:\r\n|\n|\r)\\2(?=\r\n|\n|\r|;)}s', 'null', $contents);
+        $contents = preg_replace('{<<<\s*([\'"]?)(\w+)\\1(?:\r\n|\n|\r)(?:.*?)(?:\r\n|\n|\r|\s*)\\2(?=\r\n|\n|\r|\s|;)}s', 'null', $contents);
         // strip strings
         $contents = preg_replace('{"[^"\\\\]*+(\\\\.[^"\\\\]*+)*+"|\'[^\'\\\\]*+(\\\\.[^\'\\\\]*+)*+\'}s', 'null', $contents);
         // strip leading non-php code if needed

--- a/tests/Composer/Test/Autoload/Fixtures/classmap/StripNoise.php
+++ b/tests/Composer/Test/Autoload/Fixtures/classmap/StripNoise.php
@@ -33,12 +33,18 @@ class Fail5
 
 }
 ANOTHER
-. <<<	'ONEMORE'
+. <<<	"ONEMORE"
 class Fail6
 {
 
 }
-ONEMORE;
+ONEMORE
+. <<<PHP73
+  class Fail7
+  {
+
+  }
+  PHP73;
     }
 
     public function test2()

--- a/tests/Composer/Test/Autoload/Fixtures/classmap/StripNoise.php
+++ b/tests/Composer/Test/Autoload/Fixtures/classmap/StripNoise.php
@@ -7,48 +7,81 @@ namespace Foo;
  */
 class StripNoise
 {
-    public function test()
+    public function test_heredoc()
     {
-        return <<<A
-class Fail2
+        return <<<HEREDOC
+class FailHeredocBasic
 {
-
 }
-A
-. <<<  AB
-class Fail3
+HEREDOC . <<<  WHITESPACE
+class FailHeredocWhitespace
 {
-
 }
-AB
-. <<<'TEST'
-class Fail4
+WHITESPACE . <<<"DOUBLEQUOTES"
+class FailHeredocDoubleQuotes
 {
-
 }
-TEST
-. <<< 'ANOTHER'
-class Fail5
+DOUBLEQUOTES . <<<	"DOUBLEQUOTESTABBED"
+class FailHeredocDoubleQuotesTabbed
 {
-
 }
-ANOTHER
-. <<<	"ONEMORE"
-class Fail6
-{
-
-}
-ONEMORE
-. <<<PHP73
-  class Fail7
+DOUBLEQUOTESTABBED . <<<HEREDOCPHP73
+  class FailHeredocPHP73
   {
-
   }
-  PHP73;
+  HEREDOCPHP73;
     }
 
-    public function test2()
+    public function test_nowdoc()
     {
-        $class = 'class Fail4 {}';
+        return <<<'NOWDOC'
+class FailNowdocBasic
+{
+}
+NOWDOC . <<<  'WHITESPACE'
+class FailNowdocWhitespace
+{
+}
+WHITESPACE . <<<	'NOWDOCTABBED'
+class FailNowdocTabbed
+{
+}
+NOWDOCTABBED . <<<'NOWDOCPHP73'
+  class FailNowdocPHP73
+  {
+  }
+  NOWDOCPHP73;
+    }
+
+    public function test_followed_by_parentheses()
+    {
+        return array(<<<PARENTHESES
+            class FailParentheses
+            {
+            }
+            PARENTHESES);
+    }
+
+    public function test_followed_by_comma()
+    {
+        return array(1, 2, <<<COMMA
+            class FailComma
+            {
+            }
+            COMMA, 3, 4);
+    }
+
+    public function test_followed_by_period()
+    {
+        return <<<PERIOD
+            class FailPeriod
+            {
+            }
+            PERIOD.'?>';
+    }
+
+    public function test_simple_string()
+    {
+        return 'class FailSimpleString {}';
     }
 }


### PR DESCRIPTION
* take into account relaxed changes introduced in php 7.3
  * see: https://github.com/php/php-src/commit/4887357269107ed669463c4b95bd755fbbb52490
* allow " as well as ', which was introduced in php 5.3
* allow parentheses or comma as character after closing identifier

closes #8080