### PR TITLE
Invert strict/lax schema validation

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -94,9 +94,7 @@ Out of the box, Composer supports four types:
   CMSs like the [SilverStripe installer](https://github.com/silverstripe/silverstripe-installer)
   or full fledged applications distributed as packages. This can for example
   be used by IDEs to provide listings of projects to initialize when creating
-  a new workspace.  Setting the type to `project` also makes the `name` and
-  `description` fields optional, making it a good choice for closed source
-  projects wishing to use `composer validate`.
+  a new workspace.
 - **metapackage:** An empty package that contains requirements and will trigger
   their installation, but contains no files and will not write anything to the
   filesystem. As such, it does not require a dist or source key to be

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -2,8 +2,6 @@
     "$schema": "https://json-schema.org/draft-04/schema#",
     "title": "Package",
     "type": "object",
-    "additionalProperties": false,
-    "required": [ "name", "description" ],
     "properties": {
         "name": {
             "type": "string",

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -3,26 +3,7 @@
     "title": "Package",
     "type": "object",
     "additionalProperties": false,
-    "oneOf": [
-        {
-            "properties": {
-                "type": {
-                    "not": {
-                        "enum": ["project"]
-                    }
-                }
-            },
-            "required": ["name", "description"]
-        },
-        {
-            "properties": {
-                "type": {
-                    "enum": ["project"]
-                }
-            },
-            "required": ["type"]
-        }
-    ],
+    "required": [ "name", "description" ],
     "properties": {
         "name": {
             "type": "string",

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -198,7 +198,7 @@ class JsonFile
 
         if ($schema === self::LAX_SCHEMA) {
             $schemaData->additionalProperties = true;
-            $schemaData->oneOf = null;
+            $schemaData->required = array();
         }
 
         $validator = new Validator();

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -196,9 +196,9 @@ class JsonFile
 
         $schemaData = (object) array('$ref' => $schemaFile);
 
-        if ($schema === self::LAX_SCHEMA) {
-            $schemaData->additionalProperties = true;
-            $schemaData->required = array();
+        if ($schema !== self::LAX_SCHEMA) {
+            $schemaData->additionalProperties = false;
+            $schemaData->required = array('name', 'description');
         }
 
         $validator = new Validator();

--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -63,16 +63,6 @@ class ConfigValidator
             $json->validateSchema();
         } catch (JsonValidationException $e) {
             foreach ($e->getErrors() as $message) {
-                if ($message === 'type : The property type is required') {
-                    $message .= ' (see https://getcomposer.org/doc/04-schema.md#type)';
-                }
-                if ($message === 'name : The property name is required') {
-                    $message .= ' (or set "type" to "project" to remove this requirement)';
-                }
-                if ($message === 'description : The property description is required') {
-                    $message .= ' (or set "type" to "project" to remove this requirement)';
-                }
-
                 if ($laxValid) {
                     $publishErrors[] = $message;
                 } else {

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -41,38 +41,18 @@ class ComposerSchemaTest extends TestCase
     {
         $json = '{ }';
         $result = $this->check($json);
-        $this->assertContains(array('property' => 'type', 'message' => 'The property type is required', 'constraint' => 'required'), $result);
         $this->assertContains(array('property' => 'name', 'message' => 'The property name is required', 'constraint' => 'required'), $result);
         $this->assertContains(array('property' => 'description', 'message' => 'The property description is required', 'constraint' => 'required'), $result);
-        $this->assertContains(array('property' => '', 'message' => 'Failed to match exactly one schema', 'constraint' => 'oneOf'), $result);
 
         $json = '{ "name": "vendor/package" }';
         $this->assertEquals(array(
-            array('property' => 'type', 'message' => 'The property type is required', 'constraint' => 'required'),
             array('property' => 'description', 'message' => 'The property description is required', 'constraint' => 'required'),
-            array('property' => '', 'message' => 'Failed to match exactly one schema', 'constraint' => 'oneOf'),
         ), $this->check($json));
 
         $json = '{ "description": "generic description" }';
         $this->assertEquals(array(
-            array('property' => 'type', 'message' => 'The property type is required', 'constraint' => 'required'),
             array('property' => 'name', 'message' => 'The property name is required', 'constraint' => 'required'),
-            array('property' => '', 'message' => 'Failed to match exactly one schema', 'constraint' => 'oneOf'),
         ), $this->check($json));
-
-        $json = '{ "type": "library" }';
-        $this->assertEquals(array(
-            array('property' => 'type', 'message' => 'Does not have a value in the enumeration ["project"]', 'constraint' => 'enum', 'enum' => array('project')),
-            array('property' => 'name', 'message' => 'The property name is required', 'constraint' => 'required'),
-            array('property' => 'description', 'message' => 'The property description is required', 'constraint' => 'required'),
-            array('property' => '', 'message' => 'Failed to match exactly one schema', 'constraint' => 'oneOf'),
-        ), $this->check($json));
-
-        $json = '{ "type": "project" }';
-        $this->assertTrue($this->check($json));
-
-        $json = '{ "name": "vendor/package", "description": "description" }';
-        $this->assertTrue($this->check($json));
     }
 
     public function testOptionalAbandonedProperty()

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -37,24 +37,6 @@ class ComposerSchemaTest extends TestCase
         $this->assertEquals($expectedError, $this->check($json));
     }
 
-    public function testRequiredProperties()
-    {
-        $json = '{ }';
-        $result = $this->check($json);
-        $this->assertContains(array('property' => 'name', 'message' => 'The property name is required', 'constraint' => 'required'), $result);
-        $this->assertContains(array('property' => 'description', 'message' => 'The property description is required', 'constraint' => 'required'), $result);
-
-        $json = '{ "name": "vendor/package" }';
-        $this->assertEquals(array(
-            array('property' => 'description', 'message' => 'The property description is required', 'constraint' => 'required'),
-        ), $this->check($json));
-
-        $json = '{ "description": "generic description" }';
-        $this->assertEquals(array(
-            array('property' => 'name', 'message' => 'The property name is required', 'constraint' => 'required'),
-        ), $this->check($json));
-    }
-
     public function testOptionalAbandonedProperty()
     {
         $json = '{"name": "vendor/package", "description": "description", "abandoned": true}';

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test\Json;
 
 use Seld\JsonLint\ParsingException;
 use Composer\Json\JsonFile;
+use Composer\Json\JsonValidationException;
 use Composer\Test\TestCase;
 
 class JsonFileTest extends TestCase
@@ -93,6 +94,89 @@ class JsonFileTest extends TestCase
     {
         $json = new JsonFile(__DIR__.'/Fixtures/composer.json');
         $this->assertTrue($json->validateSchema());
+        $this->assertTrue($json->validateSchema(JsonFile::LAX_SCHEMA));
+    }
+
+    public function testSchemaValidationError()
+    {
+        $file = tempnam(sys_get_temp_dir(), 'c');
+        file_put_contents($file, '{ "name": null }');
+        $json = new JsonFile($file);
+        $expectedMessage = sprintf('"%s" does not match the expected JSON schema', $file);
+        $expectedError = 'name : NULL value found, but a string is required';
+        try {
+            $json->validateSchema();
+            $this->fail('Expected exception to be thrown (strict)');
+        } catch (JsonValidationException $e) {
+            $this->assertEquals($expectedMessage, $e->getMessage());
+            $this->assertContains($expectedError, $e->getErrors());
+        }
+        try {
+            $json->validateSchema(JsonFile::LAX_SCHEMA);
+            $this->fail('Expected exception to be thrown (lax)');
+        } catch (JsonValidationException $e) {
+            $this->assertEquals($expectedMessage, $e->getMessage());
+            $this->assertContains($expectedError, $e->getErrors());
+        }
+        unlink($file);
+    }
+
+    public function testSchemaValidationLaxAdditionalProperties()
+    {
+        $file = tempnam(sys_get_temp_dir(), 'c');
+        file_put_contents($file, '{ "name": "vendor/package", "description": "generic description", "foo": "bar" }');
+        $json = new JsonFile($file);
+        try {
+            $json->validateSchema();
+            $this->fail('Expected exception to be thrown (strict)');
+        } catch (JsonValidationException $e) {
+            $this->assertEquals(sprintf('"%s" does not match the expected JSON schema', $file), $e->getMessage());
+            $this->assertEquals(array('The property foo is not defined and the definition does not allow additional properties'), $e->getErrors());
+        }
+        $this->assertTrue($json->validateSchema(JsonFile::LAX_SCHEMA));
+        unlink($file);
+    }
+
+    public function testSchemaValidationLaxRequired()
+    {
+        $file = tempnam(sys_get_temp_dir(), 'c');
+        $json = new JsonFile($file);
+
+        $expectedMessage = sprintf('"%s" does not match the expected JSON schema', $file);
+
+        file_put_contents($file, '{ }');
+        try {
+            $json->validateSchema();
+            $this->fail('Expected exception to be thrown (strict)');
+        } catch (JsonValidationException $e) {
+            $this->assertEquals($expectedMessage, $e->getMessage());
+            $errors = $e->getErrors();
+            $this->assertContains('name : The property name is required', $errors);
+            $this->assertContains('description : The property description is required', $errors);
+        }
+        $this->assertTrue($json->validateSchema(JsonFile::LAX_SCHEMA));
+
+        file_put_contents($file, '{ "name": "vendor/package" }');
+        try {
+            $json->validateSchema();
+            $this->fail('Expected exception to be thrown (strict)');
+        } catch (JsonValidationException $e) {
+            $this->assertEquals($expectedMessage, $e->getMessage());
+            $this->assertEquals(array('description : The property description is required'), $e->getErrors());
+        }
+        $this->assertTrue($json->validateSchema(JsonFile::LAX_SCHEMA));
+
+        file_put_contents($file, '{ "description": "generic description" }');
+        try {
+            $json->validateSchema();
+            $this->fail('Expected exception to be thrown (strict)');
+        } catch (JsonValidationException $e) {
+            $this->assertEquals($expectedMessage, $e->getMessage());
+            $this->assertEquals(array('name : The property name is required'), $e->getErrors());
+        }
+        $this->assertTrue($json->validateSchema(JsonFile::LAX_SCHEMA));
+
+        unlink($file);
     }
 
     public function testParseErrorDetectMissingCommaMultiline()

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -176,6 +176,34 @@ class JsonFileTest extends TestCase
         }
         $this->assertTrue($json->validateSchema(JsonFile::LAX_SCHEMA));
 
+        file_put_contents($file, '{ "type": "library" }');
+        try {
+            $json->validateSchema();
+            $this->fail('Expected exception to be thrown (strict)');
+        } catch (JsonValidationException $e) {
+            $this->assertEquals($expectedMessage, $e->getMessage());
+            $errors = $e->getErrors();
+            $this->assertContains('name : The property name is required', $errors);
+            $this->assertContains('description : The property description is required', $errors);
+        }
+        $this->assertTrue($json->validateSchema(JsonFile::LAX_SCHEMA));
+
+        file_put_contents($file, '{ "type": "project" }');
+        try {
+            $json->validateSchema();
+            $this->fail('Expected exception to be thrown (strict)');
+        } catch (JsonValidationException $e) {
+            $this->assertEquals($expectedMessage, $e->getMessage());
+            $errors = $e->getErrors();
+            $this->assertContains('name : The property name is required', $errors);
+            $this->assertContains('description : The property description is required', $errors);
+        }
+        $this->assertTrue($json->validateSchema(JsonFile::LAX_SCHEMA));
+
+        file_put_contents($file, '{ "name": "vendor/package", "description": "generic description" }');
+        $this->assertTrue($json->validateSchema());
+        $this->assertTrue($json->validateSchema(JsonFile::LAX_SCHEMA));
+
         unlink($file);
     }
 


### PR DESCRIPTION
Refs https://github.com/composer/composer/pull/9782#issuecomment-844983851:

> We could make the name/description optional in the schema, and change the rules at runtime to make them required instead of the opposite (which is what we do now). I think that probably makes the schema the most re-usable while not changing much for composer users.

This PR basically reverts the recently merged #9782 (and the follow-up commit 458bd41d8fe8df7e3da7dad8cfd09ea4dfc0d3cd) and inverts the original logic.

So name/description become always optional for pure JSON schema validation [even for non-project type], and are still always required at runtime for `composer validate` (strict errors, or warnings with `--no-check-publish`) [even for project type].
Similarly, additional properties become allowed in the schema (but are still forbidden for publication).

I think that makes sense, because you may want to have a private (non-published) custom-type package without name/description and/or with custom properties, or on the contrary, publish a project-type package (e.g. https://packagist.org/packages/symfony/skeleton).

This should also avoid the potentially confusing error output depicted in https://github.com/composer/composer/pull/9782#issuecomment-845159854 (and explained in https://github.com/composer/composer/pull/9782#issuecomment-845217123).