### PR TITLE
Remove obsolete rules

### DIFF
--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -87,20 +87,20 @@ class Pool implements \Countable
      *                                            packages must match or null to return all
      * @return PackageInterface[]  A set of packages
      */
-    public function whatProvides($name, ConstraintInterface $constraint = null, $allowProvide = true)
+    public function whatProvides($name, ConstraintInterface $constraint = null)
     {
-        $key = ((int) $allowProvide).$constraint;
+        $key = (string) $constraint;
         if (isset($this->providerCache[$name][$key])) {
             return $this->providerCache[$name][$key];
         }
 
-        return $this->providerCache[$name][$key] = $this->computeWhatProvides($name, $constraint, $allowProvide);
+        return $this->providerCache[$name][$key] = $this->computeWhatProvides($name, $constraint);
     }
 
     /**
      * @see whatProvides
      */
-    private function computeWhatProvides($name, $constraint, $allowProvide = true)
+    private function computeWhatProvides($name, $constraint)
     {
         if (!isset($this->packageByName[$name])) {
             return array();
@@ -113,14 +113,9 @@ class Pool implements \Countable
                 case self::MATCH_NONE:
                     break;
 
-                case self::MATCH_PROVIDE:
-                    if ($allowProvide) {
-                        $matches[] = $candidate;
-                    }
-                    break;
-
                 case self::MATCH:
                 case self::MATCH_REPLACE:
+                case self::MATCH_PROVIDE:
                     $matches[] = $candidate;
                     break;
 

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -160,7 +160,7 @@ class RuleSetGenerator
             $this->addedMap[$package->id] = true;
 
             $this->addedPackages[] = $package;
-            foreach ($package->getNames() as $name) {
+            foreach ($package->getNames(false) as $name) {
                 $this->addedPackagesByNames[$name][] = $package;
             }
 
@@ -179,7 +179,7 @@ class RuleSetGenerator
             }
 
             $packageName = $package->getName();
-            $obsoleteProviders = $this->pool->whatProvides($packageName, null);
+            $obsoleteProviders = $this->pool->whatProvides($packageName, null, false);
 
             foreach ($obsoleteProviders as $provider) {
                 if ($provider === $package) {

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -89,14 +89,16 @@ abstract class BasePackage implements PackageInterface
     /**
      * {@inheritDoc}
      */
-    public function getNames()
+    public function getNames($provides = true)
     {
         $names = array(
             $this->getName() => true,
         );
 
-        foreach ($this->getProvides() as $link) {
-            $names[$link->getTarget()] = true;
+        if ($provides) {
+            foreach ($this->getProvides() as $link) {
+                $names[$link->getTarget()] = true;
+            }
         }
 
         foreach ($this->getReplaces() as $link) {

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -45,9 +45,11 @@ interface PackageInterface
      * No version or release type information should be included in any of the
      * names. Provided or replaced package names need to be returned as well.
      *
+     * @param bool $provides Whether provided names should be included
+     *
      * @return array An array of strings referring to this package
      */
-    public function getNames();
+    public function getNames($provides = true);
 
     /**
      * Allows the solver to set an id for this package to refer to it.

--- a/tests/Composer/Test/Fixtures/installer/provider-conflicts.test
+++ b/tests/Composer/Test/Fixtures/installer/provider-conflicts.test
@@ -42,7 +42,7 @@ Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
     - __root__ is present at version 1.2.3 and cannot be modified by Composer
-    - provider/pkg 1.0.0 cannot be installed as that would require removing __root__ 1.2.3. They both replace root-replaced/transitive-replaced and thus cannot coexist.
+    - provider/pkg[1.0.0] cannot be installed as that would require removing __root__[1.2.3]. They both replace root-replaced/transitive-replaced and thus cannot coexist.
     - Root composer.json requires provider/pkg * -> satisfiable by provider/pkg[1.0.0].
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/provider-conflicts2.test
+++ b/tests/Composer/Test/Fixtures/installer/provider-conflicts2.test
@@ -1,5 +1,5 @@
 --TEST--
-Test that names provided by two dependents cause a conflict
+Providers of a replaced name should be installable
 --COMPOSER--
 {
     "repositories": [
@@ -28,18 +28,6 @@ Test that names provided by two dependents cause a conflict
 --RUN--
 update
 
---EXPECT-EXIT-CODE--
-2
-
---EXPECT-OUTPUT--
-Loading composer repositories with package information
-Updating dependencies
-Your requirements could not be resolved to an installable set of packages.
-
-  Problem 1
-    - Root composer.json requires provider/pkg * -> satisfiable by provider/pkg[1.0.0].
-    - Only one of these can be installed: replacer/pkg 1.0.0, provider/pkg 1.0.0.
-    - Root composer.json requires replacer/pkg * -> satisfiable by replacer/pkg[1.0.0].
-
 --EXPECT--
-
+Installing provider/pkg (1.0.0)
+Installing replacer/pkg (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/update-allow-list-require-new-replace.test
+++ b/tests/Composer/Test/Fixtures/installer/update-allow-list-require-new-replace.test
@@ -48,7 +48,7 @@ Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
     - current/dep is locked to version 1.0.0 and an update of this package was not requested.
-    - new/pkg 1.0.0 cannot be installed as that would require removing current/dep 1.0.0. new/pkg replaces current/dep and thus cannot coexist with it.
+    - new/pkg[1.0.0] cannot be installed as that would require removing current/dep[1.0.0]. new/pkg replaces current/dep and thus cannot coexist with it.
     - Root composer.json requires new/pkg 1.* -> satisfiable by new/pkg[1.0.0].
 
 Use the option --with-all-dependencies to allow updates and removals for packages currently locked to specific versions.


### PR DESCRIPTION
Started out by implementing that a package providing a name should not conflict with a package replacing it. This PR does correct this behavior but it expanded in scope due to the way this was accomplished:

The only implicit conflict (not using the conflict keyword) we have now results from packages using the same name, either by literally having the same name and being different versions, or they replace the same name, so:
    
- removed all types of obsolete rules
- simplified rule generation significantly, since there are now only explicit conflicts or same name conflicts which use a single multi conflict rule per name
- removed match types from Pool as these are no longer used
- matching by name only is no longer available in whatsProvide because mustMatchName was unused
- fixed some language in error handling
    
The effect of this is a significant reduction in rule objects (mostly because of the consistent use of multi conflict rules #8424 for all conflicts now) and consequently memory use and performance.

For example for a contao project:

before
```
[59.8MiB/2.54s] Generating rules
[2041.8MiB/27.25s] Resolving dependencies through SAT
...
[2048.1MiB/36.74s] Dependency resolution completed in 9.492 seconds
[130.6MiB/37.84s] Analyzed 16073 packages to resolve dependencies
[130.6MiB/37.84s] Analyzed 4114091 rules to resolve dependencies
[130.6MiB/37.84s] Lock file operations: 162 installs, 0 updates, 0 removals
...
[77.8MiB/37.88s] Memory usage: 77.79MiB (peak: 2048.55MiB), time: 37.88s
```

After:
```
[58.8MiB/2.59s] Generating rules
[1028.8MiB/15.63s] Resolving dependencies through SAT
....
[1034.2MiB/20.30s] Dependency resolution completed in 4.669 seconds
[96.1MiB/20.67s] Analyzed 16073 packages to resolve dependencies
[96.1MiB/20.67s] Analyzed 1747077 rules to resolve dependencies
[96.2MiB/20.67s] Lock file operations: 162 installs, 0 updates, 0 removals
...
[45.8MiB/23.38s] Memory usage: 45.77MiB (peak: 1034.6MiB), time: 20.71s
```

So close to 50% in memory reduction and runtime reduction.