### PR TITLE
Use the verbose option to determine whether to output "Changed current directory to"

### DIFF
--- a/src/Composer/Command/GlobalCommand.php
+++ b/src/Composer/Command/GlobalCommand.php
@@ -16,6 +16,7 @@ use Composer\Factory;
 use Composer\Util\Filesystem;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -31,6 +32,7 @@ class GlobalCommand extends BaseCommand
             ->setDescription('Allows running commands in the global composer dir ($COMPOSER_HOME).')
             ->setDefinition(array(
                 new InputArgument('command-name', InputArgument::REQUIRED, ''),
+                new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, ''),
                 new InputArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, ''),
             ))
             ->setHelp(
@@ -58,20 +60,11 @@ EOT
 
     public function run(InputInterface $input, OutputInterface $output)
     {
-        // extract real command name
-        $tokens = preg_split('{\s+}', $input->__toString());
-        $args = array();
-        foreach ($tokens as $token) {
-            if ($token && $token[0] !== '-') {
-                $args[] = $token;
-                if (count($args) >= 2) {
-                    break;
-                }
-            }
-        }
+        $globalInput = $this->parseGlobalInput($input);
+        $realInput = $this->parseRealInput($input);
 
         // show help for this command if no command was found
-        if (count($args) < 2) {
+        if ($realInput === null) {
             return parent::run($input, $output);
         }
 
@@ -92,13 +85,83 @@ EOT
         } catch (\Exception $e) {
             throw new \RuntimeException('Could not switch to home directory "'.$home.'"', 0, $e);
         }
-        $this->getIO()->writeError('<info>Changed current directory to '.$home.'</info>');
+
+        if ($globalInput->hasOption('verbose') && $globalInput->getOption('verbose')) {
+            $this->getIO()->write('<info>Changed current directory to '.$home.'</info>');
+        }
 
         // create new input without "global" command prefix
         $input = new StringInput(preg_replace('{\bg(?:l(?:o(?:b(?:a(?:l)?)?)?)?)?\b}', '', $input->__toString(), 1));
         $this->getApplication()->resetComposer();
 
         return $this->getApplication()->run($input, $output);
+    }
+
+    protected function splitTokens(InputInterface $input)
+    {
+        return preg_split('{\s+}', $input->__toString());
+    }
+
+    /**
+     * Parse the input which is only meant for the "global" command, not the "real" command after it
+     *
+     * @param InputInterface $input
+     * @return InputInterface
+     */
+    protected function parseGlobalInput(InputInterface $input)
+    {
+        $tokens = $this->splitTokens($input);
+        $arguments = array();
+        $options = array();
+
+        foreach ($tokens as $token) {
+            if ($token[0] !== '-') {
+                if (count($arguments) >= 1) {
+                    // break when the "global" token and its options are parsed, anything after is part of the real command
+                    break;
+                }
+
+                $arguments[] = $token;
+            } else if (count($arguments) >= 1) {
+                // only parse options passed after the "global" token, not before (e.g. "composer -v global ...")
+                $options[] = $token;
+            }
+        }
+
+        $input = new StringInput(join(' ', array_merge($arguments, $options)));
+        $input->bind($this->getDefinition());
+        return $input;
+    }
+
+    /**
+     * Parse the input which is only meant for the "real" command, basically the inverse of {@see GlobalCommand::parseGlobalInput()}
+     *
+     * @param InputInterface $input
+     * @return InputInterface
+     */
+    protected function parseRealInput(InputInterface $input)
+    {
+        $tokens = $this->splitTokens($input);
+        $allParts = array();
+        $realParts = array();
+
+        foreach ($tokens as $index => $token) {
+            if ($token[0] !== '-') {
+                $allParts[] = $token;
+
+                if (count($allParts) < 2) {
+                    // continue if we are still parsing the arguments and options of the "global" command
+                    continue;
+                }
+
+                $realParts[] = $token;
+            } else if (count($realParts) >= 1) {
+                // only parse options which are meant for the "real" command
+                $realParts[] = $token;
+            }
+        }
+
+        return ($realParts ? new StringInput(join(' ', $realParts)) : null);
     }
 
     /**


### PR DESCRIPTION
**Problem / Context**
I was writing a Node.js application which used `composer global ...` to add a repository to the global configuration (`composer global config ...`) and get the versions of a package (`composer global show --all ...`).

I used the exit code of the process as well as the output to stderr to determine whether the command executed successfully, this didn't seem to work. After debugging some stuff I realised the "Changed current directory to" message was written to stderr instead of stdout causing my check to fail.

"Changed current directory to" should (in my opinion) be written to stdout as it's not an error. But because of the nature of some commands such as `composer global show --all ...` this message shouldn't always be written to stdout because then stdout wouldn't be able to be parsed anymore when e.g. `--format=json` is used.

**Solution**
I decided to solve this by only writing the "Changed current directory to" message to stdout if `--verbose` (or any of its aliases) are passed to the `composer global` command.