### PR TITLE
Fix return typ of `OperationInterface::getReason`

### DIFF
--- a/src/Composer/DependencyResolver/Operation/OperationInterface.php
+++ b/src/Composer/DependencyResolver/Operation/OperationInterface.php
@@ -29,7 +29,7 @@ interface OperationInterface
     /**
      * Returns operation reason.
      *
-     * @return string
+     * @return string|null
      */
     public function getReason();
 

--- a/src/Composer/DependencyResolver/Operation/SolverOperation.php
+++ b/src/Composer/DependencyResolver/Operation/SolverOperation.php
@@ -26,7 +26,7 @@ abstract class SolverOperation implements OperationInterface
     /**
      * Initializes operation.
      *
-     * @param string $reason operation reason
+     * @param string|null $reason operation reason
      */
     public function __construct($reason = null)
     {
@@ -36,7 +36,7 @@ abstract class SolverOperation implements OperationInterface
     /**
      * Returns operation reason.
      *
-     * @return string
+     * @return string|null
      */
     public function getReason()
     {


### PR DESCRIPTION
Hey there,

I'd like to fix the return value of `OperationInterface::getReason` as it returned `null` in composer v1 already (in some cases, it also returned `GenericRule`...).
In v2, this method never returns anything else than `null` tho.

Would love to see this in composer v2.0.0. Thanks!