### PR TITLE
report ambiguous classes across all classmaps

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -267,13 +267,12 @@ EOF;
             $classMap = $this->addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist, null, null, $classMap, $ambiguousClasses);
         }
 
-        foreach($ambiguousClasses as $className => $ambigiousPaths)
-        {
+        foreach ($ambiguousClasses as $className => $ambigiousPaths) {
             $cleanPath = str_replace(array('$vendorDir . \'', "',\n"), array($vendorPath, ''), $classMap[$className]);
 
             $this->io->writeError(
                 '<warning>Warning: Ambiguous class resolution, "'.$className.'"'.
-                ' was found '. (count($ambigiousPaths)+1) .'x: in "'.$cleanPath.'" and "'. implode('", "', $ambigiousPaths) .'", the first will be used.</warning>'
+                ' was found '. (count($ambigiousPaths) + 1) .'x: in "'.$cleanPath.'" and "'. implode('", "', $ambigiousPaths) .'", the first will be used.</warning>'
             );
         }
 
@@ -401,8 +400,8 @@ EOF;
     /**
      * Compiles an ordered list of namespace => path mappings
      *
-     * @param  array            $packageMap  array of array(package, installDir-relative-to-composer.json)
-     * @param  PackageInterface $mainPackage root package instance
+     * @param  array            $packageMap                  array of array(package, installDir-relative-to-composer.json)
+     * @param  PackageInterface $mainPackage                 root package instance
      * @param  bool             $filterOutRequireDevPackages whether to filter out require-dev packages
      * @return array            array('psr-0' => array('Ns\\Foo' => array('installDir')))
      */

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -344,9 +344,6 @@ EOF;
             if (!isset($classMap[$class])) {
                 $classMap[$class] = $pathCode;
             } elseif ($this->io && $classMap[$class] !== $pathCode && !preg_match('{/(test|fixture|example|stub)s?/}i', strtr($classMap[$class].' '.$path, '\\', '/'))) {
-                if (!isset($ambiguousClasses[$class])) {
-                    $ambiguousClasses[$class] = array();
-                }
                 $ambiguousClasses[$class][] = $path;
             }
         }

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -268,7 +268,7 @@ EOF;
         }
 
         foreach ($ambiguousClasses as $className => $ambigiousPaths) {
-            $cleanPath = str_replace(array('$vendorDir . \'', "',\n"), array($vendorPath, ''), $classMap[$className]);
+            $cleanPath = str_replace(array('$vendorDir . \'', '$baseDir . \'', "',\n"), array($vendorPath, $basePath, ''), $classMap[$className]);
 
             $this->io->writeError(
                 '<warning>Warning: Ambiguous class resolution, "'.$className.'"'.

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -236,7 +236,7 @@ EOF;
 
         // flatten array
         $classMap = array();
-        $ambigiousClasses = array();
+        $ambiguousClasses = array();
         if ($scanPsr0Packages) {
             $namespacesToScan = array();
 
@@ -257,17 +257,17 @@ EOF;
                             continue;
                         }
 
-                        $classMap = $this->addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist, $namespace, $group['type'], $classMap, $ambigiousClasses);
+                        $classMap = $this->addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist, $namespace, $group['type'], $classMap, $ambiguousClasses);
                     }
                 }
             }
         }
 
         foreach ($autoloads['classmap'] as $dir) {
-            $classMap = $this->addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist, null, null, $classMap, $ambigiousClasses);
+            $classMap = $this->addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist, null, null, $classMap, $ambiguousClasses);
         }
 
-        foreach($ambigiousClasses as $className => $ambigiousPaths)
+        foreach($ambiguousClasses as $className => $ambigiousPaths)
         {
             $cleanPath = str_replace(array('$vendorDir . \'', "',\n"), array($vendorPath, ''), $classMap[$className]);
 
@@ -337,17 +337,17 @@ EOF;
         return 0;
     }
 
