### PR TITLE
Make ComposerRepository::asyncFetchFile() and ::fetchFileIfLastModified() protected

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1166,7 +1166,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         return $data;
     }
 
-    private function fetchFileIfLastModified($filename, $cacheKey, $lastModifiedTime)
+    protected function fetchFileIfLastModified($filename, $cacheKey, $lastModifiedTime)
     {
         $retries = 3;
         while ($retries--) {

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1226,7 +1226,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         }
     }
 
-    private function asyncFetchFile($filename, $cacheKey, $lastModifiedTime = null)
+    protected function asyncFetchFile($filename, $cacheKey, $lastModifiedTime = null)
     {
         $retries = 3;
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -508,7 +508,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         return array();
     }
 
-    private function configurePackageTransportOptions(PackageInterface $package)
+    protected function configurePackageTransportOptions(PackageInterface $package)
     {
         foreach ($package->getDistUrls() as $url) {
             if (strpos($url, $this->baseUrl) === 0) {


### PR DESCRIPTION
This is spun off from #9740, and follows the same rationale as #9818.

If ComposerRepository::asyncFetchFile() were protected, it would be possible to chain additional callbacks on the promises it returns. This would allow php-tuf/composer-integration to verify the downloaded metadata without having to do intrusive things like overriding the HttpDownloader. This also goes for ComposerRepository::fetchFileIfLastModified(); if it were protected, subclasses could take additional action after the fetch is completed.