### PR TITLE
Add major version install to programmatically install script example

### DIFF
--- a/doc/faqs/how-to-install-composer-programmatically.md
+++ b/doc/faqs/how-to-install-composer-programmatically.md
@@ -20,7 +20,7 @@ then
     exit 1
 fi
 
-php composer-setup.php --quiet
+php composer-setup.php --quiet --${COMPOSER_MAJOR_VERSION:-1}
 RESULT=$?
 rm composer-setup.php
 exit $RESULT


### PR DESCRIPTION
Add info on how to install a specific major version of composer as added in https://github.com/composer/getcomposer.org/pull/156.
This example script should be updated once the new major is released.
```diff
--- doc/faqs/how-to-install-composer-programmatically.md
+++ doc/faqs/how-to-install-composer-programmatically.md
@@ -20,7 +20,7 @@ then
     exit 1
 fi

-php composer-setup.php --quiet --${COMPOSER_MAJOR_VERSION:-1}
+php composer-setup.php --quiet --${COMPOSER_MAJOR_VERSION:-2}
 RESULT=$?
 rm composer-setup.php
 exit $RESULT
```