### PR TITLE
Add Platform-PHP version to user-agent header to improve targetted-php stats

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -34,6 +34,11 @@ class PlatformRepository extends ArrayRepository
     const PLATFORM_PACKAGE_REGEX = '{^(?:php(?:-64bit|-ipv6|-zts|-debug)?|hhvm|(?:ext|lib)-[a-z0-9](?:[_.-]?[a-z0-9]+)*|composer-(?:plugin|runtime)-api)$}iD';
 
     /**
+     * @var ?string
+     */
+    private static $lastSeenPlatformPhp = null;
+
+    /**
      * @var VersionParser
      */
     private $versionParser;
@@ -526,6 +531,10 @@ class PlatformRepository extends ArrayRepository
         $package->setExtra(array('config.platform' => true));
         parent::addPackage($package);
 
+        if ($package->getName() === 'php') {
+            self::$lastSeenPlatformPhp = implode('.', array_slice(explode('.', $package->getVersion()), 0, 3));
+        }
+
         return $package;
     }
 
@@ -619,5 +628,19 @@ class PlatformRepository extends ArrayRepository
         }
 
         return $cache[$name] = (bool) preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $name);
+    }
+
+    /**
+     * Returns the last seen config.platform.php version if defined
+     *
+     * This is a best effort attempt for internal purposes, retrieve the real
+     * packages from a PlatformRepository instance if you need a version guaranteed to
+     * be correct.
+     *
+     * @internal
+     */
+    public static function getPlatformPhpVersion()
+    {
+        return self::$lastSeenPlatformPhp;
     }
 }

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -15,6 +15,7 @@ namespace Composer\Util;
 use Composer\Composer;
 use Composer\CaBundle\CaBundle;
 use Composer\Downloader\TransportException;
+use Composer\Repository\PlatformRepository;
 use Composer\Util\Http\ProxyManager;
 use Psr\Log\LoggerInterface;
 
@@ -112,13 +113,15 @@ final class StreamContextFactory
         }
 
         if (!isset($options['http']['header']) || false === stripos(implode('', $options['http']['header']), 'user-agent')) {
+            $platformPhpVersion = PlatformRepository::getPlatformPhpVersion();
             $options['http']['header'][] = sprintf(
-                'User-Agent: Composer/%s (%s; %s; %s; %s%s)',
+                'User-Agent: Composer/%s (%s; %s; %s; %s%s%s)',
                 Composer::getVersion(),
                 function_exists('php_uname') ? php_uname('s') : 'Unknown',
                 function_exists('php_uname') ? php_uname('r') : 'Unknown',
                 $phpVersion,
                 $httpVersion,
+                $platformPhpVersion ? '; Platform-PHP '.$platformPhpVersion : '',
                 getenv('CI') ? '; CI' : ''
             );
         }


### PR DESCRIPTION
Just an idea.. not sure what others think, but this would let us collect info on what the actual php-deploy-target version of the project is, vs using what the developers are running.

For composer this results in something like `User-Agent: Composer/2.0.999-dev+source (Linux; 4.19.104-microsoft-standard; PHP 8.0.3; cURL 7.68.0; Platform-PHP 5.3.9)` - where we see although I'm using php 8, my stats for this should actually count as 5.3.9 because it's what we "deploy" to.

I am not sure if the two versions differ often enough to be important/relevant/interesting though.