### PR TITLE
Remove version argument from why and enforce it for why-not command

### DIFF
--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -25,9 +25,7 @@ use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Composer\Package\Version\VersionParser;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -38,24 +36,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class BaseDependencyCommand extends BaseCommand
 {
     const ARGUMENT_PACKAGE = 'package';
-    const ARGUMENT_CONSTRAINT = 'constraint';
+    const ARGUMENT_CONSTRAINT = 'version';
     const OPTION_RECURSIVE = 'recursive';
     const OPTION_TREE = 'tree';
 
     protected $colors;
-
-    /**
-     * Set common options and arguments.
-     */
-    protected function configure()
-    {
-        $this->setDefinition(array(
-            new InputArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect'),
-            new InputArgument(self::ARGUMENT_CONSTRAINT, InputArgument::OPTIONAL, 'Optional version constraint', '*'),
-            new InputOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package'),
-            new InputOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree'),
-        ));
-    }
 
     /**
      * Execute the command.
@@ -83,7 +68,7 @@ class BaseDependencyCommand extends BaseCommand
         list($needle, $textConstraint) = array_pad(
             explode(':', $input->getArgument(self::ARGUMENT_PACKAGE)),
             2,
-            $input->getArgument(self::ARGUMENT_CONSTRAINT)
+            $input->hasArgument(self::ARGUMENT_CONSTRAINT) ? $input->getArgument(self::ARGUMENT_CONSTRAINT) : '*'
         );
 
         // Find packages that are or provide the requested package first

--- a/src/Composer/Command/DependsCommand.php
+++ b/src/Composer/Command/DependsCommand.php
@@ -14,6 +14,8 @@ namespace Composer\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
@@ -25,12 +27,15 @@ class DependsCommand extends BaseDependencyCommand
      */
     protected function configure()
     {
-        parent::configure();
-
         $this
             ->setName('depends')
             ->setAliases(array('why'))
             ->setDescription('Shows which packages cause the given package to be installed.')
+            ->setDefinition(array(
+                new InputArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect'),
+                new InputOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package'),
+                new InputOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree'),
+            ))
             ->setHelp(
                 <<<EOT
 Displays detailed information about where a package is referenced.

--- a/src/Composer/Command/ProhibitsCommand.php
+++ b/src/Composer/Command/ProhibitsCommand.php
@@ -14,6 +14,8 @@ namespace Composer\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
@@ -25,12 +27,16 @@ class ProhibitsCommand extends BaseDependencyCommand
      */
     protected function configure()
     {
-        parent::configure();
-
         $this
             ->setName('prohibits')
             ->setAliases(array('why-not'))
             ->setDescription('Shows which packages prevent the given package from being installed.')
+            ->setDefinition(array(
+                new InputArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect'),
+                new InputArgument(self::ARGUMENT_CONSTRAINT, InputArgument::REQUIRED, 'Version constraint, which version you expected to be installed'),
+                new InputOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package'),
+                new InputOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree'),
+            ))
             ->setHelp(
                 <<<EOT
 Displays detailed information about why a package cannot be installed.


### PR DESCRIPTION
Refs #9693

Strictly speaking a minor break but as it's really the way this was intended to be used and kinda just enforces the expectations instead of loosely allowing misuse, I think it's fine.