### PR TITLE
Removed the filters from the pool

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -28,7 +28,7 @@ use Composer\Semver\Constraint\MultiConstraint;
 class PoolBuilder
 {
     private $isPackageAcceptableCallable;
-    private $filterRequires;
+    private $rootRequires;
     private $rootAliases;
     private $rootReferences;
 
@@ -40,15 +40,15 @@ class PoolBuilder
     private $packages = array();
     private $priorities = array();
 
-    public function __construct($isPackageAcceptableCallable, array $filterRequires = array())
+    public function __construct($isPackageAcceptableCallable, array $rootRequires = array())
     {
         $this->isPackageAcceptableCallable = $isPackageAcceptableCallable;
-        $this->filterRequires = $filterRequires;
+        $this->rootRequires = $rootRequires;
     }
 
     public function buildPool(array $repositories, array $rootAliases, array $rootReferences, Request $request)
     {
-        $pool = new Pool($this->filterRequires);
+        $pool = new Pool();
         $this->rootAliases = $rootAliases;
         $this->rootReferences = $rootReferences;
 

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -148,13 +148,15 @@ class Problem
                     return "\n    - The requested package ".$packageName.' could not be found, it looks like its name is invalid, "'.$illegalChars.'" is not allowed in package names.';
                 }
 
-                if ($providers = $this->pool->whatProvides($packageName, $constraint, true, true)) {
+                // TODO: The pool doesn't know about these anymore, it has to ask the RepositorySet
+                /*if ($providers = $this->pool->whatProvides($packageName, $constraint, true, true)) {
                     return "\n    - The requested package ".$packageName.$this->constraintToText($constraint).' is satisfiable by '.$this->getPackageList($providers).' but these conflict with your requirements or minimum-stability.';
-                }
+                }*/
 
-                if ($providers = $this->pool->whatProvides($packageName, null, true, true)) {
+                // TODO: The pool doesn't know about these anymore, it has to ask the RepositorySet
+                /*if ($providers = $this->pool->whatProvides($packageName, null, true, true)) {
                     return "\n    - The requested package ".$packageName.$this->constraintToText($constraint).' exists as '.$this->getPackageList($providers).' but these are rejected by your constraint.';
-                }
+                }*/
 
                 return "\n    - The requested package ".$packageName.' could not be found in any version, there may be a typo in the package name.';
             }

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -217,9 +217,10 @@ abstract class Rule
                         return $text . ' -> the requested linked library '.$lib.' has the wrong version installed or is missing from your system, make sure to have the extension providing it.';
                     }
 
-                    if ($providers = $pool->whatProvides($targetName, $this->reasonData->getConstraint(), true, true)) {
+                    // TODO: The pool doesn't know about these anymore, it has to ask the RepositorySet
+                    /*if ($providers = $pool->whatProvides($targetName, $this->reasonData->getConstraint(), true, true)) {
                         return $text . ' -> satisfiable by ' . $this->formatPackagesUnique($pool, $providers) .' but these conflict with your requirements or minimum-stability.';
-                    }
+                    }*/
 
                     return $text . ' -> no matching package found.';
                 }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -717,16 +717,16 @@ class Installer
             }
         }
 
-        $rootConstraints = array();
+        $rootRequires = array();
         foreach ($requires as $req => $constraint) {
             // skip platform requirements from the root package to avoid filtering out existing platform packages
             if ($this->ignorePlatformReqs && preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $req)) {
                 continue;
             }
             if ($constraint instanceof Link) {
-                $rootConstraints[$req] = $constraint->getConstraint();
+                $rootRequires[$req] = $constraint->getConstraint();
             } else {
-                $rootConstraints[$req] = $constraint;
+                $rootRequires[$req] = $constraint;
             }
         }
 
@@ -734,7 +734,7 @@ class Installer
         $this->fixedRootPackage->setRequires(array());
         $this->fixedRootPackage->setDevRequires(array());
 
