### PR TITLE
Validate schema name, type and version

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -7,8 +7,7 @@
     "properties": {
         "name": {
             "type": "string",
-            "description": "Package name, including 'vendor-name/' prefix.",
-            "pattern": "^.+/.+$"
+            "description": "Package name, including 'vendor-name/' prefix."
         },
         "type": {
             "description": "Package type, either 'library' for common packages, 'composer-plugin' for plugins, 'metapackage' for empty packages, or a custom type ([a-z0-9-]+) defined by whatever project this package applies to.",
@@ -42,7 +41,7 @@
         "version": {
             "type": "string",
             "description": "Package version, see https://getcomposer.org/doc/04-schema.md#version for more info on valid schemes.",
-            "pattern": "^v?\\d+((\\.\\d)?\\.\\d)?(-(dev|patch|p|alpha|a|beta|b|rc|RC)\\d?)?$"
+            "pattern": "^v?\\d+(((\\.\\d+)?\\.\\d+)?\\.\\d+)?(-.+)?$"
         },
         "time": {
             "type": "string",

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -41,7 +41,7 @@
         "version": {
             "type": "string",
             "description": "Package version, see https://getcomposer.org/doc/04-schema.md#version for more info on valid schemes.",
-            "pattern": "^v?\\d+(((\\.\\d+)?\\.\\d+)?\\.\\d+)?(-.+)?$"
+            "pattern": "^v?\\d+(((\\.\\d+)?\\.\\d+)?\\.\\d+)?"
         },
         "time": {
             "type": "string",

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -7,11 +7,13 @@
     "properties": {
         "name": {
             "type": "string",
-            "description": "Package name, including 'vendor-name/' prefix."
+            "description": "Package name, including 'vendor-name/' prefix.",
+            "pattern": "^.+/.+$"
         },
         "type": {
             "description": "Package type, either 'library' for common packages, 'composer-plugin' for plugins, 'metapackage' for empty packages, or a custom type ([a-z0-9-]+) defined by whatever project this package applies to.",
-            "type": "string"
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
         },
         "target-dir": {
             "description": "DEPRECATED: Forces the package to be installed into the given subdirectory path. This is used for autoloading PSR-0 packages that do not contain their full path. Use forward slashes for cross-platform compatibility.",
@@ -39,7 +41,8 @@
         },
         "version": {
             "type": "string",
-            "description": "Package version, see https://getcomposer.org/doc/04-schema.md#version for more info on valid schemes."
+            "description": "Package version, see https://getcomposer.org/doc/04-schema.md#version for more info on valid schemes.",
+            "pattern": "^v?\\d+((\\.\\d)?\\.\\d)?(-(dev|patch|p|alpha|a|beta|b|rc|RC)\\d?)?$"
         },
         "time": {
             "type": "string",


### PR DESCRIPTION
I'm trying to validate an artifact package and was wondering why there is no validation on the schema properties like name, type and version. 

The patterns now match the documentation at https://getcomposer.org/doc/04-schema.md, but I'm not sure this is absolutely correct. For example, as far as I know, the version can have four digits (`1.0.0.0`) in the constraint, or at least that's what `normalizeVersion` usually gives me. That might also be the patch version, so `1.0.0-p1` would be correct.

Feel free to tell me if this might cause more harm than good 😉 

/cc @Toflar 