### PR TITLE
use Symfony PHPUnit Bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,14 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
-    - php: 7.3
-      env: deps=high
     - php: nightly
-    - php: 7.4snapshot
+    - php: 7.4
+      env:
+        - deps=high
+        - SYMFONY_PHPUNIT_VERSION=7.5
   fast_finish: true
   allow_failures:
     - php: nightly
-    - php: 7.4snapshot
 
 before_install:
   # disable Xdebug if available
@@ -58,8 +58,9 @@ before_script:
   - git config --global user.email travis@example.com
 
 script:
+  - ./vendor/bin/simple-phpunit
   # run test suite directories in parallel using GNU parallel
-  - ls -d tests/Composer/Test/* | grep -v TestCase.php | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/complete.phpunit.xml --colors=always {} || (echo -e "\e[41mFAILED\e[0m {}" && exit 1);'
+#  - ls -d tests/Composer/Test/* | grep -v TestCase.php | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/complete.phpunit.xml --colors=always {} || (echo -e "\e[41mFAILED\e[0m {}" && exit 1);'
 
 before_deploy:
   - php -d phar.readonly=0 bin/compile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,4 +30,4 @@ install:
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - vendor\bin\phpunit --colors=always
+  - vendor\bin\simple-phpunit --colors=always

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "symfony/console": "2.8.38"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.7",
-        "phpunit/phpunit-mock-objects": "^2.3 || ^3.0"
+        "symfony/phpunit-bridge": "^4.2",
+        "phpspec/prophecy": "^1.10"
     },
     "suggest": {
         "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/console": "2.8.38"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.2",
+        "symfony/phpunit-bridge": "^3.4",
         "phpspec/prophecy": "^1.10"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffd75ce76e2044a19a68b4e363cf4308",
+    "content-hash": "c6641e77cf04ea9862bb529cf07b79e0",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -508,9 +508,6 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v2.8.52"
-            },
             "time": "2018-11-20T15:55:20+00:00"
         },
         {
@@ -618,9 +615,6 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v2.8.52"
-            },
             "time": "2018-11-11T11:18:13+00:00"
         },
         {
@@ -670,9 +664,6 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/finder/tree/v2.8.50"
-            },
             "time": "2018-11-11T11:18:13+00:00"
         },
         {
@@ -839,9 +830,6 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v2.8.50"
-            },
             "time": "2018-11-11T11:18:13+00:00"
         }
     ],
@@ -951,33 +939,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.9.0",
+            "version": "v1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -1010,384 +998,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-10-03T11:07:50+00:00"
-        },
-        {
-            "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
-            },
-            "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
-            },
-            "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-            "keywords": [
-                "coverage",
-                "testing",
-                "xunit"
-            ],
-            "time": "2015-10-06T15:47:00+00:00"
-        },
-        {
-            "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
-            "keywords": [
-                "filesystem",
-                "iterator"
-            ],
-            "time": "2017-11-27T13:52:08+00:00"
-        },
-        {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Simple template engine.",
-            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-            "keywords": [
-                "template"
-            ],
-            "time": "2015-06-21T13:50:34+00:00"
-        },
-        {
-            "name": "phpunit/php-timer",
-            "version": "1.0.9",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "time": "2017-02-26T11:10:40+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "time": "2017-12-04T08:55:13+00:00"
-        },
-        {
-            "name": "phpunit/phpunit",
-            "version": "4.8.36",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
-            },
-            "suggest": {
-                "phpunit/php-invoker": "~1.1"
-            },
-            "bin": [
-                "phpunit"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.8.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "https://phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
-            ],
-            "time": "2017-06-21T08:07:12+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2020-01-20T15:57:02+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1506,72 +1117,22 @@
             "time": "2017-05-22T07:24:03+00:00"
         },
         {
-            "name": "sebastian/environment",
-            "version": "1.3.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
-            "keywords": [
-                "Xdebug",
-                "environment",
-                "hhvm"
-            ],
-            "time": "2016-08-18T05:49:44+00:00"
-        },
-        {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -1580,7 +1141,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1620,71 +1181,20 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
-        },
-        {
-            "name": "sebastian/global-state",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.2"
-            },
-            "suggest": {
-                "ext-uopz": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
-            "keywords": [
-                "global state"
-            ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.5",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -1696,7 +1206,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1724,70 +1234,50 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03T07:41:43+00:00"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "symfony/phpunit-bridge",
+            "version": "v4.2.12",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "80f9ffa6afcc27c7b00e8b8446b1d5d48d94bae7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "shasum": ""
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
-            "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v2.8.52",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/02c1859112aa779d9ab394ae4f3381911d84052b",
-                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/80f9ffa6afcc27c7b00e8b8446b1d5d48d94bae7",
+                "reference": "80f9ffa6afcc27c7b00e8b8446b1d5d48d94bae7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9",
-                "symfony/polyfill-ctype": "~1.8"
+                "php": ">=5.3.3"
             },
-            "type": "library",
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "suggest": {
+                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "4.2-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
                 }
             },
             "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
                 "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
+                    "Symfony\\Bridge\\PhpUnit\\": ""
                 },
                 "exclude-from-classmap": [
                     "/Tests/"
@@ -1799,17 +1289,17 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Yaml Component",
+            "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T11:18:13+00:00"
+            "time": "2019-07-05T06:33:37+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6641e77cf04ea9862bb529cf07b79e0",
+    "content-hash": "cc6f9640996dfad00a5b03a8be01a571",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1238,16 +1238,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v4.2.12",
+            "version": "v3.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "80f9ffa6afcc27c7b00e8b8446b1d5d48d94bae7"
+                "reference": "ebfd1b428ffc14306e843092763f228bfba168d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/80f9ffa6afcc27c7b00e8b8446b1d5d48d94bae7",
-                "reference": "80f9ffa6afcc27c7b00e8b8446b1d5d48d94bae7",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/ebfd1b428ffc14306e843092763f228bfba168d0",
+                "reference": "ebfd1b428ffc14306e843092763f228bfba168d0",
                 "shasum": ""
             },
             "require": {
@@ -1265,7 +1265,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "3.4-dev"
                 },
                 "thanks": {
                     "name": "phpunit/phpunit",
@@ -1299,7 +1299,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2019-07-05T06:33:37+00:00"
+            "time": "2020-01-14T14:27:59+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,10 +8,14 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         strict="false"
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="tests/bootstrap.php"
 >
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+    </php>
     <testsuites>
         <testsuite name="Composer Test Suite">
             <directory>./tests/Composer/</directory>

--- a/tests/Composer/Test/ApplicationTest.php
+++ b/tests/Composer/Test/ApplicationTest.php
@@ -53,7 +53,7 @@ class ApplicationTest extends TestCase
 
         $index = 0;
         $outputMock->expects($this->at($index++))
-            ->method("writeError");
+            ->method("write");
 
         if (extension_loaded('xdebug')) {
             $outputMock->expects($this->at($index++))

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -351,10 +351,10 @@ class AutoloadGeneratorTest extends TestCase
         file_put_contents($this->workingDir.'/bar.php', '<?php class FilesBar {}');
 
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', false, 'TargetDir');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_target_dir.php', $this->vendorDir.'/autoload.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_real_target_dir.php', $this->vendorDir.'/composer/autoload_real.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_static_target_dir.php', $this->vendorDir.'/composer/autoload_static.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_files_target_dir.php', $this->vendorDir.'/composer/autoload_files.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_target_dir.php', $this->vendorDir.'/autoload.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_real_target_dir.php', $this->vendorDir.'/composer/autoload_real.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_static_target_dir.php', $this->vendorDir.'/composer/autoload_static.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_files_target_dir.php', $this->vendorDir.'/composer/autoload_files.php');
         $this->assertAutoloadFiles('classmap6', $this->vendorDir.'/composer', 'classmap');
     }
 
@@ -793,10 +793,10 @@ EOF;
         file_put_contents($this->workingDir.'/root.php', '<?php function testFilesAutoloadGenerationRoot() {}');
 
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', false, 'FilesAutoload');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_functions.php', $this->vendorDir.'/autoload.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_real_functions.php', $this->vendorDir.'/composer/autoload_real.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_static_functions.php', $this->vendorDir.'/composer/autoload_static.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_files_functions.php', $this->vendorDir.'/composer/autoload_files.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_functions.php', $this->vendorDir.'/autoload.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_real_functions.php', $this->vendorDir.'/composer/autoload_real.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_static_functions.php', $this->vendorDir.'/composer/autoload_static.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_files_functions.php', $this->vendorDir.'/composer/autoload_files.php');
 
         include $this->vendorDir . '/autoload.php';
         $this->assertTrue(function_exists('testFilesAutoloadGeneration1'));
@@ -861,22 +861,22 @@ EOF;
         file_put_contents($this->workingDir.'/root.php', '<?php function testFilesAutoloadGenerationRoot() {}');
 
         $this->generator->dump($this->config, $this->repository, $autoloadPackage, $this->im, 'composer', false, 'FilesAutoload');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_functions.php', $this->vendorDir.'/autoload.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_real_functions_with_include_paths.php', $this->vendorDir.'/composer/autoload_real.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_static_functions_with_include_paths.php', $this->vendorDir.'/composer/autoload_static.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_files_functions.php', $this->vendorDir.'/composer/autoload_files.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/include_paths_functions.php', $this->vendorDir.'/composer/include_paths.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_functions.php', $this->vendorDir.'/autoload.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_real_functions_with_include_paths.php', $this->vendorDir.'/composer/autoload_real.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_static_functions_with_include_paths.php', $this->vendorDir.'/composer/autoload_static.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_files_functions.php', $this->vendorDir.'/composer/autoload_files.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/include_paths_functions.php', $this->vendorDir.'/composer/include_paths.php');
 
         $this->generator->dump($this->config, $this->repository, $autoloadPackage, $this->im, 'composer', false, 'FilesAutoload');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_functions.php', $this->vendorDir.'/autoload.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_real_functions_with_include_paths.php', $this->vendorDir.'/composer/autoload_real.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_files_functions_with_removed_extra.php', $this->vendorDir.'/composer/autoload_files.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/include_paths_functions_with_removed_extra.php', $this->vendorDir.'/composer/include_paths.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_functions.php', $this->vendorDir.'/autoload.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_real_functions_with_include_paths.php', $this->vendorDir.'/composer/autoload_real.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_files_functions_with_removed_extra.php', $this->vendorDir.'/composer/autoload_files.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/include_paths_functions_with_removed_extra.php', $this->vendorDir.'/composer/include_paths.php');
 
         $this->generator->dump($this->config, $this->repository, $notAutoloadPackage, $this->im, 'composer', false, 'FilesAutoload');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_functions.php', $this->vendorDir.'/autoload.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php', $this->vendorDir.'/composer/autoload_real.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_static_functions_with_removed_include_paths_and_autolad_files.php', $this->vendorDir.'/composer/autoload_static.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_functions.php', $this->vendorDir.'/autoload.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php', $this->vendorDir.'/composer/autoload_real.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_static_functions_with_removed_include_paths_and_autolad_files.php', $this->vendorDir.'/composer/autoload_static.php');
         $this->assertFileNotExists($this->vendorDir.'/composer/autoload_files.php');
         $this->assertFileNotExists($this->vendorDir.'/composer/include_paths.php');
     }
@@ -930,9 +930,9 @@ EOF;
         file_put_contents($this->workingDir . '/root2.php', '<?php function testFilesAutoloadOrderByDependencyRoot() {}');
 
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', false, 'FilesAutoloadOrder');
-        $this->assertFileEquals(__DIR__ . '/Fixtures/autoload_functions_by_dependency.php', $this->vendorDir . '/autoload.php');
-        $this->assertFileEquals(__DIR__ . '/Fixtures/autoload_real_files_by_dependency.php', $this->vendorDir . '/composer/autoload_real.php');
-        $this->assertFileEquals(__DIR__ . '/Fixtures/autoload_static_files_by_dependency.php', $this->vendorDir . '/composer/autoload_static.php');
+        $this->assertFileContentEquals(__DIR__ . '/Fixtures/autoload_functions_by_dependency.php', $this->vendorDir . '/autoload.php');
+        $this->assertFileContentEquals(__DIR__ . '/Fixtures/autoload_real_files_by_dependency.php', $this->vendorDir . '/composer/autoload_real.php');
+        $this->assertFileContentEquals(__DIR__ . '/Fixtures/autoload_static_files_by_dependency.php', $this->vendorDir . '/composer/autoload_static.php');
 
         require $this->vendorDir . '/autoload.php';
 
@@ -1070,7 +1070,7 @@ EOF;
 
         $this->generator->dump($this->config, $this->repository, $package, $this->im, "composer", false, '_10');
 
-        $this->assertFileEquals(__DIR__.'/Fixtures/include_paths.php', $this->vendorDir.'/composer/include_paths.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/include_paths.php', $this->vendorDir.'/composer/include_paths.php');
         $this->assertEquals(
             array(
                 $this->vendorDir."/a/a/lib",
@@ -1198,8 +1198,8 @@ EOF;
         $this->fs->ensureDirectoryExists($this->vendorDir.'/a');
 
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', false, 'IncludePath');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_real_include_path.php', $this->vendorDir.'/composer/autoload_real.php');
-        $this->assertFileEquals(__DIR__.'/Fixtures/autoload_static_include_path.php', $this->vendorDir.'/composer/autoload_static.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_real_include_path.php', $this->vendorDir.'/composer/autoload_real.php');
+        $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_static_include_path.php', $this->vendorDir.'/composer/autoload_static.php');
     }
 
     public function testVendorDirExcludedFromWorkingDir()
@@ -1577,12 +1577,12 @@ EOF;
     {
         $a = __DIR__.'/Fixtures/autoload_'.$name.'.php';
         $b = $dir.'/autoload_'.$type.'.php';
-        $this->assertFileEquals($a, $b);
+        $this->assertFileContentEquals($a, $b);
     }
 
-    public static function assertFileEquals($expected, $actual, $message = '', $canonicalize = false, $ignoreCase = false)
+    public static function assertFileContentEquals($expected, $actual, $message = '', $canonicalize = false, $ignoreCase = false)
     {
-        return self::assertEquals(
+        self::assertEqualsNormalized(
             file_get_contents($expected),
             file_get_contents($actual),
             $message ?: $expected.' equals '.$actual,
@@ -1593,8 +1593,8 @@ EOF;
         );
     }
 
-    public static function assertEquals($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
+    public static function assertEqualsNormalized($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
     {
-        return parent::assertEquals(str_replace("\r", '', $expected), str_replace("\r", '', $actual), $message, $delta, $maxDepth, $canonicalize, $ignoreCase);
+        parent::assertEquals(str_replace("\r", '', $expected), str_replace("\r", '', $actual), $message, $delta, $maxDepth, $canonicalize, $ignoreCase);
     }
 }

--- a/tests/Composer/Test/Autoload/ClassLoaderTest.php
+++ b/tests/Composer/Test/Autoload/ClassLoaderTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Autoload;
 
 use Composer\Autoload\ClassLoader;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 /**
  * Tests the Composer\Autoload\ClassLoader class.

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -240,7 +240,7 @@ class ClassMapGeneratorTest extends TestCase
         $fs->removeDirectory($tempDir);
     }
 
-    protected function assertEqualsNormalized($expected, $actual, $message = null)
+    protected function assertEqualsNormalized($expected, $actual, $message = '')
     {
         foreach ($expected as $ns => $path) {
             $expected[$ns] = strtr($path, '\\', '/');

--- a/tests/Composer/Test/CacheTest.php
+++ b/tests/Composer/Test/CacheTest.php
@@ -105,11 +105,6 @@ class CacheTest extends TestCase
 
     public function testClearCache()
     {
-        $this->finder
-            ->method('removeDirectory')
-            ->with($this->root)
-            ->willReturn(true);
-
         $this->assertTrue($this->cache->clear());
 
         for ($i = 0; $i < 3; $i++) {

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -222,6 +222,7 @@ class ConfigTest extends TestCase
 
     /**
      * @dataProvider allowedUrlProvider
+     * @doesNotPerformAssertions
      *
      * @param string $url
      */

