### PR TITLE
Restore installer events and add a PRE_POOL_CREATE hook for plugins

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -43,8 +43,8 @@ Composer fires the following named events during its execution process:
 
 ### Installer Events
 
-- **pre-dependencies-solving**: occurs before the dependencies are resolved.
-- **post-dependencies-solving**: occurs after the dependencies have been resolved.
+- **pre-operations-exec**: occurs before the install/upgrade/.. operations
+  are executed when installing a lock file.
 
 ### Package Events
 

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -66,6 +66,8 @@ Composer fires the following named events during its execution process:
 - **pre-command-run**: occurs before a command is executed and allows you to
   manipulate the `InputInterface` object's options and arguments to tweak
   a command's behavior.
+- **pre-pool-create**: occurs before the Pool of packages is created, and lets
+  you filter the list of packages which is going to enter the Solver.
 
 > **Note:** Composer makes no assumptions about the state of your dependencies
 > prior to `install` or `update`. Therefore, you should not specify scripts

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -14,6 +14,8 @@ namespace Composer\EventDispatcher;
 
 use Composer\DependencyResolver\PolicyInterface;
 use Composer\DependencyResolver\Request;
+use Composer\DependencyResolver\Pool;
+use Composer\DependencyResolver\Transaction;
 use Composer\Installer\InstallerEvent;
 use Composer\IO\IOInterface;
 use Composer\Composer;
@@ -128,9 +130,9 @@ class EventDispatcher
      * @return int return code of the executed script if any, for php scripts a false return
      *             value is changed to 1, anything else to 0
      */
-    public function dispatchInstallerEvent($eventName, $devMode, PolicyInterface $policy, RepositorySet $repositorySet, RepositoryInterface $localRepo, Request $request, array $operations = array())
+    public function dispatchInstallerEvent($eventName, $devMode, RepositorySet $repositorySet, Pool $pool, Request $request, PolicyInterface $policy, Transaction $transaction = null)
     {
-        return $this->doDispatch(new InstallerEvent($eventName, $this->composer, $this->io, $devMode, $policy, $repositorySet, $localRepo, $request, $operations));
+        return $this->doDispatch(new InstallerEvent($eventName, $this->composer, $this->io, $devMode, $repositorySet, $pool, $request, $policy, $transaction));
     }
 
     /**

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -119,20 +119,17 @@ class EventDispatcher
     /**
      * Dispatch a installer event.
      *
-     * @param string              $eventName     The constant in InstallerEvents
-     * @param bool                $devMode       Whether or not we are in dev mode
-     * @param PolicyInterface     $policy        The policy
-     * @param RepositorySet       $repositorySet The repository set
-     * @param RepositoryInterface $localRepo     The installed repository
-     * @param Request             $request       The request
-     * @param array               $operations    The list of operations
+     * @param string              $eventName         The constant in InstallerEvents
+     * @param bool                $devMode           Whether or not we are in dev mode
+     * @param bool                $executeOperations True if operations will be executed, false in --dry-run
+     * @param Transaction         $transaction       The transaction contains the list of operations
      *
      * @return int return code of the executed script if any, for php scripts a false return
      *             value is changed to 1, anything else to 0
      */
