### PR TITLE
Fix PHPDoc return type for BaseCommand::getComposer

### DIFF
--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -50,7 +50,7 @@ abstract class BaseCommand extends Command
      * @param  bool              $required
      * @param  bool|null         $disablePlugins
      * @throws \RuntimeException
-     * @return Composer|null
+     * @return Composer
      */
     public function getComposer($required = true, $disablePlugins = null)
     {


### PR DESCRIPTION
The `null` will never be returned, if the Composer instance cannot be created then exception will be thrown.

Because of type `Composer|null` PHPStan return an error:

> Cannot call method getConfig() on Composer\Composer|null.

_I imagine in the future (after dropping PHP 5 support) wrong PHPDoc type can result in the wrong return type._
