### PR TITLE
MultiConflictRule conflict analysis handling on level 1 decisions

### DIFF
--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -465,35 +465,35 @@ class Solver
                     // only level 1 marks left
                     $l1num++;
                     $l1retry = true;
-                }
+                } else {
+                    $decision = $this->decisions->atOffset($decisionId);
+                    $rule = $decision[Decisions::DECISION_REASON];
 
-                $decision = $this->decisions->atOffset($decisionId);
-                $rule = $decision[Decisions::DECISION_REASON];
+                    if ($rule instanceof MultiConflictRule) {
+                        // there is only ever exactly one positive decision in a multiconflict rule
+                        foreach ($rule->getLiterals() as $literal) {
+                            if (!isset($seen[abs($literal)]) && $this->decisions->satisfy(-$literal)) {
+                                $this->learnedPool[\count($this->learnedPool) - 1][] = $rule;
+                                $l = $this->decisions->decisionLevel($literal);
+                                if (1 === $l) {
+                                    $l1num++;
+                                } elseif ($level === $l) {
+                                    $num++;
+                                } else {
+                                    // not level1 or conflict level, add to new rule
+                                    $learnedLiterals[] = $literal;
 
-                if ($rule instanceof MultiConflictRule) {
-                    // there is only ever exactly one positive decision in a multiconflict rule
-                    foreach ($rule->getLiterals() as $literal) {
-                        if (!isset($seen[abs($literal)]) && $this->decisions->satisfy(-$literal)) {
-                            $this->learnedPool[\count($this->learnedPool) - 1][] = $rule;
-                            $l = $this->decisions->decisionLevel($literal);
-                            if (1 === $l) {
-                                $l1num++;
-                            } elseif ($level === $l) {
-                                $num++;
-                            } else {
-                                // not level1 or conflict level, add to new rule
-                                $learnedLiterals[] = $literal;
-
-                                if ($l > $ruleLevel) {
-                                    $ruleLevel = $l;
+                                    if ($l > $ruleLevel) {
+                                        $ruleLevel = $l;
+                                    }
                                 }
+                                $seen[abs($literal)] = true;
+                                break;
                             }
-                            $seen[abs($literal)] = true;
-                            break;
                         }
-                    }
 
-                    $l1retry = true;
+                        $l1retry = true;
+                    }
                 }
             }
 

--- a/tests/Composer/Test/Fixtures/installer/github-issues-9290.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-9290.test
@@ -1,0 +1,96 @@
+--TEST--
+
+See Github issue #9290 ( https://github.com/composer/composer/issues/9290 ).
+MultiConflictRule with a level 1 decision needs to exit correctly.
+
+--COMPOSER--
+{
+    "require": {
+        "mailgun/mailgun-php": "^2.8"
+    },
+    "minimum-stability": "dev",
+    "repositories": {
+        "mailgun/mailgun-php": {
+            "type": "package",
+            "package": [
+                {
+                    "name": "mailgun/mailgun-php",
+                    "version": "2.x-dev",
+                    "type": "library",
+                    "require": {
+                        "php-http/httplug": "^1.0 || ^2.0",
+                        "php-http/client-common": "^1.1"
+                    }
+                }
+            ]
+        },
+        "php-http/client-common": {
+            "type": "package",
+            "package": [
+                {
+                    "name": "php-http/client-common",
+                    "version": "1.10.0",
+                    "type": "library",
+                    "require": {
+                        "php-http/httplug": "^1.1",
+                        "symfony/options-resolver": "^5.0"
+                    }
+                },
+                {
+                    "name": "php-http/client-common",
+                    "version": "1.x-dev",
+                    "type": "library",
+                    "require": {
+                        "php-http/httplug": "^1.1",
+                        "symfony/options-resolver": "^5.0"
+                    }
+                }
+            ]
+        },
+        "php-http/httplug": {
+            "type": "package",
+            "package": [
+                {
+                    "name": "php-http/httplug",
+                    "version": "v2.0.0",
+                    "type": "library"
+                },
+                {
+                    "name": "php-http/httplug",
+                    "version": "v1.1.0",
+                    "type": "library"
+                },
+                {
+                    "name": "php-http/httplug",
+                    "version": "dev-master",
+                    "type": "library",
+                    "extra": {
+                        "branch-alias": {
+                            "dev-master": "2.x-dev"
+                        }
+                    },
+                    "default-branch": true
+                }
+            ]
+        },
+        "symfony/options-resolver": {
+            "type": "package",
+            "package": [
+                {
+                    "name": "symfony/options-resolver",
+                    "version": "v5.2.0-BETA1",
+                    "type": "library"
+                }
+            ]
+        }
+    }
+}
+
+--RUN--
+update
+
+--EXPECT--
+Installing php-http/httplug (v1.1.0)
+Installing symfony/options-resolver (v5.2.0-BETA1)
+Installing php-http/client-common (1.x-dev)
+Installing mailgun/mailgun-php (2.x-dev)


### PR DESCRIPTION
Addresses https://github.com/composer/composer/issues/9290 which is also item 1 on https://github.com/composer/composer/issues/9294

After the fix in https://github.com/composer/composer/commit/851050e85c07f68ce0a0290fa53f6ed884751a6b it could now happen that $l1num gets incremented twice or $l1num and $num both got incremented for the same literal, which is not supposed to happen.