### PR TITLE
Add "no-check-version" option to ValidateCommand

### DIFF
--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -42,6 +42,7 @@ class ValidateCommand extends BaseCommand
                 new InputOption('no-check-all', null, InputOption::VALUE_NONE, 'Do not validate requires for overly strict/loose constraints'),
                 new InputOption('no-check-lock', null, InputOption::VALUE_NONE, 'Do not check if lock file is up to date'),
                 new InputOption('no-check-publish', null, InputOption::VALUE_NONE, 'Do not check for publish errors'),
+                new InputOption('no-check-version', null, InputOption::VALUE_NONE, 'Do not check if version field is present'),
                 new InputOption('with-dependencies', 'A', InputOption::VALUE_NONE, 'Also validate the composer.json of all installed dependencies'),
                 new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code for warnings as well as errors'),
                 new InputArgument('file', InputArgument::OPTIONAL, 'path to composer.json file'),
@@ -86,8 +87,9 @@ EOT
         $checkAll = $input->getOption('no-check-all') ? 0 : ValidatingArrayLoader::CHECK_ALL;
         $checkPublish = !$input->getOption('no-check-publish');
         $checkLock = !$input->getOption('no-check-lock');
+        $checkVersion = !$input->getOption('no-check-version');
         $isStrict = $input->getOption('strict');
-        list($errors, $publishErrors, $warnings) = $validator->validate($file, $checkAll);
+        list($errors, $publishErrors, $warnings) = $validator->validate($file, $checkAll, $checkVersion);
 
         $lockErrors = array();
         $composer = Factory::create($io, $file, $input->hasParameterOption('--no-plugins'));
@@ -107,7 +109,7 @@ EOT
                 $path = $composer->getInstallationManager()->getInstallPath($package);
                 $file = $path . '/composer.json';
                 if (is_dir($path) && file_exists($file)) {
-                    list($errors, $publishErrors, $warnings) = $validator->validate($file, $checkAll);
+                    list($errors, $publishErrors, $warnings) = $validator->validate($file, $checkAll, $checkVersion);
 
                     $this->outputResult($io, $package->getPrettyName(), $errors, $warnings, $checkPublish, $publishErrors);
 

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -42,7 +42,7 @@ class ValidateCommand extends BaseCommand
                 new InputOption('no-check-all', null, InputOption::VALUE_NONE, 'Do not validate requires for overly strict/loose constraints'),
                 new InputOption('no-check-lock', null, InputOption::VALUE_NONE, 'Do not check if lock file is up to date'),
                 new InputOption('no-check-publish', null, InputOption::VALUE_NONE, 'Do not check for publish errors'),
-                new InputOption('no-check-version', null, InputOption::VALUE_NONE, 'Do not check if version field is present'),
+                new InputOption('no-check-version', null, InputOption::VALUE_NONE, 'Do not report a warning if the version field is present'),
                 new InputOption('with-dependencies', 'A', InputOption::VALUE_NONE, 'Also validate the composer.json of all installed dependencies'),
                 new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code for warnings as well as errors'),
                 new InputArgument('file', InputArgument::OPTIONAL, 'path to composer.json file'),

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -87,7 +87,7 @@ EOT
         $checkAll = $input->getOption('no-check-all') ? 0 : ValidatingArrayLoader::CHECK_ALL;
         $checkPublish = !$input->getOption('no-check-publish');
         $checkLock = !$input->getOption('no-check-lock');
-        $checkVersion = !$input->getOption('no-check-version');
+        $checkVersion = $input->getOption('no-check-version') ? 0 : ConfigValidator::CHECK_VERSION;
         $isStrict = $input->getOption('strict');
         list($errors, $publishErrors, $warnings) = $validator->validate($file, $checkAll, $checkVersion);
 

--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -40,10 +40,11 @@ class ConfigValidator
      *
      * @param string $file                       The path to the file
      * @param int    $arrayLoaderValidationFlags Flags for ArrayLoader validation
+     * @param bool   $checkVersion               Whether or not check if version field is present
      *
      * @return array a triple containing the errors, publishable errors, and warnings
      */
-    public function validate($file, $arrayLoaderValidationFlags = ValidatingArrayLoader::CHECK_ALL)
+    public function validate($file, $arrayLoaderValidationFlags = ValidatingArrayLoader::CHECK_ALL, $checkVersion = true)
     {
         $errors = array();
         $publishErrors = array();
@@ -109,7 +110,7 @@ class ConfigValidator
             }
         }
 
-        if (isset($manifest['version'])) {
+        if ($checkVersion && isset($manifest['version'])) {
             $warnings[] = 'The version field is present, it is recommended to leave it out if the package is published on Packagist.';
         }
 

--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -28,6 +28,8 @@ use Composer\Spdx\SpdxLicenses;
  */
 class ConfigValidator
 {
+    const CHECK_VERSION = 1;
+
     private $io;
 
     public function __construct(IOInterface $io)
@@ -40,11 +42,11 @@ class ConfigValidator
      *
      * @param string $file                       The path to the file
      * @param int    $arrayLoaderValidationFlags Flags for ArrayLoader validation
-     * @param bool   $checkVersion               Whether or not check if version field is present
+     * @param int    $flags                      Flags for validation
      *
      * @return array a triple containing the errors, publishable errors, and warnings
      */
-    public function validate($file, $arrayLoaderValidationFlags = ValidatingArrayLoader::CHECK_ALL, $checkVersion = true)
+    public function validate($file, $arrayLoaderValidationFlags = ValidatingArrayLoader::CHECK_ALL, $flags = self::CHECK_VERSION)
     {
         $errors = array();
         $publishErrors = array();
@@ -110,7 +112,7 @@ class ConfigValidator
             }
         }
 
-        if ($checkVersion && isset($manifest['version'])) {
+        if (($flags & self::CHECK_VERSION) && isset($manifest['version'])) {
             $warnings[] = 'The version field is present, it is recommended to leave it out if the package is published on Packagist.';
         }
 


### PR DESCRIPTION
Field `version` can be a useful source of truth for packages that are not published on Packagist.