### PR TITLE
Add response info for HTTP requests in CurlDownloader

### DIFF
--- a/src/Composer/Downloader/TransportException.php
+++ b/src/Composer/Downloader/TransportException.php
@@ -20,6 +20,7 @@ class TransportException extends \RuntimeException
     protected $headers;
     protected $response;
     protected $statusCode;
+    protected $totalResponseTime;
 
     public function setHeaders($headers)
     {
@@ -49,5 +50,15 @@ class TransportException extends \RuntimeException
     public function getStatusCode()
     {
         return $this->statusCode;
+    }
+
+    public function getTotalResponseTime()
+    {
+        return $this->totalResponseTime;
+    }
+
+    public function setTotalResponseTime($totalResponseTime)
+    {
+        $this->totalResponseTime = $totalResponseTime;
     }
 }

--- a/src/Composer/Downloader/TransportException.php
+++ b/src/Composer/Downloader/TransportException.php
@@ -20,7 +20,7 @@ class TransportException extends \RuntimeException
     protected $headers;
     protected $response;
     protected $statusCode;
-    protected $responseInfo;
+    protected $responseInfo = array();
 
     public function setHeaders($headers)
     {
@@ -63,7 +63,7 @@ class TransportException extends \RuntimeException
     /**
      * @param array $responseInfo
      */
-    public function setResponseInfo($responseInfo)
+    public function setResponseInfo(array $responseInfo)
     {
         $this->responseInfo = $responseInfo;
     }

--- a/src/Composer/Downloader/TransportException.php
+++ b/src/Composer/Downloader/TransportException.php
@@ -20,7 +20,7 @@ class TransportException extends \RuntimeException
     protected $headers;
     protected $response;
     protected $statusCode;
-    protected $totalResponseTime;
+    protected $responseInfo;
 
     public function setHeaders($headers)
     {
@@ -52,13 +52,19 @@ class TransportException extends \RuntimeException
         return $this->statusCode;
     }
 
-    public function getTotalResponseTime()
+    /**
+     * @return array
+     */
+    public function getResponseInfo()
     {
-        return $this->totalResponseTime;
+        return $this->responseInfo;
     }
 
-    public function setTotalResponseTime($totalResponseTime)
+    /**
+     * @param array $responseInfo
+     */
+    public function setResponseInfo($responseInfo)
     {
-        $this->totalResponseTime = $totalResponseTime;
+        $this->responseInfo = $responseInfo;
     }
 }

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -303,9 +303,8 @@ class CurlDownloader
                     if (!$error && function_exists('curl_strerror')) {
                         $error = curl_strerror($errno);
                     }
-
                     $exception = new TransportException('curl error '.$errno.' while downloading '.Url::sanitize($progress['url']).': '.$error);
-                    $exception->setTotalResponseTime(isset($progress['total_time_us']) ? $progress['total_time_us'] : null);
+                    $exception->setResponseInfo($progress);
                     throw $exception;
                 }
                 $statusCode = $progress['http_code'];
@@ -324,14 +323,12 @@ class CurlDownloader
                         rewind($job['bodyHandle']);
                         $contents = stream_get_contents($job['bodyHandle']);
                     }
-                    $response = new Response(array('url' => $progress['url']), $statusCode, $headers, $contents);
-                    $response->setTotalResponseTime(isset($progress['total_time_us']) ? $progress['total_time_us'] : null);
+                    $response = new CurlResponse(array('url' => $progress['url']), $statusCode, $headers, $contents, $progress);
                     $this->io->writeError('['.$statusCode.'] '.Url::sanitize($progress['url']), true, IOInterface::DEBUG);
                 } else {
                     rewind($job['bodyHandle']);
                     $contents = stream_get_contents($job['bodyHandle']);
-                    $response = new Response(array('url' => $progress['url']), $statusCode, $headers, $contents);
-                    $response->setTotalResponseTime(isset($progress['total_time_us']) ? $progress['total_time_us'] : null);
+                    $response = new CurlResponse(array('url' => $progress['url']), $statusCode, $headers, $contents, $progress);
                     $this->io->writeError('['.$statusCode.'] '.Url::sanitize($progress['url']), true, IOInterface::DEBUG);
                 }
                 fclose($job['bodyHandle']);

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -305,7 +305,7 @@ class CurlDownloader
                     }
 
                     $exception = new TransportException('curl error '.$errno.' while downloading '.Url::sanitize($progress['url']).': '.$error);
-                    $exception->setTotalResponseTime($progress['total_time_us']);
+                    $exception->setTotalResponseTime(isset($progress['total_time_us']) ? $progress['total_time_us'] : null);
                     throw $exception;
                 }
                 $statusCode = $progress['http_code'];
