### PR TITLE
Add a helper to disable process timeouts

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -16,6 +16,7 @@ use Composer\Config\ConfigSourceInterface;
 use Composer\Downloader\TransportException;
 use Composer\IO\IOInterface;
 use Composer\Util\Platform;
+use Composer\Util\ProcessExecutor;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -458,5 +459,21 @@ class Config
                 $this->warnedHosts[$host] = true;
             }
         }
+    }
+
+    /**
+     * Used by long-running custom scripts in composer.json
+     *
+     * "scripts": {
+     *   "watch": [
+     *     "Composer\\Config::disableProcessTimeout",
+     *     "vendor/bin/long-running-script --watch"
+     *   ]
+     * }
+     */
+    public static function disableProcessTimeout()
+    {
+        // Override global timeout set earlier by environment or config
+        ProcessExecutor::setTimeout(0);
     }
 }


### PR DESCRIPTION
This came about because Sculpin's blog skeleton was recently changed to use Composer to manage long running processes like `yarn encore --watch` and `sculpin generate --watch`. Shortly thereafter, it was observed that this triggered the 5 minute default Composer timeout.

It seemed unwise to set the entire Composer configuration to unlimited timeouts, and I felt that this narrower approach was potentially worthy of being included in Composer itself.

The helper can be included in custom script definitions by calling
`"Composer\\Config::disableProcessTimeout"`.

Example:

```json
{
  "scripts": {
    "watch": [
      "Composer\\Config::disableProcessTimeout",
      "vendor/bin/sculpin generate --watch --server"
    ]
  }
}
```