### PR TITLE
Properly support PHP 8.0 Named Arguments (Fatal error: Uncaught ArgumentCountError: array_merge() does not accept unknown named parameters)

### DIFF
--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -81,7 +81,7 @@ class DefaultPolicy implements PolicyInterface
             $literals = $this->pruneRemoteAliases($pool, $literals);
         }
 
-        $selected = call_user_func_array('array_merge', $packages);
+        $selected = call_user_func_array('array_merge', array_values($packages));
 
         // now sort the result across all packages to respect replaces across packages
         usort($selected, function ($a, $b) use ($policy, $pool, $installedMap, $requiredPackage) {


### PR DESCRIPTION
See https://wiki.php.net/rfc/named_params#internal_functions
(implemented but not yet merged)

An ArgumentCountError will be thrown when passing variadic arguments to
a function with call_user_func_array() if extra unknown named arguments
are encountered.

Fatal error: Uncaught ArgumentCountError: array_merge() does not accept unknown named parameters in phar:///path/to/composer.phar/src/Composer/DependencyResolver/DefaultPolicy.php:84

(e.g. for `...['phpunit/phpunit' => [72]]`)

------

I'm proposing fixing this in composer 1.10 because this is a relatively straightforward fix, and composer otherwise does not warn when being run in php 8.0-dev.
I'm sorry if I missed any notes about no longer accepting patches for php 8.0 - I didn't see any other notes the readme for this branch.