### PR TITLE
Update HTTP URLs to their HTTPS if they already redirect automatically

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 *       text=auto eol=lf
 
 # These files are always considered text and should use LF.
-# See core.whitespace @ http://git-scm.com/docs/git-config for whitespace flags.
+# See core.whitespace @ https://git-scm.com/docs/git-config for whitespace flags.
 *.php   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4 diff=php
 *.json  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
 *.test  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Contributing to Composer
 ========================
 
 Please note that this project is released with a
-[Contributor Code of Conduct](http://contributor-covenant.org/version/1/4/).
+[Contributor Code of Conduct](https://www.contributor-covenant.org/version/1/4/code-of-conduct/).
 By participating in this project you agree to abide by its terms.
 
 Reporting Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,7 +759,7 @@
 ### [1.0.0-alpha6] - 2012-10-23
 
   * Schema: Added ability to pass additional options to repositories (i.e. ssh keys/client certificates to secure private repos)
-  * Schema: Added a new `~` operator that should be preferred over `>=`, see http://getcomposer.org/doc/01-basic-usage.md#package-versions
+  * Schema: Added a new `~` operator that should be preferred over `>=`, see https://getcomposer.org/doc/01-basic-usage.md#package-versions
   * Schema: Version constraints `<x.y` are assumed to be `<x.y-dev` unless specified as `<x.y-stable` to reduce confusion
   * Added `config` command to edit/list config values, including --global switch for system config
   * Added OAuth token support for the GitHub API

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For support, Stack Overflow also offers a good collection of
 [Composer related questions](https://stackoverflow.com/questions/tagged/composer-php).
 
 Please note that this project is released with a
-[Contributor Code of Conduct](http://contributor-covenant.org/version/1/4/).
+[Contributor Code of Conduct](https://www.contributor-covenant.org/version/1/4/code-of-conduct/).
 By participating in this project and its community you agree to abide by those terms.
 
 Requirements
@@ -40,8 +40,8 @@ PHP 5.3.2 or above (at least 5.3.4 recommended to avoid potential bugs)
 Authors
 -------
 
-- Nils Adermann  | [GitHub](https://github.com/naderman)  | [Twitter](https://twitter.com/naderman) | <naderman@naderman.de> | [naderman.de](http://naderman.de)
-- Jordi Boggiano | [GitHub](https://github.com/Seldaek) | [Twitter](https://twitter.com/seldaek) | <j.boggiano@seld.be> | [seld.be](http://seld.be)
+- Nils Adermann  | [GitHub](https://github.com/naderman)  | [Twitter](https://twitter.com/naderman) | <naderman@naderman.de> | [naderman.de](https://naderman.de)
+- Jordi Boggiano | [GitHub](https://github.com/Seldaek) | [Twitter](https://twitter.com/seldaek) | <j.boggiano@seld.be> | [seld.be](https://seld.be)
 
 See also the list of [contributors](https://github.com/composer/composer/contributors) who participated in this project.
 

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         {
             "name": "Nils Adermann",
             "email": "naderman@naderman.de",
-            "homepage": "http://www.naderman.de"
+            "homepage": "https://www.naderman.de"
         },
         {
             "name": "Jordi Boggiano",
             "email": "j.boggiano@seld.be",
-            "homepage": "http://seld.be"
+            "homepage": "https://seld.be"
         }
     ],
     "require": {

--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -233,7 +233,7 @@ You can even add your own code to the autoloader by adding an
 }
 ```
 
-Composer will register a [PSR-4](http://www.php-fig.org/psr/psr-4/) autoloader
+Composer will register a [PSR-4](https://www.php-fig.org/psr/psr-4/) autoloader
 for the `Acme` namespace.
 
 You define a mapping from namespaces to directories. The `src` directory would

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -4,7 +4,7 @@ This chapter will explain all of the fields available in `composer.json`.
 
 ## JSON schema
 
-We have a [JSON schema](http://json-schema.org) that documents the format and
+We have a [JSON schema](https://json-schema.org) that documents the format and
 can also be used to validate your `composer.json`. In fact, it is used by the
 `validate` command. You can find it at: https://getcomposer.org/schema.json
 
@@ -214,7 +214,7 @@ An example:
         {
             "name": "Nils Adermann",
             "email": "naderman@naderman.de",
-            "homepage": "http://www.naderman.de",
+            "homepage": "https://www.naderman.de",
             "role": "Developer"
         },
         {
@@ -471,7 +471,7 @@ Example:
 
 Autoload mapping for a PHP autoloader.
 
-[`PSR-4`](http://www.php-fig.org/psr/psr-4/) and [`PSR-0`](http://www.php-fig.org/psr/psr-0/)
+[`PSR-4`](https://www.php-fig.org/psr/psr-4/) and [`PSR-0`](http://www.php-fig.org/psr/psr-0/)
 autoloading, `classmap` generation and `files` includes are supported.
 
 PSR-4 is the recommended way since it offers greater ease of use (no need

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -710,7 +710,7 @@ variables are parsed in both Windows and Linux/Mac notations. For example
 `%USERPROFILE%/git/mypackage`.
 
 > **Note:** Repository paths can also contain wildcards like ``*`` and ``?``.
-> For details, see the [PHP glob function](http://php.net/glob).
+> For details, see the [PHP glob function](https://php.net/glob).
 
 ## Disabling Packagist.org
 

--- a/doc/07-community.md
+++ b/doc/07-community.md
@@ -19,7 +19,7 @@ The most important guidelines are described as follows:
 > Fork the project, create a feature branch, and send us a pull request.
 >
 > To ensure a consistent code base, you should make sure the code follows
-> the [PSR-2 Coding Standards](http://www.php-fig.org/psr/psr-2/).
+> the [PSR-2 Coding Standards](https://www.php-fig.org/psr/psr-2/).
 
 ## IRC / mailing list
 

--- a/res/composer-repository-schema.json
+++ b/res/composer-repository-schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "https://json-schema.org/draft-04/schema#",
     "description": "A representation of packages metadata.",
     "type": "object",
     "oneOf": [

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "https://json-schema.org/draft-04/schema#",
     "name": "Package",
     "type": "object",
     "additionalProperties": false,

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -37,8 +37,8 @@ namespace Composer\Autoload;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
- * @see    http://www.php-fig.org/psr/psr-0/
- * @see    http://www.php-fig.org/psr/psr-4/
+ * @see    https://www.php-fig.org/psr/psr-0/
+ * @see    https://www.php-fig.org/psr/psr-4/
  */
 class ClassLoader
 {

--- a/src/Composer/Util/TlsHelper.php
+++ b/src/Composer/Util/TlsHelper.php
@@ -98,7 +98,7 @@ final class TlsHelper
      * By Kevin McArthur of StormTide Digital Studios Inc.
      * @KevinSMcArthur / https://github.com/StormTide
      *
-     * See http://tools.ietf.org/html/draft-ietf-websec-key-pinning-02
+     * See https://tools.ietf.org/html/draft-ietf-websec-key-pinning-02
      *
      * This method was adapted from Sslurp.
      * https://github.com/EvanDotPro/Sslurp

--- a/tests/Composer/Test/Fixtures/functional/packages.json
+++ b/tests/Composer/Test/Fixtures/functional/packages.json
@@ -18,7 +18,7 @@
             {
                 "name": "Jordi Boggiano",
                 "email": "j.boggiano@seld.be",
-                "homepage": "http://seld.be",
+                "homepage": "https://seld.be",
                 "role": "Developer"
             }
         ],

--- a/tests/Composer/Test/Json/Fixtures/composer.json
+++ b/tests/Composer/Test/Json/Fixtures/composer.json
@@ -9,12 +9,12 @@
         {
             "name": "Nils Adermann",
             "email": "naderman@naderman.de",
-            "homepage": "http://www.naderman.de"
+            "homepage": "https://www.naderman.de"
         },
         {
             "name": "Jordi Boggiano",
             "email": "j.boggiano@seld.be",
-            "homepage": "http://seld.be"
+            "homepage": "https://seld.be"
         }
     ],
     "support": {


### PR DESCRIPTION
A low-effort PR 🙊. 

Some of the old URLs used in composer still use plain HTTP. I have scanned through, and updated them where appropriate and after checking if they automatically redirect to HTTPS. It does _not_ include HTTP URLs that refer to namespaces, schema, etc, nor change examples (that use `example.com` as the domain name). 

Thank you.

## Summary of changes

*The following domains automatically redirect HTTPS*

 - php.net
 - php-fig.org
 - getcomposer.org
 - git-scm.com
 - naderman.de
 - seld.be
 - tools.ietf.org

*URL below support both HTTP and HTTPS, and are updated to their HTTPS variants*
 - json-schema.org

*URL below redirects to a new URL, but with same contents*
  - `http://contributor-covenant.org/version/1/4/` -> `https://www.contributor-covenant.org/version/1/4/code-of-conduct/` (301 to HTTPs -> 301 to `www` -> 301 to new URL).