### PR TITLE
Composer 2: Adapt file download cache keys to changed processed URLs

### DIFF
--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -35,6 +35,11 @@ class PreFileDownloadEvent extends Event
     /**
      * @var string
      */
+    private $customCacheKey;
+
+    /**
+     * @var string
+     */
     private $type;
 
     /**
@@ -86,6 +91,26 @@ class PreFileDownloadEvent extends Event
     public function setProcessedUrl($processedUrl)
     {
         $this->processedUrl = $processedUrl;
+    }
+
+    /**
+     * Retrieves a custom package cache key for this download.
+     *
+     * @return string
+     */
+    public function getCustomCacheKey()
+    {
+        return $this->customCacheKey;
+    }
+
+    /**
+     * Sets a custom package cache key for this download.
+     *
+     * @param string $customCacheKey New cache key
+     */
+    public function setCustomCacheKey($customCacheKey)
+    {
+        $this->customCacheKey = $customCacheKey;
     }
 
     /**

--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -33,7 +33,7 @@ class PreFileDownloadEvent extends Event
     private $processedUrl;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $customCacheKey;
 
@@ -96,7 +96,7 @@ class PreFileDownloadEvent extends Event
     /**
      * Retrieves a custom package cache key for this download.
      *
-     * @return string
+     * @return string|null
      */
     public function getCustomCacheKey()
     {
@@ -106,7 +106,7 @@ class PreFileDownloadEvent extends Event
     /**
      * Sets a custom package cache key for this download.
      *
-     * @param string $customCacheKey New cache key
+     * @param string|null $customCacheKey New cache key
      */
     public function setCustomCacheKey($customCacheKey)
     {


### PR DESCRIPTION
Following up the introduction of a `setProcessedUrl` method on the `PreFileDownloadEvent` in https://github.com/composer/composer/pull/8975 we found another issue that is blocking us from upgrading plugins to Composer 2. When altering the `processedUrl` for packages the file download `cacheKey` unexpectedly does not change with it, potentially reusing outdated files.

I am therefore suggesting that the cache key gets regenerated when the processed URL gets changed during `PreFileDownloadEvent` dispatching.

For [use cases](https://github.com/ffraenz/private-composer-installer/pull/25#issuecomment-692792485) that introduce temporary processed URLs (e.g. timestamps, session tokens, etc.) further optimization may be possible by allowing plugin authors to optionally provide a custom cache key in `PreFileDownloadEvent`. They may leave time-related params out of the value from which the cache key hash is generated.

The two proposed changes only apply to file downloads of type `package` as the cache keys of `metadata` downloads do not depend on the processed URL.

/cc @mcaskill