### PR TITLE
Hide commit signature for git log.

### DIFF
--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -143,7 +143,7 @@ class GitDriver extends VcsDriver
     public function getChangeDate($identifier)
     {
         $this->process->execute(sprintf(
-            'git log -1 --format=%%at %s',
+            'git -c log.showSignature=false log -1 --format=%%at %s',
             ProcessExecutor::escape($identifier)
         ), $output, $this->repoDir);
 


### PR DESCRIPTION
Hi,

When you have `git config --global log.showSignature true`. The commit signature is displayed for each `git log` command.

If you require a project with a signed commit (eg: "foo/project": "dev-master"), you are unable to install or update.

Adding `-c log.showSignature=false` to the command seems to solve the problem.