### PR TITLE
Regex improvements with unnecessary `.*` matchers

### DIFF
--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -178,7 +178,7 @@ class SvnDownloader extends VcsDownloader
      */
     protected function getCommitLogs($fromReference, $toReference, $path)
     {
-        if (preg_match('{.*@(\d+)$}', $fromReference) && preg_match('{.*@(\d+)$}', $toReference)) {
+        if (preg_match('{@(\d+)$}', $fromReference) && preg_match('{@(\d+)$}', $toReference)) {
             // retrieve the svn base url from the checkout folder
             $command = sprintf('svn info --non-interactive --xml %s', ProcessExecutor::escape($path));
             if (0 !== $this->process->execute($command, $output, $path)) {

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -997,7 +997,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         }
 
         // url-encode $ signs in URLs as bad proxies choke on them
-        if (($pos = strpos($filename, '$')) && preg_match('{^https?://.*}i', $filename)) {
+        if (($pos = strpos($filename, '$')) && preg_match('{^https?://}i', $filename)) {
             $filename = substr($filename, 0, $pos) . '%24' . substr($filename, $pos + 1);
         }
 


### PR DESCRIPTION
A small micro-optimization in some of the regular expressions used in Composer. 

The `.*` pattern is often greedy, and sometimes doesn't provide any assertions because `*` matches **zero** or more of the given pattern. This, combined with the "any" (`"."`) used as a prefix, or worse, as a suffix, provides sub-optimal regular expressions. 

`{.*@(\d+)$}` currently in Composer, for example, is exactly the same as `{@(\d+)$}` because the `*` quantifier is _zero_ or more. However, the latter uses fewer steps. See [current](https://regex101.com/r/yRa4Oy/1/) vs [suggested](https://regex101.com/r/yRa4Oy/2).

Trailing `.*` are not necessarily a performance hit in most cases (because the engine can immediately return results), but it's an unnecessary one nonetheless. 

For all changes made here, the matched values are not captured, so the `preg_match()` call values are used as expressions for the truthiness. 