### PR TITLE
WIP: POC of a composer command showing max upgrade possible 

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -112,9 +112,9 @@ EOT
         if ($input->getOption('unbounded')) {
             $input->setOption('latest', true);
 
-            $candidates = [self::UNBOUNDED_IGNORE_TARGET_PHP_VERSION, self::UNBOUNDED_IGNORE_TARGET_STABILITY, self::UNBOUNDED_IGNORE_VERSION_LOCK];
+            $candidates = array(self::UNBOUNDED_IGNORE_TARGET_PHP_VERSION, self::UNBOUNDED_IGNORE_TARGET_STABILITY, self::UNBOUNDED_IGNORE_VERSION_LOCK);
 
-            $unboundedOptions = [];
+            $unboundedOptions = array();
             foreach ($input->getOption('unbounded') as $unboundedOption) {
                 $unboundedOption = strtolower($unboundedOption);
                 if (! in_array($unboundedOption, $candidates)) {

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -109,12 +109,12 @@ EOT
         $composer = $this->getComposer(false);
         $io = $this->getIO();
 
+        $unboundedOptions = array();
         if ($input->getOption('unbounded')) {
             $input->setOption('latest', true);
 
             $candidates = array(self::UNBOUNDED_IGNORE_TARGET_PHP_VERSION, self::UNBOUNDED_IGNORE_TARGET_STABILITY, self::UNBOUNDED_IGNORE_VERSION_LOCK);
 
-            $unboundedOptions = array();
             foreach ($input->getOption('unbounded') as $unboundedOption) {
                 $unboundedOption = strtolower($unboundedOption);
                 if (! in_array($unboundedOption, $candidates)) {

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -46,10 +46,21 @@ class VersionSelector
      * @param  string                $preferredStability
      * @return PackageInterface|bool
      */
-    public function findBestCandidate($packageName, $targetPackageVersion = null, $targetPhpVersion = null, $preferredStability = 'stable')
+    public function findBestCandidate($packageName, $targetPackageVersion = null, $targetPhpVersion = null, $preferredStability = 'stable', $forceMaxVersionWithoutContraints = false)
     {
         $constraint = $targetPackageVersion ? $this->getParser()->parseConstraints($targetPackageVersion) : null;
         $candidates = $this->pool->whatProvides(strtolower($packageName), $constraint, true);
+
+        if ($forceMaxVersionWithoutContraints) {
+            $max = null;
+            foreach ($candidates as $candidate) {
+                if (version_compare($max, $candidate->getVersion(), '<')) {
+                    $max = $candidate->getVersion();
+                    $package = $candidate;
+                }
+            }
+            return $package;
+        }
 
         if ($targetPhpVersion) {
             $phpConstraint = new Constraint('==', $this->getParser()->normalize($targetPhpVersion));

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -46,21 +46,10 @@ class VersionSelector
      * @param  string                $preferredStability
      * @return PackageInterface|bool
      */
-    public function findBestCandidate($packageName, $targetPackageVersion = null, $targetPhpVersion = null, $preferredStability = 'stable', $forceMaxVersionWithoutContraints = false)
+    public function findBestCandidate($packageName, $targetPackageVersion = null, $targetPhpVersion = null, $preferredStability = 'stable')
     {
         $constraint = $targetPackageVersion ? $this->getParser()->parseConstraints($targetPackageVersion) : null;
         $candidates = $this->pool->whatProvides(strtolower($packageName), $constraint, true);
-
-        if ($forceMaxVersionWithoutContraints) {
-            $max = null;
-            foreach ($candidates as $candidate) {
-                if (version_compare($max, $candidate->getVersion(), '<')) {
-                    $max = $candidate->getVersion();
-                    $package = $candidate;
-                }
-            }
-            return isset($package) ? $package : false;
-        }
 
         if ($targetPhpVersion) {
             $phpConstraint = new Constraint('==', $this->getParser()->normalize($targetPhpVersion));

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -59,7 +59,7 @@ class VersionSelector
                     $package = $candidate;
                 }
             }
-            return $package;
+            return isset($package) ? $package : false;
         }
 
         if ($targetPhpVersion) {


### PR DESCRIPTION
Hello,
This PR is a POC of a composer command showing max upgrade possible if ignoring versions constraints declared into composer.json file 


The idea is to automate the painful analysis of a composer.json when you decide to check which version constraints you want to upper.
Without this command, you have to check each dependency by hand in order to see if a version greater than your max boundary exists, and whether it is a (semver) BC break or not.
I insist : my proposition is a behavior, accompanied with a (badly written) POC.

So:
 - Does it seem interesting to you, 
 - Should I code it inside composer or as a plugin?
 - should it be inside the show command or as a command of its own?
 - ... 

The narrower existing command is : `bin/composer show  -lD` which output:
``` 
composer/ca-bundle        1.2.6   1.2.6   Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.
composer/semver           1.5.1   1.5.1   Semver library that offers utilities, version constraint parsing and validation.
composer/spdx-licenses    1.5.3   1.5.3   SPDX licenses list and validation library.
composer/xdebug-handler   1.4.0   1.4.1   Restarts a process without Xdebug.
justinrainbow/json-schema 5.2.9   5.2.9   A library to validate a json schema.
phpspec/prophecy          v1.10.2 v1.10.2 Highly opinionated mocking framework for PHP 5.3+
psr/log                   1.1.2   1.1.2   Common interface for logging libraries
seld/jsonlint             1.7.2   1.7.2   JSON Linter
seld/phar-utils           1.1.0   1.1.0   PHAR file format utilities, for when PHP phars you up
symfony/console           v2.8.52 v2.8.52 Symfony Console Component
symfony/filesystem        v2.8.52 v2.8.52 Symfony Filesystem Component
symfony/finder            v2.8.52 v2.8.52 Symfony Finder Component
symfony/phpunit-bridge    v3.4.37 v4.2.12 Symfony PHPUnit Bridge
symfony/process           v2.8.52 v2.8.52 Symfony Process Component
``` 

The command I propose is `bin/composer show  -u version -u php -D`  which output:
```
Option unbounded given, ignoring 'version'
Option unbounded given, ignoring 'php'
composer/ca-bundle        1.2.6   1.2.6   Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.
composer/semver           1.5.1   1.5.1   Semver library that offers utilities, version constraint parsing and validation.
composer/spdx-licenses    1.5.3   1.5.3   SPDX licenses list and validation library.
composer/xdebug-handler   1.4.0   1.4.1   Restarts a process without Xdebug.
justinrainbow/json-schema 5.2.9   5.2.9   A library to validate a json schema.
phpspec/prophecy          v1.10.2 v1.10.2 Highly opinionated mocking framework for PHP 5.3+
psr/log                   1.1.2   1.1.2   Common interface for logging libraries
seld/jsonlint             1.7.2   1.7.2   JSON Linter
seld/phar-utils           1.1.0   1.1.0   PHAR file format utilities, for when PHP phars you up
symfony/console           v2.8.52 v5.0.5  Symfony Console Component
symfony/filesystem        v2.8.52 v5.0.5  Symfony Filesystem Component
symfony/finder            v2.8.52 v5.0.5  Symfony Finder Component
symfony/phpunit-bridge    v3.4.37 v5.0.5  Symfony PHPUnit Bridge
symfony/process           v2.8.52 v5.0.5  Symfony Process Component
```

You can notice that the max version of `symfony/console` changed. 

You can callthis, if you want to remain bounded to your required PHP version `bin/composer show  -u version -D` : 
```
Option unbounded given, ignoring 'version'
composer/ca-bundle        1.2.6   1.2.6   Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.
composer/semver           1.5.1   1.5.1   Semver library that offers utilities, version constraint parsing and validation.
composer/spdx-licenses    1.5.3   1.5.3   SPDX licenses list and validation library.
composer/xdebug-handler   1.4.0   1.4.1   Restarts a process without Xdebug.
justinrainbow/json-schema 5.2.9   5.2.9   A library to validate a json schema.
phpspec/prophecy          v1.10.2 v1.10.2 Highly opinionated mocking framework for PHP 5.3+
psr/log                   1.1.2   1.1.2   Common interface for logging libraries
seld/jsonlint             1.7.2   1.7.2   JSON Linter
seld/phar-utils           1.1.0   1.1.0   PHAR file format utilities, for when PHP phars you up
symfony/console           v2.8.52 v2.8.52 Symfony Console Component
symfony/filesystem        v2.8.52 v2.8.52 Symfony Filesystem Component
symfony/finder            v2.8.52 v2.8.52 Symfony Finder Component
symfony/phpunit-bridge    v3.4.37 v4.2.12 Symfony PHPUnit Bridge
symfony/process           v2.8.52 v2.8.52 Symfony Process Component
```

This time, the the max version of `symfony/console` remained unchanged since `    "require": {"php": "^5.3.2 || ^7.0"}` is kept as a constraint. by the abscence of the `-u php` option.

NB: I created an issue to discuss of the interest of the feature : #8668 