### PR TITLE
Improve hasPackage() performance

### DIFF
--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -28,6 +28,10 @@ class ArrayRepository extends BaseRepository
 {
     /** @var PackageInterface[] */
     protected $packages;
+    
+    /** 
+      * @var PackageInterface[] indexed by package unique name and used to cache hasPackage calls
+      */
     protected $packageMap;
 
     public function __construct(array $packages = array())
@@ -151,6 +155,9 @@ class ArrayRepository extends BaseRepository
                 $this->addPackage($aliasedPackage);
             }
         }
+
+        // invalidate package map cache
+        $this->packageMap = null;
     }
 
     protected function createAliasPackage(PackageInterface $package, $alias, $prettyAlias)
@@ -170,6 +177,9 @@ class ArrayRepository extends BaseRepository
         foreach ($this->getPackages() as $key => $repoPackage) {
             if ($packageId === $repoPackage->getUniqueName()) {
                 array_splice($this->packages, $key, 1);
+
+                // invalidate package map cache
+                $this->packageMap = null;
 
                 return;
             }

--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -122,7 +122,8 @@ class ArrayRepository extends BaseRepository
      */
     public function hasPackage(PackageInterface $package)
     {
-        if (empty($this->packageMap)) {
+        if ($this->packageMap === null) {
+            $this->packageMap = array();
             foreach ($this->getPackages() as $repoPackage) {
                 $this->packageMap[$repoPackage->getUniqueName()] = $repoPackage;
             }

--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -28,6 +28,7 @@ class ArrayRepository extends BaseRepository
 {
     /** @var PackageInterface[] */
     protected $packages;
+    protected $packageMap;
 
     public function __construct(array $packages = array())
     {
@@ -121,15 +122,13 @@ class ArrayRepository extends BaseRepository
      */
     public function hasPackage(PackageInterface $package)
     {
-        $packageId = $package->getUniqueName();
-
-        foreach ($this->getPackages() as $repoPackage) {
-            if ($packageId === $repoPackage->getUniqueName()) {
-                return true;
+        if (empty($this->packageMap)) {
+            foreach ($this->getPackages() as $repoPackage) {
+                $this->packageMap[$repoPackage->getUniqueName()] = $repoPackage;
             }
         }
 
-        return false;
+        return isset($this->packageMap[$package->getUniqueName()]);
     }
 
     /**


### PR DESCRIPTION
Hi,

I've been profiling performance issues on a Magento2 install and noticed that 20% of each request was attributed to composer. Composer manages around 500 packages for that install. 

The problem is specifically with `ArrayRepository:hasPackage()`.

During bootstrapping this function is called once for each repository. Due to the loop used for name matching the complexity for n packages (executed once for each package) would be n*(n-1)/2. The proposed fix would reduce this to n. 

In practical terms this fix shaved off 200ms of each request. 

Please have a look at the profiles below. Specifically the profile "composer filtered without fix". Highlights the issue. getUniqeName is called 121k times during each request.

Overview without fix:
![full_original](https://user-images.githubusercontent.com/2926266/69286286-b1e15500-0ba7-11ea-9026-72e095e587f7.png)

Overview with fix:
![full_new](https://user-images.githubusercontent.com/2926266/69286287-b1e15500-0ba7-11ea-904f-118dfb012401.png)

Composer filtered without fix:
![composer_original](https://user-images.githubusercontent.com/2926266/69286288-b1e15500-0ba7-11ea-8bce-c068c285614a.png)

Composer filtered with fix:
![composer_new](https://user-images.githubusercontent.com/2926266/69286456-20261780-0ba8-11ea-8ddd-1014e2d91119.png)


