### PR TITLE
[POC] Optimize performance and resources of ComposerRepository

### DIFF
--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -320,12 +320,13 @@ class Pool implements \Countable
                 return false;
             }
         }
+
+        return true;
     }
 
     public function isPackageAcceptable($name, $stability)
     {
         foreach ((array) $name as $n) {
-
             // allow if package matches the global stability requirement and has no exception
             if (!isset($this->stabilityFlags[$n]) && isset($this->acceptableStabilities[$stability])) {
                 return true;

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -304,17 +304,8 @@ class Pool implements \Countable
         return $prefix.' '.$package->getPrettyString();
     }
 
-    public function isPackageAllowedByRoot($name, $version, $stability = null)
+    public function isPackageAllowedByRoot($name, $version)
     {
-        if (null === $stability) {
-            $stability = VersionParser::parseStability($stability);
-        }
-
-        // Only exclude stable versions
-        if ('stable' !== $stability) {
-            return true;
-        }
-
         $constraint = new Constraint('=', $version);
 
         // Excluded by root requires

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -325,6 +325,16 @@ class Pool implements \Countable
         return true;
     }
 
+    public function isPackageRootRequired($name)
+    {
+        return isset($this->rootRequires[$name]);
+    }
+
+    public function isPackageRootConflict($name)
+    {
+        return isset($this->rootConflicts[$name]);
+    }
+
     public function isPackageAcceptable($name, $stability)
     {
         foreach ((array) $name as $n) {

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -156,6 +156,14 @@ class Problem
                     return "\n    - The requested package ".$packageName.$this->constraintToText($constraint).' exists as '.$this->getPackageList($providers).' but these are rejected by your constraint.';
                 }
 
+                if ($this->pool->isPackageRootConflict($packageName)) {
+                    return "\n    - The requested package ".$packageName.$this->constraintToText($constraint).' was excluded by your own root composer.json "conflict" definition.';
+                }
+
+                if ($this->pool->isPackageRootRequired($packageName)) {
+                    return "\n    - The requested package ".$packageName.$this->constraintToText($constraint).' was excluded by your own root composer.json "require" definition.';
+                }
+
                 return "\n    - The requested package ".$packageName.' could not be found in any version, there may be a typo in the package name.';
             }
         }

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -156,12 +156,10 @@ class Problem
                     return "\n    - The requested package ".$packageName.$this->constraintToText($constraint).' exists as '.$this->getPackageList($providers).' but these are rejected by your constraint.';
                 }
 
-                if ($this->pool->isPackageRootConflict($packageName)) {
-                    return "\n    - The requested package ".$packageName.$this->constraintToText($constraint).' was excluded by your own root composer.json "conflict" definition.';
-                }
+                if ($this->pool->isPackageRootConflict($packageName) || $this->pool->isPackageRootRequired($packageName) && !empty($providers)) {
+                    $section = $this->pool->isPackageRootConflict($packageName) ? 'conflict' : 'require';
 
-                if ($this->pool->isPackageRootRequired($packageName)) {
-                    return "\n    - The requested package ".$packageName.$this->constraintToText($constraint).' was excluded by your own root composer.json "require" definition.';
+                    return "\n    - The requested package ".$packageName.$this->constraintToText($constraint).' was excluded by your own root composer.json "'.$section.'" definition.';
                 }
 
                 return "\n    - The requested package ".$packageName.' could not be found in any version, there may be a typo in the package name.';

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -221,6 +221,14 @@ abstract class Rule
                         return $text . ' -> satisfiable by ' . $this->formatPackagesUnique($pool, $providers) .' but these conflict with your requirements or minimum-stability.';
                     }
 
+                    if ($pool->isPackageRootConflict($targetName)) {
+                        return $text . ' -> conflicts with your root composer.json "conflict" definition.';
+                    }
+
+                    if ($pool->isPackageRootRequired($targetName)) {
+                        return $text . ' -> conflicts with your root composer.json "require" definition.';
+                    }
+
                     return $text . ' -> no matching package found.';
                 }
 

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -870,20 +870,30 @@ class Installer
             }
         }
 
-        $rootConstraints = array();
+        $rootRequires = array();
         foreach ($requires as $req => $constraint) {
             // skip platform requirements from the root package to avoid filtering out existing platform packages
             if ($this->ignorePlatformReqs && preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $req)) {
                 continue;
             }
             if ($constraint instanceof Link) {
-                $rootConstraints[$req] = $constraint->getConstraint();
+                $rootRequires[$req] = $constraint->getConstraint();
             } else {
-                $rootConstraints[$req] = $constraint;
+                $rootRequires[$req] = $constraint;
             }
         }
 
