### PR TITLE
Respect disable-tls in Versions::getLatest

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -430,7 +430,11 @@ EOT
         }
 
         $versionsUtil = new Versions($config, $this->rfs);
-        $latest = $versionsUtil->getLatest();
+        try {
+            $latest = $versionsUtil->getLatest();
+        } catch (\Exception $e) {
+            return $e;
+        }
 
         if (Composer::VERSION !== $latest['version'] && Composer::VERSION !== '@package_version@') {
             return '<comment>You are not running the latest '.$versionsUtil->getChannel().' version, run `composer self-update` to update ('.Composer::VERSION.' => '.$latest['version'].')</comment>';

--- a/src/Composer/SelfUpdate/Versions.php
+++ b/src/Composer/SelfUpdate/Versions.php
@@ -61,7 +61,12 @@ class Versions
 
     public function getLatest()
     {
-        $protocol = extension_loaded('openssl') ? 'https' : 'http';
+        if ($this->config->get('disable-tls') === true) {
+            $protocol = 'http';
+        } else {
+            $protocol = 'https';
+        }
+
         $versions = JsonFile::parseJson($this->rfs->getContents('getcomposer.org', $protocol . '://getcomposer.org/versions', false));
 
         foreach ($versions[$this->getChannel()] as $version) {


### PR DESCRIPTION
Use http to get the latest version when disable-tls is true and error-
trap DiagnoseCommand::checkVersion so that all checks can complete.
Fixes #8657.