### PR TITLE
Tweaked symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,17 +31,14 @@
         "psr/log": "^1.0",
         "seld/jsonlint": "^1.4",
         "seld/phar-utils": "^1.0",
-        "symfony/console": "^2.8.52 || ^3.4 || ^4.4 || ^5.0",
-        "symfony/filesystem": "^2.8.52 || ^3.4 || ^4.4 || ^5.0",
-        "symfony/finder": "^2.8.52 || ^3.4 || ^4.4 || ^5.0",
-        "symfony/process": "^2.8.52 || ^3.4 || ^4.4 || ^5.0",
+        "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0",
+        "symfony/filesystem": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0",
+        "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0",
+        "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0",
         "react/promise": "^1.2 || ^2.7"
     },
-    "conflict": {
-        "symfony/console": "2.8.38"
-    },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.2 || ^5",
+        "symfony/phpunit-bridge": "^4.4 || ^5.0",
         "phpspec/prophecy": "^1.10"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "react/promise": "^1.2 || ^2.7"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/phpunit-bridge": "^4.2 || ^5.0",
         "phpspec/prophecy": "^1.10"
     },
     "suggest": {


### PR DESCRIPTION
`2.8.52` was released on 13th November 2019, and the simultaneous 3.4.x release was `3.4.35`. I've removed the conflict line since it's no longer relevant due to the minimum version of symfony/console.