### PR TITLE
Fix risky test

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         failOnRisky="true"
          strict="false"
          processIsolation="false"
          stopOnFailure="false"

--- a/tests/Composer/Test/Command/ArchiveCommandTest.php
+++ b/tests/Composer/Test/Command/ArchiveCommandTest.php
@@ -57,7 +57,7 @@ class ArchiveCommandTest extends TestCase
                 'isInteractive',
                 'getComposer',
             ))->getMock();
-        $command->expects($this->any())->method('getComposer')
+        $command->expects($this->atLeastOnce())->method('getComposer')
             ->willReturn($composer);
         $command->method('isInteractive')->willReturn(false);
 
@@ -70,25 +70,7 @@ class ArchiveCommandTest extends TestCase
 
         $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
             ->getMock();
-
-        $ed = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
-            ->disableOriginalConstructor()->getMock();
-
-        $composer = new Composer;
         $config = Factory::createConfig();
-
-        $manager = $this->getMockBuilder('Composer\Package\Archiver\ArchiveManager')
-            ->disableOriginalConstructor()->getMock();
-
-        $factory = $this->getMockBuilder('Composer\Factory')->getMock();
-        $factory->method('createArchiveManager')->willReturn($manager);
-
-        $package = $this->getMockBuilder('Composer\Package\RootPackageInterface')
-            ->getMock();
-
-        $composer->setArchiveManager($manager);
-        $composer->setEventDispatcher($ed);
-        $composer->setPackage($package);
 
         $command = $this->getMockBuilder('Composer\Command\ArchiveCommand')
             ->setMethods(array(
@@ -100,11 +82,11 @@ class ArchiveCommandTest extends TestCase
                 'getComposer',
                 'archive',
             ))->getMock();
-        $command->expects($this->any())->method('getComposer')
-            ->willReturnOnConsecutiveCalls(null, $composer);
-        $command->expects($this->any())->method('archive')
+        $command->expects($this->once())->method('getComposer')
+            ->willReturn(null);
+        $command->expects($this->once())->method('archive')
             ->with(
-                $this->isType('object'),
+                $this->isInstanceOf('Composer\IO\IOInterface'),
                 $config,
                 null,
                 null,


### PR DESCRIPTION
#8562 introduced a risky test `ArchiveCommandTest::testUsesConfigFromFactoryWhenComposerIsNotDefined()` which did not make sure that the method is really called and contained some unused test code. 
PHPUnit config has been updated to prevent such tests to pass but it will only fail on v5.7 and up because PHPUnit 4.8 does not support `failOnRisky` directive.