### PR TITLE
Fixed incorrect private annotation

### DIFF
--- a/src/Composer/Package/Link.php
+++ b/src/Composer/Package/Link.php
@@ -30,7 +30,7 @@ class Link
     /**
      * Will be converted into a constant once the min PHP version allows this
      *
-     * @private
+     * @internal
      * @var string[]
      */
     public static $TYPES = array(


### PR DESCRIPTION
This property is accessed from outside of the class, so it needs to be marked as internal, not private, to indicate that it should not be used by code that is not composer itself.