### PR TITLE
Command::execute() should always return an integer

### DIFF
--- a/src/Composer/Command/AboutCommand.php
+++ b/src/Composer/Command/AboutCommand.php
@@ -42,5 +42,7 @@ EOT
 See https://getcomposer.org/ for more information.</comment>
 EOT
         );
+
+        return 0;
     }
 }

--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -62,7 +62,7 @@ class BaseDependencyCommand extends BaseCommand
      * @param  InputInterface  $input
      * @param  OutputInterface $output
      * @param  bool            $inverted Whether to invert matching process (why-not vs why behaviour)
-     * @return int|null        Exit code of the operation.
+     * @return int             Exit code of the operation.
      */
     protected function doExecute(InputInterface $input, OutputInterface $output, $inverted = false)
     {

--- a/src/Composer/Command/ClearCacheCommand.php
+++ b/src/Composer/Command/ClearCacheCommand.php
@@ -70,5 +70,7 @@ EOT
         }
 
         $io->writeError('<info>All caches cleared.</info>');
+
+        return 0;
     }
 }

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -463,13 +463,19 @@ EOT
                 $this->getIO()->writeError('<info>You are now running Composer with SSL/TLS protection enabled.</info>');
             }
 
-            return $this->configSource->removeConfigSetting($settingKey);
+            $this->configSource->removeConfigSetting($settingKey);
+
+            return 0;
         }
         if (isset($uniqueConfigValues[$settingKey])) {
-            return $this->handleSingleValue($settingKey, $uniqueConfigValues[$settingKey], $values, 'addConfigSetting');
+            $this->handleSingleValue($settingKey, $uniqueConfigValues[$settingKey], $values, 'addConfigSetting');
+
+            return 0;
         }
         if (isset($multiConfigValues[$settingKey])) {
-            return $this->handleMultiValue($settingKey, $multiConfigValues[$settingKey], $values, 'addConfigSetting');
+            $this->handleMultiValue($settingKey, $multiConfigValues[$settingKey], $values, 'addConfigSetting');
+
+            return 0;
         }
 
         // handle properties
