### PR TITLE
resolve `$baseDir` in ambigious class resolution error

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -326,7 +326,6 @@ EOF;
         return 0;
     }
 
-
     private function addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist = null, $namespaceFilter = null, $autoloadType = null, array $classMap = array())
     {
         foreach ($this->generateClassMap($dir, $blacklist, $namespaceFilter, $autoloadType) as $class => $path) {

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -326,6 +326,7 @@ EOF;
         return 0;
     }
 
+
     private function addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist = null, $namespaceFilter = null, $autoloadType = null, array $classMap = array())
     {
         foreach ($this->generateClassMap($dir, $blacklist, $namespaceFilter, $autoloadType) as $class => $path) {
@@ -334,8 +335,8 @@ EOF;
                 $classMap[$class] = $pathCode;
             } elseif ($this->io && $classMap[$class] !== $pathCode && !preg_match('{/(test|fixture|example|stub)s?/}i', strtr($classMap[$class].' '.$path, '\\', '/'))) {
                 $this->io->writeError(
-                    '<warning>Warning: Ambiguous class resolution, "'.$class.'"'.
-                    ' was found in both "'.str_replace(array('$vendorDir . \'', "',\n"), array($vendorPath, ''), $classMap[$class]).'" and "'.$path.'", the first will be used.</warning>'
+                    '<warning>Warning: Ambiguous class resolution, "'.$class.'"'. $classMap[$class].
+                    ' was found in both "'.str_replace(array('$vendorDir . \'', '$baseDir . \'', "',\n"), array($vendorPath, $basePath, ''), $classMap[$class]).'" and "'.$path.'", the first will be used.</warning>'
                 );
             }
         }

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -335,7 +335,7 @@ EOF;
                 $classMap[$class] = $pathCode;
             } elseif ($this->io && $classMap[$class] !== $pathCode && !preg_match('{/(test|fixture|example|stub)s?/}i', strtr($classMap[$class].' '.$path, '\\', '/'))) {
                 $this->io->writeError(
-                    '<warning>Warning: Ambiguous class resolution, "'.$class.'"'. $classMap[$class].
+                    '<warning>Warning: Ambiguous class resolution, "'.$class.'"'.
                     ' was found in both "'.str_replace(array('$vendorDir . \'', '$baseDir . \'', "',\n"), array($vendorPath, $basePath, ''), $classMap[$class]).'" and "'.$path.'", the first will be used.</warning>'
                 );
             }


### PR DESCRIPTION
closes https://github.com/composer/composer/issues/8650

before this change
```
Warning: Ambiguous class resolution, "Composer\Util\Zip",
 was found in both "$baseDir . '/src/Composer/Util/Zip.php" and "C:/dvl/Zend/DefaultWorkspace13/composer/src2/Composer/Util/Zip.php", the first will be used.
```

after this change
```
Warning: Ambiguous class resolution, "Composer\Util\Zip",
 was found in both "C:/dvl/Zend/DefaultWorkspace13/composer/src/Composer/Util/Zip.php" and "C:/dvl/Zend/DefaultWorkspace13/composer/src2/Composer/Util/Zip.php", the first will be used.
```

`$baseDir` is getting resolved within the paths of the error message.