### PR TITLE
Correctly avoid partial updates in require commands

### DIFF
--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -314,7 +314,7 @@ EOT
 
         // if no lock is present, or the file is brand new, we do not do a
         // partial update as this is not supported by the Installer
-        if (!$this->firstRequire && $composer->getConfig()->get('lock')) {
+        if (!$this->firstRequire && $composer->getLocker()->isLocked()) {
             $install->setUpdateAllowList(array_keys($requirements));
         }
 


### PR DESCRIPTION
The installer does not support partial updates, when
no lock file is present. The check in require command
to prevent a partial update however does not check whether
a lock file is present, but whether a lock file should be written,
which most likely always is true.

This check is now changed to check if a lock file is actually present.