@@ -530,38 +536,51 @@ EOT
             throw new \InvalidArgumentException('The '.$settingKey.' property can not be set in the global config.json file. Use `composer global config` to apply changes to the global composer.json');
         }
         if ($input->getOption('unset') && (isset($uniqueProps[$settingKey]) || isset($multiProps[$settingKey]))) {
-            return $this->configSource->removeProperty($settingKey);
+            $this->configSource->removeProperty($settingKey);
+
+            return 0;
         }
         if (isset($uniqueProps[$settingKey])) {
-            return $this->handleSingleValue($settingKey, $uniqueProps[$settingKey], $values, 'addProperty');
+            $this->handleSingleValue($settingKey, $uniqueProps[$settingKey], $values, 'addProperty');
+
+            return 0;
         }
         if (isset($multiProps[$settingKey])) {
-            return $this->handleMultiValue($settingKey, $multiProps[$settingKey], $values, 'addProperty');
+            $this->handleMultiValue($settingKey, $multiProps[$settingKey], $values, 'addProperty');
+
+            return 0;
         }
 
         // handle repositories
         if (preg_match('/^repos?(?:itories)?\.(.+)/', $settingKey, $matches)) {
             if ($input->getOption('unset')) {
-                return $this->configSource->removeRepository($matches[1]);
+                $this->configSource->removeRepository($matches[1]);
+
+                return 0;
             }
 
             if (2 === count($values)) {
-                return $this->configSource->addRepository($matches[1], array(
+                $this->configSource->addRepository($matches[1], array(
                     'type' => $values[0],
                     'url' => $values[1],
                 ));
+
+                return 0;
             }
 
             if (1 === count($values)) {
                 $value = strtolower($values[0]);
                 if (true === $booleanValidator($value)) {
                     if (false === $booleanNormalizer($value)) {
-                        return $this->configSource->addRepository($matches[1], false);
+                        $this->configSource->addRepository($matches[1], false);
+
+                        return 0;
                     }
                 } else {
                     $value = JsonFile::parseJson($values[0]);
+                    $this->configSource->addRepository($matches[1], $value);
 
-                    return $this->configSource->addRepository($matches[1], $value);
+                    return 0;
                 }
             }
 
@@ -571,22 +590,32 @@ EOT
         // handle extra
         if (preg_match('/^extra\.(.+)/', $settingKey, $matches)) {
             if ($input->getOption('unset')) {
-                return $this->configSource->removeProperty($settingKey);
+                $this->configSource->removeProperty($settingKey);
+
+                return 0;
             }
 
-            return $this->configSource->addProperty($settingKey, $values[0]);
+            $this->configSource->addProperty($settingKey, $values[0]);
+
+            return 0;
         }
 
         // handle platform
         if (preg_match('/^platform\.(.+)/', $settingKey, $matches)) {
             if ($input->getOption('unset')) {
-                return $this->configSource->removeConfigSetting($settingKey);
+                $this->configSource->removeConfigSetting($settingKey);
+
+                return 0;
             }
 
-            return $this->configSource->addConfigSetting($settingKey, $values[0]);
+            $this->configSource->addConfigSetting($settingKey, $values[0]);
+
+            return 0;
         }
         if ($settingKey === 'platform' && $input->getOption('unset')) {
-            return $this->configSource->removeConfigSetting($settingKey);
+            $this->configSource->removeConfigSetting($settingKey);
+
+            return 0;
         }
 
         // handle auth
@@ -595,7 +624,7 @@ EOT
                 $this->authConfigSource->removeConfigSetting($matches[1].'.'.$matches[2]);
                 $this->configSource->removeConfigSetting($matches[1].'.'.$matches[2]);
 
-                return;
+                return 0;
             }
 
             if ($matches[1] === 'bitbucket-oauth') {
@@ -618,16 +647,20 @@ EOT
                 $this->authConfigSource->addConfigSetting($matches[1].'.'.$matches[2], array('username' => $values[0], 'password' => $values[1]));
             }
 
-            return;
+            return 0;
         }
 
         // handle script
         if (preg_match('/^scripts\.(.+)/', $settingKey, $matches)) {
             if ($input->getOption('unset')) {
-                return $this->configSource->removeProperty($settingKey);
+                $this->configSource->removeProperty($settingKey);
+
+                return 0;
             }
 
-            return $this->configSource->addProperty($settingKey, count($values) > 1 ? $values : $values[0]);
+            $this->configSource->addProperty($settingKey, count($values) > 1 ? $values : $values[0]);
+
+            return 0;
         }
 
         throw new \InvalidArgumentException('Setting '.$settingKey.' does not exist or is not supported by this command');

--- a/src/Composer/Command/DependsCommand.php
+++ b/src/Composer/Command/DependsCommand.php
@@ -48,7 +48,7 @@ EOT
      *
      * @param  InputInterface  $input
      * @param  OutputInterface $output
-     * @return int|null
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -84,5 +84,7 @@ EOT
         } else {
             $this->getIO()->overwriteError('<info>Generated autoload files containing '. $numberOfClasses .' classes</info>');
         }
+
+        return 0;
     }
 }

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -152,6 +152,8 @@ EOT
         if ($input->isInteractive() && $this->hasDependencies($options) && $io->askConfirmation($question, true)) {
             $this->installDependencies($output);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -110,6 +110,8 @@ EOT
             default:
                 throw new \RuntimeException(sprintf('Unsupported format "%s".  See help for supported formats.', $format));
         }
+
+        return 0;
     }
 
     /**

--- a/src/Composer/Command/ProhibitsCommand.php
+++ b/src/Composer/Command/ProhibitsCommand.php
@@ -48,7 +48,7 @@ EOT
      *
      * @param  InputInterface  $input
      * @param  OutputInterface $output
-     * @return int|null
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -79,5 +79,7 @@ EOT
         foreach ($results as $result) {
             $io->write($result['name'] . (isset($result['description']) ? ' '. $result['description'] : ''));
         }
+
+        return 0;
     }
 }

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -254,6 +254,8 @@ TAGSPUBKEY
         } else {
             $io->writeError('<warning>A backup of the current version could not be written to '.$backupFile.', no rollback possible</warning>');
         }
+
+        return 0;
     }
 
     protected function fetchKeys(IOInterface $io, Config $config)

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -61,7 +61,7 @@ EOT
     /**
      * @param  InputInterface  $input
      * @param  OutputInterface $output
-     * @return int|null
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -118,7 +118,7 @@ EOT
                 $io->write(sprintf('<info>%s</info>', $suggestion));
             }
 
-            return;
+            return 0;
         }
 
         // Grouped by package
@@ -148,5 +148,7 @@ EOT
                 $io->write('');
             }
         }
+
+        return 0;
     }
 }


### PR DESCRIPTION
In Symfony 4.4, a deprecation error is triggered if `Command::execute()` does not return an integer, see symfony/symfony#33747. This PR adds the necessary `return` statements.