### PR TITLE
Fix symlink check

### DIFF
--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -43,7 +43,7 @@ class ArchivableFilesFinder extends \FilterIterator
     {
         $fs = new Filesystem();
 
-        $sources = $fs->normalizePath($sources);
+        $sources = $fs->normalizePath(realpath($sources));
 
         if ($ignoreFilters) {
             $filters = array();
@@ -58,7 +58,7 @@ class ArchivableFilesFinder extends \FilterIterator
         $this->finder = new Finder();
 
         $filter = function (\SplFileInfo $file) use ($sources, $filters, $fs) {
-            if ($file->isLink() && strpos($file->getLinkTarget(), $sources) !== 0) {
+            if ($file->isLink() && strpos($file->getRealPath(), $sources) !== 0) {
                 return false;
             }
 


### PR DESCRIPTION
Given you have a symlink in one of your path repositories and mirroring-strategy enabled.

```bash
lrwxrwxrwx 1 inf inf    8 27. Aug 17:41 Create.html -> New.html
-rw-r--r-- 1 inf inf  750 27. Aug 17:24 Edit.html
-rw-r--r-- 1 inf inf    0 27. Aug 17:24 List.html
-rw-r--r-- 1 inf inf 5064 27. Aug 17:24 New.html
-rw-r--r-- 1 inf inf  716 27. Aug 17:24 Show.html
```

`$file->getLinkTarget()` just returns a relative path in this example. It does not return an absolute normalized path.
`$sources` is always a normalized path.

`strpos` can never be `0`.

Use `$file->getRealPath()` to fix the strpos-check.