### PR TITLE
Added composer wrapper command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "symfony/console": "2.8.38"
     },
     "require-dev": {
+        "mikey179/vfsstream": "^1.6.5",
         "phpunit/phpunit": "^4.8.35 || ^5.7",
         "phpunit/phpunit-mock-objects": "^2.3 || ^3.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0367be765bb2ea718da11dbb9b3ed793",
+    "content-hash": "8c36732f764481b1d5247956e7f1e239",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -872,6 +872,52 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "095238a0711c974ae5b4ebf4c4534a23f3f6c99d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/095238a0711c974ae5b4ebf4c4534a23f3f6c99d",
+                "reference": "095238a0711c974ae5b4ebf4c4534a23f3f6c99d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2019-04-08T13:54:32+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",

--- a/src/Composer/Command/WrapCommand.php
+++ b/src/Composer/Command/WrapCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Command;
+
+use Composer\Util\Filesystem;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class WrapCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('wrap')
+            ->setDescription('Create local ./composer wrapper')
+            ->setHelp(
+                <<<EOT
+Nearly every README for a non-ancient PHP project begins with composer install. Some of them explain how to install composer itself, some of them don't and rely on developer's experience, web search engine of developer's choice, or implicitly on a globally installed composer. Well, there's nothing wrong with that, really, but I think we can do better.
+
+Here is a couple of assumptions:
+
+* composer is meant to be up to date;
+* composer is born to be installed locally (to be upgraded easily at will, for example).
+
+So, if there was a script that checked if composer was there, installed it if it wasn't, upgraded if outdated, and finally proxied parameters as is to it as if we referred to a composer itself, all the issues outined above would have been solved...
+
+Read more at https://github.com/kamazee/composer-wrapper
+EOT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $cwd = getcwd();
+
+        $this->safeCopy(__DIR__. '/../Wrapper/ComposerWrapper.php', $cwd . '/composer');
+    }
+
+    /**
+     * Copy file using stream_copy_to_stream to work around https://bugs.php.net/bug.php?id=6463
+     *
+     * @param string $source
+     * @param string $target
+     */
+    protected function safeCopy($source, $target)
+    {
+        $source = fopen($source, 'r');
+        $target = fopen($target, 'w+');
+
+        stream_copy_to_stream($source, $target);
+        fclose($source);
+        fclose($target);
+    }
+}

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -420,6 +420,7 @@ class Application extends BaseApplication
             new Command\ExecCommand(),
             new Command\OutdatedCommand(),
             new Command\CheckPlatformReqsCommand(),
