### PR TITLE
validate: suggest composer update --lock

### DIFF
--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -93,7 +93,7 @@ EOT
         $composer = Factory::create($io, $file, $input->hasParameterOption('--no-plugins'));
         $locker = $composer->getLocker();
         if ($locker->isLocked() && !$locker->isFresh()) {
-            $lockErrors[] = 'The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update`.';
+            $lockErrors[] = 'The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update --lock`.';
         }
 
         $this->outputResult($io, $file, $errors, $warnings, $checkPublish, $publishErrors, $checkLock, $lockErrors, true, $isStrict);


### PR DESCRIPTION
Suggest more safer `composer update --lock` command when lock file is not up to date.