### PR TITLE
Fix initial values of CompletePackage properties

### DIFF
--- a/src/Composer/Package/CompletePackage.php
+++ b/src/Composer/Package/CompletePackage.php
@@ -19,10 +19,10 @@ namespace Composer\Package;
  */
 class CompletePackage extends Package implements CompletePackageInterface
 {
-    protected $repositories;
+    protected $repositories = array();
     protected $license = array();
-    protected $keywords;
-    protected $authors;
+    protected $keywords = array();
+    protected $authors = array();
     protected $description;
     protected $homepage;
     protected $scripts = array();


### PR DESCRIPTION
Hello there :slightly_smiling_face: :wave: 

in the [ArrayLoader](https://github.com/composer/composer/blob/master/src/Composer/Package/Loader/ArrayLoader.php#L281-L283) the authors are only set if the value is an array. If this is not the case or simply no authors are given in the composer.json, the [`$authors` property](https://github.com/composer/composer/blob/master/src/Composer/Package/CompletePackage.php#L25) stays `null`

So the annotation on the interface for `getAuthors` is not correct. 

I guess this is also the case for other properties, but this just showed up for us, as we need to tell PHPStan, that `getAuthors` returns `array|null`
Let me know, if I should also fix the other properties :slightly_smiling_face: 

EDIT:
As suggested, I changed the initial values of the properties of the `CompletePackage` class