### PR TITLE
Mono/1.10.5

### DIFF
--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -45,14 +45,14 @@ class Composer
      * const SOURCE_VERSION = '';
      *
      * source (git clone):
-     * const VERSION = '@package_version@';
-     * const BRANCH_ALIAS_VERSION = '@package_branch_alias_version@';
-     * const RELEASE_DATE = '@release_date@';
+     * const VERSION = '1.10.5';
+     * const BRANCH_ALIAS_VERSION = '';
+     * const RELEASE_DATE = '2020-04-10 11:44:22';
      * const SOURCE_VERSION = '1.8-dev+source';
      */
-    const VERSION = '@package_version@';
-    const BRANCH_ALIAS_VERSION = '@package_branch_alias_version@';
-    const RELEASE_DATE = '@release_date@';
+    const VERSION = '1.10.5';
+    const BRANCH_ALIAS_VERSION = '';
+    const RELEASE_DATE = '2020-04-10 11:44:22';
     const SOURCE_VERSION = '1.10-dev+source';
 
     public static function getVersion()

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -122,6 +122,7 @@ class RepositoryFactory
         $rm->setRepositoryClass('package', 'Composer\Repository\PackageRepository');
         $rm->setRepositoryClass('pear', 'Composer\Repository\PearRepository');
         $rm->setRepositoryClass('git', 'Composer\Repository\VcsRepository');
+        $rm->setRepositoryClass('gitmono', 'Composer\Repository\VcsRepository');
         $rm->setRepositoryClass('git-bitbucket', 'Composer\Repository\VcsRepository');
         $rm->setRepositoryClass('github', 'Composer\Repository\VcsRepository');
         $rm->setRepositoryClass('gitlab', 'Composer\Repository\VcsRepository');

--- a/src/Composer/Repository/Vcs/GitMonoDriver.php
+++ b/src/Composer/Repository/Vcs/GitMonoDriver.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Repository\Vcs;
+
+/**
+ * @author Matthew Davis <mdavi1982@gmail.com>
+ */
+class GitMonoDriver extends GitDriver
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRootIdentifier()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function normalizeTag( $tag )
+    {
+        return basename($tag);
+    }
+}

--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -172,4 +172,12 @@ abstract class VcsDriver implements VcsDriverInterface
     {
         return;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function normalizeTag( $tag )
+    {
+	return $tag;
+    }
 }

--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -56,6 +56,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
             'gitlab' => 'Composer\Repository\Vcs\GitLabDriver',
             'git-bitbucket' => 'Composer\Repository\Vcs\GitBitbucketDriver',
             'git' => 'Composer\Repository\Vcs\GitDriver',
+            'gitmono' => 'Composer\Repository\Vcs\GitMonoDriver',
             'hg-bitbucket' => 'Composer\Repository\Vcs\HgBitbucketDriver',
             'hg' => 'Composer\Repository\Vcs\HgDriver',
             'perforce' => 'Composer\Repository\Vcs\PerforceDriver',
@@ -168,7 +169,8 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
                 $this->io->overwriteError($msg, false);
             }
 
-            // strip the release- prefix from tags if present
+	    // strip the release- prefix from tags if present
+	    $tag = $driver->normalizeTag( $tag );
             $tag = str_replace('release-', '', $tag);
 
             $cachedPackage = $this->getCachedPackageVersion($tag, $identifier, $isVerbose, $isVeryVerbose);


### PR DESCRIPTION
If you try to run a mono-repository in Git where, within a single repository, you have multiple projects existing as their own unrelated branches, composer has some bugs related to branches and tags connected to a project. It mistakenly mixes tags and branches improperly to the wrong projects. This code change creates a new repository type called "gitmono" that does not suffer these ill effects. These changes also allow for namespacing tags within the mono-repository (refs/tags/<project name>/<schematic version>). 