### PR TITLE
Fix JsonFile when using custom json schema with no "name" and "descri…

### DIFF
--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -180,6 +180,7 @@ class JsonFile
     {
         $content = file_get_contents($this->path);
         $data = json_decode($content);
+        $requiredSchemaData = array();
 
         if (null === $data && 'null' !== $content) {
             self::validateSyntax($content, $this->path);
@@ -187,6 +188,7 @@ class JsonFile
 
         if (null === $schemaFile) {
             $schemaFile = __DIR__ . self::COMPOSER_SCHEMA_PATH;
+            $requiredSchemaData = array('name', 'description');
         }
 
         // Prepend with file:// only when not using a special schema already (e.g. in the phar)
@@ -198,7 +200,7 @@ class JsonFile
 
         if ($schema !== self::LAX_SCHEMA) {
             $schemaData->additionalProperties = false;
-            $schemaData->required = array('name', 'description');
+            $schemaData->required = $requiredSchemaData;
         }
 
         $validator = new Validator();

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -207,6 +207,38 @@ class JsonFileTest extends TestCase
         unlink($file);
     }
 
+    public function testCustomSchemaValidationLax()
+    {
+        $file = tempnam(sys_get_temp_dir(), 'c');
+        file_put_contents($file, '{ "custom": "property", "another custom": "property" }');
+
+        $schema = tempnam(sys_get_temp_dir(), 'c');
+        file_put_contents($schema, '{ "properties": { "custom": { "type": "string" }}}');
+
+        $json = new JsonFile($file);
+
+        $this->assertTrue($json->validateSchema(JsonFile::LAX_SCHEMA, $schema));
+
+        unlink($file);
+        unlink($schema);
+    }
+
+    public function testCustomSchemaValidationStrict()
+    {
+        $file = tempnam(sys_get_temp_dir(), 'c');
+        file_put_contents($file, '{ "custom": "property" }');
+
+        $schema = tempnam(sys_get_temp_dir(), 'c');
+        file_put_contents($schema, '{ "properties": { "custom": { "type": "string" }}}');
+
+        $json = new JsonFile($file);
+
+        $this->assertTrue($json->validateSchema(JsonFile::STRICT_SCHEMA, $schema));
+
+        unlink($file);
+        unlink($schema);
+    }
+
     public function testParseErrorDetectMissingCommaMultiline()
     {
         $json = '{


### PR DESCRIPTION
Hi,

due to changes in #9912 I am getting the next errors when using a custom json schema and validation is set to `STRICT_SCHEMA`:
- "name : The property name is required"
- "description : The property description is required"

As I understood from the discussions, these required properties are needed for validate composer schema in some scenarios,
but they should not affect custom schema files.

This PR:
 - applies required `name` and `description` only when composer schema is used with `STRICT_SCHEMA`
 - adds tests using custom schema

 @guilliamxavier could you check if I am missing something? Thanks!