### PR TITLE
close #8784, Added --locked option to composer show command. Displaying locked packages with --all option

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -357,6 +357,7 @@ php composer.phar show monolog/monolog 1.0.2
 
 * **--all :** List all packages available in all your repositories.
 * **--installed (-i):** List the packages that are installed (this is enabled by default, and deprecated).
+* **--locked:** List the locked packages from composer.lock.
 * **--platform (-p):** List only platform packages (php & extensions).
 * **--available (-a):** List available packages only.
 * **--self (-s):** List the root package info.


### PR DESCRIPTION
Hey, In this pull request I added `--locked` option to `composer show`. I also added displaying locked packages when using `composer show --all`