### PR TITLE
Fixed description of StatusCommand: It do list all changes in vendor, not only for "source" ones

### DIFF
--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -43,7 +43,7 @@ class StatusCommand extends BaseCommand
     {
         $this
             ->setName('status')
-            ->setDescription('Shows a list of locally modified packages, for packages installed from source.')
+            ->setDescription('Shows a list of locally modified packages.')
             ->setDefinition(array(
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Show modified files for each directory that contains changes.'),
             ))


### PR DESCRIPTION
I tested it, and even with "dist" packages, the status command is able to find modified vendor 
(And that's amazing, thanks)