### PR TITLE
PHP 8.1: fix deprecation warnings about incorrect default values

### DIFF
--- a/src/Composer/Package/Archiver/PharArchiver.php
+++ b/src/Composer/Package/Archiver/PharArchiver.php
@@ -52,7 +52,12 @@ class PharArchiver implements ArchiverInterface
                 $target = $filename . '.tar';
             }
 
-            $phar = new \PharData($target, null, null, static::$formats[$format]);
+            $phar = new \PharData(
+                $target,
+                \FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_FILEINFO,
+                '',
+                static::$formats[$format]
+            );
             $files = new ArchivableFilesFinder($sources, $excludes, $ignoreFilters);
             $filesOnly = new ArchivableFilesFilter($files);
             $phar->buildFromIterator($filesOnly, $sources);

--- a/src/Composer/Repository/Vcs/BitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/BitbucketDriver.php
@@ -86,7 +86,7 @@ abstract class BitbucketDriver extends VcsDriver
             $this->repository,
             http_build_query(
                 array('fields' => '-project,-owner'),
-                null,
+                '',
                 '&'
             )
         );
@@ -286,7 +286,7 @@ abstract class BitbucketDriver extends VcsDriver
                         'fields' => 'values.name,values.target.hash,next',
                         'sort' => '-target.date',
                     ),
-                    null,
+                    '',
                     '&'
                 )
             );
@@ -330,7 +330,7 @@ abstract class BitbucketDriver extends VcsDriver
                         'fields' => 'values.name,values.target.hash,values.heads,next',
                         'sort' => '-target.date',
                     ),
-                    null,
+                    '',
                     '&'
                 )
             );

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -172,7 +172,7 @@ class GitLab
             'username' => $username,
             'password' => $password,
             'grant_type' => 'password',
-        ), null, '&');
+        ), '', '&');
         $options = array(
             'retry-auth-failure' => false,
             'http' => array(

--- a/src/Composer/Util/NoProxyPattern.php
+++ b/src/Composer/Util/NoProxyPattern.php
@@ -39,7 +39,7 @@ class NoProxyPattern
      */
     public function __construct($pattern)
     {
-        $this->hostNames = preg_split('{[\s,]+}', $pattern, null, PREG_SPLIT_NO_EMPTY);
+        $this->hostNames = preg_split('{[\s,]+}', $pattern, -1, PREG_SPLIT_NO_EMPTY);
         $this->noproxy = empty($this->hostNames) || '*' === $this->hostNames[0];
     }
 

--- a/tests/Composer/Test/AllFunctionalTest.php
+++ b/tests/Composer/Test/AllFunctionalTest.php
@@ -181,7 +181,7 @@ class AllFunctionalTest extends TestCase
 
     private function parseTestFile($file)
     {
-        $tokens = preg_split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file), null, PREG_SPLIT_DELIM_CAPTURE);
+        $tokens = preg_split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file), -1, PREG_SPLIT_DELIM_CAPTURE);
         $data = array();
         $section = null;
 

--- a/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
@@ -175,7 +175,7 @@ class PoolBuilderTest extends TestCase
 
     protected function readTestFile(\SplFileInfo $file, $fixturesDir)
     {
-        $tokens = preg_split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file->getRealPath()), null, PREG_SPLIT_DELIM_CAPTURE);
+        $tokens = preg_split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file->getRealPath()), -1, PREG_SPLIT_DELIM_CAPTURE);
 
         $sectionInfo = array(
             'TEST' => true,

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -484,7 +484,7 @@ class InstallerTest extends TestCase
 
     protected function readTestFile(\SplFileInfo $file, $fixturesDir)
     {
-        $tokens = preg_split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file->getRealPath()), null, PREG_SPLIT_DELIM_CAPTURE);
+        $tokens = preg_split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file->getRealPath()), -1, PREG_SPLIT_DELIM_CAPTURE);
 
         $sectionInfo = array(
             'TEST' => true,


### PR DESCRIPTION
To "ignore" an optional parameter when another optional parameter after it needs to be passed, the default value should be passed, not `null`.


###  PHP 8.1/Tests: fix some deprecation warnings

The default value for the `preg_split()` `$limit` parameter is `-1`, not `null`.

Fixes numerous `preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated` notices when running the test suite.

Ref: https://www.php.net/manual/en/function.preg-split.php

### PHP 8.1/NoProxyPattern: fix deprecation warning

The default value for the `preg_split()` `$limit` parameter is `-1`, not `null`.

Fixes some `preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated` notices when running the test suite.

```
Deprecation triggered by Composer\Test\Util\Http\ProxyManagerTest::testGetProxyForRequest:
preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated

Stack trace:
0 [internal function]: Symfony\Bridge\PhpUnit\DeprecationErrorHandler->handleError(8192, '...', '...', 42)
1 src/Composer/Util/NoProxyPattern.php(42): preg_split('...', '...', NULL, 1)
2 src/Composer/Util/Http/ProxyManager.php(148): Composer\Util\NoProxyPattern->__construct('...')
3 src/Composer/Util/Http/ProxyManager.php(50): Composer\Util\Http\ProxyManager->initProxyData()
4 src/Composer/Util/Http/ProxyManager.php(59): Composer\Util\Http\ProxyManager->__construct()
5 tests/Composer/Test/Util/Http/ProxyManagerTest.php(75): Composer\Util\Http\ProxyManager::getInstance()
...
```

Ref: https://www.php.net/manual/en/function.preg-split.php

### PHP 8.1: fix deprecation warnings / http_build_query()

This fixes all relevant calls to the PHP native `http_build_query()` function.
The second parameter of which is the _optional_ `$numeric_prefix` parameter which expects a `string`.

A parameter being optional, however, does not automatically make it nullable.

As of PHP 8.1, passing `null` to a non-nullable PHP native function will generate a deprecation notice.
In this case, these function calls yielded a `http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated` notice.

Changing the `null` to an empty string fixes this without BC-break.

Fixes a few deprecation warnings found when running the tests.

Refs:
* https://www.php.net/manual/en/function.http-build-query.php
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg

### PHP 8.1: fix deprecation notices / PharData::__construct()

This fixes all relevant calls to the PHP native `PharData::__construct()` method.

The second parameter of this method is the _optional_ `$flags` parameter which expects an `int` of flags to be passed to the `Phar` parent class `RecursiveDirectoryIterator`.
Fixed by passing the default value for the `$flags` parameter as per the `RecursiveDirectoryIterator::__construct()` method.

The third parameter of the method is the _optional_ `$alias` parameter which expects an `string`.
Fixed by passing an empty string.

Fixes various notices along the lines of:
```
Deprecation triggered by Composer\Test\Package\Archiver\ArchiveManagerTest::testArchiveTar:
PharData::__construct(): Passing null to parameter #2 ($flags) of type int is deprecated

Stack trace:
0 [internal function]: Symfony\Bridge\PhpUnit\DeprecationErrorHandler->handleError(8192, '...', '...', 55)
1 src/Composer/Package/Archiver/PharArchiver.php(55): PharData->__construct('...', NULL, NULL, 2)
2 src/Composer/Package/Archiver/ArchiveManager.php(193): Composer\Package\Archiver\PharArchiver->archive('...', '...', '...', Array, false)
3 tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php(65): Composer\Package\Archiver\ArchiveManager->archive(Object(Composer\Package\CompletePackage), '...', '...')
...
```

Refs:
* https://www.php.net/manual/en/phardata.construct.php
* https://www.php.net/manual/en/recursivedirectoryiterator.construct.php