### PR TITLE
BinaryInstaller: install full binaries on WSL when bin-compat=auto

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -82,7 +82,7 @@ class BinaryInstaller
             }
 
             if ($this->binCompat === "auto") {
-                if (Platform::isWindows()) {
+                if (Platform::isWindows() || Platform::isWindowsSubsystemForLinux()) {
                     $this->installFullBinaries($binPath, $link, $bin, $package);
                 } else {
                     $this->installSymlinkBinaries($binPath, $link);

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -75,6 +75,11 @@ class Platform
     public static function isWindowsSubsystemForLinux() {
         if (null === self::$isWindowsSubsystemForLinux) {
             self::$isWindowsSubsystemForLinux = false;
+            
+            // while WSL will be hosted within windows, WSL itself cannot be windows based itself.
+            if (self::isWindows()) {
+                return self::$isWindowsSubsystemForLinux = false;
+            }
 
             $process = new ProcessExecutor();
             try {

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -21,6 +21,8 @@ class Platform
 {
     /** @var ?bool */
     private static $isVirtualBoxGuest = null;
+    /** @var ?bool */
+    private static $isWindowsSubsystemForLinux = null;
 
     /**
      * Parses tildes and environment variables in paths.
@@ -65,6 +67,26 @@ class Platform
         }
 
         throw new \RuntimeException('Could not determine user directory');
+    }
+
+    /**
+     * @return bool Whether the host machine is running on the Windows Subsystem for Linux (WSL)
+     */
+    public static function isWindowsSubsystemForLinux() {
+        if (null === self::$isWindowsSubsystemForLinux) {
+            self::$isWindowsSubsystemForLinux = false;
+
+            $process = new ProcessExecutor();
+            try {
+                if (0 === $process->execute('cat /proc/version | grep "Microsoft"', $ignoredOutput)) {
+                    return self::$isWindowsSubsystemForLinux = true;
+                }
+            } catch (\Exception $e) {
+                // noop
+            }
+        }
+
+        return self::$isWindowsSubsystemForLinux;
     }
 
     /**

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -72,7 +72,8 @@ class Platform
     /**
      * @return bool Whether the host machine is running on the Windows Subsystem for Linux (WSL)
      */
-    public static function isWindowsSubsystemForLinux() {
+    public static function isWindowsSubsystemForLinux()
+    {
         if (null === self::$isWindowsSubsystemForLinux) {
             self::$isWindowsSubsystemForLinux = false;
             
@@ -81,13 +82,8 @@ class Platform
                 return self::$isWindowsSubsystemForLinux = false;
             }
 
-            $process = new ProcessExecutor();
-            try {
-                if (0 === $process->execute('cat /proc/version | grep "Microsoft"', $ignoredOutput)) {
-                    return self::$isWindowsSubsystemForLinux = true;
-                }
-            } catch (\Exception $e) {
-                // noop
+            if (is_readable('/proc/version') && false !== stripos(file_get_contents('/proc/version'), 'microsoft')) {
+                return self::$isWindowsSubsystemForLinux = true;
             }
         }
 


### PR DESCRIPTION
feature detect WSL and install all binaries in this case.

this is usefull to get the *.bat files on a windows host, which can then be invoked from the regular CLI, or used within IDEs etc.

closes https://github.com/composer/composer/issues/9841

tested on Windows10x64 in WSL, CMD and git-bash-for-windows