### PR TITLE
Avoid loading packages found in a higher prio repo entirely from lower prio repos

### DIFF
--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -36,7 +36,6 @@ class Pool implements \Countable
     protected $packages = array();
     protected $packageByName = array();
     protected $packageByExactName = array();
-    protected $priorities = array();
     protected $versionParser;
     protected $providerCache = array();
 
@@ -45,13 +44,12 @@ class Pool implements \Countable
         $this->versionParser = new VersionParser;
     }
 
-    public function setPackages(array $packages, array $priorities = array())
+    public function setPackages(array $packages)
     {
         $id = 1;
 
         foreach ($packages as $i => $package) {
             $this->packages[] = $package;
-            $this->priorities[] = isset($priorities[$i]) ? $priorities[$i] : 0;
 
             $package->id = $id++;
             $names = $package->getNames();
@@ -61,11 +59,6 @@ class Pool implements \Countable
                 $this->packageByName[$provided][] = $package;
             }
         }
-    }
-
-    public function getPriority($id)
-    {
-        return $this->priorities[$id - 1];
     }
 
     /**

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -38,7 +38,6 @@ class PoolBuilder
     private $loadedNames = array();
 
     private $packages = array();
-    private $priorities = array();
 
     public function __construct($isPackageAcceptableCallable, array $rootRequires = array())
     {
@@ -134,7 +133,6 @@ class PoolBuilder
                 if (!$found) {
                     foreach ($aliasedPackages as $index => $packageOrAlias) {
                         unset($this->packages[$index]);
-                        unset($this->priorities[$index]);
                     }
                 }
             }
@@ -149,7 +147,7 @@ class PoolBuilder
             }
         }
 
-        $pool->setPackages($this->packages, $this->priorities);
+        $pool->setPackages($this->packages);
 
         unset($this->aliasMap);
         unset($this->loadedNames);
@@ -158,11 +156,10 @@ class PoolBuilder
         return $pool;
     }
 
-    private function loadPackage(Request $request, PackageInterface $package, $repoIndex)
+    private function loadPackage(Request $request, PackageInterface $package)
     {
         $index = count($this->packages);
         $this->packages[] = $package;
-        $this->priorities[] = -$repoIndex;
 
         if ($package instanceof AliasPackage) {
             $this->aliasMap[spl_object_hash($package->getAliasOf())][$index] = $package;
@@ -192,7 +189,6 @@ class PoolBuilder
 
             $package->getRepository()->addPackage($aliasPackage); // TODO do we need this?
             $this->packages[] = $aliasPackage;
-            $this->priorities[] = -$repoIndex;
             $this->aliasMap[spl_object_hash($aliasPackage->getAliasOf())][$index+1] = $aliasPackage;
         }
 

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -97,9 +97,14 @@ class PoolBuilder
                 }
 
                 // TODO should we really pass the callable into here?
-                $packages = $repository->loadPackages($loadNames, $this->isPackageAcceptableCallable);
+                $result = $repository->loadPackages($loadNames, $this->isPackageAcceptableCallable);
 
-                foreach ($packages as $package) {
+                foreach ($result['namesFound'] as $name) {
+                    // avoid loading the same package again from other repositories once it has been found
+                    unset($loadNames[$name]);
+                }
+                foreach ($result['packages'] as $package) {
+
                     if (call_user_func($this->isPackageAcceptableCallable, $package->getNames(), $package->getStability())) {
                         $newLoadNames += $this->loadPackage($request, $package, $key);
                     }

--- a/src/Composer/Repository/BaseRepository.php
+++ b/src/Composer/Repository/BaseRepository.php
@@ -25,40 +25,6 @@ use Composer\Package\Link;
  */
 abstract class BaseRepository implements RepositoryInterface
 {
-    // TODO should this stay here? some repos need a better implementation
-    public function loadPackages(array $packageMap, $isPackageAcceptableCallable)
-    {
-        $packages = $this->getPackages();
-
-        $result = array();
-        $namesFound = array();
-        foreach ($packages as $package) {
-            if (array_key_exists($package->getName(), $packageMap)) {
-                if (
-                    (!$packageMap[$package->getName()] || $packageMap[$package->getName()]->matches(new Constraint('==', $package->getVersion())))
-                    && call_user_func($isPackageAcceptableCallable, $package->getNames(), $package->getStability())
-                ) {
-                    $result[spl_object_hash($package)] = $package;
-                    if ($package instanceof AliasPackage && !isset($result[spl_object_hash($package->getAliasOf())])) {
-                        $result[spl_object_hash($package->getAliasOf())] = $package->getAliasOf();
-                    }
-                }
-
-                $namesFound[$package->getName()] = true;
-            }
-        }
-
-        foreach ($packages as $package) {
-            if ($package instanceof AliasPackage) {
-                if (isset($result[spl_object_hash($package->getAliasOf())])) {
-                    $result[spl_object_hash($package)] = $package;
-                }
-            }
-        }
-
-        return array('namesFound' => array_keys($namesFound), 'packages' => $result);
-    }
-
     /**
      * Returns a list of links causing the requested needle packages to be installed, as an associative array with the
      * dependent's name as key, and an array containing in order the PackageInterface and Link describing the relationship

--- a/src/Composer/Repository/BaseRepository.php
+++ b/src/Composer/Repository/BaseRepository.php
@@ -31,16 +31,20 @@ abstract class BaseRepository implements RepositoryInterface
         $packages = $this->getPackages();
 
         $result = array();
+        $namesFound = array();
         foreach ($packages as $package) {
-            if (
-                array_key_exists($package->getName(), $packageMap)
-                && (!$packageMap[$package->getName()] || $packageMap[$package->getName()]->matches(new Constraint('==', $package->getVersion())))
-                && call_user_func($isPackageAcceptableCallable, $package->getNames(), $package->getStability())
-            ) {
-                $result[spl_object_hash($package)] = $package;
-                if ($package instanceof AliasPackage && !isset($result[spl_object_hash($package->getAliasOf())])) {
-                    $result[spl_object_hash($package->getAliasOf())] = $package->getAliasOf();
+            if (array_key_exists($package->getName(), $packageMap)) {
+                if (
+                    (!$packageMap[$package->getName()] || $packageMap[$package->getName()]->matches(new Constraint('==', $package->getVersion())))
+                    && call_user_func($isPackageAcceptableCallable, $package->getNames(), $package->getStability())
+                ) {
+                    $result[spl_object_hash($package)] = $package;
+                    if ($package instanceof AliasPackage && !isset($result[spl_object_hash($package->getAliasOf())])) {
+                        $result[spl_object_hash($package->getAliasOf())] = $package->getAliasOf();
+                    }
                 }
+
+                $namesFound[$package->getName()] = true;
             }
         }
 
@@ -52,7 +56,7 @@ abstract class BaseRepository implements RepositoryInterface
             }
         }
 
-        return $result;
+        return array('namesFound' => array_keys($namesFound), 'packages' => $result);
     }
 
     /**

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -143,7 +143,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
             $packages = $this->loadAsyncPackages(array($name => $constraint));
 
-            return reset($packages);
+            return reset($packages['packages']);
         }
 
         if ($hasProviders) {
@@ -181,7 +181,9 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 return array();
             }
 
-            return $this->loadAsyncPackages(array($name => $constraint));
+            $result = $this->loadAsyncPackages(array($name => $constraint));
+
+            return $result['packages'];
         }
 
         if ($hasProviders) {
@@ -239,7 +241,9 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     $packageMap[$name] = new EmptyConstraint();
                 }
 
-                return array_values($this->loadAsyncPackages($packageMap));
+                $result = $this->loadAsyncPackages($packageMap);
+
+                return array_values($result['packages']);
             }
 
             if ($this->hasPartialPackages()) {
@@ -297,6 +301,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         }
 
         $packages = array();
+        $namesFound = array();
 
         if ($hasProviders || $this->hasPartialPackages()) {
             foreach ($packageNameMap as $name => $constraint) {
@@ -313,6 +318,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     if ($candidate->getName() !== $name) {
                         throw new \LogicException('whatProvides should never return a package with a different name than the requested one');
                     }
+                    $namesFound[$name] = true;
                     if (!$constraint || $constraint->matches(new Constraint('==', $candidate->getVersion()))) {
                         $matches[spl_object_hash($candidate)] = $candidate;
                         if ($candidate instanceof AliasPackage && !isset($matches[spl_object_hash($candidate->getAliasOf())])) {
@@ -343,10 +349,12 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 }, ARRAY_FILTER_USE_KEY);
             }
 
-            $packages = array_merge($packages, $this->loadAsyncPackages($packageNameMap, $isPackageAcceptableCallable));
+            $result = $this->loadAsyncPackages($packageNameMap, $isPackageAcceptableCallable);
+            $packages = array_merge($packages, $result['packages']);
+            $namesFound = array_merge($namesFound, $result['namesFound']);
         }
 
-        return $packages;
+        return array('namesFound' => array_keys($namesFound), 'packages' => $packages);
     }
 
     /**
@@ -586,6 +594,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         $this->loadRootServerFile();
 
         $packages = array();
+        $namesFound = array();
         $promises = array();
         $repo = $this;
 
@@ -619,7 +628,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
 
             $promises[] = $this->asyncFetchFile($url, $cacheKey, $lastModified)
-                ->then(function ($response) use (&$packages, $contents, $realName, $constraint, $repo, $isPackageAcceptableCallable) {
+                ->then(function ($response) use (&$packages, &$namesFound, $contents, $realName, $constraint, $repo, $isPackageAcceptableCallable) {
                     if (true === $response) {
                         $response = $contents;
                     }
@@ -657,6 +666,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                         unset($expanded, $expandedVersion, $versionData);
                     }
 
+                    $namesFound[$realName] = true;
                     $versionsToLoad = array();
                     foreach ($versions as $version) {
                         if (!isset($version['version_normalized'])) {
@@ -683,7 +693,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         $this->loop->wait($promises);
 
-        return $packages;
+        return array('namesFound' => $namesFound, 'packages' => $packages);
         // RepositorySet should call loadMetadata, getMetadata when all promises resolved, then metadataComplete when done so we can GC the loaded json and whatnot then as needed
     }
 

--- a/src/Composer/Repository/CompositeRepository.php
+++ b/src/Composer/Repository/CompositeRepository.php
@@ -95,6 +95,26 @@ class CompositeRepository extends BaseRepository
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function loadPackages(array $packageMap, $isPackageAcceptableCallable)
+    {
+        $packages = array();
+        $namesFound = array();
+        foreach ($this->repositories as $repository) {
+            /* @var $repository RepositoryInterface */
+            $result = $repository->findPackages($name, $constraint);
+            $packages[] = $result['packages'];
+            $namesFound[] = $result['namesFound'];
+        }
+
+        return array(
+            'packages' => $packages ? call_user_func_array('array_merge', $packages) : array(),
+            'namesFound' => $namesFound ? array_unique(call_user_func_array('array_merge', $namesFound)) : array(),
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function search($query, $mode = 0, $type = null)

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -69,7 +69,7 @@ interface RepositoryInterface extends \Countable
      *
      * @param ConstraintInterface[] $packageNameMap package names pointing to constraints
      * @param $isPackageAcceptableCallable
-     * @return PackageInterface[]
+     * @return array [namesFound => string[], packages => PackageInterface[]]
      */
     public function loadPackages(array $packageNameMap, $isPackageAcceptableCallable);
 

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -65,6 +65,9 @@ class RepositorySet
     /**
      * Adds a repository to this repository set
      *
+     * The first repos added have a higher priority. As soon as a package is found in any
+     * repository the search for that package ends, and following repos will not be consulted.
+     *
      * @param RepositoryInterface $repo        A package repository
      */
     public function addRepository(RepositoryInterface $repo)
@@ -132,17 +135,6 @@ class RepositorySet
         }
 
         return $candidates;
