### PR TITLE
use more precise phpstan/psam return-types

### DIFF
--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -28,6 +28,9 @@ class ArchiveManager
     protected $downloadManager;
     protected $loop;
 
+    /**
+     * @var ArchiverInterface[]
+     */
     protected $archivers = array();
 
     /**

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -269,7 +269,8 @@ interface PackageInterface
      * Returns a set of package names and reasons why they are useful in
      * combination with this package.
      *
-     * @return array<string, string> An array of package suggestions with descriptions
+     * @return array An array of package suggestions with descriptions
+     * @return array<string, string>
      */
     public function getSuggests();
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -159,7 +159,7 @@ interface PackageInterface
     /**
      * Returns the urls of the distribution archive of this version, including mirrors
      *
-     * @return array
+     * @return string[]
      */
     public function getDistUrls();
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -283,7 +283,7 @@ interface PackageInterface
      * directories for autoloading using the type specified.
      *
      * @return array Mapping of autoloading rules
-     * @psalm-return array<string, array<string, string>>
+     * @psalm-return array{psr-0?: array<string, string>, psr-4?: array<string, string>, classmap?: list<string>, file?: list<string>}
      */
     public function getAutoload();
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -296,7 +296,7 @@ interface PackageInterface
      * directories for autoloading using the type specified.
      *
      * @return array Mapping of dev autoloading rules
-     * @psalm-return array<string, array<string, string>>
+     * @psalm-return array{psr-0?: array<string, string>, psr-4?: array<string, string>, classmap?: list<string>, file?: list<string>}
      */
     public function getDevAutoload();
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -269,7 +269,7 @@ interface PackageInterface
      * Returns a set of package names and reasons why they are useful in
      * combination with this package.
      *
-     * @return array An array of package suggestions with descriptions
+     * @return array<string, string> An array of package suggestions with descriptions
      */
     public function getSuggests();
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -283,6 +283,7 @@ interface PackageInterface
      * directories for autoloading using the type specified.
      *
      * @return array Mapping of autoloading rules
+     * @psalm-return array<string, array<string, string>>
      */
     public function getAutoload();
 
@@ -295,6 +296,7 @@ interface PackageInterface
      * directories for autoloading using the type specified.
      *
      * @return array Mapping of dev autoloading rules
+     * @psalm-return array<string, array<string, string>>
      */
     public function getDevAutoload();
 
@@ -302,7 +304,7 @@ interface PackageInterface
      * Returns a list of directories which should get added to PHP's
      * include path.
      *
-     * @return array
+     * @return string[]
      */
     public function getIncludePaths();
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -270,7 +270,7 @@ interface PackageInterface
      * combination with this package.
      *
      * @return array An array of package suggestions with descriptions
-     * @return array<string, string>
+     * @psalm-return array<string, string>
      */
     public function getSuggests();
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -47,7 +47,7 @@ interface PackageInterface
      *
      * @param bool $provides Whether provided names should be included
      *
-     * @return array An array of strings referring to this package
+     * @return string[] An array of strings referring to this package
      */
     public function getNames($provides = true);
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -325,7 +325,7 @@ interface PackageInterface
     /**
      * Returns the package binaries
      *
-     * @return array
+     * @return string[]
      */
     public function getBinaries();
 

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -69,6 +69,7 @@ interface RepositoryInterface extends \Countable
      * @param ConstraintInterface[] $packageNameMap package names pointing to constraints
      * @param array $acceptableStabilities
      * @param array $stabilityFlags
+     * @psalm-return array{namesFound: string[], packages: PackageInterface[]}
      * @return array [namesFound => string[], packages => PackageInterface[]]
      */
     public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags);
@@ -80,6 +81,7 @@ interface RepositoryInterface extends \Countable
      * @param int    $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only
      * @param string $type  The type of package to search for. Defaults to all types of packages
      *
+     * @psalm-return array{name: string, description: string}
      * @return array[] an array of array('name' => '...', 'description' => '...')
      */
     public function search($query, $mode = 0, $type = null);
@@ -91,6 +93,7 @@ interface RepositoryInterface extends \Countable
      *
      * @param string $packageName package name which must be provided
      *
+     * @psalm-return array{name: string, description: string, type: string}
      * @return array[] an array with the provider name as key and value of array('name' => '...', 'description' => '...', 'type' => '...')
      */
     public function getProviders($packageName);

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -69,8 +69,9 @@ interface RepositoryInterface extends \Countable
      * @param ConstraintInterface[] $packageNameMap package names pointing to constraints
      * @param array $acceptableStabilities
      * @param array $stabilityFlags
-     * @psalm-return array{namesFound: string[], packages: PackageInterface[]}
+     * 
      * @return array [namesFound => string[], packages => PackageInterface[]]
+     * @psalm-return array{namesFound: string[], packages: PackageInterface[]}
      */
     public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags);
 
@@ -81,8 +82,8 @@ interface RepositoryInterface extends \Countable
      * @param int    $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only
      * @param string $type  The type of package to search for. Defaults to all types of packages
      *
-     * @psalm-return array{name: string, description: string}
      * @return array[] an array of array('name' => '...', 'description' => '...')
+     * @psalm-return array{name: string, description: string}
      */
     public function search($query, $mode = 0, $type = null);
 
@@ -93,8 +94,8 @@ interface RepositoryInterface extends \Countable
      *
      * @param string $packageName package name which must be provided
      *
-     * @psalm-return array{name: string, description: string, type: string}
      * @return array[] an array with the provider name as key and value of array('name' => '...', 'description' => '...', 'type' => '...')
+     * @psalm-return array{name: string, description: string, type: string}
      */
     public function getProviders($packageName);
 

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -71,7 +71,7 @@ interface RepositoryInterface extends \Countable
      * @param array $stabilityFlags
      * 
      * @return array [namesFound => string[], packages => PackageInterface[]]
-     * @psalm-return list<array{namesFound: string[], packages: PackageInterface[]}>
+     * @psalm-return array{namesFound: string[], packages: PackageInterface[]}
      */
     public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags);
 
@@ -83,7 +83,7 @@ interface RepositoryInterface extends \Countable
      * @param string $type  The type of package to search for. Defaults to all types of packages
      *
      * @return array[] an array of array('name' => '...', 'description' => '...')
-     * @psalm-return array{name: string, description: string}
+     * @psalm-return list<array{name: string, description: string}>
      */
     public function search($query, $mode = 0, $type = null);
 

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -95,7 +95,7 @@ interface RepositoryInterface extends \Countable
      * @param string $packageName package name which must be provided
      *
      * @return array[] an array with the provider name as key and value of array('name' => '...', 'description' => '...', 'type' => '...')
-     * @psalm-return array{name: string, description: string, type: string}
+     * @psalm-return array<string, array{name: string, description: string, type: string}>
      */
     public function getProviders($packageName);
 

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -71,7 +71,7 @@ interface RepositoryInterface extends \Countable
      * @param array $stabilityFlags
      * 
      * @return array [namesFound => string[], packages => PackageInterface[]]
-     * @psalm-return array{namesFound: string[], packages: PackageInterface[]}
+     * @psalm-return list<array{namesFound: string[], packages: PackageInterface[]}>
      */
     public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags);
 


### PR DESCRIPTION
used `@psalm-return` in places where types are more advanced and my IDE (phpstorm) would not understand the type.

using regular `@return` in places where "regular IDEs" support the notation