### PR TITLE
AuthHelper: Allow fall-through GitLab-specific HTTP headers for auth

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -205,7 +205,10 @@ class AuthHelper
                     $headers[] = 'Authorization: token '.$auth['username'];
                     $authenticationDisplayMessage = 'Using GitHub token authentication';
                 }
-            } elseif (in_array($origin, $this->config->get('gitlab-domains'), true)) {
+            } elseif (
+                in_array($origin, $this->config->get('gitlab-domains'), true)
+                && in_array($auth['password'], array('oauth2', 'private-token', 'gitlab-ci-token'), true)
+            ) {
                 if ($auth['password'] === 'oauth2') {
                     $headers[] = 'Authorization: Bearer '.$auth['username'];
                     $authenticationDisplayMessage = 'Using GitLab OAuth token authentication';

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -280,6 +280,14 @@ class AuthHelperTest extends TestCase
                     'password' => 'my_password'
                 )
             ),
+            array(
+                'https://gitlab.com',
+                'gitlab.com',
+                array(
+                    'username' => 'my_username',
+                    'password' => 'my_password'
+                )
+            ),
         );
     }
 
@@ -302,7 +310,7 @@ class AuthHelperTest extends TestCase
         $this->config->expects($this->once())
             ->method('get')
             ->with('gitlab-domains')
-            ->willReturn(array());
+            ->willReturn(array($origin));
 
         $this->io->expects($this->once())
             ->method('writeError')


### PR DESCRIPTION
Previously, `AuthHelper` consumed the authentication credentials for GitLab domains and added access tokens as GitLab-specific headers.
[Composer repositories now supported in GitLab](https://php.watch/articles/composer-gitlab-repositories) require standard Authorization headers with a personal access to function, which failed to work due to out GitLab-specific headers.

With this commit, AuthHelper checks if the password is an access token, and falls through to HTTP basic authentication even if the domain name is a GitLab domain name.