### PR TITLE
Parallel zip installs

### DIFF
--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -23,6 +23,7 @@ use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Composer\Util\Filesystem;
 use Composer\Util\Loop;
+use Composer\Util\ProcessExecutor;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -112,9 +113,10 @@ EOT
             $archiveManager = $composer->getArchiveManager();
         } else {
             $factory = new Factory;
+            $process = new ProcessExecutor();
             $httpDownloader = $factory->createHttpDownloader($io, $config);
-            $downloadManager = $factory->createDownloadManager($io, $config, $httpDownloader);
-            $archiveManager = $factory->createArchiveManager($config, $downloadManager, new Loop($httpDownloader));
+            $downloadManager = $factory->createDownloadManager($io, $config, $httpDownloader, $process);
+            $archiveManager = $factory->createArchiveManager($config, $downloadManager, new Loop($httpDownloader, $process));
         }
 
         if ($packageName) {

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -201,6 +201,8 @@ EOT
 
         // install dependencies of the created project
         if ($noInstall === false) {
+            $composer->getInstallationManager()->setOutputProgress(!$noProgress);
+
             $installer = Installer::create($io, $composer);
             $installer->setPreferSource($preferSource)
                 ->setPreferDist($preferDist)
@@ -211,6 +213,10 @@ EOT
                 ->setOptimizeAutoloader($config->get('optimize-autoloader'))
                 ->setClassMapAuthoritative($config->get('classmap-authoritative'))
                 ->setApcuAutoloader($config->get('apcu-autoloader'));
+
+            if (!$composer->getLocker()->isLocked()) {
+                $installer->setUpdate(true);
+            }
 
             if ($disablePlugins) {
                 $installer->disablePlugins();
@@ -405,7 +411,8 @@ EOT
             ->setPreferDist($preferDist);
 
         $projectInstaller = new ProjectInstaller($directory, $dm, $fs);
-        $im = $factory->createInstallationManager(new Loop($httpDownloader), $io);
+        $im = $factory->createInstallationManager(new Loop($httpDownloader, $process), $io);
+        $im->setOutputProgress(!$noProgress);
         $im->addInstaller($projectInstaller);
         $im->execute(new InstalledFilesystemRepository(new JsonFile('php://memory')), array(new InstallOperation($package)));
         $im->notifyInstalls($io);

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -106,6 +106,8 @@ EOT
 
         $ignorePlatformReqs = $input->getOption('ignore-platform-reqs') ?: ($input->getOption('ignore-platform-req') ?: false);
 
+        $composer->getInstallationManager()->setOutputProgress(!$input->getOption('no-progress'));
+
         $install
             ->setDryRun($input->getOption('dry-run'))
             ->setVerbose($input->getOption('verbose'))

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -220,6 +220,8 @@ EOT
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'remove', $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
 
+        $composer->getInstallationManager()->setOutputProgress(!$input->getOption('no-progress'));
+
         $install = Installer::create($io, $composer);
 
         $updateDevMode = !$input->getOption('update-no-dev');

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -286,6 +286,8 @@ EOT
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'require', $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
 
+        $composer->getInstallationManager()->setOutputProgress(!$input->getOption('no-progress'));
+
         $install = Installer::create($io, $composer);
 
         $ignorePlatformReqs = $input->getOption('ignore-platform-reqs') ?: ($input->getOption('ignore-platform-req') ?: false);

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -180,6 +180,8 @@ EOT
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'update', $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
 
+        $composer->getInstallationManager()->setOutputProgress(!$input->getOption('no-progress'));
+
         $install = Installer::create($io, $composer);
 
         $config = $composer->getConfig();

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -95,7 +95,7 @@ abstract class ArchiveDownloader extends FileDownloader
             $filesystem->unlink($fileName);
 
             /**
-             * Returns the folder content, excluding dotfiles
+             * Returns the folder content, excluding .DS_Store
              *
              * @param  string         $dir Directory
              * @return \SplFileInfo[]

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -62,6 +62,7 @@ abstract class ArchiveDownloader extends FileDownloader
         } while (is_dir($temporaryDir));
 
         $this->addCleanupPath($package, $temporaryDir);
+        $this->addCleanupPath($package, $path);
 
         $this->filesystem->ensureDirectoryExists($temporaryDir);
         $fileName = $this->getFileName($package, $path);
@@ -77,6 +78,7 @@ abstract class ArchiveDownloader extends FileDownloader
             $filesystem->removeDirectory($path);
             $filesystem->removeDirectory($temporaryDir);
             $self->removeCleanupPath($package, $temporaryDir);
+            $self->removeCleanupPath($package, $path);
         };
 
         $promise = null;
@@ -142,6 +144,7 @@ abstract class ArchiveDownloader extends FileDownloader
 
             $filesystem->removeDirectory($temporaryDir);
             $self->removeCleanupPath($package, $temporaryDir);
+            $self->removeCleanupPath($package, $path);
         }, function ($e) use ($cleanup) {
             $cleanup();
 

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -29,14 +29,12 @@ abstract class ArchiveDownloader extends FileDownloader
 {
     public function download(PackageInterface $package, $path, PackageInterface $prevPackage = null, $output = true)
     {
-        $res = parent::download($package, $path, $prevPackage, $output);
-
         // if not downgrading and the dir already exists it seems we have an inconsistent state in the vendor dir and the user should fix it
         if (!$prevPackage && is_dir($path) && !$this->filesystem->isDirEmpty($path)) {
             throw new IrrecoverableDownloadException('Expected empty path to extract '.$package.' into but directory exists: '.$path);
         }
 
-        return $res;
+        return parent::download($package, $path, $prevPackage, $output);
     }
 
     /**

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -16,6 +16,7 @@ use Composer\Package\PackageInterface;
 use Symfony\Component\Finder\Finder;
 use Composer\IO\IOInterface;
 use Composer\Exception\IrrecoverableDownloadException;
+use React\Promise\PromiseInterface;
 
 /**
  * Base downloader for archives
@@ -60,26 +61,62 @@ abstract class ArchiveDownloader extends FileDownloader
             $temporaryDir = $this->config->get('vendor-dir').'/composer/'.substr(md5(uniqid('', true)), 0, 8);
         } while (is_dir($temporaryDir));
 
+        $this->addCleanupPath($package, $temporaryDir);
+
+        $this->filesystem->ensureDirectoryExists($temporaryDir);
         $fileName = $this->getFileName($package, $path);
 
-        try {
-            $this->filesystem->ensureDirectoryExists($temporaryDir);
-            try {
-                $this->extract($package, $fileName, $temporaryDir);
-            } catch (\Exception $e) {
-                // remove cache if the file was corrupted
-                parent::clearLastCacheWrite($package);
-                throw $e;
-            }
+        $filesystem = $this->filesystem;
+        $self = $this;
 
-            $this->filesystem->unlink($fileName);
+        $cleanup = function () use ($path, $filesystem, $temporaryDir, $package, $self) {
+            // remove cache if the file was corrupted
+            $self->clearLastCacheWrite($package);
+
+            // clean up
+            $filesystem->removeDirectory($path);
+            $filesystem->removeDirectory($temporaryDir);
+            $self->removeCleanupPath($package, $temporaryDir);
+        };
+
+        $promise = null;
+        try {
+            $promise = $this->extract($package, $fileName, $temporaryDir);
+        } catch (\Exception $e) {
+            $cleanup();
+            throw $e;
+        }
+
+        if (!$promise instanceof PromiseInterface) {
+            $promise = \React\Promise\resolve();
+        }
+
+        return $promise->then(function () use ($self, $package, $filesystem, $fileName, $temporaryDir, $path) {
+            $filesystem->unlink($fileName);
+
+            /**
+             * Returns the folder content, excluding dotfiles
+             *
+             * @param  string         $dir Directory
+             * @return \SplFileInfo[]
+             */
+            $getFolderContent = function ($dir) {
+                $finder = Finder::create()
+                    ->ignoreVCS(false)
+                    ->ignoreDotFiles(false)
+                    ->notName('.DS_Store')
+                    ->depth(0)
+                    ->in($dir);
+
+                return iterator_to_array($finder);
+            };
 
             $renameAsOne = false;
-            if (!file_exists($path) || ($this->filesystem->isDirEmpty($path) && $this->filesystem->removeDirectory($path))) {
+            if (!file_exists($path) || ($filesystem->isDirEmpty($path) && $filesystem->removeDirectory($path))) {
                 $renameAsOne = true;
             }
 
-            $contentDir = $this->getFolderContent($temporaryDir);
+            $contentDir = $getFolderContent($temporaryDir);
             $singleDirAtTopLevel = 1 === count($contentDir) && is_dir(reset($contentDir));
 
             if ($renameAsOne) {
@@ -89,28 +126,27 @@ abstract class ArchiveDownloader extends FileDownloader
                 } else {
                     $extractedDir = $temporaryDir;
                 }
-                $this->filesystem->rename($extractedDir, $path);
+                $filesystem->rename($extractedDir, $path);
             } else {
                 // only one dir in the archive, extract its contents out of it
                 if ($singleDirAtTopLevel) {
-                    $contentDir = $this->getFolderContent((string) reset($contentDir));
+                    $contentDir = $getFolderContent((string) reset($contentDir));
                 }
 
                 // move files back out of the temp dir
                 foreach ($contentDir as $file) {
                     $file = (string) $file;
-                    $this->filesystem->rename($file, $path . '/' . basename($file));
+                    $filesystem->rename($file, $path . '/' . basename($file));
                 }
             }
 
-            $this->filesystem->removeDirectory($temporaryDir);
-        } catch (\Exception $e) {
-            // clean up
-            $this->filesystem->removeDirectory($path);
-            $this->filesystem->removeDirectory($temporaryDir);
+            $filesystem->removeDirectory($temporaryDir);
+            $self->removeCleanupPath($package, $temporaryDir);
+        }, function ($e) use ($cleanup) {
+            $cleanup();
 
             throw $e;
-        }
+        });
     }
 
     /**
@@ -119,25 +155,8 @@ abstract class ArchiveDownloader extends FileDownloader
      * @param string $file Extracted file
      * @param string $path Directory
      *
+     * @return PromiseInterface|null
      * @throws \UnexpectedValueException If can not extract downloaded file to path
      */
     abstract protected function extract(PackageInterface $package, $file, $path);