--- a/tests/Composer/Test/Console/HtmlOutputFormatterTest.php
+++ b/tests/Composer/Test/Console/HtmlOutputFormatterTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Console;
 
 use Composer\Console\HtmlOutputFormatter;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 
 class HtmlOutputFormatterTest extends TestCase

--- a/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php
@@ -17,7 +17,7 @@ use Composer\DependencyResolver\Rule;
 use Composer\DependencyResolver\RuleSet;
 use Composer\DependencyResolver\RuleSetIterator;
 use Composer\DependencyResolver\Pool;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class RuleSetIteratorTest extends TestCase
 {

--- a/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
@@ -12,7 +12,7 @@
 
 namespace Composer\Test\Downloader;
 
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class ArchiveDownloaderTest extends TestCase
 {

--- a/tests/Composer/Test/Downloader/DownloadManagerTest.php
+++ b/tests/Composer/Test/Downloader/DownloadManagerTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Downloader;
 
 use Composer\Downloader\DownloadManager;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class DownloadManagerTest extends TestCase
 {

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -208,7 +208,7 @@ class FileDownloaderTest extends TestCase
 
     public function testDowngradeShowsAppropriateMessage()
     {
-        $oldPackage = $this->getMock('Composer\Package\PackageInterface');
+        $oldPackage = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $oldPackage->expects($this->once())
             ->method('getFullPrettyVersion')
             ->will($this->returnValue('1.2.0'));
@@ -216,7 +216,7 @@ class FileDownloaderTest extends TestCase
             ->method('getVersion')
             ->will($this->returnValue('1.2.0.0'));
 
-        $newPackage = $this->getMock('Composer\Package\PackageInterface');
+        $newPackage = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $newPackage->expects($this->once())
             ->method('getFullPrettyVersion')
             ->will($this->returnValue('1.0.0'));
@@ -230,14 +230,14 @@ class FileDownloaderTest extends TestCase
             ->method('getDistUrls')
             ->will($this->returnValue(array($distUrl)));
 
-        $ioMock = $this->getMock('Composer\IO\IOInterface');
+        $ioMock = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $ioMock->expects($this->at(0))
             ->method('writeError')
             ->with($this->stringContains('Downgrading'));
 
         $path = $this->getUniqueTmpDirectory();
         touch($path.'/script.js');
-        $filesystem = $this->getMock('Composer\Util\Filesystem');
+        $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $filesystem->expects($this->once())
             ->method('removeDirectory')
             ->will($this->returnValue(true));

--- a/tests/Composer/Test/Downloader/FossilDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FossilDownloaderTest.php
@@ -153,7 +153,7 @@ class FossilDownloaderTest extends TestCase
             ->method('execute')
             ->with($this->equalTo($expectedResetCommand));
         $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
-        $filesystem->expects($this->any())
+        $filesystem->expects($this->once())
             ->method('removeDirectory')
             ->with($this->equalTo('composerPath'))
             ->will($this->returnValue(true));

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -712,7 +712,7 @@ composer https://github.com/old/url (push)
             ->with($this->equalTo($expectedGitResetCommand))
             ->will($this->returnValue(0));
         $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
-        $filesystem->expects($this->any())
+        $filesystem->expects($this->once())
             ->method('removeDirectory')
             ->with($this->equalTo('composerPath'))
             ->will($this->returnValue(true));

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -619,7 +619,7 @@ composer https://github.com/old/url (push)
 
     public function testDowngradeShowsAppropriateMessage()
     {
-        $oldPackage = $this->getMock('Composer\Package\PackageInterface');
+        $oldPackage = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $oldPackage->expects($this->any())
             ->method('getVersion')
             ->will($this->returnValue('1.2.0.0'));
@@ -633,7 +633,7 @@ composer https://github.com/old/url (push)
             ->method('getSourceUrls')
             ->will($this->returnValue(array('/foo/bar', 'https://github.com/composer/composer')));
 
-        $newPackage = $this->getMock('Composer\Package\PackageInterface');
+        $newPackage = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $newPackage->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
@@ -647,12 +647,12 @@ composer https://github.com/old/url (push)
             ->method('getFullPrettyVersion')
             ->will($this->returnValue('1.0.0'));
 
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->any())
             ->method('execute')
             ->will($this->returnValue(0));
 
-        $ioMock = $this->getMock('Composer\IO\IOInterface');
+        $ioMock = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $ioMock->expects($this->at(0))
             ->method('writeError')
             ->with($this->stringContains('Downgrading'));
@@ -664,7 +664,7 @@ composer https://github.com/old/url (push)
 
     public function testNotUsingDowngradingWithReferences()
     {
-        $oldPackage = $this->getMock('Composer\Package\PackageInterface');
+        $oldPackage = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $oldPackage->expects($this->any())
             ->method('getVersion')
             ->will($this->returnValue('dev-ref'));
@@ -675,7 +675,7 @@ composer https://github.com/old/url (push)
             ->method('getSourceUrls')
             ->will($this->returnValue(array('/foo/bar', 'https://github.com/composer/composer')));
 
-        $newPackage = $this->getMock('Composer\Package\PackageInterface');
+        $newPackage = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $newPackage->expects($this->any())
             ->method('getSourceReference')
             ->will($this->returnValue('ref'));
@@ -686,12 +686,12 @@ composer https://github.com/old/url (push)
             ->method('getVersion')
             ->will($this->returnValue('dev-ref2'));
 
-        $processExecutor = $this->getMock('Composer\Util\ProcessExecutor');
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
         $processExecutor->expects($this->any())
             ->method('execute')
             ->will($this->returnValue(0));
 
-        $ioMock = $this->getMock('Composer\IO\IOInterface');
+        $ioMock = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $ioMock->expects($this->at(0))
             ->method('writeError')
             ->with($this->stringContains('updating'));

--- a/tests/Composer/Test/Downloader/HgDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/HgDownloaderTest.php
@@ -142,7 +142,7 @@ class HgDownloaderTest extends TestCase
             ->method('execute')
             ->with($this->equalTo($expectedResetCommand));
         $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
-        $filesystem->expects($this->any())
+        $filesystem->expects($this->once())
             ->method('removeDirectory')
             ->with($this->equalTo('composerPath'))
             ->will($this->returnValue(true));

--- a/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
@@ -103,6 +103,9 @@ class PerforceDownloaderTest extends TestCase
         return $repository;
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testInitPerforceInstantiatesANewPerforceObject()
     {
         $this->downloader->initPerforce($this->package, $this->testPath, 'SOURCE_REF');

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -53,7 +53,7 @@ class EventDispatcherTest extends TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error_Deprecated
+     * @group legacy
      */
     public function testDispatcherCanConvertScriptEventToCommandEventForListener()
     {
@@ -62,6 +62,7 @@ class EventDispatcherTest extends TestCase
             'Composer\Test\EventDispatcher\EventDispatcherTest::expectsCommandEvent',
         ), $io);
 
+        $this->setExpectedException('PHPUnit\Framework\Error\Deprecated');
         $this->assertEquals(1, $dispatcher->dispatchScript(ScriptEvents::POST_INSTALL_CMD, false));
     }
 

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -16,7 +16,7 @@ use Composer\Installer\InstallationManager;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class InstallationManagerTest extends TestCase
 {

--- a/tests/Composer/Test/Installer/InstallerEventTest.php
+++ b/tests/Composer/Test/Installer/InstallerEventTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Installer;
 
 use Composer\Installer\InstallerEvent;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class InstallerEventTest extends TestCase
 {

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -35,7 +35,7 @@ class LibraryInstallerTest extends TestCase
         $this->fs = new Filesystem;
 
         $this->composer = new Composer();
-        $this->config = new Config();
+        $this->config = new Config(false);
         $this->composer->setConfig($this->config);
 
         $this->rootDir = $this->getUniqueTmpDirectory();

--- a/tests/Composer/Test/Installer/MetapackageInstallerTest.php
+++ b/tests/Composer/Test/Installer/MetapackageInstallerTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Installer;
 
 use Composer\Installer\MetapackageInstaller;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class MetapackageInstallerTest extends TestCase
 {

--- a/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
+++ b/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Installer;
 
 use Composer\Installer\SuggestedPackagesReporter;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 /**
  * @coversDefaultClass Composer\Installer\SuggestedPackagesReporter

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Json;
 
 use JsonSchema\Validator;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 /**
  * @author Rob Bast <rob.bast@gmail.com>

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -14,7 +14,7 @@ namespace Composer\Test\Json;
 
 use Seld\JsonLint\ParsingException;
 use Composer\Json\JsonFile;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class JsonFileTest extends TestCase
 {

--- a/tests/Composer/Test/Json/JsonFormatterTest.php
+++ b/tests/Composer/Test/Json/JsonFormatterTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Json;
 
 use Composer\Json\JsonFormatter;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class JsonFormatterTest extends TestCase
 {

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Json;
 
 use Composer\Json\JsonManipulator;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class JsonManipulatorTest extends TestCase
 {

--- a/tests/Composer/Test/Json/JsonValidationExceptionTest.php
+++ b/tests/Composer/Test/Json/JsonValidationExceptionTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Json;
 
 use Composer\Json\JsonValidationException;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class JsonValidationExceptionTest extends TestCase
 {

--- a/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
+++ b/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Package\Archiver;
 
 use Composer\Package\Archiver\GitExcludeFilter;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class GitExcludeFilterTest extends TestCase
 {

--- a/tests/Composer/Test/Package/Archiver/HgExcludeFilterTest.php
+++ b/tests/Composer/Test/Package/Archiver/HgExcludeFilterTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Package\Archiver;
 
 use Composer\Package\Archiver\HgExcludeFilter;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class HgExcludeFilterTest extends TestCase
 {

--- a/tests/Composer/Test/Package/BasePackageTest.php
+++ b/tests/Composer/Test/Package/BasePackageTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Package;
 
 use Composer\Package\BasePackage;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class BasePackageTest extends TestCase
 {

--- a/tests/Composer/Test/Package/BasePackageTest.php
+++ b/tests/Composer/Test/Package/BasePackageTest.php
@@ -17,6 +17,9 @@ use Composer\Test\TestCase;
 
 class BasePackageTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testSetSameRepository()
     {
         $package = $this->getMockForAbstractClass('Composer\Package\BasePackage', array('foo'));

--- a/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
+++ b/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
@@ -15,7 +15,7 @@ namespace Composer\Test\Package\Dumper;
 use Composer\Package\Dumper\ArrayDumper;
 use Composer\Package\Link;
 use Composer\Semver\Constraint\Constraint;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class ArrayDumperTest extends TestCase
 {

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -83,7 +83,7 @@ class ArrayLoaderTest extends TestCase
         $this->assertEquals('1.2.3.4', $package->getVersion());
     }
 
-    public function testParseDumpProvider()
+    public function parseDumpProvider()
     {
         $validConfig = array(
             'name' => 'A/B',
@@ -142,7 +142,7 @@ class ArrayLoaderTest extends TestCase
      * The default parser should default to loading the config as this
      * allows require-dev libraries to have transport options included.
      *
-     * @dataProvider testParseDumpProvider
+     * @dataProvider parseDumpProvider
      */
     public function testParseDumpDefaultLoadConfig($config)
     {
@@ -153,7 +153,7 @@ class ArrayLoaderTest extends TestCase
     }
 
     /**
-     * @dataProvider testParseDumpProvider
+     * @dataProvider parseDumpProvider
      */
     public function testParseDumpTrueLoadConfig($config)
     {
@@ -165,7 +165,7 @@ class ArrayLoaderTest extends TestCase
     }
 
     /**
-     * @dataProvider testParseDumpProvider
+     * @dataProvider parseDumpProvider
      */
     public function testParseDumpFalseLoadConfig($config)
     {

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -14,7 +14,7 @@ namespace Composer\Test\Package\Loader;
 
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\Dumper\ArrayDumper;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class ArrayLoaderTest extends TestCase
 {

--- a/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
@@ -17,7 +17,7 @@ use Composer\Package\Loader\RootPackageLoader;
 use Composer\Package\BasePackage;
 use Composer\Package\Version\VersionGuesser;
 use Composer\Semver\VersionParser;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 use Prophecy\Argument;
 
 class RootPackageLoaderTest extends TestCase

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -14,7 +14,7 @@ namespace Composer\Test\Package\Loader;
 
 use Composer\Package\Loader\ValidatingArrayLoader;
 use Composer\Package\Loader\InvalidPackageException;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class ValidatingArrayLoaderTest extends TestCase
 {

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -14,7 +14,7 @@ namespace Composer\Test\Package;
 
 use Composer\Package\Locker;
 use Composer\IO\NullIO;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class LockerTest extends TestCase
 {

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -15,7 +15,7 @@ namespace Composer\Test\Package\Version;
 use Composer\Config;
 use Composer\Package\Version\VersionGuesser;
 use Composer\Semver\VersionParser;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class VersionGuesserTest extends TestCase
 {

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Package\Version;
 
 use Composer\Package\Version\VersionParser;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class VersionParserTest extends TestCase
 {

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -16,7 +16,7 @@ use Composer\Package\Version\VersionSelector;
 use Composer\Package\Package;
 use Composer\Package\Link;
 use Composer\Semver\VersionParser;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class VersionSelectorTest extends TestCase
 {

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -102,7 +102,7 @@ class PluginInstallerTest extends TestCase
         $this->autoloadGenerator = new AutoloadGenerator($dispatcher);
 
         $this->composer = new Composer();
-        $config = new Config();
+        $config = new Config(false);
         $this->composer->setConfig($config);
         $this->composer->setDownloadManager($dm);
         $this->composer->setRepositoryManager($rm);

--- a/tests/Composer/Test/Question/StrictConfirmationQuestionTest.php
+++ b/tests/Composer/Test/Question/StrictConfirmationQuestionTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Question;
 
 use Composer\Question\StrictConfirmationQuestion;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArrayInput;

--- a/tests/Composer/Test/Repository/Pear/ChannelReaderTest.php
+++ b/tests/Composer/Test/Repository/Pear/ChannelReaderTest.php
@@ -62,8 +62,10 @@ class ChannelReaderTest extends TestCase
 
         $reader = new \Composer\Repository\Pear\ChannelReader($rfs);
 
-        $reader->read('http://pear.1.0.net/');
-        $reader->read('http://pear.1.1.net/');
+        $pear10 = $reader->read('http://pear.1.0.net/');
+        $this->assertCount(2, $pear10->getPackages());
+        $pear11 = $reader->read('http://pear.1.1.net/');
+        $this->assertCount(3, $pear11->getPackages());
     }
 
     public function testShouldCreatePackages()

--- a/tests/Composer/Test/Repository/RepositoryManagerTest.php
+++ b/tests/Composer/Test/Repository/RepositoryManagerTest.php
@@ -84,7 +84,7 @@ class RepositoryManagerTest extends TestCase
         $rm->setRepositoryClass('artifact', 'Composer\Repository\ArtifactRepository');
 
         $rm->createRepository('composer', array('url' => 'http://example.org'));
-        $rm->createRepository($type, $options);
+        $this->assertInstanceOf('Composer\Repository\RepositoryInterface', $rm->createRepository($type, $options));
     }
 
     public function creationCases()

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -239,6 +239,11 @@ class GitHubDriverTest extends TestCase
             ->with($this->equalTo('github.com'), $this->equalTo($composerJsonUrl), $this->equalTo(false))
             ->will($this->returnValue('{"encoding": "base64", "content": "' . base64_encode('{"name": "composer/packagist"}') . '"}'));
 
+        $remoteFilesystem->expects($this->at(2))
+            ->method('getContents')
+            ->with($this->equalTo('github.com'), $this->equalTo('https://api.github.com/repos/composer/packagist/commits/SOMESHA'), $this->equalTo(false))
+            ->will($this->returnValue('{"commit": {"committer":{ "date": "2012-09-10"}}}'));
+
         $repoConfig = array(
             'url' => $repoUrl,
         );

--- a/tests/Composer/Test/TestCase.php
+++ b/tests/Composer/Test/TestCase.php
@@ -105,4 +105,24 @@ abstract class TestCase extends BaseTestCase
             $this->markTestSkipped($executableName . ' is not found or not executable.');
         }
     }
+
+    /**
+     * @param string      $exception
+     * @param string|null $message
+     * @param int|null    $code
+     */
+    public function setExpectedException($exception, $message = null, $code = null)
+    {
+        if (!class_exists('PHPUnit\Framework\Error\Notice')) {
+            $exception = str_replace('PHPUnit\\Framework\\Error\\', 'PHPUnit_Framework_Error_', $exception);
+        }
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($exception);
+            if (null !== $message) {
+                $this->expectExceptionMessage($message);
+            }
+        } else {
+            parent::setExpectedException($exception, $message, $code);
+        }
+    }
 }

--- a/tests/Composer/Test/Util/BitbucketTest.php
+++ b/tests/Composer/Test/Util/BitbucketTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Bitbucket;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 /**
  * @author Paul Wenke <wenke.paul@gmail.com>

--- a/tests/Composer/Test/Util/ErrorHandlerTest.php
+++ b/tests/Composer/Test/Util/ErrorHandlerTest.php
@@ -20,14 +20,22 @@ use Composer\Test\TestCase;
  */
 class ErrorHandlerTest extends TestCase
 {
+    public function setUp()
+    {
+        ErrorHandler::register();
+    }
+
+    public function tearDown()
+    {
+        restore_error_handler();
+    }
+
     /**
      * Test ErrorHandler handles notices
      */
     public function testErrorHandlerCaptureNotice()
     {
         $this->setExpectedException('\ErrorException', 'Undefined index: baz');
-
-        ErrorHandler::register();
 
         $array = array('foo' => 'bar');
         $array['baz'];
@@ -40,18 +48,15 @@ class ErrorHandlerTest extends TestCase
     {
         $this->setExpectedException('\ErrorException', 'array_merge');
 
-        ErrorHandler::register();
-
         array_merge(array(), 'string');
     }
 
     /**
      * Test ErrorHandler handles warnings
+     * @doesNotPerformAssertions
      */
     public function testErrorHandlerRespectsAtOperator()
     {
-        ErrorHandler::register();
-
         @trigger_error('test', E_USER_NOTICE);
     }
 }

--- a/tests/Composer/Test/Util/GitHubTest.php
+++ b/tests/Composer/Test/Util/GitHubTest.php
@@ -14,7 +14,7 @@ namespace Composer\Test\Util;
 
 use Composer\Downloader\TransportException;
 use Composer\Util\GitHub;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 

--- a/tests/Composer/Test/Util/GitLabTest.php
+++ b/tests/Composer/Test/Util/GitLabTest.php
@@ -14,7 +14,7 @@ namespace Composer\Test\Util;
 
 use Composer\Downloader\TransportException;
 use Composer\Util\GitLab;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 /**
  * @author Jérôme Tamarelle <jerome@tamarelle.net>

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -7,7 +7,7 @@ use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
 use Composer\Util\Git;
 use Composer\Util\ProcessExecutor;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class GitTest extends TestCase
 {

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -102,6 +102,7 @@ class GitTest extends TestCase
         $this->mockConfig($protocol);
 
         $this->process
+            ->expects($this->atLeast(2))
             ->method('execute')
             ->willReturnMap(array(
                 array('git command failing', null, null, 1),
@@ -113,11 +114,13 @@ class GitTest extends TestCase
             ->willReturn(false);
 
         $this->io
+            ->expects($this->atLeastOnce())
             ->method('hasAuthentication')
             ->with($this->equalTo('github.com'))
             ->willReturn(true);
 
         $this->io
+            ->expects($this->atLeastOnce())
             ->method('getAuthentication')
             ->with($this->equalTo('github.com'))
             ->willReturn(array('username' => 'token', 'password' => $gitHubToken));

--- a/tests/Composer/Test/Util/IniHelperTest.php
+++ b/tests/Composer/Test/Util/IniHelperTest.php
@@ -14,7 +14,7 @@ namespace Composer\Test\Util;
 
 use Composer\Util\IniHelper;
 use Composer\XdebugHandler\XdebugHandler;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 /**
  * @author John Stevenson <john-stevenson@blueyonder.co.uk>

--- a/tests/Composer/Test/Util/NoProxyPatternTest.php
+++ b/tests/Composer/Test/Util/NoProxyPatternTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\NoProxyPattern;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class NoProxyPatternTest extends TestCase
 {

--- a/tests/Composer/Test/Util/PerforceTest.php
+++ b/tests/Composer/Test/Util/PerforceTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Perforce;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 use Composer\Util\ProcessExecutor;
 
 /**

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Platform;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 /**
  * PlatformTest

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -110,7 +110,7 @@ class ProcessExecutorTest extends TestCase
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
         $process = new ProcessExecutor(new ConsoleIO(new ArrayInput(array()), $output, new HelperSet(array())));
 
-        $process->execute('echo \'<error>foo</error>\'');
+        $process->execute('php -r "echo \'<error>foo</error>\'.PHP_EOL;"');
         $this->assertSame('<error>foo</error>'.PHP_EOL, $output->fetch());
     }
 }

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\RemoteFilesystem;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class RemoteFilesystemTest extends TestCase
 {
@@ -64,6 +64,12 @@ class RemoteFilesystemTest extends TestCase
             ->will($this->returnValue(true))
         ;
 
+        $io
+            ->expects($this->once())
+            ->method('getAuthentication')
+            ->will($this->returnValue(array('username' => null, 'password' => null)))
+        ;
+
         $streamOptions = array('ssl' => array(
             'allow_self_signed' => true,
         ));
@@ -79,6 +85,12 @@ class RemoteFilesystemTest extends TestCase
             ->expects($this->once())
             ->method('hasAuthentication')
             ->will($this->returnValue(true))
+        ;
+
+        $io
+            ->expects($this->once())
+            ->method('getAuthentication')
+            ->will($this->returnValue(array('username' => null, 'password' => null)))
         ;
 
         $streamOptions = array('http' => array(

--- a/tests/Composer/Test/Util/SilencerTest.php
+++ b/tests/Composer/Test/Util/SilencerTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Silencer;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 /**
  * SilencerTest

--- a/tests/Composer/Test/Util/StreamContextFactoryTest.php
+++ b/tests/Composer/Test/Util/StreamContextFactoryTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\StreamContextFactory;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class StreamContextFactoryTest extends TestCase
 {

--- a/tests/Composer/Test/Util/SvnTest.php
+++ b/tests/Composer/Test/Util/SvnTest.php
@@ -16,7 +16,7 @@ use Composer\Config;
 use Composer\IO\NullIO;
 use Composer\Util\Platform;
 use Composer\Util\Svn;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class SvnTest extends TestCase
 {

--- a/tests/Composer/Test/Util/TlsHelperTest.php
+++ b/tests/Composer/Test/Util/TlsHelperTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\TlsHelper;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 class TlsHelperTest extends TestCase
 {

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Url;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 use Composer\Config;
 
 class UrlTest extends TestCase

--- a/tests/Composer/Test/Util/ZipTest.php
+++ b/tests/Composer/Test/Util/ZipTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Util;
 
 use Composer\Util\Zip;
-use PHPUnit\Framework\TestCase;
+use Composer\Test\TestCase;
 
 /**
  * @author Andreas Schempp <andreas.schempp@terminal42.ch>


### PR DESCRIPTION
This PR makes use of Symfony PHPUnit Bridge to test against multiple versions of PHPUnit.
`setExpectedException()` has been added to `\Composer\Test\TestCase` to provide compatibility with all versions. Please make sure to always extend this base test class.

- [x] Use Symfony PHPUnit Bridge
- [x] Run tests on PHP 7.4
- [x] Fix PHP 7.4 test issues (`Trying to access array offset on value of type null`)
- [x] Fix risky tests
- [x] Fix Windows build (using php `echo` instead of system one)

Note that tests are no longer run in parallel but it doesn't really affect performance.