### PR TITLE
Do not unnecessarily load replaced packages into the pool

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -474,7 +474,6 @@ class PoolBuilder
 
                     if ($request->getUpdateAllowTransitiveRootDependencies() || !$skippedRootRequires) {
                         $this->unlockPackage($request, $repositories, $replace);
-                        $this->markPackageNameForLoading($request, $replace, $link->getConstraint());
                     } else {
                         foreach ($skippedRootRequires as $rootRequire) {
                             if (!isset($this->updateAllowWarned[$rootRequire])) {

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/avoid-loading-replaced-packages.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/avoid-loading-replaced-packages.test
@@ -1,17 +1,14 @@
 --TEST--
-Fixed packages and replacers get unfixed correctly (refs https://github.com/composer/composer/pull/8942)
+Do not load replaced packages into the pool unless they are required elsewhere
 
 --REQUEST--
 {
     "require": {
-        "root/req1": "*",
-        "root/req3": "*"
+        "root/req1": "*"
     },
     "locked": [
         {"name": "root/req1", "version": "1.0.0", "require": {"replacer/pkg": "1.*"}},
-        {"name": "root/req3", "version": "1.0.0", "require": {"replaced/pkg": "1.*", "dep/dep": "2.*"}},
-        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "*"}},
-        {"name": "dep/dep", "version": "2.3.5"}
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "*"}}
     ],
     "allowList": [
         "root/req1"
@@ -28,21 +25,15 @@ Fixed packages and replacers get unfixed correctly (refs https://github.com/comp
     [
         {"name": "root/req1", "version": "1.0.0", "require": {"replacer/pkg": "1.*"}},
         {"name": "root/req1", "version": "1.1.0", "require": {"replacer/pkg": "1.*"}},
-        {"name": "root/req3", "version": "1.0.0", "require": {"replaced/pkg": "1.*"}},
-        {"name": "root/req3", "version": "1.1.0", "require": {"replaced/pkg": "1.*"}},
         {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "*"}},
         {"name": "replacer/pkg", "version": "1.1.0", "replace": {"replaced/pkg": "*"}},
         {"name": "replaced/pkg", "version": "1.2.3"},
-        {"name": "replaced/pkg", "version": "1.2.4"},
-        {"name": "dep/dep", "version": "2.3.5"},
-        {"name": "dep/dep", "version": "2.3.6"}
+        {"name": "replaced/pkg", "version": "1.2.4"}
     ]
 ]
 
 --EXPECT--
 [
-    "root/req3-1.0.0.0 (locked)",
-    "dep/dep-2.3.5.0 (locked)",
     "root/req1-1.0.0.0",
     "root/req1-1.1.0.0",
     "replacer/pkg-1.0.0.0",
@@ -51,8 +42,6 @@ Fixed packages and replacers get unfixed correctly (refs https://github.com/comp
 
 --EXPECT-OPTIMIZED--
 [
-    "root/req3-1.0.0.0 (locked)",
-    "dep/dep-2.3.5.0 (locked)",
     "root/req1-1.1.0.0",
     "replacer/pkg-1.1.0.0"
 ]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace-partial-update-all.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace-partial-update-all.test
@@ -101,7 +101,6 @@ Check that replacers from additional repositories are loaded when doing a partia
     "indirect/replacer-1.0.0.0",
     "replacer/package-1.2.0.0",
     "replacer/package-1.0.0.0",
-    "base/package-1.0.0.0",
     "shared/dep-1.0.0.0",
     "shared/dep-1.2.0.0"
 ]
@@ -112,6 +111,5 @@ Check that replacers from additional repositories are loaded when doing a partia
     "indirect/replacer-1.0.0.0",
     "replacer/package-1.2.0.0",
     "replacer/package-1.0.0.0",
-    "base/package-1.0.0.0",
     "shared/dep-1.2.0.0"
 ]


### PR DESCRIPTION
I'm seeing slow performance with composer and Drupal. I thought it may be related to the Pool Optimiser PR not having much impact on Drupal installations (see https://github.com/composer/composer/pull/9261#issuecomment-703171395) but it might not be. To be specific, this is when performing updates. It heavily impacts dependabot.

To reproduce. Take the composer.json from https://github.com/drupal/recommended-project/blob/9.2.x/composer.json
Then install `composer install --profile`
Then install a module `composer require drupal/media_entity_twitter:2.5.0 --profile`
Modify composer.json for media_entity_twitter to `^2.0`
Then update that module `composer update -W drupal/media_entity_twitter --profile` (goes to 2.6.0 currently.)

The timings I get are:

    $ composer --version
    Composer version 2.0.7 2020-11-13 17:31:06
    $ composer install --profile
    [31.7MiB/31.07s] Memory usage: 31.66MiB (peak: 228.37MiB), time: 31.07s
    $ composer require drupal/media_entity_twitter:2.5.0 --profile
    [19.1MiB/3.14s] Memory usage: 19.07MiB (peak: 20.42MiB), time: 3.14s
    $ nano composer.json
    $ composer update -W drupal/media_entity_twitter --profile
    [46.9MiB/25.46s] Memory usage: 46.86MiB (peak: 203.91MiB), time: 25.46s

As you can see the update takes a long time. When using a composer version that outputs the network requests, you can see many many 404 like these:

    [23.5MiB/4.08s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-bridge.json
    [23.5MiB/4.19s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-front-matter.json
    [23.5MiB/4.34s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-diff.json
    [23.5MiB/4.35s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-php-storage.json
    [23.6MiB/4.43s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-discovery.json
    [23.6MiB/4.52s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-file-cache.json
    [23.6MiB/4.58s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-file-security.json
    [23.6MiB/4.62s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-filesystem.json
    [23.6MiB/4.83s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-http-foundation.json
    [23.6MiB/4.87s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-graph.json
    [23.6MiB/4.95s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-gettext.json
    [23.6MiB/5.00s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-proxy-builder.json
    [23.7MiB/5.05s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-render.json
    [23.7MiB/5.06s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-uuid.json
    [23.7MiB/5.09s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-plugin.json
    [23.7MiB/5.29s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-utility.json
    [23.7MiB/5.29s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/datetime.json
    [23.7MiB/5.35s] [404] https://packages.drupal.org/files/packages/8/p2/drupal/core-transliteration.json

This goes on for a while.

Essentially the drupal/core-recommended depends on drupal/core package which has a large replaces list. This list contains the name of every core module. Whether or not it should is left for discussion elsewhere (there are reasons to do so.) This list of replaced packages for the most part do not exist - for example drupal/taxonomy is, and has always been, a core module (I think). When you run an update it sees that media_entity_twitter depends on drupal/core and thus unlocks it as a non-root dependency and marks it for load, but it then proceeds to load all the replacements - even though no other package ever requires them.

So it seems somewhat unnecessary to be loading the replaced packages. If there is indeed a require to one of them somewhere, it would make sense. Maybe I'm missing something.

With this PR the 404s disappear and the timings for the update becomes as expected:

    $ composer update -W drupal/media_entity_twitter --profile
    [29.7MiB/5.84s] Memory usage: 29.66MiB (peak: 250.26MiB), time: 5.84s

Savings of 20 seconds.

WDYT?

CC @Toflar after discussion in #9261 (Thanks!)