### PR TITLE
Cannot find file by class name with duplicated namespace separators

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -372,6 +372,10 @@ class ClassLoader
         // PSR-4 lookup
         $logicalPathPsr4 = strtr($class, '\\', DIRECTORY_SEPARATOR) . $ext;
 
+        if (strpos($logicalPathPsr4, DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR) !== false) {
+            return false;
+        }
+
         $first = $class[0];
         if (isset($this->prefixLengthsPsr4[$first])) {
             $subPath = $class;

--- a/tests/Composer/Test/Autoload/ClassLoaderTest.php
+++ b/tests/Composer/Test/Autoload/ClassLoaderTest.php
@@ -59,4 +59,16 @@ class ClassLoaderTest extends TestCase
         $loader = new ClassLoader();
         $this->assertEmpty($loader->getPrefixes());
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPsr0DoubleNamespaceSeparator()
+    {
+        $loader = new ClassLoader();
+        $loader->add('Namespaced\\', __DIR__ . '/Fixtures/');
+
+        $this->assertFalse($loader->findFile('Namespaced\\\\Foo'));
+        $this->assertInternalType('string', $loader->findFile('Namespaced\\Foo'));
+    }
 }


### PR DESCRIPTION
Fixes #8129