### PR TITLE
Check if SODIUM_LIBRARY_VERSION is defined

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -402,7 +402,9 @@ class PlatformRepository extends ArrayRepository
 
                 case 'libsodium':
                 case 'sodium':
-                    $this->addLibrary('libsodium', $this->runtime->getConstant('SODIUM_LIBRARY_VERSION'));
+                    if ($this->runtime->hasConstant('SODIUM_LIBRARY_VERSION')) {
+                        $this->addLibrary('libsodium', $this->runtime->getConstant('SODIUM_LIBRARY_VERSION'));
+                    }
                     break;
 
                 case 'sqlite3':


### PR DESCRIPTION
PackageRepository assumes that if the `libsodium`/`sodium` extension is installed, that the `SODIUM_LIBRARY_VERSION` constant will be defined, however that constant wasn’t added until v2 of the Sodium extension.

This PR checks to make sure the constant is defined before attempting to reference it.