### PR TITLE
GitHub: don't display access token in debug log on redirect

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -1128,10 +1128,6 @@ class RemoteFilesystem
     {
         // GitHub repository rename result in redirect locations containing the access_token as GET parameter
         // e.g. https://api.github.com/repositories/9999999999?access_token=github_token
-        if (preg_match('{^(https?://([a-z0-9-]+\.)*github\.com/.*)\?access_token=[a-z0-9]+}', $url, $matches)) {
-            return $matches[1];
-        }
-
-        return $url;
+        return preg_replace('{([&?]access_token=)[^&]+}', '$1***', $url);
     }
 }


### PR DESCRIPTION
If you rename a private repository on GitHub which has been added as VCS repository the redirect url will contain the access token as GET parameter which will then be displayed in the log output.

```
Downloading https://api.github.com/repos/pcom-test-group/test-repo [] 
 []
Following redirect (2) https://api.github.com/repositories/82816341?access_token=my-github-token []
Downloading https://api.github.com/repositories/82816341?access_token=my-github-token []
```

Note: this is not an issue for GitLab because GitLab keeps the url the same even if you rename a project.