### PR TITLE
Fix for issue with outdated command flags

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -196,7 +196,7 @@ EOT
                 throw new \UnexpectedValueException('A valid composer.json and composer.lock files is required to run this command with --locked');
             }
             $locker = $composer->getLocker();
-            $lockedRepo = $locker->getLockedRepository(true);
+            $lockedRepo = $locker->getLockedRepository(!$input->getOption('no-dev'));
             $repos = $installedRepo = new InstalledRepository(array($lockedRepo));
         } else {
             // --installed / default case

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Command;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\Test\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class ShowCommandTest extends TestCase
+{
+    public function testThatNoDevFlagIsUsedInConjunctionWithLockedFlag()
+    {
+        $input = new ArrayInput(array('--locked' => true, '--no-dev' => true));
+        $output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+
+
+        $repository = $this->createMock('Composer\Repository\LockArrayRepository');
+        $repository->expects($this->once())
+            ->method('getPackages')
+            ->willReturn(array());
+
+        $locker = $this->createMock('Composer\Package\Locker');
+        $locker->expects($this->once())
+            ->method('isLocked')
+            ->willReturn(true);
+        $locker->expects($this->once())
+            ->method('getLockedRepository')
+            ->with(false)
+            ->willReturn($repository);
+
+        $composer = new Composer;
+        $composer->setConfig(new Config);
+        $composer->setLocker($locker);
+        $composer->setEventDispatcher($this->createMock('Composer\EventDispatcher\EventDispatcher'));
+
+        $command = $this->getMockBuilder('Composer\Command\ShowCommand')
+            ->setMethods(array('getComposer', 'getApplication'))
+            ->getMock();
+
+        $command->expects($this->atLeastOnce())
+            ->method('getComposer')
+            ->willReturn($composer);
+
+        $command->method('getApplication')
+            ->willReturn($this->createMock('Symfony\Component\Console\Application'));
+
+        $command->run($input, $output);
+    }
+}

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -22,15 +22,22 @@ class ShowCommandTest extends TestCase
     public function testThatNoDevFlagIsUsedInConjunctionWithLockedFlag()
     {
         $input = new ArrayInput(array('--locked' => true, '--no-dev' => true));
-        $output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+        $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+            ->getMock();
 
+        $ed = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $repository = $this->createMock('Composer\Repository\LockArrayRepository');
+        $repository = $this->getMockBuilder('Composer\Repository\LockArrayRepository')
+            ->getMock();
         $repository->expects($this->once())
             ->method('getPackages')
             ->willReturn(array());
 
-        $locker = $this->createMock('Composer\Package\Locker');
+        $locker = $this->getMockBuilder('Composer\Package\Locker')
+            ->disableOriginalConstructor()
+            ->getMock();
         $locker->expects($this->once())
             ->method('isLocked')
             ->willReturn(true);
@@ -42,7 +49,7 @@ class ShowCommandTest extends TestCase
         $composer = new Composer;
         $composer->setConfig(new Config);
         $composer->setLocker($locker);
-        $composer->setEventDispatcher($this->createMock('Composer\EventDispatcher\EventDispatcher'));
+        $composer->setEventDispatcher($ed);
 
         $command = $this->getMockBuilder('Composer\Command\ShowCommand')
             ->setMethods(array('getComposer', 'getApplication'))
@@ -53,7 +60,7 @@ class ShowCommandTest extends TestCase
             ->willReturn($composer);
 
         $command->method('getApplication')
-            ->willReturn($this->createMock('Symfony\Component\Console\Application'));
+            ->willReturn($this->getMockBuilder('Symfony\Component\Console\Application')->getMock());
 
         $command->run($input, $output);
     }


### PR DESCRIPTION
This PR fixes issue with `--no-dev` flag being ignored when used with `--locked` flag.

Related to: https://github.com/composer/composer/issues/9788