### PR TITLE
Use CompilingMatcher in DefaultPolicy

### DIFF
--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -15,6 +15,7 @@ namespace Composer\DependencyResolver;
 use Composer\Package\PackageInterface;
 use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
+use Composer\Semver\CompilingMatcher;
 use Composer\Semver\Constraint\Constraint;
 
 /**
@@ -39,9 +40,8 @@ class DefaultPolicy implements PolicyInterface
         }
 
         $constraint = new Constraint($operator, $b->getVersion());
-        $version = new Constraint('==', $a->getVersion());
 
-        return $constraint->matchSpecific($version, true);
+        return CompilingMatcher::match($constraint, Constraint::OP_EQ, $a->getVersion());
     }
 
     public function selectPreferredPackages(Pool $pool, array $literals, $requiredPackage = null)


### PR DESCRIPTION
While fiddling around I found that we're not using the new `CompilingMatcher` in the `DefaultPolicy`.
I think we should but the failing unit tests indicate that there might be an issue in `composer/semver`.