### PR TITLE
Fix: Bitbucket getChangeDate throws exception for branches containing a slash

### DIFF
--- a/src/Composer/Repository/Vcs/BitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/BitbucketDriver.php
@@ -218,6 +218,13 @@ abstract class BitbucketDriver extends VcsDriver
             return $this->fallbackDriver->getChangeDate($identifier);
         }
 
+        if (strpos($identifier, '/') !== false) {
+            $branches = $this->getBranches();
+            if (isset($branches[$identifier])) {
+                $identifier = $branches[$identifier];
+            }
+        }
+
         $resource = sprintf(
             'https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s?fields=date',
             $this->owner,


### PR DESCRIPTION
Calling the getChangeDate method in the BitbucketDriver with an identifier containing a slash will result in a 404 exception.

Note: this is only an issue while using the VcsRepositories directly outside of a regular composer install or update. For instance to check if a vcs repository contains a composer file.

