### PR TITLE
Introduce "links" feature

### DIFF
--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -52,6 +52,7 @@ class InstallCommand extends BaseCommand
                 new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
+                new InputOption('ignore-links', null, InputOption::VALUE_NONE, 'Ignore all package links in composer.lock.'),
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Should not be provided, use composer require instead to add a given package to composer.json.'),
             ))
             ->setHelp(
@@ -122,6 +123,7 @@ EOT
             ->setClassMapAuthoritative($authoritative)
             ->setApcuAutoloader($apcu, $apcuPrefix)
             ->setIgnorePlatformRequirements($ignorePlatformReqs)
+            ->setIgnoreLinks($input->getOption('ignore-links'))
         ;
 
         if ($input->getOption('no-plugins')) {

--- a/src/Composer/Command/LinkCommand.php
+++ b/src/Composer/Command/LinkCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Command;
+
+use Composer\Json\JsonFile;
+use Composer\Util\Filesystem;
+use Composer\Util\Platform;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ */
+class LinkCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('link')
+            ->setDescription('Add current package to a "links repository".')
+            ->setDefinition(array(
+                new InputArgument('path', InputArgument::OPTIONAL, 'Target path for the links repository. If not provided defaults to Composer home.'),
+            ))
+            ->setHelp(
+                <<<EOT
+The link command "exports" a package to a "links repository", a
+JSON file containing a map of package names to to local paths.
+When running update command with `--load-links` or `--links-from`
+Composer will symlink packages in links repository instead of
+pulling them from their remote repositories.
+EOT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = $this->getIO();
+
+        $composer = $this->getComposer(false);
+        if (!$composer) {
+            $io->writeError('<error>Link command can only be executed from a package root folder.</error>');
+
+            return 1;
+        }
+
+        $filesystem = new Filesystem();
+
+        $customPath = $input->getArgument('path');
+        if ($customPath) {
+            $realPath = realpath($filesystem->normalizePath(Platform::expandPath($customPath)));
+            if (!$realPath || !is_dir($realPath) || !is_writable($realPath)) {
+                $io->writeError('<error>"'.$customPath.'" is not a valid writable directory.</error>');
+
+                return 2;
+            }
+        }
+
+        $package = $composer->getPackage();
+        $name = $package->getName();
+        $configPath = $composer->getConfig()->getConfigSource()->getName();
+        $source = $filesystem->normalizePath(dirname($configPath));
+
+        $path = $customPath ? $realPath : $composer->getConfig()->get('home');
+        $filepath = $filesystem->normalizePath($path).'/composer-links.json';
+
+        $jsonFile = new JsonFile($filepath, null, $io);
+
+        $data = $jsonFile->exists() ? $jsonFile->read() : array();
+        $packages = isset($data['packages']) ? $data['packages'] : array();
+        if (!is_array($packages)) {
+            $data = array('packages' => array());
+        }
+        $newPackages = array();
+        $updated = false;
+
+        foreach ($packages as $package) {
+            if ($package['name'] !== $name) {
+                $newPackages[] = $package;
+                continue;
+            }
+
+            $newPackages[] = array('name' => $name, 'path' => $source);
+            $updated = true;
+        }
+
+        if (!$updated) {
+            $newPackages[] = array('name' => $name, 'path' => $source);
+        }
+
+        $data['packages'] = $newPackages;
+        $jsonFile->write($data);
+
+        $message = sprintf('Link for package "%s" %s successfully %s links repository at '.$path.'.', $name, $updated ? 'updated' : 'added', $updated ? 'in' : 'to');
+        $io->write('<info>'.$message.'</info>');
+
+        return 0;
+    }
+}

--- a/src/Composer/Command/LinkCommand.php
+++ b/src/Composer/Command/LinkCommand.php
@@ -58,6 +58,7 @@ EOT
         $filesystem = new Filesystem();
 
         $customPath = $input->getArgument('path');
+        $realPath = null;
         if ($customPath) {
             $realPath = realpath($filesystem->normalizePath(Platform::expandPath($customPath)));
             if (!$realPath || !is_dir($realPath) || !is_writable($realPath)) {

--- a/src/Composer/Command/UnlinkCommand.php
+++ b/src/Composer/Command/UnlinkCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Command;
+
+use Composer\Json\JsonFile;
+use Composer\Util\Filesystem;
+use Composer\Util\Platform;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ */
+class UnlinkCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('unlink')
+            ->setDescription('Remove current package from a "links repository".')
+            ->setDefinition(array(
+                new InputArgument('path', InputArgument::OPTIONAL, 'Links repository path to remove link from. If not provided defaults to Composer home.'),
+            ))
+            ->setHelp(
+                <<<EOT
+The link command remove a package from a "links repository", a
+JSON file containing a map of package names to local paths.
+Reverts the link command.
+EOT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = $this->getIO();
+
+        $composer = $this->getComposer(false);
+        if (!$composer) {
+            $io->writeError('<error>Link command can only be executed from a package root folder.</error>');
+
+            return 1;
+        }
+
+        $filesystem = new Filesystem();
+
+        $customPath = $input->getArgument('path');
+        if ($customPath) {
+            $realPath = realpath($filesystem->normalizePath(Platform::expandPath($customPath)));
+            if (!$realPath || !is_dir($realPath) || !is_writable($realPath)) {
+                $io->writeError('<error>"'.$customPath.'" is not a valid writable directory.</error>');
+
+                return 1;
+            }
+        }
+
+        $package = $composer->getPackage();
+        $name = $package->getName();
+        $configPath = $composer->getConfig()->getConfigSource()->getName();
+        $source = $filesystem->normalizePath(dirname($configPath));
+
+        $path = $customPath ? $realPath : $composer->getConfig()->get('home');
+        $filepath = $filesystem->normalizePath($path).'/composer-links.json';
+
+        $jsonFile = new JsonFile($filepath, null, $io);
+        if (!$jsonFile->exists()) {
+            $io->write('<warning>There is no links repository at '.$path.'.</warning>');
+
+            return 1;
+        }
+
+        $data = $jsonFile->read();
+        $packages = isset($data['packages']) ? $data['packages'] : array();
+        if (!is_array($packages)) {
+            $data = array('packages' => array());
+        }
+        $found = false;
+
+        $newPackages = array();
+        foreach ($packages as $package) {
+            if ($package['name'] !== $name) {
+                $newPackages[] = $package;
+                continue;
+            }
+
+            $found = true;
+        }
+
+        if (!$found) {
+            $io->write('<warning>Package "'.$name.'" not found in links repository at '.$path.'.</warning>');
+
+            return 2;
+        }
+
+        $data['packages'] = $newPackages;
+        $jsonFile->write($data);
+
+        $message = sprintf('Link for package "%s" removed successfully from links repository at '.$path.'.', $name);
+        $io->write('<info>'.$message.'</info>');
+
+        return 0;
+    }
+}

--- a/src/Composer/Command/UnlinkCommand.php
+++ b/src/Composer/Command/UnlinkCommand.php
@@ -56,6 +56,7 @@ EOT
         $filesystem = new Filesystem();
 
         $customPath = $input->getArgument('path');
+        $realPath = null;
         if ($customPath) {
             $realPath = realpath($filesystem->normalizePath(Platform::expandPath($customPath)));
             if (!$realPath || !is_dir($realPath) || !is_writable($realPath)) {
@@ -67,9 +68,6 @@ EOT
 
         $package = $composer->getPackage();
         $name = $package->getName();
-        $configPath = $composer->getConfig()->getConfigSource()->getName();
-        $source = $filesystem->normalizePath(dirname($configPath));
-
         $path = $customPath ? $realPath : $composer->getConfig()->get('home');
         $filepath = $filesystem->normalizePath($path).'/composer-links.json';
 

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -67,6 +67,8 @@ class UpdateCommand extends BaseCommand
                 new InputOption('prefer-lowest', null, InputOption::VALUE_NONE, 'Prefer lowest versions of dependencies.'),
                 new InputOption('interactive', 'i', InputOption::VALUE_NONE, 'Interactive interface with autocompletion to select the packages to update.'),
                 new InputOption('root-reqs', null, InputOption::VALUE_NONE, 'Restricts the update to your first degree dependencies.'),
+                new InputOption('load-links', null, InputOption::VALUE_NONE, 'Load from local paths packages previously "exported" via `link` command to Composer default links repository.'),
+                new InputOption('links-from', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Similar to `--load-links`, load local packages exported to given link repositories.'),
             ))
             ->setHelp(
                 <<<EOT
@@ -202,6 +204,11 @@ EOT
 
         $ignorePlatformReqs = $input->getOption('ignore-platform-reqs') ?: ($input->getOption('ignore-platform-req') ?: false);
 
+        $loadLinksFromPaths = $input->getOption('links-from');
+        if ($input->getOption('load-links')) {
+            $loadLinksFromPaths[] = $config->get('home');
+        }
+
         $install
             ->setDryRun($input->getOption('dry-run'))
             ->setVerbose($input->getOption('verbose'))
@@ -221,6 +228,7 @@ EOT
             ->setIgnorePlatformRequirements($ignorePlatformReqs)
             ->setPreferStable($input->getOption('prefer-stable'))
             ->setPreferLowest($input->getOption('prefer-lowest'))
+            ->setLinkPackagesRepoPaths($loadLinksFromPaths)
         ;
 
         if ($input->getOption('no-plugins')) {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -478,6 +478,8 @@ class Application extends BaseApplication
             new Command\OutdatedCommand(),
             new Command\CheckPlatformReqsCommand(),
             new Command\FundCommand(),
+            new Command\LinkCommand(),
+            new Command\UnlinkCommand(),
         ));
 
         if (strpos(__FILE__, 'phar:') === 0) {

--- a/src/Composer/DependencyResolver/LockTransaction.php
+++ b/src/Composer/DependencyResolver/LockTransaction.php
@@ -43,20 +43,20 @@ class LockTransaction extends Transaction
      */
     protected $resultPackages;
 
-    public function __construct(Pool $pool, $presentMap, $unlockableMap, $decisions)
+    public function __construct(Pool $pool, $presentMap, $unlockableMap, $decisions, $linkedPackages)
     {
         $this->presentMap = $presentMap;
         $this->unlockableMap = $unlockableMap;
 
-        $this->setResultPackages($pool, $decisions);
+        $this->setResultPackages($pool, $decisions, $linkedPackages);
         parent::__construct($this->presentMap, $this->resultPackages['all']);
 
     }
 
     // TODO make this a bit prettier instead of the two text indexes?
-    public function setResultPackages(Pool $pool, Decisions $decisions)
+    public function setResultPackages(Pool $pool, Decisions $decisions, $linkedPackages)
     {
-        $this->resultPackages = array('all' => array(), 'non-dev' => array(), 'dev' => array());
+        $this->resultPackages = array('all' => array(), 'non-dev' => array(), 'dev' => array(), 'links' => array());
         foreach ($decisions as $i => $decision) {
             $literal = $decision[Decisions::DECISION_LITERAL];
 
@@ -67,6 +67,14 @@ class LockTransaction extends Transaction
                 if (!isset($this->unlockableMap[$package->id])) {
                     $this->resultPackages['non-dev'][] = $package;
                 }
+            }
+        }
+
+        foreach ($linkedPackages as $package) {
+            $this->resultPackages['all'][] = $package;
+            $this->resultPackages['links'][] = $package;
+            if (!isset($this->unlockableMap[$package->id])) {
+                $this->resultPackages['non-dev'][] = $package;
             }
         }
     }

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -20,6 +20,7 @@ use Composer\Package\PackageInterface;
 use Composer\Package\Version\StabilityFilter;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PrePoolCreateEvent;
+use Composer\Repository\PackageLinks;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RootPackageRepository;
 use Composer\Semver\CompilingMatcher;
@@ -121,7 +122,7 @@ class PoolBuilder
         $this->io = $io;
     }
 
-    public function buildPool(array $repositories, Request $request)
+    public function buildPool(array $repositories, Request $request, PackageLinks $packageLinks = null)
     {
         if ($request->getUpdateAllowList()) {
             $this->updateAllowList = $request->getUpdateAllowList();
@@ -206,6 +207,14 @@ class PoolBuilder
                         unset($this->packages[$index]);
                     }
                 }
+            }
+        }
+
+        if ($packageLinks) {
+            foreach ($packageLinks->getAllPackages() as $package) {
+                $index = $this->indexCounter++;
+                $this->packages[$index] = $package;
+                $this->stabilityFlags[$package->getName()] = BasePackage::STABILITY_DEV;
             }
         }
 

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -16,8 +16,11 @@ use Composer\Config\JsonConfigSource;
 use Composer\Json\JsonFile;
 use Composer\IO\IOInterface;
 use Composer\Package\Archiver;
