### PR TITLE
Document the alternatives to disable the default script timeout

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -264,11 +264,11 @@ of all following scripts in the current terminal environment:
 export COMPOSER_PROCESS_TIMEOUT=0
 ```
 
-To disable the timeout of a single script call, you must use the `run` composer
+To disable the timeout of a single script call, you must use the `run-script` composer
 command and specify the `--timeout` parameter:
 
 ```
-composer run test --timeout=0
+composer run-script test --timeout=0
 ```
 
 ## Referencing scripts

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -224,11 +224,13 @@ to the `phpunit` script.
 Although Composer is not intended to manage long-running processes and other
 such aspects of PHP projects, it can sometimes be handy to disable the process
 timeout on custom commands. This timeout defaults to 300 seconds and can be
-overridden for all commands using the config key `process-timeout`, or for
-specific commands using an argument to the `run-script` command.
+overridden in a variety of ways depending on the desired effect: it's possible
+to disable it for all command using the config key `process-timeout`, or for
+a specific call using the `--timeout` parameter of the `run` (`run-scripts`)
+command, or using a static helper for specific scripts.
 
-A static helper also exists that can disable the process timeout for a specific
-script directly in composer.json:
+To disable the timeout for specific scripts with the static helper directly in
+composer.json:
 
 ```json
 {
@@ -239,6 +241,31 @@ script directly in composer.json:
         ]
     }
 }
+```
+
+To disable the timeout for every script on a given project, you can use the
+composer.json configuration:
+
+```json
+{
+    "config": {
+        "process-timeout": 0
+    }
+}
+```
+
+It's also possible to set the global environment variable to disable the timeout
+of all following scripts in the current terminal environment:
+
+```
+export COMPOSER_PROCESS_TIMEOUT=0
+```
+
+To disable the timeout of a single script call, you must use the `run` composer
+command and specify the `--timeout` parameter:
+
+```
+composer run test --timeout=0
 ```
 
 ## Referencing scripts

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -224,10 +224,13 @@ to the `phpunit` script.
 Although Composer is not intended to manage long-running processes and other
 such aspects of PHP projects, it can sometimes be handy to disable the process
 timeout on custom commands. This timeout defaults to 300 seconds and can be
-overridden in a variety of ways depending on the desired effect: it's possible
-to disable it for all command using the config key `process-timeout`, or for
-a specific call using the `--timeout` parameter of the `run` (`run-scripts`)
-command, or using a static helper for specific scripts.
+overridden in a variety of ways depending on the desired effect:
+
+- disable it for all commands using the config key `process-timeout`,
+- disable it for the current or future invocations of composer using the
+  environment variable `COMPOSER_PROCESS_TIMEOUT`,
+- for a specific invocation using the `--timeout` flag of the `run-script` command,
+- using a static helper for specific scripts.
 
 To disable the timeout for specific scripts with the static helper directly in
 composer.json:

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -268,7 +268,7 @@ To disable the timeout of a single script call, you must use the `run-script` co
 command and specify the `--timeout` parameter:
 
 ```
-composer run-script test --timeout=0
+composer run-script --timeout=0 test
 ```
 
 ## Referencing scripts


### PR DESCRIPTION
Mentioning and giving an example of the usage of the 4 options to disable the default script timeout of 300 seconds:
1. Static helper (already exists and kept).
2. Config key "process-timeout".
3. Environment variable "COMPOSER_PROCESS_TIMEOUT".
4. The "--timeout" parameter.