### PR TITLE
Reject promise within "HttpDownloader" when an exception is thrown

### DIFF
--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -268,10 +268,14 @@ class HttpDownloader
             return;
         }
 
-        if ($job['request']['copyTo']) {
-            $job['curl_id'] = $this->curl->download($resolve, $reject, $origin, $url, $options, $job['request']['copyTo']);
-        } else {
-            $job['curl_id'] = $this->curl->download($resolve, $reject, $origin, $url, $options);
+        try {
+            if ($job['request']['copyTo']) {
+                $job['curl_id'] = $this->curl->download($resolve, $reject, $origin, $url, $options, $job['request']['copyTo']);
+            } else {
+                $job['curl_id'] = $this->curl->download($resolve, $reject, $origin, $url, $options);
+            }
+        } catch (\Exception $exception) {
+            $reject($exception);
         }
     }
 


### PR DESCRIPTION
### Description
An infinite loop was caused by promises which weren't either resolved or rejected within the [`Composer\Util\HttpDownloader::startJob`](https://github.com/composer/composer/blob/master/src/Composer/Util/HttpDownloader.php#L243) when an exception was thrown by the [`Composer\Util\Http\CurlDownloader::download`](https://github.com/composer/composer/blob/master/src/Composer/Util/Http/CurlDownloader.php#L112) method.

A promise and reject callback are passed to the aforementioned methods but are only passed through to [`$this->jobs`](https://github.com/composer/composer/blob/master/src/Composer/Util/Http/CurlDownloader.php#L223) but not invoked if there is an exception within [`Composer\Util\Http\CurlDownloader::initDownload`](https://github.com/composer/composer/blob/master/src/Composer/Util/Http/CurlDownloader.php#L126) itself.

In case if exceptions thrown by the method itself there could be two scenarios.

- [An exception thrown when HTTP is used if `secure-http` is enabled](https://github.com/composer/composer/blob/master/src/Composer/Util/Http/CurlDownloader.php#L138)
- [If `$copyTo` is passed and the the file wasn't able to be written](https://github.com/composer/composer/blob/master/src/Composer/Util/Http/CurlDownloader.php#L155)

I decided to catch these exceptions and pass them to the `$reject` callback within `Composer\Util\HttpDownloader` rather than `Composer\Util\Http\CurlDownloader` because `Composer\Util\Http\CurlDownloader::download` returns the job id which was started and I wouldn't know what to return if an exception came up.

### Related Issues
- #9424