-
-    /**
-     * Returns the folder content, excluding dotfiles
-     *
-     * @param  string         $dir Directory
-     * @return \SplFileInfo[]
-     */
-    private function getFolderContent($dir)
-    {
-        $finder = Finder::create()
-            ->ignoreVCS(false)
-            ->ignoreDotFiles(false)
-            ->notName('.DS_Store')
-            ->depth(0)
-            ->in($dir);
-
-        return iterator_to_array($finder);
-    }
 }

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -55,6 +55,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
      * @private this is only public for php 5.3 support in closures
      */
     public $lastCacheWrites = array();
+    private $additionalCleanupPaths = array();
 
     /**
      * Constructor.
@@ -258,6 +259,12 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             $path,
         );
 
+        if (isset($this->additionalCleanupPaths[$package->getName()])) {
+            foreach ($this->additionalCleanupPaths[$package->getName()] as $path) {
+                $this->filesystem->remove($path);
+            }
+        }
+
         foreach ($dirsToCleanUp as $dir) {
             if (is_dir($dir) && $this->filesystem->isDirEmpty($dir)) {
                 $this->filesystem->removeDirectory($dir);
@@ -288,6 +295,29 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
         if ($this->cache && isset($this->lastCacheWrites[$package->getName()])) {
             $this->cache->remove($this->lastCacheWrites[$package->getName()]);
             unset($this->lastCacheWrites[$package->getName()]);
+        }
+    }
+
+    /**
+     * TODO mark private in v3
+     * @protected This is public due to PHP 5.3
+     */
+    public function addCleanupPath(PackageInterface $package, $path)
+    {
+        $this->additionalCleanupPaths[$package->getName()][] = $path;
+    }
+
+    /**
+     * TODO mark private in v3
+     * @protected This is public due to PHP 5.3
+     */
+    public function removeCleanupPath(PackageInterface $package, $path)
+    {
+        if (isset($this->additionalCleanupPaths[$package->getName()])) {
+            $idx = array_search($path, $this->additionalCleanupPaths[$package->getName()]);
+            if (false !== $idx) {
+                unset($this->additionalCleanupPaths[$package->getName()][$idx]);
+            }
         }
     }
 

