### PR TITLE
GitDriver: use authentication for supports check

### DIFF
--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -219,8 +219,17 @@ class GitDriver extends VcsDriver
             return false;
         }
 
-        $process = new ProcessExecutor($io);
+        $gitUtil = new GitUtil($io, $config, new ProcessExecutor($io), new Filesystem());
+        GitUtil::cleanEnv();
 
-        return $process->execute('git ls-remote --heads ' . ProcessExecutor::escape($url), $output) === 0;
+        try {
+            $gitUtil->runCommand(function ($url) {
+                return 'git ls-remote --heads ' . ProcessExecutor::escape($url);
+            }, $url, sys_get_temp_dir());
+        } catch (\RuntimeException $e) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
The GitDriver wasn't using authentication when trying to determine whether a URL is a git repository. The `GitDriver::supports` methods therefore returned always false for private git repositories which for instance look like regular URLs.