### PR TITLE
Allow versions like: "1.0.0-dev" and "4.8.0-p1"

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -40,7 +40,7 @@
         "version": {
             "type": "string",
             "description": "Package version, see https://getcomposer.org/doc/04-schema.md#version for more info on valid schemes.",
-            "pattern": "^v?\\d+(\\.\\d+){0,3}|^dev-"
+            "pattern": "^v?\\d+(\\.\\d+){0,3}(-(dev|(p(atch)?|a(lpha)?|b(eta)?|RC)(\\d+)?))?$"
         },
         "time": {
             "type": "string",


### PR DESCRIPTION
We use the schema in PhpStorm to validate `composer.json` and now the schema is not correct.

See https://youtrack.jetbrains.com/issue/WI-60011 for reference.
