### PR TITLE
Put the github token authentication back

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -230,6 +230,14 @@ class RemoteFilesystem
 
         $origFileUrl = $fileUrl;
 
+        if (isset($options['github-token'])) {
+            // only add the access_token if it is actually a github URL (in case we were redirected to S3)
+            if (preg_match('{^https://api\.github\.com/}', $fileUrl)) {
+                $options['http']['header'][] = 'Authorization: token '.$options['github-token'];
+            }
+            unset($options['github-token']);
+        }
+
         if (isset($options['gitlab-token'])) {
             $fileUrl .= (false === strpos($fileUrl, '?') ? '?' : '&') . 'access_token='.$options['gitlab-token'];
             unset($options['gitlab-token']);


### PR DESCRIPTION
This was originally created here: https://github.com/composer/composer/pull/8747
But for some reason, this got removed in a merge 8b934a415f9b3787efe9a0201defaa011f8b68f9 to 1.10, not sure if this was on purpose.
re-adding, because this is breaking again.