### PR TITLE
Fix using composer with symfony/process:^4

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -71,6 +71,10 @@ class ProcessExecutor
             $process = new Process($command, $cwd, null, null, static::getTimeout());
         }
 
+        if (!is_dir($cwd)) {
+            @mkdir($cwd, 0777, true);
+        }
+
         $callback = is_callable($output) ? $output : array($this, 'outputHandler');
         $process->run($callback);
 


### PR DESCRIPTION
Hi,

this PR removes a deprecation warning/exception when using composer in a project with never `symfony/process` versions.

Starting with `symfony/process:3.4` running a process in a directory which doesn't exist throws a deprecation warning and starting with `symfony/process:4` this throws an exception see: https://github.com/symfony/process/blob/a305eb1f68e6a16009ddc26f2f97cd96e30cfae5/Process.php#L329-L331

Compared to the current implementation this will now always create an empty directory whenever we run a command in that directory e.g. when we run git clone for a vcs repository. To keep the current behaviour consistent shall I delete the directory after the command is run if it is empty? This happens for instance when git clone fails.