### PR TITLE
Add (default) base name of archive into composer.json

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -883,6 +883,21 @@ A set of options for creating package archives.
 
 The following options are supported:
 
+* **name:** Allows configuring base name for archive.
+  By default (if not configured, and `--file` is not passed as command-line argument),
+  `preg_replace('#[^a-z0-9-_]#i', '-', name)` is used.
+
+Example:
+
+```json
+{
+    "name": "org/strangeName",
+    "archive": {
+        "name": "Strange_name"
+    }
+}
+```
+
 * **exclude:** Allows configuring a list of patterns for excluded paths. The
   pattern syntax matches .gitignore files. A leading exclamation mark (!) will
   result in any matching files to be included even if a previous pattern

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -354,6 +354,10 @@
             "type": ["object"],
             "description": "Options for creating package archives for distribution.",
             "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "A base name for archive."
+                },
                 "exclude": {
                     "type": "array",
                     "description": "A list of patterns for paths to exclude or include if prefixed with an exclamation mark."

--- a/src/Composer/Package/AliasPackage.php
+++ b/src/Composer/Package/AliasPackage.php
@@ -387,6 +387,11 @@ class AliasPackage extends BasePackage implements CompletePackageInterface
         return $this->aliasOf->getNotificationUrl();
     }
 
+    public function getArchiveName()
+    {
+        return $this->aliasOf->getArchiveName();
+    }
+
     public function getArchiveExcludes()
     {
         return $this->aliasOf->getArchiveExcludes();

--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -72,7 +72,12 @@ class ArchiveManager
      */
     public function getPackageFilename(PackageInterface $package)
     {
-        $nameParts = array(preg_replace('#[^a-z0-9-_]#i', '-', $package->getName()));
+        if ($package->getArchiveName()) {
+            $baseName = $package->getArchiveName();
+        } else {
+            $baseName = preg_replace('#[^a-z0-9-_]#i', '-', $package->getName());
+        }
+        $nameParts = array($baseName);
 
         if (preg_match('{^[a-f0-9]{40}$}', $package->getDistReference())) {
             array_push($nameParts, $package->getDistReference(), $package->getDistType());
@@ -125,20 +130,6 @@ class ArchiveManager
         }
 
         $filesystem = new Filesystem();
-        if (null === $fileName) {
-            $packageName = $this->getPackageFilename($package);
-        } else {
-            $packageName = $fileName;
-        }
-
-        // Archive filename
-        $filesystem->ensureDirectoryExists($targetDir);
-        $target = realpath($targetDir).'/'.$packageName.'.'.$format;
-        $filesystem->ensureDirectoryExists(dirname($target));
-
-        if (!$this->overwriteFiles && file_exists($target)) {
-            return $target;
-        }
 
         if ($package instanceof RootPackageInterface) {
             $sourcePath = realpath('.');
@@ -159,10 +150,28 @@ class ArchiveManager
             if (file_exists($composerJsonPath = $sourcePath.'/composer.json')) {
                 $jsonFile = new JsonFile($composerJsonPath);
                 $jsonData = $jsonFile->read();
+                if (!empty($jsonData['archive']['name'])) {
+                    $package->setArchiveName($jsonData['archive']['name']);
+                }
                 if (!empty($jsonData['archive']['exclude'])) {
                     $package->setArchiveExcludes($jsonData['archive']['exclude']);
                 }
             }
+        }
+
+        if (null === $fileName) {
+            $packageName = $this->getPackageFilename($package);
+        } else {
+            $packageName = $fileName;
+        }
+
+        // Archive filename
+        $filesystem->ensureDirectoryExists($targetDir);
+        $target = realpath($targetDir).'/'.$packageName.'.'.$format;
+        $filesystem->ensureDirectoryExists(dirname($target));
+
+        if (!$this->overwriteFiles && file_exists($target)) {
+            return $target;
         }
 
         // Create the archive

--- a/src/Composer/Package/Dumper/ArrayDumper.php
+++ b/src/Composer/Package/Dumper/ArrayDumper.php
@@ -70,6 +70,9 @@ class ArrayDumper
             }
         }
 
+        if ($package->getArchiveName()) {
+            $data['archive']['name'] = $package->getArchiveName();
+        }
         if ($package->getArchiveExcludes()) {
             $data['archive']['exclude'] = $package->getArchiveExcludes();
         }

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -159,6 +159,9 @@ class ArrayLoader implements LoaderInterface
             $package->setNotificationUrl($config['notification-url']);
         }
 
+        if (!empty($config['archive']['name'])) {
+            $package->setArchiveName($config['archive']['name']);
+        }
         if (!empty($config['archive']['exclude'])) {
             $package->setArchiveExcludes($config['archive']['exclude']);
         }

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -57,6 +57,7 @@ class Package extends BasePackage
     protected $autoload = array();
     protected $devAutoload = array();
     protected $includePaths = array();
+    protected $archiveName;
     protected $archiveExcludes = array();
 
     /**
@@ -549,6 +550,24 @@ class Package extends BasePackage
     public function getNotificationUrl()
     {
         return $this->notificationUrl;
+    }
+
+    /**
+     * Sets default base filename for archive
+     *
+     * @param string $name
+     */
+    public function setArchiveName($name)
+    {
+        $this->archiveName = $name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getArchiveName()
+    {
+        return $this->archiveName;
     }
 
     /**

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -346,6 +346,13 @@ interface PackageInterface
     public function getPrettyString();
 
     /**
+     * Returns default base filename for archive
+     *
+     * @return array
+     */
+    public function getArchiveName();
+
+    /**
      * Returns a list of patterns to exclude from package archives
      *
      * @return array


### PR DESCRIPTION
`--file` argument for `archive` command, introduced in #4397 and #4479, is great, but:

* Written by hands, it's just tedious
* Used from CI, command becomes non-reusable. You can't have a single command to build any package

I propose to add `name` property into `archive` section of `composer.json` and use it for base name for archive, if `--file` argument was not provided.
*Base* means that Composer still concatenates it with version (and this is not configurable).

I haven't write any tests yet. They are probably required, but I'm not sure on the test strategy.
Let's discuss.