+            new Command\WrapCommand(),
         ));
 
         if ('phar:' === substr(__FILE__, 0, 5)) {

--- a/src/Composer/Wrapper/ComposerWrapper.php
+++ b/src/Composer/Wrapper/ComposerWrapper.php
@@ -1,0 +1,262 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * This is a wrapper around composer that installs or updates it
+ * and delegates call to it as if composer itself was called.
+ *
+ * If it breaks, check out newer version or report an issue at
+ * https://github.com/kamazee/composer-wrapper
+ *
+ * @version 1.0.0
+ */
+if (!class_exists('ComposerWrapper')) {
+    class ComposerWrapper
+    {
+        const COMPOSER_HASHBANG = "#!/usr/bin/env php\n";
+        const EXPECTED_INSTALLER_CHECKSUM_URL = 'https://composer.github.io/installer.sig';
+        const INSTALLER_URL = 'https://getcomposer.org/installer';
+        const INSTALLER_FILE = 'composer-setup.php';
+        const EXIT_CODE_SUCCESS = 0;
+        const EXIT_CODE_ERROR_DOWNLOADING_CHECKSUM = 1;
+        const MSG_ERROR_DOWNLOADING_CHECKSUM = 'Error when downloading composer installer checksum';
+        const EXIT_CODE_ERROR_DOWNLOADING_INSTALLER = 2;
+        const MSG_ERROR_DOWNLOADING_INSTALLER = 'Error when downloading composer installer';
+        const EXIT_CODE_ERROR_INSTALLER_CHECKSUM_MISMATCH = 3;
+        const MSG_ERROR_INSTALLER_CHECKSUM_MISMATCH = 'Failed to install composer: checksum of composer installer does not match expected checksum';
+        const EXIT_CODE_ERROR_WHEN_INSTALLING = 4;
+        const MSG_ERROR_WHEN_INSTALLING = 'Error when running composer installer';
+        const EXIT_CODE_ERROR_MAKING_EXECUTABLE = 5;
+        const MSG_SELF_UPDATE_FAILED = 'composer self-update failed; proceeding with existing';
+        const EXIT_CODE_COMPOSER_EXCEPTION = 6;
+
+        protected function file_get_contents()
+        {
+            return \call_user_func_array('file_get_contents', func_get_args());
+        }
+
+        protected function copy()
+        {
+            return \call_user_func_array('copy', func_get_args());
+        }
+
+        protected function passthru($command, &$exitCode)
+        {
+            passthru($command, $exitCode);
+        }
+
+        protected function unlink()
+        {
+            return call_user_func_array('unlink', func_get_args());
+        }
+
+        public function getPhpBinary()
+        {
+            if (defined('PHP_BINARY')) {
+                return PHP_BINARY;
+            }
+
+            return PHP_BINDIR . '/php';
+        }
+
+        public function installComposer($dir)
+        {
+            $installerPathName = $dir . DIRECTORY_SEPARATOR . static::INSTALLER_FILE;
+            if (!$this->copy(static::INSTALLER_URL, $installerPathName)) {
+                throw new Exception(
+                    self::MSG_ERROR_DOWNLOADING_INSTALLER, self::EXIT_CODE_ERROR_DOWNLOADING_INSTALLER
+                );
+            }
+
+            $this->verifyChecksum($installerPathName);
+
+            \passthru(
+                \sprintf(
+                    '%s %s --install-dir=%s',
+                    \escapeshellarg($this->getPhpBinary()),
+                    \escapeshellarg($installerPathName),
+                    \escapeshellarg($dir)
+                ),
+                $exitCode
+            );
+
+            $this->unlink($installerPathName);
+
+            if (self::EXIT_CODE_SUCCESS !== $exitCode) {
+                throw new Exception(
+                    self::MSG_ERROR_WHEN_INSTALLING, self::EXIT_CODE_ERROR_WHEN_INSTALLING
+                );
+            }
+
+            unset($exitCode);
+        }
+
+        protected function verifyChecksum($installerPathName)
+        {
+            $expectedInstallerHash = $this->file_get_contents(static::EXPECTED_INSTALLER_CHECKSUM_URL);
+            if (empty($expectedInstallerHash)) {
+                throw new Exception(
+                    self::MSG_ERROR_DOWNLOADING_CHECKSUM, self::EXIT_CODE_ERROR_DOWNLOADING_CHECKSUM
+                );
+            }
+
+            $expectedInstallerHash = trim($expectedInstallerHash);
+
+            $actualInstallerHash = \hash_file('sha384', $installerPathName);
+            if ($expectedInstallerHash !== $actualInstallerHash) {
+                $this->unlink($installerPathName);
+
+                throw new Exception(
+                    self::MSG_ERROR_INSTALLER_CHECKSUM_MISMATCH, self::EXIT_CODE_ERROR_INSTALLER_CHECKSUM_MISMATCH
+                );
+            }
+        }
+
+        protected function ensureInstalled($filename)
+        {
+            if (\file_exists($filename)) {
+                return;
+            }
+
+            $this->installComposer(dirname($filename));
+        }
+
+        protected function ensureExecutable($filename)
+        {
+            if (!\file_exists($filename)) {
+                throw new Exception("Can't make $filename executable: it doesn't exist");
+            }
+
+            if (\is_executable($filename)) {
+                return;
+            }
+
+            $currentMode = \fileperms($filename);
+            $executablePermissions = $currentMode | 0111;
+            if (false === \chmod($filename, $executablePermissions)) {
+                throw new Exception(
+                    "Can't make $filename executable", self::EXIT_CODE_ERROR_MAKING_EXECUTABLE
+                );
+            }
+        }
+
+        protected function ensureUpToDate($filename)
+        {
+            if (!\file_exists($filename)) {
+                throw new \Exception("Can't run composer self-update for $filename: it doesn't exist");
+            }
+
+            $composerUpdateFrequency = '7 days';
+            $composerUpdateFrequencyEnv = \getenv(
+                'COMPOSER_UPDATE_FREQ'
+            );
+            if (\strlen($composerUpdateFrequencyEnv) > 1) {
+                $composerUpdateFrequency = $composerUpdateFrequencyEnv;
+            }
+
+            $now = new \DateTime('now', new DateTimeZone('UTC'));
+            $nowClone = clone $now;
+            $nowPlusFrequency = $nowClone->modify($composerUpdateFrequency);
+
+            if ($nowPlusFrequency < $now) {
+                $this->showError('Composer update frequency must not be negative');
+            }
+
+            $mtimeTimestamp = \filemtime($filename);
+            $mtimePlusFrequency = \DateTime::createFromFormat(
+                'U',
+                $mtimeTimestamp,
+                new \DateTimeZone('UTC')
+            )->modify($composerUpdateFrequency);
+
+            if ($mtimePlusFrequency <= $now) {
+                $this->passthru(
+                    \sprintf('%s self-update', \escapeshellarg($filename)),
+                    $exitCode
+                );
+
+                // composer exits both when self-update downloaded a new version
+                // and when no new version was available (and everything went OK)
+                if (self::EXIT_CODE_SUCCESS === $exitCode) {
+                    \touch($filename);
+                } else {
+                    // if self-update failed, next call should try it again, hence no touch()
+                    $this->showError(self::MSG_SELF_UPDATE_FAILED);
+                }
+            }
+        }
+
+        protected function delegate($filename)
+        {
+            \ob_start(
+                function ($buffer) {
+                    if (0 === \strpos($buffer, ComposerWrapper::COMPOSER_HASHBANG)) {
+                        return \substr($buffer, \strlen(ComposerWrapper::COMPOSER_HASHBANG));
+                    }
+
+                    return false;
+                }
+            );
+
+            try {
+                require $filename;
+            } catch (Exception $e) {
+                \ob_end_flush();
+                throw new Exception(
+                    "Composer exception was thrown: {$e->getMessage()}", self::EXIT_CODE_COMPOSER_EXCEPTION, $e
+                );
+            }
+
+            \ob_end_flush();
+        }
+
+        public function showError($text)
+        {
+            \fwrite(STDERR, $text . "\n");
+        }
+
+        /**
+         * @return string
+         * @throws Exception
+         */
+        private function getComposerDir()
+        {
+            $defaultComposerDir = __DIR__;
+            $composerDirEnv = \getenv('COMPOSER_DIR');
+
+            if (\strlen($composerDirEnv) > 0) {
+                if (!is_dir($composerDirEnv)) {
+                    throw new \Exception("$composerDirEnv is not a dir");
+                }
+
+                return $composerDirEnv;
+            }
+
+            return $defaultComposerDir;
+        }
+
+        /**
+         * @throws Exception
+         */
+        public function run()
+        {
+            $composerPathName = "{$this->getComposerDir()}/composer.phar";
+
+            $this->ensureInstalled($composerPathName);
+            $this->ensureExecutable($composerPathName);
+            $this->ensureUpToDate($composerPathName);
+            $this->delegate($composerPathName);
+        }
+    }
+}
+
+if ('cli' === \PHP_SAPI && @\realpath($_SERVER['argv'][0]) === __FILE__) {
+    $runner = new ComposerWrapper();
+
+    try {
+        $runner->run();
+    } catch (Exception $e) {
+        $runner->showError('ERROR: ' . $e->getMessage());
+        exit($e->getCode());
+    }
+}

--- a/tests/Composer/Test/Command/WrapCommandTest.php
+++ b/tests/Composer/Test/Command/WrapCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Command;
+
+use Composer\Command\InitCommand;
+use Composer\Command\WrapCommand;
+use Composer\Test\TestCase;
+use Composer\Util\Filesystem;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class WrapCommandTest extends TestCase
+{
+    public function testWith()
+    {
+        $wrap = new WrapCommand();
+        $input = new ArrayInput(array());
+
+        $directory = self::getUniqueTmpDirectory();
+        chdir($directory);
+        $wrap->run($input, new NullOutput());
+
+        self::assertFileExists($directory . '/composer');
+    }
+}

--- a/tests/Composer/Test/Wrapper/ComposerWrapperTest.php
+++ b/tests/Composer/Test/Wrapper/ComposerWrapperTest.php
@@ -1,0 +1,561 @@
+<?php
+
+namespace Composer\Test\Wrapper;
+
+use org\bovigo\vfs\vfsStream;
+use Composer\Test\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+use ReflectionMethod;
+use ReflectionClass;
+use ComposerWrapper;
+use DateTime;
+
+class ComposerWrapperTest extends TestCase
+{
+    const WRAPPER = '../../../../src/Composer/Wrapper/ComposerWrapper.php';
+    const WRAPPER_CLASS = 'ComposerWrapper';
+    const INSTALLER = '<?php die("This is a stub and should never be executed");';
+
+    private $oldComposerDirEnv;
+    private $oldComposerUpdateFreq;
+
+    private static function fullWrapperPath()
+    {
+        return realpath(__DIR__ . '/' . self::WRAPPER);
+    }
+    private static function getInstance()
+    {
+        $class = self::WRAPPER_CLASS;
+        return new $class;
+    }
+
+    public function setUp()
+    {
+        $this->load();
+        $this->assertTrue(class_exists(self::WRAPPER_CLASS));
+        $this->oldComposerDirEnv = getenv('COMPOSER_DIR');
+        $this->oldComposerUpdateFreq = getenv('COMPOSER_UPDATE_FREQ');
+    }
+
+    public function tearDown()
+    {
+        if ($this->oldComposerDirEnv != getenv('COMPOSER_DIR')) {
+            putenv('COMPOSER_DIR=' . $this->oldComposerDirEnv);
+        }
+
+        if ($this->oldComposerUpdateFreq != getenv('COMPOSER_UPDATE_FREQ')) {
+            putenv('COMPOSER_UPDATE_FREQ=' . $this->oldComposerUpdateFreq);
+        }
+
+    }
+
+    /**
+     * @test
+     */
+    public function runUsesCorrectDefaultDir()
+    {
+        $this->runCallsAllRequiredMethods(dirname(self::fullWrapperPath()));
+    }
+
+    /**
+     * @test
+     */
+    public function runUsesDirFromEnvIfCorrect()
+    {
+        putenv(sprintf('COMPOSER_DIR=%s', __DIR__));
+        $this->runCallsAllRequiredMethods(__DIR__);
+    }
+
+    /**
+     * @test
+     * @expectedException Exception
+     * @expectedExceptionMessage is not a dir
+     */
+    public function runThrowsOnMissingDirFromEnv()
+    {
+        $nonExistingDir = __DIR__ . '/i_dont_exist';
+        $expectedError = "$nonExistingDir is not a dir";
+        $this->expectExceptionCompat('Exception', $expectedError);
+
+        putenv("COMPOSER_DIR=$nonExistingDir");
+        self::getInstance()->run();
+    }
+
+    /**
+     * @test
+     */
+    public function runThrowsOnNonDirFromEnv()
+    {
+        $nonDir = __FILE__;
+        $expectedExceptionMessage = "$nonDir is not a dir";
+        $this->expectExceptionCompat('Exception', $expectedExceptionMessage);
+
+        putenv("COMPOSER_DIR=$nonDir");
+        self::getInstance()->run();
+    }
+
+    /**
+     * @test
+     */
+    public function installsIfNotInstalled()
+    {
+        $dir = vfsStream::setup()->url();
+        $filename = "$dir/composer.phar";
+        /** @var PHPUnit_Framework_MockObject_MockObject|ComposerWrapper $mock */
+        $mock = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('installComposer'))
+            ->getMock();
+        $mock->expects($this->once())
+            ->method('installComposer')
+            ->with($dir)
+            ->willReturn(null);
+
+        self::callNonPublic($mock, 'ensureInstalled', array($filename));
+    }
+
+    /**
+     * @test
+     */
+    public function installWorksIfPhpIsInDirWithSpaces()
+    {
+        $dirWithSpaces = __DIR__ . '/directory with spaces';
+        $wrapper = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('copy', 'verifyChecksum', 'getPhpBinary', 'unlink'))
+            ->getMock();
+
+        $wrapper->expects($this->once())->method('copy')->willReturn(true);
+        $wrapper->expects($this->once())->method('verifyChecksum');
+        $wrapper->expects($this->once())
+            ->method('getPhpBinary')
+            ->willReturn($dirWithSpaces . '/php');
+        $wrapper->expects($this->once())->method('unlink');
+
+        $installerPathName = $dirWithSpaces . '/composer-setup.php';
+        $this->expectOutputWithShebang(
+            "I was called with $installerPathName --install-dir=$dirWithSpaces"
+        );
+
+        self::callNonPublic($wrapper, 'installComposer', array($dirWithSpaces));
+    }
+
+    /**
+     * @test
+     */
+    public function doesntTryToInstallWhenInstalled()
+    {
+        $vfs = vfsStream::setup();
+        $dir = $vfs->url();
+        $filename = "$dir/composer.phar";
+        // Just "touch()" doesn't work for VFS until PHP 5.4
+        file_put_contents($filename, '');
+        /** @var PHPUnit_Framework_MockObject_MockObject|ComposerWrapper $mock */
+        $mock = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('installComposer'))
+            ->getMock();
+        $mock->expects($this->never())
+            ->method('installComposer');
+
+        self::callNonPublic($mock, 'ensureInstalled', array($filename));
+    }
+
+    /**
+     * @test
+     * @dataProvider failedDownloadResultsProvider
+     */
+    public function throwsOnFailureToDownloadChecksum($downloadResult)
+    {
+        /** @var PHPUnit_Framework_MockObject_MockObject|ComposerWrapper $mock */
+        $mock = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('file_get_contents', 'copy'))
+            ->getMock();
+
+        $installerFile = __DIR__ . '/' . ComposerWrapper::INSTALLER_FILE;
+        $mock->expects($this->once())
+            ->method('copy')
+            ->with(ComposerWrapper::INSTALLER_URL, $installerFile)
+            ->willReturn(true);
+
+        $mock->expects($this->once())
+            ->method('file_get_contents')
+            ->with(ComposerWrapper::EXPECTED_INSTALLER_CHECKSUM_URL)
+            ->willReturn($downloadResult);
+
+        $this->expectExceptionCompat('Exception', ComposerWrapper::MSG_ERROR_DOWNLOADING_CHECKSUM);
+
+        $mock->installComposer(__DIR__);
+    }
+
+    public static function failedDownloadResultsProvider()
+    {
+        return array(
+            'complete failure' => array(false),
+            'a sudden nothing' => array(''),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function throwsOnFailureToDownloadInstaller()
+    {
+        $this->expectExceptionCompat(
+            'Exception',
+            ComposerWrapper::MSG_ERROR_DOWNLOADING_INSTALLER
+        );
+
+        $mock = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('copy', 'validateChecksum'))
+            ->getMock();
+
+        $mock->expects($this->never())
+            ->method('validateChecksum');
+
+        $dir = __DIR__;
+        $installerFile = $dir . DIRECTORY_SEPARATOR . ComposerWrapper::INSTALLER_FILE;
+        $mock->expects($this->once())
+            ->method('copy')
+            ->with(ComposerWrapper::INSTALLER_URL, $installerFile)
+            ->willReturn(false);
+
+        self::callNonPublic($mock, 'installComposer', array($dir));
+    }
+
+    /**
+     * @test
+     */
+    public function throwsOnInstallerChecksumMismatch()
+    {
+        $this->expectExceptionCompat(
+            'Exception',
+            ComposerWrapper::MSG_ERROR_INSTALLER_CHECKSUM_MISMATCH
+        );
+
+        $mock = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('file_get_contents', 'copy'))
+            ->getMock();
+
+        $installer = '<?php echo "THIS PHP FILE SHOULD NOT HAVE BEEN EXECUTED"; exit(1);';
+        $dir = vfsStream::setup()->url();
+
+        $installerFile = "$dir/composer-setup.php";
+        file_put_contents($installerFile, $installer);
+        $realHash = hash('sha384', $installer);
+
+        // Replacing last character with underscore definitely breaks it
+        $brokenHash = substr($realHash, 0, -1) . '_';
+
+        $mock->expects($this->once())
+            ->method('file_get_contents')
+            ->with(ComposerWrapper::EXPECTED_INSTALLER_CHECKSUM_URL)
+            ->willReturn($brokenHash);
+
+        $mock->expects($this->once())
+            ->method('copy')
+            ->with(ComposerWrapper::INSTALLER_URL, $installerFile)
+            ->willReturn(true);
+
+        try {
+            self::callNonPublic($mock, 'installComposer', array($dir));
+        } catch (Exception $e) {
+            $this->assertFileNotExists($installerFile);
+            throw $e;
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function acceptsDownloadedChecksumWithLineFeed()
+    {
+        $this->expectOutputWithShebang('Installer was called and will succeed');
+
+        $dir = __DIR__ . '/installer_success';
+        $installerFile = $dir . DIRECTORY_SEPARATOR . ComposerWrapper::INSTALLER_FILE;
+
+        $mock = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('file_get_contents', 'copy', 'unlink'))
+            ->getMock();
+
+        // Real downloaded checksum has an EOL character at the end
+        $mock->expects($this->once())
+            ->method('file_get_contents')
+            ->with(ComposerWrapper::EXPECTED_INSTALLER_CHECKSUM_URL)
+            ->willReturn(hash_file('sha384', $installerFile) . "\n");
+
+        $mock->expects($this->once())
+            ->method('copy')
+            ->with(ComposerWrapper::INSTALLER_URL, $installerFile)
+            ->willReturn(true);
+
+        $mock->expects($this->once())
+            ->method('unlink')
+            ->with($installerFile)
+            ->willReturn(true);
+
+        self::callNonPublic($mock, 'installComposer', array($dir));
+    }
+
+    /**
+     * @test
+     */
+    public function throwsOnInstallerFailure()
+    {
+        $this->expectOutputWithShebang('Installer was called and will return an error');
+        $this->expectExceptionCompat('Exception', ComposerWrapper::MSG_ERROR_WHEN_INSTALLING);
+
+        $mock = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('file_get_contents', 'copy', 'unlink'))
+            ->getMock();
+
+        $dir = __DIR__ . '/installer_failure';
+        $installerFile = $dir . DIRECTORY_SEPARATOR . ComposerWrapper::INSTALLER_FILE;
+
+        $mock->expects($this->once())
+            ->method('file_get_contents')
+            ->with(ComposerWrapper::EXPECTED_INSTALLER_CHECKSUM_URL)
+            ->willReturn(hash_file('sha384', $installerFile));
+
+        $mock->expects($this->once())
+            ->method('copy')
+            ->with(ComposerWrapper::INSTALLER_URL, $installerFile)
+            ->willReturn(true);
+
+        $mock->expects($this->once())
+            ->method('unlink')
+            ->with($installerFile)
+            ->willReturn(true);
+
+        self::callNonPublic($mock, 'installComposer', array($dir));
+    }
+
+    /**
+     * @test
+     * @dataProvider permissionsProvider
+     */
+    public function makesExecutable($permissionsBefore, $expectedPermissionsAfter)
+    {
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('At least PHP 5.4 is required to test chmod() on vfs');
+        }
+
+        $dir = vfsStream::setup()->url();
+        $file = "$dir/composer.phar";
+        file_put_contents($file, '');
+        chmod($file, $permissionsBefore);
+        $wrapper = new ComposerWrapper();
+        self::callNonPublic($wrapper, 'ensureExecutable', array($file));
+        // & 0777 grabs last 3 octal values, e.g. 0100644 -> 0644
+        $this->assertEquals($expectedPermissionsAfter, fileperms($file) & 0777);
+    }
+
+    public static function permissionsProvider()
+    {
+        return array(
+            'sets executable, does not add writable' => array(0444, 0555),
+            'preserves writability' => array(0666, 0777),
+            'preserves level of permissions' => array(0644, 0755),
+            'does not change anything when already executable and read-only' => array(0555, 0555),
+            'does not change anything when already executable and writable' => array(0777, 0777),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function triesToSelfUpdateWhenOutdated()
+    {
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('At least PHP 5.4 is required to use touch() on vfs');
+        }
+
+        $root = vfsStream::setup();
+
+        $now = new DateTime();
+        $composerLastModified = new DateTime('-7 days -1 minute');
+        $file = vfsStream::newFile('composer.phar', 0755);
+        $root->addChild($file);
+        $file->lastModified($composerLastModified->getTimestamp());
+
+        $wrapper = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('passthru'))
+            ->getMock();
+        $wrapper->expects($this->once())
+            ->method('passthru')
+            ->with("'{$file->url()}' self-update", $this->anything())
+            ->willReturnCallback(function ($command, &$exitCode) { $exitCode = 0; });
+
+        self::callNonPublic($wrapper, 'ensureUpToDate', array($file->url()));
+        clearstatcache(null, $file->url());
+        $this->assertGreaterThanOrEqual($now->getTimestamp(), filemtime($file->url()));
+    }
+
+    /**
+     * @test
+     */
+    public function selfUpdateWorksInDirectoryWithSpaces()
+    {
+        $dirWithSpaces = __DIR__ . '/directory with spaces';
+        putenv('COMPOSER_DIR=' . $dirWithSpaces);
+        putenv('COMPOSER_UPDATE_FREQ=0 seconds');
+        $wrapper = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('showError'))
+            ->getMock();
+
+        $wrapper->expects($this->never())->method('showError');
+        $this->expectOutputWithShebang('I was called with self-update');
+
+        self::callNonPublic($wrapper, 'ensureUpToDate', array($dirWithSpaces . '/composer.phar'));
+    }
+
+    /**
+     * @test
+     */
+    public function doesNotTryToSelfUpdateWhenUpToDate()
+    {
+        $root = vfsStream::setup();
+        $file = vfsStream::newFile('composer.phar', 0755);
+        $root->addChild($file);
+
+        $wrapper = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('passthru'))
+            ->getMock();
+        $wrapper->expects($this->never())
+            ->method('passthru');
+
+        self::callNonPublic($wrapper, 'ensureUpToDate', array($file->url()));
+    }
+
+    /**
+     * @test
+     */
+    public function printsWarningWhenUpdateFailsToSelfUpdate()
+    {
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('At least PHP 5.4 is required to use touch() on vfs');
+        }
+
+        $root = vfsStream::setup();
+
+        $composerLastModified = new DateTime('-7 days -1 minute');
+        $file = vfsStream::newFile('composer.phar', 0755);
+        $root->addChild($file);
+        $file->lastModified($composerLastModified->getTimestamp());
+
+        $wrapper = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods(array('passthru', 'showError'))
+            ->getMock();
+        $wrapper->expects($this->once())
+            ->method('passthru')
+            ->with("'{$file->url()}' self-update", $this->anything())
+            ->willReturnCallback(function ($command, &$exitCode) { $exitCode = 1; });
+        $wrapper->expects($this->once())
+            ->method('showError')
+            ->with(ComposerWrapper::MSG_SELF_UPDATE_FAILED);
+
+        self::callNonPublic($wrapper, 'ensureUpToDate', array($file->url()));
+
+        clearstatcache(null, $file->url());
+        $this->assertEquals($composerLastModified->getTimestamp(), filemtime($file->url()));
+    }
+
+    /**
+     * @test
+     */
+    public function composerExceptionProcessed()
+    {
+        $root = vfsStream::setup();
+        $composerDir = $root->url();
+        $composer = vfsStream::newFile('composer.phar', 0755);
+        $root->addChild($composer);
+        $expectedExceptionText = 'Expected exception text';
+        $content = sprintf('<?php throw new Exception("%s");', $expectedExceptionText);
+        $composer->setContent($content);
+
+        $this->expectExceptionCompat('Exception', $expectedExceptionText);
+        putenv("COMPOSER_DIR=$composerDir");
+        $this->runCallsAllRequiredMethods($composerDir, false);
+    }
+
+    private function runCallsAllRequiredMethods($expectedComposerDir, $mockDelegate = true)
+    {
+        $methods = array('ensureInstalled', 'ensureExecutable', 'ensureUpToDate');
+        if ($mockDelegate) {
+            $methods[] = 'delegate';
+        }
+
+        /** @var PHPUnit_Framework_MockObject_MockObject|ComposerWrapper $runnerMock */
+        $runnerMock = $this->getMockBuilder(self::WRAPPER_CLASS)
+            ->setMethods($methods)
+            ->getMock();
+
+        foreach ($methods as $method) {
+            $runnerMock->expects($this->once())
+                ->method($method)
+                ->with("$expectedComposerDir/composer.phar")
+                ->willReturn(null);
+        }
+
+        $runnerMock->run();
+    }
+
+    /**
+     * @test
+     */
+    public function passThroughWrapperWorksWithReferences()
+    {
+        $testScriptPath = __DIR__ . '/passthru/error.php';
+        $this->expectOutputWithShebang("$testScriptPath was executed");
+        $wrapper = new ComposerWrapper();
+        $exitCode = null;
+        $class = new ReflectionClass($wrapper);
+        $method = $class->getMethod('passthru');
+        $method->setAccessible(true);
+        $method->invokeArgs(
+            $wrapper,
+            array(
+                $wrapper->getPhpBinary() . ' ' . escapeshellarg($testScriptPath),
+                &$exitCode
+            )
+        );
+        $this->assertEquals(1, $exitCode);
+    }
+
+    private function load()
+    {
+        $this->expectOutputWithShebang();
+        return require self::fullWrapperPath();
+    }
+
+    private function expectOutputWithShebang($output = null)
+    {
+        $shebang = $this->getExpectedShebang();
+        $this->expectOutputString($shebang . $output);
+    }
+
+    private function getExpectedShebang()
+    {
+        $wrapperFileLines = file(self::fullWrapperPath());
+        return $wrapperFileLines[0];
+    }
+
+    private function expectExceptionCompat($class, $message)
+    {
+        if (
+            method_exists($this, 'expectExceptionMessage') &&
+            method_exists($this, 'expectException')
+        ) {
+            $this->expectException($class);
+            $this->expectExceptionMessage($message);
+        } elseif (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedException($class, $message);
+        }
+    }
+
+    private static function callNonPublic($object, $method, $args)
+    {
+        $method = new ReflectionMethod($object, $method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $args);
+    }
+}

