### PR TITLE
:sparkles: Ask for target directory when using `create-project`

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -748,6 +748,7 @@ By default the command checks for the packages on packagist.org.
 * **--ignore-platform-req:** ignore a specific platform requirement(`php`,
   `hhvm`, `lib-*` and `ext-*`) and force the installation even if the local machine
   does not fulfill it.
+* **--ask:** Ask user to provide target directory for new project.
 
 ## dump-autoload (dumpautoload)
 

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -84,6 +84,7 @@ class CreateProjectCommand extends BaseCommand
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Whether to skip installation of the package dependencies.'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
+                new InputOption('ask', null, InputOption::VALUE_NONE, 'Whether to ask for project directory.'),
             ))
             ->setHelp(
                 <<<EOT
@@ -128,6 +129,10 @@ EOT
         if ($input->getOption('no-custom-installers')) {
             $io->writeError('<warning>You are using the deprecated option "no-custom-installers". Use "no-plugins" instead.</warning>');
             $input->setOption('no-plugins', true);
+        }
+
+        if ($input->isInteractive() && $input->getOption('ask')) {
+            $input->setArgument('directory', $io->ask('New project directory <comment>[optional]</comment>: '));
         }
 
         $ignorePlatformReqs = $input->getOption('ignore-platform-reqs') ?: ($input->getOption('ignore-platform-req') ?: false);


### PR DESCRIPTION
The `create-project` command is used by a lot of projects as part of their installation documentation, for example [Symfony][symfony-install], [Laravel][laravel-install] and [Statamic][statamic-install]. The `create-project` command accepts a `directory` argument which authors of installation instructions must try to convey to readers as being a value the reader must replace with their desired directory. 

This Pull Request is for a change to add a new `ask` option which allows documentation authors to remove any reference to the `directory` argument and instead have Composer prompt the reader for their target directory. This does not change the default behaviour.

```console
dev:~$ composer create-project symfony/symfony --ask
New project directory [optional]:
```

Here are a couple of screenshots of the documentation from Symfony, Laravel and Statamic that demonstrate the problem.

## [Statamic][statamic-install]:

### Before

<img width="713" alt="Screenshot 2020-09-03 at 18 01 25" src="https://user-images.githubusercontent.com/349689/92145165-bb267000-ee0f-11ea-8812-4b0e7fabc1fb.png">

### After

<img width="713" alt="Screenshot 2020-09-03 at 18 01 18" src="https://user-images.githubusercontent.com/349689/92145160-b8c41600-ee0f-11ea-883d-7e3d132c0387.png">

## [Symfony][symfony-install]:
<img width="743" alt="Screenshot 2020-09-03 at 17 46 15" src="https://user-images.githubusercontent.com/349689/92143932-e019e380-ee0d-11ea-9136-785d46ded0a4.png">

## [Laravel][laravel-install]:
<img width="721" alt="Screenshot 2020-09-03 at 17 45 35" src="https://user-images.githubusercontent.com/349689/92143930-df814d00-ee0d-11ea-8bca-790ac1ce6ee5.png">

[symfony-install]: https://symfony.com/doc/current/quick_tour/the_big_picture.html#downloading-symfony
[laravel-install]: https://laravel.com/docs/7.x/installation#installing-laravel
[statamic-install]: https://statamic.dev/installation#creating-a-new-statamic-project