### PR TITLE
Fix PHP 8 deprecated warnings

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -336,7 +336,7 @@ EOF;
         return 0;
     }
 
-    private function addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist = null, $namespaceFilter = null, $autoloadType = null, array $classMap, array &$ambiguousClasses)
+    private function addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $blacklist, $namespaceFilter, $autoloadType, array $classMap, array &$ambiguousClasses)
     {
         foreach ($this->generateClassMap($dir, $blacklist, $namespaceFilter, $autoloadType) as $class => $path) {
             $pathCode = $this->getPathCode($filesystem, $basePath, $vendorPath, $path).",\n";


### PR DESCRIPTION
The PR fixes this PHP 8 deprecated warning:
PHP Deprecated:  Required parameter $ambiguousClasses follows optional parameter $blacklist in phar://.../composer.phar/src/Composer/Autoload/AutoloadGenerator.php on line 339