### PR TITLE
Filter impossible packages from the pool

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -275,6 +275,8 @@ class PoolBuilder
             $this->unacceptableFixedOrLockedPackages = $prePoolCreateEvent->getUnacceptableFixedPackages();
         }
 
+        $this->filterImpossiblePackages($request);
+
         $pool = new Pool($this->packages, $this->unacceptableFixedOrLockedPackages);
 
         $this->aliasMap = array();
@@ -586,6 +588,53 @@ class PoolBuilder
                 $this->io->writeError('<warning>Package "' . $pattern . '" listed for update is not locked.</warning>');
             }
         }
+    }
+
+    /**
+     * Use the list of fixed and locked packages to constrain the loaded packages
+     * This will reduce packages with significant numbers of historical versions to a smaller number
+     * and reduce the resulting rule set that is generated
+     *
+     * @param Request $request
+     *
+     * @return void
+     */
+    private function filterImpossiblePackages(Request $request)
+    {
+        $packageIndex = [];
+        $packagesToFilter = [];
+        foreach ($this->packages as $id => $package) {
+            /** @var PackageInterface $package */
+            $packageIndex[$package->getName()][$id] = $package;
+        }
+        foreach ($request->getFixedOrLockedPackages() as $package) {
+            /** @var PackageInterface $package */
+            foreach ($package->getRequires() as $link) {
+                $require = $link->getTarget();
+                if (empty($packageIndex[$require])) {
+                    continue;
+                }
+                $linkConstraint = $link->getConstraint();
+                $versionsToFilter = [];
+                foreach ($packageIndex[$require] as $id => $linkedPackage) {
+                    /** @var PackageInterface $linkedPackage */
+                    if (!$linkConstraint->matches(new Constraint('==', $linkedPackage->getVersion()))) {
+                        // Do not filter a package aliased by another package
+                        if (!empty($this->aliasMap[spl_object_hash($linkedPackage)])) {
+                            continue;
+                        }
+                        // Do not filter locked packages
+                        if ($request->isFixedPackage($linkedPackage) || $request->isLockedPackage($linkedPackage)) {
+                            continue;
+                        }
+                        $versionsToFilter[$id] = $id;
+                        $packagesToFilter[$id] = $id;
+                    }
+                }
+                $packageIndex[$require] = array_diff_key($packageIndex[$require], $versionsToFilter);
+            }
+        }
+        $this->packages = array_diff_key($this->packages, $packagesToFilter);
     }
 
     /**

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages.test
@@ -27,9 +27,9 @@ Do not load packages into the pool that cannot meet the fixed/locked requirement
     [
         {"name": "some/pkg", "version": "1.0.4", "require": {"dep/dep": "*"}},
         {"name": "root/req", "version": "1.0.0", "require": {"dep/dep": "2.*"}},
-        {"name": "dep/dep", "version": "1.0.0"},
-        {"name": "dep/dep", "version": "1.0.1"},
-        {"name": "dep/dep", "version": "1.0.2"},
+        {"name": "dep/dep", "version": "1.0.0", "provide": {"other/pkg": "*"}},
+        {"name": "dep/dep", "version": "1.0.1", "provide": {"other/pkg": "*"}},
+        {"name": "dep/dep", "version": "1.0.2", "provide": {"other/pkg": "*"}},
         {"name": "dep/dep", "version": "2.0.0"},
         {"name": "dep/dep", "version": "2.0.1"}
     ]
@@ -39,6 +39,16 @@ Do not load packages into the pool that cannot meet the fixed/locked requirement
 [
     2,
     "some/pkg-1.0.4.0",
+    "dep/dep-1.0.0.0",
+    "dep/dep-1.0.1.0",
+    "dep/dep-1.0.2.0",
     "dep/dep-2.0.0.0",
+    "dep/dep-2.0.1.0"
+]
+
+--EXPECT-OPTIMIZED--
+[
+    2,
+    "some/pkg-1.0.4.0",
     "dep/dep-2.0.1.0"
 ]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages.test
@@ -1,0 +1,44 @@
+--TEST--
+Do not load packages into the pool that cannot meet the fixed/locked requirements, when a loose requirement is encountered during update
+
+--REQUEST--
+{
+    "require": {
+        "some/pkg": "*",
+        "root/req": "*"
+    },
+    "locked": [
+        {"name": "some/pkg", "version": "1.0.3", "require": {"dep/dep": "*"}, "id": 1},
+        {"name": "root/req", "version": "1.0.0", "require": {"dep/dep": "2.*"}, "id": 2},
+        {"name": "dep/dep", "version": "2.0.0", "id": 3}
+    ],
+    "allowList": [
+        "some/pkg"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name": "some/pkg", "version": "1.0.4", "require": {"dep/dep": "*"}},
+        {"name": "root/req", "version": "1.0.0", "require": {"dep/dep": "2.*"}},
+        {"name": "dep/dep", "version": "1.0.0"},
+        {"name": "dep/dep", "version": "1.0.1"},
+        {"name": "dep/dep", "version": "1.0.2"},
+        {"name": "dep/dep", "version": "2.0.0"},
+        {"name": "dep/dep", "version": "2.0.1"}
+    ]
+]
+
+--EXPECT--
+[
+    2,
+    "some/pkg-1.0.4.0",
+    "dep/dep-2.0.0.0",
+    "dep/dep-2.0.1.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repos-always-but-not-their-transitive-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repos-always-but-not-their-transitive-deps.test
@@ -86,6 +86,5 @@ Partially updating one root requirement with transitive deps fully updates trans
    "symlinked/path-pkg-2.0.0.0",
    "root/update-1.0.4.0",
    "symlinked/transitive2-2.0.4.0",
-   "mirrored/transitive2-1.0.7.0",
-   "mirrored/transitive2-2.0.8.0"
+   "mirrored/transitive2-1.0.7.0"
 ]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
@@ -45,8 +45,7 @@ locked packages still need to be taking into account for loading all necessary v
     "dep/pkg2-1.0.0.0",
     "dep/pkg2-1.2.0.0",
     "dep/pkg1-1.0.0.0",
-    "dep/pkg1-1.0.1.0",
-    "dep/pkg1-2.0.0.0"
+    "dep/pkg1-1.0.1.0"
 ]
 
 --EXPECT-OPTIMIZED--

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
@@ -45,7 +45,8 @@ locked packages still need to be taking into account for loading all necessary v
     "dep/pkg2-1.0.0.0",
     "dep/pkg2-1.2.0.0",
     "dep/pkg1-1.0.0.0",
-    "dep/pkg1-1.0.1.0"
+    "dep/pkg1-1.0.1.0",
+    "dep/pkg1-2.0.0.0"
 ]
 
 --EXPECT-OPTIMIZED--
@@ -54,6 +55,5 @@ locked packages still need to be taking into account for loading all necessary v
     "root/req2-1.0.0.0 (locked)",
     "dep/pkg2-1.0.0.0",
     "dep/pkg2-1.2.0.0",
-    "dep/pkg1-1.0.1.0",
-    "dep/pkg1-2.0.0.0"
+    "dep/pkg1-1.0.1.0"
 ]


### PR DESCRIPTION
I have noticed updates of some Drupal packages can be fairly slow. This seems to affect at varying levels. One module I found it reproduces with is if you have `drupal/block_permissions` installed. It appears to be due to the fact it has a requires of `drupal/core ~8` and in the latest version `drupal/core ^8 || ^9`.

When processing the update of the module it then causes the drupal/core package to be downloaded and added to the pool in all versions since 8.0.0 all the way to 8.9 and then 9.0 all the way to 9.2, and all symfony packages that are depended on in-between those versions. This then generates a significant number of conflict rules.

Using the composer.json at https://github.com/drupal/recommended-project/blob/8.9.x/composer.json to reproduce. When editing with nano change the requirement on block_permissions to "^1.0".

    $ composer install
    ...
    $ composer require drupal/block_permissions:1.0.0
    ...
    $ nano composer.json
    ...
    $ composer -vvv update -W drupal/block_permissions --profile
    [488.1MiB/27.72s] Dependency resolution completed in 0.436 seconds
    [87.9MiB/27.84s] Analyzed 10213 packages to resolve dependencies
    [87.9MiB/27.84s] Analyzed 736505 rules to resolve dependencies
    ...
    [56.1MiB/28.01s] Memory usage: 56.06MiB (peak: 488.6MiB), time: 28.01s

As you can see, nearly 3 quarters of a million rules. In fact, on my project I'm having these issues with - there's around 990,000. The majority are conflict rules.

Specifically this means we can't use dependabot as effectively as we'd hoped - as each check of a module for updates takes a significant amount of time. The PR in #9619 reduces the time a large amount but it still is slow.

This PR aims to reduce the rule count - similar to the Pool Optimisation in #9261 (Maybe this should be a second optimisation rule that can be disabled?) - that aims updates only - and hopefully speed up dependabot and just general updates. It does it by taking the list of packages still fixed, and filtering the pool. This removes all the versions of drupal/core in the pool that do not meet the requirement in the composer.json that are still fixed. Thus reducing the package count substantially.

I do not believe problem output should be impacted as I think if a package did come in needing a different version of something, that would be unlocked by `-w` / `-W` if needed to allow that recalculation. Though I may have missed something so worth some eyes.

For me it reduces the time by a good 5 seconds for the above scenario. It also significantly reduces the memory usage to about a 10th of what it was.

    $ composer -vvv update -W drupal/block_permissions --profile
    [55.5MiB/23.68s] Dependency resolution completed in 0.012 seconds
    [50.2MiB/23.68s] Analyzed 2450 packages to resolve dependencies
    [50.2MiB/23.68s] Analyzed 5948 rules to resolve dependencies
    ...
    [43.5MiB/23.84s] Memory usage: 43.53MiB (peak: 73.47MiB), time: 23.84s

When combined with the PR in #9619 it reduces timings and memory further.

    Just PR 9619
    [40.5MiB/8.13s] Memory usage: 40.48MiB (peak: 520.66MiB), time: 8.13s
    Combined
    [25.3MiB/6.42s] Memory usage: 25.25MiB (peak: 60.39MiB), time: 6.42s

CC @Toflar as this was based on my investigating drupal bits in the Pool Optimiser PR #9261.

(Background: trying to make Dependabot faster so we can use on Drupal effectively - GitHub's own hits 45 minute timeout for us - running ourselves it takes over an hour, about 75 minutes - with the above two PR it makes the full run less than 5 minutes and significantly less memory, bandwidth and CO2 :wink: ... if it turns out is it working that is! )