--- a/tests/Composer/Test/Wrapper/directory with spaces/composer.phar
+++ b/tests/Composer/Test/Wrapper/directory with spaces/composer.phar
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+
+echo 'I was called with ' . implode(array_slice($_SERVER['argv'], 1));

--- a/tests/Composer/Test/Wrapper/directory with spaces/php
+++ b/tests/Composer/Test/Wrapper/directory with spaces/php
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+
+echo 'I was called with ' . implode(' ', array_slice($_SERVER['argv'], 1));

--- a/tests/Composer/Test/Wrapper/installer_failure/composer-setup.php
+++ b/tests/Composer/Test/Wrapper/installer_failure/composer-setup.php
@@ -1,0 +1,4 @@
+<?php
+
+echo 'Installer was called and will return an error';
+exit(1);

--- a/tests/Composer/Test/Wrapper/installer_success/composer-setup.php
+++ b/tests/Composer/Test/Wrapper/installer_success/composer-setup.php
@@ -1,0 +1,4 @@
+<?php
+
+echo 'Installer was called and will succeed';
+exit(0);

--- a/tests/Composer/Test/Wrapper/passthru/error.php
+++ b/tests/Composer/Test/Wrapper/passthru/error.php
@@ -1,0 +1,5 @@
+<?php
+
+echo __FILE__  . " was executed";
+
+exit(1);


