### PR TITLE
Remove callback and pass stabilities all the way instead

### DIFF
--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -38,24 +38,26 @@ class Pool implements \Countable
     protected $packageByExactName = array();
     protected $versionParser;
     protected $providerCache = array();
+    protected $unacceptableFixedPackages;
 
-    public function __construct()
+    public function __construct(array $packages = array(), array $unacceptableFixedPackages = array())
     {
         $this->versionParser = new VersionParser;
+        $this->setPackages($packages);
+        $this->unacceptableFixedPackages = $unacceptableFixedPackages;
     }
 
-    public function setPackages(array $packages)
+    private function setPackages(array $packages)
     {
         $id = 1;
 
-        foreach ($packages as $i => $package) {
+        foreach ($packages as $package) {
             $this->packages[] = $package;
 
             $package->id = $id++;
-            $names = $package->getNames();
             $this->packageByExactName[$package->getName()][$package->id] = $package;
 
-            foreach ($names as $provided) {
+            foreach ($package->getNames() as $provided) {
                 $this->packageByName[$provided][] = $package;
             }
         }
@@ -226,5 +228,10 @@ class Pool implements \Countable
         }
 
         return self::MATCH_NONE;
+    }
+
+    public function isUnacceptableFixedPackage(PackageInterface $package)
+    {
+        return in_array($package, $this->unacceptableFixedPackages, true);
     }
 }

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -35,10 +35,9 @@ class PoolBuilder
 
     private $aliasMap = array();
     private $nameConstraints = array();
-
     private $loadedNames = array();
-
     private $packages = array();
+    private $unacceptableFixedPackages = array();
 
     public function __construct(array $acceptableStabilities, array $stabilityFlags, array $rootAliases, array $rootReferences, array $rootRequires = array())
     {
@@ -65,6 +64,8 @@ class PoolBuilder
                 || StabilityFilter::isPackageAcceptable($this->acceptableStabilities, $this->stabilityFlags, $package->getNames(), $package->getStability())
             ) {
                 $loadNames += $this->loadPackage($request, $package);
+            } else {
+                $this->unacceptableFixedPackages[] = $package;
             }
         }
 
@@ -137,11 +138,13 @@ class PoolBuilder
             }
         }
 
-        $pool->setPackages($this->packages);
+        $pool = new Pool($this->packages, $this->unacceptableFixedPackages);
 
-        unset($this->aliasMap);
-        unset($this->loadedNames);
-        unset($this->nameConstraints);
+        $this->aliasMap = array();
+        $this->nameConstraints = array();
+        $this->loadedNames = array();
+        $this->packages = array();
+        $this->unacceptableFixedPackages = array();
 
         return $pool;
     }

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -25,10 +25,11 @@ use Composer\Semver\Constraint\MultiConstraint;
  */
 class PoolBuilder
 {
-    private $isPackageAcceptableCallable;
-    private $rootRequires;
+    private $acceptableStabilities;
+    private $stabilityFlags;
     private $rootAliases;
     private $rootReferences;
+    private $rootRequires;
 
     private $aliasMap = array();
     private $nameConstraints = array();
@@ -37,17 +38,18 @@ class PoolBuilder
 
     private $packages = array();
 
-    public function __construct($isPackageAcceptableCallable, array $rootRequires = array())
+    public function __construct(array $acceptableStabilities, array $stabilityFlags, array $rootAliases, array $rootReferences, array $rootRequires = array())
     {
-        $this->isPackageAcceptableCallable = $isPackageAcceptableCallable;
+        $this->acceptableStabilities = $acceptableStabilities;
+        $this->stabilityFlags = $stabilityFlags;
+        $this->rootAliases = $rootAliases;
+        $this->rootReferences = $rootReferences;
         $this->rootRequires = $rootRequires;
     }
 
-    public function buildPool(array $repositories, array $rootAliases, array $rootReferences, Request $request)
+    public function buildPool(array $repositories, Request $request)
     {
         $pool = new Pool();
-        $this->rootAliases = $rootAliases;
-        $this->rootReferences = $rootReferences;
 
         // TODO do we really want the request here? kind of want a root requirements thingy instead
         $loadNames = array();
@@ -87,17 +89,14 @@ class PoolBuilder
                     continue;
                 }
 
-                // TODO should we really pass the callable into here?
-                $result = $repository->loadPackages($loadNames, $this->isPackageAcceptableCallable);
+                $result = $repository->loadPackages($loadNames, $this->acceptableStabilities, $this->stabilityFlags);
 
                 foreach ($result['namesFound'] as $name) {
                     // avoid loading the same package again from other repositories once it has been found
                     unset($loadNames[$name]);
                 }
                 foreach ($result['packages'] as $package) {
-                    if (call_user_func($this->isPackageAcceptableCallable, $package->getNames(), $package->getStability())) {
-                        $newLoadNames += $this->loadPackage($request, $package);
-                    }
+                    $newLoadNames += $this->loadPackage($request, $package);
                 }
             }
 

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -16,7 +16,9 @@ use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
+use Composer\Package\Version\StabilityFilter;
 use Composer\Repository\PlatformRepository;
