### PR TITLE
In CurlDownloader, use the global timeout (instead of a hardcoded 5-minute timeout)

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -20,6 +20,7 @@ use Composer\Util\StreamContextFactory;
 use Composer\Util\AuthHelper;
 use Composer\Util\Url;
 use Composer\Util\HttpDownloader;
+use Composer\Util\ProcessExecutor;
 use React\Promise\Promise;
 
 /**
@@ -160,7 +161,7 @@ class CurlDownloader
         curl_setopt($curlHandle, CURLOPT_URL, $url);
         curl_setopt($curlHandle, CURLOPT_FOLLOWLOCATION, false);
         curl_setopt($curlHandle, CURLOPT_CONNECTTIMEOUT, 10);
-        curl_setopt($curlHandle, CURLOPT_TIMEOUT, 300);
+        curl_setopt($curlHandle, CURLOPT_TIMEOUT, ProcessExecutor::getTimeout());
         curl_setopt($curlHandle, CURLOPT_WRITEHEADER, $headerHandle);
         curl_setopt($curlHandle, CURLOPT_FILE, $bodyHandle);
         curl_setopt($curlHandle, CURLOPT_ENCODING, "gzip");


### PR DESCRIPTION
`CurlDownloader` is hardcoded to a 5-minute timeout.  When downloading a large file on a slow internet connection, it hits this timeout, then aborts and restarts the download from the beginning, and `composer install` is unable to make any progress.

This PR modifies `CurlDownloader` to use the global `ProcessExecutor` timeout (`COMPOSER_PROCESS_TIMEOUT`) instead.  (`COMPOSER_PROCESS_TIMEOUT` defaults to 5 minutes, just like the hardcoded value in `CurlDownloader`, so the default behavior remains the same when that environment variable is not set.)  With this PR, when I set `COMPOSER_PROCESS_TIMEOUT` to an appropriate value for my internet connection, `composer install` is able to complete successfully.