### PR TITLE
Allow referencing scripts to extends @composer

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -184,7 +184,7 @@ class EventDispatcher
                 $args = array_merge($script, $event->getArguments());
                 $flags = $event->getFlags();
                 if (substr($callable, 0, 10) === '@composer ') {
-                    $exec = $this->getPhpExecCommand() . ' ' . ProcessExecutor::escape(getenv('COMPOSER_BINARY')) . substr($callable, 9);
+                    $exec = $this->getPhpExecCommand() . ' ' . ProcessExecutor::escape(getenv('COMPOSER_BINARY')) . ' ' . implode(' ', $args);
                     if (0 !== ($exitCode = $this->process->execute($exec))) {
                         $this->io->writeError(sprintf('<error>Script %s handling the %s event returned with error code '.$exitCode.'</error>', $callable, $event->getName()), true, IOInterface::QUIET);
 


### PR DESCRIPTION
Hi.

Actually, if you execute a script that reference another that itself reference `@composer` you can't extend it.

By exemple :
```json
…
"scripts": {
    "install-dev": "@composer install --prefer-dist --no-scripts --no-interaction --no-suggest --optimize-autoloader",
    "install-prod": "@install-dev --no-dev --classmap-authoritative"
}
…
```
```shell
$ composer install-prod -vvv
…
> install-prod: @install-dev --no-dev --classmap-authoritative
> install-dev: @composer install --prefer-dist --no-scripts --no-interaction --no-suggest --optimize-autoloader
Executing command (CWD): '/usr/local/Cellar/php/7.3.7/bin/php' -d allow_url_fopen='1' -d disable_functions='' -d memory_limit='1536M' '<obfuscated>/composer/bin/composer' install --prefer-dist --no-scripts --no-interaction --no-suggest --optimize-autoloader
…
```

As you can see `composer` command is executed without `--no-dev` and ` --classmap-authoritative` args.

This PR solve this problem