### PR TITLE
PHPStan fixes: `autoload_files`, and `ignoreErrors`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -89,7 +89,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          extensions: "intl"
+          extensions: "intl, zip"
           ini-values: "memory_limit=-1, phar.readonly=0"
           php-version: "${{ matrix.php-version }}"
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -52,5 +52,5 @@ jobs:
 
       - name: Run PHPStan
         run: |
-          bin/composer require --dev phpstan/phpstan:^0.12 phpunit/phpunit:^7.5 --with-all-dependencies
+          bin/composer require --dev phpstan/phpstan:^0.12.26 phpunit/phpunit:^7.5 --with-all-dependencies
           vendor/bin/phpstan analyse --configuration=phpstan/config.neon || vendor/bin/phpstan analyse --configuration=phpstan/config.neon --error-format=checkstyle | cs2pr

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -31,7 +31,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          extensions: "intl"
+          extensions: "intl, zip"
           ini-values: "memory_limit=-1"
           php-version: "${{ matrix.php-version }}"
           tools: "cs2pr"

--- a/phpstan/config.neon
+++ b/phpstan/config.neon
@@ -26,15 +26,8 @@ parameters:
         # BC with older PHPUnit
         - '~^Call to an undefined static method PHPUnit\\Framework\\TestCase::setExpectedException\(\)\.$~'
 
-        - # Windows SAPI functions, already checked before using them.
-            message: '~^Function sapi_windows_set_ctrl_handler not found.$~'
-            paths:
-                - ../src/Composer/Command/CreateProjectCommand.php
-                - ../src/Composer/Installer/InstallationManager.php
-
-        - # ZipArchive::LIBZIP_VERSION Class constant is already checked before use.
-            message: '~^Access to undefined constant ZipArchive::LIBZIP_VERSION.$~'
-            path: ../src/Composer/Repository/PlatformRepository.php
+        # ZipArchive::* Class constants are already checked before use.
+        - '~^Access to undefined constant ZipArchive::~'
 
     paths:
         - ../src

--- a/phpstan/config.neon
+++ b/phpstan/config.neon
@@ -32,6 +32,10 @@ parameters:
                 - ../src/Composer/Command/CreateProjectCommand.php
                 - ../src/Composer/Installer/InstallationManager.php
 
+        - # ZipArchive::LIBZIP_VERSION Class constant is already checked before use.
+            message: '~^Access to undefined constant ZipArchive::LIBZIP_VERSION.$~'
+            path: ../src/Composer/Repository/PlatformRepository.php
+
     paths:
         - ../src
         - ../tests

--- a/phpstan/config.neon
+++ b/phpstan/config.neon
@@ -25,6 +25,13 @@ parameters:
 
         # BC with older PHPUnit
         - '~^Call to an undefined static method PHPUnit\\Framework\\TestCase::setExpectedException\(\)\.$~'
+
+        - # Windows SAPI functions, already checked before using them.
+            message: '~^Function sapi_windows_set_ctrl_handler not found.$~'
+            paths:
+                - ../src/Composer/Command/CreateProjectCommand.php
+                - ../src/Composer/Installer/InstallationManager.php
+
     paths:
         - ../src
         - ../tests

--- a/phpstan/config.neon
+++ b/phpstan/config.neon
@@ -1,7 +1,5 @@
 parameters:
     level: 1
-    autoload_files:
-        - '../src/bootstrap.php'
     excludes_analyse:
        - '../tests/Composer/Test/Fixtures/*'
        - '../tests/Composer/Test/Autoload/Fixtures/*'


### PR DESCRIPTION
Includes a few improvements in PHPStan CI runs. 
 - Require PHPStan `^0.12.26` (currently `^0.12`) because this version contains major improvements how files are autoloaded. 
 - Remove `autoload_files` from PHPStan `config.neon` because PHPStan no longer needs to autoload files for it to analyze files. 
 - Add `ignoreErrors` pattern for the use of `sapi_windows_set_ctrl_handler` function. The ignore pattern is specific about files, where we already have `function_exists()` calls to make sure this function is available. 
 - Add `ignoreErrors` pattern for `ZipArchive::LIBZIP_VERSION` usage, which is checked before hand. This rule is specific to the single usage we have in Composer. 

With this PR, we bring down PHPStan report from **6 errors and 1 warning** to **1 error**.

The only remaining warning is about the usage of `ZipArchive::OPSYS_UNIX`, which I'm not 100% sure if we should ignore because there doesn't appear to be `defined()` call to safe-guard it. 