### PR TITLE
HgDriver: don't run command in non-existing directory

### DIFF
--- a/src/Composer/Repository/Vcs/HgDriver.php
+++ b/src/Composer/Repository/Vcs/HgDriver.php
@@ -71,7 +71,7 @@ class HgDriver extends VcsDriver
                     return sprintf('hg clone --noupdate %s %s', ProcessExecutor::escape($url), ProcessExecutor::escape($repoDir));
                 };
 
-                $hgUtils->runCommand($command, $this->url, $this->repoDir);
+                $hgUtils->runCommand($command, $this->url, null);
             }
         }
 


### PR DESCRIPTION
This PR follows https://github.com/composer/composer/pull/8358 and is now addressing the issue instead of blindly creating directories.

In the HgDriver implementation the initial clone for a repository is executed in the directory which is created by the clone command -> the dir does not exist when running the command. This results in a deprecation warning using symfony/process:3.4 and an exception using symfony/process:^4.