+use Composer\Package\Loader\ArrayLoader;
+use Composer\Package\Loader\ValidatingArrayLoader;
 use Composer\Package\Version\VersionGuesser;
 use Composer\Package\RootPackageInterface;
+use Composer\Repository\PackageLinks;
 use Composer\Repository\RepositoryManager;
 use Composer\Repository\RepositoryFactory;
 use Composer\Repository\WritableRepositoryInterface;
@@ -646,6 +649,20 @@ class Factory
         }
 
         return $httpDownloader;
+    }
+
+    /**
+     * @param IOInterface $io
+     * @param ProcessExecutor|null $process
+     * @param bool $fromLocked
+     * @return PackageLinks
+     */
+    public static function createPackageLinks(IOInterface $io, ProcessExecutor $process = null, $fromLocked = false)
+    {
+        $loader = new ValidatingArrayLoader(new ArrayLoader());
+        $filesystem = new Filesystem($process);
+
+        return new PackageLinks($io, $loader, $filesystem, $fromLocked);
     }
 
     /**

--- a/src/Composer/Package/LinkPackage.php
+++ b/src/Composer/Package/LinkPackage.php
@@ -82,7 +82,7 @@ class LinkPackage extends CompletePackage implements CompletePackageInterface
     }
 
     /**
-     * @param $repoPath
+     * @param string $repoPath
      */
     public function setLinkRepoPath($repoPath)
     {

--- a/src/Composer/Package/LinkPackage.php
+++ b/src/Composer/Package/LinkPackage.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Package;
+
+use Composer\Semver\Constraint\ConstraintInterface;
+use Composer\Semver\Constraint\MultiConstraint;
+use Composer\Package\Version\VersionParser;
+
+/**
+ * Complete package loaded from local path.
+ *
+ * @author Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ */
+class LinkPackage extends CompletePackage implements CompletePackageInterface
+{
+    /** @var string */
+    private $repoPath;
+
+    /** @var ConstraintInterface[] */
+    private $constraints;
+
+    /**
+     * Link packages bypass Solver, but for each requirement of a package this method is called
+     * to ensure the local package is installed only if required using a compatible set of
+     * requirements.
+     *
+     * @param ConstraintInterface $constraint
+     * @param string|null $branchAlias
+     * @return void
+     *
+     * TODO: Unit tests...
+     */
+    public function checkConstraint(ConstraintInterface $constraint, $branchAlias = null)
+    {
+        $verifier = $this->constraints ? MultiConstraint::create($this->constraints) : null;
+        // No previous requirements or the current requirement is compatible with the previous: OK
+        if (!$verifier || $verifier->matches($constraint)) {
+            // Push current requirement to stack
+            $this->constraints[] = $constraint;
+
+            return;
+        }
+
+        $constraintString = $constraint->getPrettyString();
+        // If something requires explicitly 'dev-local' we just accept it
+        if ('dev-local' === $constraintString) {
+            return;
+        }
+
+        if ('dev' === VersionParser::parseStability($constraintString)) {
+            $versionParser = $this->getVersionParser();
+            $alias = $this->getBranchAlias($constraintString);
+            if ($alias) {
+                // Normalize aliased version and re-run constraint check, using non-dev version
+                // or this will be an endless recursive loop.
+                $normalized = $versionParser->normalizeBranch(substr($alias, 0, strlen($alias)-4));
+                preg_match('{(?:^dev-)?(.+?)(?:-dev)?$}', $normalized, $matches);
+                $this->checkConstraint($versionParser->parseConstraints($matches[1]), $constraintString);
+                return;
+            }
+
+            // Being pragmatical here: if the branch is not aliased but it is the default branch,
+            // we accept it anyway to ensure requirements like "dev-master" are always "linkable".
+            $mainBranch = $versionParser->normalizeDefaultBranch($constraintString);
+            // TODO: Should 'dev-main' be part of `VersionParser::normalizeDefaultBranch()`?
+            if ('9999999-dev' === $mainBranch || 'dev-main' === $mainBranch) {
+                return;
+            }
+        }
+
+        throw new LinkPackageConstraintException($this, $constraint, $verifier, $branchAlias);
+    }
+
+    /**
+     * @param $repoPath
+     */
+    public function setLinkRepoPath($repoPath)
+    {
+        $this->repoPath = $repoPath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLinkRepoPath()
+    {
+        return $this->repoPath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getConstraintsPrettyString()
+    {
+        if ($this->constraints) {
+            return MultiConstraint::create($this->constraints)->getPrettyString();
+        }
+
+        return 'dev-local';
+    }
+
+    /**
+     * @param string $branch
+     * @return string|null
+     */
+    private function getBranchAlias($branch)
+    {
+        $extra = $this->getExtra();
+        $branchAlias = isset($extra['branch-alias']) ? $extra['branch-alias'] : array();
+
+        return empty($branchAlias[$branch]) ? null : (string) $branchAlias[$branch];
+    }
+
+    /**
+     * @return VersionParser
+     */
+    private function getVersionParser()
+    {
+        static $versionParser;
+        $versionParser or $versionParser = new VersionParser();
+
+        return $versionParser;
+    }
+}

--- a/src/Composer/Package/LinkPackageConstraintException.php
+++ b/src/Composer/Package/LinkPackageConstraintException.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Package;
+
+use Composer\Semver\Constraint\ConstraintInterface;
+use Composer\Semver\Constraint\MultiConstraint;
+
+/**
+ * Exception thrown when an attempt is made to use a linked package for conflicting requirements.
+ *
+ * @author Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ */
+class LinkPackageConstraintException extends \RuntimeException
+{
+    public function __construct(
+        LinkPackage $package,
+        ConstraintInterface $constraint,
+        MultiConstraint $previous,
+        $branchAlias = null
+    ) {
+
+        $message = sprintf(
+            "Linked package \"%s\"\ncan't replace \"%s\"\nbecause already used to replace\n\"%s\".",
+            $package->getName(),
+            $branchAlias ? $branchAlias : $constraint->getPrettyString(),
+            $previous->getPrettyString()
+        );
+
+        parent::__construct($message);
+    }
+}

--- a/src/Composer/Package/LinkPackageConstraintException.php
+++ b/src/Composer/Package/LinkPackageConstraintException.php
@@ -29,10 +29,11 @@ class LinkPackageConstraintException extends \RuntimeException
         $branchAlias = null
     ) {
 
+        $constraintString = $constraint->getPrettyString();
         $message = sprintf(
-            "Linked package \"%s\"\ncan't replace \"%s\"\nbecause already used to replace\n\"%s\".",
+            "Linked package \"%s\"\ncan't replace %s\nbecause already used to replace\n\"%s\".",
             $package->getName(),
-            $branchAlias ? $branchAlias : $constraint->getPrettyString(),
+            $branchAlias ? "\"$branchAlias\" (alias of $constraintString)" : "\"$constraintString\"",
             $previous->getPrettyString()
         );
 

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -391,7 +391,7 @@ class Locker
         }
 
         $links = $this->lockLinks($packageLinks);
-        if ($links) {
+        if (!empty($links['packages'])) {
             $lock['links'] = $links;
         }
 
@@ -489,6 +489,7 @@ class Locker
                 'repository' => $linkPackage->getLinkRepoPath(),
             );
         }
+
         $links['repositories'] = $packageLinks->getLoadedLinkRepoPaths();
 
         return $links;

--- a/src/Composer/Repository/PackageLinks.php
+++ b/src/Composer/Repository/PackageLinks.php
@@ -1,0 +1,285 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Repository;
+
+use Composer\IO\IOInterface;
+use Composer\Json\JsonFile;
+use Composer\Package\Link;
+use Composer\Package\LinkPackage;
+use Composer\Package\Loader\LoaderInterface;
+use Composer\Package\Loader\ValidatingArrayLoader;
+use Composer\Package\PackageInterface;
+use Composer\Semver\Constraint\Constraint;
+use Composer\Util\Filesystem;
+
+/**
+ * Manages local "links" to packages.
+ *
+ * @author Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ */
+class PackageLinks
+{
+    protected $io;
+    protected $filesystem;
+    protected $loader;
+
+    /** @var array<string, array{path:string, repo:string}> */
+    protected $packagesData = array();
+
+    /** @var LinkPackage[] */
+    protected $packages = array();
+
+    /** @var ArrayRepository<LinkPackage> */
+    protected $repository;
+
+    /** @var LinkPackage[] */
+    protected $required = array();
+
+    /** @var array<string, bool> */
+    private $linksRepoLoaded = array();
+
+    /** @var bool */
+    private $packagesDataLoaded = false;
+
+    /** @var bool */
+    private $fromLocked;
+
+    /**
+     * @param IOInterface $io
+     * @param LoaderInterface $loader
+     * @param Filesystem $filesystem
+     * @param bool $fromLocked
+     */
+    public function __construct(IOInterface $io, LoaderInterface $loader, Filesystem $filesystem, $fromLocked = false)
+    {
+        $this->io = $io;
+        $this->loader = $loader;
+        $this->filesystem = $filesystem;
+        $this->repository = new ArrayRepository();
+        $this->fromLocked = (bool)$fromLocked;
+    }
+
+    /**
+     * Loads `composer-links.json` from given path and stores info for all packages in it.
+     *
+     * @param string $path
+     */
+    public function loadLinksFromPath($path)
+    {
+        $repoPath = $this->filesystem->normalizePath($path);
+        if (!$repoPath || isset($this->linksRepoLoaded[$repoPath])) {
+            return;
+        }
+
+        // We're not going to load same file more than once.
+        $this->linksRepoLoaded[$repoPath] = true;
+
+        $jsonFile = new JsonFile($repoPath.'/composer-links.json');
+        $repo = $jsonFile->getPath();
+
+        if (!$jsonFile->exists()) {
+            $this->io->writeError(
+                'Links repository '.$repo.' does not exists.',
+                true,
+                IOInterface::VERBOSE
+            );
+
+            return;
+        }
+
+        $linksData = $jsonFile->read();
+        $invalidMsg = 'Links repository '.$repo.' does not contain valid package links data.';
+
+        if (!is_array($linksData) || empty($linksData['packages']) || !is_array($linksData['packages'])) {
+            throw new \UnexpectedValueException($invalidMsg);
+        }
+
+        $this->io->writeError(
+            '<info>Loading link packages data from '.$repo.'</info>',
+            true,
+            IOInterface::VERBOSE
+        );
+
+        $loaded = 0;
+        foreach ($linksData['packages'] as $linkPackage) {
+            if (!is_array($linkPackage) || empty($linkPackage['name']) || empty($linkPackage['path']) || ValidatingArrayLoader::hasPackageNamingError($linkPackage['name'])) {
+                throw new \UnexpectedValueException($invalidMsg);
+            }
+
+            $name = $linkPackage['name'];
+            $path = $this->filesystem->normalizePath($linkPackage['path']);
+
+            if (!empty($this->packagesData[$name])) {
+                // If a package was already linked from another links repository using a different
+                // path we need to bail because we can't load a package from two different paths.
+                if ($path !== $this->packagesData[$name]['path']) {
+                    throw new \RuntimeException(
+                        sprintf(
+                            "Package \"%s\" is already linked\nfrom \"%s\" via \"%s\",\ncan't be linked from \"%s\" as set in \"%s\".",
+                            $name,
+                            $this->packagesData[$name]['path'],
+                            $this->packagesData[$name]['repo'],
+                            $path,
+                            $repo
+                        )
+                    );
+                }
+                continue;
+            }
+
+            $loaded++;
+            $this->packagesData[$name] = compact('path', 'repo');
+        }
+
+        if ($loaded > 0) {
+            // Set this to false to inform `getAllPackages` that there are new packages to load.
+            $this->packagesDataLoaded = false;
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLoadedLinkRepoPaths()
+    {
+        return array_keys($this->linksRepoLoaded);
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPackages()
+    {
+        return (bool)$this->packagesData;
+    }
+
+    /**
+     * @param string $package
+     * @return bool
+     */
+    public function hasPackage($package)
+    {
+        return !empty($this->packagesData[$package]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllPackageNames()
+    {
+        return array_keys($this->packagesData);
+    }
+
+    /**
+     * @return LinkPackage[]
+     */
+    public function getAllPackages()
+    {
+        if (!$this->packagesDataLoaded) {
+            array_map(array($this, 'getPackage'), $this->getAllPackageNames());
+            $this->packagesDataLoaded = true;
+        }
+
+        return $this->packages;
+    }
+
+    /**
+     * @param string $name
+     * @return LinkPackage
+     */
+    public function getPackage($name)
+    {
+        if (isset($this->packages[$name])) {
+            return $this->packages[$name];
+        }
+
+        if (!$this->hasPackage($name)) {
+            throw new \UnexpectedValueException('"'.$name.'" is not a linked package.');
+        }
+
+        $json = new JsonFile($this->packagesData[$name]['path'].'/composer.json');
+        $json->validateSchema();
+
+        $data = $json->read();
+        unset($data['source'], $data['dist'], $data['installation-source']);
+        $data['version'] = 'dev-local';
+
+        /** @var LinkPackage $package */
+        $package = $this->loader->load($data, 'Composer\Package\LinkPackage');
+
+        $package->setDistType('path');
+        $package->setDistUrl($this->packagesData[$name]['path']);
+        $package->setDistReference('local');
+        $package->setDistSha1Checksum(sha1(serialize($data)));
+        $package->setLinkRepoPath($this->packagesData[$name]['repo']);
+        $this->packages[$name] = $package;
+        $this->repository->addPackage($package);
+
+        return $package;
+    }
+
+    /**
+     * @return ArrayRepository
+     */
+    public function getRepository()
+    {
+        // Ensures all packages data is loaded.
+        $this->getAllPackages();
+
+        return $this->repository;
+    }
+
+    /**
+     * @param PackageInterface|Link|array $reasonData
+     * @return void
+     */
+    public function setRequired($reasonData)
+    {
+        $isArray = is_array($reasonData);
+        if ($isArray && isset($reasonData['package'])) {
+            $reasonData = $reasonData['package'];
+        } elseif ($isArray && isset($reasonData['packageName'])) {
+            $reasonData = $this->getPackage($reasonData['packageName']);
+        }
+
+        $version = '';
+        if ($reasonData instanceof PackageInterface) {
+            $version = $reasonData->getVersion();
+            if (!$reasonData instanceof LinkPackage) {
+                $reasonData = $this->getPackage($reasonData->getName());
+            }
+        }
+
+        $isLink = $reasonData instanceof Link;
+        $package = $isLink ? $this->getPackage($reasonData->getTarget()) : $reasonData;
+        if (!$package instanceof LinkPackage) {
+            return;
+        }
+
+        if (!$this->fromLocked || $version !== 'dev-local') {
+            $constraint = $isLink ? $reasonData->getConstraint() : new Constraint('==', $version);
+            $package->checkConstraint($constraint);
+        }
+
+        // Use name as key to ensure same package is added once.
+        $this->required[$package->getName()] = $package;
+    }
+
+    /**
+     * @return LinkPackage[]
+     */
+    public function getAllRequired()
+    {
+        return array_values($this->required);
+    }
+}

--- a/src/Composer/Repository/PackageLinks.php
+++ b/src/Composer/Repository/PackageLinks.php
@@ -39,7 +39,7 @@ class PackageLinks
     /** @var LinkPackage[] */
     protected $packages = array();
 
-    /** @var ArrayRepository<LinkPackage> */
+    /** @var ArrayRepository */
     protected $repository;
 
     /** @var LinkPackage[] */


### PR DESCRIPTION
This PR introduces **"link" functionality** to Composer, inspired by [npm link](https://docs.npmjs.com/cli/v6/commands/npm-link). See #601.

## New commands
- **`composer link`** command, which exceuted from a package's folder export package's path to a "link repository": a JSON file containing a map of package names to local paths. The "link repository" file is created if not exists yet. It is located by default in Composer home, but the command accept as argument an alternative path.
- **`composer unlink`** command. Specular to `link` command removes what `composer link` adds.

## New command options
- **`--load-links`** flag for `composer update` command. When used any required package that was previously exported with `composer link` will be symlinked in the installation folder from the local path instead of being pulled from the actual repository.
- **`--links-from`** option for `composer update` command. Similar to `--load-links` this allows to load packages from alternative link repositories (it is an array option): it is the companion of using `composer link` with custom path parameter. Can be used in combination with `--load-links` to load links from default link repository _and_ from custom one(s).
- **`--ignore-links`** option for `composer install` command. Instruct Composer to ignore any linked packages information eventually present in the `composer.lock`.

## How it works

### On update
When `--load-links` and/or `--link-from` are used, an `ArrayRepository` is created containing all packages defined in the "links repository". This repository is pre-pended to the Installer's `RepositorySet` so packages in it will take precedence.
Moreover, packages in the link repository bypass the Solver so that linked local packages requirements are accepted for install even if the requirement does not match the local package version, which is hardcoded to `dev-local`.
Note: every linked package keeps track of the actual requirement for it, and thows an exception if it is required using a non-compatible set of requirements. In other words if `composer update` without links fails for a version conflict in the requirement for a package "foo/bar", then running `composer update --load-links` will also fail even if "foo/bar" is linked and so bypass Solver.

### On install
Considering linked packages are normal packages with a dist type of "path" and no source, there's nothing new or special about how they are locked. So on install they would normally be installed with no issue.
The `--ignore-links` flag make the `ArrayRepository` created for linked packages to be empty, which means that Composer will look for the packages in the remote repository which likely means that installation will fail. This flag can be used to avoid linked packages can be installed "by accident".

## Other changes

- The `composer.lock` has a new "links" section with information about linked packages and the link repository they are loaded from
- The `composer show` command, when using to show a single package, eventually shows information about a package being linked (e.g. the link repository path).
- A `LinkPackage` class is added. It extends `CompletePackage` and it is used to represent packages loaded from links. It carries information for the link repostory path and it is responsible to check a linked package is loaded for a compatible set of requirements.
- A `PackageLinks` class is added to take care all the link-related funcitonality, like loading packages from link repositories and instantiate the `ArrayRepository`.
- A `LinkPackageConstraintException` class is added. It is an exception thown if a linked package is required using a non compatible set of requirements.

## Is it working already?

I tested manually the most common use cases and **it appears so**.

## Is it backward compatible?

Some existing methods have now a new parameter which has a default.

This is done mostly either in constructors (where signature changes are allowed) or in internal classes (that should not be extended by 3rd party).
There are only 2 cases of non-constructor signature changes in classes not marked as internal, those are:
- `PoolBuilder::buildPool()`
- `Locaker::setLockData()`

If plugins are defining classes extending those two classes and overriding those two methods it would break. Not sure if in a project like Composer this prevents to ship the feature without major version bump.

Maybe those two classes or methods are worth to be marked internal? If not, the additional parameter passed to the two methods could be passed to their classes' constructor.

## What is missing

Unit tests. Both updating existing ones and adding new ones.