### PR TITLE
Escape special characters in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### [2.0.0-RC1] 2020-09-10
 
   * Added more advanced filtering to avoid loading all versions of all referenced packages when resolving dependencies, which should reduce memory usage further in some cases
-  * Added support for many new lib-* packages in the platform repository and improved version detection for some ext-* and lib-* packages
+  * Added support for many new lib-\* packages in the platform repository and improved version detection for some ext-\* and lib-\* packages
   * Added an `--ask` flag to `create-project` command to make Composer prompt for the install dir name, [useful for project install instructions](https://github.com/composer/composer/pull/9181)
   * Added support for tar in artifact repositories
   * Added a `cache-read-only` config option to make the cache usable in read only mode for containers and such
@@ -212,7 +212,7 @@
   * Fixed archive command to persist file permissions inside the zip files
   * Fixed init/require command to avoid suggesting packages which are already selected in the search results
   * Fixed create-project UX issues
-  * Fixed filemtime for vendor/composer/* files is now only changing when the files actually change
+  * Fixed filemtime for vendor/composer/\* files is now only changing when the files actually change
   * Fixed issues detecting docker environment with an active open_basedir
 
 ### [1.9.3] 2020-02-04
@@ -222,7 +222,7 @@
 ### [1.9.2] 2020-01-14
 
   * Fixed minor git driver bugs
-  * Fixed schema validation for version field to allow dev-* versions too
+  * Fixed schema validation for version field to allow dev-\* versions too
   * Fixed external processes' output being formatted even though it should not
   * Fixed issue with path repositories when trying to install feature branches
 
@@ -523,7 +523,7 @@
   * Fixed dist downloads from Bitbucket
   * Fixed some regressions related to xdebug disabling
   * Fixed `--minor-only` flag in `outdated` command
-  * Fixed handling of config.platform.php which did not replace other php-* package's versions
+  * Fixed handling of config.platform.php which did not replace other php-\* package's versions
 
 ### [1.3.0] - 2016-12-24
 
@@ -945,7 +945,7 @@
   * Added a recommendation for package names to be `lower-cased/with-dashes`, it will be enforced for new packages on Pacakgist
   * Added `require` command to add a package to your requirements and install it
   * Added a whitelist to `update`. Calling `composer update foo/bar foo/baz` allows you to update only those packages
-  * Added support for overriding repositories in the system config (define repositories in ~/.composer/config.json)
+  * Added support for overriding repositories in the system config (define repositories in `~/.composer/config.json`)
   * Added `lib-*` packages to the platform repository, e.g. `lib-pcre` contains the pcre version
   * Added caching of GitHub metadata (faster startup time with custom GitHub VCS repos)
   * Added caching of SVN metadata (faster startup time with custom SVN VCS repos)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### [2.0.0-RC1] 2020-09-10
 
   * Added more advanced filtering to avoid loading all versions of all referenced packages when resolving dependencies, which should reduce memory usage further in some cases
-  * Added support for many new lib-\* packages in the platform repository and improved version detection for some ext-\* and lib-\* packages
+  * Added support for many new `lib-*` packages in the platform repository and improved version detection for some `ext-*` and `lib-*` packages
   * Added an `--ask` flag to `create-project` command to make Composer prompt for the install dir name, [useful for project install instructions](https://github.com/composer/composer/pull/9181)
   * Added support for tar in artifact repositories
   * Added a `cache-read-only` config option to make the cache usable in read only mode for containers and such
@@ -212,7 +212,7 @@
   * Fixed archive command to persist file permissions inside the zip files
   * Fixed init/require command to avoid suggesting packages which are already selected in the search results
   * Fixed create-project UX issues
-  * Fixed filemtime for vendor/composer/\* files is now only changing when the files actually change
+  * Fixed filemtime for `vendor/composer/*` files is now only changing when the files actually change
   * Fixed issues detecting docker environment with an active open_basedir
 
 ### [1.9.3] 2020-02-04
@@ -222,7 +222,7 @@
 ### [1.9.2] 2020-01-14
 
   * Fixed minor git driver bugs
-  * Fixed schema validation for version field to allow dev-\* versions too
+  * Fixed schema validation for version field to allow `dev-*` versions too
   * Fixed external processes' output being formatted even though it should not
   * Fixed issue with path repositories when trying to install feature branches
 
@@ -523,7 +523,7 @@
   * Fixed dist downloads from Bitbucket
   * Fixed some regressions related to xdebug disabling
   * Fixed `--minor-only` flag in `outdated` command
-  * Fixed handling of config.platform.php which did not replace other php-\* package's versions
+  * Fixed handling of config.platform.php which did not replace other `php-*` package's versions
 
 ### [1.3.0] - 2016-12-24
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -5,7 +5,7 @@
 - The new platform-check feature means that Composer checks the runtime PHP version and available extensions to ensure they match the project dependencies. If a mismatch is found, it exits with error details to make sure problems are not overlooked. To avoid issues when deploying to production it is recommended to run `composer check-platform-reqs` with the production PHP process as part of your build or deployment process.
 - If a package exists in a higher priority repository, it will now be entirely ignored in lower priority repositories. See [repository priorities](https://getcomposer.org/repoprio) for details.
 - Invalid PSR-0 / PSR-4 class configurations will not autoload anymore in optimized-autoloader mode, as per the warnings introduced in 1.10
-- On linux systems supporting the XDG Base Directory Specification, Composer will now prefer using XDG_CONFIG_DIR/composer over ~/.composer if both are available (1.x used ~/.composer first)
+- On linux systems supporting the XDG Base Directory Specification, Composer will now prefer using XDG_CONFIG_DIR/composer over `~/.composer` if both are available (1.x used `~/.composer` first)
 - Package names now must comply to our [naming guidelines](doc/04-schema.md#name) or Composer will abort, as per the warnings introduced in 1.8.1
 - Deprecated --no-suggest flag as it is not needed anymore
 - PEAR support (repository, downloader, etc.) has been removed
@@ -55,7 +55,7 @@
 #### Composer v1
 
 - Composer resolves dependencies (dispatching PRE/POST_DEPENDENCIES_SOLVING)
-- It then iterates over all packages one by one (dispatching PRE_PACKAGE_INSTALL/UPDATE/UNINSTALL, then PRE_FILE_DOWNLOAD if needed, then POST_PACKAGE_*)
+- It then iterates over all packages one by one (dispatching PRE_PACKAGE_INSTALL/UPDATE/UNINSTALL, then PRE_FILE_DOWNLOAD if needed, then POST_PACKAGE_\*)
 - And finally writes the lock file at the end
 
 #### Composer v2
@@ -71,7 +71,7 @@ Install then does:
 
 - Dispatches PRE_OPERATIONS_EXEC with the full list of operations to be executed
 - Downloads all the packages not in cache yet in parallel (dispatching PRE_FILE_DOWNLOAD for those not in cache yet)
-- It then iterates over all packages and executes updates/installs/uninstalls in parallel (dispatching PRE_PACKAGE_INSTALL/UPDATE/UNINSTALL then POST_PACKAGE_* but one package started last may finish installing before another is done for example).
+- It then iterates over all packages and executes updates/installs/uninstalls in parallel (dispatching PRE_PACKAGE_INSTALL/UPDATE/UNINSTALL then POST_PACKAGE_\* but one package started last may finish installing before another is done for example).
 
 ## For Composer repository implementors
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -433,7 +433,7 @@ including their current and latest versions. This is basically an alias for
 The color coding is as such:
 
 - **green (=)**: Dependency is in the latest version and is up to date.
-- **yellow (\~)**: Dependency has a new version available that includes backwards compatibility breaks according to semver, so upgrade when
+- **yellow (`~`)**: Dependency has a new version available that includes backwards compatibility breaks according to semver, so upgrade when
   you can but it may involve work.
 - **red (!)**: Dependency has a new version that is semver-compatible and you should upgrade it.
 
@@ -658,7 +658,7 @@ See the [Config](06-config.md) chapter for valid configuration options.
   option this lists the global configuration only.
 * **--file="..." (-f):** Operate on a specific file instead of composer.json. Note
   that this cannot be used in conjunction with the `--global` option.
-* **--absolute:** Returns absolute paths when fetching \*-dir config values
+* **--absolute:** Returns absolute paths when fetching `*-dir` config values
   instead of relative.
 * **--json:** JSON decode the setting value, to be used with `extra.*` keys.
 * **--merge:** Merge the setting value with the current value, to be used with `extra.*` keys in combination with `--json`.

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -433,7 +433,7 @@ including their current and latest versions. This is basically an alias for
 The color coding is as such:
 
 - **green (=)**: Dependency is in the latest version and is up to date.
-- **yellow (~)**: Dependency has a new version available that includes backwards compatibility breaks according to semver, so upgrade when
+- **yellow (\~)**: Dependency has a new version available that includes backwards compatibility breaks according to semver, so upgrade when
   you can but it may involve work.
 - **red (!)**: Dependency has a new version that is semver-compatible and you should upgrade it.
 
@@ -658,7 +658,7 @@ See the [Config](06-config.md) chapter for valid configuration options.
   option this lists the global configuration only.
 * **--file="..." (-f):** Operate on a specific file instead of composer.json. Note
   that this cannot be used in conjunction with the `--global` option.
-* **--absolute:** Returns absolute paths when fetching *-dir config values
+* **--absolute:** Returns absolute paths when fetching \*-dir config values
   instead of relative.
 * **--json:** JSON decode the setting value, to be used with `extra.*` keys.
 * **--merge:** Merge the setting value with the current value, to be used with `extra.*` keys in combination with `--json`.

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -621,7 +621,7 @@ variables are parsed in both Windows and Linux/Mac notations. For example
 `/home/<username>/git/mypackage`, equivalent to `$HOME/git/mypackage` or
 `%USERPROFILE%/git/mypackage`.
 
-> **Note:** Repository paths can also contain wildcards like ``*`` and ``?``.
+> **Note:** Repository paths can also contain wildcards like `*` and `?`.
 > For details, see the [PHP glob function](https://php.net/glob).
 
 ## Disabling Packagist.org

--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -102,10 +102,10 @@ section or directly in the repository definition.
 
 > **Note:** Using the command line environment variable method also has security implications.
 > These credentials will most likely be stored in memory,
-> and on be persisted to a file like ```~/.bash_history```(linux) or ```ConsoleHost_history.txt```
+> and on be persisted to a file like `~/.bash_history`(linux) or `ConsoleHost_history.txt`
 > (PowerShell on Windows) when closing a session.
 
-The final option to supply Composer with credentials is to use the ```COMPOSER_AUTH``` environment variable.
+The final option to supply Composer with credentials is to use the `COMPOSER_AUTH` environment variable.
 These variables can be either passed as command line variables or set in actual environment variables.
 Read more about the usage of this environment variable [here](../03-cli.md#COMPOSER_AUTH).
 
@@ -221,7 +221,7 @@ composer config [--global] --editor --auth
 > **Note:** For the gitlab authentication to work on private gitlab instances, the
 > [`gitlab-domains`](../06-config.md#gitlab-domains) section should also contain the url.
 
-When creating a gitlab token manually, make sure it has either the ```read_api``` or ```api``` scope.
+When creating a gitlab token manually, make sure it has either the `read_api` or `api` scope.
 
 ### Command line gitlab-token
 
@@ -245,7 +245,7 @@ composer config [--global] --editor --auth
 
 ## github-oauth
 
-To create a new access token, head to your [token settings section on Github](https://github.com/settings/tokens) and [generate a new token](https://github.com/settings/tokens/new). For public repositories when rate limited, the ```public_repo``` scope is required, for private repositories the ```repo:status``` scope is needed.
+To create a new access token, head to your [token settings section on Github](https://github.com/settings/tokens) and [generate a new token](https://github.com/settings/tokens/new). For public repositories when rate limited, the `public_repo` scope is required, for private repositories the `repo:status` scope is needed.
 Read more about it [here](https://github.com/blog/1509-personal-api-tokens).
 
 ### Command line github-oauth

--- a/doc/articles/versions.md
+++ b/doc/articles/versions.md
@@ -126,7 +126,7 @@ with a wildcard. For example `1.0 - 2.0` is equivalent to `>=1.0.0 <2.1` as the
 
 Example: `1.0 - 2.0`
 
-### Wildcard Version Range (.*)
+### Wildcard Version Range (.\*)
 
 You can specify a pattern with a `*` wildcard. `1.0.*` is the equivalent of
 `>=1.0 <1.1`.
@@ -135,7 +135,7 @@ Example: `1.0.*`
 
 ## Next Significant Release Operators
 
-### Tilde Version Range (~)
+### Tilde Version Range (\~)
 
 The `~` operator is best explained by example: `~1.2` is equivalent to
 `>=1.2 <2.0.0`, while `~1.2.3` is equivalent to `>=1.2.3 <1.3.0`. As you can see

--- a/doc/articles/versions.md
+++ b/doc/articles/versions.md
@@ -126,7 +126,7 @@ with a wildcard. For example `1.0 - 2.0` is equivalent to `>=1.0.0 <2.1` as the
 
 Example: `1.0 - 2.0`
 
-### Wildcard Version Range (.\*)
+### Wildcard Version Range (`.*`)
 
 You can specify a pattern with a `*` wildcard. `1.0.*` is the equivalent of
 `>=1.0 <1.1`.
@@ -135,7 +135,7 @@ Example: `1.0.*`
 
 ## Next Significant Release Operators
 
-### Tilde Version Range (\~)
+### Tilde Version Range (`~`)
 
 The `~` operator is best explained by example: `~1.2` is equivalent to
 `>=1.2 <2.0.0`, while `~1.2.3` is equivalent to `>=1.2.3 <1.3.0`. As you can see

--- a/doc/fixtures/fixtures.md
+++ b/doc/fixtures/fixtures.md
@@ -13,10 +13,9 @@ also be used as (initial) fixtures for tests.
 All these repositories contain the following packages.
 
 * `foo/bar` versions 1.0.0, 1.0.1 and 1.1.0; dev-default and 1.0.x-dev branches.
-   On dev-default and in 1.1.0, `bar/baz` ~1.0 is required.
+   On dev-default and in 1.1.0, `bar/baz` \~1.0 is required.
 * `qux/quux` only has a dev-default branch. It `replace`s `gar/nix`.
 * `gar/nix` has a 1.0.0 version and a dev-default branch. It is being replaced
    by `qux/quux`.
 * `bar/baz` has a 1.0.0 version and 1.0.x-dev as well as dev-default branches.
    Additionally, 1.1.x-dev is a branch alias for dev-default.
-

--- a/doc/fixtures/fixtures.md
+++ b/doc/fixtures/fixtures.md
@@ -12,10 +12,10 @@ also be used as (initial) fixtures for tests.
 
 All these repositories contain the following packages.
 
-* `foo/bar` versions 1.0.0, 1.0.1 and 1.1.0; dev-default and 1.0.x-dev branches.
-   On dev-default and in 1.1.0, `bar/baz` \~1.0 is required.
-* `qux/quux` only has a dev-default branch. It `replace`s `gar/nix`.
-* `gar/nix` has a 1.0.0 version and a dev-default branch. It is being replaced
+* `foo/bar` versions `1.0.0`, `1.0.1` and `1.1.0`; `dev-default` and `1.0.x-dev` branches.
+   On `dev-default` and in `1.1.0`, `bar/baz` `~1.0` is required.
+* `qux/quux` only has a `dev-default` branch. It `replace`s `gar/nix`.
+* `gar/nix` has a `1.0.0` version and a `dev-default` branch. It is being replaced
    by `qux/quux`.
-* `bar/baz` has a 1.0.0 version and 1.0.x-dev as well as dev-default branches.
-   Additionally, 1.1.x-dev is a branch alias for dev-default.
+* `bar/baz` has a `1.0.0` version and `1.0.x-dev` as well as `dev-default` branches.
+   Additionally, `1.1.x-dev` is a branch alias for `dev-default`.


### PR DESCRIPTION
Some characters in Markdown have special meaning and should be escaped if used in text.

<details><summary>Example</summary>

This screen-shot was taken from https://getcomposer.org/changelog/2.0.0-RC1 at time of authorship. Note the second bullet has some unintentionally-emphasised text.

![Screenshot_2020-10-24_11-53-45](https://user-images.githubusercontent.com/334786/97079934-b308d680-15ef-11eb-9710-227f0333f992.png)

</details>