### PR TITLE
Add option to configure the env of the Process

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -40,6 +40,10 @@ class ProcessExecutor
      * @psalm-var array<int, array<string, mixed>>
      */
     private $jobs = array();
+    /**
+     * @psalm-var array<string, string>
+     */
+    private $env = array();
     private $runningJobs = 0;
     private $maxJobs = 10;
     private $idGen = 0;
@@ -48,6 +52,11 @@ class ProcessExecutor
     public function __construct(IOInterface $io = null)
     {
         $this->io = $io;
+    }
+
+    public function setEnv(array $env)
+    {
+        $this->env = $env;
     }
 
     /**
@@ -84,6 +93,18 @@ class ProcessExecutor
         return $this->doExecute($command, $cwd, false);
     }
 
+    /**
+     * @return array|null
+     */
+    private function getEnv()
+    {
+        if(empty($this->env)){
+            return null;
+        }
+
+        return $this->env;
+    }
+
     private function doExecute($command, $cwd, $tty, &$output = null)
     {
         if ($this->io && $this->io->isDebug()) {
@@ -109,9 +130,9 @@ class ProcessExecutor
 
         // TODO in v3, commands should be passed in as arrays of cmd + args
         if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandline')) {
-            $process = Process::fromShellCommandline($command, $cwd, null, null, static::getTimeout());
+            $process = Process::fromShellCommandline($command, $cwd, $this->getEnv(), null, static::getTimeout());
         } else {
-            $process = new Process($command, $cwd, null, null, static::getTimeout());
+            $process = new Process($command, $cwd, $this->getEnv(), null, static::getTimeout());
         }
         if (!Platform::isWindows() && $tty) {
             try {

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -132,13 +132,13 @@ class ProcessExecutorTest extends TestCase
     public function testSetCustomEnv()
     {
         $process = new ProcessExecutor;
-        $process->execute(array('echo', '$CUSTOM_ENV_VAR'), $firstOutput);
+        $process->execute('echo "$CUSTOM_ENV_VAR"', $firstOutput);
         $this->assertEquals('', trim($firstOutput));
         $process->setEnv(array('CUSTOM_ENV_VAR' => 'env_value'));
-        $process->execute(array('echo', '$CUSTOM_ENV_VAR'), $secondOutput);
+        $process->execute('echo "$CUSTOM_ENV_VAR"', $secondOutput);
         $this->assertEquals('env_value', trim($secondOutput));
         $process->setEnv(array());
-        $process->execute(array('echo', '$CUSTOM_ENV_VAR'), $thirdOutput);
+        $process->execute('echo "$CUSTOM_ENV_VAR"', $thirdOutput);
         $this->assertEquals('', trim($thirdOutput));
     }
 }

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -128,4 +128,17 @@ class ProcessExecutorTest extends TestCase
         $end = microtime(true);
         $this->assertTrue($end - $start < 0.5, 'Canceling took longer than it should, lasted '.($end - $start));
     }
+
+    public function testSetCustomEnv()
+    {
+        $process = new ProcessExecutor;
+        $process->execute('echo $CUSTOM_ENV_VAR', $firstOutput);
+        $this->assertEquals('', trim($firstOutput));
+        $process->setEnv(['CUSTOM_ENV_VAR' => 'env_value']);
+        $process->execute('echo $CUSTOM_ENV_VAR', $secondOutput);
+        $this->assertEquals('env_value', trim($secondOutput));
+        $process->setEnv([]);
+        $process->execute('echo $CUSTOM_ENV_VAR', $thirdOutput);
+        $this->assertEquals('', trim($thirdOutput));
+    }
 }

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -134,10 +134,10 @@ class ProcessExecutorTest extends TestCase
         $process = new ProcessExecutor;
         $process->execute('echo $CUSTOM_ENV_VAR', $firstOutput);
         $this->assertEquals('', trim($firstOutput));
-        $process->setEnv(['CUSTOM_ENV_VAR' => 'env_value']);
+        $process->setEnv(array('CUSTOM_ENV_VAR' => 'env_value'));
         $process->execute('echo $CUSTOM_ENV_VAR', $secondOutput);
         $this->assertEquals('env_value', trim($secondOutput));
-        $process->setEnv([]);
+        $process->setEnv(array());
         $process->execute('echo $CUSTOM_ENV_VAR', $thirdOutput);
         $this->assertEquals('', trim($thirdOutput));
     }

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -132,13 +132,13 @@ class ProcessExecutorTest extends TestCase
     public function testSetCustomEnv()
     {
         $process = new ProcessExecutor;
-        $process->execute('echo $CUSTOM_ENV_VAR', $firstOutput);
+        $process->execute(array('echo', '$CUSTOM_ENV_VAR'), $firstOutput);
         $this->assertEquals('', trim($firstOutput));
         $process->setEnv(array('CUSTOM_ENV_VAR' => 'env_value'));
-        $process->execute('echo $CUSTOM_ENV_VAR', $secondOutput);
+        $process->execute(array('echo', '$CUSTOM_ENV_VAR'), $secondOutput);
         $this->assertEquals('env_value', trim($secondOutput));
         $process->setEnv(array());
-        $process->execute('echo $CUSTOM_ENV_VAR', $thirdOutput);
+        $process->execute(array('echo', '$CUSTOM_ENV_VAR'), $thirdOutput);
         $this->assertEquals('', trim($thirdOutput));
     }
 }

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -132,13 +132,13 @@ class ProcessExecutorTest extends TestCase
     public function testSetCustomEnv()
     {
         $process = new ProcessExecutor;
-        $process->execute('echo "$CUSTOM_ENV_VAR"', $firstOutput);
+        $process->execute("echo \$CUSTOM_ENV_VAR", $firstOutput);
         $this->assertEquals('', trim($firstOutput));
         $process->setEnv(array('CUSTOM_ENV_VAR' => 'env_value'));
-        $process->execute('echo "$CUSTOM_ENV_VAR"', $secondOutput);
+        $process->execute("echo \$CUSTOM_ENV_VAR", $secondOutput);
         $this->assertEquals('env_value', trim($secondOutput));
         $process->setEnv(array());
-        $process->execute('echo "$CUSTOM_ENV_VAR"', $thirdOutput);
+        $process->execute("echo \$CUSTOM_ENV_VAR", $thirdOutput);
         $this->assertEquals('', trim($thirdOutput));
     }
 }


### PR DESCRIPTION
Hey guys,

first of all, thanks for your brilliant work.

This PR adds the option to set custom Environment Variables to the ProcessExecuter.
These will be passed to the Process on creation.

I feature was born out of the need to set a custom GIT_SSH_COMMAND programmatically.

If you need further infos or more tests, just drop a line.