-    }
-
-    public function getPriority(RepositoryInterface $repo)
-    {
-        $priority = array_search($repo, $this->repositories, true);
-
-        if (false === $priority) {
-            throw new \RuntimeException("Could not determine repository priority. The repository was not registered in the pool.");
-        }
-
-        return -$priority;
     }
 
     /**

--- a/tests/Composer/Test/DependencyResolver/DefaultPolicyTest.php
+++ b/tests/Composer/Test/DependencyResolver/DefaultPolicyTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\DependencyResolver;
 
 use Composer\Repository\ArrayRepository;
+use Composer\Repository\LockArrayRepository;
 use Composer\Repository\RepositoryInterface;
 use Composer\DependencyResolver\DefaultPolicy;
 use Composer\DependencyResolver\Pool;
@@ -28,7 +29,7 @@ class DefaultPolicyTest extends TestCase
     protected $repositorySet;
     /** @var ArrayRepository */
     protected $repo;
-    /** @var ArrayRepository */
+    /** @var LockArrayRepository */
     protected $repoLocked;
     /** @var DefaultPolicy */
     protected $policy;
@@ -37,7 +38,7 @@ class DefaultPolicyTest extends TestCase
     {
         $this->repositorySet = new RepositorySet(array(), array(), 'dev');
         $this->repo = new ArrayRepository;
-        $this->repoLocked = new ArrayRepository;
+        $this->repoLocked = new LockArrayRepository;
 
         $this->policy = new DefaultPolicy;
     }
