### PR TITLE
Respect parent setting, handling exceptions

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -419,7 +419,10 @@ class Application extends BaseApplication
             } catch (\InvalidArgumentException $e) {
                 if ($required) {
                     $this->io->writeError($e->getMessage());
-                    exit(1);
+                    if ($this->areExceptionsCaught()){
+                        exit(1);
+                    }
+                    throw $e;
                 }
             } catch (JsonValidationException $e) {
                 if ($required) {


### PR DESCRIPTION
I just fell in a case where I had the following code, that always have to return result or exception, and during some commands execution, I was leading to nothing.


```php
    $application = new Application();
    $application->setAutoExit(false);
    $application->setCatchExceptions(false);
    $input = new StringInput($command);

        try {    
            $exitCode = $application->run($input, $this->getOutput());
        } catch (\Exception $exception) {
            $this->error($exception->getMessage());
            $exitCode = 1;
        } finally {
            return $this->printResult($exitCode, $command);
        }
```

Debugging the code, it lead me to this error:
```bash
Composer could not find a composer.json file in /app/public
To initialize a project, please create a composer.json file as described in the https://getcomposer.org/ "Getting Started" section
```
Although, it wasn't possible to get it, as the code exits, ignoring the parent setting

