### PR TITLE
Filesystem: use is_dir() instead of file_exists() which is faster

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -131,7 +131,7 @@ class Filesystem
         // clear stat cache because external processes aren't tracked by the php stat cache
         clearstatcache();
 
-        if ($result && !file_exists($directory)) {
+        if ($result && !is_dir($directory)) {
             return true;
         }
 
@@ -600,7 +600,7 @@ class Filesystem
         if (!function_exists('symlink')) {
             return false;
         }
-    
+
         $cwd = getcwd();
 
         $relativePath = $this->findShortestPath($link, $target);


### PR DESCRIPTION
this reproducible saves 1-2 seconds while running `COMPOSER_DISABLE_NETWORK=1 php
 composer/bin/composer install -vvv --profile` on the [rector/rector project](https://github.com/rectorphp/rector)

before: 63-65 seconds

after (with this patch): 61-63 seconds

```
...
[14.3MiB/54.17s] Generating autoload files
[16.2MiB/56.32s] > post-autoload-dump: PackageVersions\Installer->dumpVersionsClass
[16.3MiB/56.32s] composer/package-versions-deprecated: Generating version class...
[16.3MiB/56.33s] composer/package-versions-deprecated: ...done generating version class
[15.5MiB/56.42s] 80 packages you are using are looking for funding.
[15.5MiB/56.42s] Use the `composer fund` command to find out more!
[15.5MiB/56.42s] > post-install-cmd: Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin->onDependenciesChangedEvent
[15.5MiB/56.42s] Running PHPCodeSniffer Composer Installer
[15.5MiB/56.42s] Executing command (/mnt/c/dvl/GitHub/rector/vendor/bin): phpcs --config-show installed_paths
[15.5MiB/59.08s] Executing command (/mnt/c/dvl/GitHub/rector/vendor/squizlabs/php_codesniffer): '/usr/bin/php7.4' -d allow_url_fopen='1' -d disable_functions='' -d memory_limit='-1' ./bin/phpcs --config-set installed_paths ../../slevomat/coding-standard
[15.5MiB/59.37s] Executing command (/mnt/c/dvl/GitHub/rector/vendor/bin): phpcs --config-show installed_paths
[15.5MiB/59.64s] PHP CodeSniffer Config installed_paths set to ../../slevomat/coding-standard
[15.5MiB/59.64s] Using config file: /mnt/c/dvl/GitHub/rector/vendor/squizlabs/php_codesniffer/CodeSniffer.conf

Config value "installed_paths" added successfully

[15.5MiB/59.64s] Memory usage: 15.5MiB (peak: 17.53MiB), time: 62.64s
```