### PR TITLE
Update CurlDownloader enable support for client ssl-certificates

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -63,6 +63,9 @@ class CurlDownloader
             'capath' => CURLOPT_CAPATH,
             'verify_peer' => CURLOPT_SSL_VERIFYPEER,
             'verify_peer_name' => CURLOPT_SSL_VERIFYHOST,
+            'local_cert' => CURLOPT_SSLCERT,
+            'local_pk' => CURLOPT_SSLKEY,
+            'passphrase' => CURLOPT_SSLKEYPASSWD,
         ),
     );
 


### PR DESCRIPTION
`сomposer-1` used for http requests `RemoteFilesystem` with context, with passed directly from `options` section of repository and there was not problems to pass client ssl-certificates to `stream-context`.

Upgrading to `composer-2` (with `ext-curl` installed) causes HTTP-requests to fail - `CurlDownloader` doesn't use client ssl-certificates.

Sample `config.json`:
```json
{
    "repositories": {
        "private-repo": {
            "type": "composer",
            "url": "https://private.repo.example.com",
            "options": {
                "ssl": {
                    "local_cert": "/users/user/.composer/certs.d/pravate-repo-user.cert",
                    "local_pk": "/users/user/.composer/certs.d/pravate-repo-user.key"
                }
            }
        }
    }
}
```

There is no need (for me) to store `passphrase` at `config.json`, but I think - let's make it possible to use it by anyone who needs this.