### PR TITLE
backport the legacy event api that allowed the substitue of rfs

### DIFF
--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -55,6 +55,16 @@ class PreFileDownloadEvent extends Event
     }
 
     /**
+     * Sets the http downloader
+     *
+     * @param HttpDownloader $httpDownloader
+     */
+    public function setHttpDownloader(HttpDownloader $httpDownloader)
+    {
+        $this->httpDownloader = $httpDownloader;
+    }
+
+    /**
      * Retrieves the processed URL this remote filesystem will be used for
      *
      * @return string


### PR DESCRIPTION
as found at https://getcomposer.org/apidoc/1.10.1/Composer/Plugin/PreFileDownloadEvent.html#method_setRemoteFilesystem