### PR TITLE
Partial updates should remove all unused dependencies

### DIFF
--- a/src/Composer/DependencyResolver/LockTransaction.php
+++ b/src/Composer/DependencyResolver/LockTransaction.php
@@ -62,6 +62,7 @@ class LockTransaction extends Transaction
 
             if ($literal > 0) {
                 $package = $pool->literalToPackage($literal);
+
                 $this->resultPackages['all'][] = $package;
                 if (!isset($this->unlockableMap[$package->id])) {
                     $this->resultPackages['non-dev'][] = $package;

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -31,13 +31,13 @@ class Pool implements \Countable
     protected $packageByName = array();
     protected $versionParser;
     protected $providerCache = array();
-    protected $unacceptableFixedPackages;
+    protected $unacceptableFixedOrLockedPackages;
 
-    public function __construct(array $packages = array(), array $unacceptableFixedPackages = array())
+    public function __construct(array $packages = array(), array $unacceptableFixedOrLockedPackages = array())
     {
         $this->versionParser = new VersionParser;
         $this->setPackages($packages);
-        $this->unacceptableFixedPackages = $unacceptableFixedPackages;
+        $this->unacceptableFixedOrLockedPackages = $unacceptableFixedOrLockedPackages;
     }
 
     private function setPackages(array $packages)
@@ -181,9 +181,9 @@ class Pool implements \Countable
         return false;
     }
 
-    public function isUnacceptableFixedPackage(PackageInterface $package)
+    public function isUnacceptableFixedOrLockedPackage(PackageInterface $package)
     {
-        return \in_array($package, $this->unacceptableFixedPackages, true);
+        return \in_array($package, $this->unacceptableFixedOrLockedPackages, true);
     }
 
     public function __toString()

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -130,7 +130,6 @@ class PoolBuilder
             foreach ($request->getLockedRepository()->getPackages() as $lockedPackage) {
                 if (!$this->isUpdateAllowed($lockedPackage)) {
                     $request->lockPackage($lockedPackage);
-                    $fixedOrLockedPackages[] = $lockedPackage;
                     $lockedName = $lockedPackage->getName();
                     // remember which packages we skipped loading remote content for in this partial update
                     $this->skippedLoad[$lockedName] = $lockedName;

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -229,11 +229,11 @@ class Problem
             return array("- Root composer.json requires linked library ".$packageName.self::constraintToText($constraint).' but ', 'it has the wrong version installed or is missing from your system, make sure to load the extension providing it.');
         }
 
-        $fixedPackage = null;
-        foreach ($request->getFixedPackages() as $package) {
+        $lockedPackage = null;
+        foreach ($request->getLockedPackages() as $package) {
             if ($package->getName() === $packageName) {
-                $fixedPackage = $package;
-                if ($pool->isUnacceptableFixedPackage($package)) {
+                $lockedPackage = $package;
+                if ($pool->isUnacceptableFixedOrLockedPackage($package)) {
                     return array("- ", $package->getPrettyName().' is fixed to '.$package->getPrettyVersion().' (lock file version) by a partial update but that version is rejected by your minimum-stability. Make sure you list it as an argument for the update command.');
                 }
                 break;
@@ -253,13 +253,13 @@ class Problem
                 }
             }
 
-            if ($fixedPackage) {
-                $fixedConstraint = new Constraint('==', $fixedPackage->getVersion());
+            if ($lockedPackage) {
+                $fixedConstraint = new Constraint('==', $lockedPackage->getVersion());
                 $filtered = array_filter($packages, function ($p) use ($fixedConstraint) {
                     return $fixedConstraint->matches(new Constraint('==', $p->getVersion()));
                 });
                 if (0 === count($filtered)) {
-                    return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose).' but the package is fixed to '.$fixedPackage->getPrettyVersion().' (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.');
+                    return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose).' but the package is fixed to '.$lockedPackage->getPrettyVersion().' (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.');
                 }
             }
 

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -45,6 +45,7 @@ class Request
     protected $requires = array();
     protected $fixedPackages = array();
     protected $lockedPackages = array();
+    protected $fixedLockedPackages = array();
     protected $updateAllowList = array();
     protected $updateAllowTransitiveDependencies = false;
 
@@ -82,6 +83,15 @@ class Request
     public function lockPackage(PackageInterface $package)
     {
         $this->lockedPackages[spl_object_hash($package)] = $package;
+    }
+
+    /**
+     * Mark a package fixed, but also keep track it is from the lock file (needed for composer install error reporting)
+     */
+    public function fixLockedPackage(PackageInterface $package)
+    {
+        $this->fixedPackages[spl_object_hash($package)] = $package;
+        $this->fixedLockedPackages[spl_object_hash($package)] = $package;
     }
 
     public function unlockPackage(PackageInterface $package)
@@ -132,7 +142,7 @@ class Request
 
     public function isLockedPackage(PackageInterface $package)
     {
-        return isset($this->lockedPackages[spl_object_hash($package)]);
+        return isset($this->lockedPackages[spl_object_hash($package)]) || isset($this->fixedLockedPackages[spl_object_hash($package)]);
     }
 
     public function getFixedOrLockedPackages()

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -68,9 +68,10 @@ class Request
     }
 
     /**
-     * Mark an existing package as being installed and having to remain installed
+     * Mark a package as currently present and having to remain installed
      *
-     * @param bool $lockable if set to false, the package will not be written to the lock file
+     * This is used for platform packages which cannot be modified by Composer. A rule enforcing their installation is
+     * generated for dependency resolution. Partial updates with dependencies cannot in any way modify these packages.
      */
     public function fixPackage(PackageInterface $package)
     {
@@ -78,7 +79,14 @@ class Request
     }
 
     /**
-     * Mark an existing package as installed but removable
+     * Mark a package as locked to a specific version but removable
+     *
+     * This is used for lock file packages which need to be treated similar to fixed packages by the pool builder in
+     * that by default they should really only have the currently present version loaded and no remote alternatives.
+     *
+     * However unlike fixed packages there will not be a special rule enforcing their installation for the solver, so
+     * if nothing requires these packages they will be removed. Additionally in a partial update these packages can be
+     * unlocked, meaning other versions can be installed if explicitly requested as part of the update.
      */
     public function lockPackage(PackageInterface $package)
     {
@@ -86,7 +94,11 @@ class Request
     }
 
     /**
-     * Mark a package fixed, but also keep track it is from the lock file (needed for composer install error reporting)
+     * Marks a locked package fixed. So it's treated irremovable like a platform package.
+     *
+     * This is necessary for the composer install step which verifies the lock file integrity and should not allow
+     * removal of any packages. At the same time lock packages there cannot simply be marked fixed, as error reporting
+     * would then report them as platform packages, so this still marks them as locked packages at the same time.
      */
     public function fixLockedPackage(PackageInterface $package)
     {

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -189,7 +189,7 @@ abstract class Rule
                 }));
                 if (count($packagesNonAlias) === 1) {
                     $package = $packagesNonAlias[0];
-                    if (!($package instanceof AliasPackage) && $request->isLockedPackage($package)) {
+                    if ($request->isLockedPackage($package)) {
                         return $package->getPrettyName().' is locked to version '.$package->getPrettyVersion()." and an update of this package was not requested.";
                     }
                 }

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -199,6 +199,10 @@ abstract class Rule
             case self::RULE_FIXED:
                 $package = $this->deduplicateDefaultBranchAlias($this->reasonData['package']);
 
+                if ($request->isLockedPackage($package)) {
+                    return $package->getPrettyName().' is locked to version '.$package->getPrettyVersion().' and an update of this package was not requested.';
+                }
+
                 return $package->getPrettyName().' is present at version '.$package->getPrettyVersion() . ' and cannot be modified by Composer';
 
             case self::RULE_PACKAGE_CONFLICT:

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -125,23 +125,25 @@ abstract class Rule
 
     public function isCausedByLock(RepositorySet $repositorySet, Request $request, Pool $pool)
     {
-        if ($this->getReason() === self::RULE_FIXED && $this->reasonData['lockable']) {
-            return true;
-        }
-
         if ($this->getReason() === self::RULE_PACKAGE_REQUIRES) {
             if (PlatformRepository::isPlatformPackage($this->reasonData->getTarget())) {
                 return false;
             }
-            foreach ($request->getFixedPackages() as $package) {
-                if ($package->getName() === $this->reasonData->getTarget()) {
-                    if ($pool->isUnacceptableFixedPackage($package)) {
-                        return true;
+            if ($request->getLockedRepository()) {
+                foreach ($request->getLockedRepository()->getPackages() as $package) {
+                    if ($package->getName() === $this->reasonData->getTarget()) {
+                        if ($pool->isUnacceptableFixedOrLockedPackage($package)) {
+                            return true;
+                        }
+                        if (!$this->reasonData->getConstraint()->matches(new Constraint('=', $package->getVersion()))) {
+                            return true;
+                        }
+                        // required package was locked but has been unlocked and still matches
+                        if (!$request->isLockedPackage($package)) {
+                            return true;
+                        }
+                        break;
                     }
-                    if (!$this->reasonData->getConstraint()->matches(new Constraint('=', $package->getVersion()))) {
-                        return true;
-                    }
-                    break;
                 }
             }
         }
@@ -150,15 +152,17 @@ abstract class Rule
             if (PlatformRepository::isPlatformPackage($this->reasonData['packageName'])) {
                 return false;
             }
-            foreach ($request->getFixedPackages() as $package) {
-                if ($package->getName() === $this->reasonData['packageName']) {
-                    if ($pool->isUnacceptableFixedPackage($package)) {
-                        return true;
+            if ($request->getLockedRepository()) {
+                foreach ($request->getLockedRepository()->getPackages() as $package) {
+                    if ($package->getName() === $this->reasonData['packageName']) {
+                        if ($pool->isUnacceptableFixedOrLockedPackage($package)) {
+                            return true;
+                        }
+                        if (!$this->reasonData['constraint']->matches(new Constraint('=', $package->getVersion()))) {
+                            return true;
+                        }
+                        break;
                     }
-                    if (!$this->reasonData['constraint']->matches(new Constraint('=', $package->getVersion()))) {
-                        return true;
-                    }
-                    break;
                 }
             }
         }
@@ -180,13 +184,20 @@ abstract class Rule
                     return 'No package found to satisfy root composer.json require '.$packageName.($constraint ? ' '.$constraint->getPrettyString() : '');
                 }
 
+                $packagesNonAlias = array_values(array_filter($packages, function ($p) {
+                    return !($p instanceof AliasPackage);
+                }));
+                if (count($packagesNonAlias) === 1) {
+                    $package = $packagesNonAlias[0];
+                    if (!($package instanceof AliasPackage) && $request->isLockedPackage($package)) {
+                        return $package->getPrettyName().' is locked to version '.$package->getPrettyVersion()." and an update of this package was not requested.";
+                    }
+                }
+
                 return 'Root composer.json requires '.$packageName.($constraint ? ' '.$constraint->getPrettyString() : '').' -> satisfiable by '.$this->formatPackagesUnique($pool, $packages, $isVerbose).'.';
 
             case self::RULE_FIXED:
                 $package = $this->deduplicateDefaultBranchAlias($this->reasonData['package']);
-                if ($this->reasonData['lockable']) {
-                    return $package->getPrettyName().' is locked to version '.$package->getPrettyVersion().' and an update of this package was not requested.';
-                }
 
                 return $package->getPrettyName().' is present at version '.$package->getPrettyVersion() . ' and cannot be modified by Composer';
 

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -223,12 +223,10 @@ class RuleSetGenerator
 
     protected function addRulesForRequest(Request $request, $ignorePlatformReqs)
     {
-        $unlockableMap = $request->getUnlockableMap();
-
         foreach ($request->getFixedPackages() as $package) {
             if ($package->id == -1) {
                 // fixed package was not added to the pool as it did not pass the stability requirements, this is fine
-                if ($this->pool->isUnacceptableFixedPackage($package)) {
+                if ($this->pool->isUnacceptableFixedOrLockedPackage($package)) {
                     continue;
                 }
 
@@ -240,7 +238,6 @@ class RuleSetGenerator
 
             $rule = $this->createInstallOneOfRule(array($package), Rule::RULE_FIXED, array(
                 'package' => $package,
-                'lockable' => !isset($unlockableMap[$package->id]),
             ));
             $this->addRule(RuleSet::TYPE_REQUEST, $rule);
         }

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -215,7 +215,7 @@ class Solver
             throw new SolverProblemsException($this->problems, $this->learnedPool);
         }
 
-        return new LockTransaction($this->pool, $request->getPresentMap(), $request->getUnlockableMap(), $this->decisions);
+        return new LockTransaction($this->pool, $request->getPresentMap(), $request->getFixedPackagesMap(), $this->decisions);
     }
 
     /**

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -633,7 +633,7 @@ class Installer
             }
 
             foreach ($lockedRepository->getPackages() as $package) {
-                $request->fixPackage($package);
+                $request->fixLockedPackage($package);
             }
 
             foreach ($this->locker->getPlatformRequirements($this->devMode) as $link) {
@@ -651,7 +651,6 @@ class Installer
                 // installing the locked packages on this platform resulted in lock modifying operations, there wasn't a conflict, but the lock file as-is seems to not work on this system
                 if (0 !== count($lockTransaction->getOperations())) {
                     $this->io->writeError('<error>Your lock file cannot be installed on this system without changes. Please run composer update.</error>', true, IOInterface::QUIET);
-                    // TODO actually display operations to explain what happened?
                     return 1;
                 }
             } catch (SolverProblemsException $e) {

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -821,9 +821,9 @@ class Installer
     {
         $request = new Request($lockedRepository);
 
-        $request->fixPackage($rootPackage, false);
+        $request->fixPackage($rootPackage);
         if ($rootPackage instanceof RootAliasPackage) {
-            $request->fixPackage($rootPackage->getAliasOf(), false);
+            $request->fixPackage($rootPackage->getAliasOf());
         }
 
         $fixedPackages = $platformRepo->getPackages();
@@ -841,7 +841,7 @@ class Installer
                 || !isset($provided[$package->getName()])
                 || !$provided[$package->getName()]->getConstraint()->matches(new Constraint('=', $package->getVersion()))
             ) {
-                $request->fixPackage($package, false);
+                $request->fixPackage($package);
             }
         }
 

--- a/tests/Composer/Test/Fixtures/installer/alias-solver-problems2.test
+++ b/tests/Composer/Test/Fixtures/installer/alias-solver-problems2.test
@@ -43,9 +43,6 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - locked/pkg is locked to version dev-master and an update of this package was not requested.
-    - locked/pkg dev-master requires locked/dependency 1.0.0 -> found locked/dependency[1.0.0] in lock file but not in remote repositories, make sure you avoid updating this package to keep the one from lock file.
-  Problem 2
     - locked/pkg dev-master requires locked/dependency 1.0.0 -> found locked/dependency[1.0.0] in lock file but not in remote repositories, make sure you avoid updating this package to keep the one from lock file.
     - locked/pkg is locked to version dev-master and an update of this package was not requested.
 

--- a/tests/Composer/Test/Fixtures/installer/partial-update-from-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-from-lock.test
@@ -21,7 +21,8 @@ Partial update from lock file should update everything to the state of the lock,
     "require": {
         "a/old": "*",
         "b/unstable": "*",
-        "c/uptodate": "*"
+        "c/uptodate": "*",
+        "e/newreq": "*"
     }
 }
 --LOCK--
@@ -60,7 +61,6 @@ update b/unstable
         { "name": "a/old", "version": "1.0.0", "type": "library" },
         { "name": "b/unstable", "version": "1.0.0", "type": "library", "require": {"f/dependency": "1.*"} },
         { "name": "c/uptodate", "version": "1.0.0", "type": "library" },
-        { "name": "d/removed", "version": "1.0.0", "type": "library" },
         { "name": "e/newreq", "version": "1.0.0", "type": "library" },
         { "name": "f/dependency", "version": "1.0.0", "type": "library" }
     ],
@@ -77,5 +77,4 @@ update b/unstable
 Upgrading a/old (0.9.0 => 1.0.0)
 Downgrading b/unstable (1.1.0-alpha => 1.0.0)
 Downgrading c/uptodate (2.0.0 => 1.0.0)
-Installing d/removed (1.0.0)
 Installing e/newreq (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/remove-deletes-unused-deps.test
+++ b/tests/Composer/Test/Fixtures/installer/remove-deletes-unused-deps.test
@@ -1,0 +1,46 @@
+--TEST--
+Removing a package deletes unused dependencies and does not update other dependencies
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "root/a", "version": "1.0.0", "require": { "dep/c": "*", "dep/d": "*"} },
+                { "name": "remove/b", "version": "1.0.0", "require": { "dep/c": "*", "dep/e": "*"} },
+                { "name": "dep/c", "version": "1.0.0" },
+                { "name": "dep/c", "version": "1.2.0" },
+                { "name": "dep/d", "version": "1.0.0" },
+                { "name": "dep/d", "version": "1.2.0" },
+                { "name": "dep/e", "version": "1.0.0" },
+                { "name": "unrelated/f", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "root/a": "*"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        { "name": "root/a", "version": "1.0.0", "require": { "dep/c": "*", "dep/d": "*"} },
+        { "name": "remove/b", "version": "1.0.0", "require": { "dep/c": "*", "dep/e": "*"} },
+        { "name": "dep/c", "version": "1.0.0" },
+        { "name": "dep/d", "version": "1.0.0" },
+        { "name": "dep/e", "version": "1.0.0" },
+        { "name": "unrelated/f", "version": "1.0.0" }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false
+}
+--RUN--
+update remove/b
+--EXPECT--
+Installing dep/d (1.0.0)
+Installing dep/c (1.0.0)
+Installing root/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/remove-does-nothing-if-removal-requires-update-of-dep.test
+++ b/tests/Composer/Test/Fixtures/installer/remove-does-nothing-if-removal-requires-update-of-dep.test
@@ -1,0 +1,39 @@
+--TEST--
+Removing a package has no effect if another package would require an update in order to find a correct set of dependencies without the removed package
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "root/a", "version": "1.0.0", "require": { "remove/b": "*", "dep/c": "*"} },
+                { "name": "remove/b", "version": "1.0.0", "require": { "dep/c": "*"} },
+                { "name": "dep/c", "version": "1.0.0" },
+                { "name": "dep/c", "version": "1.2.0", "replace": { "remove/b": "1.0.0"} }
+            ]
+        }
+    ],
+    "require": {
+        "root/a": "*"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        { "name": "root/a", "version": "1.0.0", "require": { "remove/b": "*", "dep/c": "*"} },
+        { "name": "remove/b", "version": "1.0.0", "require": { "dep/c": "*"} },
+        { "name": "dep/c", "version": "1.0.0" }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false
+}
+--RUN--
+update remove/b
+--EXPECT--
+Installing dep/c (1.0.0)
+Installing remove/b (1.0.0)
+Installing root/a (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/root-alias-change-with-circular-dep.test
+++ b/tests/Composer/Test/Fixtures/installer/root-alias-change-with-circular-dep.test
@@ -62,6 +62,4 @@ Your lock file does not contain a compatible set of packages. Please run compose
     - b/requirer is locked to version 1.0.0 and an update of this package was not requested.
     - b/requirer 1.0.0 requires root/pkg ^1 -> found root/pkg[2.x-dev] but it does not match the constraint.
 
-Use the option --with-all-dependencies to allow upgrades, downgrades and removals for packages currently locked to specific versions.
-
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/update-allow-list-require-new-replace.test
+++ b/tests/Composer/Test/Fixtures/installer/update-allow-list-require-new-replace.test
@@ -1,5 +1,5 @@
 --TEST--
-If a new requirement cannot be installed on a partial update due to replace, there should be a suggestion to use --with-all-dependencies
+A partial update for a new package yet to be installed should remove another dependency it replaces if that allows installation.
 --COMPOSER--
 {
     "repositories": [
@@ -39,17 +39,6 @@ If a new requirement cannot be installed on a partial update due to replace, the
 }
 --RUN--
 update new/pkg
---EXPECT-EXIT-CODE--
-2
---EXPECT-OUTPUT--
-Loading composer repositories with package information
-Updating dependencies
-Your requirements could not be resolved to an installable set of packages.
-
-  Problem 1
-    - current/dep is locked to version 1.0.0 and an update of this package was not requested.
-    - new/pkg[1.0.0] cannot be installed as that would require removing current/dep[1.0.0]. new/pkg replaces current/dep and thus cannot coexist with it.
-    - Root composer.json requires new/pkg 1.* -> satisfiable by new/pkg[1.0.0].
-
-Use the option --with-all-dependencies to allow upgrades, downgrades and removals for packages currently locked to specific versions.
 --EXPECT--
+Removing current/dep (1.0.0)
+Installing new/pkg (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/update-allow-list-with-dependencies-require-new-replace-mutual.test
+++ b/tests/Composer/Test/Fixtures/installer/update-allow-list-with-dependencies-require-new-replace-mutual.test
@@ -45,6 +45,7 @@ Require a new package in the composer.json and updating with its name as an argu
 --RUN--
 update new/pkg --with-dependencies
 --EXPECT--
+Removing current/dep-provide (1.0.0)
 Removing current/dep (1.0.0)
 Installing new/pkg (1.0.0)
 Installing new/pkg-provide (1.0.0)


### PR DESCRIPTION
Instead of marking locked packages as fixed, we change the pool builder to load only the locked version and treat it like a fixed package for loading purposes. But removing the actual request fix, makes the solver treat it as a regular optional dependency. As a consequence locked packages may be removed on a partial update of another package, but they still cannot be updated. This keeps the performance improvements achieved by fixing packages (no loading of alternatives unless explicitly listed for update) but it removes the automatic decision to install locked packages.

Tests fail because this changes some other assumptions, but I believe in a way that we would actually prefer.

For example a locked dependency may now get removed in favour of another package which can satisfy the same dependency when running composer require.

This is made clear by `update-allow-list-require-new-replace.test`: Here the requirement new/pkg is added and a partial update for the new package is run, however it replaces a dependency of another package which previously could not get removed during a partial update, and the update resulted in a conflict. With this PR it now removes the locked dependency and installs the new package without a problem.

Addresses https://github.com/composer/composer/issues/8870