### PR TITLE
Making a fallback for broken auth on github

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -424,6 +424,13 @@ class RemoteFilesystem
             }
         }
 
+        // check for github 404 when downloading .zip over non-codeload url
+        if($statusCode === 404 && preg_match('/https:\/\/github.com\/([^\/]+)\/([^\/]+)\/archive\/([^\/]+)\.([^\/]+)/',$fileUrl,$matches)) {
+            list($match,$user,$repo,$version,$extension) = $matches;
+            $fileUrl = "https://codeload.github.com/$user/$repo/$extension/$version";
+            return $this->get($this->originUrl, $fileUrl, $additionalOptions, $this->fileName, $this->progress);
+        }
+        
         // handle 3xx redirects, 304 Not Modified is excluded
         $hasFollowedRedirect = false;
         if ($statusCode >= 300 && $statusCode <= 399 && $statusCode !== 304 && $this->redirects < $this->maxRedirects) {

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -277,7 +277,7 @@ class RemoteFilesystem
 
         if (isset($options['github-token'])) {
             // only add the access_token if it is actually a github URL (in case we were redirected to S3)
-            if (preg_match('{^https?://([a-z0-9-]+\.)*github\.com/}', $fileUrl)) {
+            if (preg_match('{^https?://api\.github\.com/}', $fileUrl)) {
                 $options['http']['header'][] = 'Authorization: token '.$options['github-token'];
             }
             unset($options['github-token']);
@@ -424,13 +424,6 @@ class RemoteFilesystem
             }
         }
 
-        // check for github 404 when downloading .zip over non-codeload url
-        if($statusCode === 404 && preg_match('/https:\/\/github.com\/([^\/]+)\/([^\/]+)\/archive\/([^\/]+)\.([^\/]+)/',$fileUrl,$matches)) {
-            list($match,$user,$repo,$version,$extension) = $matches;
-            $fileUrl = "https://codeload.github.com/$user/$repo/$extension/$version";
-            return $this->get($this->originUrl, $fileUrl, $additionalOptions, $this->fileName, $this->progress);
-        }
-        
         // handle 3xx redirects, 304 Not Modified is excluded
         $hasFollowedRedirect = false;
         if ($statusCode >= 300 && $statusCode <= 399 && $statusCode !== 304 && $this->redirects < $this->maxRedirects) {


### PR DESCRIPTION
TLDR: We shouldn't be adding authentication on anything but the api.github.com url

Following the discussion about github deprecating auth via query string https://github.com/composer/composer/issues/8454
(Original blog post here https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters )

A fix was created see: https://github.com/composer/composer/commit/4b6c25d4bc33d49097320e29e6e5705b12e9d6ef

The problem is that this broke hardcoded URLs to tag archives. This works:

```
% curl -sv https://github.com/components/codemirror/archive/5.48.2.zip |& grep HTTP
> GET /components/codemirror/archive/5.48.2.zip HTTP/1.1
< HTTP/1.1 302 Found
```

Add a scopeless token, and it doesn't redirect anymore:

```
% curl -sv -H "Authorization: token <TOKENHERE>" https://github.com/components/codemirror/archive/5.48.2.zip |& grep HTTP
> GET /components/codemirror/archive/5.48.2.zip HTTP/1.1
< HTTP/1.1 404 Not Found
```


Why is this a problem?

In the PHP world, it is really not uncommon to see composer.lock files that have hardcoded URLs like this. There are a number of them hosted publicly on GitHub. [Here is a random example](https://github.com/eGovPDX/portlandor/blob/master/composer.lock):

```
        {
            "name": "codemirror/codemirror",
            "version": "5.48.2",
            "dist": {
                "type": "zip",
                "url": "https://github.com/components/codemirror/archive/5.48.2.zip"
            },
            "require": {
                "composer/installers": "~1.0"
            },
            "type": "drupal-library",
            "extra": {
                "installer-name": "codemirror"
            }
        },
```

This used to work, now it doesn't. 