### PR TITLE
Fix phpstan phpdocs issues

### DIFF
--- a/phpstan/config.neon
+++ b/phpstan/config.neon
@@ -1,5 +1,6 @@
 parameters:
     level: 1
+    checkClassCaseSensitivity: true # Level 2 rule
     excludes_analyse:
        - '../tests/Composer/Test/Fixtures/*'
        - '../tests/Composer/Test/Autoload/Fixtures/*'
@@ -34,3 +35,25 @@ parameters:
 
 rules:
     - Composer\PHPStanRules\AnonymousFunctionWithThisRule
+    # Level 2 rules
+    - PHPStan\Rules\Cast\EchoRule
+    - PHPStan\Rules\Cast\InvalidCastRule
+    - PHPStan\Rules\Cast\InvalidPartOfEncapsedStringRule
+    - PHPStan\Rules\Cast\PrintRule
+    - PHPStan\Rules\Functions\IncompatibleDefaultParameterTypeRule
+    - PHPStan\Rules\Generics\ClassAncestorsRule
+    - PHPStan\Rules\Generics\ClassTemplateTypeRule
+    - PHPStan\Rules\Generics\FunctionTemplateTypeRule
+    - PHPStan\Rules\Generics\FunctionSignatureVarianceRule
+    - PHPStan\Rules\Generics\InterfaceAncestorsRule
+    - PHPStan\Rules\Generics\InterfaceTemplateTypeRule
+    - PHPStan\Rules\Generics\MethodTemplateTypeRule
+    - PHPStan\Rules\Generics\MethodSignatureVarianceRule
+    - PHPStan\Rules\Generics\TraitTemplateTypeRule
+    - PHPStan\Rules\Operators\InvalidBinaryOperationRule
+    - PHPStan\Rules\Operators\InvalidUnaryOperationRule
+    - PHPStan\Rules\Operators\InvalidComparisonOperationRule
+    - PHPStan\Rules\PhpDoc\IncompatiblePhpDocTypeRule
+    - PHPStan\Rules\PhpDoc\IncompatiblePropertyPhpDocTypeRule
+    - PHPStan\Rules\PhpDoc\InvalidPhpDocTagValueRule
+    - PHPStan\Rules\PhpDoc\InvalidPHPStanDocTagRule

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -392,7 +392,7 @@ TAGSPUBKEY
      * @param  string $localFilename The composer.phar location
      * @param  string $newFilename The downloaded or backup phar
      * @param  string $backupTarget The filename to use for the backup
-     * @throws \FilesystemException If the file cannot be moved
+     * @throws FilesystemException If the file cannot be moved
      * @return bool Whether the phar is valid and has been moved
      */
     protected function setLocalPhar($localFilename, $newFilename, $backupTarget = null)

--- a/src/Composer/DependencyResolver/Operation/OperationInterface.php
+++ b/src/Composer/DependencyResolver/Operation/OperationInterface.php
@@ -29,7 +29,7 @@ interface OperationInterface
     /**
      * Serializes the operation in a human readable format
      *
-     * @param $lock bool Whether this is an operation on the lock file
+     * @param bool $lock Whether this is an operation on the lock file
      * @return string
      */
     public function show($lock);

--- a/src/Composer/Installer/PackageEvent.php
+++ b/src/Composer/Installer/PackageEvent.php
@@ -66,7 +66,6 @@ class PackageEvent extends Event
      * @param IOInterface          $io
      * @param bool                 $devMode
      * @param RepositoryInterface  $localRepo
-     * @param Request              $request
      * @param OperationInterface[] $operations
      * @param OperationInterface   $operation
      */

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -599,7 +599,7 @@ class PlatformRepository extends ArrayRepository
     /**
      * Check if a package name is a platform package.
      *
-     * @param $name
+     * @param mixed $name
      * @return bool
      */
     public static function isPlatformPackage($name)

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -599,7 +599,7 @@ class PlatformRepository extends ArrayRepository
     /**
      * Check if a package name is a platform package.
      *
-     * @param mixed $name
+     * @param string $name
      * @return bool
      */
     public static function isPlatformPackage($name)

--- a/src/Composer/Util/Bitbucket.php
+++ b/src/Composer/Util/Bitbucket.php
@@ -90,7 +90,6 @@ class Bitbucket
     }
 
     /**
-     * @param  string $originUrl
      * @return bool
      */
     private function requestAccessToken()

--- a/src/Composer/Util/Http/ProxyManager.php
+++ b/src/Composer/Util/Http/ProxyManager.php
@@ -152,7 +152,7 @@ class ProxyManager
     /**
      * Sets initial data
      *
-     * @param string $proxyUrl Proxy url
+     * @param string $url Proxy url
      * @param string $scheme Environment variable scheme
      */
     private function setData($url, $scheme)

--- a/src/Composer/Util/NoProxyPattern.php
+++ b/src/Composer/Util/NoProxyPattern.php
@@ -174,7 +174,7 @@ class NoProxyPattern
      * @param int $index
      * @param string $hostName
      *
-     * @return {null|stdClass} Null if the hostname is invalid
+     * @return null|stdClass Null if the hostname is invalid
      */
     private function getRule($index, $hostName)
     {

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -1073,7 +1073,7 @@ Linked Version => 1.2.11',
      * @param array<string,string|false> $expectations
      * @param array<string,mixed> $functions
      * @param array<string,mixed> $constants
-     * @param array<string,class-string> $classes
+     * @param array<string,class-string> $classDefinitions
      */
     public function testLibraryInformation(
         $extensions,

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -514,8 +514,8 @@ class AuthHelperTest extends TestCase
     }
 
     /**
-     * @param $origin
-     * @param $auth
+     * @param mixed $origin
+     * @param mixed $auth
      */
     private function expectsAuthentication($origin, $auth)
     {

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -514,8 +514,8 @@ class AuthHelperTest extends TestCase
     }
 
     /**
-     * @param mixed $origin
-     * @param mixed $auth
+     * @param string $origin
+     * @param array $auth
      */
     private function expectsAuthentication($origin, $auth)
     {


### PR DESCRIPTION
Hi,

after reading #9450, I think we can adopt an intermediate step when increasing phpstan level.

Level 2 show ~280 errors and could be hard fixing them without a baseline. Instead of increase full level we can add explicit rules from a higher level and fix errors progressively easier.

This PR fixes phpdocs issues and add some phpstan level 2 rules to config file.