### PR TITLE
Auto-detect dev-mode in autoload-dump and deprecate dump-autoload --no-dev

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -284,7 +284,7 @@ uninstalled.
 * **--no-scripts:** Skips execution of scripts defined in `composer.json`.
 * **--update-no-dev:** Run the dependency update with the --no-dev option.
 * **--update-with-dependencies (-w):** Also update dependencies of the removed packages.
-  (Deprecrated, is now default behavior)
+  (Deprecated, is now default behavior)
 * **--update-with-all-dependencies (-W):** Allows all inherited dependencies to be updated,
   including those that are root requirements.
 * **--ignore-platform-reqs:** ignore all platform requirements (`php`, `hhvm`,
@@ -790,7 +790,8 @@ performance.
 * **--apcu:** Use APCu to cache found/not-found classes.
 * **--apcu-prefix:** Use a custom prefix for the APCu autoloader cache.
   Implicitly enables `--apcu`.
-* **--no-dev:** Disables autoload-dev rules.
+* **--no-dev:** Disables autoload-dev rules. (Deprecated: Composer now infers this
+  automatically according to the last `install` or `update` run.)
 * **--ignore-platform-reqs:** ignore all `php`, `hhvm`, `lib-*` and `ext-*`
   requirements and skip the [platform check](07-runtime.md#platform-check) for these.
   See also the [`platform`](06-config.md#platform) config option.

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -162,10 +162,11 @@ class MyClass
 }
 ```
 
-**Note:** During a composer install or update process, a variable named
+**Note:** During a Composer `install` or `update` command run, a variable named
 `COMPOSER_DEV_MODE` will be added to the environment. If the command was run
 with the `--no-dev` flag, this variable will be set to 0, otherwise it will be
-set to 1.
+set to 1. The variable is also available while `dump-autoload` runs, and it
+will be set to same as the last `install` or `update` was run in.
 
 ## Event classes
 

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -35,7 +35,7 @@ class DumpAutoloadCommand extends BaseCommand
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.'),
                 new InputOption('apcu', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
                 new InputOption('apcu-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables autoload-dev rules.'),
+                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'DEPRECATED: Disables autoload-dev rules. Composer now infers this automatically according to the last install or update run.'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
             ))
@@ -77,7 +77,10 @@ EOT
         $ignorePlatformReqs = $input->getOption('ignore-platform-reqs') ?: ($input->getOption('ignore-platform-req') ?: false);
 
         $generator = $composer->getAutoloadGenerator();
-        $generator->setDevMode(!$input->getOption('no-dev'));
+        if ($input->getOption('no-dev')) {
+            $this->getIO()->writeError('<warning>You are using the deprecated option "--no-dev". Composer now infers the value automatically according to the last install or update run.</warning>');
+            $generator->setDevMode(false);
+        }
         $generator->setClassMapAuthoritative($authoritative);
         $generator->setApcu($apcu, $apcuPrefix);
         $generator->setRunScripts(!$input->getOption('no-scripts'));

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -302,7 +302,6 @@ class Installer
                 $this->io->writeError('<info>Generating autoload files</info>');
             }
 
-            $this->autoloadGenerator->setDevMode($this->devMode);
             $this->autoloadGenerator->setClassMapAuthoritative($this->classMapAuthoritative);
             $this->autoloadGenerator->setApcu($this->apcuAutoloader, $this->apcuAutoloaderPrefix);
             $this->autoloadGenerator->setRunScripts($this->runScripts);


### PR DESCRIPTION
Triggered by https://github.com/composer/package-versions-deprecated/issues/23 - I realized this now can be automated. IMO there really should be no reason to dump an autoloader without dev packages, if you installed dev packages. This causes inconsistencies like InstalledVersions having packages which are then not autoloadable, so should be discouraged.
