### PR TITLE
PHP 8.1 | Fix "Implicit conversion from non-compatible float" deprecation notice

### DIFF
--- a/src/Composer/Platform/Version.php
+++ b/src/Composer/Platform/Version.php
@@ -97,7 +97,7 @@ class Version
         return sprintf(
             '%d.%d.%d',
             $versionId / ($base * $base),
-            ($versionId / $base) % $base,
+            (int) ($versionId / $base) % $base,
             $versionId % $base
         );
     }


### PR DESCRIPTION
As reported in #9931.

Unfortunately I gave not been able to track down the input which is causing the notices to be thrown, which is why I haven't added a test case to the unit tests. Would be great if someone would known the exact input to use for those.

The issue (and fix) can be verified by using the "quick preview" option and choosing `git.master` with this code sample: https://3v4l.org/1fr2g

Fixes #9931
