### PR TITLE
VcsRepositories: mark archived repositories as abandoned

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -34,6 +34,7 @@ class GitHubDriver extends VcsDriver
     protected $hasIssues;
     protected $infoCache = array();
     protected $isPrivate = false;
+    private $isArchived = false;
 
     /**
      * Git Driver
@@ -161,6 +162,9 @@ class GitHubDriver extends VcsDriver
                 }
                 if (!isset($composer['support']['issues']) && $this->hasIssues) {
                     $composer['support']['issues'] = sprintf('https://%s/%s/%s/issues', $this->originUrl, $this->owner, $this->repository);
+                }
+                if (!isset($composer['abandoned']) && $this->isArchived) {
+                    $composer['abandoned'] = true;
                 }
             }
 
@@ -425,6 +429,7 @@ class GitHubDriver extends VcsDriver
             $this->rootIdentifier = 'master';
         }
         $this->hasIssues = !empty($this->repoData['has_issues']);
+        $this->isArchived = !empty($this->repoData['archived']);
     }
 
     protected function attemptCloneFallback()

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -207,7 +207,49 @@ class GitHubDriverTest extends TestCase
         $this->assertEquals($repoUrl, $source['url']);
         $this->assertEquals($sha, $source['reference']);
 
-        $gitHubDriver->getComposerInformation($identifier);
+        $data = $gitHubDriver->getComposerInformation($identifier);
+
+        $this->assertArrayNotHasKey('abandoned', $data);
+    }
+
+    public function testPublicRepositoryArchived()
+    {
+        $repoUrl = 'http://github.com/composer/packagist';
+        $repoApiUrl = 'https://api.github.com/repos/composer/packagist';
+        $identifier = 'v0.0.0';
+        $sha = 'SOMESHA';
+        $composerJsonUrl = 'https://api.github.com/repos/composer/packagist/contents/composer.json?ref=' . $sha;
+
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $io->expects($this->any())
+            ->method('isInteractive')
+            ->will($this->returnValue(true));
+
+        $remoteFilesystem = $this->getMockBuilder('Composer\Util\RemoteFilesystem')
+            ->setConstructorArgs(array($io))
+            ->getMock();
+
+        $remoteFilesystem->expects($this->at(0))
+            ->method('getContents')
+            ->with($this->equalTo('github.com'), $this->equalTo($repoApiUrl), $this->equalTo(false))
+            ->will($this->returnValue('{"master_branch": "test_master", "owner": {"login": "composer"}, "name": "packagist", "archived": true}'));
+
+        $remoteFilesystem->expects($this->at(1))
+            ->method('getContents')
+            ->with($this->equalTo('github.com'), $this->equalTo($composerJsonUrl), $this->equalTo(false))
+            ->will($this->returnValue('{"encoding": "base64", "content": "' . base64_encode('{"name": "composer/packagist"}') . '"}'));
+
+        $repoConfig = array(
+            'url' => $repoUrl,
+        );
+
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, null, $remoteFilesystem);
+        $gitHubDriver->initialize();
+        $this->setAttribute($gitHubDriver, 'tags', array($identifier => $sha));
+
+        $data = $gitHubDriver->getComposerInformation($sha);
+
+        $this->assertTrue($data['abandoned']);
     }
 
     public function testPrivateRepositoryNoInteraction()


### PR DESCRIPTION
This implements: https://github.com/composer/packagist/issues/1055

Note:
* Bitbucket does not have an archive functionality
* GitLab only provides the properties if the project data is accessed with authentication