### PR TITLE
PoolBuilder: Ensure versions matching locked constraints get loaded

### DIFF
--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -271,7 +271,7 @@ class Problem
                 return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose).' in lock file but not in remote repositories, make sure you avoid updating this package to keep the one from lock file.');
             }
 
-            return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose).' but '.(self::hasMultipleNames($packages) ? 'these conflict' : 'it conflicts').' with another require.');
+            return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose).' but these were not loaded, likely because '.(self::hasMultipleNames($packages) ? 'they conflict' : 'it conflicts').' with another require.');
         }
 
         // check if the package is found when bypassing stability checks

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
@@ -1,0 +1,47 @@
+--TEST--
+Unlocking a package also unlocks its dependencies when transitive deps are true. But version constraints from other
+locked packages still need to be taking into account for loading all necessary versions of these transitive deps.
+
+--REQUEST--
+{
+    "require": {
+        "root/req1": "*",
+        "root/req2": "*"
+    },
+    "locked": [
+        {"name": "root/req1", "version": "1.0.0", "require": {"dep/pkg1": "1.*"}},
+        {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg2": "1.*"}},
+        {"name": "dep/pkg1", "version": "1.0.0"},
+        {"name": "dep/pkg2", "version": "1.0.0"}
+    ],
+    "allowList": [
+        "dep/pkg2"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name": "root/req1", "version": "1.0.0", "require": {"dep/pkg1": "1.*"}},
+        {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg2": "1.*"}},
+        {"name": "dep/pkg1", "version": "1.0.0"},
+        {"name": "dep/pkg1", "version": "2.0.0"},
+        {"name": "dep/pkg2", "version": "1.0.0"},
+        {"name": "dep/pkg2", "version": "1.2.0", "require": {"dep/pkg1": "2.*"}}
+    ]
+]
+
+--EXPECT--
+[
+    "root/req1-1.0.0.0 (locked)",
+    "root/req2-1.0.0.0 (locked)",
+    "dep/pkg2-1.0.0.0",
+    "dep/pkg2-1.2.0.0",
+    "dep/pkg1-1.0.0.0",
+    "dep/pkg1-2.0.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
@@ -11,7 +11,7 @@ locked packages still need to be taking into account for loading all necessary v
     "locked": [
         {"name": "root/req1", "version": "1.0.0", "require": {"dep/pkg1": "1.*"}},
         {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg2": "1.*"}},
-        {"name": "dep/pkg1", "version": "1.0.0"},
+        {"name": "dep/pkg1", "version": "1.0.0", "author": "old"},
         {"name": "dep/pkg2", "version": "1.0.0"}
     ],
     "allowList": [
@@ -29,7 +29,8 @@ locked packages still need to be taking into account for loading all necessary v
     [
         {"name": "root/req1", "version": "1.0.0", "require": {"dep/pkg1": "1.*"}},
         {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg2": "1.*"}},
-        {"name": "dep/pkg1", "version": "1.0.0"},
+        {"name": "dep/pkg1", "version": "1.0.0", "author": "new"},
+        {"name": "dep/pkg1", "version": "1.0.1"},
         {"name": "dep/pkg1", "version": "2.0.0"},
         {"name": "dep/pkg2", "version": "1.0.0"},
         {"name": "dep/pkg2", "version": "1.2.0", "require": {"dep/pkg1": "2.*"}}
@@ -43,5 +44,6 @@ locked packages still need to be taking into account for loading all necessary v
     "dep/pkg2-1.0.0.0",
     "dep/pkg2-1.2.0.0",
     "dep/pkg1-1.0.0.0",
+    "dep/pkg1-1.0.1.0",
     "dep/pkg1-2.0.0.0"
 ]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
@@ -32,6 +32,7 @@ locked packages still need to be taking into account for loading all necessary v
         {"name": "dep/pkg1", "version": "1.0.0", "author": "new"},
         {"name": "dep/pkg1", "version": "1.0.1"},
         {"name": "dep/pkg1", "version": "2.0.0"},
+        {"name": "dep/pkg1", "version": "3.0.0"},
         {"name": "dep/pkg2", "version": "1.0.0"},
         {"name": "dep/pkg2", "version": "1.2.0", "require": {"dep/pkg1": "2.*"}}
     ]

--- a/tests/Composer/Test/Fixtures/installer/partial-update-keeps-older-dep-if-still-required-with-provide.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-keeps-older-dep-if-still-required-with-provide.test
@@ -1,0 +1,65 @@
+--TEST--
+Ensure that a partial update of a dependency does not conflict if the only way to proceed is using an old locked version.
+
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {"name": "root/req1", "version": "1.0.0", "require": {"virtual/pkg1": "1.*"}},
+                {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg2": "1.*", "dep/pkg1": "*"}},
+                {"name": "dep/pkg1", "version": "1.0.0", "provide": {"virtual/pkg1": "1.0.0"}},
+                {"name": "dep/pkg1", "version": "2.0.0"},
+                {"name": "dep/pkg2", "version": "1.0.0"},
+                {"name": "dep/pkg2", "version": "1.0.1"},
+                {"name": "dep/pkg2", "version": "1.2.0", "require": {"virtual/pkg1": "2.*"}}
+            ]
+        }
+    ],
+    "require": {
+        "root/req1": "*",
+        "root/req2": "*"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        {"name": "dep/pkg1", "version": "1.0.0", "type": "library", "provide": {"virtual/pkg1": "1.0.0"}},
+        {"name": "dep/pkg2", "version": "1.0.0", "type": "library"},
+        {"name": "root/req1", "version": "1.0.0", "require": {"virtual/pkg1": "1.*"}, "type": "library"},
+        {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg2": "1.*", "dep/pkg1": "*"}, "type": "library"}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--RUN--
+update dep/pkg2 --with-dependencies
+--EXPECT-LOCK--
+{
+    "packages": [
+        {"name": "dep/pkg1", "version": "1.0.0", "type": "library", "provide": {"virtual/pkg1": "1.0.0"}},
+        {"name": "dep/pkg2", "version": "1.0.1", "type": "library"},
+        {"name": "root/req1", "version": "1.0.0", "require": {"virtual/pkg1": "1.*"}, "type": "library"},
+        {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg2": "1.*", "dep/pkg1": "*"}, "type": "library"}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--EXPECT--
+Installing dep/pkg1 (1.0.0)
+Installing root/req1 (1.0.0)
+Installing dep/pkg2 (1.0.1)
+Installing root/req2 (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/partial-update-keeps-older-dep-if-still-required.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-keeps-older-dep-if-still-required.test
@@ -1,0 +1,65 @@
+--TEST--
+Ensure that a partial update of a dependency does not conflict if the only way to proceed is using an old locked version.
+
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {"name": "root/req1", "version": "1.0.0", "require": {"dep/pkg1": "1.*"}},
+                {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg2": "1.*"}},
+                {"name": "dep/pkg1", "version": "1.0.0"},
+                {"name": "dep/pkg1", "version": "2.0.0"},
+                {"name": "dep/pkg2", "version": "1.0.0"},
+                {"name": "dep/pkg2", "version": "1.0.1"},
+                {"name": "dep/pkg2", "version": "1.2.0", "require": {"dep/pkg1": "2.*"}}
+            ]
+        }
+    ],
+    "require": {
+        "root/req1": "*",
+        "root/req2": "*"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        {"name": "dep/pkg1", "version": "1.0.0", "type": "library"},
+        {"name": "dep/pkg2", "version": "1.0.1", "type": "library"},
+        {"name": "root/req1", "version": "1.0.0", "require": {"dep/pkg1": "1.*"}, "type": "library"},
+        {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg2": "1.*"}, "type": "library"}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--RUN--
+update dep/pkg2 --with-dependencies
+--EXPECT-LOCK--
+{
+    "packages": [
+        {"name": "dep/pkg1", "version": "1.0.0", "type": "library"},
+        {"name": "dep/pkg2", "version": "1.0.1", "type": "library"},
+        {"name": "root/req1", "version": "1.0.0", "require": {"dep/pkg1": "1.*"}, "type": "library"},
+        {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg2": "1.*"}, "type": "library"}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--EXPECT--
+Installing dep/pkg1 (1.0.0)
+Installing root/req1 (1.0.0)
+Installing dep/pkg2 (1.0.1)
+Installing root/req2 (1.0.0)


### PR DESCRIPTION
This fixes an issue experienced by user as an unexplainable conflict:

```
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - root/req1 is locked to version 1.0.0 and an update of this package was not requested.
    - root/req1 1.0.0 requires dep/pkg1 1.* -> found dep/pkg1[1.0.0] but these were not loaded, likely because it conflicts with another require.
```

The explanation "because it conflicts with another require" is false in this case. The package simply didn't get loaded into the pool because of a bug.

Fixes https://github.com/composer/composer/issues/9489