### PR TITLE
Fix git init -b being unavailable for older versions

### DIFF
--- a/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
@@ -115,10 +115,16 @@ class ArchiveManagerTest extends ArchiverTest
         chdir($this->testDir);
 
         $output = null;
-        $result = $this->process->execute('git init -q -b master', $output, $this->testDir);
+        $result = $this->process->execute('git init -q', $output, $this->testDir);
         if ($result > 0) {
             chdir($currentWorkDir);
             throw new \RuntimeException('Could not init: '.$this->process->getErrorOutput());
+        }
+
+        $result = $this->process->execute('git checkout -b master', $output, $this->testDir);
+        if ($result > 0) {
+            chdir($currentWorkDir);
+            throw new \RuntimeException('Could not checkout master branch: '.$this->process->getErrorOutput());
         }
 
         $result = $this->process->execute('git config user.email "you@example.com"', $output, $this->testDir);

--- a/tests/Composer/Test/Repository/VcsRepositoryTest.php
+++ b/tests/Composer/Test/Repository/VcsRepositoryTest.php
@@ -58,7 +58,8 @@ class VcsRepositoryTest extends TestCase
             }
         };
 
-        $exec('git init -q -b master');
+        $exec('git init -q');
+        $exec('git checkout -b master');
         $exec('git config user.email composertest@example.org');
         $exec('git config user.name ComposerTest');
         $exec('git config commit.gpgsign false');


### PR DESCRIPTION
On older versions of git `init` doesn't have the `-b` flag. That was introduced in v2.28.0.

Instead switch to using `git checkout -b` which has much wider support (2.4.12 was as far back as I could check on the docs).