### PR TITLE
Add new summary format for licenses

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -785,7 +785,7 @@ Lists the name, version and license of every package installed. Use
 
 ### Options
 
-* **--format:** Format of the output: text or json (default: "text")
+* **--format:** Format of the output: text, json or summary (default: "text")
 * **--no-dev:** Remove dev dependencies from the output
 
 ## run-script

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @author Benoît Merlet <benoit.merlet@gmail.com>
@@ -111,6 +112,27 @@ EOT
                 )));
                 break;
 
+            case 'summary':
+                $dependencies = array();
+                foreach ($packages as $package) {
+                    $license = $package->getLicense()[0];
+                    if (!isset($dependencies[$license])) {
+                        $dependencies[$license] = 0;
+                    }
+                    $dependencies[$license]++;
+                }
+
+                $rows = array();
+                foreach ($dependencies as $usedLicense => $numberOfDependencies) {
+                    $rows[] = array($usedLicense, $numberOfDependencies);
+                }
+
+                $symfonyIo = new SymfonyStyle($input, $output);
+                $symfonyIo->table(
+                    array('License', 'Number of dependencies'),
+                    $rows
+                );
+                break;
             default:
                 throw new \RuntimeException(sprintf('Unsupported format "%s".  See help for supported formats.', $format));
         }

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -115,11 +115,12 @@ EOT
             case 'summary':
                 $dependencies = array();
                 foreach ($packages as $package) {
-                    $license = $package->getLicense()[0];
-                    if (!isset($dependencies[$license])) {
-                        $dependencies[$license] = 0;
+                    $license = $package->getLicense();
+                    $licenseName = $license[0];
+                    if (!isset($dependencies[$licenseName])) {
+                        $dependencies[$licenseName] = 0;
                     }
-                    $dependencies[$license]++;
+                    $dependencies[$licenseName]++;
                 }
 
                 $rows = array();


### PR DESCRIPTION
This was inspired by https://www.npmjs.com/package/license-checker which has a `--summary` option to have a list of used licenses and the number of dependencies using each license.

Here's how it looks when executed:
![image](https://user-images.githubusercontent.com/12606789/84506912-5223d600-acc0-11ea-9c34-b8654055cee2.png)
