### PR TITLE
Remove require-dev key from packages in lock

### DIFF
--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -368,6 +368,9 @@ class Locker
             $spec = $this->dumper->dump($package);
             unset($spec['version_normalized']);
 
+            // Remove require-dev as it is root-only
+            unset($spec['require-dev']);
+
             // always move time to the end of the package definition
             $time = isset($spec['time']) ? $spec['time'] : null;
             unset($spec['time']);


### PR DESCRIPTION
I often find myself reviewing changes in composer.lock to see what was updated. When doing so changes to `require-dev` section of dependencies is just noise since it doesn't influence my project, that's why I propose to remove the key to make it easier to find the relevant information.