### PR TITLE
Free $solver asap

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -473,6 +473,8 @@ class Installer
         $solver = new Solver($policy, $pool, $installedRepo, $this->io);
         try {
             $operations = $solver->solve($request, $this->ignorePlatformReqs);
+            $ruleSetSize = $solver->getRuleSetSize();
+            $solver = null;
         } catch (SolverProblemsException $e) {
             $this->io->writeError('<error>Your requirements could not be resolved to an installable set of packages.</error>', true, IOInterface::QUIET);
             $this->io->writeError($e->getMessage());
@@ -489,7 +491,7 @@ class Installer
         $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, $this->devMode, $policy, $pool, $installedRepo, $request, $operations);
 
         $this->io->writeError("Analyzed ".count($pool)." packages to resolve dependencies", true, IOInterface::VERBOSE);
-        $this->io->writeError("Analyzed ".$solver->getRuleSetSize()." rules to resolve dependencies", true, IOInterface::VERBOSE);
+        $this->io->writeError("Analyzed ".$ruleSetSize." rules to resolve dependencies", true, IOInterface::VERBOSE);
 
         // execute operations
         if (!$operations) {


### PR DESCRIPTION
The `$solver` variable in the `Installer::doInstall()` method holds a pretty big object.
Keeping this object around is not needed once dependencies are solved.
In my use case, this reduces the peak memory from 1.3GB to 1.0GB.
Not bad :)

Discovered while working on https://github.com/symfony/flex/pull/520