### PR TITLE
`composer require vendor/package` does not generate correct constraint for packages with four-digit version

### DIFF
--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -150,16 +150,18 @@ class VersionSelector
         $semanticVersionParts = explode('.', $version);
 
         // check to see if we have a semver-looking version
-        if (count($semanticVersionParts) == 4 && preg_match('{^0\D?}', $semanticVersionParts[3])) {
-            // remove the last parts (i.e. the patch version number and any extra)
+        if (count($semanticVersionParts) !== 4) {
+            return $prettyVersion;
+        }
+
+        // remove the last parts (i.e. the patch version number and any extra)
+        if (preg_match('{^0\D?}', $semanticVersionParts[3])) {
             if ($semanticVersionParts[0] === '0') {
                 unset($semanticVersionParts[3]);
             } else {
                 unset($semanticVersionParts[2], $semanticVersionParts[3]);
             }
             $version = implode('.', $semanticVersionParts);
-        } else {
-            return $prettyVersion;
         }
 
         // append stability flag if not default

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -247,6 +247,7 @@ class VersionSelectorTest extends TestCase
             array('0.1.3', false, 'stable', '^0.1.3'),
             array('0.0.3', false, 'stable', '^0.0.3'),
             array('0.0.3-alpha', false, 'alpha', '^0.0.3@alpha'),
+            array('0.1.2.3', false, 'stable', '^0.1.2.3'),
             // date-based versions are not touched at all
             array('v20121020', false, 'stable', 'v20121020'),
             array('v20121020.2', false, 'stable', 'v20121020.2'),


### PR DESCRIPTION
If last version of required package has 4 digits, Composer does not use `^` as prefix for constraint and uses version name instead. So for version `0.1.2.3` constraint is `0.1.2.3` instead of `^0.1.2.3`.

**Expected:**

```
$ composer require rob006/flarum-lang-polish
Using version ^0.3.12.5 for rob006/flarum-lang-polish
```

**Actual:**

```
$ composer require rob006/flarum-lang-polish
Using version v0.3.12.5 for rob006/flarum-lang-polish
```