### PR TITLE
Annotate phpstan errors in pull requests

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -34,6 +34,7 @@ jobs:
           extensions: "intl"
           ini-values: "memory_limit=-1"
           php-version: "${{ matrix.php-version }}"
+          tools: "cs2pr"
 
       - name: "Determine composer cache directory"
         id: "determine-composer-cache-directory"
@@ -52,4 +53,4 @@ jobs:
       - name: Run PHPStan
         run: |
           bin/composer require --dev phpstan/phpstan:^0.12 phpunit/phpunit:^7.5 --with-all-dependencies
-          vendor/bin/phpstan analyse --configuration=phpstan/config.neon
+          vendor/bin/phpstan analyse --configuration=phpstan/config.neon --error-format=checkstyle | cs2pr


### PR DESCRIPTION
Utilizing https://github.com/staabm/annotate-pull-request-from-checkstyle

phpstan errors get promoted into the „Files-changed“ Tab

Example:
![Context Example](https://github.com/mheap/phpunit-github-actions-printer/blob/master/phpunit-printer-context.png?raw=true)