### PR TITLE
[POC] Poolbuilder optimizer

### DIFF
--- a/src/Composer/DependencyResolver/LoadPackageOperation.php
+++ b/src/Composer/DependencyResolver/LoadPackageOperation.php
@@ -1,0 +1,104 @@
+<?php
+
+
+namespace Composer\DependencyResolver;
+
+
+use Composer\Semver\Constraint\ConstraintInterface;
+
+class LoadPackageOperation
+{
+    /** @var string */
+    private $source;
+
+    /** @var string */
+    private $sourceVersion;
+
+    /** @var string */
+    private $target;
+
+    /** @var ConstraintInterface */
+    private $targetConstraint;
+
+    /** @var int */
+    private $levelFoundOn;
+
+    /**
+     * @param string $source
+     * @param string $sourceVersion
+     * @param string $target
+     * @param ConstraintInterface $targetConstraint
+     * @param int $levelFoundOn
+     */
+    public function __construct($source, $sourceVersion, $target, ConstraintInterface $targetConstraint, $levelFoundOn)
+    {
+        $this->source = $source;
+        $this->sourceVersion = $sourceVersion;
+        $this->target = $target;
+        $this->targetConstraint = $targetConstraint;
+        $this->levelFoundOn = $levelFoundOn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSource()
+    {
+        return $this->source;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSourceVersion()
+    {
+        return $this->sourceVersion;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
+     * @return ConstraintInterface
+     */
+    public function getTargetConstraint()
+    {
+        return $this->targetConstraint;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLevelFoundOn()
+    {
+        return $this->levelFoundOn;
+    }
+
+    /**
+     * @param ConstraintInterface $targetConstraint
+     * @return LoadPackageOperation
+     */
+    public function withTargetConstraint(ConstraintInterface $targetConstraint)
+    {
+        $new = clone $this;
+        $new->targetConstraint = $targetConstraint;
+
+        return $new;
+    }
+
+    public function __toString()
+    {
+        return sprintf('%s@%s -> %s@%s [found on level %d]',
+            $this->getSource(),
+            $this->getSourceVersion(),
+            $this->getTarget(),
+            $this->getTargetConstraint()->getPrettyString(),
+            $this->getLevelFoundOn()
+        );
+    }
+}


### PR DESCRIPTION
Now that https://github.com/composer/composer/pull/8850 got merged, let's try to take the pool builder to yet another level and optimizing things even more :) 

To better understand what the idea in this PR is, we should maybe go back to see what Composer 1.10 (or pre #8850) did and what it does now.

For this, it's maybe easiest to use and example and an illustration of our dependencies.
So let's assume we have a root requirement for `packageA` in `^2.0` which then requires `packageC` and `packageB` whereas `packageB` requires `packageC` as well but with a different constraint:

![dep](https://user-images.githubusercontent.com/481937/91853561-a8bb0380-ec62-11ea-8a89-aa06dc1e4e6a.png)

As you can see, dependencies are of course circular because packages can reference the same packages already found but it kind of helps to visualize them as a "dependency tree". You start on the very top and at some point you're done.

Here's what Composer 1.10 (or pre #8850) loaded into the pool:

* All versions of `packageA` fulfilling the constraint `^2.0`
* All versions of `packageB`
* All versions of `packageC`

As you can see, there was no optimization in terms of which package versions are even referenced anywhere in the dependency tree. Except for the root requirement, just **all versions of all packages** ever published were loaded into the pool.

Here's what Composer loads now (post #8850):

* All versions of `packageA` fulfilling the constraint `^2.0`
* All versions of `packageB` fulfilling the constraint `^1.1`
* All versions of `packageC` fulfilling the constraint `^2.0 || ^3.0 || ^3.0` (which gets simplified to `^2.0 || ^3.0`)

We've now reduced the amount of package versions loaded to **any package version** referenced **anywhere** in the dependency tree. So we don't blindly load all package versions ever published anymore but we still load quite a lot of them.

Here's what this PR tries to do:

* All versions of `packageA` fulfilling the constraint `^2.0`
* All versions of `packageB` fulfilling the constraint `^1.1`
* All versions of `packageC` fulfilling the constraint `^3.0`

How?

If you look at how a dependency tree is structured, you'll notice a rather simple rule:
The higher up in the dependency tree a package was required, the more likely it was controlled/requested by the user.
The highest level (level 0) being your root composer.json which is of course 100% controlled by the user and
contains 100% of what the user requests. Then, on level 1, we have all the direct dependencies of the root
dependencies, making those ones **extremely likely** to be requested by the user as well.
In other words, the higher up the dependency tree the requirer of a package was found, the higher the probability
that this constraint can be used as a hard requirement and does not need to be expanded on.

If you look at our example dependency tree, you can see that `packageC` was first found on level 1 (`packageA` is a root requirement = level 0). It was then required again but this time it was on level 2.

So why don't we do this during the loading process already?

I thought about it but it doesn't work. If we don't load all the packages referenced anywhere in the dependency tree, we might miss out on `replace` statements thus ending in an incorrect result.
We have to load all of the versions referenced anywhere in the tree first. Only then we can filter after we've properly handeld the replace statements.

This is a POC illustrating the concept. I didn't work on any tests or anything else but I'd love to read the feedback. Maybe someone wants to run some tests etc.

I've ran it on one of my bigger projects and it was able to filter out `25%` of the ~16,000 package versions found.
Current master: `[104.8MiB/31.22s] Memory usage: 104.76MiB (peak: 1130.78MiB), time: 31.22s`
This PR: `[87.8MiB/21.57s] Memory usage: 87.76MiB (peak: 647.36MiB), time: 21.57s`

Note that even if the optimizer only filters out 5%, it's still going to be beneficial as every additional package version found increases the number of rules to create exponentially :) 

