### PR TITLE
Allow $schema field in composer.json

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -7,7 +7,7 @@
     "properties": {
         "$schema": {
 			"type": "string",
-			"description": "The URL to the schema."
+			"description": "The URL to the schema.",
             "enum": [
                 "https://getcomposer.org/schema.json"
             ]

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -5,6 +5,13 @@
     "additionalProperties": false,
     "required": [ "name", "description" ],
     "properties": {
+        "$schema": {
+			"type": "string",
+			"description": "The URL to the schema."
+            "enum": [
+                "https://getcomposer.org/schema.json"
+            ]
+		},
         "name": {
             "type": "string",
             "description": "Package name, including 'vendor-name/' prefix.",


### PR DESCRIPTION
When I add 
```json
"$schema":"https://getcomposer.org/schema.json"
```
to my composer file, it says
```
WARNING: Property $schema is not allowed.
```
This commit fixes that.


haha I got #9700