@@ -325,13 +325,13 @@ class CurlDownloader
                         $contents = stream_get_contents($job['bodyHandle']);
                     }
                     $response = new Response(array('url' => $progress['url']), $statusCode, $headers, $contents);
-                    $response->setTotalResponseTime($progress['total_time_us']);
+                    $response->setTotalResponseTime(isset($progress['total_time_us']) ? $progress['total_time_us'] : null);
                     $this->io->writeError('['.$statusCode.'] '.Url::sanitize($progress['url']), true, IOInterface::DEBUG);
                 } else {
                     rewind($job['bodyHandle']);
                     $contents = stream_get_contents($job['bodyHandle']);
                     $response = new Response(array('url' => $progress['url']), $statusCode, $headers, $contents);
-                    $response->setTotalResponseTime($progress['total_time_us']);
+                    $response->setTotalResponseTime(isset($progress['total_time_us']) ? $progress['total_time_us'] : null);
                     $this->io->writeError('['.$statusCode.'] '.Url::sanitize($progress['url']), true, IOInterface::DEBUG);
                 }
                 fclose($job['bodyHandle']);

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -303,7 +303,10 @@ class CurlDownloader
                     if (!$error && function_exists('curl_strerror')) {
                         $error = curl_strerror($errno);
                     }
-                    throw new TransportException('curl error '.$errno.' while downloading '.Url::sanitize($progress['url']).': '.$error);
+
+                    $exception = new TransportException('curl error '.$errno.' while downloading '.Url::sanitize($progress['url']).': '.$error);
+                    $exception->setTotalResponseTime($progress['total_time_us']);
+                    throw $exception;
                 }
                 $statusCode = $progress['http_code'];
                 rewind($job['headerHandle']);
@@ -322,11 +325,13 @@ class CurlDownloader
                         $contents = stream_get_contents($job['bodyHandle']);
                     }
                     $response = new Response(array('url' => $progress['url']), $statusCode, $headers, $contents);
+                    $response->setTotalResponseTime($progress['total_time_us']);
                     $this->io->writeError('['.$statusCode.'] '.Url::sanitize($progress['url']), true, IOInterface::DEBUG);
                 } else {
                     rewind($job['bodyHandle']);
                     $contents = stream_get_contents($job['bodyHandle']);
                     $response = new Response(array('url' => $progress['url']), $statusCode, $headers, $contents);
+                    $response->setTotalResponseTime($progress['total_time_us']);
                     $this->io->writeError('['.$statusCode.'] '.Url::sanitize($progress['url']), true, IOInterface::DEBUG);
                 }
                 fclose($job['bodyHandle']);

--- a/src/Composer/Util/Http/CurlResponse.php
+++ b/src/Composer/Util/Http/CurlResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Util\Http;
+
+class CurlResponse extends Response
+{
+    private $curlInfo;
+
+    public function __construct(array $request, $code, array $headers, $body, array $curlInfo)
+    {
+        parent::__construct($request, $code, $headers, $body);
+        $this->curlInfo = $curlInfo;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCurlInfo()
+    {
+        return $this->curlInfo;
+    }
+}

--- a/src/Composer/Util/Http/Response.php
+++ b/src/Composer/Util/Http/Response.php
@@ -20,6 +20,7 @@ class Response
     private $code;
     private $headers;
     private $body;
+    private $totalResponseTime;
 
     public function __construct(array $request, $code, array $headers, $body)
     {
@@ -67,6 +68,20 @@ class Response
     public function getBody()
     {
         return $this->body;
+    }
+
+    /**
+     * Total duration time it took for the response in micro seconds
+     * @return int|null
+     */
+    public function getTotalResponseTime()
+    {
+        return $this->totalResponseTime;
+    }
+
+    public function setTotalResponseTime($totalResponseTime)
+    {
+        $this->totalResponseTime = $totalResponseTime;
     }
 
     public function decodeJson()

--- a/src/Composer/Util/Http/Response.php
+++ b/src/Composer/Util/Http/Response.php
@@ -20,7 +20,6 @@ class Response
     private $code;
     private $headers;
     private $body;
-    private $totalResponseTime;
 
     public function __construct(array $request, $code, array $headers, $body)
     {
@@ -68,20 +67,6 @@ class Response
     public function getBody()
     {
         return $this->body;
-    }
-
-    /**
-     * Total duration time it took for the response in micro seconds
-     * @return int|null
-     */
-    public function getTotalResponseTime()
-    {
-        return $this->totalResponseTime;
-    }
-
-    public function setTotalResponseTime($totalResponseTime)
-    {
-        $this->totalResponseTime = $totalResponseTime;
     }
 
     public function decodeJson()


### PR DESCRIPTION
This PR adds a way to expose response information for HTTP requests in CurlDownloader. The response information stored is from `curl_getinfo()`.

This makes it possible to log certain data, like for instance the total response time per HTTP request.