### PR TITLE
ComposerRepository: avoid notice if includes do not provide a sha1

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -637,7 +637,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         if (isset($data['includes'])) {
             foreach ($data['includes'] as $include => $metadata) {
-                if ($this->cache->sha1($include) === $metadata['sha1']) {
+                if (isset($metadata['sha1']) && $this->cache->sha1($include) === $metadata['sha1']) {
                     $includedData = json_decode($this->cache->read($include), true);
                 } else {
                     $includedData = $this->fetchFile($include);


### PR DESCRIPTION
Starting with PHP 7.4 Composer repositories that do not provide a sha1 hash for includes like the example listed below trigger a PHP notice

`Notice: Trying to access array offset on value of type null at vendor/composer/composer/src/Composer/Repository/ComposerRepository.php:640`

```
{
  includes: {
     path-to-include/include.json: null
 }
}
```