### PR TITLE
Adds backticks around `composer fund` to improve readability.

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -328,7 +328,7 @@ class Installer
                     1 === $fundingCount ? '' : 's',
                     1 === $fundingCount ? 'is' : 'are'
                 ),
-                '<info>Use the composer fund command to find out more!</info>',
+                '<info>Use the `composer fund` command to find out more!</info>',
             ));
         }
 

--- a/tests/Composer/Test/Fixtures/installer/install-funding-notice.test
+++ b/tests/Composer/Test/Fixtures/installer/install-funding-notice.test
@@ -47,7 +47,7 @@ Package operations: 3 installs, 0 updates, 0 removals
 Writing lock file
 Generating autoload files
 2 packages you are using are looking for funding.
-Use the composer fund command to find out more!
+Use the `composer fund` command to find out more!
 --EXPECT--
 Installing b/b (1.0.0)
 Installing d/d (1.0.0)


### PR DESCRIPTION
I think adding some backticks would make this more discernible within the sentence, thus promoting the use of the command :)