### PR TITLE
Discard changes is incomplete if Git project has additional folders

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -451,7 +451,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
     protected function discardChanges($path)
     {
         $path = $this->normalizePath($path);
-        if (0 !== $this->process->execute('git reset --hard', $output, $path)) {
+        if (0 !== $this->process->execute('git clean -df && git reset --hard', $output, $path)) {
             throw new \RuntimeException("Could not reset changes\n\n:".$this->process->getErrorOutput());
         }
 


### PR DESCRIPTION
Problem:
A package which is installed using Git is not cleaned up completely during `composer install`.

How to reproduce:
1. Install a package as a Git repository (including `.git` folder)
1. Make some modifications to the package (incl. adding new files and folders)
1. Update the package + confirm discard notice. Composer warns about the modified files and asks if these changes should be discarded.
1. The result is that all files that were modified have been reverted (`git reset --hard`), but any files which are not part of the Git repository are still there.

Expected result:
Git project folders should be clean when choosing "discard changes".

Solution:
Run `git clean -df` when attempting to discard local changes.