### PR TITLE
Allow optional name and description fields for project type

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -3,7 +3,26 @@
     "name": "Package",
     "type": "object",
     "additionalProperties": false,
-    "required": [ "name", "description" ],
+    "oneOf": [
+        {
+            "properties": {
+                "type": {
+                    "not": {
+                        "enum": ["project"]
+                    }
+                }
+            },
+            "required": ["name", "description"]
+        },
+        {
+            "properties": {
+                "type": {
+                    "enum": ["project"]
+                }
+            },
+            "required": ["type"]
+        }
+    ],
     "properties": {
         "name": {
             "type": "string",

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -198,7 +198,7 @@ class JsonFile
 
         if ($schema === self::LAX_SCHEMA) {
             $schemaData->additionalProperties = true;
-            $schemaData->required = array();
+            $schemaData->oneOf = null;
         }
 
         $validator = new Validator();

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -41,18 +41,35 @@ class ComposerSchemaTest extends TestCase
     {
         $json = '{ }';
         $result = $this->check($json);
-        $this->assertContains(array('property' => 'name', 'message' => 'The property name is required', 'constraint' => 'required'), $result);
-        $this->assertContains(array('property' => 'description', 'message' => 'The property description is required', 'constraint' => 'required'), $result);
+        $this->assertContains(array('property' => 'type', 'message' => 'The property type is required', 'constraint' => 'required'), $result);
 
         $json = '{ "name": "vendor/package" }';
         $this->assertEquals(array(
+            array('property' => 'type', 'message' => 'The property type is required', 'constraint' => 'required'),
             array('property' => 'description', 'message' => 'The property description is required', 'constraint' => 'required'),
+            array('property' => '', 'message' => 'Failed to match exactly one schema', 'constraint' => 'oneOf'),
         ), $this->check($json));
 
         $json = '{ "description": "generic description" }';
         $this->assertEquals(array(
+            array('property' => 'type', 'message' => 'The property type is required', 'constraint' => 'required'),
             array('property' => 'name', 'message' => 'The property name is required', 'constraint' => 'required'),
+            array('property' => '', 'message' => 'Failed to match exactly one schema', 'constraint' => 'oneOf'),
         ), $this->check($json));
+
+        $json = '{ "type": "library" }';
+        $this->assertEquals(array(
+            array('property' => 'type', 'message' => 'Does not have a value in the enumeration ["project"]', 'constraint' => 'enum', 'enum' => array('project')),
+            array('property' => 'name', 'message' => 'The property name is required', 'constraint' => 'required'),
+            array('property' => 'description', 'message' => 'The property description is required', 'constraint' => 'required'),
+            array('property' => '', 'message' => 'Failed to match exactly one schema', 'constraint' => 'oneOf'),
+        ), $this->check($json));
+
+        $json = '{ "type": "project" }';
+        $this->assertTrue($this->check($json));
+
+        $json = '{ "name": "vendor/package", "description": "description" }';
+        $this->assertTrue($this->check($json));
     }
 
     public function testOptionalAbandonedProperty()

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -42,6 +42,9 @@ class ComposerSchemaTest extends TestCase
         $json = '{ }';
         $result = $this->check($json);
         $this->assertContains(array('property' => 'type', 'message' => 'The property type is required', 'constraint' => 'required'), $result);
+        $this->assertContains(array('property' => 'name', 'message' => 'The property name is required', 'constraint' => 'required'), $result);
+        $this->assertContains(array('property' => 'description', 'message' => 'The property description is required', 'constraint' => 'required'), $result);
+        $this->assertContains(array('property' => '', 'message' => 'Failed to match exactly one schema', 'constraint' => 'oneOf'), $result);
 
         $json = '{ "name": "vendor/package" }';
         $this->assertEquals(array(


### PR DESCRIPTION
According to documentation [name](https://getcomposer.org/doc/04-schema.md#name) and [description](https://getcomposer.org/doc/04-schema.md#description) are optional for non-published packages