### PR TITLE
feat(Cache): make cache writes more atomic

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -114,21 +114,21 @@ class Cache
 
             $this->io->writeError('Writing '.$this->root . $file.' into cache', true, IOInterface::DEBUG);
 
+            $tempFileName = $this->root . $file . uniqid('.', true) . '.tmp';
             try {
-                $tempFileName = $this->root . $file . uniqid('.tmp.', true);
                 return file_put_contents($tempFileName, $contents) !== false && rename($tempFileName, $this->root . $file);
             } catch (\ErrorException $e) {
                 $this->io->writeError('<warning>Failed to write into cache: '.$e->getMessage().'</warning>', true, IOInterface::DEBUG);
                 if (preg_match('{^file_put_contents\(\): Only ([0-9]+) of ([0-9]+) bytes written}', $e->getMessage(), $m)) {
                     // Remove partial file.
-                    unlink($this->root . $file);
+                    unlink($tempFileName);
 
                     $message = sprintf(
                         '<warning>Writing %1$s into cache failed after %2$u of %3$u bytes written, only %4$u bytes of free space available</warning>',
-                        $this->root . $file,
+                        $tempFileName,
                         $m[1],
                         $m[2],
-                        @disk_free_space($this->root . dirname($file))
+                        @disk_free_space($this->root . dirname($tempFileName))
                     );
 
                     $this->io->writeError($message);

--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -115,7 +115,8 @@ class Cache
             $this->io->writeError('Writing '.$this->root . $file.' into cache', true, IOInterface::DEBUG);
 
             try {
-                return file_put_contents($this->root . $file.'.tmp', $contents) !== false && rename($this->root . $file . '.tmp', $this->root . $file);
+                $tempFileName = $this->root . $file . uniqid('.tmp.', true);
+                return file_put_contents($tempFileName, $contents) !== false && rename($tempFileName, $this->root . $file);
             } catch (\ErrorException $e) {
                 $this->io->writeError('<warning>Failed to write into cache: '.$e->getMessage().'</warning>', true, IOInterface::DEBUG);
                 if (preg_match('{^file_put_contents\(\): Only ([0-9]+) of ([0-9]+) bytes written}', $e->getMessage(), $m)) {

--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -128,7 +128,7 @@ class Cache
                         $tempFileName,
                         $m[1],
                         $m[2],
-                        @disk_free_space($this->root . dirname($tempFileName))
+                        @disk_free_space(dirname($tempFileName))
                     );
 
                     $this->io->writeError($message);


### PR DESCRIPTION
Running parallel writes to cache may lead to race condition, when .tmp file is already renamed.

I'm getting error during tests via GitLab CI:
 - using docker-runners with shared composer cache (by mounting `/var/composer/cache`)
 - 3 parallel jobs (phpstan, phpcs, phpunit)
 - each make own `composer install`
 - usually all jobs pass install-phase without errors
 - sometimes one of jobs fails to install (see #9568)

May be there is other way:
 - to reproduce this race condition (it is necessary?)
 - workaround this problem with locks (ex. flock+timeout) - for me using locks is a proper way, but it would be a bit more complicated rather then just using more unique temporary filenames for every file/install.

Closes #9568