### PR TITLE
Update PathDownloader.php

### DIFF
--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -180,7 +180,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
     {
         $realUrl = realpath($package->getDistUrl());
 
-        if ($path === $realUrl) {
+        if (realpath($path) === $realUrl) {
             if ($output) {
                 $this->io->writeError("  - " . UninstallOperation::format($package).", source is still present in $path");
             }


### PR DESCRIPTION
If a path repository points at a directory that is managed by composer installers, the path that gets set ends up being relative, and this check fails to see that the source is already present, and therefore removes it.

Since ->install is already using realpath around the $path argument, remove should as well.

For an example repository that demonstrates this bug See: https://github.com/ryanaslett/pathrepotestcase