### PR TITLE
Pool builder cleanups

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -52,6 +52,7 @@ class PoolBuilder
         // TODO do we really want the request here? kind of want a root requirements thingy instead
         $loadNames = array();
         foreach ($request->getFixedPackages() as $package) {
+            $this->nameConstraints[$package->getName()] = null;
             $this->loadedNames[$package->getName()] = true;
             unset($loadNames[$package->getName()]);
             $loadNames += $this->loadPackage($request, $package);

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -16,8 +16,6 @@ use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
-use Composer\Repository\ComposerRepository;
-use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Repository\PlatformRepository;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\Constraint\MultiConstraint;
@@ -54,13 +52,17 @@ class PoolBuilder
         // TODO do we really want the request here? kind of want a root requirements thingy instead
         $loadNames = array();
         foreach ($request->getFixedPackages() as $package) {
-            // TODO can actually use very specific constraint
-            $loadNames[$package->getName()] = null;
+            $this->loadedNames[$package->getName()] = true;
+            unset($loadNames[$package->getName()]);
+            $loadNames += $this->loadPackage($request, $package);
         }
 
         foreach ($request->getJobs() as $job) {
             switch ($job['cmd']) {
                 case 'install':
+                    if (isset($this->loadedNames[$job['packageName']])) {
+                        continue 2;
+                    }
                     // TODO currently lock above is always NULL if we adjust that, this needs to merge constraints
                     // TODO does it really make sense that we can have install requests for the same package that is actively locked with non-matching constraints?
                     // also see the solver-problems.test test case
@@ -71,27 +73,16 @@ class PoolBuilder
             }
         }
 
-        // packages from the locked repository only get loaded if they are explicitly fixed
-        foreach ($repositories as $key => $repository) {
-            if ($repository === $request->getLockedRepository()) {
-                foreach ($repository->getPackages() as $lockedPackage) {
-                    foreach ($request->getFixedPackages() as $package) {
-                        if ($package === $lockedPackage) {
-                            $loadNames += $this->loadPackage($request, $package, $key);
-                        }
-                    }
-                }
-            }
-        }
-
         while (!empty($loadNames)) {
             foreach ($loadNames as $name => $void) {
                 $this->loadedNames[$name] = true;
             }
 
             $newLoadNames = array();
-            foreach ($repositories as $key => $repository) {
-                if ($repository instanceof PlatformRepository || $repository instanceof InstalledRepositoryInterface || $repository === $request->getLockedRepository()) {
+            foreach ($repositories as $repository) {
+                // these repos have their packages fixed if they need to be loaded so we
+                // never need to load anything else from them
+                if ($repository instanceof PlatformRepository || $repository === $request->getLockedRepository()) {
                     continue;
                 }
 
@@ -103,9 +94,8 @@ class PoolBuilder
                     unset($loadNames[$name]);
                 }
                 foreach ($result['packages'] as $package) {
-
                     if (call_user_func($this->isPackageAcceptableCallable, $package->getNames(), $package->getStability())) {
-                        $newLoadNames += $this->loadPackage($request, $package, $key);
+                        $newLoadNames += $this->loadPackage($request, $package);
                     }
                 }
             }
@@ -135,15 +125,6 @@ class PoolBuilder
                     foreach ($aliasedPackages as $index => $packageOrAlias) {
                         unset($this->packages[$index]);
                     }
-                }
-            }
-        }
-
-        foreach ($repositories as $key => $repository) {
-            if ($repository instanceof PlatformRepository ||
-                $repository instanceof InstalledRepositoryInterface) {
-                foreach ($repository->getPackages() as $package) {
-                    $this->loadPackage($request, $package, $key);
                 }
             }
         }

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -45,6 +45,8 @@ class Request
 
     /**
      * Mark an existing package as being installed and having to remain installed
+     *
+     * @param bool $lockable if set to false, the package will not be written to the lock file
      */
     public function fixPackage(PackageInterface $package, $lockable = true)
     {

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -48,10 +48,6 @@ class Request
      */
     public function fixPackage(PackageInterface $package, $lockable = true)
     {
-        if ($package instanceof RootAliasPackage) {
-            $package = $package->getAliasOf();
-        }
-
         $this->fixedPackages[spl_object_hash($package)] = $package;
 
         if (!$lockable) {

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -35,6 +35,7 @@ use Composer\Installer\NoopInstaller;
 use Composer\Installer\SuggestedPackagesReporter;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
+use Composer\Package\RootAliasPackage;
 use Composer\Package\BasePackage;
 use Composer\Package\CompletePackage;
 use Composer\Package\Link;
@@ -779,6 +780,9 @@ class Installer
         $request = new Request($lockedRepository);
 
         $request->fixPackage($rootPackage, false);
+        if ($rootPackage instanceof RootAliasPackage) {
+            $request->fixPackage($rootPackage->getAliasOf(), false);
+        }
 
         $fixedPackages = $platformRepo->getPackages();
         if ($this->additionalFixedRepository) {

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -50,6 +50,7 @@ use Composer\Package\PackageInterface;
 use Composer\Package\RootPackageInterface;
 use Composer\Repository\CompositeRepository;
 use Composer\Repository\InstalledArrayRepository;
+use Composer\Repository\RootPackageRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryInterface;
 use Composer\Repository\RepositoryManager;
@@ -735,7 +736,7 @@ class Installer
         $this->fixedRootPackage->setDevRequires(array());
 
         $repositorySet = new RepositorySet($rootAliases, $this->package->getReferences(), $minimumStability, $stabilityFlags, $rootRequires);
-        $repositorySet->addRepository(new InstalledArrayRepository(array($this->fixedRootPackage)));
+        $repositorySet->addRepository(new RootPackageRepository(array($this->fixedRootPackage)));
         $repositorySet->addRepository($platformRepo);
         if ($this->additionalFixedRepository) {
             $repositorySet->addRepository($this->additionalFixedRepository);

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -20,6 +20,7 @@ use Composer\Package\Version\VersionParser;
 use Composer\Repository\CompositeRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\LockArrayRepository;
+use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Test\DependencyResolver\PoolTest;
 
@@ -146,6 +147,12 @@ class RepositorySet
     public function createPool(Request $request)
     {
         $poolBuilder = new PoolBuilder(array($this, 'isPackageAcceptable'), $this->rootRequires);
+
+        foreach ($this->repositories as $repo) {
+            if ($repo instanceof InstalledRepositoryInterface) {
+                throw new \LogicException('The pool can not accept packages from an installed repository');
+            }
+        }
 
         return $this->pool = $poolBuilder->buildPool($this->repositories, $this->rootAliases, $this->rootReferences, $request);
     }

--- a/src/Composer/Repository/RootPackageRepository.php
+++ b/src/Composer/Repository/RootPackageRepository.php
@@ -13,12 +13,12 @@
 namespace Composer\Repository;
 
 /**
- * Installed array repository.
+ * Root package repository.
  *
- * This is used as an in-memory InstalledRepository mostly for testing purposes
+ * This is used for serving the RootPackage inside an in-memory InstalledRepository
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class InstalledArrayRepository extends WritableArrayRepository implements InstalledRepositoryInterface
+class RootPackageRepository extends ArrayRepository
 {
 }

--- a/tests/Composer/Test/Fixtures/installer/solver-problems.test
+++ b/tests/Composer/Test/Fixtures/installer/solver-problems.test
@@ -61,12 +61,10 @@ Your requirements could not be resolved to an installable set of packages.
   Problem 2
     - The requested package bogus/pkg could not be found in any version, there may be a typo in the package name.
   Problem 3
+    - The requested package stable-requiree-excluded/pkg could not be found in any version, there may be a typo in the package name.
+  Problem 4
     - Installation request for requirer/pkg 1.* -> satisfiable by requirer/pkg[1.0.0].
     - requirer/pkg 1.0.0 requires dependency/pkg 1.0.0 -> no matching package found.
-  Problem 4
-    - stable-requiree-excluded/pkg is locked to version 1.0.0 and an update of this package was not requested.
-    - Same name, can only install one of: stable-requiree-excluded/pkg[1.0.0, 1.0.1].
-    - Installation request for stable-requiree-excluded/pkg 1.0.1 -> satisfiable by stable-requiree-excluded/pkg[1.0.1].
 
 Potential causes:
  - A typo in the package name


### PR DESCRIPTION
Avoids loading fixed packages from remote repos entirely, which is good, but it breaks a test as the problem reporting doesn't work anymore since the package is missing.

Fixes https://github.com/composer/composer/issues/3672