### PR TITLE
Reset file access on Windows admin self-update

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -425,7 +425,14 @@ TAGSPUBKEY
         }
 
         try {
-            rename($newFilename, $localFilename);
+            if (Platform::isWindows()) {
+                // use copy to apply permissions from the destination directory
+                // as rename uses source permissions and may block other users
+                copy($newFilename, $localFilename);
+                @unlink($newFilename);
+            } else {
+                rename($newFilename, $localFilename);
+            }
 
             return true;
         } catch (\Exception $e) {
@@ -534,7 +541,7 @@ TAGSPUBKEY
     /**
      * Invokes a UAC prompt to update composer.phar as an admin
      *
-     * Uses a .vbs script to elevate and run the cmd.exe move command.
+     * Uses a .vbs script to elevate and run the cmd.exe copy command.
      *
      * @param  string $localFilename The composer.phar location
      * @param  string $newFilename   The downloaded or backup phar
@@ -560,13 +567,13 @@ TAGSPUBKEY
 
         $checksum = hash_file('sha256', $newFilename);
 
-        // cmd's internal move is fussy about backslashes
+        // cmd's internal copy is fussy about backslashes
         $source = str_replace('/', '\\', $newFilename);
         $destination = str_replace('/', '\\', $localFilename);
 
         $vbs = <<<EOT
 Set UAC = CreateObject("Shell.Application")
-UAC.ShellExecute "cmd.exe", "/c move /y ""$source"" ""$destination""", "", "runas", 0
+UAC.ShellExecute "cmd.exe", "/c copy /b /y ""$source"" ""$destination""", "", "runas", 0
 Wscript.Sleep(300)
 EOT;
 
@@ -574,11 +581,12 @@ EOT;
         exec('"'.$script.'"');
         @unlink($script);
 
-        // see if the file was moved
-        if ($result = (hash_file('sha256', $localFilename) === $checksum)) {
+        // see if the file was moved and is still accessible
+        if ($result = is_readable($localFilename) && (hash_file('sha256', $localFilename) === $checksum)) {
             $io->writeError('<info>Operation succeeded.</info>');
+            @unlink($newFilename);
         } else {
-            $io->writeError('<error>Operation failed (file not written). '.$helpMessage.'</error>');
+            $io->writeError('<error>Operation failed.'.$helpMessage.'</error>');
         }
 
         return $result;


### PR DESCRIPTION
Windows PHP `rename` uses MoveFileEx which preserves the source file
permissions when creating the destination file*. If the user is running
as an Admin and the destination file is in a common (non-user) location,
then the permission for other users will be replaced by the admin user.

This means that other users will no longer be able to run
composer.phar

Additionally, the UAC elevation feature uses the cmd.exe `move` command
which behaves as above, rather than the `copy` command which creates the
destination file with permissions inherited from the parent folder - but
only if inheritance is enabled, which is the default.

This fix runs `icacls` after admin operations to reset the inherited
permissions. This is equivalent to deleting the destination file first,
then creating it as new from the source file.

*PHP's use of MoveFileEx results in copy semantics when the source and
destination files are on different volumes.

## Testing
Download and unzip [composer-2.1-dev+711721a.zip](https://github.com/composer/composer/files/6050457/composer-2.1-dev%2B711721a.zip). Create a `test` folder in `C:\Program Files` and copy this composer.phar here

```cmd
# From an Administrator cmd prompt
mkdir "C:\Program Files\test"
copy /B <path to>\composer.phar "C:\Program Files\test\composer.phar"
```
To test:

```cmd
# From a User cmd prompt
cd "C:\Program Files\test"

# See the current permissions
icacls composer.phar

# The Users permissions will look like (in English):
BUILTIN\Users:(I)(RX)

# Run the update
php composer.phar self-update

# Check that the Users permissions are present and the same
icacls composer.phar
```

_Note:_ The User permissions are inherited (I) from the parent folder with read-execute (RX) access.

