### PR TITLE
Use compiled constraint in Composer

### DIFF
--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -14,6 +14,7 @@ namespace Composer\DependencyResolver;
 
 use Composer\Package\AliasPackage;
 use Composer\Package\Version\VersionParser;
+use Composer\Semver\CompilingMatcher;
 use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Package\PackageInterface;
@@ -146,9 +147,7 @@ class Pool implements \Countable
         $candidateVersion = $candidate->getVersion();
 
         if ($candidateName === $name) {
-            $pkgConstraint = new Constraint('==', $candidateVersion);
-
-            if ($constraint === null || $constraint->matches($pkgConstraint)) {
+            if ($constraint === null || CompilingMatcher::match($constraint, Constraint::OP_EQ, $candidateVersion)) {
                 return true;
             }
 

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -12,21 +12,21 @@
 
 namespace Composer\DependencyResolver;
 
+use Composer\EventDispatcher\EventDispatcher;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
-use Composer\Package\Package;
 use Composer\Package\PackageInterface;
 use Composer\Package\Version\StabilityFilter;
+use Composer\Plugin\PluginEvents;
+use Composer\Plugin\PrePoolCreateEvent;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RootPackageRepository;
+use Composer\Semver\CompilingMatcher;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Semver\Constraint\MatchAllConstraint;
 use Composer\Semver\Constraint\MultiConstraint;
-use Composer\EventDispatcher\EventDispatcher;
-use Composer\Plugin\PrePoolCreateEvent;
-use Composer\Plugin\PluginEvents;
 
 /**
  * @author Nils Adermann <naderman@naderman.de>
@@ -209,7 +209,7 @@ class PoolBuilder
 
                 $found = false;
                 foreach ($aliasedPackages as $packageOrAlias) {
-                    if ($constraint->matches(new Constraint('==', $packageOrAlias->getVersion()))) {
+                    if (CompilingMatcher::match($constraint, Constraint::OP_EQ, $packageOrAlias->getVersion())) {
                         $found = true;
                     }
                 }

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -23,6 +23,7 @@ use Composer\Config;
 use Composer\Composer;
 use Composer\Factory;
 use Composer\IO\IOInterface;
+use Composer\Semver\CompilingMatcher;
 use Composer\Util\HttpDownloader;
 use Composer\Util\Loop;
 use Composer\Plugin\PluginEvents;
@@ -764,7 +765,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 continue;
             }
 
-            if ($constraint && !$constraint->matches(new Constraint('==', $version))) {
+            if ($constraint && !CompilingMatcher::match($constraint, Constraint::OP_EQ, $version)) {
                 continue;
             }
 


### PR DESCRIPTION
This is draft of integrating compiled constraint in Composer:

https://github.com/composer/semver/pull/86.

I Probably need help to find the right way to inject the `Compiledatcher` with the right cache dir configured.

Note: I did not replace ALL  occurrences of `->matches()` but just the one that are the most often called. 