### PR TITLE
Platform Check: Add a special case for `zend-opcache`

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -640,6 +640,10 @@ EOF;
                         }
                     }
 
+                    if ($match[1] === 'zend-opcache') {
+                        $match[1] = 'zend opcache';
+                    }
+
                     $extension = var_export($match[1], true);
                     if ($match[1] === 'pcntl' || $match[1] === 'readline') {
                         $requiredExtensions[$extension] = "PHP_SAPI !== 'cli' || extension_loaded($extension) || \$missingExtensions[] = $extension;\n";


### PR DESCRIPTION
Ref #8946

The platform-check feature maps `ext-X` to `extension_loaded('X')` calls. While most of the extensions can be tested this way, the `zend-opcache` extension requires `zend opcache` to be probed instead of the `zend-opcache` name.

This commit adds a special case for `zend-opcache` to use the correct name in `extension_loaded()` calls in generated `platform_check.php` files.