### PR TITLE
added package homepage information to the command 'show'

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -579,6 +579,7 @@ EOT
     {
         $io = $this->getIO();
         $io->write('<info>name</info>     : ' . $package->getPrettyName());
+        $io->write('<info>homepage</info> : ' . $package->getHomepage());
         $io->write('<info>descrip.</info> : ' . $package->getDescription());
         $io->write('<info>keywords</info> : ' . implode(', ', $package->getKeywords() ?: array()));
         $this->printVersions($package, $versions, $installedRepo);


### PR DESCRIPTION
This PR follows #8364 and now the command `show` includes the package's homepage URL.