### PR TITLE
Added --json and --merge options to ConfigCommand

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -605,6 +605,8 @@ See the [Config](06-config.md) chapter for valid configuration options.
   that this cannot be used in conjunction with the `--global` option.
 * **--absolute:** Returns absolute paths when fetching *-dir config values
   instead of relative.
+* **--json:** JSON decode the setting value, to be used with `extra.*` keys.
+* **--merge:** Merge the setting value with the current value, to be used with `extra.*` keys in combination with `--json`.
 
 ### Modifying Repositories
 
@@ -632,6 +634,13 @@ php composer.phar config extra.foo.bar value
 
 The dots indicate array nesting, a max depth of 3 levels is allowed though. The above
 would set `"extra": { "foo": { "bar": "value" } }`.
+
+If you have a complex value to add/modify, you can use the `--json` and `--merge` flags
+to edit extra fields as json:
+
+```sh
+php composer.phar config --json extra.foo.bar '{"baz": true, "qux": []}'
+```
 
 ## create-project
 

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -73,8 +73,8 @@ class ConfigCommand extends BaseCommand
                 new InputOption('list', 'l', InputOption::VALUE_NONE, 'List configuration settings'),
                 new InputOption('file', 'f', InputOption::VALUE_REQUIRED, 'If you want to choose a different composer.json or config.json'),
                 new InputOption('absolute', null, InputOption::VALUE_NONE, 'Returns absolute paths when fetching *-dir config values instead of relative'),
-                new InputOption('json', 'j', InputOption::VALUE_NONE, 'JSON decode the setting value'),
-                new InputOption('merge', 'm', InputOption::VALUE_NONE, 'Merge the setting value with the current value'),
+                new InputOption('json', 'j', InputOption::VALUE_NONE, 'JSON decode the setting value, to be used with extra.* keys'),
+                new InputOption('merge', 'm', InputOption::VALUE_NONE, 'Merge the setting value with the current value, to be used with extra.* keys in combination with --json'),
                 new InputArgument('setting-key', null, 'Setting key'),
                 new InputArgument('setting-value', InputArgument::IS_ARRAY, 'Setting value'),
             ))
@@ -120,6 +120,10 @@ To add or edit suggested packages you can use:
 To add or edit extra properties you can use:
 
     <comment>%command.full_name% extra.property value</comment>
+
+Or to add a complex value you can use json with:
+
+    <comment>%command.full_name% extra.property --json '{"foo":true, "bar": []}'</comment>
 
 To edit the file in an external editor:
 
@@ -625,17 +629,17 @@ EOT
 
             $value = $values[0];
             if ($input->getOption('json')) {
-              $value = JsonFile::parseJson($value);
-              if ($input->getOption('merge')) {
-                $current_value = $this->configFile->read();
-                $bits = explode('.', $settingKey);
-                foreach ($bits as $bit) {
-                  $current_value = isset($current_value[$bit]) ? $current_value[$bit] : NULL;
+                $value = JsonFile::parseJson($value);
+                if ($input->getOption('merge')) {
+                    $currentValue = $this->configFile->read();
+                    $bits = explode('.', $settingKey);
+                    foreach ($bits as $bit) {
+                        $currentValue = isset($currentValue[$bit]) ? $currentValue[$bit] : null;
+                    }
+                    if (is_array($currentValue)) {
+                        $value = array_merge($currentValue, $value);
+                    }
                 }
-                if (is_array($current_value)) {
-                  $value = array_merge($current_value, $value);
-                }
-              }
             }
             $this->configSource->addProperty($settingKey, $value);
 


### PR DESCRIPTION
This is a PR for https://github.com/composer/composer/issues/8353#issuecomment-599117797.

The goal is to enable using composer config for setting deeper than the current limit of 3 by allowing the value to be specified as a JSON array or object. For example:

`composer config --json extra.patches.vendor/project '{"Patch title": "http://example.com/url/to/patch.patch"}'`

