### PR TITLE
Adds ability to use generated env vars in scripts and handlers

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -335,4 +335,14 @@ Defaults to `php-only` which only checks the PHP version. Set to `true` to also
 check the presence of extension. If set to `false`, Composer will not create and
 require a `platform_check.php` file as part of the autoloader bootstrap.
 
+## set-script-vars
+
+Defaults to `false`. Sets the following environment variables for use in scripts:
+
+| Name | Description | Example value |
+|------|-------------|---------------|
+| `$COMPOSER_PACKAGE_NAME` | The value of `name` from the package's `composer.json` | `vendor/package` |
+| `$COMPOSER_PACKAGE_VERSION` | The guessed version from VCS, or the value of `version` from the package's `composer.json` | `1.2.9999999.9999999-dev` |
+| `$COMPOSER_PACKAGE_PRETTY_VERSION` | The "pretty" version of `$COMPOSER_PACKAGE_VERSION` | `1.2.x-dev` |
+
 &larr; [Repositories](05-repositories.md)  |  [Runtime](07-runtime.md) &rarr;

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -364,7 +364,13 @@ To set an environment variable in a cross-platform way, you can use `@putenv`:
 }
 ```
 
-## Custom descriptions.
+## Using values from `composer.json`
+
+You can use environment variables referenced in
+[set-script-vars](../06-config.md#set-script-vars) in your `scripts` if you have
+`set-script-vars` configured to `true`
+
+## Custom descriptions
 
 You can set custom script descriptions with the following in your `composer.json`:
 

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -66,6 +66,7 @@ class Config
         'use-github-api' => true,
         'lock' => true,
         'platform-check' => 'php-only',
+        'set-script-vars' => false,
         // valid keys without defaults (auth config stuff):
         // bitbucket-oauth
         // github-oauth

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -303,14 +303,15 @@ class EventDispatcher
             return $this->process->executeTty($exec, null, $scriptEnvVars);
         }
 
-        $outputHandler = function($type, $buffer) {
-            if (null === $this->io) {
+        $io = $this->io;
+        $outputHandler = function($type, $buffer) use ($io) {
+            if (null === $io) {
                 echo $buffer;
             } else {
                 if (Process::ERR === $type) {
-                    $this->io->writeErrorRaw($buffer, false);
+                    $io->writeErrorRaw($buffer, false);
                 } else {
-                    $this->io->writeRaw($buffer, false);
+                    $io->writeRaw($buffer, false);
                 }
             }
         };

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -114,8 +114,8 @@ class GitTest extends TestCase
             ->expects($this->atLeast(2))
             ->method('execute')
             ->willReturnMap(array(
-                array('git command failing', null, null, 1),
-                array('git command ok', null, null, 0),
+                array('git command failing', null, null, null, 1),
+                array('git command ok', null, null, null, 0),
             ));
 
         $this->io


### PR DESCRIPTION
When enabled (`set-script-vars` config is `true`), this adds the following for use in scripts without having to either wrap them in handlers or have them read the json:

- `$COMPOSER_PACKAGE_NAME`
- `$COMPOSER_PACKAGE_VERSION`
- `$COMPOSER_PACKAGE_PRETTY_VERSION`

A simple example (assuming private packages using the `version` key in `composer.json`):

```json
{
    "scripts": {
        "release": [
            "git tag -a v$COMPOSER_PACKAGE_VERSION -m \"Version $COMPOSER_PACKAGE_VERSION\"",
            "git push --tags",
            "slack-notify -text \"$COMPOSER_PACKAGE_NAME@$COMPOSER_PACKAGE_VERSION has been released!\""
        ]
    }
}
```

The values chosen were based on what I've personally wanted and what made sense when comparing to https://github.com/npm/rfcs/pull/183