### PR TITLE
macOS cache dir

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -198,9 +198,10 @@ versions. See also [COMPOSER_HOME](03-cli.md#composer-home).
 ## cache-dir
 
 Defaults to `C:\Users\<user>\AppData\Local\Composer` on Windows,
-`$XDG_CACHE_HOME/composer` on unix systems that follow the XDG Base Directory
-Specifications, and `$home/cache` on other unix systems. Stores all the caches
-used by Composer. See also [COMPOSER_HOME](03-cli.md#composer-home).
+`/Users/<user>/Library/Caches/composer` on macOS, `$XDG_CACHE_HOME/composer`
+on unix systems that follow the XDG Base Directory Specifications, and
+`$home/cache` on other unix systems. Stores all the caches used by Composer.
+See also [COMPOSER_HOME](03-cli.md#composer-home).
 
 ## cache-files-dir
 

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -121,6 +121,10 @@ class Factory
         }
 
         $userDir = self::getUserDir();
+        if (PHP_OS === 'Darwin') {
+            return $userDir . '/Library/Caches/composer';
+        }
+
         if ($home === $userDir . '/.composer' && is_dir($home . '/cache')) {
             return $home . '/cache';
         }

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -122,6 +122,11 @@ class Factory
 
         $userDir = self::getUserDir();
         if (PHP_OS === 'Darwin') {
+            // Migrate existing cache dir in old location if present
+            if (is_dir($home . '/cache') && !is_dir($userDir . '/Library/Caches/composer')) {
+                Silencer::call('rename', $home . '/cache', $userDir . '/Library/Caches/composer');
+            }
+            
             return $userDir . '/Library/Caches/composer';
         }
 


### PR DESCRIPTION
Other popular CLI apps that put caches in `~/Library/Caches` in macOS:
- [helm](https://helm.sh/)
- [heroku](https://devcenter.heroku.com/articles/heroku-cli)
- [homebrew](https://brew.sh/)
- [pip](https://pypi.org/project/pip/)
- [vercel](https://vercel.com/cli)
- [yarn](https://yarnpkg.com/)

Those apps may also leverage `~/Library/Application Support` or `~/Library/Preferences` which may be a place for `$COMPOSER_HOME`
