### PR TITLE
Remove unnecessary overridden method

### DIFF
--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -28,10 +28,6 @@ use Composer\DependencyResolver\Operation\InstallOperation;
  */
 abstract class ArchiveDownloader extends FileDownloader
 {
-    public function download(PackageInterface $package, $path, PackageInterface $prevPackage = null, $output = true)
-    {
-        return parent::download($package, $path, $prevPackage, $output);
-    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
The method just called its parent without further logic.

I guess this method was more complex in the past and what we have right now is just the leftovers