### PR DESCRIPTION
## What for?

Nearly every README for a non-ancient PHP project begins with `composer install`. Some of them explain how to install composer itself, some of them don't and rely on developer's experience, web search engine of developer's choice, or implicitly on a globally installed composer.
Well, there's nothing wrong with that, really, but I think we can do better.

Here is a couple of assumptions:
* composer is meant to be up to date;
* composer is born to be installed locally (to be upgraded easily at will, for example).

So, if there was a script that checked if composer was there, installed it if it wasn't, upgraded if outdated, and finally proxied parameters as is to it as if we referred to a composer itself, all the issues outlined above would have been solved...

## How To

1. Go to a directory within your project where "binaries" (well, usually just CLI entry points) reside
2a. If you already have globally installed composer run `composer wrap` command. The `composer` file will be added to current working directory.
2b .... Or just copy file content from github sources directly into local `composer` file:
```
curl https://raw.githubusercontent.com/benbor/composer/composer-wrapper/src/Composer/Wrapper/ComposerWrapper.php -o composer
```
\* after merge this PR, the script should be placed in more suitable place, aka  https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
3. Add execution permissions to `composer` file: `chmod +x composer`
4. Add `composer` file to version control
5. Add `composer.phar` in that directory into version control ignore file

Done, your colleagues should worry never again about installing composer and keeping it up to date, and neither should ops team care how it appears on a build server!

