### PR TITLE
Fire POST_FILE_DOWNLOAD event for metadata fetched by ComposerRepository

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -192,7 +192,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
                 }
 
                 if ($eventDispatcher) {
-                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, $fileName, $checksum, $url['processed'], $package);
+                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, $fileName, $checksum, $url['processed'], 'package', $package);
                     $eventDispatcher->dispatch($postFileDownloadEvent->getName(), $postFileDownloadEvent);
                 }
 

--- a/src/Composer/Plugin/PluginInterface.php
+++ b/src/Composer/Plugin/PluginInterface.php
@@ -32,7 +32,7 @@ interface PluginInterface
      *
      * @var string
      */
-    const PLUGIN_API_VERSION = '2.0.0';
+    const PLUGIN_API_VERSION = '2.1.0';
 
     /**
      * Apply plugin modifications to Composer

--- a/src/Composer/Plugin/PostFileDownloadEvent.php
+++ b/src/Composer/Plugin/PostFileDownloadEvent.php
@@ -109,7 +109,7 @@ class PostFileDownloadEvent extends Event
      * Returns the context of this download, if any.
      *
      * If this download is of type package, the package object is returned. If
-     * this download is of type metadata, the HTTP response is returned.
+     * this download is of type metadata, an array{response: Response, repository: RepositoryInterface} is returned.
      *
      * @return mixed
      */

--- a/src/Composer/Plugin/PostFileDownloadEvent.php
+++ b/src/Composer/Plugin/PostFileDownloadEvent.php
@@ -54,11 +54,17 @@ class PostFileDownloadEvent extends Event
      * @param string|null      $fileName The file name
      * @param string|null      $checksum The checksum
      * @param string           $url      The processed url
-     * @param mixed            $context  Additional context for the download.
      * @param string           $type     The type (package or metadata).
+     * @param mixed            $context  Additional context for the download.
      */
-    public function __construct($name, $fileName, $checksum, $url, $context = null, $type = 'package')
+    public function __construct($name, $fileName, $checksum, $url, $type, $context = null)
     {
+        if ($context === null && $type instanceof PackageInterface) {
+            $context = $type;
+            $type = 'package';
+            trigger_error('PostFileDownloadEvent::__construct should receive a $type=package and the package object in $context since Composer 2.1.', E_USER_DEPRECATED);
+        }
+
         parent::__construct($name);
         $this->fileName = $fileName;
         $this->checksum = $checksum;
@@ -118,10 +124,13 @@ class PostFileDownloadEvent extends Event
      * If this download is of type metadata, null is returned.
      *
      * @return \Composer\Package\PackageInterface|null The package.
+     * @deprecated Use getContext instead
      */
     public function getPackage()
     {
+        trigger_error('PostFileDownloadEvent::getPackage is deprecated since Composer 2.1, use getContext instead.', E_USER_DEPRECATED);
         $context = $this->getContext();
+
         return $context instanceof PackageInterface ? $context : null;
     }
 

--- a/src/Composer/Plugin/PostFileDownloadEvent.php
+++ b/src/Composer/Plugin/PostFileDownloadEvent.php
@@ -38,32 +38,41 @@ class PostFileDownloadEvent extends Event
     private $url;
 
     /**
-     * @var \Composer\Package\PackageInterface
+     * @var mixed
      */
-    private $package;
+    private $context;
+
+    /**
+     * @var string
+     */
+    private $type;
 
     /**
      * Constructor.
      *
      * @param string           $name     The event name
-     * @param string           $fileName The file name
+     * @param string|null      $fileName The file name
      * @param string|null      $checksum The checksum
      * @param string           $url      The processed url
-     * @param PackageInterface $package  The package.
+     * @param mixed            $context  Additional context for the download.
+     * @param string           $type     The type (package or metadata).
      */
-    public function __construct($name, $fileName, $checksum, $url, PackageInterface $package)
+    public function __construct($name, $fileName, $checksum, $url, $context = null, $type = 'package')
     {
         parent::__construct($name);
         $this->fileName = $fileName;
         $this->checksum = $checksum;
         $this->url = $url;
-        $this->package = $package;
+        $this->context = $context;
+        $this->type = $type;
     }
 
     /**
      * Retrieves the target file name location.
      *
-     * @return string
+     * If this download is of type metadata, null is returned.
+     *
+     * @return string|null
      */
     public function getFileName()
     {
@@ -91,12 +100,38 @@ class PostFileDownloadEvent extends Event
     }
 
     /**
+     * Returns the context of this download, if any.
+     *
+     * If this download is of type package, the package object is returned. If
+     * this download is of type metadata, the HTTP response is returned.
+     *
+     * @return mixed
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
      * Get the package.
      *
-     * @return \Composer\Package\PackageInterface The package.
+     * If this download is of type metadata, null is returned.
+     *
+     * @return \Composer\Package\PackageInterface|null The package.
      */
     public function getPackage()
     {
-        return $this->package;
+        $context = $this->getContext();
+        return $context instanceof PackageInterface ? $context : null;
+    }
+
+    /**
+     * Returns the type of this download (package, metadata).
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
     }
 }

--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -127,6 +127,7 @@ class PreFileDownloadEvent extends Event
      * Returns the context of this download, if any.
      *
      * If this download is of type package, the package object is returned.
+     * If the type is metadata, an array{repository: RepositoryInterface} is returned.
      *
      * @return mixed
      */

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1112,7 +1112,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 }
 
                 if ($this->eventDispatcher) {
-                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, $sha256, $filename, $response, 'metadata');
+                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, $sha256, $filename, 'metadata', $response);
                     $this->eventDispatcher->dispatch($postFileDownloadEvent->getName(), $postFileDownloadEvent);
                 }
 