+use Composer\Repository\RootPackageRepository;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\Constraint\MultiConstraint;
 
@@ -57,7 +59,12 @@ class PoolBuilder
             $this->nameConstraints[$package->getName()] = null;
             $this->loadedNames[$package->getName()] = true;
             unset($loadNames[$package->getName()]);
-            $loadNames += $this->loadPackage($request, $package);
+            if (
+                $package->getRepository() instanceof RootPackageRepository
+                || StabilityFilter::isPackageAcceptable($this->acceptableStabilities, $this->stabilityFlags, $package->getNames(), $package->getStability())
+            ) {
+                $loadNames += $this->loadPackage($request, $package);
+            }
         }
 
         foreach ($request->getJobs() as $job) {

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -61,6 +61,7 @@ class PoolBuilder
             unset($loadNames[$package->getName()]);
             if (
                 $package->getRepository() instanceof RootPackageRepository
+                || $package->getRepository() instanceof PlatformRepository
                 || StabilityFilter::isPackageAcceptable($this->acceptableStabilities, $this->stabilityFlags, $package->getNames(), $package->getStability())
             ) {
                 $loadNames += $this->loadPackage($request, $package);

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -224,10 +224,6 @@ class Problem
                 }
 
                 return 'Installation request for '.$packageName.$this->constraintToText($constraint).' -> satisfiable by '.$this->getPackageList($packages).'.';
-            case 'update':
-                return 'Update request for '.$packageName.$this->constraintToText($constraint).'.';
-            case 'remove':
-                return 'Removal request for '.$packageName.$this->constraintToText($constraint).'';
         }
 
         if (isset($constraint)) {

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -38,11 +38,6 @@ class Request
         $this->addJob($packageName, 'install', $constraint);
     }
 
