### PR TITLE
Fix self usage in closures results in fatal error on PHP 5.3

### DIFF
--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -188,13 +188,13 @@ class HttpDownloader
         $curl = $this->curl;
 
         $canceler = function () use (&$job, $curl) {
-            if ($job['status'] === self::STATUS_QUEUED) {
-                $job['status'] = self::STATUS_ABORTED;
+            if ($job['status'] === HttpDownloader::STATUS_QUEUED) {
+                $job['status'] = HttpDownloader::STATUS_ABORTED;
             }
-            if ($job['status'] !== self::STATUS_STARTED) {
+            if ($job['status'] !== HttpDownloader::STATUS_STARTED) {
                 return;
             }
-            $job['status'] = self::STATUS_ABORTED;
+            $job['status'] = HttpDownloader::STATUS_ABORTED;
             if (isset($job['curl_id'])) {
                 $curl->abortRequest($job['curl_id']);
             }

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -158,13 +158,13 @@ class ProcessExecutor
         $io = $this->io;
 
         $canceler = function () use (&$job) {
-            if ($job['status'] === self::STATUS_QUEUED) {
-                $job['status'] = self::STATUS_ABORTED;
+            if ($job['status'] === ProcessExecutor::STATUS_QUEUED) {
+                $job['status'] = ProcessExecutor::STATUS_ABORTED;
             }
-            if ($job['status'] !== self::STATUS_STARTED) {
+            if ($job['status'] !== ProcessExecutor::STATUS_STARTED) {
                 return;
             }
-            $job['status'] = self::STATUS_ABORTED;
+            $job['status'] = ProcessExecutor::STATUS_ABORTED;
             try {
                 if (defined('SIGINT')) {
                     $job['process']->signal(SIGINT);

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -16,6 +16,7 @@ use Composer\IO\ConsoleIO;
 use Composer\Util\ProcessExecutor;
 use Composer\Test\TestCase;
 use Composer\IO\BufferIO;
+use React\Promise\Promise;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -112,5 +113,16 @@ class ProcessExecutorTest extends TestCase
 
         $process->execute('php -r "echo \'<error>foo</error>\'.PHP_EOL;"');
         $this->assertSame('<error>foo</error>'.PHP_EOL, $output->fetch());
+    }
+
+    public function testExecuteAsyncCancel()
+    {
+        $process = new ProcessExecutor($buffer = new BufferIO('', StreamOutput::VERBOSITY_DEBUG));
+        $process->enableAsync();
+        /** @var Promise $promise */
+        $promise = $process->executeAsync('echo foo');
+        $this->assertEquals(1,  $process->countActiveJobs());
+        $promise->cancel();
+        $this->assertEquals(0,  $process->countActiveJobs());
     }
 }


### PR DESCRIPTION
Added test to cancel ProcessExecutor::asyncExecute.
This failed for PHP 5.3.