### PR TITLE
Add support for autoloading Enums

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -215,7 +215,7 @@ class ClassMapGenerator
     private static function findClasses($path)
     {
         $extraTypes = PHP_VERSION_ID < 50400 ? '' : '|trait';
-        if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>=')) {
+        if (PHP_VERSION_ID >= 80100 || (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>='))) {
             $extraTypes .= '|enum';
         }
 

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -96,6 +96,16 @@ class ClassMapGeneratorTest extends TestCase
                 'Dummy\Test\AnonClassHolder' => __DIR__ . '/Fixtures/php7.0/anonclass.php',
             ));
         }
+
+        if (PHP_VERSION_ID >= 80100) {
+            $data[] = array(__DIR__ . '/Fixtures/php8.1', array(
+                'RolesBasicEnum' => __DIR__ . '/Fixtures/php8.1/enum_basic.php',
+                'RolesBackedEnum' => __DIR__ . '/Fixtures/php8.1/enum_backed.php',
+                'RolesClassLikeEnum' => __DIR__ . '/Fixtures/php8.1/enum_class_semantics.php',
+                'Foo\Bar\RolesClassLikeNamespacedEnum' => __DIR__ . '/Fixtures/php8.1/enum_namespaced.php',
+            ));
+        }
+
         if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>=')) {
             $data[] = array(__DIR__ . '/Fixtures/hhvm3.3', array(
                 'FooEnum' => __DIR__ . '/Fixtures/hhvm3.3/HackEnum.php',

--- a/tests/Composer/Test/Autoload/Fixtures/php8.1/enum_backed.php
+++ b/tests/Composer/Test/Autoload/Fixtures/php8.1/enum_backed.php
@@ -1,0 +1,7 @@
+<?php
+
+enum RolesBackedEnum: string {
+    case Admin = 'Administrator';
+    case Guest = 'Guest';
+    case Moderator = 'Moderator';
+}

--- a/tests/Composer/Test/Autoload/Fixtures/php8.1/enum_basic.php
+++ b/tests/Composer/Test/Autoload/Fixtures/php8.1/enum_basic.php
@@ -1,0 +1,7 @@
+<?php
+
+enum RolesBasicEnum {
+    case ADMIN;
+    case Guest;
+    case Moderator;
+}

--- a/tests/Composer/Test/Autoload/Fixtures/php8.1/enum_class_semantics.php
+++ b/tests/Composer/Test/Autoload/Fixtures/php8.1/enum_class_semantics.php
@@ -1,0 +1,7 @@
+<?php
+
+enum RolesClassLikeEnum: string implements TestFoo {
+    case Admin = 'Administrator';
+    case Guest = 'Guest';
+    case Moderator = 'Moderator';
+}

--- a/tests/Composer/Test/Autoload/Fixtures/php8.1/enum_namespaced.php
+++ b/tests/Composer/Test/Autoload/Fixtures/php8.1/enum_namespaced.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Foo\Bar;
+
+enum RolesClassLikeNamespacedEnum: string implements TestFoo {
+    case Admin = 'Administrator';
+    case Guest = 'Guest';
+    case Moderator = 'Moderator';
+}


### PR DESCRIPTION
PHP 8.1 supports Enums, and [Enums follow class-semantics](https://php.watch/versions/8.1/enums#class-semantics-autoload).

Composer's class-map generator currently looks for `class`, `interface`, and `trait` keywords. If Composer is run in PHP 8.1 or later, Composer now additionally looks for `enum` keyword as well. This is similar to how Hack's `enum` support is added.

This PR also adds tests for basic enums, backed enums, namespaced enums, and an enum that implements an interface and extends a class.