**Just use the `composer` script instead of actual composer, and it will make sure you have an actual composer installed and up to date!**

`./composer install`, `./composer update`, `./composer dump-autoload`, and other commands you used to should just work as if you had installed composer yourself.

## Configuration

All the configuration is done through [*environment variables*](https://www.digitalocean.com/community/tutorials/how-to-read-and-set-environmental-and-shell-variables-on-a-linux-vps) in order to not interact with composer's CLI parameters. The following environment variables are supported:

* `COMPOSER_UPDATE_FREQ`. Time between checks for updates (defaults to 7 days). This is a [relative time specifier](http://php.net/manual/en/datetime.formats.relative.php) that is fed to [`DateTime::modify`](http://php.net/manual/en/datetime.modify.php). It's chosen because it can be perfectly readable by someone who knows no PHP and doesn't want to (e.g. ops people), and it's recommended to keep it that way, e.g. "5 days", "2 weeks", "1 month".
* `COMPOSER_DIR`. Directory where composer.phar will be searched for and copied to. Defaults to the directory where the script is located (`__DIR__`); note: *not* the current working directory! Sometimes it's useful to keep real composer.phar a couple of levels higher up the directory where wrapper is placed, for example, on a CI server: it would help avoid downloading composer afresh for every build.  


## Similar solutions

* graddlew -  wrapper for Graddle https://docs.gradle.org/current/userguide/gradle_wrapper.html
* mvnw - maven wrapper https://www.baeldung.com/maven-wrapper

## Credits
Original idea https://github.com/kamazee/composer-wrapper