-    public function dispatchInstallerEvent($eventName, $devMode, RepositorySet $repositorySet, Pool $pool, Request $request, PolicyInterface $policy, Transaction $transaction = null)
+    public function dispatchInstallerEvent($eventName, $devMode, $executeOperations, Transaction $transaction)
     {
-        return $this->doDispatch(new InstallerEvent($eventName, $this->composer, $this->io, $devMode, $repositorySet, $pool, $request, $policy, $transaction));
+        return $this->doDispatch(new InstallerEvent($eventName, $this->composer, $this->io, $devMode, $executeOperations, $transaction));
     }
 
     /**

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -381,10 +381,8 @@ class Installer
             }
         }
 
-        // TODO reenable events
-        //$this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $repositorySet, $installedRepo, $request);
-
         $pool = $repositorySet->createPool($request);
+        $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $repositorySet, $pool, $request, $policy);
 
         // solve dependencies
         $solver = new Solver($policy, $pool, $this->io, $repositorySet);
@@ -403,7 +401,7 @@ class Installer
         }
 
         // TODO should we warn people / error if plugins in vendor folder do not match contents of lock file before update?
-        //$this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, $this->devMode, $policy, $repositorySet, $lockedRepository, $request, $lockTransaction);
+        $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, $this->devMode, $repositorySet, $pool, $request, $policy, $lockTransaction);
 
         $this->io->writeError("Analyzed ".count($pool)." packages to resolve dependencies", true, IOInterface::VERBOSE);
         $this->io->writeError("Analyzed ".$ruleSetSize." rules to resolve dependencies", true, IOInterface::VERBOSE);
@@ -526,11 +524,11 @@ class Installer
 
         $pool = $repositorySet->createPool($request);
 
-        //$this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, false, $policy, $pool, $installedRepo, $request);
+        $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, false, $repositorySet, $pool, $request, $policy);
         $solver = new Solver($policy, $pool, $this->io, $repositorySet);
         try {
             $nonDevLockTransaction = $solver->solve($request, $this->ignorePlatformReqs);
-            //$this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, false, $policy, $pool, $installedRepo, $request, $ops);
+            $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, false, $repositorySet, $pool, $request, $policy, $nonDevLockTransaction);
             $solver = null;
         } catch (SolverProblemsException $e) {
             $this->io->writeError('<error>Unable to find a compatible set of packages based on your non-dev requirements alone.</error>', true, IOInterface::QUIET);
@@ -580,9 +578,8 @@ class Installer
                 $request->requireName($link->getTarget(), $link->getConstraint());
             }
 
-            //$this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $policy, $repositorySet, $installedRepo, $request);
-
             $pool = $repositorySet->createPool($request);
+            $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $repositorySet, $pool, $request, $policy);
 
             // solve dependencies
             $solver = new Solver($policy, $pool, $this->io, $repositorySet);
@@ -604,7 +601,7 @@ class Installer
             }
 
             // TODO should we warn people / error if plugins in vendor folder do not match contents of lock file before update?
-            //$this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, $this->devMode, $policy, $repositorySet, $installedRepo, $request, $lockTransaction);
+            $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, $this->devMode, $repositorySet, $pool, $request, $policy, $lockTransaction);
         }
 
         // TODO in how far do we need to do anything here to ensure dev packages being updated to latest in lock without version change are treated correctly?

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -381,7 +381,7 @@ class Installer
             }
         }
 
-        $pool = $repositorySet->createPool($request);
+        $pool = $repositorySet->createPool($request, $this->eventDispatcher);
         $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $repositorySet, $pool, $request, $policy);
 
         // solve dependencies
@@ -522,7 +522,7 @@ class Installer
             $request->requireName($link->getTarget(), $link->getConstraint());
         }
 
-        $pool = $repositorySet->createPool($request);
+        $pool = $repositorySet->createPool($request, $this->eventDispatcher);
 
         $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, false, $repositorySet, $pool, $request, $policy);
         $solver = new Solver($policy, $pool, $this->io, $repositorySet);
@@ -578,7 +578,7 @@ class Installer
                 $request->requireName($link->getTarget(), $link->getConstraint());
             }
 
-            $pool = $repositorySet->createPool($request);
+            $pool = $repositorySet->createPool($request, $this->eventDispatcher);
             $this->eventDispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, $this->devMode, $repositorySet, $pool, $request, $policy);
 
             // solve dependencies

--- a/src/Composer/Installer/InstallerEvent.php
+++ b/src/Composer/Installer/InstallerEvent.php
@@ -14,11 +14,11 @@ namespace Composer\Installer;
 
 use Composer\Composer;
 use Composer\DependencyResolver\PolicyInterface;
-use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Request;
+use Composer\DependencyResolver\Pool;
+use Composer\DependencyResolver\Transaction;
 use Composer\EventDispatcher\Event;
 use Composer\IO\IOInterface;
-use Composer\Repository\RepositoryInterface;
 use Composer\Repository\RepositorySet;
 
 /**
@@ -44,19 +44,14 @@ class InstallerEvent extends Event
     private $devMode;
 
     /**
-     * @var PolicyInterface
-     */
-    private $policy;
-
-    /**
      * @var RepositorySet
      */
     private $repositorySet;
 
     /**
-     * @var RepositoryInterface
+     * @var Pool
      */
-    private $localRepo;
+    private $pool;
 
     /**
      * @var Request
@@ -64,9 +59,14 @@ class InstallerEvent extends Event
     private $request;
 
     /**
-     * @var OperationInterface[]
+     * @var PolicyInterface
      */
