### PR TITLE
Optimize extension checks

### DIFF
--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_extensions_required.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_extensions_required.php
@@ -8,13 +8,6 @@ if (!(PHP_VERSION_ID >= 70200 && PHP_VERSION_ID < 80000)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.0" and "< 8.0.0". You are running ' . PHP_VERSION  .  '.';
 }
 
-$missingExtensions = array_diff(array (
-), array_map('strtolower', get_loaded_extensions()));
-
-if (0 !== count($missingExtensions)) {
-    $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
-}
-
-if (0 !== count($issues)) {
+if ($issues) {
     die('Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues));
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_lower_bound.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_lower_bound.php
@@ -8,13 +8,6 @@ if (!(PHP_VERSION_ID >= 0 && PHP_VERSION_ID < 80000)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 0" and "< 8.0.0". You are running ' . PHP_VERSION  .  '.';
 }
 
-$missingExtensions = array_diff(array (
-), array_map('strtolower', get_loaded_extensions()));
-
-if (0 !== count($missingExtensions)) {
-    $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
-}
-
-if (0 !== count($issues)) {
+if ($issues) {
     die('Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues));
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_required.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_required.php
@@ -8,15 +8,14 @@ if (!(PHP_VERSION_ID >= 0 && PHP_VERSION_ID < 99999)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 0" and "< 99999". You are running ' . PHP_VERSION  .  '.';
 }
 
-$missingExtensions = array_diff(array (
-  0 => 'json',
-  1 => 'xml',
-), array_map('strtolower', get_loaded_extensions()));
+$missingExtensions = array();
+extension_loaded('json') || $missingExtensions[] = 'json';
+extension_loaded('xml') || $missingExtensions[] = 'xml';
 
-if (0 !== count($missingExtensions)) {
+if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if (0 !== count($issues)) {
+if ($issues) {
     die('Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues));
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_upper_bound.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_upper_bound.php
@@ -8,13 +8,6 @@ if (!(PHP_VERSION_ID >= 70200 && PHP_VERSION_ID < 99999)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.0" and "< 99999". You are running ' . PHP_VERSION  .  '.';
 }
 
-$missingExtensions = array_diff(array (
-), array_map('strtolower', get_loaded_extensions()));
-
-if (0 !== count($missingExtensions)) {
-    $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
-}
-
-if (0 !== count($issues)) {
+if ($issues) {
     die('Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues));
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/specific_php_release.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/specific_php_release.php
@@ -8,13 +8,6 @@ if (!(PHP_VERSION_ID >= 70208 && PHP_VERSION_ID < 80000)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.8" and "< 8.0.0". You are running ' . PHP_VERSION  .  '.';
 }
 
-$missingExtensions = array_diff(array (
-), array_map('strtolower', get_loaded_extensions()));
-
-if (0 !== count($missingExtensions)) {
-    $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
-}
-
-if (0 !== count($issues)) {
+if ($issues) {
     die('Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues));
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/typical.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/typical.php
@@ -8,15 +8,14 @@ if (!(PHP_VERSION_ID >= 70200 && PHP_VERSION_ID < 80000)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.0" and "< 8.0.0". You are running ' . PHP_VERSION  .  '.';
 }
 
-$missingExtensions = array_diff(array (
-  0 => 'json',
-  1 => 'xml',
-), array_map('strtolower', get_loaded_extensions()));
+$missingExtensions = array();
+extension_loaded('json') || $missingExtensions[] = 'json';
+extension_loaded('xml') || $missingExtensions[] = 'xml';
 
-if (0 !== count($missingExtensions)) {
+if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if (0 !== count($issues)) {
+if ($issues) {
     die('Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues));
 }


### PR DESCRIPTION
Small optimization of the code generated after #8546
`extension_loaded()` can be optimized out by opcache so better use it.