### PR TITLE
Document availability of self-update command

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -607,6 +607,9 @@ you may have to run the command with `root` privileges
 sudo -H composer self-update
 ```
 
+If Composer was not installed as a PHAR, this command is not available.
+(This is sometimes the case when Composer was installed by an operating system package manager.)
+
 ### Options
 
 * **--rollback (-r):** Rollback to the last version you had installed.


### PR DESCRIPTION
The self-update command is only available when running as a PHAR (see commit 761ad6d171); notably, it is not defined in the Ubuntu package.

![Screenshot from 2020-10-26 13-04-07](https://user-images.githubusercontent.com/2346599/97170310-c3ee4f00-178b-11eb-8038-6b8c73512b0d.png)
