### PR TITLE
fix deprecations in PHP 8

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -326,13 +326,22 @@ class EventDispatcher
             return $event;
         }
 
-        $typehint = $reflected->getClass();
-
-        if (!$typehint instanceof \ReflectionClass) {
-            return $event;
+        $expected = null;
+        $isClass = false;
+        if (\PHP_VERSION_ID >= 70000) {
+            $reflectionType = $reflected->getType();
+            if ($reflectionType) {
+                $expected = $reflectionType instanceof \ReflectionNamedType ? $reflectionType->getName() : (string)$reflectionType;
+                $isClass = !$reflectionType->isBuiltin();
+            }
+        } else {
+            $expected = $reflected->getClass() ? $reflected->getClass()->getName() : null;
+            $isClass = null !== $expected;
         }
 
-        $expected = $typehint->getName();
+        if (!$isClass) {
+            return $event;
+        }
 
         // BC support
         if (!$event instanceof $expected && $expected === 'Composer\Script\CommandEvent') {

--- a/src/Composer/Repository/RepositoryManager.php
+++ b/src/Composer/Repository/RepositoryManager.php
@@ -127,8 +127,20 @@ class RepositoryManager
 
         $reflMethod = new \ReflectionMethod($class, '__construct');
         $params = $reflMethod->getParameters();
-        if (isset($params[4]) && $params[4]->getClass() && $params[4]->getClass()->getName() === 'Composer\Util\RemoteFilesystem') {
-            return new $class($config, $this->io, $this->config, $this->eventDispatcher, $this->rfs);
+        if (isset($params[4])) {
+            $paramType = null;
+            if (\PHP_VERSION_ID >= 70000) {
+                $reflectionType = $params[4]->getType();
+                if ($reflectionType) {
+                    $paramType = $reflectionType instanceof \ReflectionNamedType ? $reflectionType->getName() : (string)$reflectionType;
+                }
+            } else {
+                $paramType = $params[4]->getClass() ? $params[4]->getClass()->getName() : null;
+            }
+
+            if ($paramType  === 'Composer\Util\RemoteFilesystem') {
+                return new $class($config, $this->io, $this->config, $this->eventDispatcher, $this->rfs);
+            }
         }
 
         return new $class($config, $this->io, $this->config, $this->eventDispatcher);


### PR DESCRIPTION
Method `ReflectionParameter::getClass()` is deprecated in PHP 8, `ReflectionParameter::getType` is only available in PHP 7.0, `ReflectionType::__toString()` is deprecated in PHP 7.4, and `ReflectionNamedType` is only avilable in PHP 7.4+


![image](https://user-images.githubusercontent.com/29315886/82586575-b22acf00-9b8f-11ea-951f-8c0a3a0a0999.png)


I'm also working on a fix for the json-scheme package :) 