### PR TITLE
Version Guesser: Look at branches on remotes origin & upstream to look for version numbers too

### DIFF
--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -142,7 +142,7 @@ class VersionGuesser
                 }
 
                 if ($branch && !preg_match('{^ *.+/HEAD }', $branch)) {
-                    if (preg_match('{^(?:\* )? *((?:remotes/(?:origin|upstream)/)[^\s/]+) *([a-f0-9]+) .*$}', $branch, $match)) {
+                    if (preg_match('{^(?:\* )? *((?:remotes/(?:origin|upstream)/)?[^\s/]+) *([a-f0-9]+) .*$}', $branch, $match)) {
                         $branches[] = $match[1];
                     }
                 }

--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -118,7 +118,7 @@ class VersionGuesser
         $isDetached = false;
 
         // try to fetch current version from git branch
-        if (0 === $this->process->execute('git branch --no-color --no-abbrev -v', $output, $path)) {
+        if (0 === $this->process->execute('git branch -a --no-color --no-abbrev -v', $output, $path)) {
             $branches = array();
             $isFeatureBranch = false;
 
@@ -141,8 +141,8 @@ class VersionGuesser
                     }
                 }
 
-                if ($branch && !preg_match('{^ *[^/]+/HEAD }', $branch)) {
-                    if (preg_match('{^(?:\* )? *(\S+) *([a-f0-9]+) .*$}', $branch, $match)) {
+                if ($branch && !preg_match('{^ *.+/HEAD }', $branch)) {
+                    if (preg_match('{^(?:\* )? *((?:remotes/(?:origin|upstream)/)[^\s/]+) *([a-f0-9]+) .*$}', $branch, $match)) {
                         $branches[] = $match[1];
                     }
                 }
@@ -245,13 +245,14 @@ class VersionGuesser
             }
 
             foreach ($branches as $candidate) {
+                $candidateVersion = preg_replace('{^remotes/\S+/}', '', $candidate);
                 // return directly, if branch is configured to be non-feature branch
-                if ($candidate === $branch && preg_match('{^(' . $nonFeatureBranches . ')$}', $candidate)) {
+                if ($candidate === $branch && preg_match('{^(' . $nonFeatureBranches . ')$}', $candidateVersion)) {
                     break;
                 }
 
                 // do not compare against itself or other feature branches
-                if ($candidate === $branch || !preg_match('{^(' . $nonFeatureBranches . '|master|trunk|default|develop|\d+\..+)$}', $candidate, $match)) {
+                if ($candidate === $branch || !preg_match('{^(' . $nonFeatureBranches . '|master|trunk|default|develop|\d+\..+)$}', $candidateVersion, $match)) {
                     continue;
                 }
 
@@ -262,8 +263,11 @@ class VersionGuesser
 
                 if (strlen($output) < $length) {
                     $length = strlen($output);
-                    $version = $this->versionParser->normalizeBranch($candidate);
-                    $prettyVersion = 'dev-' . $match[1];
+                    $version = $this->versionParser->normalizeBranch($candidateVersion);
+                    $prettyVersion = 'dev-' . $candidateVersion;
+                    if ($length === 0) {
+                        break;
+                    }
                 }
             }
         }

--- a/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
@@ -137,7 +137,7 @@ class RootPackageLoaderTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* latest-production 38137d2f6c70e775e137b2d8a7a7d3eaebf7c7e5 Commit message\n  master 4f6ed96b0bc363d2aa4404c3412de1c011f67c66 Commit message\n";
 
                 return 0;
@@ -187,7 +187,7 @@ class RootPackageLoaderTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* latest-production 38137d2f6c70e775e137b2d8a7a7d3eaebf7c7e5 Commit message\n  master 4f6ed96b0bc363d2aa4404c3412de1c011f67c66 Commit message\n";
 
                 return 0;

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -48,7 +48,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at($step))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
 
                 return 128;
             })
@@ -116,7 +116,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self, $commitHash, $anotherCommitHash) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* master $commitHash Commit message\n(no branch) $anotherCommitHash Commit message\n";
 
                 return 0;
@@ -153,7 +153,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self, $commitHash, $anotherCommitHash) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "  arbitrary $commitHash Commit message\n* current $anotherCommitHash Another message\n";
 
                 return 0;
@@ -200,7 +200,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self, $commitHash, $anotherCommitHash) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "  latest-testing $commitHash Commit message\n* current $anotherCommitHash Another message\n";
 
                 return 0;
@@ -247,7 +247,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self, $commitHash, $anotherCommitHash) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* latest-testing $commitHash Commit message\n  current $anotherCommitHash Another message\n  master $anotherCommitHash Another message\n";
 
                 return 0;
@@ -282,7 +282,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self, $commitHash) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* (no branch) $commitHash Commit message\n";
 
                 return 0;
@@ -313,7 +313,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self, $commitHash) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* (HEAD detached at FETCH_HEAD) $commitHash Commit message\n";
 
                 return 0;
@@ -343,7 +343,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self, $commitHash) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* (HEAD detached at 03a15d220) $commitHash Commit message\n";
 
                 return 0;
@@ -372,7 +372,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* (HEAD detached at v2.0.5-alpha2) 433b98d4218c181bae01865901aac045585e8a1a Commit message\n";
 
                 return 0;
@@ -413,7 +413,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* (HEAD detached at 1.0.0) c006f0c12bbbf197b5c071ffb1c0e9812bb14a4d Commit message\n";
 
                 return 0;
@@ -455,7 +455,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* foo 03a15d220da53c52eddd5f32ffca64a7b3801bea Commit message\n";
 
                 return 0;
@@ -485,7 +485,7 @@ class VersionGuesserTest extends TestCase
             ->expects($this->at(0))
             ->method('execute')
             ->willReturnCallback(function ($command, &$output) use ($self) {
-                $self->assertEquals('git branch --no-color --no-abbrev -v', $command);
+                $self->assertEquals('git branch -a --no-color --no-abbrev -v', $command);
                 $output = "* 1.5 03a15d220da53c52eddd5f32ffca64a7b3801bea Commit message\n";
 
                 return 0;


### PR DESCRIPTION
Addresses https://github.com/composer/packagist/issues/1125 which previously only worked reliably when using a branch alias for git master.