### PR TITLE
Transaction: Define a total order on packages to keep behavior on PHP8

### DIFF
--- a/src/Composer/DependencyResolver/Transaction.php
+++ b/src/Composer/DependencyResolver/Transaction.php
@@ -61,8 +61,12 @@ class Transaction
     {
         $packageSort = function (PackageInterface $a, PackageInterface $b) {
             // sort alias packages by the same name behind their non alias version
-            if ($a->getName() == $b->getName() && $a instanceof AliasPackage != $b instanceof AliasPackage) {
-                return $a instanceof AliasPackage ? -1 : 1;
+            if ($a->getName() == $b->getName()) {
+                if ($a instanceof AliasPackage != $b instanceof AliasPackage) {
+                    return $a instanceof AliasPackage ? -1 : 1;
+                }
+                // if names are the same, compare version, e.g. to sort aliases reliably, actual order does not matter
+                return strcmp($b->getVersion(), $a->getVersion());
             }
             return strcmp($b->getName(), $a->getName());
         };

--- a/tests/Composer/Test/DependencyResolver/TransactionTest.php
+++ b/tests/Composer/Test/DependencyResolver/TransactionTest.php
@@ -58,8 +58,8 @@ class TransactionTest extends TestCase
             array('job' => 'update', 'from' => $packageB, 'to' => $packageBnew),
             array('job' => 'install', 'package' => $packageG),
             array('job' => 'install', 'package' => $packageF),
-            array('job' => 'markAliasInstalled', 'package' => $packageFalias1),
             array('job' => 'markAliasInstalled', 'package' => $packageFalias2),
+            array('job' => 'markAliasInstalled', 'package' => $packageFalias1),
             array('job' => 'install', 'package' => $packageD),
         );
 

--- a/tests/Composer/Test/Fixtures/installer/install-aliased-alias.test
+++ b/tests/Composer/Test/Fixtures/installer/install-aliased-alias.test
@@ -32,7 +32,7 @@ Installing double aliased package
 install
 --EXPECT--
 Installing b/b (dev-foo)
-Marking b/b (dev-master) as installed, alias of b/b (dev-foo)
 Marking b/b (1.0.x-dev) as installed, alias of b/b (dev-foo)
+Marking b/b (dev-master) as installed, alias of b/b (dev-foo)
 Installing a/a (dev-master)
 Marking a/a (9999999-dev) as installed, alias of a/a (dev-master)


### PR DESCRIPTION
So far the ordering of alias packages with the same name was undefined
so the actual order was determined by implementation of the sorting
algorithm in PHP. As of PHP8 sort is stable by default which changes the
outcome in some of our test cases.

With the fully defined total order the order can longer change depending
on sorting algorithm used and remains the same across PHP versions.