### PR TITLE
Fix the example link for the list endpoint

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -80,4 +80,4 @@ The providers-api is optional, but if you implement it it should return packages
 
 This is also optional, it should accept an optional `?filter=xx` query param, which can contain `*` as wildcards matching any substring.
 
-It must return an array of package names as `{"packageNames": ["a/b", "c/d"]}`. See https://packagist.org/packages/list.json?filter=composer/* for example.
+It must return an array of package names as `{"packageNames": ["a/b", "c/d"]}`. See <https://packagist.org/packages/list.json?filter=composer/*> for example.


### PR DESCRIPTION
The autolinking from GFM does not include the `*` char in the link. Using an explicit link in the markdown fixes it.