### PR TITLE
Allow querying InstalledVersions::isInstalled() for no-dev packages

### DIFF
--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -53,13 +53,14 @@ class InstalledVersions
      * This also returns true if the package name is provided or replaced by another package
      *
      * @param  string $packageName
+     * @param  bool   $includeDevRequirements
      * @return bool
      */
-    public static function isInstalled($packageName)
+    public static function isInstalled($packageName, $includeDevRequirements = true)
     {
         foreach (self::getInstalled() as $installed) {
             if (isset($installed['versions'][$packageName])) {
-                return true;
+                return $includeDevRequirements || empty($installed['versions'][$packageName]['dev-requirement']);
             }
         }
 
@@ -73,10 +74,9 @@ class InstalledVersions
      *
      *   Composer\InstalledVersions::satisfies(new VersionParser, 'foo/bar', '^2.3')
      *
-     * @param VersionParser $parser      Install composer/semver to have access to this class and functionality
-     * @param string        $packageName
-     * @param string|null   $constraint  A version constraint to check for, if you pass one you have to make sure composer/semver is required by your package
-     *
+     * @param  VersionParser $parser      Install composer/semver to have access to this class and functionality
+     * @param  string        $packageName
+     * @param  string|null   $constraint  A version constraint to check for, if you pass one you have to make sure composer/semver is required by your package
      * @return bool
      */
     public static function satisfies(VersionParser $parser, $packageName, $constraint)

--- a/tests/Composer/Test/InstalledVersionsTest.php
+++ b/tests/Composer/Test/InstalledVersionsTest.php
@@ -54,9 +54,9 @@ class InstalledVersionsTest extends TestCase
     /**
      * @dataProvider isInstalledProvider
      */
-    public function testIsInstalled($expected, $name, $constraint = null)
+    public function testIsInstalled($expected, $name, $includeDevRequirements = true)
     {
-        $this->assertSame($expected, InstalledVersions::isInstalled($name));
+        $this->assertSame($expected, InstalledVersions::isInstalled($name, $includeDevRequirements));
     }
 
     public static function isInstalledProvider()
@@ -65,10 +65,10 @@ class InstalledVersionsTest extends TestCase
             array(true,  'foo/impl'),
             array(true,  'foo/replaced'),
             array(true,  'c/c'),
+            array(false, 'c/c', false),
             array(true,  '__root__'),
             array(true,  'b/replacer'),
             array(false, 'not/there'),
-            array(false, 'not/there', '^1.0'),
         );
     }
 
@@ -191,6 +191,7 @@ class InstalledVersionsTest extends TestCase
                 '1.10.x-dev',
             ),
             'reference' => 'sourceref-by-default',
+            'dev-requirement' => true,
             'name' => '__root__',
         ), InstalledVersions::getRootPackage());
     }

--- a/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
@@ -130,6 +130,7 @@ class FilesystemRepositoryTest extends TestCase
         $rootPackage = $this->getAliasPackage($rootPackage, '1.10.x-dev');
 
         $repository = new FilesystemRepository($json, true, $rootPackage);
+        $repository->setDevPackageNames(array('c/c'));
         $pkg = $this->getPackage('a/provider', '1.1');
         $this->configureLinks($pkg, array('provide' => array('foo/impl' => '^1.1', 'foo/impl2' => '2.0')));
         $pkg->setDistReference('distref-as-no-source');

--- a/tests/Composer/Test/Repository/Fixtures/installed.php
+++ b/tests/Composer/Test/Repository/Fixtures/installed.php
@@ -18,6 +18,7 @@ return array(
             '1.10.x-dev',
         ),
         'reference' => 'sourceref-by-default',
+        'dev-requirement' => true,
         'name' => '__root__',
     ),
     'versions' => array(
@@ -28,12 +29,14 @@ return array(
                 '1.10.x-dev',
             ),
             'reference' => 'sourceref-by-default',
+            'dev-requirement' => false,
         ),
         'a/provider' => array(
             'pretty_version' => '1.1',
             'version' => '1.1.0.0',
             'aliases' => array(),
             'reference' => 'distref-as-no-source',
+            'dev-requirement' => false,
         ),
         'a/provider2' => array(
             'pretty_version' => '1.2',
@@ -42,20 +45,24 @@ return array(
               '1.4',
             ),
             'reference' => 'distref-as-installed-from-dist',
+            'dev-requirement' => false,
         ),
         'b/replacer' => array(
             'pretty_version' => '2.2',
             'version' => '2.2.0.0',
             'aliases' => array(),
             'reference' => null,
+            'dev-requirement' => false,
         ),
         'c/c' => array(
             'pretty_version' => '3.0',
             'version' => '3.0.0.0',
             'aliases' => array(),
             'reference' => null,
+            'dev-requirement' => true,
         ),
         'foo/impl' => array(
+            'dev-requirement' => false,
             'provided' => array(
                 '^1.1',
                 '1.2',
@@ -64,6 +71,7 @@ return array(
             ),
         ),
         'foo/impl2' => array(
+            'dev-requirement' => false,
             'provided' => array(
                 '2.0',
             ),
@@ -72,6 +80,7 @@ return array(
             ),
         ),
         'foo/replaced' => array(
+            'dev-requirement' => false,
             'replaced' => array(
                 '^3.0',
             ),

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,4 +17,5 @@ if (function_exists('date_default_timezone_set') && function_exists('date_defaul
 }
 
 require __DIR__.'/../src/bootstrap.php';
+require __DIR__.'/../src/Composer/InstalledVersions.php';
 require __DIR__.'/Composer/Test/TestCase.php';


### PR DESCRIPTION
Will help to fix issues like https://github.com/symfony/symfony/issues/40136