### PR TITLE
Replace cascading str_replace() calls with strtr()

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -1064,8 +1064,7 @@ INITIALIZER;
                         $path = preg_replace('{/+}', '/', preg_quote(trim(strtr($path, '\\', '/'), '/')));
 
                         // add support for wildcards * and **
-                        $path = str_replace('\\*\\*', '.+?', $path);
-                        $path = str_replace('\\*', '[^/]+?', $path);
+                        $path = strtr($path, array('\\*\\*' => '.+?', '\\*' => '[^/]+?'));
 
                         // add support for up-level relative paths
                         $updir = null;

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -196,9 +196,11 @@ class PluginManager
                     $className = substr($class, $separatorPos + 1);
                 }
                 $code = preg_replace('{^((?:final\s+)?(?:\s*))class\s+('.preg_quote($className).')}mi', '$1class $2_composer_tmp'.self::$classCounter, $code, 1);
-                $code = str_replace('__FILE__', var_export($path, true), $code);
-                $code = str_replace('__DIR__', var_export(dirname($path), true), $code);
-                $code = str_replace('__CLASS__', var_export($class, true), $code);
+                $code = strtr($code, array(
+                    '__FILE__' => var_export($path, true),
+                    '__DIR__' => var_export(dirname($path), true),
+                    '__CLASS__' => var_export($class, true),
+                ));
                 $code = preg_replace('/^\s*<\?(php)?/i', '', $code, 1);
                 eval($code);
                 $class .= '_composer_tmp'.self::$classCounter;


### PR DESCRIPTION
Replaces cascading `str_replace()` calls with a single `strtr()` call that makes it more readable and provides a micro performance improvement.
Some instances of cascading `str_replace()` calls were not refactored due to the potential recurring replacement patterns.

Thank you.