### PR TITLE
Add documentation for Composer\\Config::disableProcessTimeout

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -9,6 +9,20 @@ Defaults to `300`. The duration processes like git clones can run before
 Composer assumes they died out. You may need to make this higher if you have a
 slow connection or huge vendors.
 
+To disable the process timeout on a custom command under `scripts`, a static
+helper is available:
+
+```json
+{
+    "scripts": {
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "phpunit"
+        ]
+    }
+}
+```
+
 ## use-include-path
 
 Defaults to `false`. If `true`, the Composer autoloader will also look for classes

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -221,6 +221,26 @@ to the `phpunit` script.
 > are easily accessible. In this example no matter if the `phpunit` binary is
 > actually in `vendor/bin/phpunit` or `bin/phpunit` it will be found and executed.
 
+Although Composer is not intended to manage long-running processes and other
+such aspects of PHP projects, it can sometimes be handy to disable the process
+timeout on custom commands. This timeout defaults to 300 seconds and can be
+overridden for all commands using the config key `process-timeout`, or for
+specific commands using an argument to the `run-script` command.
+
+A static helper also exists that can disable the process timeout for a specific
+script directly in composer.json:
+
+```json
+{
+    "scripts": {
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "phpunit"
+        ]
+    }
+}
+```
+
 ## Referencing scripts
 
 To enable script re-use and avoid duplicates, you can call a script from another


### PR DESCRIPTION
This change modifies the `06-config.md` section and the `scripts` article to provide information about the new `Composer\\Config::disableProcessTimeout` helper added in #8088.

It also adds some extra information about process timeouts in general, and is careful to preface the disable-timeout helper documentation with a note that Composer isn't exactly intended for that use case.