### PR TITLE
Fix support of provided packages in the why-not command

### DIFF
--- a/src/Composer/Repository/BaseRepository.php
+++ b/src/Composer/Repository/BaseRepository.php
@@ -146,6 +146,16 @@ abstract class BaseRepository implements RepositoryInterface
                         }
 
                         $version = new Constraint('=', $pkg->getVersion());
+
+                        if ($link->getTarget() !== $pkg->getName()) {
+                            foreach (array_merge($pkg->getReplaces(), $pkg->getProvides()) as $prov) {
+                                if ($link->getTarget() === $prov->getTarget()) {
+                                    $version = $prov->getConstraint();
+                                    break;
+                                }
+                            }
+                        }
+
                         if (!$link->getConstraint()->matches($version)) {
                             // if we have a root package (we should but can not guarantee..) we show
                             // the root requires as well to perhaps allow to find an issue there
@@ -157,6 +167,7 @@ abstract class BaseRepository implements RepositoryInterface
                                         continue 3;
                                     }
                                 }
+
                                 $results[] = array($package, $link, false);
                                 $results[] = array($rootPackage, new Link($rootPackage->getName(), $link->getTarget(), null, 'does not require', 'but ' . $pkg->getPrettyVersion() . ' is installed'), false);
                             } else {


### PR DESCRIPTION
The version provided by such a rule is defined by the constraint of the rule, not by the package version.

Closes #8415