### PR TITLE
Normalize minimum-stability `rc` to `RC` in `InitCommand`

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -16,6 +16,7 @@ use Composer\DependencyResolver\Pool;
 use Composer\Factory;
 use Composer\Json\JsonFile;
 use Composer\Package\BasePackage;
+use Composer\Package\Package;
 use Composer\Package\Version\VersionParser;
 use Composer\Package\Version\VersionSelector;
 use Composer\Repository\CompositeRepository;
@@ -702,13 +703,13 @@ EOT
     private function getMinimumStability(InputInterface $input)
     {
         if ($input->hasOption('stability')) {
-            return $input->getOption('stability') ?: 'stable';
+            return VersionParser::normalizeStability($input->getOption('stability') ?: 'stable');
         }
 
         $file = Factory::getComposerFile();
         if (is_file($file) && is_readable($file) && is_array($composer = json_decode(file_get_contents($file), true))) {
             if (!empty($composer['minimum-stability'])) {
-                return $composer['minimum-stability'];
+                return VersionParser::normalizeStability($composer['minimum-stability']);
             }
         }
 


### PR DESCRIPTION
A `minimum-stability` of `rc` is valid according to `composer-schema.json` and works fine with install and update and generally in version comparisons, because it's normalized to `RC`.

This change makes it work in `InitCommand` and `RequireCommand` too.

I know that only RC is documented, but considering that install and update work, it should not hurt to make it work in require too.

Example composer.json:
```json
{
    "name": "pweyck/rc-test",
    "description": "This works with composer install, but not composer require",
    "type": "library",
    "require": {
        "shopware/core": "v6.1.0"
    },
    "license": "MIT",
    "authors": [
        {
            "name": "Patrick Weyck",
            "email": "p.weyck@shopware.com"
        }
    ],
    "minimum-stability": "rc"
}
```
Install works but require produces an error:
```
Reading ./composer.json
Loading config file ./composer.json
Checked CA file /etc/ca-certificates/extracted/tls-ca-bundle.pem: valid
Executing command (/home/pw/projects/composer/tmp): git branch --no-color --no-abbrev -v
Failed to initialize global composer: Composer could not find the config file: /home/pw/.composer/composer.json
To initialize a project, please create a composer.json file as described in the https://getcomposer.org/ "Getting Started" section
Reading /home/pw/projects/composer/tmp/vendor/composer/installed.json
Running 1.10-dev+source (@release_date@) with PHP 7.4.1 on Linux / 4.19.91-1-MANJARO


  [ErrorException]
  Undefined index: rc


Exception trace:
 () at /home/pw/projects/composer/src/Composer/DependencyResolver/Pool.php:61
 Composer\Util\ErrorHandler::handle() at /home/pw/projects/composer/src/Composer/DependencyResolver/Pool.php:61
 Composer\DependencyResolver\Pool->__construct() at /home/pw/projects/composer/src/Composer/Command/InitCommand.php:695
 Composer\Command\InitCommand->getPool() at /home/pw/projects/composer/src/Composer/Command/InitCommand.php:736
 Composer\Command\InitCommand->findBestVersionAndNameForPackage() at /home/pw/projects/composer/src/Composer/Command/InitCommand.php:415
 Composer\Command\InitCommand->determineRequirements() at /home/pw/projects/composer/src/Composer/Command/RequireCommand.php:163
 Composer\Command\RequireCommand->execute() at /home/pw/projects/composer/vendor/symfony/console/Command/Command.php:245
 Symfony\Component\Console\Command\Command->run() at /home/pw/projects/composer/vendor/symfony/console/Application.php:835
 Symfony\Component\Console\Application->doRunCommand() at /home/pw/projects/composer/vendor/symfony/console/Application.php:185
 Symfony\Component\Console\Application->doRun() at /home/pw/projects/composer/src/Composer/Console/Application.php:275
 Composer\Console\Application->doRun() at /home/pw/projects/composer/vendor/symfony/console/Application.php:117
 Symfony\Component\Console\Application->run() at /home/pw/projects/composer/src/Composer/Console/Application.php:113
 Composer\Console\Application->run() at /home/pw/projects/composer/bin/composer:62
```
