### PR TITLE
Add package naming pattern to the composer.json JSON schema

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -7,7 +7,8 @@
     "properties": {
         "name": {
             "type": "string",
-            "description": "Package name, including 'vendor-name/' prefix."
+            "description": "Package name, including 'vendor-name/' prefix.",
+            "pattern": "^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$"
         },
         "type": {
             "description": "Package type, either 'library' for common packages, 'composer-plugin' for plugins, 'metapackage' for empty packages, or a custom type ([a-z0-9-]+) defined by whatever project this package applies to.",

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -20,6 +20,23 @@ use Composer\Test\TestCase;
  */
 class ComposerSchemaTest extends TestCase
 {
+    public function testNamePattern()
+    {
+        $expectedError = array(
+            array(
+                'property' => 'name',
+                'message' => 'Does not match the regex pattern ^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$',
+                'constraint' => 'pattern',
+                'pattern' => '^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$'
+            ),
+        );
+
+        $json = '{"name": "vendor/-pack__age", "description": "description"}';
+        $this->assertEquals($expectedError, $this->check($json));
+        $json = '{"name": "Vendor/Package", "description": "description"}';
+        $this->assertEquals($expectedError, $this->check($json));
+    }
+
     public function testRequiredProperties()
     {
         $json = '{ }';
@@ -41,13 +58,13 @@ class ComposerSchemaTest extends TestCase
 
     public function testOptionalAbandonedProperty()
     {
-        $json = '{"name": "name", "description": "description", "abandoned": true}';
+        $json = '{"name": "vendor/package", "description": "description", "abandoned": true}';
         $this->assertTrue($this->check($json));
     }
 
     public function testRequireTypes()
     {
-        $json = '{"name": "name", "description": "description", "require": {"a": ["b"]} }';
+        $json = '{"name": "vendor/package", "description": "description", "require": {"a": ["b"]} }';
         $this->assertEquals(array(
             array('property' => 'require.a', 'message' => 'Array value found, but a string is required', 'constraint' => 'type'),
         ), $this->check($json));


### PR DESCRIPTION
as discussed in #8749

```
$ ../bin/composer validate

                                                                                                              
  [Composer\Json\JsonValidationException]                                                                     
  "./composer.json" does not match the expected JSON schema:                                                  
   - name : Does not match the regex pattern ^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$  
                                                                                                              

```