### PR TITLE
Fix output listing some updates that do not really happen when updating mirrors/--lock

### DIFF
--- a/src/Composer/DependencyResolver/LockTransaction.php
+++ b/src/Composer/DependencyResolver/LockTransaction.php
@@ -93,12 +93,13 @@ class LockTransaction extends Transaction
                 // we do not reset references if the currently present package didn't have any, or if the type of VCS has changed
                 if ($updateMirrors && !isset($this->presentMap[spl_object_hash($package)])) {
                     foreach ($this->presentMap as $presentPackage) {
-                        if ($package->getName() == $presentPackage->getName() &&
-                            $package->getVersion() == $presentPackage->getVersion() &&
-                            $presentPackage->getSourceReference() &&
-                            $presentPackage->getSourceType() === $package->getSourceType()
-                        ) {
-                            $package->setSourceDistReferences($presentPackage->getSourceReference());
+                        if ($package->getName() == $presentPackage->getName() && $package->getVersion() == $presentPackage->getVersion()) {
+                            if ($presentPackage->getSourceReference() && $presentPackage->getSourceType() === $package->getSourceType()) {
+                                $package->setSourceDistReferences($presentPackage->getSourceReference());
+                            }
+                            if ($presentPackage->getReleaseDate()) {
+                                $package->setReleaseDate($presentPackage->getReleaseDate());
+                            }
                         }
                     }
                 }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -446,6 +446,15 @@ class Installer
                     $installsUpdates[] = $operation;
                     $installNames[] = $operation->getPackage()->getPrettyName().':'.$operation->getPackage()->getFullPrettyVersion();
                 } elseif ($operation instanceof UpdateOperation) {
+                    // when mirrors/metadata from a package gets updated we do not want to list it as an
+                    // update in the output as it is only an internal lock file metadata update
+                    if ($this->updateMirrors
+                        && $operation->getInitialPackage()->getName() == $operation->getTargetPackage()->getName()
+                        && $operation->getInitialPackage()->getVersion() == $operation->getTargetPackage()->getVersion()
+                    ) {
+                        continue;
+                    }
+
                     $installsUpdates[] = $operation;
                     $updateNames[] = $operation->getTargetPackage()->getPrettyName().':'.$operation->getTargetPackage()->getFullPrettyVersion();
                 } elseif ($operation instanceof UninstallOperation) {

--- a/tests/Composer/Test/Fixtures/installer/update-mirrors-changes-url.test
+++ b/tests/Composer/Test/Fixtures/installer/update-mirrors-changes-url.test
@@ -17,7 +17,8 @@ g/g is dev and installed in a different ref than the #ref, so it gets updated an
                 {
                     "name": "a/a", "version": "dev-master",
                     "source": { "reference": "2222222222222222222222222222222222222222", "url": "https://github.com/a/newa", "type": "git" },
-                    "dist": { "reference": "2222222222222222222222222222222222222222", "url": "https://api.github.com/repos/a/newa/zipball/2222222222222222222222222222222222222222", "type": "zip" }
+                    "dist": { "reference": "2222222222222222222222222222222222222222", "url": "https://api.github.com/repos/a/newa/zipball/2222222222222222222222222222222222222222", "type": "zip" },
+                    "time": "2021-03-27T14:32:16+00:00"
                 },
                 {
                     "name": "b/b", "version": "2.0.3",
@@ -67,7 +68,8 @@ g/g is dev and installed in a different ref than the #ref, so it gets updated an
     {
         "name": "a/a", "version": "dev-master",
         "source": { "reference": "1111111111111111111111111111111111111111", "url": "https://github.com/a/a", "type": "git" },
-        "dist": { "reference": "1111111111111111111111111111111111111111", "url": "https://api.github.com/repos/a/a/zipball/1111111111111111111111111111111111111111", "type": "zip" }
+        "dist": { "reference": "1111111111111111111111111111111111111111", "url": "https://api.github.com/repos/a/a/zipball/1111111111111111111111111111111111111111", "type": "zip" },
+        "time": "2021-03-14T16:24:37+00:00"
     },
     {
         "name": "b/b", "version": "2.0.3",
@@ -102,6 +104,7 @@ g/g is dev and installed in a different ref than the #ref, so it gets updated an
             "name": "a/a", "version": "dev-master",
             "source": { "reference": "1111111111111111111111111111111111111111", "url": "https://github.com/a/a", "type": "git" },
             "dist": { "reference": "1111111111111111111111111111111111111111", "url": "https://api.github.com/repos/a/a/zipball/1111111111111111111111111111111111111111", "type": "zip" },
+            "time": "2021-03-14T16:24:37+00:00",
             "type": "library"
         },
         {
@@ -151,6 +154,7 @@ g/g is dev and installed in a different ref than the #ref, so it gets updated an
             "name": "a/a", "version": "dev-master",
             "source": { "reference": "1111111111111111111111111111111111111111", "url": "https://github.com/a/newa", "type": "git" },
             "dist": { "reference": "1111111111111111111111111111111111111111", "url": "https://api.github.com/repos/a/newa/zipball/1111111111111111111111111111111111111111", "type": "zip" },
+            "time": "2021-03-27T14:32:16+00:00",
             "type": "library"
         },
         {
@@ -202,3 +206,12 @@ g/g is dev and installed in a different ref than the #ref, so it gets updated an
 --RUN--
 update mirrors
 --EXPECT--
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Lock file operations: 0 installs, 0 updates, 0 removals
+Writing lock file
+Installing dependencies from lock file (including require-dev)
+Nothing to install, update or remove
+Generating autoload files

--- a/tests/Composer/Test/Fixtures/installer/update-mirrors-changes-url.test
+++ b/tests/Composer/Test/Fixtures/installer/update-mirrors-changes-url.test
@@ -154,7 +154,7 @@ g/g is dev and installed in a different ref than the #ref, so it gets updated an
             "name": "a/a", "version": "dev-master",
             "source": { "reference": "1111111111111111111111111111111111111111", "url": "https://github.com/a/newa", "type": "git" },
             "dist": { "reference": "1111111111111111111111111111111111111111", "url": "https://api.github.com/repos/a/newa/zipball/1111111111111111111111111111111111111111", "type": "zip" },
-            "time": "2021-03-27T14:32:16+00:00",
+            "time": "2021-03-14T16:24:37+00:00",
             "type": "library"
         },
         {


### PR DESCRIPTION
Fixes #9812

Note that without the fix, the test I changed would have an output of:

```
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 5 updates, 0 removals
  - Upgrading a/a (dev-master 1111111 => dev-master 2222222)
  - Upgrading b/b (2.0.3 1111111 => 2.0.3 2222222)
  - Upgrading c/c (1.0.0 1111111 => 1.0.0 2222222)
  - Upgrading f/f (dev-master 1111111 => dev-master 2222222)
  - Upgrading g/g (dev-master 0000000 => dev-master 1111111)
Writing lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
```

The issue is we do output the update operations which do happen but then in LockTransaction::getNewLockPackages those changes are internally reverted by restoring the old references in the packages written to the lock file.

Possibly related to https://github.com/composer/composer/issues/8827 for a more proper fix later.