### PR TITLE
Config option to disable lockfile generation

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -296,4 +296,9 @@ Example:
 Defaults to `true`. If set to `false`, Composer will not create `.htaccess` files
 in the composer home, cache, and data directories.
 
+## lock
+
+Defaults to `true`. If set to `false`, Composer will not create a `composer.lock` 
+file.
+
 &larr; [Repositories](05-repositories.md)  |  [Community](07-community.md) &rarr;

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -290,6 +290,10 @@
                 "sort-packages": {
                     "type": "boolean",
                     "description": "Defaults to false. If set to true, Composer will sort packages when adding/updating a new dependency."
+                },
+                "lock": {
+                    "type": "boolean",
+                    "description": "Defaults to true. If set to false, Composer will not create a composer.lock file."
                 }
             }
         },

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -412,6 +412,7 @@ EOT
             ),
             'github-expose-hostname' => array($booleanValidator, $booleanNormalizer),
             'htaccess-protect' => array($booleanValidator, $booleanNormalizer),
+            'lock' => array($booleanValidator, $booleanNormalizer),
         );
         $multiConfigValues = array(
             'github-protocols' => array(

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -63,6 +63,7 @@ class Config
         'archive-dir' => '.',
         'htaccess-protect' => true,
         'use-github-api' => true,
+        'lock' => true,
         // valid keys without defaults (auth config stuff):
         // bitbucket-oauth
         // github-oauth
@@ -328,6 +329,8 @@ class Config
             case 'secure-http':
                 return $this->config[$key] !== 'false' && (bool) $this->config[$key];
             case 'use-github-api':
+                return $this->config[$key] !== 'false' && (bool) $this->config[$key];
+            case 'lock':
                 return $this->config[$key] !== 'false' && (bool) $this->config[$key];
             default:
                 if (!isset($this->config[$key])) {

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -118,7 +118,7 @@ class Installer
     protected $preferStable = false;
     protected $preferLowest = false;
     protected $skipSuggest = false;
-    protected $writeLock = true;
+    protected $writeLock;
     protected $executeOperations = true;
 
     /**
@@ -164,6 +164,8 @@ class Installer
         $this->installationManager = $installationManager;
         $this->eventDispatcher = $eventDispatcher;
         $this->autoloadGenerator = $autoloadGenerator;
+
+        $this->writeLock = $config->get('lock');
     }
 
     /**

--- a/tests/Composer/Test/Fixtures/installer/install-without-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/install-without-lock.test
@@ -1,0 +1,25 @@
+--TEST--
+Installs from composer.json without writing a lock file
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    },
+    "config": {
+        "lock": "false"
+    }
+}
+--RUN--
+install
+--EXPECT--
+Installing a/a (1.0.0)
+--EXPECT-LOCK--
+false

--- a/tests/Composer/Test/Fixtures/installer/update-without-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/update-without-lock.test
@@ -1,0 +1,25 @@
+--TEST--
+Updates when no lock file is present without writing a lock file
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.0"
+    },
+    "config": {
+        "lock": false
+    }
+}
+--RUN--
+update
+--EXPECT--
+Installing a/a (1.0.0)
+--EXPECT-LOCK--
+false

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -197,6 +197,9 @@ class InstallerTest extends TestCase
                     // so store value temporarily in reference for later assetion
                     $actualLock = $hash;
                 }));
+        } elseif ($expectLock === false) {
+            $lockJsonMock->expects($this->never())
+                ->method('write');
         }
 
         $contents = json_encode($composerConfig);
@@ -319,7 +322,11 @@ class InstallerTest extends TestCase
                 }
                 $run = $testData['RUN'];
                 if (!empty($testData['EXPECT-LOCK'])) {
-                    $expectLock = JsonFile::parseJson($testData['EXPECT-LOCK']);
+                    if ($testData['EXPECT-LOCK'] === 'false') {
+                        $expectLock = false;
+                    } else {
+                        $expectLock = JsonFile::parseJson($testData['EXPECT-LOCK']);
+                    }
                 }
                 $expectOutput = isset($testData['EXPECT-OUTPUT']) ? $testData['EXPECT-OUTPUT'] : null;
                 $expect = $testData['EXPECT'];


### PR DESCRIPTION
This implements the feature proposed in #8354 to make workflows without a versioned lockfile less error-prone. 