### PR TITLE
Fix Windows test regression from commit 149250a

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -155,7 +155,7 @@ class ProcessExecutor
         //@see https://bugs.php.net/bug.php?id=43784
         //@see https://bugs.php.net/bug.php?id=49446
         if ('\\' === DIRECTORY_SEPARATOR) {
-            if ('' === $argument) {
+            if ((string) $argument === '') {
                 return escapeshellarg($argument);
             }
 

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -734,7 +734,7 @@ composer https://github.com/old/url (push)
             $cmd = str_replace('cd ', 'cd /D ', $cmd);
             $cmd = str_replace('composerPath', getcwd().'/composerPath', $cmd);
 
-            return str_replace('""', '', strtr($cmd, "'", '"'));
+            return strtr($cmd, "'", '"');
         }
 
         return $cmd;


### PR DESCRIPTION
Commit: 149250ab92feadd9fe045b54d6e42f33d185a595

ProcessExecutor::escape handled a false value inconsistently across
platforms, returning an emtpy string on Windows, otherwise `''`. This
is fixed to return `""` on Windows.

The GitDownloaderTest code has been appropriately updated.

See https://ci.appveyor.com/project/Seldaek/composer/builds/28664380 

@Seldaek This was caused by introducing a `preg_replace` value to escape the url, at: https://github.com/composer/composer/commit/149250ab92feadd9fe045b54d6e42f33d185a595#diff-c730819db325e3e10b8a4ef1be25373fR130

So the url was escaped twice:

1. from a `false` value, resulting in an empty string
2. from an empty string value (via `preg_replace` called with the `false` value), resulting in `""`

I guess the best behaviour would be not to use `false` as a url! This is introduced by the call to `realpath` in VcsDownloader::update https://github.com/composer/composer/blob/7e929503671fc94de8ba16d665936e63f46d5a56/src/Composer/Downloader/VcsDownloader.php#L142-L145