### PR TITLE
Fix misc phpdoc and strpos arg order nits for suggestions

### DIFF
--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -90,7 +90,7 @@ EOT
                 continue;
             }
             foreach ($package['suggest'] as $suggestion => $reason) {
-                if (false === strpos('/', $suggestion) && null !== $platform->findPackage($suggestion, '*')) {
+                if (null !== $platform->findPackage($suggestion, '*')) {
                     continue;
                 }
                 if (!isset($installed[$suggestion])) {

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -239,7 +239,7 @@ abstract class BasePackage implements PackageInterface
      * Build a regexp from a package name, expanding * globs as required
      *
      * @param  string $whiteListedPattern
-     * @param  bool $wrap Wrap the cleaned string by the given string
+     * @param  string $wrap Wrap the cleaned string by the given string
      * @return string
      */
     public static function packageNameToRegexp($whiteListedPattern, $wrap = '{^%s$}i')

--- a/src/Composer/Util/Zip.php
+++ b/src/Composer/Util/Zip.php
@@ -21,7 +21,6 @@ class Zip
      * Gets content of the root composer.json inside a ZIP archive.
      *
      * @param string $pathToZip
-     * @param string $filename
      *
      * @return string|null
      */


### PR DESCRIPTION
https://www.php.net/strpos has the signature
`strpos ( string $haystack , mixed $needle [, int $offset = 0 ] ) : int`
(The needle is usually the constant)

`strpos('/', $suggestion)` would only be false for `'/'` and `''`.

So the existing check would just not suggest **anything** that was
already installed (from pecl, built-in, or composer).

The intent seems to be to not suggest non-vendored php packages
that were already installed. (b20cc22ebb1d9f8ed467f0ea353391be7442ad3d)