### PR TITLE
Allow more finegrained control over what caches to clear

### DIFF
--- a/src/Composer/Command/ClearCacheCommand.php
+++ b/src/Composer/Command/ClearCacheCommand.php
@@ -16,6 +16,7 @@ use Composer\Cache;
 use Composer\Factory;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
 
 /**
  * @author David Neilsen <petah.p@gmail.com>
@@ -28,10 +29,16 @@ class ClearCacheCommand extends BaseCommand
             ->setName('clear-cache')
             ->setAliases(array('clearcache'))
             ->setDescription('Clears composer\'s internal package cache.')
+            ->setDefinition(array(
+                new InputArgument('vendor', InputArgument::OPTIONAL, 'Optional "vendor" to clear the cache for.'),
+            ))
             ->setHelp(
                 <<<EOT
 The <info>clear-cache</info> deletes all cached packages from composer's
 cache directory.
+
+If you specify a vendor to clear the cache for, composer will only delete
+the cached packages published under that namespace.
 
 Read more at https://getcomposer.org/doc/03-cli.md#clear-cache-clearcache-
 EOT


### PR DESCRIPTION
_Still a WIP, but I'm happy to receive feedback, let me know what you think about this and how you'd want this to work!_

The current idea is to add a `vendor` (and/or `package`) argument to the `clear-cache` command, so the usage will look like this:

```bash
# Clears all the caches from the `illuminate/*` namespace.
$ php composer.phar clear-cache illuminate

# Clears the `monolog/monolog` package from the cache.
$ php composer.phar clear-cache monolog/monolog
```

This should be a non-breaking change, seeing as the `vendor`/`package` argument will be optional.

## Todo
- [ ] Settle on an API that just _works_
- [ ] Write tests
- [ ] Make it work
- [ ] Update the documentation
  - [ ] In the code ("help" section)
  - [ ] In [the `doc/` folder](https://github.com/composer/composer/tree/master/doc)