### PR TITLE
StreamContextFactory: set the proxy protocol always to tcp:// (fixes #8255)

### DIFF
--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -77,7 +77,7 @@ final class StreamContextFactory
             // http(s):// is not supported in proxy
             $proxyURL = str_replace(array('http://', 'https://'), array('tcp://', 'ssl://'), $proxyURL);
 
-            if (0 === strpos($proxyURL, 'ssl:') && !extension_loaded('openssl')) {
+            if (preg_match('{^https://}i', $url) && !extension_loaded('openssl')) {
                 throw new \RuntimeException('You must enable the openssl extension to use a proxy over https');
             }
 

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -74,8 +74,15 @@ final class StreamContextFactory
                 $proxyURL .= ":443";
             }
 
-            // http(s):// is not supported in proxy
-            $proxyURL = str_replace(array('http://', 'https://'), array('tcp://', 'ssl://'), $proxyURL);
+            /*
+             * When accessing https resources, PHP sends a HTTP CONNECT request
+             * to the proxy to open a tunnel. This tunnel is then used to
+             * forward TLS traffic. The CONNECT request is sent through
+             * plaintext, therefore we set the 'tcp://' protocol.
+             * This does not mean that the traffic to the remote server is
+             * unencrypted.
+             */
+            $proxyURL = str_replace(array('http://', 'https://'), 'tcp://', $proxyURL);
 
             if (preg_match('{^https://}i', $url) && !extension_loaded('openssl')) {
                 throw new \RuntimeException('You must enable the openssl extension to use a proxy over https');

--- a/tests/Composer/Test/Util/StreamContextFactoryTest.php
+++ b/tests/Composer/Test/Util/StreamContextFactoryTest.php
@@ -172,7 +172,7 @@ class StreamContextFactoryTest extends TestCase
 
         $expected = array(
             'http' => array(
-                'proxy' => 'ssl://woopproxy.net:443',
+                'proxy' => 'tcp://woopproxy.net:443',
                 'request_fulluri' => true,
                 'method' => 'GET',
                 'max_redirects' => 20,
@@ -220,8 +220,8 @@ class StreamContextFactoryTest extends TestCase
     public function dataSSLProxy()
     {
         return array(
-            array('ssl://proxyserver:443', 'https://proxyserver/'),
-            array('ssl://proxyserver:8443', 'https://proxyserver:8443'),
+            array('tcp://proxyserver:443', 'https://proxyserver/'),
+            array('tcp://proxyserver:8443', 'https://proxyserver:8443'),
         );
     }
 


### PR DESCRIPTION
Fixes: #8255 