### PR TITLE
Implemented way to use preferred-install for defining granular preferences through CLI

### DIFF
--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -167,6 +167,10 @@ class JsonManipulator
 
     public function addProperty($name, $value)
     {
+	    if ( substr( $name, 0, 7 ) === 'config.' ) {
+		    return $this->addConfigSetting( substr( $name, 7 ), $value );
+	    }
+
         if (substr($name, 0, 6) === 'extra.') {
             return $this->addSubNode('extra', substr($name, 6), $value);
         }
@@ -180,6 +184,10 @@ class JsonManipulator
 
     public function removeProperty($name)
     {
+	    if ( substr( $name, 0, 7 ) === 'config.' ) {
+		    return $this->removeConfigSetting( substr( $name, 7 ) );
+	    }
+
         if (substr($name, 0, 6) === 'extra.') {
             return $this->removeSubNode('extra', substr($name, 6));
         }

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -1814,6 +1814,51 @@ class JsonManipulatorTest extends TestCase
 ', $manipulator->getContents());
     }
 
+	public function testAddConfigWithPackage() {
+		$manipulator = new JsonManipulator('{
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "authors": [],
+                "extra": {
+                    "package-xml": "package.xml"
+                }
+            }
+        }
+    ],
+    "config": {
+        "platform": {
+            "php": "5.3.9"
+        }
+    }
+}');
+
+		$this->assertTrue($manipulator->addProperty('config.preferred-install.my-organization/stable-package', 'dist'));
+		$this->assertEquals('{
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "authors": [],
+                "extra": {
+                    "package-xml": "package.xml"
+                }
+            }
+        }
+    ],
+    "config": {
+        "platform": {
+            "php": "5.3.9"
+        },
+        "preferred-install": {
+            "my-organization/stable-package": "dist"
+        }
+    }
+}
+', $manipulator->getContents());
+	}
+
     public function testAddRepositoryCanInitializeEmptyRepositories()
     {
         $manipulator = new JsonManipulator('{


### PR DESCRIPTION
Reported in https://github.com/composer/composer/issues/6301

Currently, preferred-install accepts the hash of patterns as the value in the composer.json. I've followed the same approach as used in extra and platform for letting the user define install preferences through CLI in the format:

```
composer config preferred-install my-organization/stable-package.dist
composer config preferred-install my-other-organization/stable-package.source
composer config preferred-install my-other-organization/stable-package.auto
```