--- a/src/Composer/Downloader/GzipDownloader.php
+++ b/src/Composer/Downloader/GzipDownloader.php
@@ -29,15 +29,6 @@ use Composer\Util\Filesystem;
  */
 class GzipDownloader extends ArchiveDownloader
 {
-    /** @var ProcessExecutor */
-    protected $process;
-
-    public function __construct(IOInterface $io, Config $config, HttpDownloader $downloader, EventDispatcher $eventDispatcher = null, Cache $cache = null, Filesystem $fs = null, ProcessExecutor $process = null)
-    {
-        $this->process = $process ?: new ProcessExecutor($io);
-        parent::__construct($io, $config, $downloader, $eventDispatcher, $cache, $fs);
-    }
-
     protected function extract(PackageInterface $package, $file, $path)
     {
         $filename = pathinfo(parse_url($package->getDistUrl(), PHP_URL_PATH), PATHINFO_FILENAME);

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -39,15 +39,6 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
     const STRATEGY_SYMLINK = 10;
     const STRATEGY_MIRROR = 20;
 
-    /** @var ProcessExecutor */
-    private $process;
-
-    public function __construct(IOInterface $io, Config $config, HttpDownloader $downloader, EventDispatcher $eventDispatcher = null, Cache $cache = null, Filesystem $fs = null, ProcessExecutor $process = null)
-    {
-        $this->process = $process ?: new ProcessExecutor($io);
-        parent::__construct($io, $config, $downloader, $eventDispatcher, $cache, $fs);
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Composer/Downloader/RarDownloader.php
+++ b/src/Composer/Downloader/RarDownloader.php
@@ -33,15 +33,6 @@ use RarArchive;
  */
 class RarDownloader extends ArchiveDownloader
 {
-    /** @var ProcessExecutor */
-    protected $process;
-
-    public function __construct(IOInterface $io, Config $config, HttpDownloader $downloader, EventDispatcher $eventDispatcher = null, Cache $cache = null, Filesystem $fs = null, ProcessExecutor $process = null)
-    {
-        $this->process = $process ?: new ProcessExecutor($io);
-        parent::__construct($io, $config, $downloader, $eventDispatcher, $cache, $fs);
-    }
-
     protected function extract(PackageInterface $package, $file, $path)
     {
         $processError = null;

--- a/src/Composer/Downloader/XzDownloader.php
+++ b/src/Composer/Downloader/XzDownloader.php
@@ -29,16 +29,6 @@ use Composer\Util\Filesystem;
  */
 class XzDownloader extends ArchiveDownloader
 {
-    /** @var ProcessExecutor */
-    protected $process;
-
-    public function __construct(IOInterface $io, Config $config, HttpDownloader $downloader, EventDispatcher $eventDispatcher = null, Cache $cache = null, Filesystem $fs = null, ProcessExecutor $process = null)
-    {
-        $this->process = $process ?: new ProcessExecutor($io);
-
-        parent::__construct($io, $config, $downloader, $eventDispatcher, $cache, $fs);
-    }
-
     protected function extract(PackageInterface $package, $file, $path)
     {
         $command = 'tar -xJf ' . ProcessExecutor::escape($file) . ' -C ' . ProcessExecutor::escape($path);

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -86,9 +86,8 @@ class ZipDownloader extends ArchiveDownloader
      * @param  string $file         File to extract
      * @param  string $path         Path where to extract file
      * @param  bool   $isLastChance If true it is called as a fallback and should throw an exception
-     * @return bool   Success status
      */
-    protected function extractWithSystemUnzip($file, $path, $isLastChance)
+    private function extractWithSystemUnzip(PackageInterface $package, $file, $path, $isLastChance, $async = false)
     {
         if (!self::$hasZipArchive) {
             // Force Exception throwing if the Other alternative is not available
@@ -98,18 +97,47 @@ class ZipDownloader extends ArchiveDownloader
         if (!self::$hasSystemUnzip && !$isLastChance) {
             // This was call as the favorite extract way, but is not available
             // We switch to the alternative
-            return $this->extractWithZipArchive($file, $path, true);
+            return $this->extractWithZipArchive($package, $file, $path, true);
+        }
+
+        // When called after a ZipArchive failed, perhaps there is some files to overwrite
+        $overwrite = $isLastChance ? '-o' : '';
+        $command = 'unzip -qq '.$overwrite.' '.ProcessExecutor::escape($file).' -d '.ProcessExecutor::escape($path);
+
+        if ($async) {
+            $self = $this;
+            $io = $this->io;
+            $tryFallback = function ($processError) use ($isLastChance, $io, $self, $file, $path, $package) {
+                if ($isLastChance) {
+                    throw $processError;
+                }
+
+                $io->writeError('    <warning>'.$processError->getMessage().'</warning>');
+                $io->writeError('    The archive may contain identical file names with different capitalization (which fails on case insensitive filesystems)');
+                $io->writeError('    Unzip with unzip command failed, falling back to ZipArchive class');
+
+                return $self->extractWithZipArchive($package, $file, $path, true);
+            };
+
+            try {
+                $promise = $this->process->executeAsync($command);
+
+                return $promise->then(function ($process) use ($tryFallback, $command, $package) {
+                    if (!$process->isSuccessful()) {
+                        return $tryFallback(new \RuntimeException('Failed to extract '.$package->getName().': ('.$process->getExitCode().') '.$command."\n\n".$process->getErrorOutput()));
+                    }
+                });
+            } catch (\Exception $e) {
+                return $tryFallback($e);
+            } catch (\Throwable $e) {
+                return $tryFallback($e);
+            }
         }
 
         $processError = null;
-        // When called after a ZipArchive failed, perhaps there is some files to overwrite
-        $overwrite = $isLastChance ? '-o' : '';
-
-        $command = 'unzip -qq '.$overwrite.' '.ProcessExecutor::escape($file).' -d '.ProcessExecutor::escape($path);
-
         try {
             if (0 === $exitCode = $this->process->execute($command, $ignoredOutput)) {
-                return true;
+                return \React\Promise\resolve();
             }
 
             $processError = new \RuntimeException('Failed to execute ('.$exitCode.') '.$command."\n\n".$this->process->getErrorOutput());
@@ -121,11 +149,11 @@ class ZipDownloader extends ArchiveDownloader
             throw $processError;
         }
 
-        $this->io->writeError('    '.$processError->getMessage());
+        $this->io->writeError('    <warning>'.$processError->getMessage().'</warning>');
         $this->io->writeError('    The archive may contain identical file names with different capitalization (which fails on case insensitive filesystems)');
         $this->io->writeError('    Unzip with unzip command failed, falling back to ZipArchive class');
 
-        return $this->extractWithZipArchive($file, $path, true);
+        return $this->extractWithZipArchive($package, $file, $path, true);
     }
 
     /**
@@ -134,9 +162,11 @@ class ZipDownloader extends ArchiveDownloader
      * @param  string $file         File to extract
      * @param  string $path         Path where to extract file
      * @param  bool   $isLastChance If true it is called as a fallback and should throw an exception
-     * @return bool   Success status
+     *
+     * TODO v3 should make this private once we can drop PHP 5.3 support
+     * @protected
      */
-    protected function extractWithZipArchive($file, $path, $isLastChance)
+    public function extractWithZipArchive(PackageInterface $package, $file, $path, $isLastChance)
     {
         if (!self::$hasSystemUnzip) {
             // Force Exception throwing if the Other alternative is not available
@@ -146,7 +176,7 @@ class ZipDownloader extends ArchiveDownloader
         if (!self::$hasZipArchive && !$isLastChance) {
             // This was call as the favorite extract way, but is not available
             // We switch to the alternative
-            return $this->extractWithSystemUnzip($file, $path, true);
+            return $this->extractWithSystemUnzip($package, $file, $path, true);
         }
 
         $processError = null;
@@ -159,7 +189,7 @@ class ZipDownloader extends ArchiveDownloader
                 if (true === $extractResult) {
                     $zipArchive->close();
 
-                    return true;
+                    return \React\Promise\resolve();
                 }
 
                 $processError = new \RuntimeException(rtrim("There was an error extracting the ZIP file, it is either corrupted or using an invalid format.\n"));
@@ -170,16 +200,18 @@ class ZipDownloader extends ArchiveDownloader
             $processError = new \RuntimeException('The archive may contain identical file names with different capitalization (which fails on case insensitive filesystems): '.$e->getMessage(), 0, $e);
         } catch (\Exception $e) {
             $processError = $e;
+        } catch (\Throwable $e) {
+            $processError = $e;
         }
 
         if ($isLastChance) {
             throw $processError;
         }
 
-        $this->io->writeError('    '.$processError->getMessage());
+        $this->io->writeError('    <warning>'.$processError->getMessage().'</warning>');
         $this->io->writeError('    Unzip with ZipArchive class failed, falling back to unzip command');
 
-        return $this->extractWithSystemUnzip($file, $path, true);
+        return $this->extractWithSystemUnzip($package, $file, $path, true);
     }
 
     /**
@@ -192,10 +224,10 @@ class ZipDownloader extends ArchiveDownloader
     {
         // Each extract calls its alternative if not available or fails
         if (self::$isWindows) {
-            $this->extractWithZipArchive($file, $path, false);
-        } else {
-            $this->extractWithSystemUnzip($file, $path, false);
+            return $this->extractWithZipArchive($package, $file, $path, false);
         }
+
+        return $this->extractWithSystemUnzip($package, $file, $path, false, true);
     }
 
     /**

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -34,16 +34,8 @@ class ZipDownloader extends ArchiveDownloader
     private static $hasZipArchive;
     private static $isWindows;
 
-    /** @var ProcessExecutor */
-    protected $process;
     /** @var ZipArchive|null */
     private $zipArchiveObject;
-
-    public function __construct(IOInterface $io, Config $config, HttpDownloader $downloader, EventDispatcher $eventDispatcher = null, Cache $cache = null, Filesystem $fs = null, ProcessExecutor $process = null)
-    {
-        $this->process = $process ?: new ProcessExecutor($io);
-        parent::__construct($io, $config, $downloader, $eventDispatcher, $cache, $fs);
-    }
 
     /**
      * {@inheritDoc}

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -495,11 +495,11 @@ class Factory
         $dm->setDownloader('perforce', new Downloader\PerforceDownloader($io, $config, $process, $fs));
         $dm->setDownloader('zip', new Downloader\ZipDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs, $process));
         $dm->setDownloader('rar', new Downloader\RarDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs, $process));
-        $dm->setDownloader('tar', new Downloader\TarDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs));
+        $dm->setDownloader('tar', new Downloader\TarDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs, $process));
         $dm->setDownloader('gzip', new Downloader\GzipDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs, $process));
         $dm->setDownloader('xz', new Downloader\XzDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs, $process));
-        $dm->setDownloader('phar', new Downloader\PharDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs));
-        $dm->setDownloader('file', new Downloader\FileDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs));
+        $dm->setDownloader('phar', new Downloader\PharDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs, $process));
+        $dm->setDownloader('file', new Downloader\FileDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs, $process));
         $dm->setDownloader('path', new Downloader\PathDownloader($io, $config, $httpDownloader, $eventDispatcher, $cache, $fs, $process));
 
         return $dm;

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -336,7 +336,7 @@ class Factory
 
         $httpDownloader = self::createHttpDownloader($io, $config);
         $process = new ProcessExecutor($io);
-        $loop = new Loop($httpDownloader);
+        $loop = new Loop($httpDownloader, $process);
         $composer->setLoop($loop);
 
         // initialize event dispatcher

--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -14,6 +14,7 @@ namespace Composer\IO;
 
 use Composer\Question\StrictConfirmationQuestion;
 use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -251,6 +252,15 @@ class ConsoleIO extends BaseIO
         } else {
             $this->lastMessage = $messages;
         }
+    }
+
+    /**
+     * @param int $max
+     * @return ProgressBar
+     */
+    public function getProgressBar($max = 0)
+    {
+        return new ProgressBar($this->getErrorOutput(), $max);
     }
 
     /**

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -685,7 +685,7 @@ class Installer
         }
 
         if ($this->executeOperations) {
-            $this->installationManager->execute($localRepo, $localRepoTransaction->getOperations(), $this->devMode);
+            $this->installationManager->execute($localRepo, $localRepoTransaction->getOperations(), $this->devMode, $this->runScripts);
         } else {
             foreach ($localRepoTransaction->getOperations() as $operation) {
                 // output op, but alias op only in debug verbosity

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -184,6 +184,8 @@ class InstallationManager
         $runCleanup = function () use (&$cleanupPromises, $loop) {
             $promises = array();
 
+            $loop->abortJobs();
+
             foreach ($cleanupPromises as $cleanup) {
                 $promises[] = new \React\Promise\Promise(function ($resolve, $reject) use ($cleanup) {
                     $promise = $cleanup();

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -13,6 +13,7 @@
 namespace Composer\Installer;
 
 use Composer\IO\IOInterface;
+use Composer\IO\ConsoleIO;
 use Composer\Package\PackageInterface;
 use Composer\Package\AliasPackage;
 use Composer\Repository\RepositoryInterface;
@@ -330,7 +331,14 @@ class InstallationManager
 
             // execute all prepare => installs/updates/removes => cleanup steps
             if (!empty($promises)) {
-                $this->loop->wait($promises);
+                $progress = null;
+                if ($io instanceof ConsoleIO && !$io->isDebug()) {
+                    $progress = $io->getProgressBar();
+                }
+                $this->loop->wait($promises, $progress);
+                if ($progress) {
+                    $progress->clear();
+                }
             }
         } catch (\Exception $e) {
             $runCleanup();

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -272,73 +272,23 @@ class InstallationManager
                 $this->loop->wait($promises);
             }
 
-            foreach ($operations as $index => $operation) {
-                $opType = $operation->getOperationType();
+            // execute operations in batches to make sure every plugin is installed in the
+            // right order and activated before the packages depending on it are installed
+            while ($operations) {
+                $batch = array();
 
-                // ignoring alias ops as they don't need to execute anything
-                if (!in_array($opType, array('update', 'install', 'uninstall'))) {
-                    // output alias ops in debug verbosity as they have no output otherwise
-                    if ($this->io->isDebug()) {
-                        $this->io->writeError('  - ' . $operation->show(false));
+                foreach ($operations as $index => $operation) {
+                    unset($operations[$index]);
+                    $batch[$index] = $operation;
+                    if (in_array($operation->getOperationType(), array('update', 'install'), true)) {
+                        $package = $operation->getOperationType() === 'update' ? $operation->getTargetPackage() : $operation->getPackage();
+                        if ($package->getType() === 'composer-plugin' || $package->getType() === 'composer-installer') {
+                            break;
+                        }
                     }
-                    $this->$opType($repo, $operation);
-
-                    continue;
                 }
 
-                if ($opType === 'update') {
-                    $package = $operation->getTargetPackage();
-                    $initialPackage = $operation->getInitialPackage();
-                } else {
-                    $package = $operation->getPackage();
-                    $initialPackage = null;
-                }
-                $installer = $this->getInstaller($package->getType());
-
-                $event = 'Composer\Installer\PackageEvents::PRE_PACKAGE_'.strtoupper($opType);
-                if (defined($event) && $runScripts && $this->eventDispatcher) {
-                    $this->eventDispatcher->dispatchPackageEvent(constant($event), $devMode, $repo, $operations, $operation);
-                }
-
-                $dispatcher = $this->eventDispatcher;
-                $installManager = $this;
-                $loop = $this->loop;
-                $io = $this->io;
-
-                $promise = $installer->prepare($opType, $package, $initialPackage);
-                if (!$promise instanceof PromiseInterface) {
-                    $promise = \React\Promise\resolve();
-                }
-
-                $promise = $promise->then(function () use ($opType, $installManager, $repo, $operation) {
-                    return $installManager->$opType($repo, $operation);
-                })->then($cleanupPromises[$index])
-                ->then(function () use ($opType, $runScripts, $dispatcher, $installManager, $devMode, $repo, $operations, $operation) {
-                    $repo->write($devMode, $installManager);
-
-                    $event = 'Composer\Installer\PackageEvents::POST_PACKAGE_'.strtoupper($opType);
-                    if (defined($event) && $runScripts && $dispatcher) {
-                        $dispatcher->dispatchPackageEvent(constant($event), $devMode, $repo, $operations, $operation);
-                    }
-                }, function ($e) use ($opType, $package, $io) {
-                    $io->writeError('    <error>' . ucfirst($opType) .' of '.$package->getPrettyName().' failed</error>');
-
-                    throw $e;
-                });
-
-                $promises[] = $promise;
-            }
-
-            // execute all prepare => installs/updates/removes => cleanup steps
-            if (!empty($promises)) {
-                $progress = null;
-                if ($io instanceof ConsoleIO && !$io->isDebug()) {
-                    $progress = $io->getProgressBar();
-                }
-                $this->loop->wait($promises, $progress);
-                if ($progress) {
-                    $progress->clear();
-                }
+                $this->executeBatch($repo, $batch, $cleanupPromises, $devMode, $runScripts);
             }
         } catch (\Exception $e) {
             $runCleanup();
@@ -364,6 +314,77 @@ class InstallationManager
         // as that can trigger an update of some files like InstalledVersions.php if
         // running a new composer version
         $repo->write($devMode, $this);
+    }
+
+    private function executeBatch(RepositoryInterface $repo, array $operations, array $cleanupPromises, $devMode, $runScripts)
+    {
+        foreach ($operations as $index => $operation) {
+            $opType = $operation->getOperationType();
+
+            // ignoring alias ops as they don't need to execute anything
+            if (!in_array($opType, array('update', 'install', 'uninstall'))) {
+                // output alias ops in debug verbosity as they have no output otherwise
+                if ($this->io->isDebug()) {
+                    $this->io->writeError('  - ' . $operation->show(false));
+                }
+                $this->$opType($repo, $operation);
+
+                continue;
+            }
+
+            if ($opType === 'update') {
+                $package = $operation->getTargetPackage();
+                $initialPackage = $operation->getInitialPackage();
+            } else {
+                $package = $operation->getPackage();
+                $initialPackage = null;
+            }
+            $installer = $this->getInstaller($package->getType());
+
+            $event = 'Composer\Installer\PackageEvents::PRE_PACKAGE_'.strtoupper($opType);
+            if (defined($event) && $runScripts && $this->eventDispatcher) {
+                $this->eventDispatcher->dispatchPackageEvent(constant($event), $devMode, $repo, $operations, $operation);
+            }
+
+            $dispatcher = $this->eventDispatcher;
+            $installManager = $this;
+            $io = $this->io;
+
+            $promise = $installer->prepare($opType, $package, $initialPackage);
+            if (!$promise instanceof PromiseInterface) {
+                $promise = \React\Promise\resolve();
+            }
+
+            $promise = $promise->then(function () use ($opType, $installManager, $repo, $operation) {
+                return $installManager->$opType($repo, $operation);
+            })->then($cleanupPromises[$index])
+            ->then(function () use ($opType, $runScripts, $dispatcher, $installManager, $devMode, $repo, $operations, $operation) {
+                $repo->write($devMode, $installManager);
+
+                $event = 'Composer\Installer\PackageEvents::POST_PACKAGE_'.strtoupper($opType);
+                if (defined($event) && $runScripts && $dispatcher) {
+                    $dispatcher->dispatchPackageEvent(constant($event), $devMode, $repo, $operations, $operation);
+                }
+            }, function ($e) use ($opType, $package, $io) {
+                $io->writeError('    <error>' . ucfirst($opType) .' of '.$package->getPrettyName().' failed</error>');
+
+                throw $e;
+            });
+
+            $promises[] = $promise;
+        }
+
+        // execute all prepare => installs/updates/removes => cleanup steps
+        if (!empty($promises)) {
+            $progress = null;
+            if ($io instanceof ConsoleIO && !$io->isDebug() && count($promises) > 1) {
+                $progress = $io->getProgressBar();
+            }
+            $this->loop->wait($promises, $progress);
+            if ($progress) {
+                $progress->clear();
+            }
+        }
     }
 
     /**

--- a/src/Composer/Util/Loop.php
+++ b/src/Composer/Util/Loop.php
@@ -76,4 +76,13 @@ class Loop
             throw $uncaught;
         }
     }
+
+    public function abortJobs()
+    {
+        if ($this->currentPromises) {
+            foreach ($this->currentPromises as $promise) {
+                $promise->cancel();
+            }
+        }
+    }
 }

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -281,15 +281,11 @@ class ProcessExecutor
         }
 
         if (null !== $index) {
-            if ($this->jobs[$index]['status'] === self::STATUS_COMPLETED || $this->jobs[$index]['status'] === self::STATUS_FAILED || $this->jobs[$index]['status'] === self::STATUS_ABORTED) {
-                return false;
-            }
-
-            return true;
+            return $this->jobs[$index]['status'] < self::STATUS_COMPLETED;
         }
 
         foreach ($this->jobs as $job) {
-            if (!in_array($job['status'], array(self::STATUS_COMPLETED, self::STATUS_FAILED, self::STATUS_ABORTED), true)) {
+            if ($job['status'] < self::STATUS_COMPLETED) {
                 return true;
             } else {
                 unset($this->jobs[$job['id']]);

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -16,17 +16,31 @@ use Composer\IO\IOInterface;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessUtils;
 use Symfony\Component\Process\Exception\RuntimeException;
+use React\Promise\Promise;
 
 /**
  * @author Robert Schönthal <seroscho@googlemail.com>
+ * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 class ProcessExecutor
 {
+    const STATUS_QUEUED = 1;
+    const STATUS_STARTED = 2;
+    const STATUS_COMPLETED = 3;
+    const STATUS_FAILED = 4;
+    const STATUS_ABORTED = 5;
+
     protected static $timeout = 300;
 
     protected $captureOutput;
     protected $errorOutput;
     protected $io;
+
+    private $jobs = array();
+    private $runningJobs = 0;
+    private $maxJobs = 10;
+    private $idGen = 0;
+    private $allowAsync = false;
 
     public function __construct(IOInterface $io = null)
     {
@@ -110,6 +124,196 @@ class ProcessExecutor
         $this->errorOutput = $process->getErrorOutput();
 
         return $process->getExitCode();
+    }
+
+    /**
+     * starts a process on the commandline in async mode
+     *
+     * @param  string $command the command to execute
+     * @param  mixed  $output  the output will be written into this var if passed by ref
+     *                         if a callable is passed it will be used as output handler
+     * @param  string $cwd     the working directory
+     * @return int    statuscode
+     */
+    public function executeAsync($command, $cwd = null)
+    {
+        if (!$this->allowAsync) {
+            throw new \LogicException('You must use the ProcessExecutor instance which is part of a Composer\Loop instance to be able to run async processes');
+        }
+
+        $job = array(
+            'id' => $this->idGen++,
+            'status' => self::STATUS_QUEUED,
+            'command' => $command,
+            'cwd' => $cwd,
+        );
+
+        $resolver = function ($resolve, $reject) use (&$job) {
+            $job['status'] = ProcessExecutor::STATUS_QUEUED;
+            $job['resolve'] = $resolve;
+            $job['reject'] = $reject;
+        };
+
+        $self = $this;
+        $io = $this->io;
+
+        $canceler = function () use (&$job) {
+            if ($job['status'] === self::STATUS_QUEUED) {
+                $job['status'] = self::STATUS_ABORTED;
+            }
+            if ($job['status'] !== self::STATUS_STARTED) {
+                return;
+            }
+            $job['status'] = self::STATUS_ABORTED;
+            try {
+                if (defined('SIGINT')) {
+                    $job['process']->signal(SIGINT);
+                }
+            } catch (\Exception $e) {
+                // signal can throw in various conditions, but we don't care if it fails
+            }
+            $job['process']->stop(1);
+        };
+
+        $promise = new Promise($resolver, $canceler);
+        $promise = $promise->then(function () use (&$job, $self) {
+            if ($job['process']->isSuccessful()) {
+                $job['status'] = ProcessExecutor::STATUS_COMPLETED;
+            } else {
+                $job['status'] = ProcessExecutor::STATUS_FAILED;
+            }
+
+            // TODO 3.0 this should be done directly on $this when PHP 5.3 is dropped
+            $self->markJobDone();
+
+            return $job['process'];
+        }, function () use (&$job, $self) {
+            $job['status'] = ProcessExecutor::STATUS_FAILED;
+
+            $self->markJobDone();
+
+            return \React\Promise\reject($job['process']);
+        });
+        $this->jobs[$job['id']] =& $job;
+
+        if ($this->runningJobs < $this->maxJobs) {
+            $this->startJob($job['id']);
+        }
+
+        return $promise;
+    }
+
+    private function startJob($id)
+    {
+        $job =& $this->jobs[$id];
+        if ($job['status'] !== self::STATUS_QUEUED) {
+            return;
+        }
+
+        // start job
+        $job['status'] = self::STATUS_STARTED;
+        $this->runningJobs++;
+
+        $command = $job['command'];
+        $cwd = $job['cwd'];
+
+        if ($this->io && $this->io->isDebug()) {
+            $safeCommand = preg_replace_callback('{://(?P<user>[^:/\s]+):(?P<password>[^@\s/]+)@}i', function ($m) {
+                if (preg_match('{^[a-f0-9]{12,}$}', $m['user'])) {
+                    return '://***:***@';
+                }
+
+                return '://'.$m['user'].':***@';
+            }, $command);
+            $safeCommand = preg_replace("{--password (.*[^\\\\]\') }", '--password \'***\' ', $safeCommand);
+            $this->io->writeError('Executing async command ('.($cwd ?: 'CWD').'): '.$safeCommand);
+        }
+
+        // make sure that null translate to the proper directory in case the dir is a symlink
+        // and we call a git command, because msysgit does not handle symlinks properly
+        if (null === $cwd && Platform::isWindows() && false !== strpos($command, 'git') && getcwd()) {
+            $cwd = realpath(getcwd());
+        }
+
+        // TODO in v3, commands should be passed in as arrays of cmd + args
+        if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandline')) {
+            $process = Process::fromShellCommandline($command, $cwd, null, null, static::getTimeout());
+        } else {
+            $process = new Process($command, $cwd, null, null, static::getTimeout());
+        }
+
+        $job['process'] = $process;
+
+        $process->start();
+    }
+
+    public function wait($index = null)
+    {
+        while (true) {
+            if (!$this->hasActiveJob($index)) {
+                return;
+            }
+
+            usleep(1000);
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public function enableAsync()
+    {
+        $this->allowAsync = true;
+    }
+
+    /**
+     * @internal
+     */
+    public function hasActiveJob($index = null)
+    {
+        // tick
+        foreach ($this->jobs as &$job) {
+            if ($job['status'] === self::STATUS_STARTED) {
+                if (!$job['process']->isRunning()) {
+                    call_user_func($job['resolve'], $job['process']);
+                }
+            }
+        }
+
+        if (null !== $index) {
+            if ($this->jobs[$index]['status'] === self::STATUS_COMPLETED || $this->jobs[$index]['status'] === self::STATUS_FAILED || $this->jobs[$index]['status'] === self::STATUS_ABORTED) {
+                return false;
+            }
+
+            return true;
+        }
+
+        foreach ($this->jobs as $job) {
+            if (!in_array($job['status'], array(self::STATUS_COMPLETED, self::STATUS_FAILED, self::STATUS_ABORTED), true)) {
+                return true;
+            } else {
+                unset($this->jobs[$job['id']]);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @private
+     */
+    public function markJobDone()
+    {
+        $this->runningJobs--;
+
+        foreach ($this->jobs as $job) {
+            if ($job['status'] === self::STATUS_QUEUED) {
+                $this->startJob($job['id']);
+                if ($this->runningJobs >= $this->maxJobs) {
+                    return;
+                }
+            }
+        }
     }
 
     public function splitLines($output)

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -187,12 +187,12 @@ class ProcessExecutor
             $self->markJobDone();
 
             return $job['process'];
-        }, function () use (&$job, $self) {
+        }, function ($e) use (&$job, $self) {
             $job['status'] = ProcessExecutor::STATUS_FAILED;
 
             $self->markJobDone();
 
-            return \React\Promise\reject($job['process']);
+            throw $e;
         });
         $this->jobs[$job['id']] =& $job;
 
@@ -272,7 +272,7 @@ class ProcessExecutor
     public function hasActiveJob($index = null)
     {
         // tick
-        foreach ($this->jobs as &$job) {
+        foreach ($this->jobs as $job) {
             if ($job['status'] === self::STATUS_STARTED) {
                 if (!$job['process']->isRunning()) {
                     call_user_func($job['resolve'], $job['process']);

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -20,6 +20,7 @@ use Composer\Util\HttpDownloader;
 use Composer\Util\Http\Response;
 
 /**
+ * @internal
  * @author François Pluchino <francois.pluchino@opendisplay.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Nils Adermann <naderman@naderman.de>

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -139,8 +139,8 @@ class FileDownloaderTest extends TestCase
             ->will($this->returnValue($path.'/vendor'));
 
         try {
-            $promise = $downloader->download($packageMock, $path);
             $loop = new Loop($this->httpDownloader);
+            $promise = $downloader->download($packageMock, $path);
             $loop->wait(array($promise));
 
             $this->fail('Download was expected to throw');
@@ -225,8 +225,8 @@ class FileDownloaderTest extends TestCase
         touch($dlFile);
 
         try {
-            $promise = $downloader->download($packageMock, $path);
             $loop = new Loop($this->httpDownloader);
+            $promise = $downloader->download($packageMock, $path);
             $loop->wait(array($promise));
 
             $this->fail('Download was expected to throw');
@@ -296,8 +296,8 @@ class FileDownloaderTest extends TestCase
         mkdir(dirname($dlFile), 0777, true);
         touch($dlFile);
 
-        $promise = $downloader->download($newPackage, $path, $oldPackage);
         $loop = new Loop($this->httpDownloader);
+        $promise = $downloader->download($newPackage, $path, $oldPackage);
         $loop->wait(array($promise));
 
         $downloader->update($oldPackage, $newPackage, $path);

--- a/tests/Composer/Test/Downloader/XzDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/XzDownloaderTest.php
@@ -70,8 +70,8 @@ class XzDownloaderTest extends TestCase
         $downloader = new XzDownloader($io, $config, $httpDownloader = new HttpDownloader($io, $this->getMockBuilder('Composer\Config')->getMock()), null, null, null);
 
         try {
-            $promise = $downloader->download($packageMock, $this->testDir.'/install-path');
             $loop = new Loop($httpDownloader);
+            $promise = $downloader->download($packageMock, $this->testDir.'/install-path');
             $loop->wait(array($promise));
             $downloader->install($packageMock, $this->testDir.'/install-path');
 

--- a/tests/Composer/Test/Downloader/ZipDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ZipDownloaderTest.php
@@ -92,8 +92,8 @@ class ZipDownloaderTest extends TestCase
         $this->setPrivateProperty('hasSystemUnzip', false);
 
         try {
-            $promise = $downloader->download($this->package, $path = sys_get_temp_dir().'/composer-zip-test');
             $loop = new Loop($this->httpDownloader);
+            $promise = $downloader->download($this->package, $path = sys_get_temp_dir().'/composer-zip-test');
             $loop->wait(array($promise));
             $downloader->install($this->package, $path);
 

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -189,16 +189,19 @@ class ComposerRepositoryTest extends TestCase
             ->getMock();
 
         $httpDownloader->expects($this->at(0))
+            ->method('enableAsync');
+
+        $httpDownloader->expects($this->at(1))
             ->method('get')
             ->with($url = 'http://example.org/packages.json')
             ->willReturn(new \Composer\Util\Http\Response(array('url' => $url), 200, array(), json_encode(array('search' => '/search.json?q=%query%&type=%type%'))));
 
-        $httpDownloader->expects($this->at(1))
+        $httpDownloader->expects($this->at(2))
             ->method('get')
             ->with($url = 'http://example.org/search.json?q=foo&type=composer-plugin')
             ->willReturn(new \Composer\Util\Http\Response(array('url' => $url), 200, array(), json_encode($result)));
 
-        $httpDownloader->expects($this->at(2))
+        $httpDownloader->expects($this->at(3))
             ->method('get')
             ->with($url = 'http://example.org/search.json?q=foo&type=library')
             ->willReturn(new \Composer\Util\Http\Response(array('url' => $url), 200, array(), json_encode(array())));
@@ -291,6 +294,9 @@ class ComposerRepositoryTest extends TestCase
             ->getMock();
 
         $httpDownloader->expects($this->at(0))
+            ->method('enableAsync');
+
+        $httpDownloader->expects($this->at(1))
             ->method('get')
             ->with($url = 'http://example.org/packages.json')
             ->willReturn(new \Composer\Util\Http\Response(array('url' => $url), 200, array(), json_encode(array(


### PR DESCRIPTION
This adds support for async processes, and on linux/OSX if `unzip` is present it will be used to extract package archives in parallel.

This speeds up extraction time by 30-50% in a few tests I made. Curious to get feedback from others, especially HDD users as I am not sure how it'll behave there.

For example here is `time` output for an install of 197 packages:


parallel-installs:
```
real    0m47.391s
user    0m6.266s
sys     1m19.531s
```

master:
```
real    1m15.275s
user    0m5.297s
sys     1m3.094s
```

And a more reasonable one with 47 packages:

parallel-installs:
```
real    0m19.097s
user    0m1.844s
sys     0m30.109s
```

master:
```
real    0m30.592s
user    0m2.141s
sys     0m26.328s
```

