### PR TITLE
Fixed CurlDownloader on PHP 8

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -218,10 +218,10 @@ class CurlDownloader
             $job = $this->jobs[$id];
             curl_multi_remove_handle($this->multiHandle, $job['handle']);
             curl_close($job['handle']);
-            if (is_resource($job['headerHandle'])) {
+            if (false !== $job['headerHandle']) {
                 fclose($job['headerHandle']);
             }
-            if (is_resource($job['bodyHandle'])) {
+            if (false !== $job['bodyHandle']) {
                 fclose($job['bodyHandle']);
             }
             if ($job['filename']) {
@@ -335,10 +335,10 @@ class CurlDownloader
                     $e->setResponse($response->getBody());
                 }
 
-                if (is_resource($job['headerHandle'])) {
+                if (false !== $job['headerHandle']) {
                     fclose($job['headerHandle']);
                 }
-                if (is_resource($job['bodyHandle'])) {
+                if (false !== $job['bodyHandle']) {
                     fclose($job['bodyHandle']);
                 }
                 if ($job['filename']) {


### PR DESCRIPTION
PHP 8 has replaced resources in the curl extension with classes (https://github.com/php/php-src/commit/b516566b84c210ce6ceddeb238e45d4b1bcb32ce), and added support for casting to ints, just like used to be possible with resources (https://github.com/php/php-src/commit/1c4463c77aa0291d065d5177428bbe080ca4755a).

It suffices simply to change composers code to check the handle is not false, as is recommended in their [upgrading docs](https://github.com/php/php-src/blob/1c4463c77aa0291d065d5177428bbe080ca4755a/UPGRADING#L748-L757).