### PR TITLE
Fix availability of $urls in FileDownloader

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -142,6 +142,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
         $reject = null;
         $download = function () use ($io, $output, $httpDownloader, $cache, $cacheKeyGenerator, $eventDispatcher, $package, $fileName, &$urls, &$accept, &$reject) {
             $url = reset($urls);
+            $index = key($urls);
 
             if ($eventDispatcher) {
                 $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $httpDownloader, $url['processed'], 'package', $package);
@@ -153,6 +154,8 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
                 }
                 $url['processed'] = $preFileDownloadEvent->getProcessedUrl();
             }
+
+            $urls[$index] = $url;
 
             $checksum = $package->getDistSha1Checksum();
             $cacheKey = $url['cacheKey'];

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -12,7 +12,11 @@
 
 namespace Composer\Test\Downloader;
 
+use Composer\Config;
 use Composer\Downloader\FileDownloader;
+use Composer\EventDispatcher\EventDispatcher;
+use Composer\Plugin\PluginEvents;
+use Composer\Plugin\PreFileDownloadEvent;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Util\Http\Response;
@@ -136,6 +140,193 @@ class FileDownloaderTest extends TestCase
             ->method('get')
             ->with('vendor-dir')
             ->will($this->returnValue($path.'/vendor'));
+
+        try {
+            $loop = new Loop($this->httpDownloader);
+            $promise = $downloader->download($packageMock, $path);
+            $loop->wait(array($promise));
+
+            $this->fail('Download was expected to throw');
+        } catch (\Exception $e) {
+            if (is_dir($path)) {
+                $fs = new Filesystem();
+                $fs->removeDirectory($path);
+            } elseif (is_file($path)) {
+                unlink($path);
+            }
+
+            $this->assertInstanceOf('UnexpectedValueException', $e, $e->getMessage());
+            $this->assertStringContainsString('could not be saved to', $e->getMessage());
+        }
+    }
+
+    public function testDownloadWithCustomProcessedUrl()
+    {
+        $self = $this;
+
+        $path = $this->getUniqueTmpDirectory();
+        $config = new Config(false, $path);
+
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
+        $packageMock->expects($this->any())
+            ->method('getDistUrl')
+            ->will($this->returnValue('url'));
+        $packageMock->expects($this->any())
+            ->method('getDistUrls')
+            ->will($this->returnValue(array('url')));
+
+        $rootPackageMock = $this->getMockBuilder('Composer\Package\RootPackageInterface')->getMock();
+        $rootPackageMock->expects($this->any())
+            ->method('getScripts')
+            ->will($this->returnValue(array()));
+
+        $composerMock = $this->getMockBuilder('Composer\Composer')->getMock();
+        $composerMock->expects($this->any())
+            ->method('getPackage')
+            ->will($this->returnValue($rootPackageMock));
+        $composerMock->expects($this->any())
+            ->method('getConfig')
+            ->will($this->returnValue($config));
+
+        $expectedUrl      = 'foobar';
+        $expectedCacheKey = '/'.sha1($expectedUrl).'.';
+
+        $dispatcher = new EventDispatcher(
+            $composerMock,
+            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock()
+        );
+        $dispatcher->addListener(PluginEvents::PRE_FILE_DOWNLOAD, function ( PreFileDownloadEvent $event ) use ($expectedUrl) {
+            $event->setProcessedUrl($expectedUrl);
+        });
+
+        $cacheMock = $this->getMockBuilder('Composer\Cache')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $cacheMock
+            ->expects($this->any())
+            ->method('copyTo')
+            ->will($this->returnCallback(function ($cacheKey) use ($self, $expectedCacheKey) {
+                $self->assertEquals($expectedCacheKey, $cacheKey, 'Failed assertion on $cacheKey argument of Cache::copyTo method:');
+
+                return false;
+            }));
+        $cacheMock
+            ->expects($this->any())
+            ->method('copyFrom')
+            ->will($this->returnCallback(function ($cacheKey) use ($self, $expectedCacheKey) {
+                $self->assertEquals($expectedCacheKey, $cacheKey, 'Failed assertion on $cacheKey argument of Cache::copyFrom method:');
+
+                return false;
+            }));
+
+        $httpDownloaderMock = $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock();
+        $httpDownloaderMock
+            ->expects($this->any())
+            ->method('addCopy')
+            ->will($this->returnCallback(function ($url) use ($self, $expectedUrl) {
+                $self->assertEquals($expectedUrl, $url, 'Failed assertion on $url argument of HttpDownloader::addCopy method:');
+
+                return \React\Promise\resolve(
+                    new Response(array('url' => 'http://example.org/'), 200, array(), 'file~')
+                );
+            }));
+
+        $downloader = $this->getDownloader(null, $config, $dispatcher, $cacheMock, $httpDownloaderMock);
+
+        try {
+            $loop = new Loop($this->httpDownloader);
+            $promise = $downloader->download($packageMock, $path);
+            $loop->wait(array($promise));
+
+            $this->fail('Download was expected to throw');
+        } catch (\Exception $e) {
+            if (is_dir($path)) {
+                $fs = new Filesystem();
+                $fs->removeDirectory($path);
+            } elseif (is_file($path)) {
+                unlink($path);
+            }
+
+            $this->assertInstanceOf('UnexpectedValueException', $e, $e->getMessage());
+            $this->assertStringContainsString('could not be saved to', $e->getMessage());
+        }
+    }
+
+    public function testDownloadWithCustomCacheKey()
+    {
+        $self = $this;
+
+        $path = $this->getUniqueTmpDirectory();
+        $config = new Config(false, $path);
+
+        $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
+        $packageMock->expects($this->any())
+            ->method('getDistUrl')
+            ->will($this->returnValue('url'));
+        $packageMock->expects($this->any())
+            ->method('getDistUrls')
+            ->will($this->returnValue(array('url')));
+
+        $rootPackageMock = $this->getMockBuilder('Composer\Package\RootPackageInterface')->getMock();
+        $rootPackageMock->expects($this->any())
+            ->method('getScripts')
+            ->will($this->returnValue(array()));
+
+        $composerMock = $this->getMockBuilder('Composer\Composer')->getMock();
+        $composerMock->expects($this->any())
+            ->method('getPackage')
+            ->will($this->returnValue($rootPackageMock));
+        $composerMock->expects($this->any())
+            ->method('getConfig')
+            ->will($this->returnValue($config));
+
+        $expectedUrl      = 'url';
+        $customCacheKey   = 'xyzzy';
+        $expectedCacheKey = '/'.sha1($customCacheKey).'.';
+
+        $dispatcher = new EventDispatcher(
+            $composerMock,
+            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock()
+        );
+        $dispatcher->addListener(PluginEvents::PRE_FILE_DOWNLOAD, function ( PreFileDownloadEvent $event ) use ($customCacheKey) {
+            $event->setCustomCacheKey($customCacheKey);
+        });
+
+        $cacheMock = $this->getMockBuilder('Composer\Cache')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $cacheMock
+            ->expects($this->any())
+            ->method('copyTo')
+            ->will($this->returnCallback(function ($cacheKey) use ($self, $expectedCacheKey) {
+                $self->assertEquals($expectedCacheKey, $cacheKey, 'Failed assertion on $cacheKey argument of Cache::copyTo method:');
+
+                return false;
+            }));
+        $cacheMock
+            ->expects($this->any())
+            ->method('copyFrom')
+            ->will($this->returnCallback(function ($cacheKey) use ($self, $expectedCacheKey) {
+                $self->assertEquals($expectedCacheKey, $cacheKey, 'Failed assertion on $cacheKey argument of Cache::copyFrom method:');
+
+                return false;
+            }));
+
+        $httpDownloaderMock = $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock();
+        $httpDownloaderMock
+            ->expects($this->any())
+            ->method('addCopy')
+            ->will($this->returnCallback(function ($url) use ($self, $expectedUrl) {
+                $self->assertEquals($expectedUrl, $url, 'Failed assertion on $url argument of HttpDownloader::addCopy method:');
+
+                return \React\Promise\resolve(
+                    new Response(array('url' => 'http://example.org/'), 200, array(), 'file~')
+                );
+            }));
+
+        $downloader = $this->getDownloader(null, $config, $dispatcher, $cacheMock, $httpDownloaderMock);
 
         try {
             $loop = new Loop($this->httpDownloader);


### PR DESCRIPTION
Fixes #9220, as per [comment](https://github.com/composer/composer/pull/9220#issuecomment-709510751):

> The `$urls` variable is passed by reference to each callback (`$download`, `$accept`, `$reject`) but the manipulations, in `$download`, made to `$url` are done on a copy:
> 
> ```php
> $download = function () use ($io, $output, $httpDownloader, $cache, $cacheKeyGenerator, $eventDispatcher, $package, $fileName, &$urls, &$accept, &$reject) {
>     $url = reset($urls);
> ```
> 
> Once `$accept` is called, it still has the original dataset:
> 
> ```php
> $accept = function ($response) use ($cache, $package, $fileName, $self, &$urls) {
>     $url = reset($urls);
> ```

This pull request ensures the manipulated `$url` is reassigned back to `$urls` to be available to `$accept` and `$reject`.