### PR TITLE
Platform check: Trigger native PHP error

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -734,7 +734,8 @@ EXT_CHECKS;
 
 \$issues = array();
 ${requiredPhp}${requiredExtensions}
-if (\$issues) {
+if (\$issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\\n\\n" . implode("\\n", \$issues) . "\\n\\n";
     exit(104);
 }

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -734,10 +734,11 @@ EXT_CHECKS;
 
 \$issues = array();
 ${requiredPhp}${requiredExtensions}
-if (\$issues && !headers_sent()) {
-    header('HTTP/1.1 500 Internal Server Error');
-    echo 'Composer detected issues in your platform:' . "\\n\\n" . implode("\\n", \$issues) . "\\n\\n";
-    exit(104);
+if (\$issues) {
+    trigger_error(
+        'Composer detected issues in your platform: ' . implode(', ', \$issues),
+        E_USER_ERROR
+    );
 }
 
 PLATFORM_CHECK;

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_extensions_required.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_extensions_required.php
@@ -8,7 +8,8 @@ if (!(PHP_VERSION_ID >= 70200)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.0". You are running ' . PHP_VERSION  .  '.';
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_extensions_required.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_extensions_required.php
@@ -8,8 +8,9 @@ if (!(PHP_VERSION_ID >= 70200)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.0". You are running ' . PHP_VERSION  .  '.';
 }
 
-if ($issues && !headers_sent()) {
-    header('HTTP/1.1 500 Internal Server Error');
-    echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
-    exit(104);
+if ($issues) {
+    trigger_error(
+        'Composer detected issues in your platform: ' . implode(', ', $issues),
+        E_USER_ERROR
+    );
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_required.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_required.php
@@ -12,8 +12,9 @@ if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if ($issues && !headers_sent()) {
-    header('HTTP/1.1 500 Internal Server Error');
-    echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
-    exit(104);
+if ($issues) {
+    trigger_error(
+        'Composer detected issues in your platform: ' . implode(', ', $issues),
+        E_USER_ERROR
+    );
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_required.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_required.php
@@ -12,7 +12,8 @@ if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_upper_bound.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_upper_bound.php
@@ -8,7 +8,8 @@ if (!(PHP_VERSION_ID >= 70200)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.0". You are running ' . PHP_VERSION  .  '.';
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_upper_bound.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_upper_bound.php
@@ -8,8 +8,9 @@ if (!(PHP_VERSION_ID >= 70200)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.0". You are running ' . PHP_VERSION  .  '.';
 }
 
-if ($issues && !headers_sent()) {
-    header('HTTP/1.1 500 Internal Server Error');
-    echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
-    exit(104);
+if ($issues) {
+    trigger_error(
+        'Composer detected issues in your platform: ' . implode(', ', $issues),
+        E_USER_ERROR
+    );
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/replaced_provided_exts.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/replaced_provided_exts.php
@@ -11,7 +11,8 @@ if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/replaced_provided_exts.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/replaced_provided_exts.php
@@ -11,8 +11,9 @@ if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if ($issues && !headers_sent()) {
-    header('HTTP/1.1 500 Internal Server Error');
-    echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
-    exit(104);
+if ($issues) {
+    trigger_error(
+        'Composer detected issues in your platform: ' . implode(', ', $issues),
+        E_USER_ERROR
+    );
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/specific_php_release.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/specific_php_release.php
@@ -8,8 +8,9 @@ if (!(PHP_VERSION_ID >= 70208)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.8". You are running ' . PHP_VERSION  .  '.';
 }
 
-if ($issues && !headers_sent()) {
-    header('HTTP/1.1 500 Internal Server Error');
-    echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
-    exit(104);
+if ($issues) {
+    trigger_error(
+        'Composer detected issues in your platform: ' . implode(', ', $issues),
+        E_USER_ERROR
+    );
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/specific_php_release.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/specific_php_release.php
@@ -8,7 +8,8 @@ if (!(PHP_VERSION_ID >= 70208)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.2.8". You are running ' . PHP_VERSION  .  '.';
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/typical.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/typical.php
@@ -16,8 +16,9 @@ if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if ($issues && !headers_sent()) {
-    header('HTTP/1.1 500 Internal Server Error');
-    echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
-    exit(104);
+if ($issues) {
+    trigger_error(
+        'Composer detected issues in your platform: ' . implode(', ', $issues),
+        E_USER_ERROR
+    );
 }

--- a/tests/Composer/Test/Autoload/Fixtures/platform/typical.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/typical.php
@@ -16,7 +16,8 @@ if ($missingExtensions) {
     $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions);
 }
 
-if ($issues) {
+if ($issues && !headers_sent()) {
+    header('HTTP/1.1 500 Internal Server Error');
     echo 'Composer detected issues in your platform:' . "\n\n" . implode("\n", $issues) . "\n\n";
     exit(104);
 }


### PR DESCRIPTION
Following up #9412 and #9410 I found current error handling with mechanism `header(); echo …; die(1+);` is not satisfied for success debugging on most implementations.

General monitoring tools prefers to monitor native error log instead to parsing response body (tested on [Google App Engine](https://cloud.google.com/appengine) and [Google Run](https://cloud.google.com/run)).

Here are two reasons:

- native error handling in any level (regardless to app-level or sys-level),
- **security** – printing too detailed internal error message in runtime is very sensitive, it can provide implementation details for attackers,
- indepentent to SAPI (cli, cgi, etc.), environment, and others, because it's produce native error state in app runtime lifecycle.

**This PR is replacement to #9410 and it's conflicts with them.** Only one can be merged, I prefer this PR.

## FAQ
**This PR is cause to show empty page without body.**

That's right. I understand it's unpleasantly. This is standard way to propagate raw errors. User can change this behavior by setting php runtime like:
```ini
ini_set('display_errors', 1);
ini_set('display_startup_errors', 1);
error_reporting(E_ALL);
```
or by [custom error handling](https://www.php.net/manual/en/function.set-error-handler.php).
