### PR TITLE
Make ComposerRepository::configurePackageTransportOptions() protected.

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -508,7 +508,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         return array();
     }
 
-    private function configurePackageTransportOptions(PackageInterface $package)
+    protected function configurePackageTransportOptions(PackageInterface $package)
     {
         foreach ($package->getDistUrls() as $url) {
             if (strpos($url, $this->baseUrl) === 0) {


### PR DESCRIPTION
This is spun off from discussion in #9740.

The php-tuf/composer-integration plugin, which aims to help secure Composer operations with The Update Framework, has to do some..._interesting_ things to work properly. Amongst those interesting things is the roundabout use of a specialized package loader in order to set certain transport options on packages. @Seldaek pointed out that it would be easier and cleaner to just override ComposerRepository::configurePackageTransportOptions(), but unfortunately that's a private method. This PR proposes to change it to protected so that it can be extended and overridden by subclasses of ComposerRepository.