### PR TITLE
Add composer-runtime-api version constant

### DIFF
--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -55,6 +55,17 @@ class Composer
     const RELEASE_DATE = '@release_date@';
     const SOURCE_VERSION = '1.10-dev+source';
 
+    /**
+     * Version number of the internal composer-runtime-api package
+     *
+     * This is used to version features available to projects at runtime
+     * like the platform-check file, the Composer\InstalledVersions class
+     * and possibly others in the future.
+     *
+     * @var string
+     */
+    const RUNTIME_API_VERSION = '1.0.0';
+
     public static function getVersion()
     {
         // no replacement done, this must be a source checkout

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Repository;
 
+use Composer\Composer;
 use Composer\Package\CompletePackage;
 use Composer\Package\PackageInterface;
 use Composer\Package\Version\VersionParser;
@@ -73,6 +74,12 @@ class PlatformRepository extends ArrayRepository
         $composerPluginApi = new CompletePackage('composer-plugin-api', $version, $prettyVersion);
         $composerPluginApi->setDescription('The Composer Plugin API');
         $this->addPackage($composerPluginApi);
+
+        $prettyVersion = Composer::RUNTIME_API_VERSION;
+        $version = $this->versionParser->normalize($prettyVersion);
+        $composerRuntimeApi = new CompletePackage('composer-runtime-api', $version, $prettyVersion);
+        $composerRuntimeApi->setDescription('The Composer Runtime API');
+        $this->addPackage($composerRuntimeApi);
 
         try {
             $prettyVersion = PHP_VERSION;


### PR DESCRIPTION
Fixes #8846 

I tried a partial cherry pick of 0ab48a1773e55ee1706d43e739fa5719811a87c8, so surely this is incomplete... at the very least it would need tests, but I couldn't find any on master. 