@@ -116,44 +117,6 @@ class DefaultPolicyTest extends TestCase
 
         $literals = array($packageA1->getId(), $packageA2->getId());
         $expected = array($packageA2->getId());
-
-        $selected = $this->policy->selectPreferredPackages($pool, $literals);
-
-        $this->assertSame($expected, $selected);
-    }
-
-    public function testSelectNewestOverLocked()
-    {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '2.0'));
-        $this->repoLocked->addPackage($packageAInstalled = $this->getPackage('A', '1.0'));
-        $this->repositorySet->addRepository($this->repo);
-        $this->repositorySet->addRepository($this->repoLocked);
-
-        $pool = $this->repositorySet->createPoolForPackage('A');
-
-        $literals = array($packageA->getId(), $packageAInstalled->getId());
-        $expected = array($packageA->getId());
-
-        $selected = $this->policy->selectPreferredPackages($pool, $literals);
-
-        $this->assertSame($expected, $selected);
-    }
-
-    public function testSelectFirstRepo()
-    {
-        $otherRepository = new ArrayRepository;
-
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $otherRepository->addPackage($packageAImportant = $this->getPackage('A', '1.0'));
-
-        $this->repositorySet->addRepository($otherRepository);
-        $this->repositorySet->addRepository($this->repo);
-        $this->repositorySet->addRepository($this->repoLocked);
-
-        $pool = $this->repositorySet->createPoolForPackage('A');
-
-        $literals = array($packageA->getId(), $packageAImportant->getId());
-        $expected = array($packageAImportant->getId());
 
         $selected = $this->policy->selectPreferredPackages($pool, $literals);
 

--- a/tests/Composer/Test/Fixtures/installer/repositories-priorities.test
+++ b/tests/Composer/Test/Fixtures/installer/repositories-priorities.test
@@ -1,0 +1,42 @@
+--TEST--
+Packages found in a higher priority repository take precedence even if they are not found in the requested version
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "foo/a", "version": "1.0.0" }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "foo/a", "version": "2.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "foo/a": "2.*"
+    }
+}
+--RUN--
+update
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - The requested package foo/a could not be found in any version, there may be a typo in the package name.
+
+Potential causes:
+ - A typo in the package name
+ - The package is not available in a stable-enough version according to your minimum-stability setting
+   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
+ - It's a private package and you forgot to add a custom repository to find it
+
+Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
+--EXPECT--
+--EXPECT-EXIT-CODE--
+2

--- a/tests/Composer/Test/Fixtures/installer/repositories-priorities2.test
+++ b/tests/Composer/Test/Fixtures/installer/repositories-priorities2.test
@@ -1,0 +1,26 @@
+--TEST--
+Packages found in a higher priority repository take precedence
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "foo/a", "version": "1.0.0" }
+            ]
+        },
+        {
+            "type": "package",
+            "package": [
+                { "name": "foo/a", "version": "1.1.0" }
+            ]
+        }
+    ],
+    "require": {
+        "foo/a": "1.*"
+    }
+}
+--RUN--
+update
+--EXPECT--
+Installing foo/a (1.0.0)


### PR DESCRIPTION
@naderman Question: the way I understand things, this makes the concept of priorities in PoolBuilder/Pool/DefaultPolicy entirely irrelevant. If that's correct I can also delete all that. 

Fixes #5076