### PR TITLE
Optimize rule creation for alias packages

### DIFF
--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -167,6 +167,12 @@ class RuleSetGenerator
             } else {
                 $workQueue->enqueue($package->getAliasOf());
                 $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRequireRule($package, array($package->getAliasOf()), Rule::RULE_PACKAGE_ALIAS, $package));
+
+                // if alias package has no self.version requires, its requirements do not
+                // need to be added as the aliased package processing will take care of it
+                if (!$package->hasSelfVersionRequires()) {
+                    continue;
+                }
             }
 
             foreach ($package->getRequires() as $link) {

--- a/src/Composer/Package/AliasPackage.php
+++ b/src/Composer/Package/AliasPackage.php
@@ -25,6 +25,7 @@ class AliasPackage extends BasePackage implements CompletePackageInterface
     protected $dev;
     protected $rootPackageAlias = false;
     protected $stability;
+    protected $hasSelfVersionRequires = false;
 
     /** @var PackageInterface */
     protected $aliasOf;
@@ -192,6 +193,9 @@ class AliasPackage extends BasePackage implements CompletePackageInterface
         } else {
             foreach ($links as $index => $link) {
                 if ('self.version' === $link->getPrettyConstraint()) {
+                    if ($linkType === 'requires') {
+                        $this->hasSelfVersionRequires = true;
+                    }
                     $links[$index] = new Link($link->getSource(), $link->getTarget(), $constraint = new Constraint('=', $this->version), $linkType, $prettyVersion);
                     $constraint->setPrettyString($prettyVersion);
                 }
@@ -199,6 +203,11 @@ class AliasPackage extends BasePackage implements CompletePackageInterface
         }
 
         return $links;
+    }
+
+    public function hasSelfVersionRequires()
+    {
+        return $this->hasSelfVersionRequires;
     }
 
     /***************************************

--- a/tests/Composer/Test/Fixtures/installer/alias-solver-problems.test
+++ b/tests/Composer/Test/Fixtures/installer/alias-solver-problems.test
@@ -48,9 +48,9 @@ Your requirements could not be resolved to an installable set of packages.
     - Root composer.json requires b/b *@dev -> satisfiable by b/b[dev-master].
     - a/a dev-master requires d/d 1.0.0 -> satisfiable by d/d[1.0.0].
     - You can only install one version of a package, so only one of these can be installed: d/d[1.0.0, 2.0.0].
-    - Conclusion: install d/d 2.0.0, learned rules:
+    - b/b dev-master requires d/d 2.0.0 -> satisfiable by d/d[2.0.0].
+    - Conclusion: install b/b dev-master, learned rules:
         - Root composer.json requires b/b *@dev -> satisfiable by b/b[dev-master].
-        - b/b dev-master requires d/d 2.0.0 -> satisfiable by d/d[2.0.0].
     - Root composer.json requires a/a *@dev -> satisfiable by a/a[dev-master].
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/alias-solver-problems2.test
+++ b/tests/Composer/Test/Fixtures/installer/alias-solver-problems2.test
@@ -47,7 +47,7 @@ Your requirements could not be resolved to an installable set of packages.
     - locked/pkg dev-master requires locked/dependency 1.0.0 -> found locked/dependency[1.0.0] in lock file but not in remote repositories, make sure you avoid updating this package to keep the one from lock file.
   Problem 2
     - locked/pkg dev-master requires locked/dependency 1.0.0 -> found locked/dependency[1.0.0] in lock file but not in remote repositories, make sure you avoid updating this package to keep the one from lock file.
-    - Root composer.json requires locked/pkg *@dev -> satisfiable by locked/pkg[dev-master].
+    - locked/pkg is locked to version dev-master and an update of this package was not requested.
 
 Use the option --with-all-dependencies to allow upgrades, downgrades and removals for packages currently locked to specific versions.
 --EXPECT--


### PR DESCRIPTION
From a couple tests, this can speed up the actual dependency resolution CPU time quite a bit (got ~50% reduction) but mainly when used with `minimum-stability: dev`, as that leads to having way more alias packages.

Would be good to have more people test this to check it does not have any bad side effects.