-    private $operations;
+    private $policy;
+
+    /**
+     * @var Transaction|null
+     */
+    private $transaction;
 
     /**
      * Constructor.
@@ -75,24 +75,24 @@ class InstallerEvent extends Event
      * @param Composer             $composer
      * @param IOInterface          $io
      * @param bool                 $devMode
-     * @param PolicyInterface      $policy
      * @param RepositorySet        $repositorySet
-     * @param RepositoryInterface  $localRepo
+     * @param Pool                 $pool
      * @param Request              $request
-     * @param OperationInterface[] $operations
+     * @param PolicyInterface      $policy
+     * @param Transaction          $transaction
      */
-    public function __construct($eventName, Composer $composer, IOInterface $io, $devMode, PolicyInterface $policy, RepositorySet $repositorySet, RepositoryInterface $localRepo, Request $request, array $operations = array())
+    public function __construct($eventName, Composer $composer, IOInterface $io, $devMode, RepositorySet $repositorySet, Pool $pool, Request $request, PolicyInterface $policy, Transaction $transaction = null)
     {
         parent::__construct($eventName);
 
         $this->composer = $composer;
         $this->io = $io;
         $this->devMode = $devMode;
-        $this->policy = $policy;
         $this->repositorySet = $repositorySet;
-        $this->localRepo = $localRepo;
+        $this->pool = $pool;
         $this->request = $request;
-        $this->operations = $operations;
+        $this->policy = $policy;
+        $this->transaction = $transaction;
     }
 
     /**
@@ -136,11 +136,11 @@ class InstallerEvent extends Event
     }
 
     /**
-     * @return RepositoryInterface
+     * @return Pool
      */
-    public function getLocalRepo()
+    public function getPool()
     {
-        return $this->localRepo;
+        return $this->pool;
     }
 
     /**
@@ -152,10 +152,10 @@ class InstallerEvent extends Event
     }
 
     /**
-     * @return OperationInterface[]
+     * @return Transaction|null
      */
-    public function getOperations()
+    public function getTransaction()
     {
-        return $this->operations;
+        return $this->transaction;
     }
 }

--- a/src/Composer/Installer/InstallerEvent.php
+++ b/src/Composer/Installer/InstallerEvent.php
@@ -21,11 +21,6 @@ use Composer\EventDispatcher\Event;
 use Composer\IO\IOInterface;
 use Composer\Repository\RepositorySet;
 
-/**
- * An event for all installer.
- *
- * @author François Pluchino <francois.pluchino@gmail.com>
- */
 class InstallerEvent extends Event
 {
     /**
@@ -44,27 +39,12 @@ class InstallerEvent extends Event
     private $devMode;
 
     /**
-     * @var RepositorySet
+     * @var bool
      */
-    private $repositorySet;
+    private $executeOperations;
 
     /**
-     * @var Pool
-     */
-    private $pool;
-
-    /**
-     * @var Request
-     */
-    private $request;
-
-    /**
-     * @var PolicyInterface
-     */
-    private $policy;
-
-    /**
-     * @var Transaction|null
+     * @var Transaction
      */
     private $transaction;
 
@@ -75,23 +55,17 @@ class InstallerEvent extends Event
      * @param Composer             $composer
      * @param IOInterface          $io
      * @param bool                 $devMode
-     * @param RepositorySet        $repositorySet
-     * @param Pool                 $pool
-     * @param Request              $request
-     * @param PolicyInterface      $policy
+     * @param bool                 $executeOperations
      * @param Transaction          $transaction
      */
-    public function __construct($eventName, Composer $composer, IOInterface $io, $devMode, RepositorySet $repositorySet, Pool $pool, Request $request, PolicyInterface $policy, Transaction $transaction = null)
+    public function __construct($eventName, Composer $composer, IOInterface $io, $devMode, $executeOperations, Transaction $transaction)
     {
         parent::__construct($eventName);
 
         $this->composer = $composer;
         $this->io = $io;
         $this->devMode = $devMode;
-        $this->repositorySet = $repositorySet;
-        $this->pool = $pool;
-        $this->request = $request;
-        $this->policy = $policy;
+        $this->executeOperations = $executeOperations;
         $this->transaction = $transaction;
     }
 
@@ -120,35 +94,11 @@ class InstallerEvent extends Event
     }
 
     /**
-     * @return PolicyInterface
+     * @return bool
      */