-    private function addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist = null, $namespaceFilter = null, $autoloadType = null, array $classMap, array &$ambigiousClasses)
+    private function addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist = null, $namespaceFilter = null, $autoloadType = null, array $classMap, array &$ambiguousClasses)
     {
         foreach ($this->generateClassMap($dir, $blacklist, $namespaceFilter, $autoloadType) as $class => $path) {
             $pathCode = $this->getPathCode($filesystem, $basePath, $vendorPath, $path).",\n";
             if (!isset($classMap[$class])) {
                 $classMap[$class] = $pathCode;
             } elseif ($this->io && $classMap[$class] !== $pathCode && !preg_match('{/(test|fixture|example|stub)s?/}i', strtr($classMap[$class].' '.$path, '\\', '/'))) {
-                if (!isset($ambigiousClasses[$class])) {
-                    $ambigiousClasses[$class] = array();
+                if (!isset($ambiguousClasses[$class])) {
+                    $ambiguousClasses[$class] = array();
                 }
-                $ambigiousClasses[$class][] = $path;
+                $ambiguousClasses[$class][] = $path;
             }
         }
 


### PR DESCRIPTION
when composer builds classmaps those are either build from the `classmap` key in `composer.json` or in `classMapAuthoritative`-mode for psr-0/4 classes.

see https://github.com/composer/composer/blob/f154d5c09d69a6338d6a955bf51cc264d0448b3d/src/Composer/Autoload/AutoloadGenerator.php#L237-L267

before this PR composer did only check whether the classes are ambiguous within either the defined classmap or the psr-0/4 namespaces.
It did not check whether classes defined via classmap are ambiguous with class from the psr-0/4 autoloading or vice versa.

with this PR we collect all `ambigiousClasses` across `addClassMapCode` call-sites and report the classes afterwards.
with this change classes will also be detected which happen more then 2 times, therefore the error message was adjusted.


without this change:
```
$ php bin/composer dump-autoload -vv
Generating autoload files
Warning: Ambiguous class resolution, "Composer\Autoload\AutoloadGenerator" was found in both "$baseDir . '/src2/Composer/Autoload/AutoloadGenerator.php" and "C:/dvl/Zend/DefaultWorkspace13/composer/src3/Compose
r/Autoload/AutoloadGenerator.php", the first will be used.
Warning: Ambiguous class resolution, "Composer\Autoload\ClassLoader" was found in both "$baseDir . '/src2/Composer/Autoload/ClassLoader.php" and "C:/dvl/Zend/DefaultWorkspace13/composer/src3/Composer/Autoload/C
lassLoader.php", the first will be used.
Warning: Ambiguous class resolution, "Composer\Autoload\ClassMapGenerator" was found in both "$baseDir . '/src2/Composer/Autoload/ClassMapGenerator.php" and "C:/dvl/Zend/DefaultWorkspace13/composer/src3/Compose
r/Autoload/ClassMapGenerator.php", the first will be used.
```

after the patch applied:
```
$ php bin/composer dump-autoload -vv
Generating autoload files
Warning: Ambiguous class resolution, "Composer\Autoload\AutoloadGenerator" was found 3x in "$baseDir . '/src/Composer/Autoload/AutoloadGenerator.php" and "C:/dvl/Zend/DefaultWorkspace13/composer/src2/Composer/A
utoload/AutoloadGenerator.php", "C:/dvl/Zend/DefaultWorkspace13/composer/src3/Composer/Autoload/AutoloadGenerator.php", the first will be used.
Warning: Ambiguous class resolution, "Composer\Autoload\ClassLoader" was found 3x in "$baseDir . '/src/Composer/Autoload/ClassLoader.php" and "C:/dvl/Zend/DefaultWorkspace13/composer/src2/Composer/Autoload/Clas
sLoader.php", "C:/dvl/Zend/DefaultWorkspace13/composer/src3/Composer/Autoload/ClassLoader.php", the first will be used.
Warning: Ambiguous class resolution, "Composer\Autoload\ClassMapGenerator" was found 3x in "$baseDir . '/src/Composer/Autoload/ClassMapGenerator.php" and "C:/dvl/Zend/DefaultWorkspace13/composer/src2/Composer/A
utoload/ClassMapGenerator.php", "C:/dvl/Zend/DefaultWorkspace13/composer/src3/Composer/Autoload/ClassMapGenerator.php", the first will be used.
Generated autoload files containing 764 classes
```