### PR TITLE
#8461: [ZipDownloader] Print `unzip` exit code when the command is failed

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -105,11 +105,11 @@ class ZipDownloader extends ArchiveDownloader
         $command = 'unzip -qq '.$overwrite.' '.ProcessExecutor::escape($file).' -d '.ProcessExecutor::escape($path);
 
         try {
-            if (0 === $this->process->execute($command, $ignoredOutput)) {
+            if (0 === $exitCode = $this->process->execute($command, $ignoredOutput)) {
                 return true;
             }
 
-            $processError = new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
+            $processError = new \RuntimeException('Failed to execute ('.$exitCode.') '.$command."\n\n".$this->process->getErrorOutput());
         } catch (\Exception $e) {
             $processError = $e;
         }

--- a/tests/Composer/Test/Downloader/ZipDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ZipDownloaderTest.php
@@ -184,7 +184,7 @@ class ZipDownloaderTest extends TestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage Failed to execute unzip
+     * @expectedExceptionMessage Failed to execute (1) unzip
      */
     public function testSystemUnzipOnlyFailed()
     {
@@ -310,7 +310,7 @@ class ZipDownloaderTest extends TestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage Failed to execute unzip
+     * @expectedExceptionMessage Failed to execute (1) unzip
      */
     public function testWindowsFallbackFailed()
     {


### PR DESCRIPTION
https://github.com/composer/composer/issues/8461