### PR TITLE
Add allowInstalledRepositories to installer

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -154,6 +154,11 @@ class Installer
     protected $additionalFixedRepository;
 
     /**
+     * @var bool
+     */
+    protected $allowInstalledRepositories = false;
+
+    /**
      * Constructor
      *
      * @param IOInterface          $io
@@ -179,6 +184,11 @@ class Installer
         $this->autoloadGenerator = $autoloadGenerator;
 
         $this->writeLock = $config->get('lock');
+    }
+
+    public function allowInstalledRepositories($allow = true)
+    {
+        $this->allowInstalledRepositories = $allow;
     }
 
     /**
@@ -769,6 +779,10 @@ class Installer
             $repositorySet->addRepository($this->additionalFixedRepository);
         }
 
+        if ($this->allowInstalledRepositories) {
+            $repositorySet->allowInstalledRepositories();
+        }
+
         return $repositorySet;
     }
 
@@ -869,6 +883,11 @@ class Installer
         }
 
         return $aliases;
+    }
+
+    public function getPackage()
+    {
+        return $this->package;
     }
 
     /**


### PR DESCRIPTION
This change is needed to upgrade a library which embeds composer into a phar application. It is used there to merge the internal already installed dependencies (inside of the phar) with the "external" ones.
The external ones are plugins which are installed via a "composer.json" named "nanbando.json".

For ^1.0 it worked great but with ^2.0 it needs to set the flag `allowInstalledRepositories` to allow a installed repository for updates / installs.

Linked PR:

* Embedded Composer library https://github.com/nanbando/dflydev-embedded-composer/pull/1
* Nanbando (the phar application) https://github.com/nanbando/core/pull/108