### PR TITLE
Add documentation how to run plugins manually

### DIFF
--- a/doc/articles/plugins.md
+++ b/doc/articles/plugins.md
@@ -261,6 +261,11 @@ Now the `custom-plugin-command` is available alongside Composer commands.
 
 > _Composer commands are based on the [Symfony Console Component][10]._
 
+## Running plugins manually
+
+Plugins for an event can be run manually by the `run-script` command. This works the same way as 
+[running scripts manually](scripts.md#running-scripts-manually).
+
 ## Using Plugins
 
 Plugin packages are automatically loaded as soon as they are installed and will

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -189,7 +189,7 @@ composer run-script [--dev] [--no-dev] script
 ```
 
 For example `composer run-script post-install-cmd` will run any
-**post-install-cmd** scripts that have been defined.
+**post-install-cmd** scripts and [plugins](plugins.md) that have been defined.
 
 You can also give additional arguments to the script handler by appending `--`
 followed by the handler arguments. e.g.


### PR DESCRIPTION
By trial, I figured out that also plugins can be run manually. Would be nice if documentation would show that as well.