-    public function getPolicy()
+    public function isExecutingOperations()
     {
-        return $this->policy;
-    }
-
-    /**
-     * @return RepositorySet
-     */
-    public function getRepositorySet()
-    {
-        return $this->repositorySet;
-    }
-
-    /**
-     * @return Pool
-     */
-    public function getPool()
-    {
-        return $this->pool;
-    }
-
-    /**
-     * @return Request
-     */
-    public function getRequest()
-    {
-        return $this->request;
+        return $this->executeOperations;
     }
 
     /**

--- a/src/Composer/Installer/InstallerEvents.php
+++ b/src/Composer/Installer/InstallerEvents.php
@@ -12,32 +12,15 @@
 
 namespace Composer\Installer;
 
-/**
- * The Installer Events.
- *
- * @author François Pluchino <francois.pluchino@gmail.com>
- */
 class InstallerEvents
 {
     /**
-     * The PRE_DEPENDENCIES_SOLVING event occurs as a installer begins
-     * resolve operations.
+     * The PRE_OPERATIONS_EXEC event occurs before the lock file gets
+     * installed and operations are executed.
      *
-     * The event listener method receives a
-     * Composer\Installer\InstallerEvent instance.
-     *
-     * @var string
-     */
-    const PRE_DEPENDENCIES_SOLVING = 'pre-dependencies-solving';
-
-    /**
-     * The POST_DEPENDENCIES_SOLVING event occurs as a installer after
-     * resolve operations.
-     *
-     * The event listener method receives a
-     * Composer\Installer\InstallerEvent instance.
+     * The event listener method receives an Composer\Installer\InstallerEvent instance.
      *
      * @var string
      */
-    const POST_DEPENDENCIES_SOLVING = 'post-dependencies-solving';
+    const PRE_OPERATIONS_EXEC = 'pre-operations-exec';
 }

--- a/src/Composer/Plugin/PluginEvents.php
+++ b/src/Composer/Plugin/PluginEvents.php
@@ -58,4 +58,15 @@ class PluginEvents
      * @var string
      */
     const PRE_COMMAND_RUN = 'pre-command-run';
+
+    /**
+     * The PRE_POOL_CREATE event occurs before the Pool of packages is created, and lets
+     * you filter the list of packages which is going to enter the Solver
+     *
+     * The event listener method receives a
+     * Composer\Plugin\PrePoolCreateEvent instance.
+     *
+     * @var string
+     */
+    const PRE_POOL_CREATE = 'pre-pool-create';
 }

