### PR TITLE
RemoteFileSystem: don't throw zlib error on empty response

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -823,7 +823,7 @@ class RemoteFilesystem
                     $result = file_get_contents('compress.zlib://data:application/octet-stream;base64,'.base64_encode($result));
                 }
 
-                if (!$result) {
+                if ($result === false) {
                     throw new TransportException('Failed to decode zlib stream');
                 }
             }


### PR DESCRIPTION
The RemoteFileSystem currently throws `new TransportException('Failed to decode zlib stream')` in case the server returns an encoded empty string as response e.g. in case of a 403.