### PR TITLE
Make sure the root aliases always get installed when a package is updated

### DIFF
--- a/src/Composer/DependencyResolver/LockTransaction.php
+++ b/src/Composer/DependencyResolver/LockTransaction.php
@@ -133,6 +133,10 @@ class LockTransaction extends Transaction
             }
         }
 
+        usort($usedAliases, function ($a, $b) {
+            return strcmp($a['package'], $b['package']);
+        });
+
         return $usedAliases;
     }
 }

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -55,6 +55,11 @@ class Pool implements \Countable
         }
     }
 
+    public function getPackages()
+    {
+        return $this->packages;
+    }
+
     /**
      * Retrieves the package object for a given package id.
      *

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -231,7 +231,7 @@ class RuleSetGenerator
                 }
 
                 // otherwise, looks like a bug
-                throw new \LogicException("Fixed package ".$package->getName()." ".$package->getVersion().($package instanceof AliasPackage ? " (alias)" : "")." was not added to solver pool.");
+                throw new \LogicException("Fixed package ".$package->getPrettyString()." was not added to solver pool.");
             }
 
             $this->addRulesForPackage($package, $ignorePlatformReqs);
@@ -262,6 +262,17 @@ class RuleSetGenerator
         }
     }
 
+    protected function addRulesForRootAliases()
+    {
+        foreach ($this->pool->getPackages() as $package) {
+            // if it is a root alias, make sure that if the aliased version gets installed
+            // the alias must be installed too
+            if ($package instanceof AliasPackage && $package->isRootPackageAlias()) {
+                $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRequireRule($package->getAliasOf(), array($package), Rule::RULE_PACKAGE_REQUIRES, $package->getAliasOf()));
+            }
+        }
+    }
+
     /**
      * @param bool|array $ignorePlatformReqs
      */
@@ -276,6 +287,8 @@ class RuleSetGenerator
         $this->conflictsForName = array();
 
         $this->addRulesForRequest($request, $ignorePlatformReqs);
+
+        $this->addRulesForRootAliases();
 
         $this->addConflictRules($ignorePlatformReqs);
 

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -262,13 +262,14 @@ class RuleSetGenerator
         }
     }
 
-    protected function addRulesForRootAliases()
+    protected function addRulesForRootAliases($ignorePlatformReqs)
     {
         foreach ($this->pool->getPackages() as $package) {
             // if it is a root alias, make sure that if the aliased version gets installed
             // the alias must be installed too
-            if ($package instanceof AliasPackage && $package->isRootPackageAlias()) {
+            if ($package instanceof AliasPackage && $package->isRootPackageAlias() && isset($this->addedMap[$package->getAliasOf()->id])) {
                 $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRequireRule($package->getAliasOf(), array($package), Rule::RULE_PACKAGE_REQUIRES, $package->getAliasOf()));
+                $this->addRulesForPackage($package, $ignorePlatformReqs);
             }
         }
     }
@@ -288,7 +289,7 @@ class RuleSetGenerator
 
         $this->addRulesForRequest($request, $ignorePlatformReqs);
 
-        $this->addRulesForRootAliases();
+        $this->addRulesForRootAliases($ignorePlatformReqs);
 
         $this->addConflictRules($ignorePlatformReqs);
 

--- a/tests/Composer/Test/Fixtures/installer/alias-in-lock2.test
+++ b/tests/Composer/Test/Fixtures/installer/alias-in-lock2.test
@@ -1,5 +1,5 @@
 --TEST--
