### PR TITLE
Url: fix sanitize for new github tokens

### DIFF
--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -110,8 +110,8 @@ class Url
         $url = preg_replace('{([&?]access_token=)[^&]+}', '$1***', $url);
 
         $url = preg_replace_callback('{^(?P<prefix>[a-z0-9]+://)?(?P<user>[^:/\s@]+):(?P<password>[^@\s/]+)@}i', function ($m) {
-            // if the username looks like a long (12char+) hex string, or a modern github token (e.g. gp1_xxx) we obfuscate that
-            if (preg_match('{^([a-f0-9]{12,}|g[a-z]\d_[a-zA-Z0-9_]+)$}', $m['user'])) {
+            // if the username looks like a long (12char+) hex string, or a modern github token (e.g. ghp_xxx) we obfuscate that
+            if (preg_match('{^([a-f0-9]{12,}|gh[a-z]_[a-zA-Z0-9_]+)$}', $m['user'])) {
                 return $m['prefix'].'***:***@';
             }
 

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -78,6 +78,7 @@ class UrlTest extends TestCase
             array('https://foo:***@example.org:123/', 'https://foo:bar@example.org:123/'),
             array('https://example.org/foo/bar?access_token=***', 'https://example.org/foo/bar?access_token=abcdef'),
             array('https://example.org/foo/bar?foo=bar&access_token=***', 'https://example.org/foo/bar?foo=bar&access_token=abcdef'),
+            array('https://***:***@github.com/acme/repo', 'https://ghp_1234567890abcdefghijklmnopqrstuvwxyzAB:x-oauth-basic@github.com/acme/repo'),
             // without scheme
             array('foo:***@example.org/', 'foo:bar@example.org/'),
             array('foo@example.org/', 'foo@example.org/'),


### PR DESCRIPTION
New GitHub tokens have one of the following prefixes:
* ghp for GitHub personal access tokens
* gho for OAuth access tokens
* ghu for GitHub user-to-server tokens
* ghs for GitHub server-to-server tokens
* ghr for refresh tokens

I am not sure what the comment above was referring to `or a modern github token (e.g. gp1_xxx)` this is now using the same regex as the ProcessExecutor https://github.com/composer/composer/blob/master/src/Composer/Util/ProcessExecutor.php#L93