### PR TITLE
Filesystem: added removeDirectoryAsync() and use it in ArchiveDownloader

### DIFF
--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -139,9 +139,11 @@ abstract class ArchiveDownloader extends FileDownloader
                 }
             }
 
-            $filesystem->removeDirectory($temporaryDir);
-            $self->removeCleanupPath($package, $temporaryDir);
-            $self->removeCleanupPath($package, $path);
+            $promise = $filesystem->removeDirectory($temporaryDir, true);
+            return $promise->then(function() use ($self, $package, $path, $temporaryDir) {
+                $self->removeCleanupPath($package, $temporaryDir);
+                $self->removeCleanupPath($package, $path);
+            });
         }, function ($e) use ($cleanup) {
             $cleanup();
 

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -139,7 +139,7 @@ abstract class ArchiveDownloader extends FileDownloader
                 }
             }
 
-            $promise = $filesystem->removeDirectory($temporaryDir, true);
+            $promise = $filesystem->removeDirectoryAsync($temporaryDir);
             return $promise->then(function() use ($self, $package, $path, $temporaryDir) {
                 $self->removeCleanupPath($package, $temporaryDir);
                 $self->removeCleanupPath($package, $path);

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -113,7 +113,7 @@ class Filesystem
         // clear stat cache because external processes aren't tracked by the php stat cache
         clearstatcache();
 
-        if ($result && !file_exists($directory)) {
+        if ($result && !is_dir($directory)) {
             return true;
         }
 
@@ -151,7 +151,7 @@ class Filesystem
             clearstatcache();
 
             if ($process->isSuccessful()) {
-                if (!file_exists($directory)) {
+                if (!is_dir($directory)) {
                     return \React\Promise\resolve(true);
                 }
             }

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -131,7 +131,7 @@ class Filesystem
             $promise = $this->getProcess()->executeAsync($cmd);
 
             $self = $this;
-            return $promise->then(function ($process) use ($directory, $cmd, $self) {
+            return $promise->then(function ($process) use ($directory, $self) {
                 // clear stat cache because external processes aren't tracked by the php stat cache
                 clearstatcache();
 


### PR DESCRIPTION
this turns half of the `rm -rf ...` executions async and therefore improves performance.

before:
```
COMPOSER_DISABLE_NETWORK=1 php ../../../Users/mstaab/Documents/GitHub/composer/bin/composer install -vvv --profile
...
[15.5MiB/27.04s] Memory usage: 15.5MiB (peak: 17.53MiB), time: 27.04s
```

after:
```
COMPOSER_DISABLE_NETWORK=1 php ../../../Users/mstaab/Documents/GitHub/composer/bin/composer install -vvv --profile
...
[15.5MiB/25.83s] Memory usage: 15.5MiB (peak: 17.53MiB), time: 25.83s
```
