### PR TITLE
Sanitize repo URLs to mask HTTP auth passwords from cache directory

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -129,7 +129,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         $this->baseUrl = rtrim(preg_replace('{(?:/[^/\\\\]+\.json)?(?:[?#].*)?$}', '', $this->url), '/');
         $this->io = $io;
-        $this->cache = new Cache($io, $config->get('cache-repo-dir').'/'.preg_replace('{[^a-z0-9.]}i', '-', $this->url), 'a-z0-9.$~');
+        $this->cache = new Cache($io, $config->get('cache-repo-dir').'/'.preg_replace('{[^a-z0-9.]}i', '-', Url::sanitize($this->url)), 'a-z0-9.$~');
         $this->cache->setReadOnly($config->get('cache-read-only'));
         $this->versionParser = new VersionParser();
         $this->loader = new ArrayLoader($this->versionParser);


### PR DESCRIPTION
When a Composer repository is cached, a directory name is generated created stored package meta information fetched from that repository.
The cache directory can contain HTTP basic auth tokens, or access_token query parameters that end up in the directory name of the cache directory.

Discovered when trying out [GitLab composer repository feature](https://php.watch/articles/composer-gitlab-repositories), and the HTTP password was visible in a `composer update -vvv` command.

Using passwords/tokens in the URL is fundamentally a bad idea, but Composer already has `\Composer\Util\Url::sanitize()` that tries to mitigate such cases, and this same function is applied to the repo URL before deciding the name of the repo cache directory.