### PR TITLE
Fixed a white-space typo

### DIFF
--- a/doc/articles/plugins.md
+++ b/doc/articles/plugins.md
@@ -223,7 +223,7 @@ class Plugin implements PluginInterface, Capable
 ### Command provider
 
 The [`Composer\Plugin\Capability\CommandProvider`][9] capability allows to register
-additional commands for Composer :
+additional commands for Composer:
 
 ```php
 <?php


### PR DESCRIPTION
A colon has been wrapped to a next line due to a redundant space.