### PR TITLE
rename signature to checksum

### DIFF
--- a/doc/faqs/how-to-install-composer-programmatically.md
+++ b/doc/faqs/how-to-install-composer-programmatically.md
@@ -1,7 +1,7 @@
 # How do I install Composer programmatically?
 
 As noted on the download page, the installer script contains a
-signature which changes when the installer code changes and as such
+checksum which changes when the installer code changes and as such
 it should not be relied upon in the long term.
 
 An alternative is to use this script which only works with UNIX utilities:
@@ -9,13 +9,13 @@ An alternative is to use this script which only works with UNIX utilities:
 ```bash
 #!/bin/sh
 
-EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
+EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
 
-if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
 then
-    >&2 echo 'ERROR: Invalid installer signature'
+    >&2 echo 'ERROR: Invalid installer checksum'
     rm composer-setup.php
     exit 1
 fi


### PR DESCRIPTION
Sha-384 is a hash algorithm which can be used as checksum, but it's no digital signature.