### PR TITLE
GitLab: properly handle token which has Guest only access

### DIFF
--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -427,6 +427,30 @@ class GitLabDriver extends VcsDriver
             if ($fetchingRepoData) {
                 $json = JsonFile::parseJson($res, $url);
 
+                // Accessing the API with a token with Guest (10) access will return
+                // more data than unauthenticated access but no default_branch data
+                // accessing files via the API will then also fail
+                if (!isset($json['default_branch']) && isset($json['permissions'])) {
+                    $this->isPrivate = $json['visibility'] !== 'public';
+
+                    $moreThanGuestAccess = false;
+                    // Check both access levels (e.g. project, group)
+                    // - value will be null if no access is set
+                    // - value will be array with key access_level if set
+                    foreach ($json['permissions'] as $permission) {
+                        if ($permission && $permission['access_level'] > 10) {
+                            $moreThanGuestAccess = true;
+                        }
+                    }
+
+                    if (!$moreThanGuestAccess) {
+                        $this->io->writeError('<warning>GitLab token with Guest only access detected</warning>');
+                        $this->setupGitDriver($this->generateSshUrl());
+
+                        return $res;
+                    }
+                }
+
                 // force auth as the unauthenticated version of the API is broken
                 if (!isset($json['default_branch'])) {
                     if (!empty($json['id'])) {

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -445,9 +445,8 @@ class GitLabDriver extends VcsDriver
 
                     if (!$moreThanGuestAccess) {
                         $this->io->writeError('<warning>GitLab token with Guest only access detected</warning>');
-                        $this->setupGitDriver($this->generateSshUrl());
 
-                        return $res;
+                        return $this->attemptCloneFallback(); 
                     }
                 }
 


### PR DESCRIPTION
This causes `Notice: Undefined index: default_branch at GitLabDriver.php:22` and never tries to fallback to the git driver.