### PR TITLE
Fixes #8065: Sort plugins deterministically before loading.

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -28,7 +28,6 @@ use Composer\Script\ScriptEvents;
  */
 class AutoloadGenerator
 {
-
     /**
      * @var EventDispatcher
      */

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -960,7 +960,7 @@ INITIALIZER;
      * @param  array $packageMap
      * @return array
      */
-    public function sortPackageMap(array $packageMap)
+    protected function sortPackageMap(array $packageMap)
     {
         $packages = array();
         $paths = array();

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -17,11 +17,11 @@ use Composer\EventDispatcher\EventDispatcher;
 use Composer\Installer\InstallationManager;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
-use Composer\Package\Link;
 use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Util\Filesystem;
 use Composer\Script\ScriptEvents;
+use Composer\Util\PackageSorter;
 
 /**
  * @author Igor Wiedler <igor@wiedler.ch>
@@ -957,88 +957,6 @@ INITIALIZER;
      *
      * Packages of equal weight retain the original order
      *
-     * @param  array $packages
-     * @return array
-     */
-    public function sortPackages(array $packages) {
-        $usageList = array();
-
-        foreach ($packages as $package) { /** @var PackageInterface $package */
-            foreach (array_merge($package->getRequires(), $package->getDevRequires()) as $link) { /** @var Link $link */
-                $target = $link->getTarget();
-                $usageList[$target][] = $package->getName();
-            }
-        }
-        $computing = array();
-        $computed = array();
-        $computeImportance = function ($name) use (&$computeImportance, &$computing, &$computed, $usageList) {
-            // reusing computed importance
-            if (isset($computed[$name])) {
-                return $computed[$name];
-            }
-
-            // canceling circular dependency
-            if (isset($computing[$name])) {
-                return 0;
-            }
-
-            $computing[$name] = true;
-            $weight = 0;
-
-            if (isset($usageList[$name])) {
-                foreach ($usageList[$name] as $user) {
-                    $weight -= 1 - $computeImportance($user);
-                }
-            }
-
-            unset($computing[$name]);
-            $computed[$name] = $weight;
-
-            return $weight;
-        };
-
-        $weightList = array();
-
-        foreach ($packages as $name => $package) {
-            $weight = $computeImportance($name);
-            $weightList[$name] = $weight;
-        }
-
-        $stable_sort = function (&$array) {
-            static $transform, $restore;
-
-            $i = 0;
-
-            if (!$transform) {
-                $transform = function (&$v, $k) use (&$i) {
-                    $v = array($v, ++$i, $k, $v);
-                };
-
-                $restore = function (&$v, $k) {
-                    $v = $v[3];
-                };
-            }
-
-            array_walk($array, $transform);
-            asort($array);
-            array_walk($array, $restore);
-        };
-
-        $stable_sort($weightList);
-
-        $sortedPackages = array();
-
-        foreach (array_keys($weightList) as $name) {
-            $sortedPackages[] = $packages[$name];
-        }
-        return $sortedPackages;
-    }
-
-    /**
-     * Sorts packages by dependency weight
-     *
-     * Packages of equal weight retain the original order
-     *
      * @param  array $packageMap
      * @return array
      */
@@ -1054,7 +972,7 @@ INITIALIZER;
             $paths[$name] = $path;
         }
 
-        $sortedPackages = $this->sortPackages($packages);
+        $sortedPackages = PackageSorter::sortPackages($packages);
 
 
         $sortedPackageMap = array();

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -28,6 +28,7 @@ use Composer\Script\ScriptEvents;
  */
 class AutoloadGenerator
 {
+
     /**
      * @var EventDispatcher
      */
@@ -959,7 +960,7 @@ INITIALIZER;
      * @param  array $packageMap
      * @return array
      */
-    protected function sortPackageMap(array $packageMap)
+    public function sortPackageMap(array $packageMap)
     {
         $packages = array();
         $paths = array();

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -24,6 +24,7 @@ use Composer\Package\Link;
 use Composer\Semver\Constraint\Constraint;
 use Composer\DependencyResolver\Pool;
 use Composer\Plugin\Capability\Capability;
+use Composer\Util\PackageSorter;
 
 /**
  * Plugin manager
@@ -254,8 +255,7 @@ class PluginManager
     private function loadRepository(RepositoryInterface $repo)
     {
         $packages = $repo->getPackages();
-        $generator = $this->composer->getAutoloadGenerator();
-        $sortedPackages = array_reverse($generator->sortPackages($packages));
+        $sortedPackages = array_reverse(PackageSorter::sortPackages($packages));
         foreach ($sortedPackages as $package) {
             if (!($package instanceof CompletePackage)) {
                 continue;

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -255,11 +255,8 @@ class PluginManager
     {
         $packages = $repo->getPackages();
         $generator = $this->composer->getAutoloadGenerator();
-        $rootPackage = $this->composer->getPackage(); /** @var PackageInterface $rootPackage */
-        $packageMap = $generator->buildPackageMap($this->composer->getInstallationManager(), $rootPackage, $packages);
-        $sortedPackageMap = array_reverse($generator->sortPackageMap($packageMap));
-        foreach ($sortedPackageMap as $fullPackage) {
-            $package = $fullPackage[0]; /** @var PackageInterface $package */
+        $sortedPackages = array_reverse($generator->sortPackages($packages));
+        foreach ($sortedPackages as $package) {
             if (!($package instanceof CompletePackage)) {
                 continue;
             }

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -15,10 +15,10 @@ namespace Composer\Plugin;
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
+use Composer\Package\CompletePackage;
 use Composer\Package\Package;
 use Composer\Package\Version\VersionParser;
 use Composer\Repository\RepositoryInterface;
-use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;
 use Composer\Package\Link;
 use Composer\Semver\Constraint\Constraint;
@@ -253,8 +253,13 @@ class PluginManager
      */
     private function loadRepository(RepositoryInterface $repo)
     {
-        foreach ($repo->getPackages() as $package) { /** @var PackageInterface $package */
-            if ($package instanceof AliasPackage) {
+        $packages = $repo->getPackages();
+        $generator = $this->composer->getAutoloadGenerator();
+        $packageMap = $generator->buildPackageMap($this->composer->getInstallationManager(), $this->composer->getPackage(), $packages);
+        $sortedPackageMap = array_reverse($generator->sortPackageMap($packageMap));
+        foreach ($sortedPackageMap as $fullPackage) {
+            $package = $fullPackage[0]; /** @var PackageInterface $package */
+            if (!($package instanceof CompletePackage)) {
                 continue;
             }
             if ('composer-plugin' === $package->getType()) {

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -255,7 +255,8 @@ class PluginManager
     {
         $packages = $repo->getPackages();
         $generator = $this->composer->getAutoloadGenerator();
-        $packageMap = $generator->buildPackageMap($this->composer->getInstallationManager(), $this->composer->getPackage(), $packages);
+        $rootPackage = $this->composer->getPackage(); /** @var PackageInterface $rootPackage */
+        $packageMap = $generator->buildPackageMap($this->composer->getInstallationManager(), $rootPackage, $packages);
         $sortedPackageMap = array_reverse($generator->sortPackageMap($packageMap));
         foreach ($sortedPackageMap as $fullPackage) {
             $package = $fullPackage[0]; /** @var PackageInterface $package */

--- a/src/Composer/Util/PackageSorter.php
+++ b/src/Composer/Util/PackageSorter.php
@@ -3,8 +3,90 @@
 
 namespace Composer\Util;
 
+use Composer\Package\Link;
+use Composer\Package\PackageInterface;
 
 class PackageSorter
 {
+    /**
+     * Sorts packages by dependency weight
+     *
+     * Packages of equal weight retain the original order
+     *
+     * @param  array $packages
+     * @return array
+     */
+    public static function sortPackages(array $packages) {
+        $usageList = array();
 
+        foreach ($packages as $package) { /** @var PackageInterface $package */
+            foreach (array_merge($package->getRequires(), $package->getDevRequires()) as $link) { /** @var Link $link */
+                $target = $link->getTarget();
+                $usageList[$target][] = $package->getName();
+            }
+        }
+        $computing = array();
+        $computed = array();
+        $computeImportance = function ($name) use (&$computeImportance, &$computing, &$computed, $usageList) {
+            // reusing computed importance
+            if (isset($computed[$name])) {
+                return $computed[$name];
+            }
+
+            // canceling circular dependency
+            if (isset($computing[$name])) {
+                return 0;
+            }
+
+            $computing[$name] = true;
+            $weight = 0;
+
+            if (isset($usageList[$name])) {
+                foreach ($usageList[$name] as $user) {
+                    $weight -= 1 - $computeImportance($user);
+                }
+            }
+
+            unset($computing[$name]);
+            $computed[$name] = $weight;
+
+            return $weight;
+        };
+
+        $weightList = array();
+
+        foreach ($packages as $name => $package) {
+            $weight = $computeImportance($name);
+            $weightList[$name] = $weight;
+        }
+
+        $stable_sort = function (&$array) {
+            static $transform, $restore;
+
+            $i = 0;
+
+            if (!$transform) {
+                $transform = function (&$v, $k) use (&$i) {
+                    $v = array($v, ++$i, $k, $v);
+                };
+
+                $restore = function (&$v) {
+                    $v = $v[3];
+                };
+            }
+
+            array_walk($array, $transform);
+            asort($array);
+            array_walk($array, $restore);
+        };
+
+        $stable_sort($weightList);
+
+        $sortedPackages = array();
+
+        foreach (array_keys($weightList) as $name) {
+            $sortedPackages[] = $packages[$name];
+        }
+        return $sortedPackages;
+    }
 }

--- a/src/Composer/Util/PackageSorter.php
+++ b/src/Composer/Util/PackageSorter.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Composer\Util;
+
+
+class PackageSorter
+{
+
+}


### PR DESCRIPTION
A second shot at fixing #8065, and follow-up to #8070

Should be pretty self-explanatory. `$packages` was previously sorted non-deterministically depending on the context in which Composer was run (sometimes alphabetically, sometimes according to dependency weight). This ensures that plugins are always loaded according to dependency weight.