### PR TITLE
Improve error reporting for missing path in Repository Path

### DIFF
--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -128,7 +128,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
         $urlMatches = $this->getUrlMatches();
 
         if (empty($urlMatches)) {
-            throw new \RuntimeException('The `url` supplied for the path repository does not exist');
+            throw new \RuntimeException('The `url` supplied for the path (' . $this->url . ') repository does not exist');
         }
 
         foreach ($urlMatches as $url) {

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -125,7 +125,13 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
     {
         parent::initialize();
 
-        foreach ($this->getUrlMatches() as $url) {
+        $urlMatches = $this->getUrlMatches();
+
+        if (empty($urlMatches)) {
+            throw new \RuntimeException('The `url` supplied for the path repository does not exist');
+        }
+
+        foreach ($urlMatches as $url) {
             $path = realpath($url) . DIRECTORY_SEPARATOR;
             $composerFilePath = $path.'composer.json';
 

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -29,7 +29,6 @@ class PathRepositoryTest extends TestCase
             ->getMock();
 
         $config = new \Composer\Config();
-        $versionGuesser = null;
 
         $repositoryUrl = implode(DIRECTORY_SEPARATOR, array(__DIR__, 'Fixtures', 'path', 'missing'));
         $repository = new PathRepository(array('url' => $repositoryUrl), $ioInterface, $config);

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -34,7 +34,6 @@ class PathRepositoryTest extends TestCase
         $repositoryUrl = implode(DIRECTORY_SEPARATOR, array(__DIR__, 'Fixtures', 'path', 'missing'));
         $repository = new PathRepository(array('url' => $repositoryUrl), $ioInterface, $config);
         $repository->getPackages();
-
     }
 
     public function testLoadPackageFromFileSystemWithVersion()

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -19,6 +19,24 @@ use Composer\Test\TestCase;
 
 class PathRepositoryTest extends TestCase
 {
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testLoadPackageFromFileSystemWithIncorrectPath()
+    {
+        $ioInterface = $this->getMockBuilder('Composer\IO\IOInterface')
+            ->getMock();
+
+        $config = new \Composer\Config();
+        $versionGuesser = null;
+
+        $repositoryUrl = implode(DIRECTORY_SEPARATOR, array(__DIR__, 'Fixtures', 'path', 'missing'));
+        $repository = new PathRepository(array('url' => $repositoryUrl), $ioInterface, $config);
+        $repository->getPackages();
+
+    }
+
     public function testLoadPackageFromFileSystemWithVersion()
     {
         $ioInterface = $this->getMockBuilder('Composer\IO\IOInterface')


### PR DESCRIPTION
When using a repository with a path, if the path didn't exist there was no error reporting and the remote dependency was installed.

This change checks for an empty array being returned from the `getUrlMatches` methods and throws a RuntimeException with details about the missing path for debugging.