### PR TITLE
Suggest running 'update --lock' when .lock file is out of date

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -447,7 +447,7 @@ class Installer
             $this->io->writeError('<info>Installing dependencies'.($this->devMode ? ' (including require-dev)' : '').' from lock file</info>');
 
             if (!$this->locker->isFresh()) {
-                $this->io->writeError('<warning>Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.</warning>', true, IOInterface::QUIET);
+                $this->io->writeError('<warning>Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run "update --lock" to update them.</warning>', true, IOInterface::QUIET);
             }
 
             foreach ($lockedRepository->getPackages() as $package) {


### PR DESCRIPTION
The current warning suggests running a blanket `composer.phar update`, but I believe this to be bad practice. Instead, we'll suggest the user to run `composer.phar update --lock`, to resolve the dependencies from the `composer.json` file and update the `composer.lock` accordingly. 