### PR TITLE
Call call_user_func_array() with a numeric arguments array

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -60,7 +60,7 @@ class ClassLoader
     public function getPrefixes()
     {
         if (!empty($this->prefixesPsr0)) {
-            return call_user_func_array('array_merge', $this->prefixesPsr0);
+            return call_user_func_array('array_merge', array_values($this->prefixesPsr0));
         }
 
         return array();


### PR DESCRIPTION
Same issue as #9076, different spot. 😃 

This piece of code currently causes the test suite of Symfony's debug component to fail on php 8.