### PR TITLE
Fixes a problem with path based repositories on PHP7.4 

### DIFF
--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -155,7 +155,11 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
             if (!isset($package['version'])) {
                 $versionData = $this->versionGuesser->guessVersion($package, $path);
-                $package['version'] = $versionData['pretty_version'] ?: 'dev-master';
+                if (is_array($versionData)) {
+                    $package['version'] = $versionData['pretty_version'] ?: 'dev-master';
+                } else {
+                    $package['version'] = 'dev-master';
+                }
             }
 
             $output = '';

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -155,8 +155,8 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
             if (!isset($package['version'])) {
                 $versionData = $this->versionGuesser->guessVersion($package, $path);
-                if (is_array($versionData)) {
-                    $package['version'] = $versionData['pretty_version'] ?: 'dev-master';
+                if (is_array($versionData) && $versionData['pretty_version']) {
+                    $package['version'] = $versionData['pretty_version'];
                 } else {
                     $package['version'] = 'dev-master';
                 }


### PR DESCRIPTION
Fixes a problem with path based repositories such as:
```
  "repositories": [
    {
      "type": "path",
      "url": "../otherproject/"
    }
  ],
  "require": {
    "vendorname/otherproject": "dev-master"
  },
```
on PHP7.4beta4 (at least on Windows) where an attempt is made to access null as an array causing an error exception to be raised:
```
  [ErrorException]
  Trying to access array offset on value of type null

Exception trace:
 () at E:\Projects\composer\src\Composer\Repository\PathRepository.php:158
 Composer\Util\ErrorHandler::handle() at E:\Projects\composer\src\Composer\Repository\PathRepository.php:158
 Composer\Repository\PathRepository->initialize() at E:\Projects\composer\src\Composer\Repository\ArrayRepository.php:185
 Composer\Repository\ArrayRepository->getPackages() at E:\Projects\composer\src\Composer\DependencyResolver\Pool.php:104
 Composer\DependencyResolver\Pool->addRepository() at E:\Projects\composer\src\Composer\Installer.php:379
 Composer\Installer->doInstall() at E:\Projects\composer\src\Composer\Installer.php:229
 Composer\Installer->run() at E:\Projects\composer\src\Composer\Command\UpdateCommand.php:163
 Composer\Command\UpdateCommand->execute() at E:\Projects\composer\vendor\symfony\console\Command\Command.php:245
 Symfony\Component\Console\Command\Command->run() at E:\Projects\composer\vendor\symfony\console\Application.php:835
 Symfony\Component\Console\Application->doRunCommand() at E:\Projects\composer\vendor\symfony\console\Application.php:185
 Symfony\Component\Console\Application->doRun() at E:\Projects\composer\src\Composer\Console\Application.php:267
 Composer\Console\Application->doRun() at E:\Projects\composer\vendor\symfony\console\Application.php:117
 Symfony\Component\Console\Application->run() at E:\Projects\composer\src\Composer\Console\Application.php:106
 Composer\Console\Application->run() at E:\Projects\composer\bin\composer:62

```