### PR TITLE
Remove output "summary" from fund command

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -485,7 +485,7 @@ get machine-readable output.
 
 ### Options
 
-* **--format:** Format of the output: text, json or summary (default: "text")
+* **--format (-f):** Lets you pick between text (default) or json output format.
 
 ## depends (why)
 


### PR DESCRIPTION
`composer fund -f summary` does not exist, this pr will remove "summary" option in the docs.