### PR TITLE
RemoteFilesystem: avoid warning when setting max file size

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -248,6 +248,7 @@ class RemoteFilesystem
         $maxFileSize = null;
         if (isset($options['max_file_size'])) {
             $maxFileSize = $options['max_file_size'];
+            unset($options['max_file_size']);
         }
 
         $ctx = StreamContextFactory::getContext($fileUrl, $options, array('notification' => array($this, 'callbackGet')));


### PR DESCRIPTION
Follow up for https://github.com/composer/composer/pull/9130 prevents PHP warning `stream_context_create(): options should have the form ["wrappername"]["optionname"] = $value`