### PR TITLE
Exclude conflicts early (Performance)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,16 @@
             "homepage": "https://seld.be"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:simonberger/semver.git"
+        }
+    ],
     "require": {
         "php": "^5.3.2 || ^7.0 || ^8.0",
         "composer/ca-bundle": "^1.0",
-        "composer/semver": "^3.0",
+        "composer/semver": "dev-exclude-conflict-test",
         "composer/spdx-licenses": "^1.2",
         "composer/xdebug-handler": "^1.1",
         "justinrainbow/json-schema": "^5.2.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b94ece2895724239b36aec399e5321a",
+    "content-hash": "fd06218ced76485750b95e92051c1e9a",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -83,16 +83,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.2.0",
+            "version": "dev-exclude-conflict-test",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "da7ce661431b17a71271cdf7f5437dc722133123"
+                "url": "https://github.com/simonberger/semver.git",
+                "reference": "e924e4bbd2a27de82f7aa9a4cbe779e1838527a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/da7ce661431b17a71271cdf7f5437dc722133123",
-                "reference": "da7ce661431b17a71271cdf7f5437dc722133123",
+                "url": "https://api.github.com/repos/simonberger/semver/zipball/e924e4bbd2a27de82f7aa9a4cbe779e1838527a4",
+                "reference": "e924e4bbd2a27de82f7aa9a4cbe779e1838527a4",
                 "shasum": ""
             },
             "require": {
@@ -113,7 +113,16 @@
                     "Composer\\Semver\\": "src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Composer\\Semver\\": "tests"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "vendor/bin/simple-phpunit"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -144,23 +153,9 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.0"
+                "source": "https://github.com/simonberger/semver/tree/exclude-conflict-test"
             },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-09-09T09:39:19+00:00"
+            "time": "2020-09-17T19:01:59+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -1526,7 +1521,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "composer/semver": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -87,12 +87,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/simonberger/semver.git",
-                "reference": "e924e4bbd2a27de82f7aa9a4cbe779e1838527a4"
+                "reference": "bb13c1120e6dea91e1cc5c5b2aa1d96444ed6328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simonberger/semver/zipball/e924e4bbd2a27de82f7aa9a4cbe779e1838527a4",
-                "reference": "e924e4bbd2a27de82f7aa9a4cbe779e1838527a4",
+                "url": "https://api.github.com/repos/simonberger/semver/zipball/bb13c1120e6dea91e1cc5c5b2aa1d96444ed6328",
+                "reference": "bb13c1120e6dea91e1cc5c5b2aa1d96444ed6328",
                 "shasum": ""
             },
             "require": {
@@ -155,7 +155,7 @@
                 "issues": "https://github.com/composer/semver/issues",
                 "source": "https://github.com/simonberger/semver/tree/exclude-conflict-test"
             },
-            "time": "2020-09-17T19:01:59+00:00"
+            "time": "2020-09-21T03:32:00+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -1533,5 +1533,5 @@
     "platform-overrides": {
         "php": "5.3.9"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -174,6 +174,10 @@ class PoolBuilder
                 continue;
             }
 
+            if (isset($this->conflicts[$packageName])) {
+                $constraint = Intervals::excludeConflict($constraint, $this->conflicts[$packageName]);
+            }
+
             $this->packagesToLoad[$packageName] = $constraint;
             $this->maxExtendedReqs[$packageName] = true;
         }

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -375,9 +375,11 @@ class PoolBuilder
         foreach ($package->getConflicts() as $link) {
             $conflict = $link->getTarget();
             $conflictConstraint = $link->getConstraint();
-            if (isset($this->conflicts[$conflict]) && !Intervals::isSubsetOf($conflictConstraint, $this->conflicts[$conflict])) {
-                $newConflict = Intervals::compactConstraint(MultiConstraint::create(array($this->conflicts[$conflict], $conflictConstraint), false));
-                $this->conflicts[$conflict] = $newConflict;
+            if (isset($this->conflicts[$conflict])) {
+                if (!Intervals::isSubsetOf($conflictConstraint, $this->conflicts[$conflict])) {
+                    $newConflict = Intervals::compactConstraint(MultiConstraint::create(array($this->conflicts[$conflict], $conflictConstraint), false));
+                    $this->conflicts[$conflict] = $newConflict;
+                }
             } else {
                 $this->conflicts[$conflict] = $conflictConstraint;
             }

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -193,6 +193,8 @@ class RuleSetGenerator
 
     protected function addConflictRules($ignorePlatformReqs = false)
     {
+        return;
+
         /** @var PackageInterface $package */
         foreach ($this->addedPackages as $package) {
             foreach ($package->getConflicts() as $link) {


### PR DESCRIPTION
Starting from a discussion and a test in #8850 this excludes all conflicts from not already loaded packages.
Most of the new code comes from a branch in the composer/semver package. Because I am not satisfied with the quality it is not part of a PR yet.

I am especially interested how much this reduces the analyze packages and runtime of your projects.
And surely if it raises any problems.

Here is a [composer-conflicts-test.phar.zip](https://github.com/composer/composer/files/5241611/composer-conflicts-test.phar.zip) file

**How to test:**
- Run `composer self-update --snapshot` to get the latest 2.0 dev build
- Run `composer update --dry-run` to prime the cache
- Run `COMPOSER_DISABLE_NETWORK=1 composer update -v --dry-run --profile` to run a profile without network jitter, with current master branch
- Run `COMPOSER_DISABLE_NETWORK=1 php composer-conflicts-test.phar update -v --dry-run --profile` to run another profile with the optimizations in this branch
- The three interesting lines from the snapshot and test runs are:
`Analyzed 13476 packages to resolve dependencies  Analyzed 1590120 rules to resolve dependencies`  and `Memory usage: 107.02MiB (peak: 955.09MiB), time: 57.85s`

I took parts of @Seldaek [instruction](https://github.com/composer/composer/pull/8850#issuecomment-660145941)

The numbers I got are looking almost too good. I'll post results later.
There is still a lot to do, but I want to early make sure this is worth it and I do not miss something essential.

Todos:

- [ ] Receive some more results. Assure that this change is worth it
- [ ] Merge PR in composer/semver
    - [ ] Add tests
    - [ ] Improve code
- [ ] Add tests here
