### PR TITLE
Implemented PoolOptimizer

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,6 @@ on:
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
   COMPOSER_UPDATE_FLAGS: ""
-  COMPOSER_TESTS_ARE_RUNNING: "1"
 
 jobs:
   tests:

--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -353,3 +353,27 @@ See also https://github.com/composer/composer/issues/4180 for more information.
 Composer can unpack zipballs using either a system-provided `unzip` or `7z` (7-Zip) utility, or PHP's
 native `ZipArchive` class. On OSes where ZIP files can contain permissions and symlinks, we recommend
 installing `unzip` or `7z` as these features are not supported by `ZipArchive`.
+
+
+## Disabling the pool optimizer
+
+In Composer, the `Pool` class contains all the packages that are relevant for the dependency
+resolving process. That is what is used to generate all the rules which are then
+passed on to the dependency solver.
+In order to improve performance, Composer tries to optimize this `Pool` by removing useless
+package information early on.
+
+If all goes well, you should never notice any issues with it but in case you run into
+an unexpected result such as an unresolvable set of dependencies or conflicts where you
+think Composer is wrong, you might want to disable the optimizer by using the environment
+variable `COMPOSER_POOL_OPTIMIZER` and run the update again like so:
+
+```bash
+COMPOSER_POOL_OPTIMIZER=0 php composer.phar update
+```
+
+Now double check if the result is still the same. It will take significantly longer and use
+a lot more memory to run the dependency resolving process.
+
+If the result is different, you likely hit a problem in the pool optimizer.
+Please [report this issue](https://github.com/composer/composer/issues) so it can be fixed.

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -36,16 +36,57 @@ class Pool implements \Countable
     protected $providerCache = array();
     /** @var BasePackage[] */
     protected $unacceptableFixedOrLockedPackages;
+    /** @var array<string, array<string, string>> Map of package name => normalized version => pretty version */
+    protected $removedVersions = array();
+    /** @var array<string, array<string, string>> Map of package object hash => removed normalized versions => removed pretty version */
+    protected $removedVersionsByPackage = array();
 
     /**
      * @param BasePackage[] $packages
      * @param BasePackage[] $unacceptableFixedOrLockedPackages
+     * @param array<string, array<string, string>> $removedVersions
+     * @param array<string, array<string, string>> $removedVersionsByPackage
      */
-    public function __construct(array $packages = array(), array $unacceptableFixedOrLockedPackages = array())
+    public function __construct(array $packages = array(), array $unacceptableFixedOrLockedPackages = array(), array $removedVersions = array(), array $removedVersionsByPackage = array())
     {
         $this->versionParser = new VersionParser;
         $this->setPackages($packages);
         $this->unacceptableFixedOrLockedPackages = $unacceptableFixedOrLockedPackages;
+        $this->removedVersions = $removedVersions;
+        $this->removedVersionsByPackage = $removedVersionsByPackage;
+    }
+
+    /**
+     * @param  string $name
+     * @return array<string, string>
+     */
+    public function getRemovedVersions($name, ConstraintInterface $constraint)
+    {
+        if (!isset($this->removedVersions[$name])) {
+            return array();
+        }
+
+        $result = array();
+        foreach ($this->removedVersions[$name] as $version => $prettyVersion) {
+            if ($constraint->matches(new Constraint('==', $version))) {
+                $result[$version] = $prettyVersion;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  string $objectHash
+     * @return array<string, string>
+     */
+    public function getRemovedVersionsByPackage($objectHash)
+    {
+        if (!isset($this->removedVersionsByPackage[$objectHash])) {
+            return array();
+        }
+
+        return $this->removedVersionsByPackage[$objectHash];
     }
 
     /**

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -221,6 +221,14 @@ class Pool implements \Countable
         return \in_array($package, $this->unacceptableFixedOrLockedPackages, true);
     }
 
+    /**
+     * @return BasePackage[]
+     */
+    public function getUnacceptableFixedOrLockedPackages()
+    {
+        return $this->unacceptableFixedOrLockedPackages;
+    }
+
     public function __toString()
     {
         $str = "Pool:\n";

--- a/src/Composer/DependencyResolver/PoolOptimizer.php
+++ b/src/Composer/DependencyResolver/PoolOptimizer.php
@@ -1,0 +1,345 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\DependencyResolver;
+
+use Composer\Package\AliasPackage;
+use Composer\Package\BasePackage;
+use Composer\Semver\CompilingMatcher;
+use Composer\Semver\Constraint\ConstraintInterface;
+use Composer\Semver\Constraint\Constraint;
+use Composer\Semver\Constraint\MultiConstraint;
+use Composer\Semver\Intervals;
+
+/**
+ * Optimizes a given pool
+ *
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ */
+class PoolOptimizer
+{
+    /**
+     * @var PolicyInterface
+     */
+    private $policy;
+
+    /**
+     * @var array<int, true>
+     */
+    private $irremovablePackages = array();
+
+    /**
+     * @var array<string, array<string, ConstraintInterface>>
+     */
+    private $requireConstraintsPerPackage = array();
+
+    /**
+     * @var array<string, array<string, ConstraintInterface>>
+     */
+    private $conflictConstraintsPerPackage = array();
+
+    /**
+     * @var array<int, true>
+     */
+    private $packagesToRemove = array();
+
+    /**
+     * @var array<int, BasePackage[]>
+     */
+    private $aliasesPerPackage = array();
+
+    public function __construct(PolicyInterface $policy)
+    {
+        $this->policy = $policy;
+    }
+
+    /**
+     * @return Pool
+     */
+    public function optimize(Request $request, Pool $pool)
+    {
+        $this->prepare($request, $pool);
+
+        $optimizedPool = $this->optimizeByIdenticalDependencies($pool);
+
+        // No need to run this recursively at the moment
+        // because the current optimizations cannot provide
+        // even more gains when ran again. Might change
+        // in the future with additional optimizations.
+
+        $this->irremovablePackages = array();
+        $this->requireConstraintsPerPackage = array();
+        $this->conflictConstraintsPerPackage = array();
+        $this->packagesToRemove = array();
+        $this->aliasesPerPackage = array();
+
+        return $optimizedPool;
+    }
+
+    /**
+     * @return void
+     */
+    private function prepare(Request $request, Pool $pool)
+    {
+        $irremovablePackageConstraintGroups = array();
+
+        // Mark fixed or locked packages as irremovable
+        foreach ($request->getFixedOrLockedPackages() as $package) {
+            $irremovablePackageConstraintGroups[$package->getName()][] = new Constraint('==', $package->getVersion());
+        }
+
+        // Extract requested package requirements
+        foreach ($request->getRequires() as $require => $constraint) {
+            $constraint = Intervals::compactConstraint($constraint);
+            $this->requireConstraintsPerPackage[$require][(string) $constraint] = $constraint;
+        }
+
+        // First pass over all packages to extract information and mark package constraints irremovable
+        foreach ($pool->getPackages() as $package) {
+            // Extract package requirements
+            foreach ($package->getRequires() as $link) {
+                $constraint = Intervals::compactConstraint($link->getConstraint());
+                $this->requireConstraintsPerPackage[$link->getTarget()][(string) $constraint] = $constraint;
+            }
+            // Extract package conflicts
+            foreach ($package->getConflicts() as $link) {
+                $constraint = Intervals::compactConstraint($link->getConstraint());
+                $this->conflictConstraintsPerPackage[$link->getTarget()][(string) $constraint] = $constraint;
+            }
+
+            // Keep track of alias packages for every package so if either the alias or aliased is kept
+            // we keep the others as they are a unit of packages really
+            if ($package instanceof AliasPackage) {
+                $this->aliasesPerPackage[$package->getAliasOf()->id][] = $package;
+            }
+        }
+
+        $irremovablePackageConstraints = array();
+        foreach ($irremovablePackageConstraintGroups as $packageName => $constraints) {
+            $irremovablePackageConstraints[$packageName] = 1 === \count($constraints) ? $constraints[0] : new MultiConstraint($constraints, false);
+        }
+        unset($irremovablePackageConstraintGroups);
+
+        // Mark the packages as irremovable based on the constraints
+        foreach ($pool->getPackages() as $package) {
+            if (!isset($irremovablePackageConstraints[$package->getName()])) {
+                continue;
+            }
+
+            if (CompilingMatcher::match($irremovablePackageConstraints[$package->getName()], Constraint::OP_EQ, $package->getVersion())) {
+                $this->markPackageIrremovable($package);
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function markPackageIrremovable(BasePackage $package)
+    {
+        $this->irremovablePackages[$package->id] = true;
+        if ($package instanceof AliasPackage) {
+            // recursing here so aliasesPerPackage for the aliasOf can be checked
+            // and all its aliases marked as irremovable as well
+            $this->markPackageIrremovable($package->getAliasOf());
+        }
+        if (isset($this->aliasesPerPackage[$package->id])) {
+            foreach ($this->aliasesPerPackage[$package->id] as $aliasPackage) {
+                $this->irremovablePackages[$aliasPackage->id] = true;
+            }
+        }
+    }
+
+    /**
+     * @return Pool Optimized pool
+     */
+    private function applyRemovalsToPool(Pool $pool)
+    {
+        $packages = array();
+        foreach ($pool->getPackages() as $package) {
+            if (!isset($this->packagesToRemove[$package->id])) {
+                $packages[] = $package;
+            }
+        }
+
+        $optimizedPool = new Pool($packages, $pool->getUnacceptableFixedOrLockedPackages());
+
+        // Reset package removals
+        $this->packagesToRemove = array();
+
+        return $optimizedPool;
+    }
+
+    /**
+     * @return Pool
+     */
+    private function optimizeByIdenticalDependencies(Pool $pool)
+    {
+        $identicalDefinitionPerPackage = array();
+        $packageIdsToRemove = array();
+
+        foreach ($pool->getPackages() as $package) {
+
+            // If that package was already marked irremovable, we can skip
+            // the entire process for it
+            if (isset($this->irremovablePackages[$package->id])) {
+                continue;
+            }
+
+            $packageIdsToRemove[$package->id] = true;
+
+            $dependencyHash = $this->calculateDependencyHash($package);
+
+            foreach ($package->getNames(false) as $packageName) {
+
+                if (!isset($this->requireConstraintsPerPackage[$packageName])) {
+                    continue;
+                }
+
+                foreach ($this->requireConstraintsPerPackage[$packageName] as $requireConstraint) {
+
+                    $groupHashParts = array();
+
+                    if (CompilingMatcher::match($requireConstraint, Constraint::OP_EQ, $package->getVersion())) {
+                        $groupHashParts[] = 'require:' . (string) $requireConstraint;
+                    }
+
+                    if ($package->getReplaces()) {
+                        foreach ($package->getReplaces() as $link) {
+                            if (CompilingMatcher::match($link->getConstraint(), Constraint::OP_EQ, $package->getVersion())) {
+                                // Use the same hash part as the regular require hash because that's what the replacement does
+                                $groupHashParts[] = 'require:' . (string) $link->getConstraint();
+                            }
+                        }
+                    }
+
+                    if (isset($this->conflictConstraintsPerPackage[$packageName])) {
+                        foreach ($this->conflictConstraintsPerPackage[$packageName] as $conflictConstraint) {
+                            if (CompilingMatcher::match($conflictConstraint, Constraint::OP_EQ, $package->getVersion())) {
+                                $groupHashParts[] = 'conflict:' . (string) $conflictConstraint;
+                            }
+                        }
+                    }
+
+                    if (!$groupHashParts) {
+                        continue;
+                    }
+
+                    $identicalDefinitionPerPackage[$packageName][implode('', $groupHashParts)][$dependencyHash][] = $package;
+                }
+            }
+        }
+
+        $keepPackage = function (BasePackage $package, $aliasesPerPackage) use (&$packageIdsToRemove, &$keepPackage) {
+            unset($packageIdsToRemove[$package->id]);
+            if ($package instanceof AliasPackage) {
+                // recursing here so aliasesPerPackage for the aliasOf can be checked
+                // and all its aliases marked to be kept as well
+                $keepPackage($package->getAliasOf(), $aliasesPerPackage);
+            }
+            if (isset($aliasesPerPackage[$package->id])) {
+                foreach ($aliasesPerPackage[$package->id] as $aliasPackage) {
+                    unset($packageIdsToRemove[$aliasPackage->id]);
+                }
+            }
+        };
+
+        foreach ($identicalDefinitionPerPackage as $package => $constraintGroups) {
+            foreach ($constraintGroups as $constraintGroup) {
+                foreach ($constraintGroup as $hash => $packages) {
+
+                    // Only one package in this constraint group has the same requirements, we're not allowed to remove that package
+                    if (1 === \count($packages)) {
+                        $keepPackage($packages[0], $this->aliasesPerPackage);
+                        continue;
+                    }
+
+                    // Otherwise we find out which one is the preferred package in this constraint group which is
+                    // then not allowed to be removed either
+                    $literals = array();
+
+                    foreach ($packages as $package) {
+                        $literals[] = $package->id;
+                    }
+
+                    foreach ($this->policy->selectPreferredPackages($pool, $literals) as $preferredLiteral) {
+                        $keepPackage($pool->literalToPackage($preferredLiteral), $this->aliasesPerPackage);
+                    }
+                }
+            }
+        }
+
+        foreach ($packageIdsToRemove as $id => $dummy) {
+            $this->markPackageForRemoval($id);
+        }
+
+        // Apply removals
+        return $this->applyRemovalsToPool($pool);
+    }
+
+    /**
+     * @return string
+     */
+    private function calculateDependencyHash(BasePackage $package)
+    {
+        $hash = '';
+
+        $hashRelevantLinks = array(
+            'requires' => $package->getRequires(),
+            'conflicts' => $package->getConflicts(),
+            'replaces' => $package->getReplaces(),
+            'provides' => $package->getProvides()
+        );
+
+        foreach ($hashRelevantLinks as $key => $links) {
+            if (0 === \count($links)) {
+                continue;
+            }
+
+            // start new hash section
+            $hash .= $key . ':';
+
+            $subhash = array();
+
+            foreach ($links as $link) {
+                // To get the best dependency hash matches we should use Intervals::compactConstraint() here.
+                // However, the majority of projects are going to specify their constraints already pretty
+                // much in the best variant possible. In other words, we'd be wasting time here and it would actually hurt
+                // performance more than the additional few packages that could be filtered out would benefit the process.
+                $subhash[$link->getTarget()] = (string) $link->getConstraint();
+            }
+
+            // Sort for best result
+            ksort($subhash);
+
+            foreach ($subhash as $target => $constraint) {
+                $hash .= $target . '@' . $constraint;
+            }
+        }
+
+        return $hash;
+    }
+
+    /**
+     * @param int $id
+     * @return void
+     */
+    private function markPackageForRemoval($id)
+    {
+        // We are not allowed to remove packages if they have been marked as irremovable
+        if (isset($this->irremovablePackages[$id])) {
+            throw new \LogicException('Attempted removing a package which was previously marked irremovable');
+        }
+
+        $this->packagesToRemove[$id] = true;
+    }
+}

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -229,6 +229,41 @@ abstract class Rule
     }
 
     /**
+     * @internal
+     * @return BasePackage
+     */
+    public function getSourcePackage(Pool $pool)
+    {
+        $literals = $this->getLiterals();
+
+        switch ($this->getReason()) {
+            case self::RULE_PACKAGE_CONFLICT:
+                $package1 = $this->deduplicateDefaultBranchAlias($pool->literalToPackage($literals[0]));
+                $package2 = $this->deduplicateDefaultBranchAlias($pool->literalToPackage($literals[1]));
+
+                $conflictTarget = $package1->getPrettyString();
+                if ($reasonData = $this->getReasonData()) {
+                    // swap literals if they are not in the right order with package2 being the conflicter
+                    if ($reasonData->getSource() === $package1->getName()) {
+                        list($package2, $package1) = array($package1, $package2);
+                    }
+                }
+
+                return $package2;
+
+            case self::RULE_PACKAGE_REQUIRES:
+                $sourceLiteral = array_shift($literals);
+                $sourcePackage = $this->deduplicateDefaultBranchAlias($pool->literalToPackage($sourceLiteral));
+
+                return $sourcePackage;
+
+            default:
+                throw new \LogicException('Not implemented');
+        }
+    }
+
+
+    /**
      * @param bool $isVerbose
      * @param BasePackage[] $installedMap
      * @param array<Rule[]> $learnedPool
@@ -258,7 +293,7 @@ abstract class Rule
                     }
                 }
 
-                return 'Root composer.json requires '.$packageName.($constraint ? ' '.$constraint->getPrettyString() : '').' -> satisfiable by '.$this->formatPackagesUnique($pool, $packages, $isVerbose).'.';
+                return 'Root composer.json requires '.$packageName.($constraint ? ' '.$constraint->getPrettyString() : '').' -> satisfiable by '.$this->formatPackagesUnique($pool, $packages, $isVerbose, $constraint).'.';
 
             case self::RULE_FIXED:
                 $package = $this->deduplicateDefaultBranchAlias($this->reasonData['package']);
@@ -320,7 +355,7 @@ abstract class Rule
 
                 $text = $reasonData->getPrettyString($sourcePackage);
                 if ($requires) {
-                    $text .= ' -> satisfiable by ' . $this->formatPackagesUnique($pool, $requires, $isVerbose) . '.';
+                    $text .= ' -> satisfiable by ' . $this->formatPackagesUnique($pool, $requires, $isVerbose, $this->reasonData->getConstraint()) . '.';
                 } else {
                     $targetName = $reasonData->getTarget();
 
@@ -368,13 +403,13 @@ abstract class Rule
                     }
 
                     if ($installedPackages && $removablePackages) {
-                        return $this->formatPackagesUnique($pool, $removablePackages, $isVerbose).' cannot be installed as that would require removing '.$this->formatPackagesUnique($pool, $installedPackages, $isVerbose).'. '.$reason;
+                        return $this->formatPackagesUnique($pool, $removablePackages, $isVerbose, null, true).' cannot be installed as that would require removing '.$this->formatPackagesUnique($pool, $installedPackages, $isVerbose, null, true).'. '.$reason;
                     }
 
-                    return 'Only one of these can be installed: '.$this->formatPackagesUnique($pool, $literals, $isVerbose).'. '.$reason;
+                    return 'Only one of these can be installed: '.$this->formatPackagesUnique($pool, $literals, $isVerbose, null, true).'. '.$reason;
                 }
 
-                return 'You can only install one version of a package, so only one of these can be installed: ' . $this->formatPackagesUnique($pool, $literals, $isVerbose) . '.';
+                return 'You can only install one version of a package, so only one of these can be installed: ' . $this->formatPackagesUnique($pool, $literals, $isVerbose, null, true) . '.';
             case self::RULE_LEARNED:
                 /** @TODO currently still generates way too much output to be helpful, and in some cases can even lead to endless recursion */
                 // if (isset($learnedPool[$this->reasonData])) {
@@ -445,9 +480,10 @@ abstract class Rule
     /**
      * @param array<int|BasePackage> $packages An array containing packages or literals
      * @param bool $isVerbose
+     * @param bool $useRemovedVersionGroup
      * @return string
      */
-    protected function formatPackagesUnique(Pool $pool, array $packages, $isVerbose)
+    protected function formatPackagesUnique(Pool $pool, array $packages, $isVerbose, ConstraintInterface $constraint = null, $useRemovedVersionGroup = false)
     {
         foreach ($packages as $index => $package) {
             if (!\is_object($package)) {
@@ -455,7 +491,7 @@ abstract class Rule
             }
         }
 
-        return Problem::getPackageList($packages, $isVerbose);
+        return Problem::getPackageList($packages, $isVerbose, $pool, $constraint, $useRemovedVersionGroup);
     }
 
     /**

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -460,6 +460,8 @@ class Installer
         $this->io->writeError("Analyzed ".count($pool)." packages to resolve dependencies", true, IOInterface::VERBOSE);
         $this->io->writeError("Analyzed ".$ruleSetSize." rules to resolve dependencies", true, IOInterface::VERBOSE);
 
+        $pool = null;
+
         if (!$lockTransaction->getOperations()) {
             $this->io->writeError('Nothing to modify in lock file');
         }

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -12,6 +12,8 @@
 
 namespace Composer\Repository;
 
+use Composer\DependencyResolver\PoolOptimizer;
+use Composer\DependencyResolver\PolicyInterface;
 use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\PoolBuilder;
 use Composer\DependencyResolver\Request;
@@ -244,9 +246,9 @@ class RepositorySet
      *
      * @return Pool
      */
-    public function createPool(Request $request, IOInterface $io, EventDispatcher $eventDispatcher = null)
+    public function createPool(Request $request, IOInterface $io, EventDispatcher $eventDispatcher = null, PoolOptimizer $poolOptimizer = null)
     {
-        $poolBuilder = new PoolBuilder($this->acceptableStabilities, $this->stabilityFlags, $this->rootAliases, $this->rootReferences, $io, $eventDispatcher);
+        $poolBuilder = new PoolBuilder($this->acceptableStabilities, $this->stabilityFlags, $this->rootAliases, $this->rootReferences, $io, $eventDispatcher, $poolOptimizer);
 
         foreach ($this->repositories as $repo) {
             if (($repo instanceof InstalledRepositoryInterface || $repo instanceof InstalledRepository) && !$this->allowInstalledRepositories) {

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace-partial-update.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace-partial-update.test
@@ -105,3 +105,13 @@ Check that replacers from additional repositories are loaded when doing a partia
     "shared/dep-1.0.0.0",
     "shared/dep-1.2.0.0"
 ]
+
+--EXPECT-OPTIMIZED--
+[
+    "indirect/replacer-1.2.0.0",
+    "indirect/replacer-1.0.0.0",
+    "replacer/package-1.2.0.0",
+    "replacer/package-1.0.0.0",
+    "base/package-1.0.0.0",
+    "shared/dep-1.2.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace.test
@@ -96,3 +96,13 @@ Check that replacers from additional repositories are loaded
     "replacer/package-1.0.0.0",
     "shared/dep-1.0.0.0"
 ]
+
+--EXPECT-OPTIMIZED--
+[
+    "base/package-1.0.0.0",
+    "indirect/replacer-1.2.0.0",
+    "indirect/replacer-1.0.0.0",
+    "shared/dep-1.2.0.0",
+    "replacer/package-1.2.0.0",
+    "replacer/package-1.0.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
@@ -48,3 +48,13 @@ locked packages still need to be taking into account for loading all necessary v
     "dep/pkg1-1.0.1.0",
     "dep/pkg1-2.0.0.0"
 ]
+
+--EXPECT-OPTIMIZED--
+[
+    "root/req1-1.0.0.0 (locked)",
+    "root/req2-1.0.0.0 (locked)",
+    "dep/pkg2-1.0.0.0",
+    "dep/pkg2-1.2.0.0",
+    "dep/pkg1-1.0.1.0",
+    "dep/pkg1-2.0.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-with-replacers.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-with-replacers.test
@@ -50,3 +50,12 @@ Fixed packages and replacers get unfixed correctly (refs https://github.com/comp
     "replaced/pkg-1.2.3.0",
     "replaced/pkg-1.2.4.0"
 ]
+
+--EXPECT-OPTIMIZED--
+[
+    "root/req3-1.0.0.0 (locked)",
+    "dep/dep-2.3.5.0 (locked)",
+    "root/req1-1.1.0.0",
+    "replacer/pkg-1.1.0.0",
+    "replaced/pkg-1.2.4.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/stability-flags-take-over-minimum-stability-and-filter-packages.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/stability-flags-take-over-minimum-stability-and-filter-packages.test
@@ -46,3 +46,10 @@ Stability flags apply
     6,
     "default/pkg-1.2.0.0 (alias of 6)"
 ]
+
+--EXPECT-OPTIMIZED--
+[
+    1,
+    6,
+    "default/pkg-1.2.0.0 (alias of 6)"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/aliases.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/aliases.test
@@ -1,0 +1,99 @@
+--TEST--
+Test aliased and aliasees remain untouched if either is required, but are still optimized away otherwise.
+
+--REQUEST--
+{
+    "require": {
+        "package/a": "^1.0",
+        "package/required-aliasof-and-alias": "dev-main-both",
+        "package/required-aliasof": "dev-main-direct",
+        "package/required-alias": "1.*"
+    }
+}
+
+
+--POOL-BEFORE--
+[
+    {
+        "name": "package/a",
+        "version": "1.0.0",
+        "require": {
+            "package/required-aliasof-and-alias": "^1.0"
+        }
+    },
+    {
+        "name": "package/required-aliasof-and-alias",
+        "version": "dev-main-both",
+        "extra": {
+            "branch-alias": {
+                "dev-main-both": "1.x-dev"
+            }
+        }
+    },
+    {
+        "name": "package/required-aliasof",
+        "version": "dev-main-direct",
+        "extra": {
+            "branch-alias": {
+                "dev-main-direct": "1.x-dev"
+            }
+        }
+    },
+    {
+        "name": "package/required-alias",
+        "version": "dev-main-alias",
+        "extra": {
+            "branch-alias": {
+                "dev-main-alias": "1.x-dev"
+            }
+        }
+    },
+    {
+        "name": "package/not-referenced",
+        "version": "dev-lonesome-pkg",
+        "extra": {
+            "branch-alias": {
+                "dev-lonesome-pkg": "1.x-dev"
+            }
+        }
+    }
+]
+
+
+--POOL-AFTER--
+[
+    {
+        "name": "package/a",
+        "version": "1.0.0",
+        "require": {
+            "package/b": "^1.0"
+        }
+    },
+    {
+        "name": "package/required-aliasof-and-alias",
+        "version": "dev-main-both",
+        "extra": {
+            "branch-alias": {
+                "dev-main-both": "1.x-dev"
+            }
+        }
+    },
+    {
+        "name": "package/required-aliasof",
+        "version": "dev-main-direct",
+        "extra": {
+            "branch-alias": {
+                "dev-main-direct": "1.x-dev"
+            }
+        }
+    },
+    {
+        "name": "package/required-alias",
+        "version": "dev-main-alias",
+        "extra": {
+            "branch-alias": {
+                "dev-main-alias": "1.x-dev"
+            }
+        }
+    }
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/basic-prefer-highest.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/basic-prefer-highest.test
@@ -1,0 +1,46 @@
+--TEST--
+Test filters irrelevant package "package/b" in version 1.0.0
+
+--REQUEST--
+{
+    "require": {
+        "package/a": "^1.0"
+    }
+}
+
+
+--POOL-BEFORE--
+[
+        {
+            "name": "package/a",
+            "version": "1.0.0",
+            "require": {
+                "package/b": "^1.0"
+            }
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.0"
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.1"
+        }
+]
+
+
+--POOL-AFTER--
+[
+        {
+            "name": "package/a",
+            "version": "1.0.0",
+            "require": {
+                "package/b": "^1.0"
+            }
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.1"
+        }
+]
+

--- a/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/basic-prefer-lowest.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/basic-prefer-lowest.test
@@ -1,0 +1,47 @@
+--TEST--
+Test filters irrelevant package "package/b" in version 1.0.1 because prefer-lowest
+
+--REQUEST--
+{
+    "require": {
+        "package/a": "^1.0"
+    },
+    "preferLowest": true
+}
+
+
+--POOL-BEFORE--
+[
+        {
+            "name": "package/a",
+            "version": "1.0.0",
+            "require": {
+                "package/b": "^1.0"
+            }
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.0"
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.1"
+        }
+]
+
+
+--POOL-AFTER--
+[
+        {
+            "name": "package/a",
+            "version": "1.0.0",
+            "require": {
+                "package/b": "^1.0"
+            }
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.0"
+        }
+]
+

--- a/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/conflict.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/conflict.test
@@ -1,0 +1,107 @@
+--TEST--
+We have to make sure, conflicts are considered in the grouping so we do not remove packages
+from the pool which might end up being part of the solution.
+
+--REQUEST--
+{
+    "require": {
+        "nesty/nest": "^1.0"
+    }
+}
+
+--POOL-BEFORE--
+[
+        {
+            "name": "nesty/nest",
+            "version": "1.0.0",
+            "require": {
+                "conflicter/pkg": "^1.0",
+                "victim/pkg": "^1 <1.2"
+            }
+        },
+        {
+            "name": "conflicter/pkg",
+            "version": "1.0.1",
+            "conflict": {
+                "victim/pkg": "1.1.0 || 1.1.1"
+            }
+        },
+        {
+            "name": "conflicter/pkg",
+            "version": "1.0.2",
+            "conflict": {
+                "victim/pkg": "1.1.1 || 1.1.2"
+            }
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.0.0"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.0.1"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.0.2"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.0"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.1"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.2"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.2.0"
+        }
+]
+
+
+--POOL-AFTER--
+[
+        {
+            "name": "nesty/nest",
+            "version": "1.0.0",
+            "require": {
+                "conflicter/pkg": "^1.0",
+                "victim/pkg": "^1 <1.2"
+            }
+        },
+        {
+            "name": "conflicter/pkg",
+            "version": "1.0.1",
+            "conflict": {
+                "victim/pkg": "1.1.0 || 1.1.1"
+            }
+        },
+        {
+            "name": "conflicter/pkg",
+            "version": "1.0.2",
+            "conflict": {
+                "victim/pkg": "1.1.2"
+            }
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.0.2"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.0"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.1"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.2"
+        }
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/conflict2.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/conflict2.test
@@ -1,0 +1,103 @@
+--TEST--
+We have to make sure, conflicts are considered in the grouping so we do not remove packages
+from the pool which might end up being part of the solution.
+
+--REQUEST--
+{
+    "require": {
+        "nesty/nest": "^1.0"
+    }
+}
+
+--POOL-BEFORE--
+[
+        {
+            "name": "nesty/nest",
+            "version": "1.0.0",
+            "require": {
+                "conflicter/pkg": "^1.0",
+                "victim/pkg": "^1 <1.2"
+            }
+        },
+        {
+            "name": "conflicter/pkg",
+            "version": "1.0.1",
+            "conflict": {
+                "victim/pkg": "1.1.0"
+            }
+        },
+        {
+            "name": "conflicter/pkg",
+            "version": "1.0.2",
+            "conflict": {
+                "victim/pkg": "1.1.2"
+            }
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.0.0"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.0.1"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.0.2"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.0"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.1"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.2"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.2.0"
+        }
+]
+
+
+--POOL-AFTER--
+[
+        {
+            "name": "nesty/nest",
+            "version": "1.0.0",
+            "require": {
+                "conflicter/pkg": "^1.0",
+                "victim/pkg": "^1 <1.2"
+            }
+        },
+        {
+            "name": "conflicter/pkg",
+            "version": "1.0.1",
+            "conflict": {
+                "victim/pkg": "1.1.0 || 1.1.1"
+            }
+        },
+        {
+            "name": "conflicter/pkg",
+            "version": "1.0.2",
+            "conflict": {
+                "victim/pkg": "1.1.2"
+            }
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.0"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.1"
+        },
+        {
+            "name": "victim/pkg",
+            "version": "1.1.2"
+        }
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/group-by-required.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/group-by-required.test
@@ -1,0 +1,99 @@
+--TEST--
+We are not allowed to group packages only by their dependency definition. It's also relevant what other
+packages require (package/b@1.0.1 must not be dropped although it has the very same definition as 2.0.0 and both are
+allowed by the request). However, package/b@1.0.0 can be removed.
+
+--REQUEST--
+{
+    "require": {
+        "package/a": "^1.0"
+    }
+}
+
+
+--POOL-BEFORE--
+[
+        {
+            "name": "package/a",
+            "version": "1.0.0",
+            "require": {
+                "package/b": "^1.0 || ^2.0"
+            }
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.0",
+            "require": {
+                "package/c": "^1.0"
+            }
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.1",
+            "require": {
+                "package/c": "^1.0"
+            }
+        },
+        {
+            "name": "package/b",
+            "version": "2.0.0",
+            "require": {
+                "package/c": "^1.0"
+            }
+        },
+        {
+            "name": "package/c",
+            "version": "1.0.0",
+            "require": {
+                "package/d": "^1.0"
+            }
+        },
+        {
+            "name": "package/d",
+            "version": "1.0.0",
+            "require": {
+                "package/b": ">=1.0 <1.1"
+            }
+        }
+]
+
+
+--POOL-AFTER--
+[
+        {
+             "name": "package/a",
+             "version": "1.0.0",
+             "require": {
+                 "package/b": "^1.0 || ^2.0"
+             }
+         },
+         {
+             "name": "package/b",
+             "version": "1.0.1",
+             "require": {
+                 "package/c": "^1.0"
+             }
+         },
+         {
+             "name": "package/b",
+             "version": "2.0.0",
+             "require": {
+                 "package/c": "^1.0"
+             }
+         },
+         {
+             "name": "package/c",
+             "version": "1.0.0",
+             "require": {
+                 "package/d": "^1.0"
+             }
+         },
+         {
+             "name": "package/d",
+             "version": "1.0.0",
+             "require": {
+                 "package/b": ">=1.0 <1.1"
+             }
+         }
+]
+

--- a/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/locked-fixed-untouched.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/locked-fixed-untouched.test
@@ -1,0 +1,46 @@
+--TEST--
+Test locked and fixed packages remain untouched.
+
+--REQUEST--
+{
+    "require": {
+    },
+    "locked": [
+        {
+            "name": "package/a",
+            "version": "1.0.0"
+        }
+    ],
+    "fixed": [
+        {
+            "name": "package/c",
+            "version": "2.0.0"
+        }
+    ]
+}
+
+
+--POOL-BEFORE--
+[
+    {
+        "name": "package/a",
+        "version": "1.0.0"
+    },
+    {
+        "name": "package/c",
+        "version": "2.0.0"
+    }
+]
+
+
+--POOL-AFTER--
+[
+    {
+        "name": "package/a",
+        "version": "1.0.0"
+    },
+    {
+        "name": "package/c",
+        "version": "2.0.0"
+    }
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/replaces.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/pooloptimizer/replaces.test
@@ -1,0 +1,59 @@
+--TEST--
+Test replaced packages are correctly removed.
+
+--REQUEST--
+{
+    "require": {
+        "package/a": "^1.0"
+    }
+}
+
+
+--POOL-BEFORE--
+[
+        {
+            "name": "package/a",
+            "version": "1.0.0",
+            "require": {
+                "package/b": "^1.0"
+            }
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.0",
+            "replace": {
+                "package/c": "^1.0"
+            }
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.1",
+            "replace": {
+                "package/c": "^1.0"
+            }
+        },
+        {
+            "name": "package/c",
+            "version": "1.0.0"
+        }
+]
+
+
+--POOL-AFTER--
+[
+        {
+            "name": "package/a",
+            "version": "1.0.0",
+            "require": {
+                "package/b": "^1.0"
+            }
+        },
+        {
+            "name": "package/b",
+            "version": "1.0.1",
+            "replace": {
+                "package/c": "^1.0"
+            }
+        }
+]
+

--- a/tests/Composer/Test/DependencyResolver/PoolOptimizerTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolOptimizerTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\DependencyResolver;
+
+use Composer\DependencyResolver\DefaultPolicy;
+use Composer\DependencyResolver\Pool;
+use Composer\DependencyResolver\PoolOptimizer;
+use Composer\DependencyResolver\Request;
+use Composer\Json\JsonFile;
+use Composer\Package\AliasPackage;
+use Composer\Package\BasePackage;
+use Composer\Package\Loader\ArrayLoader;
+use Composer\Package\Version\VersionParser;
+use Composer\Repository\LockArrayRepository;
+use Composer\Test\TestCase;
+
+class PoolOptimizerTest extends TestCase
+{
+    /**
+     * @dataProvider provideIntegrationTests
+     * @param mixed[] $requestData
+     * @param BasePackage[] $packagesBefore
+     * @param BasePackage[] $expectedPackages
+     * @param string $message
+     */
+    public function testPoolOptimizer(array $requestData, array $packagesBefore, array $expectedPackages, $message)
+    {
+        $lockedRepo = new LockArrayRepository();
+
+        $request = new Request($lockedRepo);
+        $parser = new VersionParser();
+
+        if (isset($requestData['locked'])) {
+            foreach ($requestData['locked'] as $package) {
+                $request->lockPackage($this->loadPackage($package));
+            }
+        }
+        if (isset($requestData['fixed'])) {
+            foreach ($requestData['fixed'] as $package) {
+                $request->fixPackage($this->loadPackage($package));
+            }
+        }
+
+        foreach ($requestData['require'] as $package => $constraint) {
+            $request->requireName($package, $parser->parseConstraints($constraint));
+        }
+
+        $preferStable = isset($requestData['preferStable']) ? $requestData['preferStable'] : false;
+        $preferLowest = isset($requestData['preferLowest']) ? $requestData['preferLowest'] : false;
+
+        $pool = new Pool($packagesBefore);
+        $poolOptimizer = new PoolOptimizer(new DefaultPolicy($preferStable, $preferLowest));
+
+        $pool = $poolOptimizer->optimize($request, $pool);
+
+        $this->assertSame(
+            $this->reducePackagesInfoForComparison($expectedPackages),
+            $this->reducePackagesInfoForComparison($pool->getPackages()),
+            $message
+        );
+    }
+
+    public function provideIntegrationTests()
+    {
+        $fixturesDir = realpath(__DIR__.'/Fixtures/pooloptimizer/');
+        $tests = array();
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($fixturesDir), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
+            if (!preg_match('/\.test$/', $file)) {
+                continue;
+            }
+
+            try {
+                $testData = $this->readTestFile($file, $fixturesDir);
+                $message = $testData['TEST'];
+                $requestData = JsonFile::parseJson($testData['REQUEST']);
+                $packagesBefore = $this->loadPackages(JsonFile::parseJson($testData['POOL-BEFORE']));
+                $expectedPackages = $this->loadPackages(JsonFile::parseJson($testData['POOL-AFTER']));
+
+            } catch (\Exception $e) {
+                die(sprintf('Test "%s" is not valid: '.$e->getMessage(), str_replace($fixturesDir.'/', '', $file)));
+            }
+
+            $tests[basename($file)] = array($requestData, $packagesBefore, $expectedPackages, $message);
+        }
+
+        return $tests;
+    }
+
+    /**
+     * @param  string $fixturesDir
+     * @return mixed[]
+     */
+    protected function readTestFile(\SplFileInfo $file, $fixturesDir)
+    {
+        $tokens = preg_split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file->getRealPath()), -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        /** @var array<string, bool> $sectionInfo */
+        $sectionInfo = array(
+            'TEST' => true,
+            'REQUEST' => true,
+            'POOL-BEFORE' => true,
+            'POOL-AFTER' => true,
+        );
+
+        $section = null;
+        $data = array();
+        foreach ($tokens as $i => $token) {
+            if (null === $section && empty($token)) {
+                continue; // skip leading blank
+            }
+
+            if (null === $section) {
+                if (!isset($sectionInfo[$token])) {
+                    throw new \RuntimeException(sprintf(
+                        'The test file "%s" must not contain a section named "%s".',
+                        str_replace($fixturesDir.'/', '', $file),
+                        $token
+                    ));
+                }
+                $section = $token;
+                continue;
+            }
+
+            $sectionData = $token;
+
+            $data[$section] = $sectionData;
+            $section = $sectionData = null;
+        }
+
+        foreach ($sectionInfo as $section => $required) {
+            if ($required && !isset($data[$section])) {
+                throw new \RuntimeException(sprintf(
+                    'The test file "%s" must have a section named "%s".',
+                    str_replace($fixturesDir.'/', '', $file),
+                    $section
+                ));
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param BasePackage[] $packages
+     * @return string[]
+     */
+    private function reducePackagesInfoForComparison(array $packages)
+    {
+        $packagesInfo = array();
+
+        foreach ($packages as $package) {
+            $packagesInfo[] = $package->getName() . '@' . $package->getVersion() . ($package instanceof AliasPackage ? ' (alias of '.$package->getAliasOf()->getVersion().')' : '');
+        }
+
+        sort($packagesInfo);
+
+        return $packagesInfo;
+    }
+
+    /**
+     * @param mixed[][] $packagesData
+     * @return BasePackage[]
+     */
+    private function loadPackages(array $packagesData)
+    {
+        $packages = array();
+
+        foreach ($packagesData as $packageData) {
+            $packages[] = $package = $this->loadPackage($packageData);
+            if ($package instanceof AliasPackage) {
+                $packages[] = $package->getAliasOf();
+            }
+        }
+
+        return $packages;
+    }
+
+    /**
+     * @param mixed[] $packageData
+     * @return BasePackage
+     */
+    private function loadPackage(array $packageData)
+    {
+        $loader = new ArrayLoader();
+        return $loader->load($packageData);
+    }
+}

--- a/tests/Composer/Test/Fixtures/installer/conflict-downgrade-nested.test
+++ b/tests/Composer/Test/Fixtures/installer/conflict-downgrade-nested.test
@@ -1,0 +1,39 @@
+--TEST--
+
+Test that a package which has a conflict does not get installed and has to be downgraded
+
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "nesty/nest", "version": "1.0.0", "require": {
+                    "conflicter/pkg": "^1.0",
+                    "victim/pkg": "^1 <1.2"
+                } },
+                { "name": "conflicter/pkg", "version": "1.0.1", "conflict": { "victim/pkg": "1.1.0"} },
+                { "name": "victim/pkg", "version": "1.0.0" },
+                { "name": "victim/pkg", "version": "1.0.1" },
+                { "name": "victim/pkg", "version": "1.0.2" },
+                { "name": "victim/pkg", "version": "1.1.0" },
+                { "name": "victim/pkg", "version": "1.2.0" }
+            ]
+        }
+    ],
+    "require": {
+        "nesty/nest": "*"
+    }
+}
+
+
+--RUN--
+update
+
+--EXPECT-EXIT-CODE--
+0
+
+--EXPECT--
+Installing victim/pkg (1.0.2)
+Installing conflicter/pkg (1.0.1)
+Installing nesty/nest (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/conflict-downgrade.test
+++ b/tests/Composer/Test/Fixtures/installer/conflict-downgrade.test
@@ -1,0 +1,35 @@
+--TEST--
+
+Test that a package which has a conflict does not get installed and has to be downgraded
+
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "conflicter/pkg", "version": "1.0.1", "conflict": { "victim/pkg": "1.1.0"} },
+                { "name": "victim/pkg", "version": "1.0.0" },
+                { "name": "victim/pkg", "version": "1.0.1" },
+                { "name": "victim/pkg", "version": "1.0.2" },
+                { "name": "victim/pkg", "version": "1.1.0" },
+                { "name": "victim/pkg", "version": "1.2.0" }
+            ]
+        }
+    ],
+    "require": {
+        "conflicter/pkg": "^1.0",
+        "victim/pkg": "^1 <1.2"
+    }
+}
+
+
+--RUN--
+update
+
+--EXPECT-EXIT-CODE--
+0
+
+--EXPECT--
+Installing conflicter/pkg (1.0.1)
+Installing victim/pkg (1.0.2)

--- a/tests/Composer/Test/Fixtures/installer/deduplicate-solver-problems.test
+++ b/tests/Composer/Test/Fixtures/installer/deduplicate-solver-problems.test
@@ -44,5 +44,14 @@ Your requirements could not be resolved to an installable set of packages.
     - package/a[2.0.0, ..., 2.6.0] require missing/dep ^1.0 -> found missing/dep[2.0.0] but it does not match the constraint.
     - Root composer.json requires package/a * -> satisfiable by package/a[2.0.0, ..., 2.6.0].
 
+--EXPECT-OUTPUT-OPTIMIZED--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires package/a * -> satisfiable by package/a[2.6.0].
+    - package/a 2.6.0 requires missing/dep ^1.0 -> found missing/dep[2.0.0] but it does not match the constraint.
+
 --EXPECT--
 

--- a/tests/Composer/Test/Fixtures/installer/deduplicate-solver-problems.test
+++ b/tests/Composer/Test/Fixtures/installer/deduplicate-solver-problems.test
@@ -11,15 +11,15 @@ Test the error output of solver problems is deduplicated.
                 { "name": "package/a", "version": "2.0.2", "require": { "missing/dep": "^1.0" } },
                 { "name": "package/a", "version": "2.0.3", "require": { "missing/dep": "^1.0" } },
                 { "name": "package/a", "version": "2.1.0", "require": { "missing/dep": "^1.0" } },
-                { "name": "package/a", "version": "2.2.0", "require": { "missing/dep": "^1.0" } },
-                { "name": "package/a", "version": "2.3.1", "require": { "missing/dep": "^1.0" } },
-                { "name": "package/a", "version": "2.3.2", "require": { "missing/dep": "^1.0" } },
-                { "name": "package/a", "version": "2.3.3", "require": { "missing/dep": "^1.0" } },
-                { "name": "package/a", "version": "2.3.4", "require": { "missing/dep": "^1.0" } },
-                { "name": "package/a", "version": "2.3.5", "require": { "missing/dep": "^1.0" } },
-                { "name": "package/a", "version": "2.4.0", "require": { "missing/dep": "^1.0" } },
-                { "name": "package/a", "version": "2.5.0", "require": { "missing/dep": "^1.0" } },
-                { "name": "package/a", "version": "2.6.0", "require": { "missing/dep": "^1.0" } },
+                { "name": "package/a", "version": "2.2.0", "require": { "missing/dep": "^1.1" } },
+                { "name": "package/a", "version": "2.3.1", "require": { "missing/dep": "^1.1" } },
+                { "name": "package/a", "version": "2.3.2", "require": { "missing/dep": "^1.1" } },
+                { "name": "package/a", "version": "2.3.3", "require": { "missing/dep": "^1.1" } },
+                { "name": "package/a", "version": "2.3.4", "require": { "missing/dep": "^1.1" } },
+                { "name": "package/a", "version": "2.3.5", "require": { "missing/dep": "^1.1" } },
+                { "name": "package/a", "version": "2.4.0", "require": { "missing/dep": "^1.1" } },
+                { "name": "package/a", "version": "2.5.0", "require": { "missing/dep": "^1.1" } },
+                { "name": "package/a", "version": "2.6.0", "require": { "missing/dep": "^1.1" } },
                 { "name": "missing/dep", "version": "2.0.0" }
             ]
         }
@@ -41,17 +41,9 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - package/a[2.0.0, ..., 2.6.0] require missing/dep ^1.0 -> found missing/dep[2.0.0] but it does not match the constraint.
+    - package/a[2.2.0, ..., 2.6.0] require missing/dep ^1.1 -> found missing/dep[2.0.0] but it does not match the constraint.
+    - package/a[2.0.0, ..., 2.1.0] require missing/dep ^1.0 -> found missing/dep[2.0.0] but it does not match the constraint.
     - Root composer.json requires package/a * -> satisfiable by package/a[2.0.0, ..., 2.6.0].
-
---EXPECT-OUTPUT-OPTIMIZED--
-Loading composer repositories with package information
-Updating dependencies
-Your requirements could not be resolved to an installable set of packages.
-
-  Problem 1
-    - Root composer.json requires package/a * -> satisfiable by package/a[2.6.0].
-    - package/a 2.6.0 requires missing/dep ^1.0 -> found missing/dep[2.0.0] but it does not match the constraint.
 
 --EXPECT--
 

--- a/tests/Composer/Test/Fixtures/installer/github-issues-7051.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-7051.test
@@ -137,11 +137,11 @@ Your requirements could not be resolved to an installable set of packages.
   Problem 1
     - Root composer.json requires illuminate/queue * -> satisfiable by illuminate/queue[v5.2.0].
     - illuminate/queue v5.2.0 requires illuminate/console 5.2.* -> satisfiable by illuminate/console[v5.2.25, v5.2.26].
-    - illuminate/console v5.2.25 requires symfony/console 3.1.* -> satisfiable by symfony/console[v3.1.10].
-    - illuminate/console v5.2.26 requires symfony/console 2.8.* -> satisfiable by symfony/console[v2.8.8].
-    - You can only install one version of a package, so only one of these can be installed: symfony/console[v2.8.8, v3.1.10, v3.4.29].
-    - friendsofphp/php-cs-fixer v2.10.5 requires symfony/console ^3.2 || ^4.0 -> satisfiable by symfony/console[v3.4.29].
-    - Root composer.json requires friendsofphp/php-cs-fixer * -> satisfiable by friendsofphp/php-cs-fixer[v2.10.5].
+    - illuminate/console v5.2.25 requires symfony/console 3.1.* -> satisfiable by symfony/console[v3.1.9, v3.1.10].
+    - illuminate/console v5.2.26 requires symfony/console 2.8.* -> satisfiable by symfony/console[v2.8.7, v2.8.8].
+    - You can only install one version of a package, so only one of these can be installed: symfony/console[v2.8.7, v2.8.8, v3.1.9, ..., v3.4.29].
+    - friendsofphp/php-cs-fixer[v2.10.4, ..., v2.10.5] require symfony/console ^3.2 || ^4.0 -> satisfiable by symfony/console[v3.2.13, ..., v3.4.29].
+    - Root composer.json requires friendsofphp/php-cs-fixer * -> satisfiable by friendsofphp/php-cs-fixer[v2.10.4, v2.10.5].
 
 --EXPECT--
 

--- a/tests/Composer/Test/Fixtures/installer/github-issues-7051.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-7051.test
@@ -128,6 +128,21 @@ Your requirements could not be resolved to an installable set of packages.
     - You can only install one version of a package, so only one of these can be installed: symfony/console[v2.8.7, v2.8.8, v3.1.9, ..., v3.4.29].
     - illuminate/console v5.2.25 requires symfony/console 3.1.* -> satisfiable by symfony/console[v3.1.9, v3.1.10].
     - Conclusion: don't install symfony/console v3.1.10 (conflict analysis result)
+
+--EXPECT-OUTPUT-OPTIMIZED--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires illuminate/queue * -> satisfiable by illuminate/queue[v5.2.0].
+    - illuminate/queue v5.2.0 requires illuminate/console 5.2.* -> satisfiable by illuminate/console[v5.2.25, v5.2.26].
+    - illuminate/console v5.2.25 requires symfony/console 3.1.* -> satisfiable by symfony/console[v3.1.10].
+    - illuminate/console v5.2.26 requires symfony/console 2.8.* -> satisfiable by symfony/console[v2.8.8].
+    - You can only install one version of a package, so only one of these can be installed: symfony/console[v2.8.8, v3.1.10, v3.4.29].
+    - friendsofphp/php-cs-fixer v2.10.5 requires symfony/console ^3.2 || ^4.0 -> satisfiable by symfony/console[v3.4.29].
+    - Root composer.json requires friendsofphp/php-cs-fixer * -> satisfiable by friendsofphp/php-cs-fixer[v2.10.5].
+
 --EXPECT--
 
 --EXPECT-EXIT-CODE--

--- a/tests/Composer/Test/Fixtures/installer/provider-conflicts3.test
+++ b/tests/Composer/Test/Fixtures/installer/provider-conflicts3.test
@@ -50,8 +50,8 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - Only one of these can be installed: regular/pkg[1.0.3], replacer/pkg[2.0.0, 2.0.1, 2.0.2, 2.0.3]. replacer/pkg replaces regular/pkg and thus cannot coexist with it.
-    - Root composer.json requires regular/pkg 1.* -> satisfiable by regular/pkg[1.0.3].
+    - Only one of these can be installed: regular/pkg[1.0.0, 1.0.1, 1.0.2, 1.0.3], replacer/pkg[2.0.0, 2.0.1, 2.0.2, 2.0.3]. replacer/pkg replaces regular/pkg and thus cannot coexist with it.
+    - Root composer.json requires regular/pkg 1.* -> satisfiable by regular/pkg[1.0.0, 1.0.1, 1.0.2, 1.0.3].
     - Root composer.json requires replacer/pkg 2.* -> satisfiable by replacer/pkg[2.0.0, 2.0.1, 2.0.2, 2.0.3].
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/provider-conflicts3.test
+++ b/tests/Composer/Test/Fixtures/installer/provider-conflicts3.test
@@ -44,5 +44,15 @@ Your requirements could not be resolved to an installable set of packages.
     - Root composer.json requires regular/pkg 1.* -> satisfiable by regular/pkg[1.0.0, 1.0.1, 1.0.2, 1.0.3].
     - Root composer.json requires replacer/pkg 2.* -> satisfiable by replacer/pkg[2.0.0, 2.0.1, 2.0.2, 2.0.3].
 
+--EXPECT-OUTPUT-OPTIMIZED--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Only one of these can be installed: regular/pkg[1.0.3], replacer/pkg[2.0.0, 2.0.1, 2.0.2, 2.0.3]. replacer/pkg replaces regular/pkg and thus cannot coexist with it.
+    - Root composer.json requires regular/pkg 1.* -> satisfiable by regular/pkg[1.0.3].
+    - Root composer.json requires replacer/pkg 2.* -> satisfiable by replacer/pkg[2.0.0, 2.0.1, 2.0.2, 2.0.3].
+
 --EXPECT--
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,8 @@
  * file that was distributed with this source code.
  */
 
+use Composer\Util\Platform;
+
 error_reporting(E_ALL);
 
 if (function_exists('date_default_timezone_set') && function_exists('date_default_timezone_get')) {
@@ -19,3 +21,5 @@ if (function_exists('date_default_timezone_set') && function_exists('date_defaul
 require __DIR__.'/../src/bootstrap.php';
 require __DIR__.'/../src/Composer/InstalledVersions.php';
 require __DIR__.'/Composer/Test/TestCase.php';
+
+Platform::putEnv('COMPOSER_TESTS_ARE_RUNNING', '1');

--- a/tests/deprecations-8.1.json
+++ b/tests/deprecations-8.1.json
@@ -75,9 +75,14 @@
         "count": 1
     },
     {
-        "location": "Composer\\Test\\InstallerTest::testIntegration",
+        "location": "Composer\\Test\\InstallerTest::testIntegrationWithRawPool",
         "message": "preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated",
-        "count": 1640
+        "count": 1728
+    },
+    {
+        "location": "Composer\\Test\\InstallerTest::testIntegrationWithPoolOptimizer",
+        "message": "preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated",
+        "count": 1728
     },
     {
         "location": "Composer\\Test\\Package\\Archiver\\ArchivableFilesFinderTest::testManualExcludes",


### PR DESCRIPTION
This PR optimizes the `Pool` before the rules are created and passed on to the `Solver`. Every package added to the pool results in an exponential increase of the number of rules the `Solver` has to analyze so the best we can do is to try to throw away all the packages that aren't of any interest early on.

I've implemented a new `PoolOptimizer` and set up a test framework to which we can add more optimizations in the future but the current implementation already provides **huge** benefits!

It works by early selecting the correct package based on the provided policy. It's common to have loads of bugfix releases that all have the same dependency definition. If you imagine e.g. `symfony/routing` in its `4.4` LTS branch, all of them hardly ever define new `require`, `replace`, `provide` or `conflict` definitions. Chances that `4.4.0` and `4.4.14` are the same, are really high and so we don't need to keep all of the package versions in between, we can drop the irrelevant ones depending on `--prefer-stable` and `--prefer-lowest`. There's a bit more to it and it's not just that simple but that's the basic idea behind the first optimization in the new `PoolOptimizer`.

And here are the **very promising** results:

Contao Managed Edition (https://github.com/contao/managed-edition/blob/master/composer.json):

|  | 1.10.13 | master@5df1797d2 | this PR |
|------|----------:|-----------------:|--------:|
| RAM | 3351.08MiB | 1518.31MiB | 134.54MiB |
| Time | 84s | 28.95s | 3.25s |

Magento (https://github.com/magento/magento2/blob/2.4-develop/composer.json):

|  | 1.10.13 | master@5df1797d2 | this PR |
|------|----------:|-----------------:|--------:|
| RAM | 961.86MiB | 169.64MiB | 46.39MiB |
| Time | 24.61s | 4.38s | 1.17s |

Laravel 7.x (https://github.com/laravel/laravel/blob/7.x/composer.json):

|  | 1.10.13 | master@5df1797d2 | this PR |
|------|----------:|-----------------:|--------:|
| RAM | 911.97MiB | 152.42MiB | 37.62MiB |
| Time | 8.81s | 1.51s | 0.95s |

Packagist (https://github.com/composer/packagist/blob/master/composer.json)

|  | 1.10.13 | master@5df1797d2 | this PR |
|------|----------:|-----------------:|--------:|
| RAM | 3308.18MiB | 1503.63MiB | 134.73M |
| Time | 51.63s | 14.9s | 4.04s |

Of course, the more complex the dependencies (or just the more dependencies in general) the higher the benefits of this PR.

I was too lazy to calculate the benefits in % but I guess we can summarize it like so: 🚀 

I'm off for a few days now so I might not be replying to questions quickly but would love to see others giving it a try and share some numbers :) 

For the lazy folks: Here's a precompiled phar (c996457a039b2f0a5eee3b6364dfce307c614737):

[composer.phar.zip](https://github.com/composer/composer/files/5484474/composer.phar.zip)

