### PR TITLE
Fix: Improve the create-project UX

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -279,6 +279,11 @@ EOT
             $packageVersion = $requirements[0]['version'];
         }
 
+        $fs = new Filesystem();
+        if (is_dir($directory) && !$fs->isDirEmpty($directory)) {
+            throw new \InvalidArgumentException("Project directory $directory is not empty.");
+        }
+
         if (null === $stability) {
             if (preg_match('{^[^,\s]*?@('.implode('|', array_keys(BasePackage::$stabilities)).')$}i', $packageVersion, $match)) {
                 $stability = $match[1];

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -279,6 +279,12 @@ EOT
             $packageVersion = $requirements[0]['version'];
         }
 
+        // if no directory was specified, use the 2nd part of the package name
+        if (null === $directory) {
+            $parts = explode("/", $name, 2);
+            $directory = getcwd() . DIRECTORY_SEPARATOR . array_pop($parts);
+        }
+
         $fs = new Filesystem();
         if (is_dir($directory) && !$fs->isDirEmpty($directory)) {
             throw new \InvalidArgumentException("Project directory $directory is not empty.");
@@ -323,11 +329,6 @@ EOT
             }
 
             throw new \InvalidArgumentException($errorMessage .'.');
-        }
-
-        if (null === $directory) {
-            $parts = explode("/", $name, 2);
-            $directory = getcwd() . DIRECTORY_SEPARATOR . array_pop($parts);
         }
 
         // handler Ctrl+C for unix-like systems

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -285,6 +285,8 @@ EOT
             $directory = getcwd() . DIRECTORY_SEPARATOR . array_pop($parts);
         }
 
+        $io->writeError('<info>Creating a "' . $packageName . '" project at "' . $directory . '"</info>');
+
         $fs = new Filesystem();
         if (file_exists($directory)) {
             if (!is_dir($directory)) {

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -286,8 +286,12 @@ EOT
         }
 
         $fs = new Filesystem();
-        if (is_dir($directory) && !$fs->isDirEmpty($directory)) {
-            throw new \InvalidArgumentException("Project directory $directory is not empty.");
+        if (file_exists($directory)) {
+            if (!is_dir($directory)) {
+                throw new \InvalidArgumentException('Cannot create project directory at "'.$directory.'", it exists as a file.');
+            } elseif (!$fs->isDirEmpty($directory)) {
+                throw new \InvalidArgumentException('Project directory "'.$directory.'" is not empty.');
+            }
         }
 
         if (null === $stability) {

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -282,9 +282,10 @@ EOT
         // if no directory was specified, use the 2nd part of the package name
         if (null === $directory) {
             $parts = explode("/", $name, 2);
-            $directory = getcwd() . DIRECTORY_SEPARATOR . array_pop($parts);
+            $directory = array_pop($parts);
         }
 
+        $directory = getcwd() . DIRECTORY_SEPARATOR . $directory;
         $io->writeError('<info>Creating a "' . $packageName . '" project at "' . $directory . '"</info>');
 
         $fs = new Filesystem();


### PR DESCRIPTION
### Problem

On slow connections, `create-project` may not output anything for over a minute when run, implying something may be wrong that is preventing Composer from working.

This is due to the 2nd line of [`getBestCandidate()`](https://github.com/composer/composer/blob/837ad7c14e8ce364296e0d0600d04c415b6e359d/src/Composer/Package/Version/VersionSelector.php#L52) doing some network download(for me it was ~13.6MB), and only after that would any output be produced with common usage of the command(no verbosity), as a new user to Composer is likely to try from following instructions online.

The validity of the install location is also not checked until after this network activity, which if it fails, has wasted time and can take a few more MB of network traffic for repeating the same command(unclear why).

---

### Changes

Running `composer create-project --prefer-dist laravel/laravel blog` will output:

> Creating a "laravel/laravel" project at "/var/www/html/blog"

And without the `blog` install directory:

> Creating a "laravel/laravel" project at "/var/www/html/laravel"

---

If the directory is not empty, it fails fast with the current error:

>  [InvalidArgumentException]               
>  Project directory "/var/www/html/blog" is not empty.

And if the install directory is omitted:

> [InvalidArgumentException]                               
> Project directory "/var/www/html/laravel" is not empty.

If the location exists, but is a file instead of a directory, a different error:

> [InvalidArgumentException]                                                 
> Cannot create project directory at "/var/www/html/laravel", it is a file.

---

Fixes #8409 and fixes #8410