### PR TITLE
Update link to wikipedia VC -> Common terminology

### DIFF
--- a/doc/articles/versions.md
+++ b/doc/articles/versions.md
@@ -54,7 +54,7 @@ v2.0.2
 
 Normally, Composer deals with tags (as opposed to branches -- if you don't
 know what this means, read up on
-[version control systems](https://en.wikipedia.org/wiki/Version_control#Common_vocabulary)).
+[version control systems](https://en.wikipedia.org/wiki/Version_control#Common_terminology)).
 When you write a version constraint, it may reference a specific tag (e.g.,
 `1.1`) or it may reference a valid range of tags (e.g., `>=1.1 <2.0`, or
 `~4.0`). To resolve these constraints, Composer first asks the VCS to list


### PR DESCRIPTION
The wikipedia section `Version_control#Common_vocabulary` has moved to `Version_control#Common_terminology`.
You know, scrolling along is harassing :-)