### PR TITLE
Improve proxy error messages for streams

### DIFF
--- a/src/Composer/Exception/NoSslException.php
+++ b/src/Composer/Exception/NoSslException.php
@@ -13,6 +13,8 @@
 namespace Composer\Exception;
 
 /**
+ * Specific exception for Composer\Util\HttpDownloader creation.
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 class NoSslException extends \RuntimeException

--- a/tests/Composer/Test/Util/StreamContextFactoryTest.php
+++ b/tests/Composer/Test/Util/StreamContextFactoryTest.php
@@ -226,6 +226,10 @@ class StreamContextFactoryTest extends TestCase
 
     public function testInitOptionsForCurlDoesNotIncludeProxyAuthHeaders()
     {
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped('The curl is not available.');
+        }
+
         $_SERVER['http_proxy'] = 'http://username:password@proxyserver.net:3128/';
 
         $options = array();


### PR DESCRIPTION
I got my logic wrong, so this needs fixing. The exception messages have also been improved (hopefully).

Previously, this threw a RuntimeException but I changed it to a TransportException to match what I was using for secure-proxy >https not being supported natively.

However, there is also a NoSslException, which looks like it is only specifically used when the application first runs. So what should I be using for no openssl situations?

Also, I could add tests for this, but it seems a bit pointless unless the tests explicity run without openssl. What should I do.