### PR TITLE
Remove some dead code from RuleSetGenerator

### DIFF
--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -215,20 +215,6 @@ class RuleSetGenerator
         }
     }
 
-    protected function obsoleteImpossibleForAlias($package, $provider)
-    {
-        $packageIsAlias = $package instanceof AliasPackage;
-        $providerIsAlias = $provider instanceof AliasPackage;
-
-        $impossible = (
-            ($packageIsAlias && $package->getAliasOf() === $provider) ||
-            ($providerIsAlias && $provider->getAliasOf() === $package) ||
-            ($packageIsAlias && $providerIsAlias && $provider->getAliasOf() === $package->getAliasOf())
-        );
-
-        return $impossible;
-    }
-
     protected function addRulesForRequest(Request $request, $ignorePlatformReqs)
     {
         $unlockableMap = $request->getUnlockableMap();


### PR DESCRIPTION
Found this while looking at https://github.com/composer/composer/issues/3508 and the original change in https://github.com/composer/composer/pull/3482 - IMO #3508 can be closed now as addConflictRules does a single pass on all packages, there shouldn't be duplicate conflicts created anymore.
