### PR TITLE
feat: add option to prevent error_reporting() overriding runtime configuration

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -24,6 +24,7 @@ The following options are available with every command:
 * **--no-plugins:** Disables plugins.
 * **--no-cache:** Disables the use of the cache directory. Same as setting the COMPOSER_CACHE_DIR
   env var to /dev/null (or NUL on Windows).
+* **--no-runtime-error-reporting-override:** Prevent the error handler changing the error_reporting configuration from the one set by the runtime.
 * **--working-dir (-d):** If specified, use the given directory as working directory.
 * **--profile:** Display timing and memory usage information
 * **--ansi:** Force ANSI output.

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -127,7 +127,14 @@ class Application extends BaseApplication
         $io = $this->io = new ConsoleIO($input, $output, new HelperSet(array(
             new QuestionHelper(),
         )));
-        ErrorHandler::register($io);
+
+        $overrideRuntimeErrorReporting = true;
+
+        if ($input->hasParameterOption('--no-runtime-error-reporting-override')) {
+            $overrideRuntimeErrorReporting = false;
+        }
+
+        ErrorHandler::register($io, $overrideRuntimeErrorReporting);
 
         if ($input->hasParameterOption('--no-cache')) {
             $io->writeError('Disabling cache usage', true, IOInterface::DEBUG);
@@ -230,7 +237,7 @@ class Application extends BaseApplication
                 if (function_exists('posix_getuid') && posix_getuid() === 0) {
                     if ($commandName !== 'self-update' && $commandName !== 'selfupdate') {
                         $io->writeError('<warning>Do not run Composer as root/super user! See https://getcomposer.org/root for details</warning>');
-                        
+
                         if ($io->isInteractive()) {
                             if (!$io->askConfirmation('<info>Continue as root/super user</info> [<comment>yes</comment>]? ', true)) {
                                 return 1;
@@ -481,6 +488,7 @@ class Application extends BaseApplication
         $definition->addOption(new InputOption('--no-plugins', null, InputOption::VALUE_NONE, 'Whether to disable plugins.'));
         $definition->addOption(new InputOption('--working-dir', '-d', InputOption::VALUE_REQUIRED, 'If specified, use the given directory as working directory.'));
         $definition->addOption(new InputOption('--no-cache', null, InputOption::VALUE_NONE, 'Prevent use of the cache'));
+        $definition->addOption(new InputOption('--no-runtime-error-reporting-override', null, InputOption::VALUE_NONE, 'Prevent the error handler changing the error_reporting configuration from the one set by the runtime'));
 
         return $definition;
     }

--- a/src/Composer/Util/ErrorHandler.php
+++ b/src/Composer/Util/ErrorHandler.php
@@ -72,11 +72,16 @@ class ErrorHandler
      * Register error handler.
      *
      * @param IOInterface|null $io
+     * @param bool $overrideRuntimeErrorReporting
      */
-    public static function register(IOInterface $io = null)
+    public static function register(IOInterface $io = null, $overrideRuntimeErrorReporting = true)
     {
         set_error_handler(array(__CLASS__, 'handle'));
-        error_reporting(E_ALL | E_STRICT);
+
+        if ($overrideRuntimeErrorReporting) {
+            error_reporting(E_ALL | E_STRICT);
+        }
+
         self::$io = $io;
     }
 }

--- a/tests/Composer/Test/ApplicationTest.php
+++ b/tests/Composer/Test/ApplicationTest.php
@@ -39,6 +39,11 @@ class ApplicationTest extends TestCase
 
         $inputMock->expects($this->at($index++))
             ->method('hasParameterOption')
+            ->with($this->equalTo('--no-runtime-error-reporting-override'))
+            ->will($this->returnValue(false));
+
+        $inputMock->expects($this->at($index++))
+            ->method('hasParameterOption')
             ->with($this->equalTo('--no-cache'))
             ->will($this->returnValue(false));
 
@@ -100,6 +105,11 @@ class ApplicationTest extends TestCase
         $inputMock->expects($this->at($index++))
             ->method('setInteractive')
             ->with($this->equalTo(false));
+
+        $inputMock->expects($this->at($index++))
+            ->method('hasParameterOption')
+            ->with($this->equalTo('--no-runtime-error-reporting-override'))
+            ->will($this->returnValue(false));
 
         $inputMock->expects($this->at($index++))
             ->method('hasParameterOption')


### PR DESCRIPTION
This adds the ability to disable the override within the error_handler to meet what you might expect that your php.ini will be able to correctly set the error_reporting.

Somewhat fixes https://github.com/composer/composer/issues/8834 but perhaps in a more acceptable manner (I hope). 

While I agree these are very useful and I will want to be upgrading and fixing them if you are using `composer` as part of a deployment process its not very useful to have a chunk of spam messages within your logs and filling up your CI output. 

I agree in a development environment they are very important, but if you have actively configured the environment to ignore deprecations (rightly due to the Production environment) I don't fully understand the benefit. Also assuming this means scripts executing within Composer also don't get the correct runtime configuration. 

Im not 100% sure on the best way to contribute to this project so hopefully a PR to master I can also get it merged into the 1.x branch? 

Also sorry for the naming, if anyone has anything better happy to change it. 

Thanks 