### PR TITLE
Fix unfixing of packages when a replacer gets unfixed before a replacee

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -113,7 +113,7 @@ class PoolBuilder
                     $request->fixPackage($lockedPackage);
                     $lockedName = $lockedPackage->getName();
                     // remember which packages we skipped loading remote content for in this partial update
-                    $this->skippedLoad[$lockedPackage->getName()] = $lockedName;
+                    $this->skippedLoad[$lockedName] = $lockedName;
                     foreach ($lockedPackage->getReplaces() as $link) {
                         $this->skippedLoad[$link->getTarget()] = $lockedName;
                     }
@@ -413,8 +413,12 @@ class PoolBuilder
             }
         }
 
-        // if we unfixed a replaced package name, we also need to unfix the replacer itself
-        if ($this->skippedLoad[$name] !== $name) {
+        if (
+            // if we unfixed a replaced package name, we also need to unfix the replacer itself
+            $this->skippedLoad[$name] !== $name
+            // as long as it was not unfixed yet
+            && isset($this->skippedLoad[$this->skippedLoad[$name]])
+        ) {
             $this->unfixPackage($request, $this->skippedLoad[$name]);
         }
 


### PR DESCRIPTION
Refs #8882 - see in particular https://github.com/composer/composer/issues/8882#issuecomment-626372513 for context.

The code is somewhat confusing and I think we were misled there into thinking it was a recursive call for the same name. IMO what happens is rather this:

- A replacing B gets fixed, so A and B get fixed
- A gets unfixed somehow, B remains fixed
- B gets unfixed too, so it tries to unfix A, but it's already unfixed so the array access fails there.

I added the isset to avoid doing that last step if A isn't fixed anymore. I believe that's correct, but proving it with a test is unfortunately pretty damn hard right now.