--- a/src/Composer/Plugin/PrePoolCreateEvent.php
+++ b/src/Composer/Plugin/PrePoolCreateEvent.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Plugin;
+
+use Composer\EventDispatcher\Event;
+use Symfony\Component\Console\Input\InputInterface;
+use Composer\Repository\RepositoryInterface;
+use Composer\DependencyResolver\Request;
+use Composer\Package\PackageInterface;
+
+/**
+ * The pre command run event.
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class PrePoolCreateEvent extends Event
+{
+    /**
+     * @var RepositoryInterface[]
+     */
+    private $repositories;
+    /**
+     * @var Request
+     */
+    private $request;
+    /**
+     * @var array
+     */
+    private $acceptableStabilities;
+    /**
+     * @var array
+     */
+    private $stabilityFlags;
+    /**
+     * @var array
+     */
+    private $rootAliases;
+    /**
+     * @var array
+     */
+    private $rootReferences;
+    /**
+     * @var PackageInterface[]
+     */
+    private $packages;
+    /**
+     * @var PackageInterface[]
+     */
+    private $unacceptableFixedPackages;
+
+    /**
+     * @param string                $name         The event name
+     * @param RepositoryInterface[] $repositories
+     */
+    public function __construct($name, array $repositories, Request $request, array $acceptableStabilities, array $stabilityFlags, array $rootAliases, array $rootReferences, array $packages, array $unacceptableFixedPackages)
+    {
+        parent::__construct($name);
+
+        $this->repositories = $repositories;
+        $this->request = $request;
+        $this->acceptableStabilities = $acceptableStabilities;
+        $this->stabilityFlags = $stabilityFlags;
+        $this->rootAliases = $rootAliases;
+        $this->rootReferences = $rootReferences;
+        $this->packages = $packages;
+        $this->unacceptableFixedPackages = $unacceptableFixedPackages;
+    }
+
+    /**
+     * @return RepositoryInterface[]
+     */
+    public function getRepositories()
+    {
+        return $this->repositories;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAcceptableStabilities()
+    {
+        return $this->acceptableStabilities;
+    }
+
+    /**
+     * @return array
+     */
+    public function getStabilityFlags()
+    {
+        return $this->stabilityFlags;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRootAliases()
+    {
+        return $this->rootAliases;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRootReferences()
+    {
+        return $this->rootReferences;
+    }
+
+    /**
+     * @return PackageInterface[]
+     */
+    public function getPackages()
+    {
+        return $this->packages;
+    }
+
+    /**
+     * @return PackageInterface[]
+     */
+    public function getUnacceptableFixedPackages()
+    {
+        return $this->unacceptableFixedPackages;
+    }
+
+    /**
+     * @param PackageInterface[] $packages
+     */
+    public function setPackages(array $packages)
+    {
+        $this->packages = $packages;
+    }
+
+    /**
+     * @param PackageInterface[] $packages
+     */
+    public function setUnacceptableFixedPackages(array $packages)
+    {
+        $this->unacceptableFixedPackages = $packages;
+    }
+}

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -15,6 +15,7 @@ namespace Composer\Repository;
 use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\PoolBuilder;
 use Composer\DependencyResolver\Request;
+use Composer\EventDispatcher\EventDispatcher;
 use Composer\Package\BasePackage;
 use Composer\Package\Version\VersionParser;
 use Composer\Repository\CompositeRepository;
@@ -188,9 +189,9 @@ class RepositorySet
      *
      * @return Pool
      */
-    public function createPool(Request $request)
+    public function createPool(Request $request, EventDispatcher $eventDispatcher = null)
     {
-        $poolBuilder = new PoolBuilder($this->acceptableStabilities, $this->stabilityFlags, $this->rootAliases, $this->rootReferences);
+        $poolBuilder = new PoolBuilder($this->acceptableStabilities, $this->stabilityFlags, $this->rootAliases, $this->rootReferences, $eventDispatcher);
 
         foreach ($this->repositories as $repo) {
             if ($repo instanceof InstalledRepositoryInterface && !$this->allowInstalledRepositories) {

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -567,11 +567,12 @@ class EventDispatcherTest extends TestCase
 
         $policy = $this->getMockBuilder('Composer\DependencyResolver\PolicyInterface')->getMock();
         $repositorySet = $this->getMockBuilder('Composer\Repository\RepositorySet')->disableOriginalConstructor()->getMock();
-        $installedRepo = $this->getMockBuilder('Composer\Repository\CompositeRepository')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder('Composer\DependencyResolver\Pool')->disableOriginalConstructor()->getMock();
+        $transaction = $this->getMockBuilder('Composer\DependencyResolver\LockTransaction')->disableOriginalConstructor()->getMock();
         $request = $this->getMockBuilder('Composer\DependencyResolver\Request')->disableOriginalConstructor()->getMock();
 
-        $dispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, true, $policy, $repositorySet, $installedRepo, $request);
-        $dispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, true, $policy, $repositorySet, $installedRepo, $request, array());
+        $dispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, true, $repositorySet, $pool, $request, $policy);
+        $dispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, true, $repositorySet, $pool, $request, $policy, $transaction);
     }
 
     public static function call()

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -565,14 +565,9 @@ class EventDispatcherTest extends TestCase
             ->method('getListeners')
             ->will($this->returnValue(array()));
 
-        $policy = $this->getMockBuilder('Composer\DependencyResolver\PolicyInterface')->getMock();
-        $repositorySet = $this->getMockBuilder('Composer\Repository\RepositorySet')->disableOriginalConstructor()->getMock();
-        $pool = $this->getMockBuilder('Composer\DependencyResolver\Pool')->disableOriginalConstructor()->getMock();
         $transaction = $this->getMockBuilder('Composer\DependencyResolver\LockTransaction')->disableOriginalConstructor()->getMock();
-        $request = $this->getMockBuilder('Composer\DependencyResolver\Request')->disableOriginalConstructor()->getMock();
 
-        $dispatcher->dispatchInstallerEvent(InstallerEvents::PRE_DEPENDENCIES_SOLVING, true, $repositorySet, $pool, $request, $policy);
-        $dispatcher->dispatchInstallerEvent(InstallerEvents::POST_DEPENDENCIES_SOLVING, true, $repositorySet, $pool, $request, $policy, $transaction);
+        $dispatcher->dispatchInstallerEvent(InstallerEvents::PRE_OPERATIONS_EXEC, true, true, $transaction);
     }
 
     public static function call()

