### PR TITLE
Expose COMPOSER_* paths to scripts as env vars

### DIFF
--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -166,6 +166,7 @@ class FileDownloaderTest extends TestCase
 
         $path = $this->getUniqueTmpDirectory();
         $config = new Config(false, $path);
+        $config->merge(array('config' => array('home' => '~')));
 
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
@@ -259,6 +260,7 @@ class FileDownloaderTest extends TestCase
 
         $path = $this->getUniqueTmpDirectory();
         $config = new Config(false, $path);
+        $config->merge(array('config' => array('home' => '~')));
 
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -587,6 +587,7 @@ class EventDispatcherTest extends TestCase
     {
         $composer = new Composer;
         $config = new Config;
+        $config->merge(array('config' => array('home' => '~')));
         $composer->setConfig($config);
         $package = $this->getMockBuilder('Composer\Package\RootPackageInterface')->getMock();
         $composer->setPackage($package);


### PR DESCRIPTION
It has always bugged me as to why this was missing :)

To me, the main benefit of running `composer something` should be that composer would create a nice environment to make running scripts easy, as in eg: easy to spot where the vendor dir is.

This PR exposes all `COMPOSER_*` paths as env vars for this purpose.