### PR TITLE
Fix error with bin config in PHP8

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -65,10 +65,13 @@ class ArrayLoader implements LoaderInterface
         }
 
         if (isset($config['bin'])) {
-            foreach ((array) $config['bin'] as $key => $bin) {
+            if (!\is_array($config['bin'])) {
+                $config['bin'] = array($config['bin']);
+            }
+            foreach ($config['bin'] as $key => $bin) {
                 $config['bin'][$key] = ltrim($bin, '/');
             }
-            $package->setBinaries((array) $config['bin']);
+            $package->setBinaries($config['bin']);
         }
 
         if (isset($config['installation-source'])) {


### PR DESCRIPTION
The `bin` config is supposed to be an array, but before PHP8 it could also be a string and it worked fine.

From PHP8 the behaviour has changed and now a warning is emitted: `Only the first byte will be assigned to the string offset`.

It's worth mentioning it affects Composer v1 & Composer v2.