### PR TITLE
Fix URL resolution for non-HTTP(S) Composer repositories

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -562,7 +562,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     protected function canonicalizeUrl($url)
     {
         if ('/' === $url[0]) {
-            return preg_replace('{(https?://[^/]+).*}i', '$1' . $url, $this->url);
+            return preg_replace('{([^:]+://[^/]*).*}', '$1' . $url, $this->url);
         }
 
         return $url;

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -204,4 +204,47 @@ class ComposerRepositoryTest extends TestCase
             $repository->search('foo', RepositoryInterface::SEARCH_FULLTEXT, 'library')
         );
     }
+
+    /**
+     * @dataProvider canonicalizeUrlProvider
+     *
+     * @param string $expected
+     * @param string $url
+     * @param string $repositoryUrl
+     */
+    public function testCanonicalizeUrl($expected, $url, $repositoryUrl)
+    {
+        $repository = new ComposerRepository(
+            array('url' => $repositoryUrl),
+            new NullIO(),
+            FactoryMock::createConfig()
+        );
+
+        $object = new \ReflectionObject($repository);
+        $method = $object->getMethod('canonicalizeUrl');
+        $method->setAccessible(true);
+
+        $this->assertSame($expected, $method->invoke($repository, $url));
+    }
+
+    public function canonicalizeUrlProvider()
+    {
+        return array(
+            array(
+                'https://example.org/path/to/file',
+                '/path/to/file',
+                'https://example.org',
+            ),
+            array(
+                'file:///path/to/repository/file',
+                '/path/to/repository/file',
+                'file:///path/to/repository',
+            ),
+            array(
+                'https://otherdomain.example.org/path/to/file',
+                'https://otherdomain.example.org/path/to/file',
+                'https://example.org',
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Hello,

I had trouble using a local Composer repository created by [Satis](https://packagist.org/packages/composer/satis) with the [`"providers": true`](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md#other-options) option.

# Example
My `~/.composer/config.json` looks like this:
```json
{
    "repositories": {
        "myRepository": {
            "type": "composer",
            "url": "file:///path/to/repository"
        }
    }
}
```

And the `/path/to/repository/packages.json` (shortened):
```json
{
    "packages": [],
    "providers-url": "/path/to/repository/p/%package%$%hash%.json",
    "providers": {
        ...
    }
}
```

Trying to install a package from that repository leads to a `RepositorySecurityException`: https://gist.github.com/pfofi/f145951cc7b8ff95e403de51082edcc1


# Fix
The problem seems to be in [`ComposerRepository::canonicalizeUrl()`](https://github.com/composer/composer/blob/dd40d74bf6041ddcefa1ebe46fb9117d031b1ccd/src/Composer/Repository/ComposerRepository.php#L562) which only handles HTTP(S) URLs. This PR should fix that.

Thank you.