### PR TITLE
Fix VcsRepositoryTest

### DIFF
--- a/tests/Composer/Test/Repository/VcsRepositoryTest.php
+++ b/tests/Composer/Test/Repository/VcsRepositoryTest.php
@@ -42,8 +42,8 @@ class VcsRepositoryTest extends TestCase
 
             return;
         }
-        if (!@mkdir(self::$gitRepo) || !@chdir(self::$gitRepo)) {
-            $this->skipped = 'Could not create and move into the temp git repo '.self::$gitRepo;
+        if (!@chdir(self::$gitRepo)) {
+            $this->skipped = 'Could not move into the temp git repo '.self::$gitRepo;
 
             return;
         }


### PR DESCRIPTION
`getUniqueTmpDirectory` already creates the directory, so that this mkdir is always false, preventing the tests from running.