@@ -1195,7 +1195,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 }
 
                 if ($this->eventDispatcher) {
-                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $filename, $response, 'metadata');
+                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $filename, 'metadata', $response);
                     $this->eventDispatcher->dispatch($postFileDownloadEvent->getName(), $postFileDownloadEvent);
                 }
 
@@ -1288,7 +1288,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
 
             if ($eventDispatcher) {
-                $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $url, $response, 'metadata');
+                $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $url, 'metadata', $response);
                 $eventDispatcher->dispatch($postFileDownloadEvent->getName(), $postFileDownloadEvent);
             }
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1086,7 +1086,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         while ($retries--) {
             try {
                 if ($this->eventDispatcher) {
-                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata');
+                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata', array('repository' => $this));
                     $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
                     $filename = $preFileDownloadEvent->getProcessedUrl();
                 }
@@ -1112,7 +1112,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 }
 
                 if ($this->eventDispatcher) {
-                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, $sha256, $filename, 'metadata', $response);
+                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, $sha256, $filename, 'metadata', array('response' => $response, 'repository' => $this));
                     $this->eventDispatcher->dispatch($postFileDownloadEvent->getName(), $postFileDownloadEvent);
                 }
 
@@ -1178,7 +1178,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         while ($retries--) {
             try {
                 if ($this->eventDispatcher) {
-                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata');
+                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata', array('repository' => $this));
                     $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
                     $filename = $preFileDownloadEvent->getProcessedUrl();
                 }
@@ -1195,7 +1195,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 }
 
                 if ($this->eventDispatcher) {
-                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $filename, 'metadata', $response);
+                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $filename, 'metadata', array('response' => $response, 'repository' => $this));
                     $this->eventDispatcher->dispatch($postFileDownloadEvent->getName(), $postFileDownloadEvent);
                 }
 
@@ -1252,7 +1252,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         $httpDownloader = $this->httpDownloader;
         if ($this->eventDispatcher) {
-            $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata');
+            $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata', array('repository' => $this));
             $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
             $filename = $preFileDownloadEvent->getProcessedUrl();
         }
@@ -1288,7 +1288,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
 
             if ($eventDispatcher) {
-                $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $url, 'metadata', $response);
+                $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $url, 'metadata', array('response' => $response, 'repository' => $repo));
                 $eventDispatcher->dispatch($postFileDownloadEvent->getName(), $postFileDownloadEvent);
             }
 

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v8/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v8/composer.json
@@ -9,6 +9,6 @@
         ]
     },
     "require": {
-        "composer-plugin-api": "2.0.0"
+        "composer-plugin-api": "^2.0.0"
     }
 }


### PR DESCRIPTION
This is spun off from discussion in #9740 and #9819.

Right now, it's not possible for plugins (in this case, specifically php-tuf/composer-integration) to react to Composer downloading package metadata. The methods which do that grunt work cannot be overridden because they're private, and no event is dispatched after the metadata is downloaded. @Seldaek suggested modifying ComposerRepository to fire the POST_FILE_DOWNLOAD plugin event after metadata is downloaded, but before it is cached. This PR implements that.

This requires changes to the PostFileDownloadEvent class. Namely, it has be able to accept a type (`package` or `metadata`, similar to what PreFileDownloadEvent already does) and additional context beyond just an instance of `PackageInterface`.