### PR TITLE
Remove dependency on wget from install docs

### DIFF
--- a/doc/faqs/how-to-install-composer-programmatically.md
+++ b/doc/faqs/how-to-install-composer-programmatically.md
@@ -9,7 +9,7 @@ An alternative is to use this script which only works with UNIX utilities:
 ```bash
 #!/bin/sh
 
-EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
+EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
 


### PR DESCRIPTION
Some people have wget, others have cURL, but we all have PHP. ;)

It looks silly, but e.g. the `debian:buster-slim` Docker image has neither `curl` nor `wget` installed by default.
