### PR TITLE
Fix: Xdebug vs xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     - php: 7.4snapshot
 
 before_install:
-  # disable xdebug if available
+  # disable Xdebug if available
   - phpenv config-rm xdebug.ini || echo "xdebug not available"
   # disable default memory limit
   - export INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,7 +252,7 @@
   * Fixed output inconsistencies
   * Fixed unicode handling in `init` command for author names
   * Fixed useless warning when doing partial updates/removes on packages that are not currently installed
-  * Fixed xdebug disabling issue when combined with disable_functions and allow_url_fopen CLI overrides
+  * Fixed Xdebug disabling issue when combined with disable_functions and allow_url_fopen CLI overrides
 
 ### [1.4.1] - 2017-03-10
 
@@ -313,7 +313,7 @@
   * Added `gitlab-token` auth config for GitLab private tokens
   * Added `--strict` to the `outdated` command to return a non-zero exit code when there are outdated packages
   * Added ability to call php scripts using the current php interpreter (instead of finding php in PATH by default) in script handlers via `@php ...`
-  * Added `COMPOSER_ALLOW_XDEBUG` env var to circumvent the xdebug-disabling behavior
+  * Added `COMPOSER_ALLOW_XDEBUG` env var to circumvent the Xdebug-disabling behavior
   * Added `COMPOSER_MIRROR_PATH_REPOS` env var to force mirroring of path repositories vs symlinking
   * Added `COMPOSER_DEV_MODE` env var that is set by Composer to forward the dev mode to script handlers
   * Fixed support for git 2.11

--- a/bin/composer
+++ b/bin/composer
@@ -13,7 +13,7 @@ use Composer\XdebugHandler\XdebugHandler;
 
 error_reporting(-1);
 
-// Restart without xdebug
+// Restart without Xdebug
 $xdebug = new XdebugHandler('Composer', '--ansi');
 $xdebug->check();
 unset($xdebug);

--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -156,10 +156,10 @@ This issue can also happen on cPanel instances, when the shell fork bomb protect
 
 ## Xdebug impact on Composer
 
-To improve performance when the xdebug extension is enabled, Composer automatically restarts PHP without it.
+To improve performance when the Xdebug extension is enabled, Composer automatically restarts PHP without it.
 You can override this behavior by using an environment variable: `COMPOSER_ALLOW_XDEBUG=1`.
 
-Composer will always show a warning if xdebug is being used, but you can override this with an environment variable:
+Composer will always show a warning if Xdebug is being used, but you can override this with an environment variable:
 `COMPOSER_DISABLE_XDEBUG_WARN=1`. If you see this warning unexpectedly, then the restart process has failed:
 please report this [issue](https://github.com/composer/composer/issues).
 

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -205,7 +205,7 @@ class Application extends BaseApplication
             }
 
             if (extension_loaded('xdebug') && !getenv('COMPOSER_DISABLE_XDEBUG_WARN')) {
-                $io->writeError('<warning>You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug</warning>');
+                $io->writeError('<warning>You are running composer with Xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug</warning>');
             }
 
             if (defined('COMPOSER_DEV_WARNING_TIME') && $commandName !== 'self-update' && $commandName !== 'selfupdate' && time() > COMPOSER_DEV_WARNING_TIME) {

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -125,7 +125,7 @@ class PlatformRepository extends ArrayRepository
             $this->addExtension($name, $prettyVersion);
         }
 
-        // Check for xdebug in a restarted process
+        // Check for Xdebug in a restarted process
         if (!in_array('xdebug', $loadedExtensions, true) && ($prettyVersion = XdebugHandler::getSkippedVersion())) {
             $this->addExtension('xdebug', $prettyVersion);
         }

--- a/tests/Composer/Test/ApplicationTest.php
+++ b/tests/Composer/Test/ApplicationTest.php
@@ -62,7 +62,7 @@ class ApplicationTest extends TestCase
 
             $outputMock->expects($this->at($index++))
                 ->method("write")
-                ->with($this->equalTo('<warning>You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug</warning>'));
+                ->with($this->equalTo('<warning>You are running composer with Xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug</warning>'));
         }
 
         $outputMock->expects($this->at($index++))


### PR DESCRIPTION
This PR

* [x] fixes the spelling of **Xdebug**

💁‍♂ For reference, also see 

- https://twitter.com/derickr/status/1184465999971700736
- https://github.com/composer/xdebug-handler/pull/99