### PR TITLE
Upgrade to xdebug-handler 2

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -14,7 +14,7 @@ use Composer\XdebugHandler\XdebugHandler;
 error_reporting(-1);
 
 // Restart without Xdebug
-$xdebug = new XdebugHandler('Composer', '--ansi');
+$xdebug = new XdebugHandler('Composer');
 $xdebug->check();
 unset($xdebug);
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "composer/metadata-minifier": "^1.0",
         "composer/semver": "^3.0",
         "composer/spdx-licenses": "^1.2",
-        "composer/xdebug-handler": "^1.1",
+        "composer/xdebug-handler": "^2.0",
         "justinrainbow/json-schema": "^5.2.10",
         "psr/log": "^1.0",
         "seld/jsonlint": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5275194a1c51ef2f95f92838cc728abc",
+    "content-hash": "9ca39897cc82c83aa794920b6c2f0a60",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -313,16 +313,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.6",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f27e06cd9675801df441b3656569b328e04aa37c"
+                "reference": "31d57697eb1971712a08031cfaff5a846d10bdf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f27e06cd9675801df441b3656569b328e04aa37c",
-                "reference": "f27e06cd9675801df441b3656569b328e04aa37c",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/31d57697eb1971712a08031cfaff5a846d10bdf5",
+                "reference": "31d57697eb1971712a08031cfaff5a846d10bdf5",
                 "shasum": ""
             },
             "require": {
@@ -357,7 +357,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.6"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.0"
             },
             "funding": [
                 {
@@ -373,7 +373,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-25T17:01:18+00:00"
+            "time": "2021-04-09T19:40:06+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -28,6 +28,7 @@ use Composer\SelfUpdate\Keys;
 use Composer\SelfUpdate\Versions;
 use Composer\IO\NullIO;
 use Composer\Package\CompletePackageInterface;
+use Composer\XdebugHandler\XdebugHandler;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\ExecutableFinder;
@@ -535,7 +536,7 @@ EOT
 
         if (filter_var(ini_get('xdebug.profiler_enabled'), FILTER_VALIDATE_BOOLEAN)) {
             $warnings['xdebug_profile'] = true;
-        } elseif (extension_loaded('xdebug')) {
+        } elseif (XdebugHandler::isXdebugActive()) {
             $warnings['xdebug_loaded'] = true;
         }
 

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -33,6 +33,7 @@ use Composer\Util\ErrorHandler;
 use Composer\Util\HttpDownloader;
 use Composer\EventDispatcher\ScriptExecutionException;
 use Composer\Exception\NoSslException;
+use Composer\XdebugHandler\XdebugHandler;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 
 /**
@@ -237,7 +238,7 @@ class Application extends BaseApplication
                 $io->writeError('<warning>Composer only officially supports PHP 5.3.2 and above, you will most likely encounter problems with your PHP '.PHP_VERSION.', upgrading is strongly recommended.</warning>');
             }
 
-            if (extension_loaded('xdebug') && !getenv('COMPOSER_DISABLE_XDEBUG_WARN')) {
+            if (XdebugHandler::isXdebugActive() && !getenv('COMPOSER_DISABLE_XDEBUG_WARN')) {
                 $io->writeError('<warning>Composer is operating slower than normal because you have Xdebug enabled. See https://getcomposer.org/xdebug</warning>');
             }
 

--- a/tests/Composer/Test/ApplicationTest.php
+++ b/tests/Composer/Test/ApplicationTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test;
 
 use Composer\Console\Application;
+use Composer\XdebugHandler\XdebugHandler;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ApplicationTest extends TestCase
@@ -54,7 +55,7 @@ class ApplicationTest extends TestCase
         $outputMock->expects($this->at($index++))
             ->method("write");
 
-        if (extension_loaded('xdebug')) {
+        if (XdebugHandler::isXdebugActive()) {
             $outputMock->expects($this->at($index++))
                 ->method("getVerbosity")
                 ->willReturn(OutputInterface::VERBOSITY_NORMAL);


### PR DESCRIPTION
This adds support for Xdebug3 modes and changes the default behaviour from always restarting if Xdebug is loaded, to only restarting if Xdebug is active.

Xdebug is considered active if it is loaded, and for Xdebug3, if it is running in a mode other than `xdebug.mode=off`.
