### PR TITLE
"composer init --autoload" - Interactive generates PSR-4 autoloader in composer.json

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -65,6 +65,7 @@ php composer.phar init
   the list of requires. Every repository can be either an HTTP URL pointing
   to a `composer` repository or a JSON string which similar to what the
   [repositories](04-schema.md#repositories) key accepts.
+* **--autoloader (-a):** Add PSR-4 autoloader.
 
 ## install / i
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -65,7 +65,7 @@ php composer.phar init
   the list of requires. Every repository can be either an HTTP URL pointing
   to a `composer` repository or a JSON string which similar to what the
   [repositories](04-schema.md#repositories) key accepts.
-* **--autoload (-a):** Add PSR-4 autoload.
+* **--autoload (-a):** Add a PSR-4 autoload mapping to the composer.json. Automatically maps your package's namespace to the provided directory. (Expects a relative path, e.g. src/) See also [PSR-4 autoload](04-schema.md#psr-4).
 
 ## install / i
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -65,7 +65,7 @@ php composer.phar init
   the list of requires. Every repository can be either an HTTP URL pointing
   to a `composer` repository or a JSON string which similar to what the
   [repositories](04-schema.md#repositories) key accepts.
-* **--autoloader (-a):** Add PSR-4 autoloader.
+* **--autoload (-a):** Add PSR-4 autoload.
 
 ## install / i
 

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -70,7 +70,7 @@ class InitCommand extends BaseCommand
                 new InputOption('stability', 's', InputOption::VALUE_REQUIRED, 'Minimum stability (empty or one of: '.implode(', ', array_keys(BasePackage::$stabilities)).')'),
                 new InputOption('license', 'l', InputOption::VALUE_REQUIRED, 'License of package'),
                 new InputOption('repository', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add custom repositories, either by URL or using JSON arrays'),
-                new InputOption('autoload', 'a', InputOption::VALUE_REQUIRED, 'Add PSR-4 autoload'),
+                new InputOption('autoload', 'a', InputOption::VALUE_REQUIRED, 'Add PSR-4 autoload mapping. Maps your package\'s namespace to the provided directory. (Expects a relative path, e.g. src/)'),
             ))
             ->setHelp(
                 <<<EOT
@@ -428,8 +428,9 @@ EOT
 
         // --autoload - input and validation
         $autoload = $input->getOption('autoload') ?: 'src/';
+        $namespace = $this->namespaceFromPackageName($input->getOption('name'));
         $autoload = $io->askAndValidate(
-            'Would you like to set PSR-4 autoload for the "'.$this->namespaceFromPackageName($input->getOption('name')).'" namespace? [<comment>'.$autoload.'</comment>, n to skip]: ',
+            'Add PSR-4 autoload mapping? Map namespace "'.$namespace.'" to the entered relative path. [<comment>'.$autoload.'</comment>, n to skip]: ',
             function ($value) use ($autoload) {
                 if (null === $value) {
                     return $autoload;

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -70,7 +70,7 @@ class InitCommand extends BaseCommand
                 new InputOption('stability', 's', InputOption::VALUE_REQUIRED, 'Minimum stability (empty or one of: '.implode(', ', array_keys(BasePackage::$stabilities)).')'),
                 new InputOption('license', 'l', InputOption::VALUE_REQUIRED, 'License of package'),
                 new InputOption('repository', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add custom repositories, either by URL or using JSON arrays'),
-                new InputOption('autoload', 'a', InputOption::VALUE_OPTIONAL, 'Add PSR-4 autoload'),
+                new InputOption('autoload', 'a', InputOption::VALUE_REQUIRED, 'Add PSR-4 autoload'),
             ))
             ->setHelp(
                 <<<EOT

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -429,7 +429,7 @@ EOT
         // --autoload - input and validation
         $autoload = $input->getOption('autoload') ?: 'src/';
         $autoload = $io->askAndValidate(
-            'Would you like to set PSR-4 autoload for the "'.$this->namespaceFromPackageName($input->getOption('name')).'\\\" namespace? [<comment>'.$autoload.'</comment>, n to skip]: ',
+            'Would you like to set PSR-4 autoload for the "'.$this->namespaceFromPackageName($input->getOption('name')).'" namespace? [<comment>'.$autoload.'</comment>, n to skip]: ',
             function ($value) use ($autoload) {
                 if (null === $value) {
                     return $autoload;
@@ -670,7 +670,7 @@ EOT
     /**
      * Extract namespace from package's vendor name.
      *
-     * new_projects.acme-extra/package-name becomes "NewProjectsAcmeExtra"
+     * new_projects.acme-extra/package-name becomes "NewProjectsAcmeExtra\PackageName"
      *
      * @param string $packageName
      *
@@ -682,14 +682,16 @@ EOT
             return null;
         }
 
-        $allowedVendorSeparator = array('-', '.', '_');
+        $namespace = array_map(
+            function($part) {
+                $part = preg_replace('/[^a-z0-9]/i', ' ', $part);
+                $part = ucwords($part);
+                return str_replace(' ', '', $part);
+            },
+            explode('/', $packageName)
+        );
 
-        $namespace = explode('/', $packageName);
-        $namespace = str_replace($allowedVendorSeparator, ' ', $namespace[0]);
-        $namespace = ucwords($namespace);
-        $namespace = str_replace(' ', '', $namespace);
-
-        return $namespace;
+        return join('\\', $namespace);
     }
 
     protected function getGitConfig()

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -158,7 +158,7 @@ EOT
         $file->write($options);
 
         // --autoload - Create src folder
-        if ($input->isInteractive() && $autoloadPath) {
+        if ($autoloadPath) {
             $filesystem = new Filesystem();
             $filesystem->ensureDirectoryExists($autoloadPath);
 
@@ -190,22 +190,11 @@ EOT
         }
 
         // --autoload - Show post-install configuration info
-        if ($input->isInteractive() && $autoloadPath) {
+        if ($autoloadPath) {
             $namespace = $this->namespaceFromPackageName($input->getOption('name'));
-            /** @var FormatterHelper $formatter */
-            $formatter = $this->getHelperSet()->get('formatter');
-            $io->writeError(array(
-                '',
-                $formatter->formatBlock(array(
-                    '# PSR-4 autoload configured:',
-                    '# Namespace: "'.$namespace.'"',
-                    '# Path: "'.$autoloadPath.'"',
-                    '',
-                    'namespace '.$namespace.';',
-                    'require \'vendor/autoload.php\';'
-                ), 'bg=yellow;fg=black', true),
-                '',
-            ));
+
+            $io->writeError('PSR-4 autoloading configured. Use "namespace '.$namespace.';" in '.$autoloadPath);
+            $io->writeError('Include the Composer autoloader with: require \'vendor/autoload.php\';');
         }
 
         return 0;
@@ -430,7 +419,7 @@ EOT
         $autoload = $input->getOption('autoload') ?: 'src/';
         $namespace = $this->namespaceFromPackageName($input->getOption('name'));
         $autoload = $io->askAndValidate(
-            'Add PSR-4 autoload mapping? Map namespace "'.$namespace.'" to the entered relative path. [<comment>'.$autoload.'</comment>, n to skip]: ',
+            'Add PSR-4 autoload mapping? Maps namespace "'.$namespace.'" to the entered relative path. [<comment>'.$autoload.'</comment>, n to skip]: ',
             function ($value) use ($autoload) {
                 if (null === $value) {
                     return $autoload;

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -193,8 +193,8 @@ EOT
         if ($autoloadPath) {
             $namespace = $this->namespaceFromPackageName($input->getOption('name'));
 
-            $io->writeError('PSR-4 autoloading configured. Use "namespace '.$namespace.';" in '.$autoloadPath);
-            $io->writeError('Include the Composer autoloader with: require \'vendor/autoload.php\';');
+            $io->writeError('PSR-4 autoloading configured. Use "<comment>namespace '.$namespace.';</comment>" in '.$autoloadPath);
+            $io->writeError('Include the Composer autoloader with: <comment>require \'vendor/autoload.php\';</comment>');
         }
 
         return 0;

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -132,7 +132,7 @@ EOT
             $namespace = $this->namespaceFromPackageName($input->getOption('name'));
             $options['autoload'] = (object) array(
                 'psr-4' => array(
-                    $namespace . '\\' => $options['autoload'],
+                    $namespace . '\\' => $autoloadPath,
                 )
             );
         }
@@ -427,13 +427,12 @@ EOT
         $input->setOption('require-dev', $devRequirements);
 
         // --autoload - input and validation
-        $autoload = $input->getOption('autoload');
-        $autoloadPath = $autoload ?: 'src/';
+        $autoload = $input->getOption('autoload') ?: 'src/';
         $autoload = $io->askAndValidate(
-            'Would you like to set PSR-4 autoload for the "'.$this->namespaceFromPackageName($input->getOption('name')).'\\\" namespace? [<comment>'.$autoloadPath.'</comment>, n to skip]: ',
-            function ($value) use ($autoload, $autoloadPath) {
+            'Would you like to set PSR-4 autoload for the "'.$this->namespaceFromPackageName($input->getOption('name')).'\\\" namespace? [<comment>'.$autoload.'</comment>, n to skip]: ',
+            function ($value) use ($autoload) {
                 if (null === $value) {
-                    return $autoloadPath;
+                    return $autoload;
                 }
 
                 if ($value === 'n' || $value === 'no') {
@@ -985,8 +984,8 @@ EOT
     private function runDumpAutoloadCommand($output)
     {
         try {
-            $installCommand = $this->getApplication()->find('dump-autoload');
-            $installCommand->run(new ArrayInput(array()), $output);
+            $command = $this->getApplication()->find('dump-autoload');
+            $command->run(new ArrayInput(array()), $output);
         } catch (\Exception $e) {
             $this->getIO()->writeError('Could not run dump-autoload.');
         }

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -155,13 +155,18 @@ EOT
             $io->writeError('Writing composer.json');
         }
 
+        $file->write($options);
+
         // --autoload - Create src folder
         if ($autoloadPath) {
             $filesystem = new Filesystem();
             $filesystem->ensureDirectoryExists($autoloadPath);
-        }
 
-        $file->write($options);
+            // dump-autoload only for projects without added dependencies.
+            if (!$this->hasDependencies($options)) {
+                $this->runDumpAutoloadCommand($output);
+            }
+        }
 
         if ($input->isInteractive() && is_dir('.git')) {
             $ignoreFile = realpath('.gitignore');
@@ -974,6 +979,16 @@ EOT
             $installCommand->run(new ArrayInput(array()), $output);
         } catch (\Exception $e) {
             $this->getIO()->writeError('Could not install dependencies. Run `composer install` to see more information.');
+        }
+    }
+
+    private function runDumpAutoloadCommand($output)
+    {
+        try {
+            $installCommand = $this->getApplication()->find('dump-autoload');
+            $installCommand->run(new ArrayInput(array()), $output);
+        } catch (\Exception $e) {
+            $this->getIO()->writeError('Could not run dump-autoload.');
         }
     }
 

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -158,7 +158,7 @@ EOT
         $file->write($options);
 
         // --autoload - Create src folder
-        if ($autoloadPath) {
+        if ($input->isInteractive() && $autoloadPath) {
             $filesystem = new Filesystem();
             $filesystem->ensureDirectoryExists($autoloadPath);
 

--- a/tests/Composer/Test/Command/InitCommandTest.php
+++ b/tests/Composer/Test/Command/InitCommandTest.php
@@ -97,7 +97,7 @@ class InitCommandTest extends TestCase
     {
         $command = new InitCommand;
         $namespace = $command->namespaceFromPackageName('new_projects.acme-extra/package-name');
-        $this->assertEquals('NewProjectsAcmeExtra', $namespace);
+        $this->assertEquals('NewProjectsAcmeExtra\PackageName', $namespace);
     }
 
     public function testNamespaceFromInvalidPackageName()

--- a/tests/Composer/Test/Command/InitCommandTest.php
+++ b/tests/Composer/Test/Command/InitCommandTest.php
@@ -92,4 +92,26 @@ class InitCommandTest extends TestCase
         $this->setExpectedException('InvalidArgumentException');
         $command->parseAuthorString('John Smith <john>');
     }
+
+    public function testNamespaceFromValidPackageName()
+    {
+        $command = new InitCommand;
+        $namespace = $command->namespaceFromPackageName('new_projects.acme-extra/package-name');
+        $this->assertEquals('NewProjectsAcmeExtra', $namespace);
+    }
+
+    public function testNamespaceFromInvalidPackageName()
+    {
+        $command = new InitCommand;
+        $namespace = $command->namespaceFromPackageName('invalid-package-name');
+        $this->assertNull($namespace);
+    }
+
+    public function testNamespaceFromMissingPackageName()
+    {
+        $command = new InitCommand;
+        $namespace = $command->namespaceFromPackageName(null);
+        $this->assertNull($namespace);
+    }
+
 }


### PR DESCRIPTION
Hello,

This PR extends the "composer init" command. It adds the "--autoload" parameter.

**Automatically generates a PSR-4 autoload** entry in your composer.json based on your **package name** and the interactive **configured src** path. The configured path is created automatically. The autoload feature is **optional**.

This is **helpful to kickstart a new project**, because PSR-4 autoload is required most of the time for new projects.

**Example info:**
In the following examples, the name of the new composer package is: `new_projects.acme-extra/package-name`

**Interactive mode**
`composer init`
...
`Add PSR-4 autoload mapping? Map namespace "Acme\Package" to the entered relative path. [src/, n to skip]:`

**Command parameter**
`composer init --autoload src/`

**Command --help**
`-a, --autoload=AUTOLOAD Add PSR-4 autoload mapping. Maps your package's namespace to the provided directory. (Expects a relative path, e.g. src/)`

**Implementation:**
Namespace: `new_projects.acme-extra/package-name` becomes namespace `NewProjectsAcmeExtra\PackageName`.
Path: Relative paths with trailing forward slash, defaults to `src/` (subfolders allowed)

**Create autoload files**
Composer "dump-autoload" runs automatically.

**Generated PSR-4 autoload entry in composer.json**
 ```
"autoload": {
    "psr-4": {
        "NewProjectsAcmeExtra\\PackageName\\": "src/"
    }
}
```

**Onboarding - Output after confirmed generation**
This is a simple help to onboard the developer. It allows to copy and paste the namespace and autoload require.

 ```
# PSR-4 autoload configured:
# Namespace: "NewProjectsAcmeExtra\PackageName"
# Path: "src/"

namespace NewProjectsAcmeExtra\PackageName;
require 'vendor/autoload.php';
```

**Documentation**

`* **--autoload (-a):** Add a PSR-4 autoload mapping to the composer.json. Automatically maps your package's namespace to the provided directory. (Expects a relative path, e.g. src/)  See also [PSR-4 autoload](04-schema.md#psr-4).`

**Unit tests**
Included
