### PR TITLE
Optimize the `ClassLoader` class with FQFN prefixes

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -69,7 +69,7 @@ class ClassLoader
     public function getPrefixes()
     {
         if (!empty($this->prefixesPsr0)) {
-            return call_user_func_array('array_merge', array_values($this->prefixesPsr0));
+            return \call_user_func_array('array_merge', \array_values($this->prefixesPsr0));
         }
 
         return array();
@@ -101,7 +101,7 @@ class ClassLoader
     public function addClassMap(array $classMap)
     {
         if ($this->classMap) {
-            $this->classMap = array_merge($this->classMap, $classMap);
+            $this->classMap = \array_merge($this->classMap, $classMap);
         } else {
             $this->classMap = $classMap;
         }
@@ -119,12 +119,12 @@ class ClassLoader
     {
         if (!$prefix) {
             if ($prepend) {
-                $this->fallbackDirsPsr0 = array_merge(
+                $this->fallbackDirsPsr0 = \array_merge(
                     (array) $paths,
                     $this->fallbackDirsPsr0
                 );
             } else {
-                $this->fallbackDirsPsr0 = array_merge(
+                $this->fallbackDirsPsr0 = \array_merge(
                     $this->fallbackDirsPsr0,
                     (array) $paths
                 );
@@ -140,12 +140,12 @@ class ClassLoader
             return;
         }
         if ($prepend) {
-            $this->prefixesPsr0[$first][$prefix] = array_merge(
+            $this->prefixesPsr0[$first][$prefix] = \array_merge(
                 (array) $paths,
                 $this->prefixesPsr0[$first][$prefix]
             );
         } else {
-            $this->prefixesPsr0[$first][$prefix] = array_merge(
+            $this->prefixesPsr0[$first][$prefix] = \array_merge(
                 $this->prefixesPsr0[$first][$prefix],
                 (array) $paths
             );
@@ -167,19 +167,19 @@ class ClassLoader
         if (!$prefix) {
             // Register directories for the root namespace.
             if ($prepend) {
-                $this->fallbackDirsPsr4 = array_merge(
+                $this->fallbackDirsPsr4 = \array_merge(
                     (array) $paths,
                     $this->fallbackDirsPsr4
                 );
             } else {
-                $this->fallbackDirsPsr4 = array_merge(
+                $this->fallbackDirsPsr4 = \array_merge(
                     $this->fallbackDirsPsr4,
                     (array) $paths
                 );
             }
         } elseif (!isset($this->prefixDirsPsr4[$prefix])) {
             // Register directories for a new namespace.
-            $length = strlen($prefix);
+            $length = \strlen($prefix);
             if ('\\' !== $prefix[$length - 1]) {
                 throw new \InvalidArgumentException("A non-empty PSR-4 prefix must end with a namespace separator.");
             }
@@ -187,13 +187,13 @@ class ClassLoader
             $this->prefixDirsPsr4[$prefix] = (array) $paths;
         } elseif ($prepend) {
             // Prepend directories for an already registered namespace.
-            $this->prefixDirsPsr4[$prefix] = array_merge(
+            $this->prefixDirsPsr4[$prefix] = \array_merge(
                 (array) $paths,
                 $this->prefixDirsPsr4[$prefix]
             );
         } else {
             // Append directories for an already registered namespace.
-            $this->prefixDirsPsr4[$prefix] = array_merge(
+            $this->prefixDirsPsr4[$prefix] = \array_merge(
                 $this->prefixDirsPsr4[$prefix],
                 (array) $paths
             );
@@ -230,7 +230,7 @@ class ClassLoader
         if (!$prefix) {
             $this->fallbackDirsPsr4 = (array) $paths;
         } else {
-            $length = strlen($prefix);
+            $length = \strlen($prefix);
             if ('\\' !== $prefix[$length - 1]) {
                 throw new \InvalidArgumentException("A non-empty PSR-4 prefix must end with a namespace separator.");
             }
@@ -288,7 +288,7 @@ class ClassLoader
      */
     public function setApcuPrefix($apcuPrefix)
     {
-        $this->apcuPrefix = function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) ? $apcuPrefix : null;
+        $this->apcuPrefix = \function_exists('apcu_fetch') && \filter_var(\ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN) ? $apcuPrefix : null;
     }
 
     /**
@@ -308,7 +308,7 @@ class ClassLoader
      */
     public function register($prepend = false)
     {
-        spl_autoload_register(array($this, 'loadClass'), true, $prepend);
+        \spl_autoload_register(array($this, 'loadClass'), true, $prepend);
 
         if (null === $this->vendorDir) {
             return;
@@ -327,7 +327,7 @@ class ClassLoader
      */
     public function unregister()
     {
-        spl_autoload_unregister(array($this, 'loadClass'));
+        \spl_autoload_unregister(array($this, 'loadClass'));
 
         if (null !== $this->vendorDir) {
             unset(self::$registeredLoaders[$this->vendorDir]);
@@ -368,7 +368,7 @@ class ClassLoader
             return false;
         }
         if (null !== $this->apcuPrefix) {
-            $file = apcu_fetch($this->apcuPrefix.$class, $hit);
+            $file = \apcu_fetch($this->apcuPrefix.$class, $hit);
             if ($hit) {
                 return $file;
             }
@@ -377,12 +377,12 @@ class ClassLoader
         $file = $this->findFileWithExtension($class, '.php');
 
         // Search for Hack files if we are running on HHVM
-        if (false === $file && defined('HHVM_VERSION')) {
+        if (false === $file && \defined('HHVM_VERSION')) {
             $file = $this->findFileWithExtension($class, '.hh');
         }
 
         if (null !== $this->apcuPrefix) {
-            apcu_add($this->apcuPrefix.$class, $file);
+            \apcu_add($this->apcuPrefix.$class, $file);
         }
 
         if (false === $file) {
@@ -406,18 +406,18 @@ class ClassLoader
     private function findFileWithExtension($class, $ext)
     {
         // PSR-4 lookup
-        $logicalPathPsr4 = strtr($class, '\\', DIRECTORY_SEPARATOR) . $ext;
+        $logicalPathPsr4 = \strtr($class, '\\', \DIRECTORY_SEPARATOR) . $ext;
 
         $first = $class[0];
         if (isset($this->prefixLengthsPsr4[$first])) {
             $subPath = $class;
-            while (false !== $lastPos = strrpos($subPath, '\\')) {
-                $subPath = substr($subPath, 0, $lastPos);
+            while (false !== $lastPos = \strrpos($subPath, '\\')) {
+                $subPath = \substr($subPath, 0, $lastPos);
                 $search = $subPath . '\\';
                 if (isset($this->prefixDirsPsr4[$search])) {
-                    $pathEnd = DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $lastPos + 1);
+                    $pathEnd = \DIRECTORY_SEPARATOR . \substr($logicalPathPsr4, $lastPos + 1);
                     foreach ($this->prefixDirsPsr4[$search] as $dir) {
-                        if (file_exists($file = $dir . $pathEnd)) {
+                        if (\file_exists($file = $dir . $pathEnd)) {
                             return $file;
                         }
                     }
@@ -427,26 +427,26 @@ class ClassLoader
 
         // PSR-4 fallback dirs
         foreach ($this->fallbackDirsPsr4 as $dir) {
-            if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr4)) {
+            if (\file_exists($file = $dir . \DIRECTORY_SEPARATOR . $logicalPathPsr4)) {
                 return $file;
             }
         }
 
         // PSR-0 lookup
-        if (false !== $pos = strrpos($class, '\\')) {
+        if (false !== $pos = \strrpos($class, '\\')) {
             // namespaced class name
-            $logicalPathPsr0 = substr($logicalPathPsr4, 0, $pos + 1)
-                . strtr(substr($logicalPathPsr4, $pos + 1), '_', DIRECTORY_SEPARATOR);
+            $logicalPathPsr0 = \substr($logicalPathPsr4, 0, $pos + 1)
+                . \strtr(\substr($logicalPathPsr4, $pos + 1), '_', \DIRECTORY_SEPARATOR);
         } else {
             // PEAR-like class name
-            $logicalPathPsr0 = strtr($class, '_', DIRECTORY_SEPARATOR) . $ext;
+            $logicalPathPsr0 = \strtr($class, '_', \DIRECTORY_SEPARATOR) . $ext;
         }
 
         if (isset($this->prefixesPsr0[$first])) {
             foreach ($this->prefixesPsr0[$first] as $prefix => $dirs) {
-                if (0 === strpos($class, $prefix)) {
+                if (0 === \strpos($class, $prefix)) {
                     foreach ($dirs as $dir) {
-                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
+                        if (\file_exists($file = $dir . \DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
                             return $file;
                         }
                     }
@@ -456,13 +456,13 @@ class ClassLoader
 
         // PSR-0 fallback dirs
         foreach ($this->fallbackDirsPsr0 as $dir) {
-            if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
+            if (\file_exists($file = $dir . \DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
                 return $file;
             }
         }
 
         // PSR-0 include paths.
-        if ($this->useIncludePath && $file = stream_resolve_include_path($logicalPathPsr0)) {
+        if ($this->useIncludePath && $file = \stream_resolve_include_path($logicalPathPsr0)) {
             return $file;
         }
 


### PR DESCRIPTION
Performance of the `\Composer\Autoload\ClassLoader` class is paramount because it is run on all projects that depend on Composer. Every bit of performance with squeeze is worth it.

Because this class is namespaced, PHP does not attempt to inline or otherwise [optimize internal functions and constant](https://php.watch/articles/php-zend-engine-special-inlined-functions). Making them fully-qualified (with a backslash prefix, e.g. `\strlen`) enables the optimizations back. Since Composer needs to work on older PHP versions, it cannot use the more cleaner `use function strlen` pattern, but the `\strlen` still works.

This change applies the backslash to all internal PHP functions and APCu functions, making it possible the engine to inline them where possible. With this, PHP can inline its [special functions](https://php.watch/articles/php-zend-engine-special-inlined-functions#func-list), and replace `INIT_NS_FCALL_BY_NAME` OPCodes with the more performant `INIT_FCALL` OPCodes. In addition to using more performant OPCodes, the [absolute number of OPCodes](https://gist.github.com/Ayesh/adade5efc78c731efc0fd2b180d69fbb) is reduced by ~25 too.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the bugfix applies (2.0 typically, or 1.10 if it is a critical fix that should be fixed in Composer 1) 

For new features and everything else, use the master branch. -->
