### PR TITLE
MaxFileSizeExceededException should reject download job

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -225,6 +225,10 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
                 throw $e;
             }
 
+            if ($e instanceof MaxFileSizeExceededException) {
+                throw $e;
+            }
+
             if ($e instanceof TransportException) {
                 // if we got an http response with a proper code, then requesting again will probably not help, abort
                 if ((0 !== $e->getCode() && !in_array($e->getCode(), array(500, 502, 503, 504))) || !$retries) {


### PR DESCRIPTION
MaxFileSizeExceededException didn't trigger the job reject callback and never deleted the temporary file with the `~` at the end.