### PR TITLE
Add dev mode env var for scripts run command

### DIFF
--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -103,6 +103,9 @@ EOT
             ProcessExecutor::setTimeout((int) $timeout);
         }
 
+        $_SERVER['COMPOSER_DEV_MODE'] = $devMode ? '1' : '0';
+        putenv('COMPOSER_DEV_MODE='.$_SERVER['COMPOSER_DEV_MODE']);
+
         return $composer->getEventDispatcher()->dispatchScript($script, $devMode, $args);
     }
 


### PR DESCRIPTION
I propose to add COMPOSER_DEV_MODE env var for run-scripts command.

It's useful if i want to run some shell(or any non-php) script in hook, so It's impossible to check passed php var inside event.