### PR TITLE
SVN: hide passwords for debug output

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -51,6 +51,7 @@ class ProcessExecutor
 
                 return '://'.$m['user'].':***@';
             }, $command);
+            $safeCommand = preg_replace("{--password (.*[^\\\\]\') }", '--password \'***\' ', $safeCommand);
             $this->io->writeError('Executing command ('.($cwd ?: 'CWD').'): '.$safeCommand);
         }
 


### PR DESCRIPTION
Using composer with svn repositories with debug mode enabled will output the full credentials like shown in the example below:
```
Executing command (CWD): svn info --non-interactive 'https://svn.example.org/svn/glaubinix' []
Executing command (CWD): svn ls --verbose --non-interactive  --username 'glaubinix' --password 'my-actual-password'  'https://svn.example.org/svn/glaubinix/trunk' []
Executing command (CWD): svn ls --verbose --non-interactive  --username 'glaubinix' --password 'my-actual-password'  'https://svn.example.org/svn/glaubinix/branches' []
...
```