### PR TITLE
Test: Verify require for package provided or replaced by pkg itself is used

### DIFF
--- a/tests/Composer/Test/Fixtures/installer/provider-satisfies-its-own-requirement.test
+++ b/tests/Composer/Test/Fixtures/installer/provider-satisfies-its-own-requirement.test
@@ -1,0 +1,25 @@
+--TEST--
+Test that a package requiring something it provides itself, satisfies itself even though a package exists.
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "provided/pkg",
+                "version": "1.0.0"
+            }
+        }
+    ],
+    "require": {
+        "provided/pkg": "1.0.0"
+    },
+    "provide": {
+        "provided/pkg": "1.0.0"
+    }
+}
+
+--RUN--
+update
+
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/replacer-satisfies-its-own-requirement.test
+++ b/tests/Composer/Test/Fixtures/installer/replacer-satisfies-its-own-requirement.test
@@ -1,0 +1,25 @@
+--TEST--
+Test that a package requiring something it replaces itself, satisfies itself even though a package exists.
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "replaced/pkg",
+                "version": "1.0.0"
+            }
+        }
+    ],
+    "require": {
+        "replaced/pkg": "1.0.0"
+    },
+    "provide": {
+        "replaced/pkg": "1.0.0"
+    }
+}
+
+--RUN--
+update
+
+--EXPECT--


### PR DESCRIPTION
Asserts the behavior discussed in https://github.com/composer/composer/issues/9308 so it doesn't change in the future.