### PR TITLE
GH Actions: set error_reporting to E_ALL

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           coverage: "none"
           extensions: "intl, zip"
-          ini-values: "memory_limit=-1, phar.readonly=0"
+          ini-values: "memory_limit=-1, phar.readonly=0, error_reporting=E_ALL, display_errors=On"
           php-version: "${{ matrix.php-version }}"
           tools: composer
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         php-version:
           - "5.3"
-          - "7.4"
+          - "latest"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           coverage: "none"
           extensions: "intl"
-          ini-values: "memory_limit=-1"
+          ini-values: "memory_limit=-1, error_reporting=E_ALL, display_errors=On"
           php-version: "${{ matrix.php-version }}"
 
       - name: "Lint PHP files"


### PR DESCRIPTION
### GH Actions: set error reporting to E_ALL

Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.

### GH Actions: ensure linting is done against highest/lowest supported PHP version

`latest` in the matrix will always refer to the latest stable PHP release, which would now be PHP 8.0.

