### PR TITLE
Feat/gitlab deploy token

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -85,9 +85,13 @@ gitlab.com the domain names must be also specified with the
 
 ## gitlab-token
 
-A list of domain names and private tokens. For example using `{"gitlab.com":
+A list of domain names and private tokens. Private token can be either simple 
+string, or array with username and token. For example using `{"gitlab.com": 
 "privatetoken"}` as the value of this option will use `privatetoken` to access
-private repositories on gitlab. Please note: If the package is not hosted at
+private repositories on gitlab. Using `{"gitlab.com": {"username": "gitlabuser",
+ "token": "privatetoken"}}` will use both username and token for gitlab deploy 
+token functionality (https://docs.gitlab.com/ee/user/project/deploy_tokens/)
+Please note: If the package is not hosted at
 gitlab.com the domain names must be also specified with the
 [`gitlab-domains`](06-config.md#gitlab-domains) option.
 

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -135,7 +135,9 @@ abstract class BaseIO implements IOInterface
         }
 
         foreach ($gitlabToken as $domain => $token) {
-            $this->checkAndSetAuthentication($domain, $token, 'private-token');
+            $username = is_array($token) && array_key_exists("username", $token) ? $token["username"] : $token;
+            $password = is_array($token) && array_key_exists("token", $token) ? $token["token"] : 'private-token';
+            $this->checkAndSetAuthentication($domain, $username, $password);
         }
 
         // reload http basic credentials from config if available

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -135,9 +135,7 @@ abstract class BaseIO implements IOInterface
         }
 
         foreach ($gitlabToken as $domain => $token) {
-            $username = is_array($token) && array_key_exists("username", $token) ? $token["username"] : $token;
-            $password = is_array($token) && array_key_exists("token", $token) ? $token["token"] : 'private-token';
-            $this->checkAndSetAuthentication($domain, $username, $password);
+            $this->checkAndSetAuthentication($domain, $token, 'private-token');
         }
 
         // reload http basic credentials from config if available

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -184,9 +184,9 @@ class Git
                 if ($this->io->hasAuthentication($match[2])) {
                     $auth = $this->io->getAuthentication($match[2]);
                     if ($auth['password'] === 'private-token' || $auth['password'] === 'oauth2' || $auth['password'] === 'gitlab-ci-token') {
-                        $authUrl = $match[1] . '://' . rawurlencode($auth['password']) . ':' . rawurlencode($auth['username']) . '@' . $match[2] . '/' . $match[3] . '.git'; // swap username and password
+                        $authUrl = $match[1] . '://' . rawurlencode($auth['password']) . ':' . rawurlencode($auth['username']) . '@' . $match[2] . '/' . $match[3]; // swap username and password
                     } else {
-                        $authUrl = $match[1] . '://' . rawurlencode($auth['username']) . ':' . rawurlencode($auth['password']) . '@' . $match[2] . '/' . $match[3] . '.git';
+                        $authUrl = $match[1] . '://' . rawurlencode($auth['username']) . ':' . rawurlencode($auth['password']) . '@' . $match[2] . '/' . $match[3];
                     }
 
                     $command = call_user_func($commandCallable, $authUrl);

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -184,9 +184,9 @@ class Git
                 if ($this->io->hasAuthentication($match[2])) {
                     $auth = $this->io->getAuthentication($match[2]);
                     if ($auth['password'] === 'private-token' || $auth['password'] === 'oauth2' || $auth['password'] === 'gitlab-ci-token') {
-                        $authUrl = $match[1] . '://' . rawurlencode($auth['password']) . ':' . rawurlencode($auth['username']) . '@' . $match[2] . '/' . $match[3]; // swap username and password
+                        $authUrl = $match[1] . '://' . rawurlencode($auth['password']) . ':' . rawurlencode($auth['username']) . '@' . $match[2] . '/' . $match[3] . '.git'; // swap username and password
                     } else {
-                        $authUrl = $match[1] . '://' . rawurlencode($auth['username']) . ':' . rawurlencode($auth['password']) . '@' . $match[2] . '/' . $match[3];
+                        $authUrl = $match[1] . '://' . rawurlencode($auth['username']) . ':' . rawurlencode($auth['password']) . '@' . $match[2] . '/' . $match[3] . '.git';
                     }
 
                     $command = call_user_func($commandCallable, $authUrl);

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -80,7 +80,7 @@ class GitLab
 
         // if available use token from composer config
         $authTokens = $this->config->get('gitlab-token');
-        
+
         if (isset($authTokens[$originUrl])) {
             $token = $authTokens[$originUrl];
         }
@@ -179,9 +179,9 @@ class GitLab
         );
 
         $token = $this->httpDownloader->get($scheme.'://'.$apiUrl.'/oauth/token', $options)->decodeJson();
-        
-        $this->io->writeError('Token successfully created');	
-        
+
+        $this->io->writeError('Token successfully created');
+
         return $token;
     }
 }

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -71,17 +71,28 @@ class GitLab
             return true;
         }
 
-        // if available use token from composer config
-        $authTokens = $this->config->get('gitlab-token');
-
-        if (isset($authTokens[$originUrl])) {
-            $this->io->setAuthentication($originUrl, $authTokens[$originUrl], 'private-token');
+        // if available use deploy token from git config
+        if (0 === $this->process->execute('git config gitlab.deploytoken.user', $tokenUser) && 0 === $this->process->execute('git config gitlab.deploytoken.token', $tokenPassword)) {
+            $this->io->setAuthentication($originUrl, trim($tokenUser), trim($tokenPassword));
 
             return true;
         }
 
+        // if available use token from composer config
+        $authTokens = $this->config->get('gitlab-token');
+        
+        if (isset($authTokens[$originUrl])) {
+            $token = $authTokens[$originUrl];
+        }
+
         if (isset($authTokens[$bcOriginUrl])) {
-            $this->io->setAuthentication($originUrl, $authTokens[$bcOriginUrl], 'private-token');
+            $token = $authTokens[$bcOriginUrl];
+        }
+        
+        if(isset($token)){
+            $username = is_array($token) && array_key_exists("username", $token) ? $token["username"] : $token;
+            $password = is_array($token) && array_key_exists("token", $token) ? $token["token"] : 'private-token';
+            $this->io->setAuthentication($originUrl, $username, $password);
 
             return true;
         }
@@ -168,9 +179,9 @@ class GitLab
         );
 
         $token = $this->httpDownloader->get($scheme.'://'.$apiUrl.'/oauth/token', $options)->decodeJson();
-
-        $this->io->writeError('Token successfully created');
-
+        
+        $this->io->writeError('Token successfully created');	
+        
         return $token;
     }
 }

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -71,28 +71,17 @@ class GitLab
             return true;
         }
 
-        // if available use deploy token from git config
-        if (0 === $this->process->execute('git config gitlab.deploytoken.user', $tokenUser) && 0 === $this->process->execute('git config gitlab.deploytoken.token', $tokenPassword)) {
-            $this->io->setAuthentication($originUrl, trim($tokenUser), trim($tokenPassword));
+        // if available use token from composer config
+        $authTokens = $this->config->get('gitlab-token');
+
+        if (isset($authTokens[$originUrl])) {
+            $this->io->setAuthentication($originUrl, $authTokens[$originUrl], 'private-token');
 
             return true;
         }
 
-        // if available use token from composer config
-        $authTokens = $this->config->get('gitlab-token');
-        
-        if (isset($authTokens[$originUrl])) {
-            $token = $authTokens[$originUrl];
-        }
-
         if (isset($authTokens[$bcOriginUrl])) {
-            $token = $authTokens[$bcOriginUrl];
-        }
-        
-        if(isset($token)){
-            $username = is_array($token) && array_key_exists("username", $token) ? $token["username"] : $token;
-            $password = is_array($token) && array_key_exists("token", $token) ? $token["token"] : 'private-token';
-            $this->io->setAuthentication($originUrl, $username, $password);
+            $this->io->setAuthentication($originUrl, $authTokens[$bcOriginUrl], 'private-token');
 
             return true;
         }
@@ -179,9 +168,9 @@ class GitLab
         );
 
         $token = $this->httpDownloader->get($scheme.'://'.$apiUrl.'/oauth/token', $options)->decodeJson();
-        
-        $this->io->writeError('Token successfully created');	
-        
+
+        $this->io->writeError('Token successfully created');
+
         return $token;
     }
 }


### PR DESCRIPTION
Added ability to work with GitLab deploy tokens: https://docs.gitlab.com/ee/user/project/deploy_tokens/

Deploy tokens can be specified two ways:
1) GIT CONFIG:
git config --add gitlab.deploytoken.user USERNAME && git config --add gitlab.deploytoken.token TOKEN
2) Auth.json:
"gitlab-token": {
    "gitlab.com": {"username": "USERNAME", "token": "TOKEN"}
}