### PR TITLE
Fix HTTP status when Platform check failed

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -734,7 +734,8 @@ EXT_CHECKS;
 
 \$issues = array();
 ${requiredPhp}${requiredExtensions}
-if (\$issues) {
+if (\$issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\\n\\n" . implode("\\n", \$issues) . "\\n\\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_extensions_required.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_extensions_required.php
@@ -8,7 +8,8 @@ if (!(PHP_VERSION_ID >= 70200)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.0". You are running ' . PHP_VERSION  .  '.';
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_required.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_required.php
@@ -12,7 +12,8 @@ if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_upper_bound.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_upper_bound.php
@@ -8,7 +8,8 @@ if (!(PHP_VERSION_ID >= 70200)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.0". You are running ' . PHP_VERSION  .  '.';
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/replaced_provided_exts.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/replaced_provided_exts.php
@@ -11,7 +11,8 @@ if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/specific_php_release.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/specific_php_release.php
@@ -8,7 +8,8 @@ if (!(PHP_VERSION_ID >= 70208)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.8". You are running ' . PHP_VERSION  .  '.';
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/typical.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/typical.php
@@ -16,7 +16,8 @@ if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }


### PR DESCRIPTION
Composer 2 is checking platform requirements in runtime. It can cause shut down production in a lot of cases.

Here is big trouble the Error message is printed to output and replaced the Web Application. And although Composer is produced an Error message, it's introduced as a serious response of Web application ([status `200 OK`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200)).

It's Fail because the robots aren't correctly notified the response is Error and accepts the response as a valid response. It can cause mass burning of Website SEO reputation because the error message is indexed Search engine's robots and replaces the main content.

**Trust me its't very serious problem**, try to [**search "Composer detected issues in your platform"**](https://www.google.com/search?q=%22Composer+detected+issues+in+your+platform%22) for proof.

This PR is update Composer to send [status ~~`503 Service Unavailable`~~](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503) [`500 Internal Server Error`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) when the platform check fails.

## FAQ

**App should never be deployed to production with Dev deps**

You right. But Composer 2 is extremely widespread among developers, regardless of their seniority. A lot of them are juniors. The problem is the platform check is in runtime with the most default usage of Composer, it's no requires any additional configuration in `composer.json`, no specific switch in `install`/`require` command. 

Considering the extent of possible damage is necessary to respect most general cases and a variety of uses.

**Check can be disabled by `--no-platform-reqs`, and similar ways…**

You right. But as I wrote above, platform check is Composer's default behavior and it's should be gently to prevent cause damage.

**Developer should ever check production environment before deploy**

You right. But s*it happens. The App can interfere with Platform requirements for a lot of reasons:

- Web hosting can silently change the server environment. Especially its problem on Shares web hosting.
- Developer can do a seemingly innocent update (`vendor-name/package-name 1.2.3 -> 1.2.4`) and does not expect any problem (Composer is not notified about changing platform-reqs during update).
- Developers just do mistakes - we are just humans.