### PR TITLE
Fix tests on PHP 8.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -95,17 +95,7 @@ jobs:
           extensions: "intl, zip"
           ini-values: "memory_limit=-1, phar.readonly=0"
           php-version: "${{ matrix.php-version }}"
-
-      - name: "Determine composer cache directory"
-        id: "determine-composer-cache-directory"
-        run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
-
-      - name: "Cache dependencies installed with composer"
-        uses: "actions/cache@v2"
-        with:
-          path: "${{ steps.determine-composer-cache-directory.outputs.directory }}"
-          key: "php-${{ matrix.php-version }}-symfony-php-unit-version-${{ env.SYMFONY_PHPUNIT_VERSION }}-${{ hashFiles('**/composer.lock') }}"
-          restore-keys: "php-${{ matrix.php-version }}-symfony-php-unit-version-${{ env.SYMFONY_PHPUNIT_VERSION }}"
+          tools: composer:v2
 
       - name: "Handle lowest dependencies update"
         if: "contains(matrix.dependencies, 'lowest')"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,31 +38,31 @@ jobs:
         os: [ubuntu-latest]
         experimental: [false]
         include:
-          - php-version: 5.3
+          - php-version: "5.3"
             dependencies: highest
             os: ubuntu-latest
             experimental: false
-          - php-version: 5.3
+          - php-version: "5.3"
             dependencies: lowest
             os: ubuntu-latest
             experimental: false
-          - php-version: 7.4
+          - php-version: "7.4"
             dependencies: highest
             os: ubuntu-latest
             experimental: false
-          - php-version: 7.4
+          - php-version: "7.4"
             os: windows-latest
             dependencies: locked
             experimental: false
-          - php-version: 7.4
+          - php-version: "7.4"
             os: macos-latest
             dependencies: locked
             experimental: false
-          - php-version: 8.0
+          - php-version: "8.0"
             dependencies: lowest-ignore
             os: ubuntu-latest
             experimental: true
-          - php-version: 8.0
+          - php-version: "8.0"
             dependencies: highest-ignore
             os: ubuntu-latest
             experimental: true
@@ -83,7 +83,7 @@ jobs:
           elif [ "${{ matrix.php-version }}" = "7.1" ]; then
             echo "::set-env name=SYMFONY_PHPUNIT_VERSION::7.5";
           elif [ "${{ matrix.php-version }}" = "8.0" ]; then
-            echo "::set-env name=SYMFONY_PHPUNIT_VERSION::9.2";
+            echo "::set-env name=SYMFONY_PHPUNIT_VERSION::9.3";
           else
             echo "::set-env name=SYMFONY_PHPUNIT_VERSION::8.3";
           fi
@@ -95,14 +95,6 @@ jobs:
           extensions: "intl, zip"
           ini-values: "memory_limit=-1, phar.readonly=0"
           php-version: "${{ matrix.php-version }}"
-
-      - name: "Update to latest Composer snapshot"
-        if: "!startsWith(matrix.os, 'windows')"
-        run: "sudo -i composer self-update --snapshot"
-
-      - name: "Update to latest Composer snapshot on Windows"
-        if: "startsWith(matrix.os, 'windows')"
-        run: "composer self-update --snapshot"
 
       - name: "Determine composer cache directory"
         id: "determine-composer-cache-directory"
@@ -136,12 +128,10 @@ jobs:
 
       - name: "Require latest PHPUnitBridge for PHP 8"
         if: "matrix.php-version == '8.0'"
-        run: |
-          composer require --no-update --dev symfony/phpunit-bridge:^5.1
-          composer config -g platform-check false
+        run: composer require --no-update --dev symfony/phpunit-bridge:5.1.*@dev
 
       - name: "Update Symfony's PHPUnitBridge to latest available for the current PHP always as it is not really a dependency of the project"
-        run: "composer update ${{ env.COMPOSER_FLAGS }} symfony/phpunit-bridge"
+        run: "composer update ${{ env.COMPOSER_FLAGS }} symfony/phpunit-bridge --with-all-dependencies"
 
       - name: "Run install again using composer binary from source"
         run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -118,10 +118,10 @@ jobs:
 
       - name: "Require latest PHPUnitBridge for PHP 8"
         if: "matrix.php-version == '8.0'"
-        run: composer require --no-update --dev symfony/phpunit-bridge:5.1.*@dev
+        run: composer require --no-update --dev symfony/phpunit-bridge:^5.1
 
       - name: "Update Symfony's PHPUnitBridge to latest available for the current PHP always as it is not really a dependency of the project"
-        run: "composer update ${{ env.COMPOSER_FLAGS }} symfony/phpunit-bridge --with-all-dependencies"
+        run: "composer update ${{ env.COMPOSER_FLAGS }} symfony/phpunit-bridge"
 
       - name: "Run install again using composer binary from source"
         run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -51,5 +51,5 @@ jobs:
 
       - name: Run PHPStan
         run: |
