### PR TITLE
Fix path translation when MSYS_NO_PATHCONV=1

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -205,6 +205,13 @@ if [ -d /proc/cygdrive ]; then
     esac
 fi
 
+# @see https://github.com/git-for-windows/msys2-runtime/pull/11
+# @see https://github.com/msys2/MSYS2-packages/blob/f31cce2ca6e1ceba/bash/0006-bash-4.3-add-pwd-W-option.patch#L25
+if [[ "\$OSTYPE" == "msys" ]] && [[ ! -z \${MSYS_NO_PATHCONV+x} ]]; then
+    # Setting MSYS_NO_PATHCONV disables automatic unix to windows path translations by msys - translate them here.
+    dir="$(cd "\$dir" && pwd -W)";
+fi
+
 "\${dir}/$binFile" "\$@"
 
 PROXY;


### PR DESCRIPTION
Under windows git bash the following produces an unexpected result:

```bash
$ MSYS_NO_PATHCONV=1 vendor/bin/some-package-script
Could not open input file: /c/Users/me/project/vendor/some-package-script/some-package-script
```

It is due to `MSYS_NO_PATHCONV` disabling automatic path translations.
This patches detects such cases and forces the path translation so that the example command works as expected.

Reference:
https://github.com/git-for-windows/msys2-runtime/pull/11
