### PR TITLE
[Do not merge] Allow overriding self-update target file with env var COMPOSER_SELF_UPDATE_TARGET

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -917,6 +917,10 @@ if you use Composer as super user at all times like in docker containers.
 
 If set, the value is used as php's memory_limit.
 
+### COMPOSER_SELF_UPDATE_TARGET
+
+If set, makes the self-update command write the new Composer phar file into that path instead of overwriting itself. Useful for updating Composer on read-only filesystem.
+
 ### COMPOSER_MIRROR_PATH_REPOS
 
 If set to 1, this env changes the default path repository strategy to `mirror` instead


### PR DESCRIPTION
This is a replacement for PR https://github.com/composer/composer/pull/8151 after that was merged by accident.

----

This is useful if Composer is provided on a read-only filesystems, to allow self-update to work with a different destination. This assumes composer is available on the PATH and running composer self-update then results with correct use of the environment variable in the updated version written to a preferred directory on the PATH, so that subsequent invocations of composer on the PATH will now use the newer version.


You can see here how this is supposed to work. The PATH includes a writable and a read-only directory. The self-update fails if you execute it from the read-only directory, but it works with the target environment variable. Afterwards the composer.phat on the PATH has been updated, but the file in the read-only directory remains unchanged.

```
naderman@saumur:~/read-only$ echo $PATH
/home/naderman/writable:/home/naderman/read-only:/home/naderman/bin:/home/naderman/git/bin:/home/naderman/bin:/home/naderman/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
naderman@saumur:~/read-only$ ls /home/naderman/writable/
naderman@saumur:~/read-only$ which composer.phar
/home/naderman/read-only/composer.phar
naderman@saumur:~/read-only$ composer.phar --version
Composer version 1.8-dev (1.8-dev+faa7c5eea2de7e053f38c0726c01147531687361) 2019-05-19 19:10:15
naderman@saumur:~/read-only$ composer.phar self-update
Updating to version d63bf33848f396c58c5e0de834cf15f9d7094b95 (snapshot channel).
   Downloading (100%)         

                                                                                                                       
  [ErrorException]                                                                                                     
  rename(/home/naderman/.composer/cache/composer-temp.phar,/home/naderman/read-only/composer.phar): Permission denied  
                                                                                                                       

self-update [-r|--rollback] [--clean-backups] [--no-progress] [--update-keys] [--stable] [--preview] [--snapshot] [--set-channel-only] [--] [<version>]

naderman@saumur:~/read-only$ COMPOSER_SELF_UPDATE_TARGET=/home/naderman/writable/composer.phar composer.phar self-update
Updating to version d63bf33848f396c58c5e0de834cf15f9d7094b95 (snapshot channel).
   Downloading (100%)         
Use composer self-update --rollback to return to version faa7c5eea2de7e053f38c0726c01147531687361
naderman@saumur:~/read-only$ hash -r
naderman@saumur:~/read-only$ which composer.phar
/home/naderman/writable/composer.phar
naderman@saumur:~/read-only$ composer.phar --version
Composer version 1.9-dev (1.9-dev+d63bf33848f396c58c5e0de834cf15f9d7094b95) 2019-05-14 08:30:18
naderman@saumur:~/read-only$ ./composer.phar --version
Composer version 1.8-dev (1.8-dev+faa7c5eea2de7e053f38c0726c01147531687361) 2019-05-19 19:10:15
```

Personally I question whether we should really merge/encourage this. Anyone who uses the actual path to the composer.phar file will get a self-update which goes through but writes a file somewhere else instead of getting an error. After the successful self-update the file is still the old one. This seems rather counter intuitive if you're not relying on the PATH, or if you forget to clear the shell's cache of executable file locations (hash -r in my example).

Further if the environment variable is set on a system or user profile, the behavior of self-update will be difficult to understand since it will not "self-update" but write to some other fixed directory, no matter where the original composer.phar file is.

I've attached a composer.phar generated with this commit to allow for testing the self-update command:
[composer-self-update-env.zip](https://github.com/composer/composer/files/3195534/composer-self-update-env.zip)

