### PR TITLE
PHP 8.1: fix more return type deprecation warnings

### DIFF
--- a/src/Composer/Package/Archiver/ArchivableFilesFilter.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFilter.php
@@ -22,6 +22,7 @@ class ArchivableFilesFilter extends FilterIterator
     /**
      * @return bool true if the current element is acceptable, otherwise false.
      */
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         $file = $this->getInnerIterator()->current();

--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -89,6 +89,7 @@ class ArchivableFilesFinder extends \FilterIterator
         parent::__construct($this->finder->getIterator());
     }
 
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         /** @var SplFileInfo $current */


### PR DESCRIPTION
Follow up on #10008 and the various commits made for that.