### PR TITLE
Fix composer outdated command on PHP 7.4; fixes #8346

### DIFF
--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -59,7 +59,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $args = array(
-            'show',
+            'command' => 'show',
             '--latest' => true,
         );
         if (!$input->getOption('all')) {


### PR DESCRIPTION
Defining the command name insied a `Symfony\Component\Console\Input\ArrayInput` can be done using a key named `command` (argument definition is done here:  https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Console/Application.php#L900).

This prevent having the following error when using `composer outdated` on, PHP 7.4:
```
                                                      
  [ErrorException]                                    
  Trying to access array offset on value of type int  
                                                      

Exception trace:
 () at /composer/vendor/symfony/console/Input/ArrayInput.php:124
 Composer\Util\ErrorHandler::handle() at /composer/vendor/symfony/console/Input/ArrayInput.php:124
 Symfony\Component\Console\Input\ArrayInput->parse() at /composer/vendor/symfony/console/Input/Input.php:54
 Symfony\Component\Console\Input\Input->bind() at /composer/vendor/symfony/console/Command/Command.php:204
 Symfony\Component\Console\Command\Command->run() at /composer/vendor/symfony/console/Application.php:835
 Symfony\Component\Console\Application->doRunCommand() at /composer/vendor/symfony/console/Application.php:185
 Symfony\Component\Console\Application->doRun() at /composer/src/Composer/Console/Application.php:267
 Composer\Console\Application->doRun() at /composer/vendor/symfony/console/Application.php:117
 Symfony\Component\Console\Application->run() at /composer/src/Composer/Console/Application.php:106
 Composer\Console\Application->run() at /composer/src/Composer/Command/OutdatedCommand.php:85
 Composer\Command\OutdatedCommand->execute() at /composer/vendor/symfony/console/Command/Command.php:245
 Symfony\Component\Console\Command\Command->run() at /composer/vendor/symfony/console/Application.php:835
 Symfony\Component\Console\Application->doRunCommand() at /composer/vendor/symfony/console/Application.php:185
 Symfony\Component\Console\Application->doRun() at /composer/src/Composer/Console/Application.php:267
 Composer\Console\Application->doRun() at /composer/vendor/symfony/console/Application.php:117
 Symfony\Component\Console\Application->run() at /composer/src/Composer/Console/Application.php:106
 Composer\Console\Application->run() at /composer/bin/composer:62
```