### PR TITLE
Add a small delay to the CacheClear command

### DIFF
--- a/src/Composer/Command/ClearCacheCommand.php
+++ b/src/Composer/Command/ClearCacheCommand.php
@@ -14,6 +14,7 @@ namespace Composer\Command;
 
 use Composer\Cache;
 use Composer\Factory;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -69,6 +70,17 @@ EOT
             $cache->clear();
         }
 
+        $delay = 30;
+        $progressBar = new ProgressBar($output, $delay);
+        $progressBar->start();
+
+        $i = 0;
+        while ($i++ < $delay) {
+            sleep(1);
+            $progressBar->advance();
+        }
+        $progressBar->finish(); 
+        
         $io->writeError('<info>All caches cleared.</info>');
     }
 }


### PR DESCRIPTION
Yes, this is insane. But it might make sense. 

There is no real benefit of clearing the local cache. But people (including myself) like to do it because we run in to errors. 
The most common error (for me) is that I have to wait until pagagist systems are updated. So having this "forced wait" will actually "fix" my problem.