-    public function remove($packageName, ConstraintInterface $constraint = null)
-    {
-        $this->addJob($packageName, 'remove', $constraint);
-    }
-
     /**
      * Mark an existing package as being installed and having to remain installed
      *

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -290,8 +290,9 @@ class RuleSetGenerator
         $unlockableMap = $request->getUnlockableMap();
 
         foreach ($request->getFixedPackages() as $package) {
+            // fixed package was not added to the pool which must mean it did not pass the stability requirements
             if ($package->id == -1) {
-                throw new \RuntimeException("Fixed package ".$package->getName()." ".$package->getVersion().($package instanceof AliasPackage ? " (alias)" : "")." was not added to solver pool.");
+                continue;
             }
 
             $this->addRulesForPackage($package, $ignorePlatformReqs);

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -290,9 +290,14 @@ class RuleSetGenerator
         $unlockableMap = $request->getUnlockableMap();
 
         foreach ($request->getFixedPackages() as $package) {
-            // fixed package was not added to the pool which must mean it did not pass the stability requirements
             if ($package->id == -1) {
-                continue;
+                // fixed package was not added to the pool as it did not pass the stability requirements, this is fine
+                if ($this->pool->isUnacceptableFixedPackage($package)) {
+                    continue;
+                }
+
+                // otherwise, looks like a bug
+                throw new \LogicException("Fixed package ".$package->getName()." ".$package->getVersion().($package instanceof AliasPackage ? " (alias)" : "")." was not added to solver pool.");
             }
 
             $this->addRulesForPackage($package, $ignorePlatformReqs);

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -325,15 +325,6 @@ class RuleSetGenerator
                         $this->addRule(RuleSet::TYPE_JOB, $rule);
                     }
                     break;
-                case 'remove':
-                    // remove all packages with this name including uninstalled
-                    // ones to make sure none of them are picked as replacements
-                    $packages = $this->pool->whatProvides($job['packageName'], $job['constraint']);
-                    foreach ($packages as $package) {
-                        $rule = $this->createRemoveRule($package, Rule::RULE_JOB_REMOVE, $job);
-                        $this->addRule(RuleSet::TYPE_JOB, $rule);
-                    }
-                    break;
             }
         }
     }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -380,12 +380,10 @@ class Installer
         }
 
         // if the updateWhitelist is enabled, packages not in it are also fixed
-        // to the version specified in the lock, except if their stability is not
-        // acceptable anymore, to make sure that they get updated/downgraded to
-        // a working version
+        // to the version specified in the lock
         if ($this->updateWhitelist && $lockedRepository) {
             foreach ($lockedRepository->getPackages() as $lockedPackage) {
-                if (!$this->isUpdateable($lockedPackage) && $repositorySet->isPackageAcceptable($lockedPackage->getNames(), $lockedPackage->getStability())) {
+                if (!$this->isUpdateable($lockedPackage)) {
                     // TODO add reason for fix?
                     $request->fixPackage($lockedPackage);
                 }

--- a/src/Composer/Package/Version/StabilityFilter.php
+++ b/src/Composer/Package/Version/StabilityFilter.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Package\Version;
+
+use Composer\Package\BasePackage;
+
+/**
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class StabilityFilter
+{
+    /**
+     * Checks if any of the provided package names in the given stability match the configured acceptable stability and flags
+     *
+     * @return bool true if any package name is acceptable
+     */
+    public static function isPackageAcceptable(array $acceptableStabilities, array $stabilityFlags, $names, $stability)
+    {
+        foreach ($names as $name) {
+            // allow if package matches the package-specific stability flag
+            if (isset($stabilityFlags[$name])) {
+                if (BasePackage::$stabilities[$stability] <= $stabilityFlags[$name]) {
+                    return true;
+                }
+            } elseif (isset($acceptableStabilities[$stability])) {
+                // allow if package matches the global stability requirement and has no exception
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -16,6 +16,7 @@ use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;
 use Composer\Package\CompletePackageInterface;
 use Composer\Package\Version\VersionParser;
+use Composer\Package\Version\StabilityFilter;
 use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Semver\Constraint\Constraint;
 
@@ -44,7 +45,7 @@ class ArrayRepository extends BaseRepository
     /**
      * {@inheritDoc}
      */
-    public function loadPackages(array $packageMap, $isPackageAcceptableCallable)
+    public function loadPackages(array $packageMap, array $acceptableStabilities, array $stabilityFlags)
     {
         $packages = $this->getPackages();
 
@@ -54,7 +55,7 @@ class ArrayRepository extends BaseRepository
             if (array_key_exists($package->getName(), $packageMap)) {
                 if (
                     (!$packageMap[$package->getName()] || $packageMap[$package->getName()]->matches(new Constraint('==', $package->getVersion())))
-                    && call_user_func($isPackageAcceptableCallable, $package->getNames(), $package->getStability())
+                    && StabilityFilter::isPackageAcceptable($acceptableStabilities, $stabilityFlags, $package->getNames(), $package->getStability())
                 ) {
                     $result[spl_object_hash($package)] = $package;
                     if ($package instanceof AliasPackage && !isset($result[spl_object_hash($package->getAliasOf())])) {

--- a/src/Composer/Repository/CompositeRepository.php
+++ b/src/Composer/Repository/CompositeRepository.php
@@ -97,13 +97,13 @@ class CompositeRepository extends BaseRepository
     /**
      * {@inheritDoc}
      */
-    public function loadPackages(array $packageMap, $isPackageAcceptableCallable)
+    public function loadPackages(array $packageMap, array $acceptableStabilities, array $stabilityFlags)
     {
         $packages = array();
         $namesFound = array();
         foreach ($this->repositories as $repository) {
             /* @var $repository RepositoryInterface */
-            $result = $repository->findPackages($name, $constraint);
+            $result = $repository->loadPackages($packageMap, $acceptableStabilities, $stabilityFlags);
             $packages[] = $result['packages'];
             $namesFound[] = $result['namesFound'];
         }

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -56,7 +56,6 @@ interface RepositoryInterface extends \Countable
      */
     public function findPackages($name, $constraint = null);
 
-    // TODO this should really not be in this generic interface anymore
     /**
      * Returns list of registered packages.
      *
@@ -68,10 +67,11 @@ interface RepositoryInterface extends \Countable
      * Returns list of registered packages with the supplied name
      *
      * @param ConstraintInterface[] $packageNameMap package names pointing to constraints
-     * @param $isPackageAcceptableCallable
+     * @param array $acceptableStabilities
+     * @param array $stabilityFlags
      * @return array [namesFound => string[], packages => PackageInterface[]]
      */
-    public function loadPackages(array $packageNameMap, $isPackageAcceptableCallable);
+    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags);
 
     /**
      * Searches the repository for packages containing the query

--- a/tests/Composer/Test/DependencyResolver/PoolTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolTest.php
@@ -21,10 +21,9 @@ class PoolTest extends TestCase
 {
     public function testPool()
     {
-        $pool = $this->createPool();
         $package = $this->getPackage('foo', '1');
 
-        $pool->setPackages(array($package));
+        $pool = $this->createPool(array($package));
 
         $this->assertEquals(array($package), $pool->whatProvides('foo'));
         $this->assertEquals(array($package), $pool->whatProvides('foo'));
@@ -32,12 +31,11 @@ class PoolTest extends TestCase
 
     public function testWhatProvidesPackageWithConstraint()
     {
-        $pool = $this->createPool();
 
         $firstPackage = $this->getPackage('foo', '1');
         $secondPackage = $this->getPackage('foo', '2');
 
-        $pool->setPackages(array(
+        $pool = $this->createPool(array(
             $firstPackage,
             $secondPackage,
         ));
@@ -48,10 +46,9 @@ class PoolTest extends TestCase
 
     public function testPackageById()
     {
-        $pool = $this->createPool();
         $package = $this->getPackage('foo', '1');
 
-        $pool->setPackages(array($package));
+        $pool = $this->createPool(array($package));
 
         $this->assertSame($package, $pool->packageById(1));
     }
@@ -63,8 +60,8 @@ class PoolTest extends TestCase
         $this->assertEquals(array(), $pool->whatProvides('foo'));
     }
 
-    protected function createPool()
+    protected function createPool(array $packages = array())
     {
-        return new Pool();
+        return new Pool($packages);
     }
 }

--- a/tests/Composer/Test/DependencyResolver/RequestTest.php
+++ b/tests/Composer/Test/DependencyResolver/RequestTest.php
@@ -18,7 +18,7 @@ use Composer\Test\TestCase;
 
 class RequestTest extends TestCase
 {
-    public function testRequestInstallAndRemove()
+    public function testRequestInstall()
     {
         $repo = new ArrayRepository;
         $foo = $this->getPackage('foo', '1');
@@ -31,12 +31,10 @@ class RequestTest extends TestCase
 
         $request = new Request();
         $request->install('foo');
-        $request->remove('foobar');
 
         $this->assertEquals(
             array(
                 array('cmd' => 'install', 'packageName' => 'foo', 'constraint' => null),
-                array('cmd' => 'remove', 'packageName' => 'foobar', 'constraint' => null),
             ),
             $request->getJobs()
         );

--- a/tests/Composer/Test/DependencyResolver/RuleSetTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetTest.php
@@ -139,8 +139,7 @@ class RuleSetTest extends TestCase
 
     public function testPrettyString()
     {
-        $pool = new Pool();
-        $pool->setPackages(array(
+        $pool = new Pool(array(
             $p = $this->getPackage('foo', '2.1'),
         ));
 

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -93,8 +93,7 @@ class RuleTest extends TestCase
 
     public function testPrettyString()
     {
-        $pool = new Pool();
-        $pool->setPackages(array(
+        $pool = new Pool(array(
             $p1 = $this->getPackage('foo', '2.1'),
             $p2 = $this->getPackage('baz', '1.1'),
         ));

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -196,28 +196,6 @@ class SolverTest extends TestCase
         $this->checkSolverResult(array());
     }
 
-    public function testSolverRemoveSingle()
-    {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->reposComplete();
-
-        $this->request->remove('A');
-
-        $this->checkSolverResult(array(
-            array('job' => 'remove', 'package' => $packageA),
-        ));
-    }
-
-    public function testSolverRemoveUninstalled()
-    {
-        $this->repo->addPackage($this->getPackage('A', '1.0'));
-        $this->reposComplete();
-
-        $this->request->remove('A');
-
-        $this->checkSolverResult(array());
-    }
-
     public function testSolverUpdateDoesOnlyUpdate()
     {
         $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
@@ -367,7 +345,6 @@ class SolverTest extends TestCase
 
         $this->request->install('A');
         $this->request->install('C');
-        $this->request->remove('D');
 
         $this->checkSolverResult(array(
             array('job' => 'remove',  'package' => $packageD),

--- a/tests/Composer/Test/Fixtures/installer/partial-update-downgrades-non-whitelisted-unstable.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-downgrades-non-whitelisted-unstable.test
@@ -48,25 +48,23 @@ Partial update from lock file should apply lock file and downgrade unstable pack
 ]
 --RUN--
 update c/uptodate
---EXPECT-LOCK--
-{
-    "packages": [
-        { "name": "a/old", "version": "1.0.0", "type": "library" },
-        { "name": "b/unstable", "version": "1.0.0", "type": "library" },
-        { "name": "c/uptodate", "version": "1.0.0", "type": "library" },
-        { "name": "d/removed", "version": "1.0.0", "type": "library" }
-    ],
-    "packages-dev": [],
-    "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": [],
-    "prefer-stable": false,
-    "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": []
-}
 --EXPECT--
-Updating a/old (0.9.0 => 1.0.0)
-Updating b/unstable (1.1.0-alpha => 1.0.0)
-Updating c/uptodate (2.0.0 => 1.0.0)
-Installing d/removed (1.0.0)
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - The requested package b/unstable could not be found in any version, there may be a typo in the package name.
+
+Potential causes:
+ - A typo in the package name
+ - The package is not available in a stable-enough version according to your minimum-stability setting
+   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
+ - It's a private package and you forgot to add a custom repository to find it
+
+Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.


### PR DESCRIPTION
This allows optimizing the loading of ~dev files, and cleans up a few things