### PR TITLE
Update GitHub token pattern

### DIFF
--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -124,7 +124,7 @@ abstract class BaseIO implements IOInterface
         }
 
         foreach ($githubOauth as $domain => $token) {
-            if (!preg_match('{^[.a-z0-9]+$}', $token)) {
+            if (!preg_match('{^[.A-Za-z0-9_]+$}', $token)) {
                 throw new \UnexpectedValueException('Your github oauth token for '.$domain.' contains invalid characters: "'.$token.'"');
             }
             $this->checkAndSetAuthentication($domain, $token, 'x-oauth-basic');


### PR DESCRIPTION
GitHub is updating the format of auth tokens from `a-z0-9` to `A-Za-z0-9` ([notice](https://github.blog/changelog/2021-03-04-authentication-token-format-updates/)).
I'm not sure why `.` is allowed, but I dare not to remove it. In this PR, the token validation regex is updated to allow `A-Za-z0-9` instead of the current all lower-case `a-z` and disallowed `_`.