### PR TITLE
Allow to set process executor to be set from outside the VcsRepository

### DIFF
--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -22,6 +22,7 @@ use Composer\Package\Loader\LoaderInterface;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\IO\IOInterface;
 use Composer\Config;
+use Composer\Util\ProcessExecutor;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -36,6 +37,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
     protected $versionParser;
     protected $type;
     protected $loader;
+    protected $process;
     protected $repoConfig;
     protected $branchErrorOccurred = false;
     private $drivers;
@@ -80,6 +82,11 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
         $this->loader = $loader;
     }
 
+    public function setProcess(ProcessExecutor $process)
+    {
+        $this->process = $process;
+    }
+
     public function getDriver()
     {
         if ($this->driver) {
@@ -88,7 +95,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
 
         if (isset($this->drivers[$this->type])) {
             $class = $this->drivers[$this->type];
-            $this->driver = new $class($this->repoConfig, $this->io, $this->config);
+            $this->driver = new $class($this->repoConfig, $this->io, $this->config, $this->process);
             $this->driver->initialize();
 
             return $this->driver;
@@ -96,7 +103,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
 
         foreach ($this->drivers as $driver) {
             if ($driver::supports($this->io, $this->config, $this->url)) {
-                $this->driver = new $driver($this->repoConfig, $this->io, $this->config);
+                $this->driver = new $driver($this->repoConfig, $this->io, $this->config, $this->process);
                 $this->driver->initialize();
 
                 return $this->driver;
@@ -105,7 +112,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
 
         foreach ($this->drivers as $driver) {
             if ($driver::supports($this->io, $this->config, $this->url, true)) {
-                $this->driver = new $driver($this->repoConfig, $this->io, $this->config);
+                $this->driver = new $driver($this->repoConfig, $this->io, $this->config, $this->process);
                 $this->driver->initialize();
 
                 return $this->driver;

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -28,7 +28,7 @@ class ProcessExecutor
     protected $io;
     protected $env;
 
-    public function __construct(IOInterface $io = null, array $env = array())
+    public function __construct(IOInterface $io = null, $env = null)
     {
         $this->io = $io;
         $this->env = $env;

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -26,10 +26,12 @@ class ProcessExecutor
     protected $captureOutput;
     protected $errorOutput;
     protected $io;
+    protected $env;
 
-    public function __construct(IOInterface $io = null)
+    public function __construct(IOInterface $io = null, array $env = array())
     {
         $this->io = $io;
+        $this->env = $env;
     }
 
     /**
@@ -65,9 +67,9 @@ class ProcessExecutor
 
         // TODO in v3, commands should be passed in as arrays of cmd + args
         if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandline')) {
-            $process = Process::fromShellCommandline($command, $cwd, null, null, static::getTimeout());
+            $process = Process::fromShellCommandline($command, $cwd, $this->env, null, static::getTimeout());
         } else {
-            $process = new Process($command, $cwd, null, null, static::getTimeout());
+            $process = new Process($command, $cwd, $this->env, null, static::getTimeout());
         }
 
         $callback = is_callable($output) ? $output : array($this, 'outputHandler');


### PR DESCRIPTION
I'm trying to add my own git repo to Composer in some plugin and I need to pass env variables to the `ProcessExecutor`. Specifically, I need to be able to set the `GIT_SSH_COMMAND` env variable to make sure a specifiy SSH key is taken instead of the ones configured on the OS. It's a very specific use case so there's no need to make that configurable from the outside somehow but atm it's also pretty cumbersome to do as I have to extend the `ProcessExecutor` and the `VcsRepository` just to pass a simple environment variable to the process that's being executed.