### PR TITLE
Add a missing punctuation mark in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please send any sensitive issue to [security@packagist.org](mailto:security@pack
 License
 -------
 
-Composer is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
+Composer is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 Acknowledgments
 ---------------


### PR DESCRIPTION
This PR adds a missing punctuation mark in the README file.