### PR TITLE
Introduce gitlab-protocol option to force source repository URL (e.g., to HTTPS)

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -76,6 +76,11 @@ of their API. Composer may prompt for credentials when needed, but these can als
 manually set. Read more on how to get an OAuth token for GitHub and cli syntax
 [here](articles/authentication-for-private-packages.md#github-oauth).
 
+## gitlab-domains
+
+Defaults to `["gitlab.com"]`. A list of domains of GitLab servers.
+This is used if you use the `gitlab` repository type.
+
 ## gitlab-oauth
 
 A list of domain names and oauth keys. For example using `{"gitlab.com":
@@ -98,6 +103,16 @@ gitlab.com the domain names must be also specified with the
 [`gitlab-domains`](06-config.md#gitlab-domains) option. The token must have
 `api` or `read_api` scope.
 Further info can also be found [here](articles/authentication-for-private-packages.md#gitlab-token)
+
+## gitlab-protocol
+
+A protocol to force use of when creating a repository URL for the `source`
+value of the package metadata. One of `git` or `http`. (`https` is treated
+as a synonym for `http`.) Helpful when working with projects referencing
+private repositories which will later be cloned in GitLab CI jobs with a
+[GitLab CI job token](https://docs.gitlab.com/ee/user/project/new_ci_build_permissions_model.html#dependent-repositories)
+using HTTP basic auth. By default, Composer will generate a git-over-SSH
+URL for private repositories and HTTP(S) only for public.
 
 ## disable-tls
 
@@ -257,11 +272,6 @@ used for GitHub Enterprise setups.
 
 Defaults to `true`. If `false`, the OAuth tokens created to access the
 github API will have a date instead of the machine hostname.
-
-## gitlab-domains
-
-Defaults to `["gitlab.com"]`. A list of domains of GitLab servers.
-This is used if you use the `gitlab` repository type.
 
 ## use-github-api
 

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -31,6 +31,7 @@ class Config
         'preferred-install' => 'auto',
         'notify-on-install' => true,
         'github-protocols' => array('https', 'ssh', 'git'),
+        'gitlab-protocol' => null,
         'vendor-dir' => 'vendor',
         'bin-dir' => '{$vendor-dir}/bin',
         'cache-dir' => '{$home}/cache',

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -61,6 +61,13 @@ class GitLabDriver extends VcsDriver
     protected $gitDriver;
 
     /**
+     * Protocol to force use of for repository URLs.
+     *
+     * @var string One of ssh, http
+     */
+    protected $protocol;
+
+    /**
      * Defaults to true unless we can make sure it is public
      *
      * @var bool defines whether the repo is private or not
@@ -96,6 +103,14 @@ class GitLabDriver extends VcsDriver
             : (isset($this->repoConfig['secure-http']) && $this->repoConfig['secure-http'] === false ? 'http' : 'https')
         ;
         $this->originUrl = self::determineOrigin($configuredDomains, $guessedDomain, $urlParts, $match['port']);
+
+        if ($protocol = $this->config->get('gitlab-protocol')) {
+            // https treated as a synonym for http.
+            if (!in_array($protocol, array('git', 'http', 'https'))) {
+                throw new \RuntimeException('gitlab-protocol must be one of git, http.');
+            }
+            $this->protocol = $protocol === 'git' ? 'ssh' : 'http';
+        }
 
         if (false !== strpos($this->originUrl, ':') || false !== strpos($this->originUrl, '/')) {
             $this->hasNonstandardOrigin = true;
@@ -210,6 +225,9 @@ class GitLabDriver extends VcsDriver
      */
     public function getRepositoryUrl()
     {
+        if ($this->protocol) {
+            return $this->project["{$this->protocol}_url_to_repo"];
+        }
         return $this->isPrivate ? $this->project['ssh_url_to_repo'] : $this->project['http_url_to_repo'];
     }
 
@@ -360,7 +378,7 @@ class GitLabDriver extends VcsDriver
         if (isset($this->project['visibility'])) {
             $this->isPrivate = $this->project['visibility'] !== 'public';
         } else {
-            // client is not authendicated, therefore repository has to be public
+            // client is not authenticated, therefore repository has to be public
             $this->isPrivate = false;
         }
     }


### PR DESCRIPTION
Follow-on to https://github.com/composer/composer/pull/8001, also references https://github.com/composer/satis/issues/419 and https://github.com/composer/composer/issues/4744.

Introduces a `gitlab-protocol` option to force the use of a particular protocol for the `source` value when writing `composer.lock`. E.g., this is helpful when you may reference private repositories on a GitLab instance which will be pulled in using a GitLab CI token. This basic HTTP auth for dependencies is obviously not possible over git+ssh.

Includes a test and update to docs.