### PR TITLE
[WIP] Add --pretend-match-platform-reqs flag

### DIFF
--- a/tests/Composer/Test/Fixtures/installer/install-pretend-to-match-platform-package-requirements.test
+++ b/tests/Composer/Test/Fixtures/installer/install-pretend-to-match-platform-package-requirements.test
@@ -1,0 +1,21 @@
+--TEST--
+Install in ignore-platform-reqs mode
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "ext-testdummy": "*", "php": ">=98" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0",
+        "php": "99.9"
+    }
+}
+--RUN--
+install --pretend-match-platform-reqs
+--EXPECT--
+Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/require-pretend-to-match-platform-package-requirements.test
+++ b/tests/Composer/Test/Fixtures/installer/require-pretend-to-match-platform-package-requirements.test
@@ -1,0 +1,21 @@
+--TEST--
+Install in ignore-platform-reqs mode
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0", "require": { "ext-testdummy": "*", "php": "^99" } },
+                { "name": "a/a", "version": "2.0.0", "require": { "ext-testdummy": "*", "php": "^100" } }
+            ]
+        }
+    ],
+    "require": {
+        "php": "99.9"
+    }
+}
+--RUN--
+require a/a --pretend-match-platform-reqs
+--EXPECT--
+Installing a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/update-pretend-to-match-platform-package-requirements.test
+++ b/tests/Composer/Test/Fixtures/installer/update-pretend-to-match-platform-package-requirements.test
@@ -1,0 +1,27 @@
+--TEST--
+Update in ignore-platform-reqs mode
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.1", "require": { "ext-testdummy": "*", "php": "99" } },
+                { "name": "a/a", "version": "1.0.2", "require": { "ext-testdummy": "*", "php": "^99" } },
+                { "name": "a/a", "version": "2.0.0", "require": { "ext-testdummy": "*", "php": "^100" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.*",
+        "php": "99.9"
+    }
+}
+--INSTALLED--
+[
+    { "name": "a/a", "version": "1.0.0" }
+]
+--RUN--
+update --pretend-match-platform-reqs
+--EXPECT--
+Updating a/a (1.0.0) to a/a (1.0.2)


### PR DESCRIPTION
`--ignore-platform-reqs` is a handy flag for ignoring platform requirements but it comes with a few downsides:

- Ignores the PHP version your on (and maybe even the one defined in `config.platform.php`) and you might end up with a PHP 7.4 package on a PHP 7.3 project 
- It's a all or nothing solution, doesn't provide a middle ground where extension requirements are ignored but PHP version is respected

So I'm proposing the `--pretend-match-platform-reqs` flag where the PHP version is respected and composer pretend it has all the extensions the project and it's (possible) dependencies require. As a first commit into this PR I've created tests that show the expected behaviour for this flag.

This issue came up as I started integrating [`ext-parallel`](https://github.com/krakjoe/parallel/) (which requires PHP ZTS) into a project and [`Dependabot`](https://dependabot.com/) couldn't resolve dependencies anymore to automate updates. (As shown in this issue: https://github.com/reactive-apps/command-http-server/issues/40 .)

Haven't completed writing this feature as I want to gauge interest from the composer team with this PR first before investing a lot of time in it.