-          bin/composer require --dev phpstan/phpstan:^0.12.37 phpunit/phpunit:^7.5.20 --with-all-dependencies
+          bin/composer require --dev phpstan/phpstan:^0.12.42 phpunit/phpunit:^9.3 --with-all-dependencies
           vendor/bin/phpstan analyse --configuration=phpstan/config.neon

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -50,6 +50,7 @@ jobs:
         run: "composer config platform --unset && composer update ${{ env.COMPOSER_FLAGS }}"
 
       - name: Run PHPStan
+        # Locked to phpunit 7.5 here as newer ones have void return types which break inheritance
         run: |
-          bin/composer require --dev phpstan/phpstan:^0.12.42 phpunit/phpunit:^9.3 --with-all-dependencies
+          bin/composer require --dev phpstan/phpstan:^0.12.42 phpunit/phpunit:^7.5.20 --with-all-dependencies
           vendor/bin/phpstan analyse --configuration=phpstan/config.neon

--- a/phpstan/config.neon
+++ b/phpstan/config.neon
@@ -26,6 +26,7 @@ parameters:
 
         # BC with older PHPUnit
         - '~^Call to an undefined static method Composer\\Test\\PolyfillTestCase::setExpectedException\(\)\.$~'
+        - '~^Call to an undefined method Composer\\Test\\[a-zA-Z0-9\\]+::(assertFileDoesNotExist|assertMatchesRegularExpression)\(\)\.$~'
 
     paths:
         - ../src

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -941,8 +941,8 @@ EOF;
         $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_functions.php', $this->vendorDir.'/autoload.php');
         $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php', $this->vendorDir.'/composer/autoload_real.php');
         $this->assertFileContentEquals(__DIR__.'/Fixtures/autoload_static_functions_with_removed_include_paths_and_autolad_files.php', $this->vendorDir.'/composer/autoload_static.php');
-        $this->assertFileNotExists($this->vendorDir.'/composer/autoload_files.php');
-        $this->assertFileNotExists($this->vendorDir.'/composer/include_paths.php');
+        $this->assertFileDoesNotExist($this->vendorDir.'/composer/autoload_files.php');
+        $this->assertFileDoesNotExist($this->vendorDir.'/composer/include_paths.php');
     }
 
     public function testFilesAutoloadOrderByDependencies()
@@ -1223,7 +1223,7 @@ EOF;
 
         $this->generator->dump($this->config, $this->repository, $package, $this->im, "composer", false, '_12');
 
-        $this->assertFileNotExists($this->vendorDir."/composer/include_paths.php");
+        $this->assertFileDoesNotExist($this->vendorDir."/composer/include_paths.php");
     }
 
     public function testPreAndPostEventsAreDispatchedDuringAutoloadDump()

--- a/tests/Composer/Test/CacheTest.php
+++ b/tests/Composer/Test/CacheTest.php
@@ -72,7 +72,7 @@ class CacheTest extends TestCase
         $this->cache->gc(600, 1024 * 1024 * 1024);
 
         for ($i = 1; $i < 4; $i++) {
-            $this->assertFileNotExists("{$this->root}/cached.file{$i}.zip");
+            $this->assertFileDoesNotExist("{$this->root}/cached.file{$i}.zip");
         }
         $this->assertFileExists("{$this->root}/cached.file0.zip");
     }
@@ -101,7 +101,7 @@ class CacheTest extends TestCase
         $this->cache->gc(600, 1500);
 
         for ($i = 0; $i < 3; $i++) {
-            $this->assertFileNotExists("{$this->root}/cached.file{$i}.zip");
+            $this->assertFileDoesNotExist("{$this->root}/cached.file{$i}.zip");
         }
         $this->assertFileExists("{$this->root}/cached.file3.zip");
     }

--- a/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
@@ -36,7 +36,7 @@ class ArchiveDownloaderTest extends TestCase
             ->will($this->returnValue('/vendor'));
 
         $first = $method->invoke($downloader, $packageMock, '/path');
-        $this->assertRegExp('#/vendor/composer/tmp-[a-z0-9]+\.js#', $first);
+        $this->assertMatchesRegularExpression('#/vendor/composer/tmp-[a-z0-9]+\.js#', $first);
         $this->assertSame($first, $method->invoke($downloader, $packageMock, '/path'));
     }
 

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -98,7 +98,7 @@ class FileDownloaderTest extends TestCase
             ->with('vendor-dir')
             ->will($this->returnValue('/vendor'));
 
-        $this->assertRegExp('#/vendor/composer/tmp-[a-z0-9]+\.js#', $method->invoke($downloader, $packageMock, '/path'));
+        $this->assertMatchesRegularExpression('#/vendor/composer/tmp-[a-z0-9]+\.js#', $method->invoke($downloader, $packageMock, '/path'));
     }
 
     public function testDownloadButFileIsUnsaved()

