### PR TITLE
Fix --no-scripts disabling events for plugins

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -183,6 +183,7 @@ EOT
         }
 
         $composer = Factory::create($io, null, $disablePlugins);
+        $composer->getEventDispatcher()->setRunScripts(!$noScripts);
 
         // add the repository to the composer.json and use it for the install run later
         if ($repositories !== null && $addRepository) {
@@ -208,10 +209,8 @@ EOT
         $process = new ProcessExecutor($io);
         $fs = new Filesystem($process);
 
-        if ($noScripts === false) {
-            // dispatch event
-            $composer->getEventDispatcher()->dispatchScript(ScriptEvents::POST_ROOT_PACKAGE_INSTALL, $installDevPackages);
-        }
+        // dispatch event
+        $composer->getEventDispatcher()->dispatchScript(ScriptEvents::POST_ROOT_PACKAGE_INSTALL, $installDevPackages);
 
         // use the new config including the newly installed project
         $config = $composer->getConfig();
@@ -225,7 +224,6 @@ EOT
             $installer->setPreferSource($preferSource)
                 ->setPreferDist($preferDist)
                 ->setDevMode($installDevPackages)
-                ->setRunScripts(!$noScripts)
                 ->setIgnorePlatformRequirements($ignorePlatformReqs)
                 ->setSuggestedPackagesReporter($this->suggestedPackagesReporter)
                 ->setOptimizeAutoloader($config->get('optimize-autoloader'))
@@ -290,10 +288,8 @@ EOT
             }
         }
 
-        if ($noScripts === false) {
-            // dispatch event
-            $composer->getEventDispatcher()->dispatchScript(ScriptEvents::POST_CREATE_PROJECT_CMD, $installDevPackages);
-        }
+        // dispatch event
+        $composer->getEventDispatcher()->dispatchScript(ScriptEvents::POST_CREATE_PROJECT_CMD, $installDevPackages);
 
         chdir($oldCwd);
         $vendorComposerDir = $config->get('vendor-dir').'/composer';

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -52,6 +52,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $composer = $this->getComposer();
+        $composer->getEventDispatcher()->setRunScripts(!$input->getOption('no-scripts'));
 
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'dump-autoload', $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
@@ -82,7 +83,6 @@ EOT
         }
         $generator->setClassMapAuthoritative($authoritative);
         $generator->setApcu($apcu, $apcuPrefix);
-        $generator->setRunScripts(!$input->getOption('no-scripts'));
         $generator->setIgnorePlatformRequirements($ignorePlatformReqs);
         $numberOfClasses = $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
 

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -94,6 +94,7 @@ EOT
         }
 
         $composer = $this->getComposer(true, $input->getOption('no-plugins'));
+        $composer->getEventDispatcher()->setRunScripts(!$input->getOption('no-scripts'));
 
         if ((!$composer->getLocker() || !$composer->getLocker()->isLocked()) && !HttpDownloader::isCurlEnabled()) {
             $io->writeError('<warning>Composer is operating significantly slower than normal because you do not have the PHP curl extension enabled.</warning>');
@@ -123,7 +124,6 @@ EOT
             ->setPreferDist($preferDist)
             ->setDevMode(!$input->getOption('no-dev'))
             ->setDumpAutoloader(!$input->getOption('no-autoloader'))
-            ->setRunScripts(!$input->getOption('no-scripts'))
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)
             ->setApcuAutoloader($apcu, $apcuPrefix)

--- a/src/Composer/Command/ReinstallCommand.php
+++ b/src/Composer/Command/ReinstallCommand.php
@@ -69,6 +69,7 @@ EOT
         $io = $this->getIO();
 
         $composer = $this->getComposer(true, $input->getOption('no-plugins'));
+        $composer->getEventDispatcher()->setRunScripts(!$input->getOption('no-scripts'));
 
         $localRepo = $composer->getRepositoryManager()->getLocalRepository();
         $packagesToReinstall = array();
@@ -142,8 +143,8 @@ EOT
         $downloadManager->setPreferSource($preferSource);
         $downloadManager->setPreferDist($preferDist);
 
