### PR TITLE
Sort licenses summary

### DIFF
--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -34,7 +34,7 @@ class LicensesCommand extends BaseCommand
             ->setName('licenses')
             ->setDescription('Shows information about licenses of dependencies.')
             ->setDefinition(array(
-                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
+                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text, json or summary', 'text'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),
             ))
             ->setHelp(

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -96,9 +96,9 @@ EOT
                 break;
 
             case 'json':
-                $dependencies = array();
+                $usedLicenses = array();
                 foreach ($packages as $package) {
-                    $dependencies[$package->getPrettyName()] = array(
+                    $usedLicenses[$package->getPrettyName()] = array(
                         'version' => $package->getFullPrettyVersion(),
                         'license' => $package->getLicense(),
                     );
@@ -108,23 +108,23 @@ EOT
                     'name' => $root->getPrettyName(),
                     'version' => $root->getFullPrettyVersion(),
                     'license' => $root->getLicense(),
-                    'dependencies' => $dependencies,
+                    'dependencies' => $usedLicenses,
                 )));
                 break;
 
             case 'summary':
-                $dependencies = array();
+                $usedLicenses = array();
                 foreach ($packages as $package) {
                     $license = $package->getLicense();
                     $licenseName = $license[0];
-                    if (!isset($dependencies[$licenseName])) {
-                        $dependencies[$licenseName] = 0;
+                    if (!isset($usedLicenses[$licenseName])) {
+                        $usedLicenses[$licenseName] = 0;
                     }
-                    $dependencies[$licenseName]++;
+                    $usedLicenses[$licenseName]++;
                 }
 
                 $rows = array();
-                foreach ($dependencies as $usedLicense => $numberOfDependencies) {
+                foreach ($usedLicenses as $usedLicense => $numberOfDependencies) {
                     $rows[] = array($usedLicense, $numberOfDependencies);
                 }
 

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -124,7 +124,7 @@ EOT
                 }
 
                 // Sort licenses so that the most used license will appear first
-                arsort($dependencies, SORT_NUMERIC);
+                arsort($usedLicenses, SORT_NUMERIC);
 
                 $rows = array();
                 foreach ($usedLicenses as $usedLicense => $numberOfDependencies) {

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -96,9 +96,9 @@ EOT
                 break;
 
             case 'json':
-                $usedLicenses = array();
+                $dependencies = array();
                 foreach ($packages as $package) {
-                    $usedLicenses[$package->getPrettyName()] = array(
+                    $dependencies[$package->getPrettyName()] = array(
                         'version' => $package->getFullPrettyVersion(),
                         'license' => $package->getLicense(),
                     );
@@ -108,7 +108,7 @@ EOT
                     'name' => $root->getPrettyName(),
                     'version' => $root->getFullPrettyVersion(),
                     'license' => $root->getLicense(),
-                    'dependencies' => $usedLicenses,
+                    'dependencies' => $dependencies,
                 )));
                 break;
 

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -123,6 +123,9 @@ EOT
                     $usedLicenses[$licenseName]++;
                 }
 
+                // Sort licenses so that the most used license will appear first
+                arsort($dependencies, SORT_NUMERIC);
+
                 $rows = array();
                 foreach ($usedLicenses as $usedLicense => $numberOfDependencies) {
                     $rows[] = array($usedLicense, $numberOfDependencies);


### PR DESCRIPTION
### Fixed
- Used licenses in the summary overview are now correctly sorted, showing the most used license first
- Output of `composer help licenses` now shows the summary format option just like the regular docs.

---
I recently added the feature in https://github.com/composer/composer/pull/8973 and while playing around with the latest snapshot version of `2.x` I found these two small improvements.