### PR TITLE
Replace Compiler::stripWhitespace with native implementation

### DIFF
--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -191,10 +191,9 @@ class Compiler
     private function addFile($phar, $file, $strip = true)
     {
         $path = $this->getRelativeFilePath($file);
-        $content = file_get_contents($file);
-        if ($strip) {
-            $content = $this->stripWhitespace($content);
-        } elseif ('LICENSE' === basename($file)) {
+
+        $content = $strip ? php_strip_whitespace($file) : file_get_contents($file);
+        if ('LICENSE' === basename($file)) {
             $content = "\n".$content."\n";
         }
 
@@ -213,40 +212,6 @@ class Compiler
         $content = file_get_contents(__DIR__.'/../../bin/composer');
         $content = preg_replace('{^#!/usr/bin/env php\s*}', '', $content);
         $phar->addFromString('bin/composer', $content);
-    }
-
-    /**
-     * Removes whitespace from a PHP source string while preserving line numbers.
-     *
-     * @param  string $source A PHP string
-     * @return string The PHP string with the whitespace removed
-     */
-    private function stripWhitespace($source)
-    {
-        if (!function_exists('token_get_all')) {
-            return $source;
-        }
-
-        $output = '';
-        foreach (token_get_all($source) as $token) {
-            if (is_string($token)) {
-                $output .= $token;
-            } elseif (in_array($token[0], array(T_COMMENT, T_DOC_COMMENT))) {
-                $output .= str_repeat("\n", substr_count($token[1], "\n"));
-            } elseif (T_WHITESPACE === $token[0]) {
-                // reduce wide spaces
-                $whitespace = preg_replace('{[ \t]+}', ' ', $token[1]);
-                // normalize newlines to \n
-                $whitespace = preg_replace('{(?:\r\n|\r|\n)}', "\n", $whitespace);
-                // trim leading spaces
-                $whitespace = preg_replace('{\n +}', "\n", $whitespace);
-                $output .= $whitespace;
-            } else {
-                $output .= $token[1];
-            }
-        }
-
-        return $output;
     }
 
     private function getStub()


### PR DESCRIPTION
This reduces the size of composer.phar file about 2% and makes compiler a bit more simple.