### PR TITLE
PHP 8 fixes for functional optional parameters before required parameters

### DIFF
--- a/src/Composer/Installer/PackageEvent.php
+++ b/src/Composer/Installer/PackageEvent.php
@@ -70,7 +70,7 @@ class PackageEvent extends Event
      * @param OperationInterface[] $operations
      * @param OperationInterface   $operation
      */
-    public function __construct($eventName, Composer $composer, IOInterface $io, $devMode, RepositoryInterface $localRepo, array $operations = array(), OperationInterface $operation)
+    public function __construct($eventName, Composer $composer, IOInterface $io, $devMode, RepositoryInterface $localRepo, array $operations, OperationInterface $operation)
     {
         parent::__construct($eventName);
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -742,7 +742,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      * @param string $name package name (must be lowercased already)
      * @private
      */
-    public function isVersionAcceptable(array $acceptableStabilities = null, array $stabilityFlags = null, $constraint = null, $name, $versionData)
+    public function isVersionAcceptable(array $acceptableStabilities = null, array $stabilityFlags = null, $constraint, $name, $versionData)
     {
         $versions = array($versionData['version_normalized']);
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -742,7 +742,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      * @param string $name package name (must be lowercased already)
      * @private
      */
-    public function isVersionAcceptable(array $acceptableStabilities = null, array $stabilityFlags = null, $constraint, $name, $versionData)
+    public function isVersionAcceptable(array $acceptableStabilities, array $stabilityFlags, $constraint, $name, $versionData)
     {
         $versions = array($versionData['version_normalized']);
 


### PR DESCRIPTION
Related to #8686

I linted the current master branch, with PHP master builds, and found two more deprecation notices:

1. `Deprecated: Required parameter $name follows optional parameter $constraint in src\Composer\Repository\ComposerRepository.php on line 745`

2.  `Deprecated: Required parameter $operation follows optional parameter $operations in src\Composer\Installer\PackageEvent.php on line 73`
…ository\ComposerRepository::isVersionAcceptable() required arguments used after optional, which is deprecated in PHP 8.0

Optional parameters with a type declared, and a default value of `null` is excepted from this deprecation. See https://php.watch/versions/8.0/deprecate-required-param-after-optional. This is the case in `ComposerRepository::isVersionAcceptable`, which still has two optional parameters as first two parameters, but this will not raise a deprecation notice. 