### PR TITLE
Consider replaces when checking package dependents

### DIFF
--- a/src/Composer/Repository/BaseRepository.php
+++ b/src/Composer/Repository/BaseRepository.php
@@ -68,6 +68,9 @@ abstract class BaseRepository implements RepositoryInterface
             if (!$invert) {
                 $links += $package->getReplaces();
 
+                // On forward search, check if any replaced package was required and add the replaced
+                // packages to the list of needles. Contrary to the cross-reference link check below,
+                // replaced packages are the target of links.
                 foreach ($package->getReplaces() as $link) {
                     foreach ($needles as $needle) {
                         if ($link->getSource() === $needle) {

--- a/src/Composer/Repository/BaseRepository.php
+++ b/src/Composer/Repository/BaseRepository.php
@@ -67,6 +67,24 @@ abstract class BaseRepository implements RepositoryInterface
             // Replacements are considered valid reasons for a package to be installed during forward resolution
             if (!$invert) {
                 $links += $package->getReplaces();
+
+                foreach ($package->getReplaces() as $link) {
+                    foreach ($needles as $needle) {
+                        if ($link->getSource() === $needle) {
+                            if ($constraint === null || ($link->getConstraint()->matches($constraint) === !$invert)) {
+                                // already displayed this node's dependencies, cutting short
+                                if (in_array($link->getTarget(), $packagesInTree)) {
+                                    $results[$link->getTarget()] = array($package, $link, false);
+                                    continue;
+                                }
+                                $packagesInTree[] = $link->getTarget();
+                                $dependents = $recurse ? $this->getDependents($link->getTarget(), null, false, true, $packagesInTree) : array();
+                                $results[] = array($package, $link, $dependents);
+                                $needles[] = $link->getTarget();
+                            }
+                        }
+                    }
+                }
             }
 
             // Require-dev is only relevant for the root package
@@ -81,12 +99,12 @@ abstract class BaseRepository implements RepositoryInterface
                         if ($constraint === null || ($link->getConstraint()->matches($constraint) === !$invert)) {
                             // already displayed this node's dependencies, cutting short
                             if (in_array($link->getSource(), $packagesInTree)) {
-                                $results[$link->getSource()] = array($package, $link, false);
+                                $results[] = array($package, $link, false);
                                 continue;
                             }
                             $packagesInTree[] = $link->getSource();
                             $dependents = $recurse ? $this->getDependents($link->getSource(), null, false, true, $packagesInTree) : array();
-                            $results[$link->getSource()] = array($package, $link, $dependents);
+                            $results[] = array($package, $link, $dependents);
                         }
                     }
                 }

--- a/src/Composer/Repository/BaseRepository.php
+++ b/src/Composer/Repository/BaseRepository.php
@@ -74,7 +74,7 @@ abstract class BaseRepository implements RepositoryInterface
                             if ($constraint === null || ($link->getConstraint()->matches($constraint) === !$invert)) {
                                 // already displayed this node's dependencies, cutting short
                                 if (in_array($link->getTarget(), $packagesInTree)) {
-                                    $results[$link->getTarget()] = array($package, $link, false);
+                                    $results[] = array($package, $link, false);
                                     continue;
                                 }
                                 $packagesInTree[] = $link->getTarget();


### PR DESCRIPTION
I discovered that Composer does not check replaced packages when checking for dependents. Here are two example what this change does in a [Contao Managed Edition](https://contao.org).

I needed to figure out if a package was manually removed from the `composer.json` in the [Contao Manager](https://github.com/contao/contao-manager). I used the same code as `composer why` to compare installed packages against each other, but it also showed locally installed packages that were never in my `composer.json` 😆 

**Before:**
```
$ composer why symfony/contracts

There is no installed package depending on "symfony/contracts"
```

**After:**
```
$ composer why symfony/contracts

symfony/contracts             v1.1.5  replaces  symfony/cache-contracts (self.version)             
symfony/contracts             v1.1.5  replaces  symfony/event-dispatcher-contracts (self.version)  
symfony/contracts             v1.1.5  replaces  symfony/http-client-contracts (self.version)       
symfony/contracts             v1.1.5  replaces  symfony/service-contracts (self.version)           
symfony/contracts             v1.1.5  replaces  symfony/translation-contracts (self.version)       
symfony/dependency-injection  v4.3.3  requires  symfony/service-contracts (^1.1.2)                 
symfony/doctrine-bridge       v4.3.3  requires  symfony/service-contracts (^1.1)                   
symfony/event-dispatcher      v4.3.3  requires  symfony/event-dispatcher-contracts (^1.1)          
symfony/expression-language   v4.3.3  requires  symfony/service-contracts (^1.1)                   
symfony/monolog-bridge        v4.3.3  requires  symfony/service-contracts (^1.1)                   
symfony/security              v4.3.3  requires  symfony/event-dispatcher-contracts (^1.1)          
symfony/security              v4.3.3  requires  symfony/service-contracts (^1.1)                   
symfony/translation           v4.3.3  requires  symfony/translation-contracts (^1.1.2)             
symfony/twig-bridge           v4.3.3  requires  symfony/translation-contracts (^1.1)   
```

**Before:**
```
$ composer why symfony/security

nelmio/security-bundle  2.7.0  requires  symfony/security (~2.3|~3.0|~4.0) 
```

**After:**
```
$ composer why symfony/security

nelmio/security-bundle   2.7.0   requires  symfony/security (~2.3|~3.0|~4.0)      
symfony/security         v4.3.3  replaces  symfony/security-core (self.version)   
symfony/security         v4.3.3  replaces  symfony/security-csrf (self.version)   
symfony/security         v4.3.3  replaces  symfony/security-guard (self.version)  
symfony/security         v4.3.3  replaces  symfony/security-http (self.version)   
symfony/security-bundle  v4.3.3  requires  symfony/security-core (~4.3)           
symfony/security-bundle  v4.3.3  requires  symfony/security-csrf (~4.2)           
symfony/security-bundle  v4.3.3  requires  symfony/security-guard (~4.2)          
symfony/security-bundle  v4.3.3  requires  symfony/security-http (^4.3) 
```