### PR TITLE
WIP: implement unzip via composer command and run it async

### DIFF
--- a/src/Composer/Command/UnzipCommand.php
+++ b/src/Composer/Command/UnzipCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Composer\Downloader\ChangeReportInterface;
+use Composer\Downloader\DvcsDownloaderInterface;
+use Composer\Downloader\VcsCapableDownloaderInterface;
+use Composer\Package\Dumper\ArrayDumper;
+use Composer\Package\Version\VersionGuesser;
+use Composer\Package\Version\VersionParser;
+use Composer\Plugin\CommandEvent;
+use Composer\Plugin\PluginEvents;
+use Composer\Script\ScriptEvents;
+use Composer\Util\ProcessExecutor;
+use ZipArchive;
+
+/**
+ * @author Tiago Ribeiro <tiago.ribeiro@seegno.com>
+ * @author Rui Marinho <rui.marinho@seegno.com>
+ */
+class UnzipCommand extends BaseCommand
+{
+    const EXIT_ERROR_WHILE_EXTRACT = 253;
+    const EXIT_MAYBE_SAME_FILE_DIFFERENT_CAPS = 252;
+
+    /**
+     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('unzip')
+            ->setDescription('Unzip the given archive.')
+            ->setDefinition(array(
+                new InputArgument('archive', InputArgument::REQUIRED, 'Path to archive to be unzipped'),
+                new InputArgument('destination', InputArgument::REQUIRED, 'Directory to extract into'),
+            ))
+        ;
+    }
+
+    /**
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $file = $input->getArgument('archive');
+        $path = $input->getArgument('destination');
+
+        $zipArchive = new ZipArchive();
+
+        try {
+            if (true === ($retval = $zipArchive->open($file))) {
+                $extractResult = $zipArchive->extractTo($path);
+
+                if (true === $extractResult) {
+                    $zipArchive->close();
+                } else {
+                    exit(self::EXIT_ERROR_WHILE_EXTRACT);
+                }
+            } else {
+                // exit with the one of the ZipArchive::ER* errors
+                exit($retval);
+            }
+        } catch (\ErrorException $e) {
+            $this->getIO()->writeError($e->getMessage());
+            exit(self::EXIT_MAYBE_SAME_FILE_DIFFERENT_CAPS);
+        }
+
+        return 0;
+    }
+}

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -478,6 +478,7 @@ class Application extends BaseApplication
             new Command\OutdatedCommand(),
             new Command\CheckPlatformReqsCommand(),
             new Command\FundCommand(),
+            new Command\UnzipCommand(),
         ));
 
         if (strpos(__FILE__, 'phar:') === 0) {

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -290,7 +290,7 @@ class EventDispatcher
         return $this->process->execute($exec);
     }
 
-    protected function getPhpExecCommand()
+    public function getPhpExecCommand()
     {
         $finder = new PhpExecutableFinder();
         $phpPath = $finder->find(false);


### PR DESCRIPTION
I had a different look at https://github.com/composer/composer/issues/9527 and instead of utilizing a possible async native `unzip` command, I added a `composer unzip` which does the same thing the existing code does using php-native `ZipArchive`.

since its now a separate composer command, it can be called async and therefore is parallelized.

my initial testing suggests, this way of  doing it is even slower, then what we have in the current stable release. I don't see and get why this is and therefore open a DRAFT PR, with the hope having more eyes on my PR will spot a possible implementation bug .

**before this PR, using composer 2.0.8**
```
rm -rf vendor/ && time composer install

real    1m13.082s
user    0m0.030s
sys     0m0.152s
```

**with this PR**
```
rm -rf vendor/ && time php /dev/composer/bin/composer install

real    1m58.032s
user    0m0.015s
sys     0m0.077s
```