### PR TITLE
Highlight the proprietary license trick

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -160,7 +160,7 @@ The recommended notation for the most common licenses is (alphabetical):
 Optional, but it is highly recommended to supply this. More identifiers are
 listed at the [SPDX Open Source License Registry](https://spdx.org/licenses/).
 
-For closed-source software, you may use `"proprietary"` as the license identifier.
+> **Note:** For closed-source software, you may use `"proprietary"` as the license identifier.
 
 An Example:
 


### PR DESCRIPTION
From the Symfony Dev #french slack channel (symfony-devs.slack.com), people look confused regarding the value to use as license for proprietary projects, even though it's written in the documentation.

Because proprietary software is still a massive part of composer's usage, I think it can be interesting to have it as a note, more readable to people.

Extract from the conversation:
> J’étais sur la bonne page, il me manquait deux lignes de scroll pour voir ça -.- On a tous nos petits moments de faiblesse

Which roughly translates to:
> I was looking at the right page, just about two lines above... We all have our weak moments