### PR TITLE
Simplify switch with early return

### DIFF
--- a/tests/Composer/Test/AllFunctionalTest.php
+++ b/tests/Composer/Test/AllFunctionalTest.php
@@ -151,15 +151,12 @@ class AllFunctionalTest extends TestCase
         $variableReplacer = function ($match) use (&$data, $testDir) {
             list(, $var) = $match;
 
-            switch ($var) {
-                case 'testDir':
-                    $data['test_dir'] = $testDir;
-
-                    return $testDir;
-
-                default:
-                    throw new \InvalidArgumentException(sprintf('Unknown variable "%s". Supported variables: "testDir"', $var));
+            if ($var != 'testDir') {
+                throw new \InvalidArgumentException(sprintf('Unknown variable "%s". Supported variables: "testDir"', $var));
             }
+
+            $data['test_dir'] = $testDir;
+            return $testDir;
         };
 
         for ($i = 0, $c = count($tokens); $i < $c; $i++) {


### PR DESCRIPTION
As we only have one case and default, we can use an early return to simplify it.