-        $repositorySet = new RepositorySet($rootAliases, $this->package->getReferences(), $minimumStability, $stabilityFlags, $rootConstraints);
+        $repositorySet = new RepositorySet($rootAliases, $this->package->getReferences(), $minimumStability, $stabilityFlags, $rootRequires);
         $repositorySet->addRepository(new InstalledArrayRepository(array($this->fixedRootPackage)));
         $repositorySet->addRepository($platformRepo);
         if ($this->additionalFixedRepository) {

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -37,12 +37,12 @@ class RepositorySet
 
     private $acceptableStabilities;
     private $stabilityFlags;
-    protected $filterRequires;
+    protected $rootRequires;
 
     /** @var Pool */
     private $pool;
 
-    public function __construct(array $rootAliases = array(), array $rootReferences = array(), $minimumStability = 'stable', array $stabilityFlags = array(), array $filterRequires = array())
+    public function __construct(array $rootAliases = array(), array $rootReferences = array(), $minimumStability = 'stable', array $stabilityFlags = array(), array $rootRequires = array())
     {
         $this->rootAliases = $rootAliases;
         $this->rootReferences = $rootReferences;
@@ -54,10 +54,10 @@ class RepositorySet
             }
         }
         $this->stabilityFlags = $stabilityFlags;
-        $this->filterRequires = $filterRequires;
-        foreach ($filterRequires as $name => $constraint) {
+        $this->rootRequires = $rootRequires;
+        foreach ($rootRequires as $name => $constraint) {
             if (preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $name)) {
-                unset($this->filterRequires[$name]);
+                unset($this->rootRequires[$name]);
             }
         }
     }
@@ -152,7 +152,7 @@ class RepositorySet
      */
     public function createPool(Request $request)
     {
-        $poolBuilder = new PoolBuilder(array($this, 'isPackageAcceptable'), $this->filterRequires);
+        $poolBuilder = new PoolBuilder(array($this, 'isPackageAcceptable'), $this->rootRequires);
 
         return $this->pool = $poolBuilder->buildPool($this->repositories, $this->rootAliases, $this->rootReferences, $request);
     }

--- a/tests/Composer/Test/DependencyResolver/PoolTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolTest.php
@@ -65,6 +65,6 @@ class PoolTest extends TestCase
 
     protected function createPool()
     {
-        return new Pool(array('stable' => BasePackage::STABILITY_STABLE));
+        return new Pool();
     }
 }

--- a/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
@@ -27,7 +27,7 @@ class RuleSetIteratorTest extends TestCase
 
     protected function setUp()
     {
-        $this->pool = new Pool(array('stable' => BasePackage::STABILITY_STABLE));
+        $this->pool = new Pool();
 
         $this->rules = array(
             RuleSet::TYPE_JOB => array(

--- a/tests/Composer/Test/DependencyResolver/RuleSetTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetTest.php
@@ -139,7 +139,7 @@ class RuleSetTest extends TestCase
 
     public function testPrettyString()
     {
-        $pool = new Pool(array('stable' => BasePackage::STABILITY_STABLE));
+        $pool = new Pool();
         $pool->setPackages(array(
             $p = $this->getPackage('foo', '2.1'),
         ));

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -93,7 +93,7 @@ class RuleTest extends TestCase
 
     public function testPrettyString()
     {
-        $pool = new Pool(array('stable' => BasePackage::STABILITY_STABLE));
+        $pool = new Pool();
         $pool->setPackages(array(
             $p1 = $this->getPackage('foo', '2.1'),
             $p2 = $this->getPackage('baz', '1.1'),

--- a/tests/Composer/Test/Fixtures/installer/solver-problems.test
+++ b/tests/Composer/Test/Fixtures/installer/solver-problems.test
@@ -65,7 +65,7 @@ Your requirements could not be resolved to an installable set of packages.
     - requirer/pkg 1.0.0 requires dependency/pkg 1.0.0 -> no matching package found.
   Problem 4
     - stable-requiree-excluded/pkg is locked to version 1.0.0 and an update of this package was not requested.
-    - Same name, can only install one of: stable-requiree-excluded/pkg[1.0.1, 1.0.0].
+    - Same name, can only install one of: stable-requiree-excluded/pkg[1.0.0, 1.0.1].
     - Installation request for stable-requiree-excluded/pkg 1.0.1 -> satisfiable by stable-requiree-excluded/pkg[1.0.1].
 
 Potential causes:


### PR DESCRIPTION
After discussions with @naderman at #SymfonyHackday, here's the removal of the `$filterRequires` on the `Pool`. I've also renamed it to `$rootRequires` because that's what it's really is. It was only ever used for `Problem` as well as `Rule`, so it had no influence on the resolving process but it was there to display information only. This information, however, should be provided by the new `RepositorySet` and not the `Pool` itself.