### PR TITLE
Driver: only cache composer.json file without API data to disk

### DIFF
--- a/src/Composer/Repository/Vcs/BitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/BitbucketDriver.php
@@ -119,10 +119,14 @@ abstract class BitbucketDriver extends VcsDriver
 
         if (!isset($this->infoCache[$identifier])) {
             if ($this->shouldCache($identifier) && $res = $this->cache->read($identifier)) {
-                return $this->infoCache[$identifier] = JsonFile::parseJson($res);
-            }
+                $composer = JsonFile::parseJson($res);
+            } else {
+                $composer = $this->getBaseComposerInformation($identifier);
 
-            $composer = $this->getBaseComposerInformation($identifier);
+                if ($this->shouldCache($identifier)) {
+                    $this->cache->write($identifier, json_encode($composer));
+                }
+            }
 
             if ($composer) {
                 // specials for bitbucket
@@ -173,10 +177,6 @@ abstract class BitbucketDriver extends VcsDriver
             }
 
             $this->infoCache[$identifier] = $composer;
-
-            if ($this->shouldCache($identifier)) {
-                $this->cache->write($identifier, json_encode($composer));
-            }
         }
 
         return $this->infoCache[$identifier];

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -150,10 +150,14 @@ class GitHubDriver extends VcsDriver
 
         if (!isset($this->infoCache[$identifier])) {
             if ($this->shouldCache($identifier) && $res = $this->cache->read($identifier)) {
-                return $this->infoCache[$identifier] = JsonFile::parseJson($res);
-            }
+                $composer =  JsonFile::parseJson($res);
+            } else {
+                $composer = $this->getBaseComposerInformation($identifier);
 
-            $composer = $this->getBaseComposerInformation($identifier);
+                if ($this->shouldCache($identifier)) {
+                    $this->cache->write($identifier, json_encode($composer));
+                }
+            }
 
             if ($composer) {
                 // specials for github
@@ -170,10 +174,6 @@ class GitHubDriver extends VcsDriver
                 if (!isset($composer['funding']) && $funding = $this->getFundingInfo()) {
                     $composer['funding'] = $funding;
                 }
-            }
-
-            if ($this->shouldCache($identifier)) {
-                $this->cache->write($identifier, json_encode($composer));
             }
 
             $this->infoCache[$identifier] = $composer;

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -130,10 +130,14 @@ class GitLabDriver extends VcsDriver
 
         if (!isset($this->infoCache[$identifier])) {
             if ($this->shouldCache($identifier) && $res = $this->cache->read($identifier)) {
-                return $this->infoCache[$identifier] = JsonFile::parseJson($res);
-            }
+                $composer =  JsonFile::parseJson($res);
+            } else {
+                $composer = $this->getBaseComposerInformation($identifier);
 
-            $composer = $this->getBaseComposerInformation($identifier);
+                if ($this->shouldCache($identifier)) {
+                    $this->cache->write($identifier, json_encode($composer));
+                }
+            }
 
             if ($composer) {
                 // specials for gitlab (this data is only available if authentication is provided)
@@ -143,10 +147,6 @@ class GitLabDriver extends VcsDriver
                 if (!isset($composer['abandoned']) && !empty($this->project['archived'])) {
                     $composer['abandoned'] = true;
                 }
-            }
-
-            if ($this->shouldCache($identifier)) {
-                $this->cache->write($identifier, json_encode($composer));
             }
 
             $this->infoCache[$identifier] = $composer;
@@ -446,7 +446,7 @@ class GitLabDriver extends VcsDriver
                     if (!$moreThanGuestAccess) {
                         $this->io->writeError('<warning>GitLab token with Guest only access detected</warning>');
 
-                        return $this->attemptCloneFallback(); 
+                        return $this->attemptCloneFallback();
                     }
                 }
 


### PR DESCRIPTION
For VCS repositories where the API can be used (GitHub/GitLab/Bitbucket) Composer currently caches the a modified composer.json file on disk which contains additional data from the API e.g. whether a repository was archived. This currently prevents Composer from detecting whether a package was archived if there was no new commit.

Steps to reproduce:
* create a GitHub/GitLab repository
* Have a local composer.json that requires the VCS repository like
```
{
	"repositories": [{"type": "vcs", "url": "https://github.com/acme/package"}],
	"require": {
		"acme/package": "dev-master"
	}
}
```
* Run `composer update` which will output something like
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing acme/test (dev-master f8f4e1d): Cloning f8f4e1d72d from cache
Generating autoload files
```
* Archive the VCS repository on GitHub without creating a new commit
* Rerun `Composer update` where I'd now expect the abandoned message to appear but instead this is shown
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Nothing to install or update
Writing lock file
Generating autoload files
```
* Expected output
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Nothing to install or update
Package acme/package is abandoned, you should avoid using it. No replacement was suggested.
Writing lock file
Generating autoload files
```