### PR TITLE
implemented `@putenv` composer script

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -244,7 +244,11 @@ class EventDispatcher
                     }
                 }
 
-                if (substr($exec, 0, 5) === '@php ') {
+                if (substr($exec, 0, 8) === '@putenv ') {
+                    putenv(substr($exec, 8));
+
+                    continue;
+                } elseif (substr($exec, 0, 5) === '@php ') {
                     $exec = $this->getPhpExecCommand() . ' ' . substr($exec, 5);
                 } else {
                     $finder = new PhpExecutableFinder();
@@ -512,7 +516,7 @@ class EventDispatcher
      */
     protected function isComposerScript($callable)
     {
-        return '@' === substr($callable, 0, 1) && '@php ' !== substr($callable, 0, 5);
+        return '@' === substr($callable, 0, 1) && '@php ' !== substr($callable, 0, 5) && '@putenv ' !== substr($callable, 0, 8);
     }
 
     /**


### PR DESCRIPTION
`@putenv` supports setting environment variables in a x-OS compatible way

closes https://github.com/composer/composer/issues/8489 https://github.com/composer/composer/issues/8488

after this change one can write a composer.json script like

```
{
    "scripts": {
		"myscript": [
			"@putenv COMPOSER=phpstan-composer.json",
            "composer install --prefer-dist"
		]
    }
}
```

before this change one could only write e.g.
`"COMPOSER=phpstan-composer.json composer install --prefer-dist"`
which is not compatible with windows (see also related issues, linked above).

one could also write things like
`"SET COMPOSER=phpstan-composer.json"`
but this works only on windows.