### PR TITLE
Fix running tests with non standard default branch

### DIFF
--- a/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
@@ -115,7 +115,7 @@ class ArchiveManagerTest extends ArchiverTest
         chdir($this->testDir);
 
         $output = null;
-        $result = $this->process->execute('git init -q', $output, $this->testDir);
+        $result = $this->process->execute('git init -q -b master', $output, $this->testDir);
         if ($result > 0) {
             chdir($currentWorkDir);
             throw new \RuntimeException('Could not init: '.$this->process->getErrorOutput());

--- a/tests/Composer/Test/Repository/VcsRepositoryTest.php
+++ b/tests/Composer/Test/Repository/VcsRepositoryTest.php
@@ -58,7 +58,7 @@ class VcsRepositoryTest extends TestCase
             }
         };
 
-        $exec('git init');
+        $exec('git init -q -b master');
         $exec('git config user.email composertest@example.org');
         $exec('git config user.name ComposerTest');
         $exec('git config commit.gpgsign false');


### PR DESCRIPTION
When the global git config has `init.defaultbranch` set to something other than master the tests fail. This is because the tests assume that the default branch is called master but that may not be the case.

```
There were 3 errors:

1) Composer\Test\Package\Archiver\ArchiveManagerTest::testArchiveTar
RuntimeException: Failed to execute git checkout 'master' -- && git reset --hard 'master' --

fatal: invalid reference: master
```

This PR fixes the tests by ensuring that when running git init we ensure the default branch is called master regardless of how git is configured.