### PR TITLE
Give preference to actual package name over default one

### DIFF
--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -351,9 +351,9 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
 
     protected function preProcess(VcsDriverInterface $driver, array $data, $identifier)
     {
-        // keep the name of the main identifier for all packages
+        // Give preference to actual package name over default one
         $dataPackageName = isset($data['name']) ? $data['name'] : null;
-        $data['name'] = $this->packageName ?: $dataPackageName;
+        $data['name'] = $dataPackageName ?: $this->packageName;
 
         if (!isset($data['dist'])) {
             $data['dist'] = $driver->getDist($identifier);


### PR DESCRIPTION
This PR aims to modify \Composer\Repository\VcsRepository::preProcess logic according to the following use case.

### Motivation

Satis fails to dump proper package names and versions after renaming package in main branch due to how packages names are retrieved by Composer when using vcs.

In fact, it uses package name found in main branch as package name for all package versions that are retrieved from vcs. I don't know if this is a feature but looks like a bug; I'd understand this behaviour to be intentional if avoiding to read data for each vcs reference, but that is not the case, as the rest of data is properly read and managed, only name fails to be respected properly.

### Use case

Considering a sample, single branched repository, that contains a single package declared by a composer.json file. In the examples I'll use versions inside composer.json data just for clarity, but it happens the same without explicit versions and tags only.

Let's say I add an initial version to main branch, and tag it as 1.0.0:
```json
{
    "name": "vendor/wrong-package-name",
    "version": "1.0.0",
    (...)
}
```

It becomes used with the wrong name in several projects, so I cannot simply remove it.

Then I decide its time to fix package name, and I proceed as follows:
```json
{
    "name": "vendor/fixed-package-name",
    "version": "1.1.0",
    (...)
}
```

When packages are being read from vcs and added to pool, due to preProcess method behaviour, are added in the following way:
Package 1: Name: vendor/fixed-package-name, Version: 1.0.0 (does not exist as such)
Package 2: Name: vendor/fixed-package-name, Version: 1.1.0 (ok)

Instead of :
Package 1: Name: vendor/wrong-package-name, Version: 1.0.0 (ok)
Package 2: Name: vendor/fixed-package-name, Version: 1.1.0 (ok)

This issue gets still worse when fixed package name is not in the main branch, because aside of generating a new non-existing version for wrong package name, I'm unable to generate at least the fixed package name package dump, so it is not installable through Satis (no dump for vendor/fixed-package-name):
Package 1: Name: vendor/wrong-package-name, Version: 1.0.0 (ok)
Package 2: Name: vendor/wrong-package-name, Version: 1.1.0 (does not exist as such)


### How to reproduce

I've mounted this example in a sample repository, located at https://bitbucket.org/interactiv4/composer-vcs-package-name.

You can test this behaviour as follows:

- Clone the repository, cd into it and run Satis through Docker:

```
git clone git@bitbucket.org:interactiv4/composer-vcs-package-name.git && cd composer-vcs-package-name &&
composer clear-cache &&
docker run -it --rm \
  --volume "$(pwd):/build" \
  --volume "${COMPOSER_HOME:-$HOME/.composer}:/composer" \
  --volume "${HOME}/.ssh:/root/.ssh" \
  composer/satis build &&
tree web/dist/vendor/
```

Output will look something like this:

```
web/dist/vendor/
└── fixed-package-name
    ├── vendor-fixed-package-name-1.0.0-a01a14.zip
    └── vendor-fixed-package-name-1.1.0-528d8e.zip
```

### Expected behaviour

This time we will require patched composer version from original PR branch:

```
git clone git@bitbucket.org:interactiv4/composer-vcs-package-name.git && cd composer-vcs-package-name &&
composer clear-cache &&
composer create-project composer/satis:dev-main --remove-vcs &&
composer --working-dir=satis -- config repositories.composer-vcs-package-name vcs https://github.com/adrian-martinez-interactiv4/composer &&
composer --working-dir=satis -- require 'composer/composer:dev-patch-1' &&
satis/bin/satis build && 
tree web/dist/vendor/
```

This time, output will look something like this:

```
web/dist/vendor/
├── fixed-package-name
│   └── vendor-fixed-package-name-1.1.0-528d8e.zip
└── wrong-package-name
    └── vendor-wrong-package-name-1.0.0-a01a14.zip
```
