### PR TITLE
Make sure the root aliases always get loaded for root packages, even if not stored in the lock file

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -507,6 +507,11 @@ class PoolBuilder
             $this->unlockPackage($request, $this->skippedLoad[$name]);
         }
 
+        // reload the aliases for the package being unlocked
+        if (isset($this->rootAliases[$name])) {
+            $this->unusedRootAliases[$name] = $this->rootAliases[$name];
+        }
+
         unset($this->skippedLoad[$name], $this->loadedPackages[$name], $this->maxExtendedReqs[$name]);
     }
 

--- a/tests/Composer/Test/Fixtures/installer/root-alias-gets-loaded-for-locked-pkgs.test
+++ b/tests/Composer/Test/Fixtures/installer/root-alias-gets-loaded-for-locked-pkgs.test
@@ -1,0 +1,65 @@
+--TEST--
+Root alias gets loaded even if package is loaded from lock file
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "some/dep", "version": "dev-main" },
+                { "name": "foo/pkg", "version": "1.0.0", "require": {"some/dep": "^1"} }
+            ]
+        }
+    ],
+    "require": {
+        "some/dep": "dev-main as 1.0.0",
+        "foo/pkg": "^1.0"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        { "name": "some/dep", "version": "dev-main" }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--INSTALLED--
+[
+    { "name": "some/dep", "version": "dev-main" }
+]
+--RUN--
+update foo/pkg
+--EXPECT-LOCK--
+{
+    "packages": [
+        { "name": "foo/pkg", "version": "1.0.0", "require": {"some/dep": "^1"}, "type": "library" },
+        { "name": "some/dep", "version": "dev-main", "type": "library" }
+    ],
+    "packages-dev": [],
+    "aliases": [
+        {
+            "package": "some/dep",
+            "version": "dev-main",
+            "alias": "1.0.0",
+            "alias_normalized": "1.0.0.0"
+        }
+    ],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "some/dep": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--EXPECT--
+Marking some/dep (1.0.0) as installed, alias of some/dep (dev-main)
+Installing foo/pkg (1.0.0)


### PR DESCRIPTION
fixes #9448