### PR TITLE
Fix regression when inet_pton() does not exist

### DIFF
--- a/src/Composer/Platform/Runtime.php
+++ b/src/Composer/Platform/Runtime.php
@@ -35,6 +35,15 @@ class Runtime
     }
 
     /**
+     * @param string $fn
+     * @return bool
+     */
+    public function hasFunction($fn)
+    {
+        return function_exists($fn);
+    }
+
+    /**
      * @param callable $callable
      * @param array $arguments
      * @return mixed

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -125,7 +125,7 @@ class PlatformRepository extends ArrayRepository
 
         // The AF_INET6 constant is only defined if ext-sockets is available but
         // IPv6 support might still be available.
-        if ($this->runtime->hasConstant('AF_INET6') || ($this->runtime->hasFunction('inet_pton') && Silencer::call(array($this->runtime, 'invoke'), array('inet_pton', '::')) !== false)) {
+        if ($this->runtime->hasConstant('AF_INET6') || Silencer::call(array($this->runtime, 'invoke'), 'inet_pton', array('::')) !== false) {
             $phpIpv6 = new CompletePackage('php-ipv6', $version, $prettyVersion);
             $phpIpv6->setDescription('The PHP interpreter, with IPv6 support');
             $this->addPackage($phpIpv6);

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -125,7 +125,7 @@ class PlatformRepository extends ArrayRepository
 
         // The AF_INET6 constant is only defined if ext-sockets is available but
         // IPv6 support might still be available.
-        if ($this->runtime->hasConstant('AF_INET6') || Silencer::call(array($this->runtime, 'invoke'), array('inet_pton', '::')) !== false) {
+        if ($this->runtime->hasConstant('AF_INET6') || ($this->runtime->hasFunction('inet_pton') && Silencer::call(array($this->runtime, 'invoke'), array('inet_pton', '::')) !== false)) {
             $phpIpv6 = new CompletePackage('php-ipv6', $version, $prettyVersion);
             $phpIpv6->setDescription('The PHP interpreter, with IPv6 support');
             $this->addPackage($phpIpv6);

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -144,7 +144,7 @@ class PlatformRepositoryTest extends TestCase
         }
     }
 
-    public function testInetPtonRegressiom()
+    public function testInetPtonRegression()
     {
         $runtime = $this->getMockBuilder('Composer\Platform\Runtime')->getMock();
 

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -96,9 +96,6 @@ class PlatformRepositoryTest extends TestCase
                 array(
                     array('inet_pton', array('::'), ''),
                 ),
-                array(
-                    array('inet_pton', true),
-                )
             ),
             array(
                 array(
@@ -107,16 +104,15 @@ class PlatformRepositoryTest extends TestCase
                 array(
                     'php' => '7.2.31',
                 ),
-                array(),
                 array(
-                    'inet_pton' => false,
-                )
-            )
+                    array('inet_pton', array('::'), false),
+                ),
+            ),
         );
     }
 
     /** @dataProvider getPhpFlavorTestCases */
-    public function testPhpVersion(array $constants, array $packages, array $functionMap = array(), array $functionExists = array())
+    public function testPhpVersion(array $constants, array $packages, array $functions = array())
     {
         $runtime = $this->getMockBuilder('Composer\Platform\Runtime')->getMock();
         $runtime
@@ -138,11 +134,7 @@ class PlatformRepositoryTest extends TestCase
             );
         $runtime
             ->method('invoke')
-            ->willReturnMap($functionMap);
-
-        $runtime
-            ->method('hasFunction')
-            ->willReturnMap($functionExists);
+            ->willReturnMap($functions);
 
         $repository = new PlatformRepository(array(), array(), $runtime);
         foreach ($packages as $packageName => $version) {
@@ -150,6 +142,39 @@ class PlatformRepositoryTest extends TestCase
             self::assertNotNull($package, sprintf('Expected to find package "%s"', $packageName));
             self::assertSame($version, $package->getPrettyVersion(), sprintf('Expected package "%s" version to be %s, got %s', $packageName, $version, $package->getPrettyVersion()));
         }
+    }
+
+    public function testInetPtonRegressiom()
+    {
+        $runtime = $this->getMockBuilder('Composer\Platform\Runtime')->getMock();
+
+        $runtime
+            ->expects(self::once())
+            ->method('invoke')
+            ->with('inet_pton', array('::'))
+            ->willReturn(false);
+        $runtime
+            ->method('hasConstant')
+            ->willReturnMap(
+                array(
+                    array('PHP_ZTS', false),
+                    array('AF_INET6', false),
+                )
+            );
+        $runtime
+            ->method('getExtensions')
+            ->willReturn(array());
+        $runtime
+            ->method('getConstant')
+            ->willReturnMap(
+                array(
+                    array('PHP_VERSION', null, '7.0.0'),
+                    array('PHP_DEBUG', null, false),
+                )
+            );
+        $repository = new PlatformRepository(array(), array(), $runtime);
+        $package = $repository->findPackage('php-ipv6', '*');
+        self::assertNull($package);
     }
 
     public static function getLibraryTestCases()

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -95,13 +95,28 @@ class PlatformRepositoryTest extends TestCase
                 ),
                 array(
                     array('inet_pton', array('::'), ''),
+                ),
+                array(
+                    array('inet_pton', true),
+                )
+            ),
+            array(
+                array(
+                    'PHP_VERSION' => '7.2.31-1+ubuntu16.04.1+deb.sury.org+1',
+                ),
+                array(
+                    'php' => '7.2.31',
+                ),
+                array(),
+                array(
+                    'inet_pton' => false,
                 )
             )
         );
     }
 
     /** @dataProvider getPhpFlavorTestCases */
-    public function testPhpVersion(array $constants, array $packages, array $functions = array())
+    public function testPhpVersion(array $constants, array $packages, array $functionMap = array(), array $functionExists = array())
     {
         $runtime = $this->getMockBuilder('Composer\Platform\Runtime')->getMock();
         $runtime
@@ -123,7 +138,11 @@ class PlatformRepositoryTest extends TestCase
             );
         $runtime
             ->method('invoke')
-            ->willReturnMap($functions);
+            ->willReturnMap($functionMap);
+
+        $runtime
+            ->method('hasFunction')
+            ->willReturnMap($functionExists);
 
         $repository = new PlatformRepository(array(), array(), $runtime);
         foreach ($packages as $packageName => $version) {


### PR DESCRIPTION
varargs double indirection was incorrect, this fixes it + ads a regression test.

Adresses #9128 