### PR TITLE
Added `autoloader-dir` parameter to `dump-autoload` command

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -29,6 +29,8 @@ use Composer\Util\PackageSorter;
  */
 class AutoloadGenerator
 {
+    public const DEFAULT_AUTOLOADER_NAME = 'composer';
+
     /**
      * @var EventDispatcher
      */

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -29,7 +29,7 @@ use Composer\Util\PackageSorter;
  */
 class AutoloadGenerator
 {
-    public const DEFAULT_AUTOLOADER_NAME = 'composer';
+    const DEFAULT_AUTOLOADER_NAME = 'composer';
 
     /**
      * @var EventDispatcher

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -103,7 +103,7 @@ class AutoloadGenerator
         $this->runScripts = (bool) $runScripts;
     }
 
-    public function dump(Config $config, InstalledRepositoryInterface $localRepo, PackageInterface $mainPackage, InstallationManager $installationManager, $targetDir, $scanPsr0Packages = false, $suffix = '')
+    public function dump(Config $config, InstalledRepositoryInterface $localRepo, PackageInterface $mainPackage, InstallationManager $installationManager, $autoloaderDir, $scanPsr0Packages = false, $suffix = '')
     {
         if ($this->classMapAuthoritative) {
             // Force scanPsr0Packages when classmap is authoritative
@@ -124,7 +124,7 @@ class AutoloadGenerator
         $vendorPath = $filesystem->normalizePath(realpath(realpath($config->get('vendor-dir'))));
         $useGlobalIncludePath = (bool) $config->get('use-include-path');
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
-        $targetDir = $vendorPath.'/'.$targetDir;
+        $targetDir = $vendorPath.'/'.$autoloaderDir;
         $filesystem->ensureDirectoryExists($targetDir);
 
         $vendorPathCode = $filesystem->findShortestPathCode(realpath($targetDir), $vendorPath, true);
@@ -303,7 +303,11 @@ EOF;
             unlink($includeFilesFilePath);
         }
         $this->filePutContentsIfModified($targetDir.'/autoload_static.php', $this->getStaticFile($suffix, $targetDir, $vendorPath, $basePath, $staticPhpVersion));
-        $this->filePutContentsIfModified($vendorPath.'/autoload.php', $this->getAutoloadFile($vendorPathToTargetDirCode, $suffix));
+        if ($autoloaderDir === self::DEFAULT_AUTOLOADER_NAME) {
+            $this->filePutContentsIfModified($vendorPath.'/autoload.php', $this->getAutoloadFile($vendorPathToTargetDirCode, $suffix));
+        } else {
+            $this->filePutContentsIfModified($vendorPath.'/'. $autoloaderDir .'.php', $this->getAutoloadFile($vendorPathToTargetDirCode, $suffix));
+        }
         $this->filePutContentsIfModified($targetDir.'/autoload_real.php', $this->getAutoloadRealFile(true, (bool) $includePathFileContents, $targetDirLoader, (bool) $includeFilesFileContents, $vendorPathCode, $appBaseDirCode, $suffix, $useGlobalIncludePath, $prependAutoloader, $staticPhpVersion));
 
         $this->safeCopy(__DIR__.'/ClassLoader.php', $targetDir.'/ClassLoader.php');

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -35,6 +35,7 @@ class DumpAutoloadCommand extends BaseCommand
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.'),
                 new InputOption('apcu', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables autoload-dev rules.'),
+                new InputOption('autoloader-dir', null, InputOption::VALUE_OPTIONAL, 'Directory for the autoload classes.', 'composer'),
             ))
             ->setHelp(
                 <<<EOT
@@ -75,7 +76,7 @@ EOT
         $generator->setClassMapAuthoritative($authoritative);
         $generator->setApcu($apcu);
         $generator->setRunScripts(!$input->getOption('no-scripts'));
-        $numberOfClasses = $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
+        $numberOfClasses = $generator->dump($config, $localRepo, $package, $installationManager, $input->getOption('autoloader-dir'), $optimize);
 
         if ($authoritative) {
             $this->getIO()->write('<info>Generated optimized autoload files (authoritative) containing '. $numberOfClasses .' classes</info>');

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Command;
 
+use Composer\Autoload\AutoloadGenerator;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,7 +36,7 @@ class DumpAutoloadCommand extends BaseCommand
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.'),
                 new InputOption('apcu', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables autoload-dev rules.'),
-                new InputOption('autoloader-dir', null, InputOption::VALUE_OPTIONAL, 'Directory for the autoload classes.', 'composer'),
+                new InputOption('autoloader-dir', null, InputOption::VALUE_OPTIONAL, 'Directory for the autoload classes.', AutoloadGenerator::DEFAULT_AUTOLOADER_NAME),
             ))
             ->setHelp(
                 <<<EOT


### PR DESCRIPTION
I need several autoloaders because I am in a classical monorepo setup which contains several applications. the whole monorepo contains just a single composer.json.

I want composer to build a separate autoloader per application. this is something I will implent via a composer plugin (paths per app will be configured via composer.json `extra` attribute).
therefore I need to define a different class-loader name to make sure composer will not override all the files over and over again.


the use-case of this change was discussed in detail in https://github.com/composer/composer/issues/8648