-        $installationManager->execute($localRepo, $uninstallOperations, true, !$input->getOption('no-scripts'));
-        $installationManager->execute($localRepo, $installOperations, true, !$input->getOption('no-scripts'));
+        $installationManager->execute($localRepo, $uninstallOperations, true);
+        $installationManager->execute($localRepo, $installOperations, true);
 
         if (!$input->getOption('no-autoloader')) {
             $optimize = $input->getOption('optimize-autoloader') || $config->get('optimize-autoloader');
@@ -154,7 +155,6 @@ EOT
             $generator = $composer->getAutoloadGenerator();
             $generator->setClassMapAuthoritative($authoritative);
             $generator->setApcu($apcu, $apcuPrefix);
-            $generator->setRunScripts(!$input->getOption('no-scripts'));
             $generator->setIgnorePlatformRequirements($ignorePlatformReqs);
             $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
         }

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -202,6 +202,7 @@ EOT
         // Update packages
         $this->resetComposer();
         $composer = $this->getComposer(true, $input->getOption('no-plugins'));
+        $composer->getEventDispatcher()->setRunScripts(!$input->getOption('no-scripts'));
 
         if ($dryRun) {
             $rootPackage = $composer->getPackage();
@@ -255,7 +256,6 @@ EOT
             ->setInstall(!$input->getOption('no-install'))
             ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
             ->setIgnorePlatformRequirements($ignorePlatformReqs)
-            ->setRunScripts(!$input->getOption('no-scripts'))
             ->setDryRun($dryRun)
         ;
 

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -311,6 +311,7 @@ EOT
         // Update packages
         $this->resetComposer();
         $composer = $this->getComposer(true, $input->getOption('no-plugins'));
+        $composer->getEventDispatcher()->setRunScripts(!$input->getOption('no-scripts'));
 
         if ($input->getOption('dry-run')) {
             $rootPackage = $composer->getPackage();
@@ -362,7 +363,6 @@ EOT
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
             ->setDevMode($updateDevMode)
-            ->setRunScripts(!$input->getOption('no-scripts'))
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)
             ->setApcuAutoloader($apcu, $apcuPrefix)

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -116,6 +116,7 @@ EOT
         }
 
         $composer = $this->getComposer(true, $input->getOption('no-plugins'));
+        $composer->getEventDispatcher()->setRunScripts(!$input->getOption('no-scripts'));
 
         if (!HttpDownloader::isCurlEnabled()) {
             $io->writeError('<warning>Composer is operating significantly slower than normal because you do not have the PHP curl extension enabled.</warning>');
@@ -220,7 +221,6 @@ EOT
             ->setPreferDist($preferDist)
             ->setDevMode(!$input->getOption('no-dev'))
             ->setDumpAutoloader(!$input->getOption('no-autoloader'))
-            ->setRunScripts(!$input->getOption('no-scripts'))
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)
             ->setApcuAutoloader($apcu, $apcuPrefix)

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -53,6 +53,8 @@ class EventDispatcher
     protected $process;
     /** @var array<string, array<int, array<callable|string>>> */
     protected $listeners = array();
+    /** @var bool */
+    protected $runScripts = true;
     /** @var list<string> */
     private $eventStack;
 
@@ -69,6 +71,18 @@ class EventDispatcher
         $this->io = $io;
         $this->process = $process ?: new ProcessExecutor($io);
         $this->eventStack = array();
+    }
+
+    /**
+     * Set whether to run scripts or not
+     *
+     * @param bool $runScripts
+     */
+    public function setRunScripts($runScripts = true)
+    {
+        $this->runScripts = (bool) $runScripts;
+
+        return $this;
     }
 
     /**
@@ -421,7 +435,7 @@ class EventDispatcher
      */
     protected function getListeners(Event $event)
     {
-        $scriptListeners = $this->getScriptListeners($event);
+        $scriptListeners = $this->runScripts ? $this->getScriptListeners($event) : array();
 
         if (!isset($this->listeners[$event->getName()][0])) {
             $this->listeners[$event->getName()][0] = array();

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -74,7 +74,7 @@ class EventDispatcher
     }
 
     /**
-     * Set whether to run scripts or not
+     * Set whether script handlers are active or not
      *
      * @param bool $runScripts
      */

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1131,6 +1131,7 @@ class Installer
      *
      * @param  bool      $runScripts
      * @return Installer
+     * @deprecated Use setRunScripts(false) on the EventDispatcher instance being injected instead
      */
     public function setRunScripts($runScripts = true)
     {


### PR DESCRIPTION
Right now, when composer runs with `--no-scripts`, it not only disables "scripts" entries from the composer.json file, but it also prevents plugins from actually doing anything. This PR fixes it.