### PR TITLE
Ensure loading aliased package rules loads all rules for original package too #8902

### DIFF
--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -288,7 +288,10 @@ abstract class Rule
 
                 return 'Conclusion: '.$ruleText.$learnedString;
             case self::RULE_PACKAGE_ALIAS:
-                return $ruleText;
+                $aliasPackage = $this->deduplicateMasterAlias($pool->literalToPackage($literals[0]));
+                $package = $this->deduplicateMasterAlias($pool->literalToPackage($literals[1]));
+
+                return $aliasPackage->getPrettyString() .' is an alias of '.$package->getPrettyString().' and thus requires it to be installed too.';
             default:
                 return '('.$ruleText.')';
         }

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -165,6 +165,7 @@ class RuleSetGenerator
                     $this->addedPackagesByNames[$name][] = $package;
                 }
             } else {
+                $workQueue->enqueue($package->getAliasOf());
                 $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRequireRule($package, array($package->getAliasOf()), Rule::RULE_PACKAGE_ALIAS, $package));
             }
 

--- a/tests/Composer/Test/Fixtures/installer/github-issues-8902.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-8902.test
@@ -1,0 +1,46 @@
+--TEST--
+
+See Github issue #8902 ( https://github.com/composer/composer/issues/8902 ).
+
+Avoid installing packages twice if they are required in different versions and one is matched by a dev package.
+
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "beyondcode/laravel-dump-server", "version": "1.4.0", "require": { "symfony/var-dumper": "^5.0" } },
+                { "name": "laravel/framework", "version": "6.8.14", "require": { "symfony/var-dumper": "^4.3.4" } },
+                { "name": "symfony/var-dumper", "version": "4.4.0" },
+                { "name": "symfony/var-dumper", "version": "dev-master", "extra": { "branch-alias": {"dev-master": "5.2-dev"} } }
+            ]
+        }
+    ],
+    "require": {
+        "beyondcode/laravel-dump-server": "^1.3",
+        "laravel/framework": "^6.8"
+    },
+    "minimum-stability": "dev"
+}
+
+--RUN--
+update
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires beyondcode/laravel-dump-server ^1.3 -> satisfiable by beyondcode/laravel-dump-server[1.4.0].
+    - beyondcode/laravel-dump-server 1.4.0 requires symfony/var-dumper ^5.0 -> satisfiable by symfony/var-dumper[dev-master].
+    - Root composer.json requires laravel/framework ^6.8 -> satisfiable by laravel/framework[6.8.14].
+    - laravel/framework 6.8.14 requires symfony/var-dumper ^4.3.4 -> satisfiable by symfony/var-dumper[4.4.0].
+    etc...
+
+
+--EXPECT--
+
+--EXPECT-EXIT-CODE--
+2

--- a/tests/Composer/Test/Fixtures/installer/github-issues-8902.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-8902.test
@@ -34,11 +34,11 @@ Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
     - Root composer.json requires beyondcode/laravel-dump-server ^1.3 -> satisfiable by beyondcode/laravel-dump-server[1.4.0].
-    - beyondcode/laravel-dump-server 1.4.0 requires symfony/var-dumper ^5.0 -> satisfiable by symfony/var-dumper[dev-master].
-    - Root composer.json requires laravel/framework ^6.8 -> satisfiable by laravel/framework[6.8.14].
+    - You can only install one version of a package, so only one of these can be installed: symfony/var-dumper[dev-master, 4.4.0].
+    - don't install symfony/var-dumper 5.2.x-dev|install symfony/var-dumper dev-master
     - laravel/framework 6.8.14 requires symfony/var-dumper ^4.3.4 -> satisfiable by symfony/var-dumper[4.4.0].
-    etc...
-
+    - beyondcode/laravel-dump-server 1.4.0 requires symfony/var-dumper ^5.0 -> satisfiable by symfony/var-dumper[5.2.x-dev (alias of dev-master)].
+    - Root composer.json requires laravel/framework ^6.8 -> satisfiable by laravel/framework[6.8.14].
 
 --EXPECT--
 

--- a/tests/Composer/Test/Fixtures/installer/github-issues-8902.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-8902.test
@@ -35,7 +35,7 @@ Your requirements could not be resolved to an installable set of packages.
   Problem 1
     - Root composer.json requires beyondcode/laravel-dump-server ^1.3 -> satisfiable by beyondcode/laravel-dump-server[1.4.0].
     - You can only install one version of a package, so only one of these can be installed: symfony/var-dumper[dev-master, 4.4.0].
-    - don't install symfony/var-dumper 5.2.x-dev|install symfony/var-dumper dev-master
+    - symfony/var-dumper 5.2.x-dev is an alias of symfony/var-dumper dev-master and thus requires it to be installed too.
     - laravel/framework 6.8.14 requires symfony/var-dumper ^4.3.4 -> satisfiable by symfony/var-dumper[4.4.0].
     - beyondcode/laravel-dump-server 1.4.0 requires symfony/var-dumper ^5.0 -> satisfiable by symfony/var-dumper[5.2.x-dev (alias of dev-master)].
     - Root composer.json requires laravel/framework ^6.8 -> satisfiable by laravel/framework[6.8.14].


### PR DESCRIPTION
Refs #8902

Also can reproduce using real world packages with:

```json
{
    "require": {
        "beyondcode/laravel-dump-server": "^1.3",
        "laravel/framework": "^6.18"
    },
    "minimum-stability": "dev",
    "prefer-stable": true
}
```

The first composer update locks:

```
  - Locking symfony/var-dumper (dev-master 63629be)
  - Locking symfony/var-dumper (v4.4.8)
```

And actually installs both (luckily the dev package installs after the stable one, so it succeeds as the dev install wipes the dir).

Subsequent updates switch between:

```
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading symfony/var-dumper (v4.4.8 => dev-master 63629be)
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Syncing symfony/var-dumper (dev-master 63629be) into cache
  - Removing symfony/var-dumper (v4.4.8)
  - Installing symfony/var-dumper (dev-master 63629be): Cloning 63629be9cb from cache
```

and:

```
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading symfony/var-dumper (v4.4.8 => dev-master 63629be)
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Syncing symfony/var-dumper (v4.4.8) into cache
  - Downgrading symfony/var-dumper (dev-master 63629be => v4.4.8): Checking out c587e04ce5 from cache
```

In a loop.

Note that this is interesting because the lock file op is always an upgrade from 4.4.8 to dev-master, but the install op plays ping pong between stable and dev versions. Might be a secondary bug in the transaction classes?