### PR TITLE
Fixes #8065: Load composer installers first.

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -253,7 +253,15 @@ class PluginManager
      */
     private function loadRepository(RepositoryInterface $repo)
     {
-        foreach ($repo->getPackages() as $package) { /** @var PackageInterface $package */
+        $packages = $repo->getPackages();
+        foreach ($packages as $i => $package) {
+            if ($package->getName() == 'composer/installers') {
+                unset($packages[$i]);
+                array_unshift($packages, $package);
+                break;
+            }
+        }
+        foreach ($packages as $package) { /** @var PackageInterface $package */
             if ($package instanceof AliasPackage) {
                 continue;
             }


### PR DESCRIPTION
Fixes #8065. This is an alternative approach to #8085.

This is somewhat simpler but also a less general fix, in that it just bumps composer/installers (the most common cause of this problem) to the top of the list when loading plugins.