### PR TITLE
Util/Zip: fix strpos args order

### DIFF
--- a/src/Composer/Util/Zip.php
+++ b/src/Composer/Util/Zip.php
@@ -92,7 +92,7 @@ class Zip
             }
 
             // handle archives which do not have a TOC record for the directory itself
-            if (false === strpos('\\', $dirname) && false === strpos('/', $dirname)) {
+            if (false === strpos($dirname, '\\') && false === strpos($dirname, '/')) {
                 $topLevelPaths[$dirname.'/'] = true;
                 if (\count($topLevelPaths) > 1) {
                     throw new \RuntimeException('Archive has more than one top level directories, and no composer.json was found on the top level, so it\'s an invalid archive. Top level paths found were: '.implode(',', array_keys($topLevelPaths)));


### PR DESCRIPTION
`strpos()` first argument is a haystack, not a needle.

`strpos('x', $s)` is identical to `$s === 'x'` which is probably not what we want here.