### PR TITLE
respect `notify-on-install` option

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -233,13 +233,13 @@ class Installer
                 return $res;
             }
         } catch (\Exception $e) {
-            if ($this->executeOperations) {
+            if ($this->executeOperations && $this->config->get('notify-on-install')) {
                 $this->installationManager->notifyInstalls($this->io);
             }
 
             throw $e;
         }
-        if ($this->executeOperations) {
+        if ($this->executeOperations && $this->config->get('notify-on-install')) {
             $this->installationManager->notifyInstalls($this->io);
         }
 


### PR DESCRIPTION
From what I see, this option was not working since 2012, when notification logic was moved from `ComposerRepository` to `InstallationManager`:
https://github.com/composer/composer/commit/a8f74a0983306306bfaac6c2d853bed15a3703f1#diff-faebd9b86332c29e1458dc470019a9eaL85-L87
https://github.com/composer/composer/commit/a8f74a0983306306bfaac6c2d853bed15a3703f1#diff-fd5a4cc2db7062747cf9410deb222310L222-R235

