### PR TITLE
Only call sapi_windows_set_ctrl_handler() for CLI requests

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -405,7 +405,7 @@ EOT
             }
         }
         // handler Ctrl+C for Windows on PHP 7.4+
-        if (function_exists('sapi_windows_set_ctrl_handler')) {
+        if (function_exists('sapi_windows_set_ctrl_handler') && PHP_SAPI === 'cli') {
             @mkdir($directory, 0777, true);
             if ($realDir = realpath($directory)) {
                 sapi_windows_set_ctrl_handler(function () use ($realDir) {

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -208,7 +208,7 @@ class InstallationManager
         };
 
         $handleInterruptsUnix = function_exists('pcntl_async_signals') && function_exists('pcntl_signal');
-        $handleInterruptsWindows = function_exists('sapi_windows_set_ctrl_handler');
+        $handleInterruptsWindows = function_exists('sapi_windows_set_ctrl_handler') && PHP_SAPI === 'cli';
         $prevHandler = null;
         $windowsHandler = null;
         if ($handleInterruptsUnix) {


### PR DESCRIPTION
We are seeing the following PHP error when Composer is run from a web request using Windows:

> Error updating Composer requirements: CTRL events trapping is only supported on console

Here’s where it originates in PHP: https://github.com/php/php-src/blob/cb7b49dcf84846a79a19d75d0cdb82a9869c0465/win32/signal.c#L107-L110

We’ve verified that this PR fixes it, by checking if it’s a CLI request in addition to whether the `sapi_windows_set_ctrl_handler()` function exists.