### PR TITLE
Request jobs replaced by root require / fixed package

### DIFF
--- a/src/Composer/DependencyResolver/GenericRule.php
+++ b/src/Composer/DependencyResolver/GenericRule.php
@@ -26,11 +26,10 @@ class GenericRule extends Rule
      * @param array                          $literals
      * @param int|null                       $reason     A RULE_* constant describing the reason for generating this rule
      * @param Link|PackageInterface|int|null $reasonData
-     * @param array                          $job        The job this rule was created from
      */
-    public function __construct(array $literals, $reason, $reasonData, $job = null)
+    public function __construct(array $literals, $reason, $reasonData)
     {
-        parent::__construct($reason, $reasonData, $job);
+        parent::__construct($reason, $reasonData);
 
         // sort all packages ascending by id
         sort($literals);

--- a/src/Composer/DependencyResolver/MultiConflictRule.php
+++ b/src/Composer/DependencyResolver/MultiConflictRule.php
@@ -28,11 +28,10 @@ class MultiConflictRule extends Rule
      * @param array                 $literals
      * @param int                   $reason     A RULE_* constant describing the reason for generating this rule
      * @param Link|PackageInterface $reasonData
-     * @param array                 $job        The job this rule was created from
      */
-    public function __construct(array $literals, $reason, $reasonData, $job = null)
+    public function __construct(array $literals, $reason, $reasonData)
     {
-        parent::__construct($reason, $reasonData, $job);
+        parent::__construct($reason, $reasonData);
 
         if (count($literals) < 3) {
             throw new \RuntimeException("multi conflict rule requires at least 3 literals");

--- a/src/Composer/DependencyResolver/Operation/InstallOperation.php
+++ b/src/Composer/DependencyResolver/Operation/InstallOperation.php
@@ -47,11 +47,11 @@ class InstallOperation extends SolverOperation
     }
 
     /**
-     * Returns job type.
+     * Returns operation type.
      *
      * @return string
      */
-    public function getJobType()
+    public function getOperationType()
     {
         return 'install';
     }

--- a/src/Composer/DependencyResolver/Operation/MarkAliasInstalledOperation.php
+++ b/src/Composer/DependencyResolver/Operation/MarkAliasInstalledOperation.php
@@ -48,11 +48,11 @@ class MarkAliasInstalledOperation extends SolverOperation
     }
 
     /**
-     * Returns job type.
+     * Returns operation type.
      *
      * @return string
      */
-    public function getJobType()
+    public function getOperationType()
     {
         return 'markAliasInstalled';
     }

--- a/src/Composer/DependencyResolver/Operation/MarkAliasUninstalledOperation.php
+++ b/src/Composer/DependencyResolver/Operation/MarkAliasUninstalledOperation.php
@@ -48,11 +48,11 @@ class MarkAliasUninstalledOperation extends SolverOperation
     }
 
     /**
-     * Returns job type.
+     * Returns operation type.
      *
      * @return string
      */
-    public function getJobType()
+    public function getOperationType()
     {
         return 'markAliasUninstalled';
     }

--- a/src/Composer/DependencyResolver/Operation/OperationInterface.php
+++ b/src/Composer/DependencyResolver/Operation/OperationInterface.php
@@ -20,11 +20,11 @@ namespace Composer\DependencyResolver\Operation;
 interface OperationInterface
 {
     /**
-     * Returns job type.
+     * Returns operation type.
      *
      * @return string
      */
-    public function getJobType();
+    public function getOperationType();
 
     /**
      * Returns operation reason.

--- a/src/Composer/DependencyResolver/Operation/UninstallOperation.php
+++ b/src/Composer/DependencyResolver/Operation/UninstallOperation.php
@@ -47,11 +47,11 @@ class UninstallOperation extends SolverOperation
     }
 
     /**
-     * Returns job type.
+     * Returns operation type.
      *
      * @return string
      */
-    public function getJobType()
+    public function getOperationType()
     {
         return 'uninstall';
     }

--- a/src/Composer/DependencyResolver/Operation/UpdateOperation.php
+++ b/src/Composer/DependencyResolver/Operation/UpdateOperation.php
@@ -60,11 +60,11 @@ class UpdateOperation extends SolverOperation
     }
 
     /**
-     * Returns job type.
+     * Returns operation type.
      *
      * @return string
      */
-    public function getJobType()
+    public function getOperationType()
     {
         return 'update';
     }

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -69,20 +69,16 @@ class PoolBuilder
             }
         }
 