--- a/tests/Composer/Test/Downloader/XzDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/XzDownloaderTest.php
@@ -77,7 +77,7 @@ class XzDownloaderTest extends TestCase
 
             $this->fail('Download of invalid tarball should throw an exception');
         } catch (\RuntimeException $e) {
-            $this->assertRegexp('/(File format not recognized|Unrecognized archive format)/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/(File format not recognized|Unrecognized archive format)/i', $e->getMessage());
         }
     }
 }

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -71,7 +71,7 @@ class LibraryInstallerTest extends TestCase
         $this->fs->removeDirectory($this->vendorDir);
 
         new LibraryInstaller($this->io, $this->composer);
-        $this->assertFileNotExists($this->vendorDir);
+        $this->assertFileDoesNotExist($this->vendorDir);
     }
 
     public function testInstallerCreationShouldNotCreateBinDirectory()
@@ -79,7 +79,7 @@ class LibraryInstallerTest extends TestCase
         $this->fs->removeDirectory($this->binDir);
 
         new LibraryInstaller($this->io, $this->composer);
-        $this->assertFileNotExists($this->binDir);
+        $this->assertFileDoesNotExist($this->binDir);
     }
 
     public function testIsInstalled()

--- a/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
@@ -68,7 +68,7 @@ class ArchiveManagerTest extends ArchiverTest
         $this->assertFileExists($target);
 
         $tmppath = sys_get_temp_dir().'/composer_archiver/'.$this->manager->getPackageFilename($package);
-        $this->assertFileNotExists($tmppath);
+        $this->assertFileDoesNotExist($tmppath);
 
         unlink($target);
     }
@@ -90,7 +90,7 @@ class ArchiveManagerTest extends ArchiverTest
         $this->assertFileExists($target);
 
         $tmppath = sys_get_temp_dir().'/composer_archiver/'.$this->manager->getPackageFilename($package);
-        $this->assertFileNotExists($tmppath);
+        $this->assertFileDoesNotExist($tmppath);
 
         unlink($target);
     }

--- a/tests/Composer/Test/Util/ErrorHandlerTest.php
+++ b/tests/Composer/Test/Util/ErrorHandlerTest.php
@@ -35,7 +35,11 @@ class ErrorHandlerTest extends TestCase
      */
     public function testErrorHandlerCaptureNotice()
     {
-        $this->setExpectedException('\ErrorException', 'Undefined index: baz');
+        if (PHP_VERSION_ID >= 80000) {
+            $this->setExpectedException('\ErrorException', 'Undefined array key "baz"');
+        } else {
+            $this->setExpectedException('\ErrorException', 'Undefined index: baz');
+        }
 
         $array = array('foo' => 'bar');
         $array['baz'];

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -168,7 +168,7 @@ class FilesystemTest extends TestCase
 
         $fs = new Filesystem;
         $this->assertTrue($fs->removeDirectoryPhp($this->workingDir));
-        $this->assertFileNotExists($this->workingDir . "/level1/level2/hello.txt");
+        $this->assertFileDoesNotExist($this->workingDir . "/level1/level2/hello.txt");
     }
 
     public function testFileSize()
@@ -247,7 +247,7 @@ class FilesystemTest extends TestCase
         $fs = new Filesystem();
         $result = $fs->unlink($symlinked);
         $this->assertTrue($result);
-        $this->assertFileNotExists($symlinked);
+        $this->assertFileDoesNotExist($symlinked);
     }
 
     /**
@@ -279,8 +279,8 @@ class FilesystemTest extends TestCase
 
         $result = $fs->removeDirectory($symlinkedTrailingSlash);
         $this->assertTrue($result);
-        $this->assertFileNotExists($symlinkedTrailingSlash);
-        $this->assertFileNotExists($symlinked);
+        $this->assertFileDoesNotExist($symlinkedTrailingSlash);
+        $this->assertFileDoesNotExist($symlinked);
     }
 
     public function testJunctions()

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -253,7 +253,7 @@ class RemoteFilesystemTest extends TestCase
         $res = $this->callGetOptionsForUrl($io, array('example.org', array('ssl' => array('cafile' => '/some/path/file.crt'))), array(), 'http://www.example.org');
 
         $this->assertTrue(isset($res['ssl']['ciphers']));
-        $this->assertRegExp('|!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA|', $res['ssl']['ciphers']);
+        $this->assertMatchesRegularExpression('|!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA|', $res['ssl']['ciphers']);
         $this->assertTrue($res['ssl']['verify_peer']);
         $this->assertTrue($res['ssl']['SNI_enabled']);
         $this->assertEquals(7, $res['ssl']['verify_depth']);


### PR DESCRIPTION
We need PHPUnit 9.3@dev (and its @dev stability dependencies), which include PHP 8.0 support, including https://github.com/sebastianbergmann/phpunit/pull/4374 which fixes the issue with Match which is currently crashing composer's test suite on actions.