### PR TITLE
Do not hard fail on lazy repository when network is disabled and no package cache exists

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -584,8 +584,11 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     $packages = $this->fetchFile($url, $cacheKey, $hash, $useLastModifiedCheck);
                 } catch (TransportException $e) {
                     // 404s are acceptable for lazy provider repos
-                    if ($e->getStatusCode() === 404 && $this->lazyProvidersUrl) {
+                    if ($this->lazyProvidersUrl && in_array($e->getStatusCode(), array(404, 499), true)) {
                         $packages = array('packages' => array());
+                        if ($e->getStatusCode() === 499) {
+                            $this->io->error('<warning>' . $e->getMessage() . '</warning>');
+                        }
                     } else {
                         throw $e;
                     }


### PR DESCRIPTION
While testing some performance improvements I noticed disabling network does not work in projects I use lazy repositories in (discussed in https://github.com/composer/composer/pull/9171#issuecomment-690617374).
The problems are appearing if a lazy repository does not have this package and as a result of this no cache item can be found.

I added status code 499 beside 404 to not fail hard in this situation but still log the warning as it happens on regular repositories as well.