### PR TITLE
Minor improvement to ClassLoader::register no-op block

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -311,8 +311,10 @@ class ClassLoader
         spl_autoload_register(array($this, 'loadClass'), true, $prepend);
 
         if (null === $this->vendorDir) {
-            //no-op
-        } elseif ($prepend) {
+            return;
+        }
+
+        if ($prepend) {
             self::$registeredLoaders = array($this->vendorDir => $this) + self::$registeredLoaders;
         } else {
             unset(self::$registeredLoaders[$this->vendorDir]);


### PR DESCRIPTION
A recent change in the ClassAutoloader (#9635) added support for specifying a vendorDir, and `\Composer\Autoload\ClassLoader::register` now has a if-elseif-else chain.
The first block has a `// no-op` comment, followed by an `elseif` block. It's more readable to `return;`, and remove the `elseif` for readability.