-Root-defined aliases end up in lock file always on full update
+Newly defined root aliases end up in lock file only if the package is updated
 --COMPOSER--
 {
     "repositories": [
@@ -11,22 +11,38 @@ Root-defined aliases end up in lock file always on full update
                 },
                 {
                     "name": "a/aliased2", "version": "3.0.2"
-                },
-                {
-                    "name": "b/requirer", "version": "1.0.0",
-                    "require": { "a/aliased": "^3.0.3", "a/aliased2": "^3.0.0" }
                 }
             ]
         }
     ],
     "require": {
         "a/aliased": "3.0.2 as 3.0.3",
-        "a/aliased2": "3.0.2 as 3.0.3",
-        "b/requirer": "*"
+        "a/aliased2": "3.0.2 as 3.0.3"
     }
 }
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "a/aliased", "version": "3.0.2",
+            "type": "library"
+        },
+        {
+            "name": "a/aliased2", "version": "3.0.2",
+            "type": "library"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
 --RUN--
-update
+update a/aliased
 --EXPECT-LOCK--
 {
     "packages": [
@@ -37,21 +53,11 @@ update
         {
             "name": "a/aliased2", "version": "3.0.2",
             "type": "library"
-        },
-        {
-            "name": "b/requirer", "version": "1.0.0",
-            "require": { "a/aliased": "^3.0.3", "a/aliased2": "^3.0.0" },
-            "type": "library"
         }
     ],
     "packages-dev": [],
     "aliases": [{
         "package": "a/aliased",
-        "version": "3.0.2.0",
-        "alias": "3.0.3",
-        "alias_normalized": "3.0.3.0"
-    },{
-        "package": "a/aliased2",
         "version": "3.0.2.0",
         "alias": "3.0.3",
         "alias_normalized": "3.0.3.0"
@@ -64,8 +70,6 @@ update
     "platform-dev": []
 }
 --EXPECT--
-Installing a/aliased2 (3.0.2)
-Marking a/aliased2 (3.0.3) as installed, alias of a/aliased2 (3.0.2)
 Installing a/aliased (3.0.2)
 Marking a/aliased (3.0.3) as installed, alias of a/aliased (3.0.2)
-Installing b/requirer (1.0.0)
+Installing a/aliased2 (3.0.2)

--- a/tests/Composer/Test/Fixtures/installer/aliases-with-require-dev.test
+++ b/tests/Composer/Test/Fixtures/installer/aliases-with-require-dev.test
@@ -61,12 +61,12 @@ update
         }
     ],
     "aliases": [{
-        "package": "a/aliased2",
+        "package": "a/aliased",
         "version": "dev-next",
         "alias": "4.1.0-RC2",
         "alias_normalized": "4.1.0.0-RC2"
     }, {
-        "package": "a/aliased",
+        "package": "a/aliased2",
         "version": "dev-next",
         "alias": "4.1.0-RC2",
         "alias_normalized": "4.1.0.0-RC2"

--- a/tests/Composer/Test/Fixtures/installer/root-alias-gets-loaded-for-locked-pkgs.test
+++ b/tests/Composer/Test/Fixtures/installer/root-alias-gets-loaded-for-locked-pkgs.test
@@ -1,0 +1,54 @@
+--TEST--
+Newly defined root alias does not get loaded if package is loaded from lock file
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "some/dep", "version": "dev-main" },
+                { "name": "foo/pkg", "version": "1.0.0", "require": {"some/dep": "^1"} }
+            ]
+        }
+    ],
+    "require": {
+        "some/dep": "dev-main as 1.0.0",
+        "foo/pkg": "^1.0"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        { "name": "some/dep", "version": "dev-main" }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--INSTALLED--
+[
+    { "name": "some/dep", "version": "dev-main" }
+]
+--RUN--
+update foo/pkg
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires foo/pkg ^1.0 -> satisfiable by foo/pkg[1.0.0].
+    - foo/pkg 1.0.0 requires some/dep ^1 -> found some/dep[dev-main] but it does not match the constraint.
+
+Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
+
+--EXPECT--


### PR DESCRIPTION
fixes #9448

replaces and closes #9468 with a better implementation which makes sure the root aliases get stored in lock file, but newly defined aliases do not make it in there on partial updates, and do not get loaded at all on locked packages