-        foreach ($request->getJobs() as $job) {
-            switch ($job['cmd']) {
-                case 'install':
-                    if (isset($this->loadedNames[$job['packageName']])) {
-                        continue 2;
-                    }
-                    // TODO currently lock above is always NULL if we adjust that, this needs to merge constraints
-                    // TODO does it really make sense that we can have install requests for the same package that is actively locked with non-matching constraints?
-                    // also see the solver-problems.test test case
-                    $constraint = array_key_exists($job['packageName'], $loadNames) ? null : $job['constraint'];
-                    $loadNames[$job['packageName']] = $constraint;
-                    $this->nameConstraints[$job['packageName']] = $constraint ? new MultiConstraint(array($constraint), false) : null;
-                    break;
+        foreach ($request->getRequires() as $packageName => $constraint) {
+            if (isset($this->loadedNames[$packageName])) {
+                continue;
             }
+            // TODO currently lock above is always NULL if we adjust that, this needs to merge constraints
+            // TODO does it really make sense that we can have install requests for the same package that is actively locked with non-matching constraints?
+            // also see the solver-problems.test test case
+            $constraint = array_key_exists($packageName, $loadNames) ? null : $constraint;
+            $loadNames[$packageName] = $constraint;
+            $this->nameConstraints[$packageName] = $constraint ? new MultiConstraint(array($constraint), false) : null;
         }
 
         while (!empty($loadNames)) {

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -82,7 +82,6 @@ class Problem
             }
 
             $request = $rule->getReasonData();
-
             $packageName = $request['packageName'];
             $constraint = $request['constraint'];
 
@@ -92,7 +91,7 @@ class Problem
                 $packages = array();
             }
 
-            if ($request && empty($packages)) {
+            if (empty($packages)) {
                 // handle php/hhvm
                 if ($packageName === 'php' || $packageName === 'php-64bit' || $packageName === 'hhvm') {
                     $version = phpversion();

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -33,7 +33,7 @@ class Request
         $this->lockedRepository = $lockedRepository;
     }
 
-    public function require($packageName, ConstraintInterface $constraint = null)
+    public function requireName($packageName, ConstraintInterface $constraint = null)
     {
         $packageName = strtolower($packageName);
         $this->requires[$packageName] = $constraint;

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -24,7 +24,7 @@ use Composer\Semver\Constraint\ConstraintInterface;
 class Request
 {
     protected $lockedRepository;
-    protected $jobs = array();
+    protected $requires = array();
     protected $fixedPackages = array();
     protected $unlockables = array();
 
@@ -33,9 +33,10 @@ class Request
         $this->lockedRepository = $lockedRepository;
     }
 
-    public function install($packageName, ConstraintInterface $constraint = null)
+    public function require($packageName, ConstraintInterface $constraint = null)
     {
-        $this->addJob($packageName, 'install', $constraint);
+        $packageName = strtolower($packageName);
+        $this->requires[$packageName] = $constraint;
     }
 
     /**
@@ -52,20 +53,9 @@ class Request
         }
     }
 
-    protected function addJob($packageName, $cmd, ConstraintInterface $constraint = null)
+    public function getRequires()
     {
-        $packageName = strtolower($packageName);
-
-        $this->jobs[] = array(
-            'cmd' => $cmd,
-            'packageName' => $packageName,
-            'constraint' => $constraint,
-        );
-    }
-
-    public function getJobs()
-    {
-        return $this->jobs;
+        return $this->requires;
     }
 
     public function getFixedPackages()

--- a/src/Composer/DependencyResolver/Rule2Literals.php
+++ b/src/Composer/DependencyResolver/Rule2Literals.php
@@ -28,11 +28,10 @@ class Rule2Literals extends Rule
      * @param int                   $literal2
      * @param int                   $reason     A RULE_* constant describing the reason for generating this rule
      * @param Link|PackageInterface $reasonData
-     * @param array                 $job        The job this rule was created from
      */
-    public function __construct($literal1, $literal2, $reason, $reasonData, $job = null)
+    public function __construct($literal1, $literal2, $reason, $reasonData)
     {
-        parent::__construct($reason, $reasonData, $job);
+        parent::__construct($reason, $reasonData);
 
         if ($literal1 < $literal2) {
             $this->literal1 = $literal1;

--- a/src/Composer/DependencyResolver/RuleSet.php
+++ b/src/Composer/DependencyResolver/RuleSet.php
@@ -19,7 +19,7 @@ class RuleSet implements \IteratorAggregate, \Countable
 {
     // highest priority => lowest number
     const TYPE_PACKAGE = 0;
-    const TYPE_JOB = 1;
+    const TYPE_REQUEST = 1;
     const TYPE_LEARNED = 4;
 
     /**
@@ -32,7 +32,7 @@ class RuleSet implements \IteratorAggregate, \Countable
     protected static $types = array(
         255 => 'UNKNOWN',
         self::TYPE_PACKAGE => 'PACKAGE',
-        self::TYPE_JOB => 'JOB',
+        self::TYPE_REQUEST => 'REQUEST',
         self::TYPE_LEARNED => 'LEARNED',
     );
 

--- a/src/Composer/DependencyResolver/SolverProblemsException.php
+++ b/src/Composer/DependencyResolver/SolverProblemsException.php
@@ -78,8 +78,8 @@ class SolverProblemsException extends \RuntimeException
     private function hasExtensionProblems(array $reasonSets)
     {
         foreach ($reasonSets as $reasonSet) {
-            foreach ($reasonSet as $reason) {
-                if (isset($reason["rule"]) && 0 === strpos($reason["rule"]->getRequiredPackage(), 'ext-')) {
+            foreach ($reasonSet as $rule) {
+                if (0 === strpos($rule->getRequiredPackage(), 'ext-')) {
                     return true;
                 }
             }

--- a/src/Composer/DependencyResolver/Transaction.php
+++ b/src/Composer/DependencyResolver/Transaction.php
@@ -170,7 +170,7 @@ class Transaction
 
         // TODO skip updates which don't update? is this needed? we shouldn't schedule this update in the first place?
         /*
-        if ('update' === $jobType) {
+        if ('update' === $opType) {
             $targetPackage = $operation->getTargetPackage();
             if ($targetPackage->isDev()) {
                 $initialPackage = $operation->getInitialPackage();

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -371,11 +371,11 @@ class Installer
         // if we're updating mirrors we want to keep exactly the same versions installed which are in the lock file, but we want current remote metadata
         if ($this->updateMirrors) {
             foreach ($lockedRepository->getPackages() as $lockedPackage) {
-                $request->require($lockedPackage->getName(), new Constraint('==', $lockedPackage->getVersion()));
+                $request->requireName($lockedPackage->getName(), new Constraint('==', $lockedPackage->getVersion()));
             }
         } else {
             foreach ($links as $link) {
-                $request->require($link->getTarget(), $link->getConstraint());
+                $request->requireName($link->getTarget(), $link->getConstraint());
             }
         }
 
@@ -523,7 +523,7 @@ class Installer
 
         $links = $this->package->getRequires();
         foreach ($links as $link) {
-            $request->require($link->getTarget(), $link->getConstraint());
+            $request->requireName($link->getTarget(), $link->getConstraint());
         }
 
         $pool = $repositorySet->createPool($request);
@@ -581,7 +581,7 @@ class Installer
             }
 
             foreach ($this->locker->getPlatformRequirements($this->devMode) as $link) {
-                $request->require($link->getTarget(), $link->getConstraint());
+                $request->requireName($link->getTarget(), $link->getConstraint());
             }
 
             //$this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $repositorySet, $installedRepo, $request);

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -371,11 +371,11 @@ class Installer
         // if we're updating mirrors we want to keep exactly the same versions installed which are in the lock file, but we want current remote metadata
         if ($this->updateMirrors) {
             foreach ($lockedRepository->getPackages() as $lockedPackage) {
-                $request->install($lockedPackage->getName(), new Constraint('==', $lockedPackage->getVersion()));
+                $request->require($lockedPackage->getName(), new Constraint('==', $lockedPackage->getVersion()));
             }
         } else {
             foreach ($links as $link) {
-                $request->install($link->getTarget(), $link->getConstraint());
+                $request->require($link->getTarget(), $link->getConstraint());
             }
         }
 
@@ -464,13 +464,12 @@ class Installer
 
         foreach ($lockTransaction->getOperations() as $operation) {
             // collect suggestions
-            $jobType = $operation->getJobType();
             if ($operation instanceof InstallOperation) {
                 $this->suggestedPackagesReporter->addSuggestionsFromPackage($operation->getPackage());
             }
 
             // output op, but alias op only in debug verbosity
-            if (false === strpos($operation->getJobType(), 'Alias') || $this->io->isDebug()) {
+            if (false === strpos($operation->getOperationType(), 'Alias') || $this->io->isDebug()) {
                 $this->io->writeError('  - ' . $operation->show(true));
             }
         }
@@ -524,7 +523,7 @@ class Installer
 
         $links = $this->package->getRequires();
         foreach ($links as $link) {
-            $request->install($link->getTarget(), $link->getConstraint());
+            $request->require($link->getTarget(), $link->getConstraint());
         }
 
         $pool = $repositorySet->createPool($request);
@@ -582,7 +581,7 @@ class Installer
             }
 
             foreach ($this->locker->getPlatformRequirements($this->devMode) as $link) {
-                $request->install($link->getTarget(), $link->getConstraint());
+                $request->require($link->getTarget(), $link->getConstraint());
             }
 
             //$this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $repositorySet, $installedRepo, $request);
@@ -656,7 +655,7 @@ class Installer
         } else {
             foreach ($localRepoTransaction->getOperations() as $operation) {
                 // output op, but alias op only in debug verbosity
-                if (false === strpos($operation->getJobType(), 'Alias') || $this->io->isDebug()) {
+                if (false === strpos($operation->getOperationType(), 'Alias') || $this->io->isDebug()) {
                     $this->io->writeError('  - ' . $operation->show(false));
                 }
             }

--- a/src/Composer/Package/Link.php
+++ b/src/Composer/Package/Link.php
@@ -123,6 +123,6 @@ class Link
      */
     public function getPrettyString(PackageInterface $sourcePackage)
     {
-        return $sourcePackage->getPrettyString().' '.$this->description.' '.$this->target.' '.$this->constraint->getPrettyString().'';
+        return $sourcePackage->getPrettyString().' '.$this->description.' '.$this->target.($this->constraint ? ' '.$this->constraint->getPrettyString() : '');
     }
 }

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -157,7 +157,7 @@ class RepositorySet
         $request = new Request($lockedRepo);
 
         foreach ($packageNames as $packageName) {
-            $request->require($packageName);
+            $request->requireName($packageName);
         }
 
         return $this->createPool($request);

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -157,7 +157,7 @@ class RepositorySet
         $request = new Request($lockedRepo);
 
         foreach ($packageNames as $packageName) {
-            $request->install($packageName);
+            $request->require($packageName);
         }
 
         return $this->createPool($request);

--- a/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
@@ -82,7 +82,7 @@ class PoolBuilderTest extends TestCase
 
         $request = new Request();
         foreach ($requestData as $package => $constraint) {
-            $request->install($package, $parser->parseConstraints($constraint));
+            $request->require($package, $parser->parseConstraints($constraint));
         }
 
         foreach ($fixed as $fixedPackage) {

--- a/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
@@ -82,7 +82,7 @@ class PoolBuilderTest extends TestCase
 
         $request = new Request();
         foreach ($requestData as $package => $constraint) {
-            $request->require($package, $parser->parseConstraints($constraint));
+            $request->requireName($package, $parser->parseConstraints($constraint));
         }
 
         foreach ($fixed as $fixedPackage) {

--- a/tests/Composer/Test/DependencyResolver/RequestTest.php
+++ b/tests/Composer/Test/DependencyResolver/RequestTest.php
@@ -30,13 +30,13 @@ class RequestTest extends TestCase
         $repo->addPackage($foobar);
 
         $request = new Request();
-        $request->install('foo');
+        $request->require('foo');
 
         $this->assertEquals(
             array(
-                array('cmd' => 'install', 'packageName' => 'foo', 'constraint' => null),
+                'foo' => null,
             ),
-            $request->getJobs()
+            $request->getRequires()
         );
     }
 
@@ -52,13 +52,13 @@ class RequestTest extends TestCase
         $repo2->addPackage($foo2);
 
         $request = new Request();
-        $request->install('foo', $constraint = $this->getVersionConstraint('=', '1'));
+        $request->require('foo', $constraint = $this->getVersionConstraint('=', '1'));
 
         $this->assertEquals(
             array(
-                    array('cmd' => 'install', 'packageName' => 'foo', 'constraint' => $constraint),
+                'foo' => $constraint,
             ),
-            $request->getJobs()
+            $request->getRequires()
         );
     }
 }

--- a/tests/Composer/Test/DependencyResolver/RequestTest.php
+++ b/tests/Composer/Test/DependencyResolver/RequestTest.php
@@ -30,7 +30,7 @@ class RequestTest extends TestCase
         $repo->addPackage($foobar);
 
         $request = new Request();
-        $request->require('foo');
+        $request->requireName('foo');
 
         $this->assertEquals(
             array(
@@ -52,7 +52,7 @@ class RequestTest extends TestCase
         $repo2->addPackage($foo2);
 
         $request = new Request();
-        $request->require('foo', $constraint = $this->getVersionConstraint('=', '1'));
+        $request->requireName('foo', $constraint = $this->getVersionConstraint('=', '1'));
 
         $this->assertEquals(
             array(

--- a/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
@@ -30,9 +30,9 @@ class RuleSetIteratorTest extends TestCase
         $this->pool = new Pool();
 
         $this->rules = array(
-            RuleSet::TYPE_JOB => array(
-                new GenericRule(array(), Rule::RULE_JOB_INSTALL, null),
-                new GenericRule(array(), Rule::RULE_JOB_INSTALL, null),
+            RuleSet::TYPE_REQUEST => array(
+                new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, null),
+                new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, null),
             ),
             RuleSet::TYPE_LEARNED => array(
                 new GenericRule(array(), Rule::RULE_INTERNAL_ALLOW_UPDATE, null),
@@ -51,8 +51,8 @@ class RuleSetIteratorTest extends TestCase
         }
 
         $expected = array(
-            $this->rules[RuleSet::TYPE_JOB][0],
-            $this->rules[RuleSet::TYPE_JOB][1],
+            $this->rules[RuleSet::TYPE_REQUEST][0],
+            $this->rules[RuleSet::TYPE_REQUEST][1],
             $this->rules[RuleSet::TYPE_LEARNED][0],
         );
 
@@ -69,8 +69,8 @@ class RuleSetIteratorTest extends TestCase
         }
 
         $expected = array(
-            RuleSet::TYPE_JOB,
-            RuleSet::TYPE_JOB,
+            RuleSet::TYPE_REQUEST,
+            RuleSet::TYPE_REQUEST,
             RuleSet::TYPE_LEARNED,
         );
 

--- a/tests/Composer/Test/DependencyResolver/RuleSetTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetTest.php
@@ -26,9 +26,9 @@ class RuleSetTest extends TestCase
     {
         $rules = array(
             RuleSet::TYPE_PACKAGE => array(),
-            RuleSet::TYPE_JOB => array(
-                new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null),
-                new GenericRule(array(2), Rule::RULE_JOB_INSTALL, null),
+            RuleSet::TYPE_REQUEST => array(
+                new GenericRule(array(1), Rule::RULE_ROOT_REQUIRE, null),
+                new GenericRule(array(2), Rule::RULE_ROOT_REQUIRE, null),
             ),
             RuleSet::TYPE_LEARNED => array(
                 new GenericRule(array(), Rule::RULE_INTERNAL_ALLOW_UPDATE, null),
@@ -37,9 +37,9 @@ class RuleSetTest extends TestCase
 
         $ruleSet = new RuleSet;
 
-        $ruleSet->add($rules[RuleSet::TYPE_JOB][0], RuleSet::TYPE_JOB);
+        $ruleSet->add($rules[RuleSet::TYPE_REQUEST][0], RuleSet::TYPE_REQUEST);
         $ruleSet->add($rules[RuleSet::TYPE_LEARNED][0], RuleSet::TYPE_LEARNED);
-        $ruleSet->add($rules[RuleSet::TYPE_JOB][1], RuleSet::TYPE_JOB);
+        $ruleSet->add($rules[RuleSet::TYPE_REQUEST][1], RuleSet::TYPE_REQUEST);
 
         $this->assertEquals($rules, $ruleSet->getRules());
     }
@@ -47,20 +47,20 @@ class RuleSetTest extends TestCase
     public function testAddIgnoresDuplicates()
     {
         $rules = array(
-            RuleSet::TYPE_JOB => array(
-                new GenericRule(array(), Rule::RULE_JOB_INSTALL, null),
-                new GenericRule(array(), Rule::RULE_JOB_INSTALL, null),
-                new GenericRule(array(), Rule::RULE_JOB_INSTALL, null),
+            RuleSet::TYPE_REQUEST => array(
+                new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, null),
+                new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, null),
+                new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, null),
             ),
         );
 
         $ruleSet = new RuleSet;
 
-        $ruleSet->add($rules[RuleSet::TYPE_JOB][0], RuleSet::TYPE_JOB);
-        $ruleSet->add($rules[RuleSet::TYPE_JOB][1], RuleSet::TYPE_JOB);
-        $ruleSet->add($rules[RuleSet::TYPE_JOB][2], RuleSet::TYPE_JOB);
+        $ruleSet->add($rules[RuleSet::TYPE_REQUEST][0], RuleSet::TYPE_REQUEST);
+        $ruleSet->add($rules[RuleSet::TYPE_REQUEST][1], RuleSet::TYPE_REQUEST);
+        $ruleSet->add($rules[RuleSet::TYPE_REQUEST][2], RuleSet::TYPE_REQUEST);
 
-        $this->assertCount(1, $ruleSet->getIteratorFor(array(RuleSet::TYPE_JOB)));
+        $this->assertCount(1, $ruleSet->getIteratorFor(array(RuleSet::TYPE_REQUEST)));
     }
 
     /**
@@ -70,15 +70,15 @@ class RuleSetTest extends TestCase
     {
         $ruleSet = new RuleSet;
 
-        $ruleSet->add(new GenericRule(array(), Rule::RULE_JOB_INSTALL, null), 7);
+        $ruleSet->add(new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, null), 7);
     }
 
     public function testCount()
     {
         $ruleSet = new RuleSet;
 
-        $ruleSet->add(new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null), RuleSet::TYPE_JOB);
-        $ruleSet->add(new GenericRule(array(2), Rule::RULE_JOB_INSTALL, null), RuleSet::TYPE_JOB);
+        $ruleSet->add(new GenericRule(array(1), Rule::RULE_ROOT_REQUIRE, null), RuleSet::TYPE_REQUEST);
+        $ruleSet->add(new GenericRule(array(2), Rule::RULE_ROOT_REQUIRE, null), RuleSet::TYPE_REQUEST);
 
         $this->assertEquals(2, $ruleSet->count());
     }
@@ -87,8 +87,8 @@ class RuleSetTest extends TestCase
     {
         $ruleSet = new RuleSet;
 
-        $rule = new GenericRule(array(), Rule::RULE_JOB_INSTALL, null);
-        $ruleSet->add($rule, RuleSet::TYPE_JOB);
+        $rule = new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, null);
+        $ruleSet->add($rule, RuleSet::TYPE_REQUEST);
 
         $this->assertSame($rule, $ruleSet->ruleById[0]);
     }
@@ -97,9 +97,9 @@ class RuleSetTest extends TestCase
     {
         $ruleSet = new RuleSet;
 
-        $rule1 = new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new GenericRule(array(2), Rule::RULE_JOB_INSTALL, null);
-        $ruleSet->add($rule1, RuleSet::TYPE_JOB);
+        $rule1 = new GenericRule(array(1), Rule::RULE_ROOT_REQUIRE, null);
+        $rule2 = new GenericRule(array(2), Rule::RULE_ROOT_REQUIRE, null);
+        $ruleSet->add($rule1, RuleSet::TYPE_REQUEST);
         $ruleSet->add($rule2, RuleSet::TYPE_LEARNED);
 
         $iterator = $ruleSet->getIterator();
@@ -112,10 +112,10 @@ class RuleSetTest extends TestCase
     public function testGetIteratorFor()
     {
         $ruleSet = new RuleSet;
-        $rule1 = new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new GenericRule(array(2), Rule::RULE_JOB_INSTALL, null);
+        $rule1 = new GenericRule(array(1), Rule::RULE_ROOT_REQUIRE, null);
+        $rule2 = new GenericRule(array(2), Rule::RULE_ROOT_REQUIRE, null);
 
-        $ruleSet->add($rule1, RuleSet::TYPE_JOB);
+        $ruleSet->add($rule1, RuleSet::TYPE_REQUEST);
         $ruleSet->add($rule2, RuleSet::TYPE_LEARNED);
 
         $iterator = $ruleSet->getIteratorFor(RuleSet::TYPE_LEARNED);
@@ -126,13 +126,13 @@ class RuleSetTest extends TestCase
     public function testGetIteratorWithout()
     {
         $ruleSet = new RuleSet;
-        $rule1 = new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new GenericRule(array(2), Rule::RULE_JOB_INSTALL, null);
+        $rule1 = new GenericRule(array(1), Rule::RULE_ROOT_REQUIRE, null);
+        $rule2 = new GenericRule(array(2), Rule::RULE_ROOT_REQUIRE, null);
 
-        $ruleSet->add($rule1, RuleSet::TYPE_JOB);
+        $ruleSet->add($rule1, RuleSet::TYPE_REQUEST);
         $ruleSet->add($rule2, RuleSet::TYPE_LEARNED);
 
-        $iterator = $ruleSet->getIteratorWithout(RuleSet::TYPE_JOB);
+        $iterator = $ruleSet->getIteratorWithout(RuleSet::TYPE_REQUEST);
 
         $this->assertSame($rule2, $iterator->current());
     }
@@ -145,10 +145,10 @@ class RuleSetTest extends TestCase
 
         $ruleSet = new RuleSet;
         $literal = $p->getId();
-        $rule = new GenericRule(array($literal), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array($literal), Rule::RULE_ROOT_REQUIRE, array('packageName' => 'foo/bar', 'constraint' => null));
 
-        $ruleSet->add($rule, RuleSet::TYPE_JOB);
+        $ruleSet->add($rule, RuleSet::TYPE_REQUEST);
 
-        $this->assertContains('JOB     : Install command rule (install foo 2.1)', $ruleSet->getPrettyString($pool));
+        $this->assertContains('REQUEST : No package found to satisfy root composer.json require foo/bar', $ruleSet->getPrettyString($pool));
     }
 }

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -17,6 +17,7 @@ use Composer\DependencyResolver\Rule;
 use Composer\DependencyResolver\RuleSet;
 use Composer\DependencyResolver\Pool;
 use Composer\Package\BasePackage;
+use Composer\Package\Link;
 use Composer\Repository\ArrayRepository;
 use Composer\Test\TestCase;
 
@@ -24,7 +25,7 @@ class RuleTest extends TestCase
 {
     public function testGetHash()
     {
-        $rule = new GenericRule(array(123), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(123), Rule::RULE_ROOT_REQUIRE, null);
 
         $hash = unpack('ihash', md5('123', true));
         $this->assertEquals($hash['hash'], $rule->getHash());
@@ -32,39 +33,39 @@ class RuleTest extends TestCase
 
     public function testEqualsForRulesWithDifferentHashes()
     {
-        $rule = new GenericRule(array(1, 2), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new GenericRule(array(1, 3), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(1, 2), Rule::RULE_ROOT_REQUIRE, null);
+        $rule2 = new GenericRule(array(1, 3), Rule::RULE_ROOT_REQUIRE, null);
 
         $this->assertFalse($rule->equals($rule2));
     }
 
     public function testEqualsForRulesWithDifferLiteralsQuantity()
     {
-        $rule = new GenericRule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(1, 12), Rule::RULE_ROOT_REQUIRE, null);
+        $rule2 = new GenericRule(array(1), Rule::RULE_ROOT_REQUIRE, null);
 
         $this->assertFalse($rule->equals($rule2));
     }
 
     public function testEqualsForRulesWithSameLiterals()
     {
-        $rule = new GenericRule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new GenericRule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(1, 12), Rule::RULE_ROOT_REQUIRE, null);
+        $rule2 = new GenericRule(array(1, 12), Rule::RULE_ROOT_REQUIRE, null);
 
         $this->assertTrue($rule->equals($rule2));
     }
 
     public function testSetAndGetType()
     {
-        $rule = new GenericRule(array(), Rule::RULE_JOB_INSTALL, null);
-        $rule->setType(RuleSet::TYPE_JOB);
+        $rule = new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, null);
+        $rule->setType(RuleSet::TYPE_REQUEST);
 
-        $this->assertEquals(RuleSet::TYPE_JOB, $rule->getType());
+        $this->assertEquals(RuleSet::TYPE_REQUEST, $rule->getType());
     }
 
     public function testEnable()
     {
-        $rule = new GenericRule(array(), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, null);
         $rule->disable();
         $rule->enable();
 
@@ -74,7 +75,7 @@ class RuleTest extends TestCase
 
     public function testDisable()
     {
-        $rule = new GenericRule(array(), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, null);
         $rule->enable();
         $rule->disable();
 
@@ -84,8 +85,8 @@ class RuleTest extends TestCase
 
     public function testIsAssertions()
     {
-        $rule = new GenericRule(array(1, 12), Rule::RULE_JOB_INSTALL, null);
-        $rule2 = new GenericRule(array(1), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array(1, 12), Rule::RULE_ROOT_REQUIRE, null);
+        $rule2 = new GenericRule(array(1), Rule::RULE_ROOT_REQUIRE, null);
 
         $this->assertFalse($rule->isAssertion());
         $this->assertTrue($rule2->isAssertion());
@@ -98,8 +99,8 @@ class RuleTest extends TestCase
             $p2 = $this->getPackage('baz', '1.1'),
         ));
 
-        $rule = new GenericRule(array($p1->getId(), -$p2->getId()), Rule::RULE_JOB_INSTALL, null);
+        $rule = new GenericRule(array($p1->getId(), -$p2->getId()), Rule::RULE_PACKAGE_REQUIRES, new Link('baz', 'foo'));
 
-        $this->assertEquals('Install command rule (don\'t install baz 1.1|install foo 2.1)', $rule->getPrettyString($pool));
+        $this->assertEquals('baz 1.1 relates to foo -> satisfiable by foo[2.1].', $rule->getPrettyString($pool));
     }
 }

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -50,7 +50,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageA),
@@ -72,7 +72,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($this->getPackage('A', '1.0'));
         $this->reposComplete();
 
-        $this->request->install('B', $this->getVersionConstraint('==', '1'));
+        $this->request->require('B', $this->getVersionConstraint('==', '1'));
 
         $this->createSolver();
         try {
@@ -97,7 +97,7 @@ class SolverTest extends TestCase
         $this->repoSet->addRepository($repo1);
         $this->repoSet->addRepository($repo2);
 
-        $this->request->install('foo');
+        $this->request->require('foo');
 
         $this->checkSolverResult(array(
                 array('job' => 'install', 'package' => $foo1),
@@ -114,7 +114,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageB),
@@ -140,7 +140,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $newPackageB11),
@@ -164,9 +164,9 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
-        $this->request->install('B');
-        $this->request->install('C');
+        $this->request->require('A');
+        $this->request->require('B');
+        $this->request->require('C');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageA),
@@ -206,7 +206,7 @@ class SolverTest extends TestCase
         $packageA->setRequires(array('b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0.0.0'), 'requires')));
 
         $this->request->fixPackage($packageA);
-        $this->request->install('B', $this->getVersionConstraint('=', '1.1.0.0'));
+        $this->request->require('B', $this->getVersionConstraint('=', '1.1.0.0'));
 
         $this->checkSolverResult(array(
             array('job' => 'update', 'from' => $packageB, 'to' => $newPackageB),
@@ -219,7 +219,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($newPackageA = $this->getPackage('A', '1.1'));
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->checkSolverResult(array(
             array('job' => 'update', 'from' => $packageA, 'to' => $newPackageA),
@@ -238,7 +238,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->checkSolverResult(array(
             array('job' => 'update', 'from' => $packageB, 'to' => $newPackageB),
@@ -252,7 +252,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($this->getPackage('A', '1.0'));
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->checkSolverResult(array());
     }
@@ -266,7 +266,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
         $this->request->fixPackage($packageB);
 
         $this->checkSolverResult(array(
@@ -281,7 +281,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($this->getPackage('A', '2.0'));
         $this->reposComplete();
 
-        $this->request->install('A', $this->getVersionConstraint('<', '2.0.0.0'));
+        $this->request->require('A', $this->getVersionConstraint('<', '2.0.0.0'));
 
         $this->checkSolverResult(array(array(
             'job' => 'update',
@@ -297,7 +297,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($this->getPackage('A', '2.0'));
         $this->reposComplete();
 
-        $this->request->install('A', $this->getVersionConstraint('<', '2.0.0.0'));
+        $this->request->require('A', $this->getVersionConstraint('<', '2.0.0.0'));
 
         $this->checkSolverResult(array(array(
             'job' => 'update',
@@ -314,7 +314,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($this->getPackage('A', '2.0'));
         $this->reposComplete();
 
-        $this->request->install('A', $this->getVersionConstraint('<', '2.0.0.0'));
+        $this->request->require('A', $this->getVersionConstraint('<', '2.0.0.0'));
 
         $this->checkSolverResult(array(
             array(
@@ -343,8 +343,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
-        $this->request->install('C');
+        $this->request->require('A');
+        $this->request->require('C');
 
         $this->checkSolverResult(array(
             array('job' => 'remove',  'package' => $packageD),
@@ -365,7 +365,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $middlePackageB),
@@ -381,7 +381,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('B');
+        $this->request->require('B');
 
         $this->checkSolverResult(array(
             array('job' => 'remove', 'package' => $packageA),
@@ -396,7 +396,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageA),
@@ -412,7 +412,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         // must explicitly pick the provider, so error in this case
         $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
@@ -430,7 +430,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageB),
@@ -447,7 +447,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
         $this->createSolver();
@@ -464,8 +464,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
-        $this->request->install('Q');
+        $this->request->require('A');
+        $this->request->require('Q');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageQ),
@@ -502,7 +502,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('X');
+        $this->request->require('X');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $newPackageB),
@@ -521,7 +521,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageB2),
@@ -545,8 +545,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
-        $this->request->install('C');
+        $this->request->require('A');
+        $this->request->require('C');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageB),
@@ -583,8 +583,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
-        $this->request->install('D');
+        $this->request->require('A');
+        $this->request->require('D');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageD2),
@@ -619,7 +619,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('C', $this->getVersionConstraint('==', '2.0.0.0-dev'));
+        $this->request->require('C', $this->getVersionConstraint('==', '2.0.0.0-dev'));
 
         $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
 
@@ -637,8 +637,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
-        $this->request->install('B');
+        $this->request->require('A');
+        $this->request->require('B');
 
         $this->createSolver();
         try {
@@ -650,9 +650,9 @@ class SolverTest extends TestCase
 
             $msg = "\n";
             $msg .= "  Problem 1\n";
-            $msg .= "    - Installation request for a -> satisfiable by A[1.0].\n";
+            $msg .= "    - Root composer.json requires a -> satisfiable by A[1.0].\n";
             $msg .= "    - B 1.0 conflicts with A[1.0].\n";
-            $msg .= "    - Installation request for b -> satisfiable by B[1.0].\n";
+            $msg .= "    - Root composer.json requires b -> satisfiable by B[1.0].\n";
             $this->assertEquals($msg, $e->getMessage());
         }
     }
@@ -668,7 +668,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->createSolver();
         try {
@@ -681,7 +681,7 @@ class SolverTest extends TestCase
 
             $msg = "\n";
             $msg .= "  Problem 1\n";
-            $msg .= "    - Installation request for a -> satisfiable by A[1.0].\n";
+            $msg .= "    - Root composer.json requires a -> satisfiable by A[1.0].\n";
             $msg .= "    - A 1.0 requires b >= 2.0 -> no matching package found.\n\n";
             $msg .= "Potential causes:\n";
             $msg .= " - A typo in the package name\n";
@@ -716,7 +716,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->createSolver();
         try {
@@ -733,7 +733,7 @@ class SolverTest extends TestCase
             $msg .= "    - B 1.0 requires c >= 1.0 -> satisfiable by C[1.0].\n";
             $msg .= "    - Same name, can only install one of: B[0.9, 1.0].\n";
             $msg .= "    - A 1.0 requires b >= 1.0 -> satisfiable by B[1.0].\n";
-            $msg .= "    - Installation request for a -> satisfiable by A[1.0].\n";
+            $msg .= "    - Root composer.json requires a -> satisfiable by A[1.0].\n";
             $this->assertEquals($msg, $e->getMessage());
         }
     }
@@ -756,8 +756,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('symfony/twig-bridge');
-        $this->request->install('twig/twig');
+        $this->request->require('symfony/twig-bridge');
+        $this->request->require('twig/twig');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageTwig16),
@@ -782,7 +782,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A', $this->getVersionConstraint('==', '1.1.0.0'));
+        $this->request->require('A', $this->getVersionConstraint('==', '1.1.0.0'));
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageB),
@@ -804,8 +804,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A', $this->getVersionConstraint('==', '2.0'));
-        $this->request->install('B');
+        $this->request->require('A', $this->getVersionConstraint('==', '2.0'));
+        $this->request->require('B');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageA),
@@ -865,7 +865,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->install('A');
+        $this->request->require('A');
 
         $this->createSolver();
 
@@ -905,14 +905,14 @@ class SolverTest extends TestCase
 
         $result = array();
         foreach ($transaction->getOperations() as $operation) {
-            if ('update' === $operation->getJobType()) {
+            if ('update' === $operation->getOperationType()) {
                 $result[] = array(
                     'job' => 'update',
                     'from' => $operation->getInitialPackage(),
                     'to' => $operation->getTargetPackage(),
                 );
             } else {
-                $job = ('uninstall' === $operation->getJobType() ? 'remove' : 'install');
+                $job = ('uninstall' === $operation->getOperationType() ? 'remove' : 'install');
                 $result[] = array(
                     'job' => $job,
                     'package' => $operation->getPackage(),

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -50,7 +50,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageA),
@@ -72,7 +72,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($this->getPackage('A', '1.0'));
         $this->reposComplete();
 
-        $this->request->require('B', $this->getVersionConstraint('==', '1'));
+        $this->request->requireName('B', $this->getVersionConstraint('==', '1'));
 
         $this->createSolver();
         try {
@@ -97,7 +97,7 @@ class SolverTest extends TestCase
         $this->repoSet->addRepository($repo1);
         $this->repoSet->addRepository($repo2);
 
-        $this->request->require('foo');
+        $this->request->requireName('foo');
 
         $this->checkSolverResult(array(
                 array('job' => 'install', 'package' => $foo1),
@@ -114,7 +114,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageB),
@@ -140,7 +140,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $newPackageB11),
@@ -164,9 +164,9 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
-        $this->request->require('B');
-        $this->request->require('C');
+        $this->request->requireName('A');
+        $this->request->requireName('B');
+        $this->request->requireName('C');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageA),
@@ -206,7 +206,7 @@ class SolverTest extends TestCase
         $packageA->setRequires(array('b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0.0.0'), 'requires')));
 
         $this->request->fixPackage($packageA);
-        $this->request->require('B', $this->getVersionConstraint('=', '1.1.0.0'));
+        $this->request->requireName('B', $this->getVersionConstraint('=', '1.1.0.0'));
 
         $this->checkSolverResult(array(
             array('job' => 'update', 'from' => $packageB, 'to' => $newPackageB),
@@ -219,7 +219,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($newPackageA = $this->getPackage('A', '1.1'));
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->checkSolverResult(array(
             array('job' => 'update', 'from' => $packageA, 'to' => $newPackageA),
@@ -238,7 +238,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->checkSolverResult(array(
             array('job' => 'update', 'from' => $packageB, 'to' => $newPackageB),
@@ -252,7 +252,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($this->getPackage('A', '1.0'));
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->checkSolverResult(array());
     }
@@ -266,7 +266,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
         $this->request->fixPackage($packageB);
 
         $this->checkSolverResult(array(
@@ -281,7 +281,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($this->getPackage('A', '2.0'));
         $this->reposComplete();
 
-        $this->request->require('A', $this->getVersionConstraint('<', '2.0.0.0'));
+        $this->request->requireName('A', $this->getVersionConstraint('<', '2.0.0.0'));
 
         $this->checkSolverResult(array(array(
             'job' => 'update',
@@ -297,7 +297,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($this->getPackage('A', '2.0'));
         $this->reposComplete();
 
-        $this->request->require('A', $this->getVersionConstraint('<', '2.0.0.0'));
+        $this->request->requireName('A', $this->getVersionConstraint('<', '2.0.0.0'));
 
         $this->checkSolverResult(array(array(
             'job' => 'update',
@@ -314,7 +314,7 @@ class SolverTest extends TestCase
         $this->repo->addPackage($this->getPackage('A', '2.0'));
         $this->reposComplete();
 
-        $this->request->require('A', $this->getVersionConstraint('<', '2.0.0.0'));
+        $this->request->requireName('A', $this->getVersionConstraint('<', '2.0.0.0'));
 
         $this->checkSolverResult(array(
             array(
@@ -343,8 +343,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
-        $this->request->require('C');
+        $this->request->requireName('A');
+        $this->request->requireName('C');
 
         $this->checkSolverResult(array(
             array('job' => 'remove',  'package' => $packageD),
@@ -365,7 +365,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $middlePackageB),
@@ -381,7 +381,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('B');
+        $this->request->requireName('B');
 
         $this->checkSolverResult(array(
             array('job' => 'remove', 'package' => $packageA),
@@ -396,7 +396,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageA),
@@ -412,7 +412,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         // must explicitly pick the provider, so error in this case
         $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
@@ -430,7 +430,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageB),
@@ -447,7 +447,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
         $this->createSolver();
@@ -464,8 +464,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
-        $this->request->require('Q');
+        $this->request->requireName('A');
+        $this->request->requireName('Q');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageQ),
@@ -502,7 +502,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('X');
+        $this->request->requireName('X');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $newPackageB),
@@ -521,7 +521,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageB2),
@@ -545,8 +545,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
-        $this->request->require('C');
+        $this->request->requireName('A');
+        $this->request->requireName('C');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageB),
@@ -583,8 +583,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
-        $this->request->require('D');
+        $this->request->requireName('A');
+        $this->request->requireName('D');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageD2),
@@ -619,7 +619,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('C', $this->getVersionConstraint('==', '2.0.0.0-dev'));
+        $this->request->requireName('C', $this->getVersionConstraint('==', '2.0.0.0-dev'));
 
         $this->setExpectedException('Composer\DependencyResolver\SolverProblemsException');
 
@@ -637,8 +637,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
-        $this->request->require('B');
+        $this->request->requireName('A');
+        $this->request->requireName('B');
 
         $this->createSolver();
         try {
@@ -668,7 +668,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->createSolver();
         try {
@@ -716,7 +716,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->createSolver();
         try {
@@ -756,8 +756,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('symfony/twig-bridge');
-        $this->request->require('twig/twig');
+        $this->request->requireName('symfony/twig-bridge');
+        $this->request->requireName('twig/twig');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageTwig16),
@@ -782,7 +782,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A', $this->getVersionConstraint('==', '1.1.0.0'));
+        $this->request->requireName('A', $this->getVersionConstraint('==', '1.1.0.0'));
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageB),
@@ -804,8 +804,8 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A', $this->getVersionConstraint('==', '2.0'));
-        $this->request->require('B');
+        $this->request->requireName('A', $this->getVersionConstraint('==', '2.0'));
+        $this->request->requireName('B');
 
         $this->checkSolverResult(array(
             array('job' => 'install', 'package' => $packageA),
@@ -865,7 +865,7 @@ class SolverTest extends TestCase
 
         $this->reposComplete();
 
-        $this->request->require('A');
+        $this->request->requireName('A');
 
         $this->createSolver();
 

--- a/tests/Composer/Test/DependencyResolver/TransactionTest.php
+++ b/tests/Composer/Test/DependencyResolver/TransactionTest.php
@@ -71,7 +71,7 @@ class TransactionTest extends TestCase
     {
         $result = array();
         foreach ($transaction->getOperations() as $operation) {
-            if ('update' === $operation->getJobType()) {
+            if ('update' === $operation->getOperationType()) {
                 $result[] = array(
                     'job' => 'update',
                     'from' => $operation->getInitialPackage(),
@@ -79,7 +79,7 @@ class TransactionTest extends TestCase
                 );
             } else {
                 $result[] = array(
-                    'job' => $operation->getJobType(),
+                    'job' => $operation->getOperationType(),
                     'package' => $operation->getPackage(),
                 );
             }

--- a/tests/Composer/Test/Fixtures/installer/broken-deps-do-not-replace.test
+++ b/tests/Composer/Test/Fixtures/installer/broken-deps-do-not-replace.test
@@ -28,7 +28,7 @@ Your requirements could not be resolved to an installable set of packages.
   Problem 1
     - c/c 1.0.0 requires x/x 1.0 -> no matching package found.
     - b/b 1.0.0 requires c/c 1.* -> satisfiable by c/c[1.0.0].
-    - Installation request for b/b 1.* -> satisfiable by b/b[1.0.0].
+    - Root composer.json requires b/b 1.* -> satisfiable by b/b[1.0.0].
 
 Potential causes:
  - A typo in the package name

--- a/tests/Composer/Test/Fixtures/installer/github-issues-4319.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-4319.test
@@ -36,7 +36,7 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - Installation request for a/a ~1.0 -> satisfiable by a/a[1.0.0].
+    - Root composer.json requires a/a ~1.0 -> satisfiable by a/a[1.0.0].
     - a/a 1.0.0 requires php 5.5 -> your PHP version (%s) overridden by "config.platform.php" version (5.3) does not satisfy that requirement.
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/solver-problems.test
+++ b/tests/Composer/Test/Fixtures/installer/solver-problems.test
@@ -63,7 +63,7 @@ Your requirements could not be resolved to an installable set of packages.
   Problem 3
     - The requested package stable-requiree-excluded/pkg could not be found in any version, there may be a typo in the package name.
   Problem 4
-    - Installation request for requirer/pkg 1.* -> satisfiable by requirer/pkg[1.0.0].
+    - Root composer.json requires requirer/pkg 1.* -> satisfiable by requirer/pkg[1.0.0].
     - requirer/pkg 1.0.0 requires dependency/pkg 1.0.0 -> no matching package found.
 
 Potential causes:

--- a/tests/Composer/Test/Mock/InstallationManagerMock.php
+++ b/tests/Composer/Test/Mock/InstallationManagerMock.php
@@ -38,7 +38,7 @@ class InstallationManagerMock extends InstallationManager
     public function execute(RepositoryInterface $repo, array $operations, $devMode = true, $runScripts = true)
     {
         foreach ($operations as $operation) {
-            $method = $operation->getJobType();
+            $method = $operation->getOperationType();
             // skipping download() step here for tests
             $this->$method($repo, $operation);
         }


### PR DESCRIPTION
The only type of request job remaining was "install" which is really a
root requirement. The only other kind of input for the solver is now a
set of fixed packages.

Rules have been updated to account for only two kinds of former job
reason: FIXED or ROOT_REQUIRE. The job property has always been
redundant and has been removed, since reasonData suffices.

Problem reasons are always rules, so the unnecessary wrapping in an
array has been removed.

We now only ever generate a single rule per root require or fixed
package, so there is no need for the solver to special handle disabling
"jobs" anymore, the rule can just be disabled as usual.

For consistency special handling of rules for jobs in problems has been
integrated into the rule class like all other rule reasons. As part of
this change the error message for root requirements has been improved a
bit to make it clearer where the package installation request came from.

The word job has also been removed from operations, which are called
operations, not jobs.