### PR TITLE
Enhancement: Keep packages sorted in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
         "composer/xdebug-handler": "^1.1",
         "justinrainbow/json-schema": "^3.0 || ^4.0 || ^5.0",
         "psr/log": "^1.0",
+        "react/promise": "^1.2 || ^2.7",
         "seld/jsonlint": "^1.4",
         "seld/phar-utils": "^1.0",
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/filesystem": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/finder": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/process": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-        "react/promise": "^1.2 || ^2.7"
+        "symfony/process": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },
     "conflict": {
         "symfony/console": "2.8.38"
@@ -52,7 +52,8 @@
     "config": {
         "platform": {
             "php": "5.3.9"
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fb7edae7611d2e07d946d75b9cf2c63",
+    "content-hash": "ddc84de887109be2afac0aac4943b89b",
     "packages": [
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
This PR

* [x] keeps packages sorted in`composer.json`

💁‍♂ For reference, I ran

```
$ bin/composer config sort-packages true
```

followed by

```
$ bin/composer require psr/log:^1.0
```

to force sorting of packages.