### PR TITLE
Allow specifying a version requirement for CLDR

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -154,9 +154,11 @@ class PlatformRepository extends ArrayRepository
                     break;
 
                 case 'intl':
-                    # Add a seperate version for the CLDR library version
-                    $cldrVersion = \ResourceBundle::create('root', 'ICUDATA-curr', false)->get('Version');
-                    $this->addLibrary('cldr', 'The unicode CLDR project', $cldrVersion);
+                    if (class_exists('ResourceBundle', false)) {
+                        # Add a seperate version for the CLDR library version
+                        $cldrVersion = \ResourceBundle::create('root', 'ICUDATA-curr', false)->get('Version');
+                        $this->addLibrary('cldr', 'The unicode CLDR project', $cldrVersion);
+                    }
 
                     $name = 'icu';
                     $description = 'The ICU unicode and globalization support library';

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -154,7 +154,12 @@ class PlatformRepository extends ArrayRepository
                     break;
 
                 case 'intl':
-                    $name = 'ICU';
+                    # Add a seperate version for the CLDR library version
+                    $cldrVersion = \ResourceBundle::create('root', 'ICUDATA-curr', false)->get('Version');
+                    $this->addLibrary('cldr', 'The unicode CLDR project', $cldrVersion);
+
+                    $name = 'icu';
+                    $description = 'The ICU unicode and globalization support library';
                     if (defined('INTL_ICU_VERSION')) {
                         $prettyVersion = INTL_ICU_VERSION;
                     } else {
@@ -228,15 +233,7 @@ class PlatformRepository extends ArrayRepository
                     continue 2;
             }
 
-            try {
-                $version = $this->versionParser->normalize($prettyVersion);
-            } catch (\UnexpectedValueException $e) {
-                continue;
-            }
-
-            $lib = new CompletePackage('lib-'.$name, $version, $prettyVersion);
-            $lib->setDescription($description);
-            $this->addPackage($lib);
+            $this->addLibrary($name, $description, $prettyVersion);
         }
 
         $hhvmVersion = defined('HHVM_VERSION') ? HHVM_VERSION : null;
@@ -345,5 +342,23 @@ class PlatformRepository extends ArrayRepository
     private function buildPackageName($name)
     {
         return 'ext-' . str_replace(' ', '-', $name);
+    }
+
+    /**
+     * @param string $name
+     * @param string $description
+     * @param string $prettyVersion
+     */
+    private function addLibrary($name, $description, $prettyVersion)
+    {
+        try {
+            $version = $this->versionParser->normalize($prettyVersion);
+        } catch (\UnexpectedValueException $e) {
+            return;
+        }
+
+        $lib = new CompletePackage('lib-'.$name, $version, $prettyVersion);
+        $lib->setDescription($description);
+        $this->addPackage($lib);
     }
 }

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -69,10 +69,13 @@ class PlatformRepositoryTest extends TestCase {
         $this->assertSame('4.0.1.0-dev', $package->getVersion());
     }
 
-    public function testICULibraryVersion()
-    {
+    public function testICULibraryVersion() {
         if (!defined('INTL_ICU_VERSION')) {
             $this->markTestSkipped('Test only work with ext-intl present');
+        }
+
+        if (!class_exists('ResourceBundle', false)) {
+            $this->markTestSkipped('Test only work with ResourceBundle class present');
         }
 
         $platformRepository = new PlatformRepository();

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\Repository;
 
+use Composer\Package\Package;
 use Composer\Repository\PlatformRepository;
 use Composer\Test\TestCase;
 use Composer\Util\Platform;
@@ -66,5 +67,36 @@ class PlatformRepositoryTest extends TestCase {
         $package = $repository->findPackage('hhvm', '*');
         $this->assertNotNull($package, 'failed to find HHVM package');
         $this->assertSame('4.0.1.0-dev', $package->getVersion());
+    }
+
+    public function testICULibraryVersion()
+    {
+        if (!defined('INTL_ICU_VERSION')) {
+            $this->markTestSkipped('Test only work with ext-intl present');
+        }
+
+        $platformRepository = new PlatformRepository();
+        $packages = $platformRepository->getPackages();
+
+        /** @var Package $icuPackage */
+        $icuPackage = null;
+        /** @var Package $cldrPackage */
+        $cldrPackage = null;
+
+        foreach ($packages as $package) {
+            if ($package->getName() === 'lib-icu') {
+                $icuPackage = $package;
+            }
+
+            if ($package->getName() === 'lib-cldr') {
+                $cldrPackage = $package;
+            }
+        }
+
+        self::assertNotNull($icuPackage, 'Expected to find lib-icu in packages');
+        self::assertNotNull($cldrPackage, 'Expected to find lib-cldr in packages');
+
+        self::assertSame(3, substr_count($icuPackage->getVersion(), '.'), 'Expected to find real ICU version');
+        self::assertSame(3, substr_count($cldrPackage->getVersion(), '.'), 'Expected to find real CLDR version');
     }
 }


### PR DESCRIPTION
libicu ships with a version of CLDR (http://cldr.unicode.org/), which is basically the data version. It would be great if one could specify the CLDR version specifically using composer. 