### PR TITLE
Add `brew install composer` for macOS install

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -42,7 +42,15 @@ git, svn, fossil or hg depending on how the package is version-controlled.
 Composer is multi-platform and we strive to make it run equally well on Windows,
 Linux and macOS.
 
-## Installation - Linux / Unix / macOS
+## Installation - macOS
+
+macOS users may follow the Linux / Unix installation instructions for a custom installation, though the easiest way to globally install composer on macOS is with the [Homebrew package manager](https://brew.sh):
+
+```sh
+brew install composer
+```
+
+## Installation - Linux / Unix
 
 ### Downloading the Composer Executable
 

--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -44,10 +44,21 @@ Linux and macOS.
 
 ## Installation - macOS
 
-macOS users may follow the Linux / Unix installation instructions for a custom installation, though the easiest way to globally install composer on macOS is with the [Homebrew package manager](https://brew.sh):
+macOS users may follow the Linux / Unix installation instructions for a custom installation, 
+though the easiest way to globally install composer on macOS is with the 
+[Homebrew package manager](https://brew.sh):
 
 ```sh
 brew install composer
+```
+
+To ensure globally installed packages installed in `~/.composer/vendor/bin/` with 
+`composer global require PACKAGE` are available in your shell, you may need to add
+the composer vendor bin path to your `$PATH` shell variable by adding the following
+line to your `.bash_profile` or `.bashrc`:
+
+```sh
+export PATH=~/.composer/vendor/bin:$PATH
 ```
 
 ## Installation - Linux / Unix


### PR DESCRIPTION
In googling around for how to install composer (because I was trying to install [tailwindo](https://github.com/awssat/tailwindo)) I first found this official installation guide.

These installation instructions looked *way* to complicated for what I'm used to for installing a package manager on macOS. Usually I'd just `brew install npm`. Sure enough, I found [a guide to installing composer on macOS that recommended just using `brew install composer`](https://pilsniak.com/install-composer-mac-os) which seemed to do the trick.

This pull request adds a separate section for macOS installations that recommends just using `brew install composer`.