### PR TITLE
Add function_exists() for 'pcntl_signal'

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -356,7 +356,7 @@ EOT
         }
 
         // handler Ctrl+C for unix-like systems
-        if (function_exists('pcntl_async_signals')) {
+        if (function_exists('pcntl_async_signals') && function_exists('pcntl_signal')) {
             @mkdir($directory, 0777, true);
             if ($realDir = realpath($directory)) {
                 pcntl_async_signals(true);

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -96,7 +96,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (function_exists('pcntl_async_signals')) {
+        if (function_exists('pcntl_async_signals') && function_exists('pcntl_signal')) {
             pcntl_async_signals(true);
             pcntl_signal(SIGINT, array($this, 'revertComposerFile'));
             pcntl_signal(SIGTERM, array($this, 'revertComposerFile'));


### PR DESCRIPTION
When I run this command:
```
composer global require <anything>
```

I get the following output:
```
[ErrorException]  
pcntl_signal() has been disabled for security reasons
```

How to reproduce : 
- PHP >= 7.1
  - compiled with --enable-pcntl, see [this doc](https://www.php.net/manual/en/pcntl.installation.php)
  - with a php.ini directive "disable_functions" containing "pcntl_signal" (which is common on Debian OS)
- composer >= 1.8.0, see [this commit](https://github.com/composer/composer/commit/d65e1c0112944666ea31e16fbb66e9b809efb2da)

It can be easily fixed by removing "pcntl_signal" in the php.ini directive "disable_functions".

But checking availability of function in composer code seems much more effective.



