### PR TITLE
Allow to override Installer::createPlatformRepo

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -708,7 +708,7 @@ class Installer
         return 0;
     }
 
-    private function createPlatformRepo($forUpdate)
+    protected function createPlatformRepo($forUpdate)
     {
         if ($forUpdate) {
             $platformOverrides = $this->config->get('platform') ?: array();


### PR DESCRIPTION
I need this for my https://www.composer-resolver.cloud service.

Right now the cloud resolver is sort of broken because while it's true that you have to send your local platform along with the composer.json and composer.lock, these are only handled as overrides. Which means that if you e.g. do not send libsodium (because you don't have it locally) the cloud (which does provide it) will still happily resolve the dependencies. Hence, I cannot work with platform overrides, I have to replace the whole PlatformRepository.

I don't think this is a very common use case though :) So I figured just allowing me to replace it in an extended child class would be enough. No need for a setter or a factory.