### PR TITLE
Composer 2: Allow plugins to override the URL before triggering the download

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -125,7 +125,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             $url = reset($urls);
 
             if ($eventDispatcher) {
-                $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $httpDownloader, $url['processed']);
+                $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $httpDownloader, $url['processed'], 'package', $package);
                 $eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
                 $url['processed'] = $preFileDownloadEvent->getProcessedUrl();
             }

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -127,6 +127,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             if ($eventDispatcher) {
                 $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $httpDownloader, $url['processed']);
                 $eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
+                $url['processed'] = $preFileDownloadEvent->getProcessedUrl();
             }
 
             $checksum = $package->getDistSha1Checksum();

--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -67,7 +67,7 @@ class PreFileDownloadEvent extends Event
     /**
      * Sets the processed URL that will be downloaded
      *
-     * @return string
+     * @param string $processedUrl New processed URL
      */
     public function setProcessedUrl($processedUrl)
     {

--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -55,12 +55,22 @@ class PreFileDownloadEvent extends Event
     }
 
     /**
-     * Retrieves the processed URL this remote filesystem will be used for
+     * Retrieves the processed URL that will be downloaded
      *
      * @return string
      */
     public function getProcessedUrl()
     {
         return $this->processedUrl;
+    }
+
+    /**
+     * Sets the processed URL that will be downloaded
+     *
+     * @return string
+     */
+    public function setProcessedUrl($processedUrl)
+    {
+        $this->processedUrl = $processedUrl;
     }
 }

--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -33,17 +33,31 @@ class PreFileDownloadEvent extends Event
     private $processedUrl;
 
     /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var mixed
+     */
+    private $context;
+
+    /**
      * Constructor.
      *
-     * @param string           $name         The event name
-     * @param HttpDownloader $httpDownloader
-     * @param string           $processedUrl
+     * @param string          $name            The event name
+     * @param HttpDownloader  $httpDownloader
+     * @param string          $processedUrl
+     * @param string          $type
+     * @param mixed           $context
      */
-    public function __construct($name, HttpDownloader $httpDownloader, $processedUrl)
+    public function __construct($name, HttpDownloader $httpDownloader, $processedUrl, $type, $context = null)
     {
         parent::__construct($name);
         $this->httpDownloader = $httpDownloader;
         $this->processedUrl = $processedUrl;
+        $this->type = $type;
+        $this->context = $context;
     }
 
     /**
@@ -72,5 +86,26 @@ class PreFileDownloadEvent extends Event
     public function setProcessedUrl($processedUrl)
     {
         $this->processedUrl = $processedUrl;
+    }
+
+    /**
+     * Returns the type of this download (package, metadata)
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Returns the context of this download, if any.
+     * If this download is of type package, the package object is returned.
+     *
+     * @return mixed
+     */
+    public function getContext()
+    {
+        return $this->context;
     }
 }

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1013,7 +1013,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         while ($retries--) {
             try {
                 if ($this->eventDispatcher) {
-                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename);
+                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata');
                     $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
                     $filename = $preFileDownloadEvent->getProcessedUrl();
                 }
@@ -1100,7 +1100,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         while ($retries--) {
             try {
                 if ($this->eventDispatcher) {
-                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename);
+                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata');
                     $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
                     $filename = $preFileDownloadEvent->getProcessedUrl();
                 }
@@ -1167,7 +1167,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         $httpDownloader = $this->httpDownloader;
         if ($this->eventDispatcher) {
-            $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename);
+            $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata');
             $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
             $filename = $preFileDownloadEvent->getProcessedUrl();
         }

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1015,6 +1015,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 if ($this->eventDispatcher) {
                     $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename);
                     $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
+                    $filename = $preFileDownloadEvent->getProcessedUrl();
                 }
 
                 $response = $this->httpDownloader->get($filename, $this->options);
@@ -1101,6 +1102,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 if ($this->eventDispatcher) {
                     $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename);
                     $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
+                    $filename = $preFileDownloadEvent->getProcessedUrl();
                 }
 
                 $options = $this->options;
@@ -1167,6 +1169,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         if ($this->eventDispatcher) {
             $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename);
             $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
+            $filename = $preFileDownloadEvent->getProcessedUrl();
         }
 
         $options = $lastModifiedTime ? array('http' => array('header' => array('If-Modified-Since: '.$lastModifiedTime))) : array();


### PR DESCRIPTION
I am the maintainer of [private-composer-installer](https://github.com/ffraenz/private-composer-installer) offering users to inject environment values into the dist URLs of their repositories without leaking sensitive information into `composer.lock`. In the next major version ([pull request](https://github.com/ffraenz/private-composer-installer/pull/25)) I'd like to add support for Composer 2.

Currently the plugin replaces the remote file system to alter the dist URL before the download gets triggered. As explained in the [upgrade guide](https://github.com/composer/composer/blob/master/UPGRADE-2.0.md) this will no longer work in Composer 2.

As already suggested in https://github.com/composer/composer/pull/8807#issuecomment-617864883 I'd like to implement a way for plugins to alter the URL before the actual download gets triggered using the existing `PRE_FILE_DOWNLOAD` event. I'd like to suggest adding the method `setProcessedUrl` to the event object where the URL gets fed back to the caller before triggering the actual download.

I could not find existing test cases for events so I was unsure about how to implement unit tests for this change.