-        return new Pool($minimumStability, $stabilityFlags, $rootConstraints);
+        $rootConflicts = array();
+
+        foreach ($this->package->getConflicts() as $conflict => $constraint) {
+            if ($constraint instanceof Link) {
+                $rootConflicts[$conflict] = $constraint->getConstraint();
+            } else {
+                $rootConflicts[$conflict] = $constraint;
+            }
+        }
+
+        return new Pool($minimumStability, $stabilityFlags, $rootRequires, $rootConflicts);
     }
 
     /**

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -396,11 +396,9 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                         }
                     }
                 } else {
-                    $stability = VersionParser::parseStability($version['version']);
-
                     if (!$bypassFilters
-                        && (!$pool->isPackageAcceptable(strtolower($version['name']), $stability))
-                        || !$pool->isPackageAllowedByRoot(strtolower($version['name']), $version['version_normalized'], $stability)
+                        && (!$pool->isPackageAcceptable(strtolower($version['name']), VersionParser::parseStability($version['version'])))
+                        || !$pool->isPackageAllowedByRoot(strtolower($version['name']), $version['version_normalized'])
                     ) {
                         continue;
                     }

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -396,7 +396,12 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                         }
                     }
                 } else {
-                    if (!$bypassFilters && !$pool->isPackageAcceptable(strtolower($version['name']), VersionParser::parseStability($version['version']))) {
+                    $stability = VersionParser::parseStability($version['version']);
+
+                    if (!$bypassFilters
+                        && (!$pool->isPackageAcceptable(strtolower($version['name']), $stability))
+                        || !$pool->isPackageAllowedByRoot(strtolower($version['name']), $version['version_normalized'], $stability)
+                    ) {
                         continue;
                     }
 

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -194,7 +194,7 @@ class InstallerTest extends TestCase
                 ->method('write')
                 ->will($this->returnCallback(function ($hash, $options) use (&$actualLock) {
                     // need to do assertion outside of mock for nice phpunit output
-                    // so store value temporarily in reference for later assetion
+                    // so store value temporarily in reference for later assertion
                     $actualLock = $hash;
                 }));
         }

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -118,6 +118,8 @@ class ComposerRepositoryTest extends TestCase
             $ref->setValue($repo, $value);
         }
 
+        $versionParser = new VersionParser();
+
         $repo->expects($this->any())
             ->method('fetchFile')
             ->will($this->returnValue(array(
@@ -126,18 +128,22 @@ class ComposerRepositoryTest extends TestCase
                         'uid' => 1,
                         'name' => 'a',
                         'version' => 'dev-master',
+                        'version_normalized' => $versionParser->normalize('dev-master'),
                         'extra' => array('branch-alias' => array('dev-master' => '1.0.x-dev')),
                     )),
                     array(array(
                         'uid' => 2,
                         'name' => 'a',
                         'version' => 'dev-develop',
+                        'version_normalized' => $versionParser->normalize('dev-develop'),
                         'extra' => array('branch-alias' => array('dev-develop' => '1.1.x-dev')),
                     )),
                     array(array(
                         'uid' => 3,
                         'name' => 'a',
                         'version' => '0.6',
+                        'version_normalized' => $versionParser->normalize('0.6'),
+
                     )),
                 ),
             )));
@@ -150,7 +156,6 @@ class ComposerRepositoryTest extends TestCase
             ->method('isPackageAllowedByRoot')
             ->will($this->returnValue(true));
 
-        $versionParser = new VersionParser();
         $repo->setRootAliases(array(
             'a' => array(
                 $versionParser->normalize('0.6') => array('alias' => 'dev-feature', 'alias_normalized' => $versionParser->normalize('dev-feature')),

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -146,6 +146,9 @@ class ComposerRepositoryTest extends TestCase
         $pool->expects($this->any())
             ->method('isPackageAcceptable')
             ->will($this->returnValue(true));
+        $pool->expects($this->any())
+            ->method('isPackageAllowedByRoot')
+            ->will($this->returnValue(true));
 
         $versionParser = new VersionParser();
         $repo->setRootAliases(array(


### PR DESCRIPTION
I noticed that Composer always loads all of the package provider data into memory even if it could know exactly that this information is never going to be needed because it cannot resolve to valid set of dependencies.

The `Pool` already knew about the root requirements (I renamed the variable because `filterRequires` felt awkward) but not about the root conflicts, so I added that.

What happens now is that if you required for example `symfony/framework-bundle: ^4.3`, every version that does not match is not loaded into memory anymore, thus speeding up the whole process and reducing memory usage.
The same applies for conflicts.

In case you wonder what happens, if you add a conflict that strips all tags from a package, just try it out by e.g. configuring a conflict to everything lower than `symfony/framework-bundle` in version `5.0` (which doesn't exist):

```json
{
    "name": "my/project",
    "type": "project",
    "require": {
        "php": "^7.1",
        "symfony/framework-bundle": "^4.3"
    },
    "conflict": {
        "symfony/framework-bundle": "<5"
    }
}
```

Result:

```
  Problem 1
    - symfony/framework-bundle v4.3.0 conflicts with my/project[No version set (parsed as 1.0.0)].
    - symfony/framework-bundle v4.3.1 conflicts with my/project[No version set (parsed as 1.0.0)].
    - symfony/framework-bundle v4.3.2 conflicts with my/project[No version set (parsed as 1.0.0)].
    - symfony/framework-bundle v4.3.3 conflicts with my/project[No version set (parsed as 1.0.0)].
    - Installation request for my/project No version set (parsed as 1.0.0) -> satisfiable by my/project[No version set (parsed as 1.0.0)].
    - Installation request for symfony/framework-bundle ^4.3 -> satisfiable by symfony/framework-bundle[v4.3.0, v4.3.1, v4.3.2, v4.3.3].
```

So as you can see, it clearly states that it "conflicts with my/project", so the root composer.json 😊 

By adding more conflicts or better requires I can now considerably reduce memory usage and speed up the resolving process.