--- a/tests/Composer/Test/Installer/InstallerEventTest.php
+++ b/tests/Composer/Test/Installer/InstallerEventTest.php
@@ -21,21 +21,14 @@ class InstallerEventTest extends TestCase
     {
         $composer = $this->getMockBuilder('Composer\Composer')->getMock();
         $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
-        $policy = $this->getMockBuilder('Composer\DependencyResolver\PolicyInterface')->getMock();
-        $repositorySet = $this->getMockBuilder('Composer\Repository\RepositorySet')->disableOriginalConstructor()->getMock();
-        $pool = $this->getMockBuilder('Composer\DependencyResolver\Pool')->disableOriginalConstructor()->getMock();
         $transaction = $this->getMockBuilder('Composer\DependencyResolver\LockTransaction')->disableOriginalConstructor()->getMock();
-        $request = $this->getMockBuilder('Composer\DependencyResolver\Request')->disableOriginalConstructor()->getMock();
-        $event = new InstallerEvent('EVENT_NAME', $composer, $io, true, $repositorySet, $pool, $request, $policy, $transaction);
+        $event = new InstallerEvent('EVENT_NAME', $composer, $io, true, true, $transaction);
 
         $this->assertSame('EVENT_NAME', $event->getName());
         $this->assertInstanceOf('Composer\Composer', $event->getComposer());
         $this->assertInstanceOf('Composer\IO\IOInterface', $event->getIO());
         $this->assertTrue($event->isDevMode());
-        $this->assertInstanceOf('Composer\DependencyResolver\PolicyInterface', $event->getPolicy());
-        $this->assertInstanceOf('Composer\Repository\RepositorySet', $event->getRepositorySet());
-        $this->assertInstanceOf('Composer\DependencyResolver\Pool', $event->getPool());
-        $this->assertInstanceOf('Composer\DependencyResolver\Request', $event->getRequest());
+        $this->assertTrue($event->isExecutingOperations());
         $this->assertInstanceOf('Composer\DependencyResolver\Transaction', $event->getTransaction());
     }
 }

--- a/tests/Composer/Test/Installer/InstallerEventTest.php
+++ b/tests/Composer/Test/Installer/InstallerEventTest.php
@@ -23,10 +23,10 @@ class InstallerEventTest extends TestCase
         $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $policy = $this->getMockBuilder('Composer\DependencyResolver\PolicyInterface')->getMock();
         $repositorySet = $this->getMockBuilder('Composer\Repository\RepositorySet')->disableOriginalConstructor()->getMock();
-        $localRepo = $this->getMockBuilder('Composer\Repository\CompositeRepository')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder('Composer\DependencyResolver\Pool')->disableOriginalConstructor()->getMock();
+        $transaction = $this->getMockBuilder('Composer\DependencyResolver\LockTransaction')->disableOriginalConstructor()->getMock();
         $request = $this->getMockBuilder('Composer\DependencyResolver\Request')->disableOriginalConstructor()->getMock();
-        $operations = array($this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock());
-        $event = new InstallerEvent('EVENT_NAME', $composer, $io, true, $policy, $repositorySet, $localRepo, $request, $operations);
+        $event = new InstallerEvent('EVENT_NAME', $composer, $io, true, $repositorySet, $pool, $request, $policy, $transaction);
 
         $this->assertSame('EVENT_NAME', $event->getName());
         $this->assertInstanceOf('Composer\Composer', $event->getComposer());
@@ -34,8 +34,8 @@ class InstallerEventTest extends TestCase
         $this->assertTrue($event->isDevMode());
         $this->assertInstanceOf('Composer\DependencyResolver\PolicyInterface', $event->getPolicy());
         $this->assertInstanceOf('Composer\Repository\RepositorySet', $event->getRepositorySet());
-        $this->assertInstanceOf('Composer\Repository\RepositoryInterface', $event->getLocalRepo());
+        $this->assertInstanceOf('Composer\DependencyResolver\Pool', $event->getPool());
         $this->assertInstanceOf('Composer\DependencyResolver\Request', $event->getRequest());
-        $this->assertCount(1, $event->getOperations());
+        $this->assertInstanceOf('Composer\DependencyResolver\Transaction', $event->getTransaction());
     }
 }


### PR DESCRIPTION
Fixes #8348 - possibly. 

@stof I am not sure what you meant there with: 

> To keep these optimization safe, the hook allowing to add or remove packages from the pool should run before them rather than after them.

I would tend to say the opposite, that our optimizations should run first then the plugins can filter what is left. That's what I implemented here but it's definitely up for discussion where the hook should happen.

Also looping in @nicolas-grekas 