### PR TITLE
Fix missing directory separator in FileDownloader

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -310,7 +310,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
 
         $this->filesystem->emptyDirectory($path);
         $this->filesystem->ensureDirectoryExists($path);
-        $this->filesystem->rename($this->getFileName($package, $path), $path . pathinfo(parse_url($package->getDistUrl(), PHP_URL_PATH), PATHINFO_BASENAME));
+        $this->filesystem->rename($this->getFileName($package, $path), $path . '/' . pathinfo(parse_url($package->getDistUrl(), PHP_URL_PATH), PATHINFO_BASENAME));
     }
 
     /**

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -14,7 +14,6 @@ namespace Composer\Downloader;
 
 use Composer\Config;
 use Composer\Cache;
-use Composer\Factory;
 use Composer\IO\IOInterface;
 use Composer\IO\NullIO;
 use Composer\Package\Comparer\Comparer;
@@ -22,7 +21,6 @@ use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\Package\PackageInterface;
-use Composer\Package\Version\VersionParser;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PostFileDownloadEvent;
 use Composer\Plugin\PreFileDownloadEvent;


### PR DESCRIPTION
In a project I'm working on, we have some dependencies on libraries _outside_ of the `composer` ecosystem.  
To do so, we are defining those external dependencies as `file`-typed packages.

We're currently working on migrating to `composer v2.x`, when I noticed an anomaly...

When installing a [package](https://getcomposer.org/doc/05-repositories.md#package-2) with `dist.type: 'file'`, it appears that the file gets installed in the wrong target destination?

## Reproduction steps

I've created a minimal `composer.json` file that reproduces this issue in `composer v2.x`.

<details>
<summary>Sample <code>composer.json</code></summary>
<div class="highlight highlight-source-json"><pre>
{
    "repositories": [
        {
            "type": "package",
            "package": {
                "name": "composer/readme-file",
                "version": "2.0.4",
                "dist": {
                    "url": "https://raw.githubusercontent.com/composer/composer/2.0.4/README.md",
                    "type": "file"
                }
            }
        }
    ],
    "require": {
        "composer/readme-file": "2.x"
    }
}
</pre></div>
</details>

This example contains a `composer/readme-file` package, which pulls in the [README.md](https://github.com/composer/composer/blob/2.0.4/README.md) file of this repository as a composer "package".


### Expected behavior

As the package `name` is `composer/readme-file`, I'd expect the file to be stored at `vendor/composer/readme-file/README.md`.  
This is also what happens with `composer v1.x`:

```sh
$ ./composer.phar -V
Composer version 1.10.17 2020-10-30 22:31:58

$ ./composer.phar install
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing composer/readme-file (2.0.4): Loading from cache
Writing lock file
Generating autoload files

$ tree ./vendor/
./vendor/
├── autoload.php
└── composer
    ├── ...
    └── readme-file
        └── README.md
```

### Actual behavior

However, in `composer v2.x`, this is _not_ the case anymore.

The file is stored as `vendor/composer/readme-fileREADME.md` (so _concatenated_ and directly under the `vendor/composer` parent, as opposed to in its own `vendor/composer/readme-file` subdirectory):

```sh
$ ./composer.phar -V
Composer version 2.0.3 2020-10-28 15:50:55

$ ./composer.phar install
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking composer/readme-file (2.0.4)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing composer/readme-file (2.0.4)
Generating autoload files

$ tree ./vendor/
./vendor/
├── autoload.php
└── composer
    ├── ...
    └── readme-fileREADME.md
```