### PR TITLE
Fix platform check error message

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -741,6 +741,9 @@ EXT_CHECKS;
 \$issues = array();
 ${requiredPhp}${requiredExtensions}
 if (\$issues) {
+    if (!headers_sent()) {
+        header('HTTP/1.1 500 Internal Server Error');
+    }
     if (!ini_get('display_errors')) {
         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
             fwrite(STDERR, 'Composer detected issues in your platform:' . PHP_EOL.PHP_EOL . implode(PHP_EOL, \$issues) . PHP_EOL.PHP_EOL);

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_extensions_required.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_extensions_required.php
@@ -9,6 +9,9 @@ if (!(PHP_VERSION_ID >= 70200)) {
 }
 
 if ($issues) {
+    if (!headers_sent()) {
+        header('HTTP/1.1 500 Internal Server Error');
+    }
     if (!ini_get('display_errors')) {
         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
             fwrite(STDERR, 'Composer detected issues in your platform:' . PHP_EOL.PHP_EOL . implode(PHP_EOL, $issues) . PHP_EOL.PHP_EOL);

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_required.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_required.php
@@ -13,6 +13,9 @@ if ($missingExtensions) {
 }
 
 if ($issues) {
+    if (!headers_sent()) {
+        header('HTTP/1.1 500 Internal Server Error');
+    }
     if (!ini_get('display_errors')) {
         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
             fwrite(STDERR, 'Composer detected issues in your platform:' . PHP_EOL.PHP_EOL . implode(PHP_EOL, $issues) . PHP_EOL.PHP_EOL);

--- a/tests/Composer/Test/Autoload/Fixtures/platform/no_php_upper_bound.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/no_php_upper_bound.php
@@ -9,6 +9,9 @@ if (!(PHP_VERSION_ID >= 70200)) {
 }
 
 if ($issues) {
+    if (!headers_sent()) {
+        header('HTTP/1.1 500 Internal Server Error');
+    }
     if (!ini_get('display_errors')) {
         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
             fwrite(STDERR, 'Composer detected issues in your platform:' . PHP_EOL.PHP_EOL . implode(PHP_EOL, $issues) . PHP_EOL.PHP_EOL);

--- a/tests/Composer/Test/Autoload/Fixtures/platform/replaced_provided_exts.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/replaced_provided_exts.php
@@ -12,6 +12,9 @@ if ($missingExtensions) {
 }
 
 if ($issues) {
+    if (!headers_sent()) {
+        header('HTTP/1.1 500 Internal Server Error');
+    }
     if (!ini_get('display_errors')) {
         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
             fwrite(STDERR, 'Composer detected issues in your platform:' . PHP_EOL.PHP_EOL . implode(PHP_EOL, $issues) . PHP_EOL.PHP_EOL);

--- a/tests/Composer/Test/Autoload/Fixtures/platform/specific_php_release.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/specific_php_release.php
@@ -9,6 +9,9 @@ if (!(PHP_VERSION_ID >= 70208)) {
 }
 
 if ($issues) {
+    if (!headers_sent()) {
+        header('HTTP/1.1 500 Internal Server Error');
+    }
     if (!ini_get('display_errors')) {
         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
             fwrite(STDERR, 'Composer detected issues in your platform:' . PHP_EOL.PHP_EOL . implode(PHP_EOL, $issues) . PHP_EOL.PHP_EOL);

--- a/tests/Composer/Test/Autoload/Fixtures/platform/typical.php
+++ b/tests/Composer/Test/Autoload/Fixtures/platform/typical.php
@@ -17,6 +17,9 @@ if ($missingExtensions) {
 }
 
 if ($issues) {
+    if (!headers_sent()) {
+        header('HTTP/1.1 500 Internal Server Error');
+    }
     if (!ini_get('display_errors')) {
         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
             fwrite(STDERR, 'Composer detected issues in your platform:' . PHP_EOL.PHP_EOL . implode(PHP_EOL, $issues) . PHP_EOL.PHP_EOL);


### PR DESCRIPTION
Fixes bug from commit: 8c1355f448ec8087bf7ed468208f8d63794de909

- ~~Prints error to output only when `ini_get('display_errors')` is truly,~~
- Add status `500 Internal server error` to error message (see #9410 discussion; ~~note the `trigger_error()` below doesn't change status, because `echo` is already sent data to output~~).

@Seldaek however, in any case, your solution is better than my previous solution. Thanks for your great work!
