### PR TITLE
Disable the curl downloader on PHP 8

### DIFF
--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -72,7 +72,7 @@ class HttpDownloader
         $this->config = $config;
 
         // TODO enable curl only on 5.6+ if older versions cause any problem
-        if (extension_loaded('curl')) {
+        if (extension_loaded('curl') && PHP_MAJOR_VERSION < 8) {
             $this->curl = new Http\CurlDownloader($io, $config, $options, $disableTls);
         }
 


### PR DESCRIPTION
It's not clear what the replacement for casting resources to ints is for determining their ID. Perhaps `spl_object_id` would work. The related change in the PHP core for this change from resources to objects is https://github.com/php/php-src/commit/b516566b84c210ce6ceddeb238e45d4b1bcb32ce. Also note https://github.com/php/php-src/pull/5743 may be implemented, which would allow the old code to work. All we'd need to do is replace the `is_resource` checks with `!== false`.

EDIT: An alternative, would be this fix: https://github.com/composer/composer/pull/8998. Possibly the int cast changes could be reverted depending on the outcome of https://github.com/php/php-src/pull/5743.

EDIT2: That second PR to the PHP core landed. I'm closing this. The other PR is best now, and doesn't need the int cast work around.