### PR TITLE
Exclude more files from being exported

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,8 @@
 
 # Exclude non-essential files from dist
 /tests export-ignore
+.github export-ignore
+.php_cs export-ignore
+.travis.yml export-ignore
+appveyor.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
I was toying around with a deployment script and noticed these unnecessary (in a deployment context) files.