### PR TITLE
Distinguish between updates and downgrades in dry-run

### DIFF
--- a/src/Composer/DependencyResolver/Operation/UpdateOperation.php
+++ b/src/Composer/DependencyResolver/Operation/UpdateOperation.php
@@ -13,6 +13,7 @@
 namespace Composer\DependencyResolver\Operation;
 
 use Composer\Package\PackageInterface;
+use Composer\Package\Version\VersionParser;
 
 /**
  * Solver update operation.
@@ -74,7 +75,9 @@ class UpdateOperation extends SolverOperation
      */
     public function __toString()
     {
-        return 'Updating '.$this->initialPackage->getPrettyName().' ('.$this->formatVersion($this->initialPackage).') to '.
+        $actionName = VersionParser::isUpgrade($this->initialPackage->getVersion(), $this->targetPackage->getVersion()) ? 'Updating' : 'Downgrading';
+
+        return $actionName.' '.$this->initialPackage->getPrettyName().' ('.$this->formatVersion($this->initialPackage).') to '.
             $this->targetPackage->getPrettyName(). ' ('.$this->formatVersion($this->targetPackage).')';
     }
 }

--- a/tests/Composer/Test/Fixtures/installer/partial-update-downgrades-non-whitelisted-unstable.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-downgrades-non-whitelisted-unstable.test
@@ -66,6 +66,6 @@ update c/uptodate
     "platform-dev": []
 }
 --EXPECT--
-Updating b/unstable (1.1.0-alpha) to b/unstable (1.0.0)
+Downgrading b/unstable (1.1.0-alpha) to b/unstable (1.0.0)
 Updating a/old (0.9.0) to a/old (1.0.0)
 Installing d/removed (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/partial-update-from-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-from-lock.test
@@ -74,8 +74,8 @@ update b/unstable
     "platform-dev": []
 }
 --EXPECT--
-Updating b/unstable (1.1.0-alpha) to b/unstable (1.0.0)
+Downgrading b/unstable (1.1.0-alpha) to b/unstable (1.0.0)
 Updating a/old (0.9.0) to a/old (1.0.0)
-Updating c/uptodate (2.0.0) to c/uptodate (1.0.0)
+Downgrading c/uptodate (2.0.0) to c/uptodate (1.0.0)
 Installing d/removed (1.0.0)
 Installing e/newreq (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/partial-update-without-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-without-lock.test
@@ -48,4 +48,4 @@ update b/unstable
     "platform-dev": []
 }
 --EXPECT--
-Updating b/unstable (1.1.0-alpha) to b/unstable (1.0.0)
+Downgrading b/unstable (1.1.0-alpha) to b/unstable (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/update-downgrades-unstable-packages.test
+++ b/tests/Composer/Test/Fixtures/installer/update-downgrades-unstable-packages.test
@@ -46,4 +46,4 @@ Downgrading from unstable to more stable package should work even if already ins
 --RUN--
 update
 --EXPECT--
-Updating a/a (dev-master abcd) to a/a (1.0.0)
+Downgrading a/a (dev-master abcd) to a/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/update-prefer-lowest-stable.test
+++ b/tests/Composer/Test/Fixtures/installer/update-prefer-lowest-stable.test
@@ -37,4 +37,4 @@ Updates packages to their lowest stable version
 update --prefer-lowest --prefer-stable
 --EXPECT--
 Updating a/a (1.0.0-rc1) to a/a (1.0.1)
-Updating a/b (1.0.1) to a/b (1.0.0)
+Downgrading a/b (1.0.1) to a/b (1.0.0)


### PR DESCRIPTION
Currently, running `composer install --dry-run` produces different output than `composer install` when some of packages will be downgraded:

```
$ composer u --dry-run                           
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating composer/ca-bundle (1.2.6) to composer/ca-bundle (1.0.0)

$ composer u
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downgrading composer/ca-bundle (1.2.6 => 1.0.0): Loading from cache
Writing lock file
Generating autoload files
```

I usually use `--dry-run` switch to see which operations will be executed on a feature branch I am working on and `Upgrading` may be misleading for `1.2.6 -> 1.0.0` transition.

This logic is repeated in `VcsDownloader` and `FileDownloader` so it might be worth to move it somewhere else in the future.