### PR TITLE
Uses config data from Composer object whenever possible on ArchiveCommand

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -53,6 +53,7 @@ return PhpCsFixer\Config::create()
         'standardize_not_equals' => true,
         'ternary_operator_spaces' => true,
         'trailing_comma_in_multiline_array' => true,
+        'unary_operator_spaces' => true,
     ))
     ->setFinder($finder)
 ;

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -64,13 +64,19 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $config = Factory::createConfig();
         $composer = $this->getComposer(false);
+        $config = null;
+
         if ($composer) {
+            $config = $composer->getConfig();
             $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'archive', $input, $output);
             $eventDispatcher = $composer->getEventDispatcher();
             $eventDispatcher->dispatch($commandEvent->getName(), $commandEvent);
             $eventDispatcher->dispatchScript(ScriptEvents::PRE_ARCHIVE_CMD);
+        }
+
+        if (!$config) {
+            $config = Factory::createConfig();
         }
 
         if (null === $input->getOption('format')) {

--- a/tests/Composer/Test/Command/ArchiveCommandTest.php
+++ b/tests/Composer/Test/Command/ArchiveCommandTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Command;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\Factory;
+use Composer\Test\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class ArchiveCommandTest extends TestCase
+{
+    public function testUsesConfigFromComposerObject()
+    {
+        $input = new ArrayInput(array());
+
+        $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+            ->getMock();
+
+        $ed = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
+            ->disableOriginalConstructor()->getMock();
+
+        $composer = new Composer;
+        $config = new Config;
+        $config->merge(array('config' => array('archive-format' => 'zip')));
+        $composer->setConfig($config);
+
+        $manager = $this->getMockBuilder('Composer\Package\Archiver\ArchiveManager')
+            ->disableOriginalConstructor()->getMock();
+
+        $package = $this->getMockBuilder('Composer\Package\RootPackageInterface')
+            ->getMock();
+
+        $manager->expects($this->once())->method('archive')
+            ->with($package, 'zip', '.', null, false)->willReturn(getcwd());
+
+        $composer->setArchiveManager($manager);
+        $composer->setEventDispatcher($ed);
+        $composer->setPackage($package);
+
+        $command = $this->getMockBuilder('Composer\Command\ArchiveCommand')
+            ->setMethods(array(
+                'mergeApplicationDefinition',
+                'bind',
+                'getSynopsis',
+                'initialize',
+                'isInteractive',
+                'getComposer',
+            ))->getMock();
+        $command->expects($this->any())->method('getComposer')
+            ->willReturn($composer);
+        $command->method('isInteractive')->willReturn(false);
+
+        $command->run($input, $output);
+    }
+
+    public function testUsesConfigFromFactoryWhenComposerIsNotDefined()
+    {
+        $input = new ArrayInput(array());
+
+        $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+            ->getMock();
+
+        $ed = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
+            ->disableOriginalConstructor()->getMock();
+
+        $composer = new Composer;
+        $config = Factory::createConfig();
+
+        $manager = $this->getMockBuilder('Composer\Package\Archiver\ArchiveManager')
+            ->disableOriginalConstructor()->getMock();
+
+        $factory = $this->getMockBuilder('Composer\Factory')->getMock();
+        $factory->method('createArchiveManager')->willReturn($manager);
+
+        $package = $this->getMockBuilder('Composer\Package\RootPackageInterface')
+            ->getMock();
+
+        $composer->setArchiveManager($manager);
+        $composer->setEventDispatcher($ed);
+        $composer->setPackage($package);
+
+        $command = $this->getMockBuilder('Composer\Command\ArchiveCommand')
+            ->setMethods(array(
+                'mergeApplicationDefinition',
+                'bind',
+                'getSynopsis',
+                'initialize',
+                'isInteractive',
+                'getComposer',
+                'archive',
+            ))->getMock();
+        $command->expects($this->any())->method('getComposer')
+            ->willReturnOnConsecutiveCalls(null, $composer);
+        $command->expects($this->any())->method('archive')
+            ->with(
+                $this->isType('object'),
+                $config,
+                null,
+                null,
+                'tar',
+                '.',
+                null,
+                false,
+                null
+            );
+        $command->method('isInteractive')->willReturn(false);
+
+        $command->run($input, $output);
+    }
+}


### PR DESCRIPTION
It was previously blindly getting a new instance from the factory thus ignoring what is on Composer object config data.