### PR TITLE
ClassMapGenerator: fix two bugs (long heredocs + markers in text)

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -246,7 +246,7 @@ class ClassMapGenerator
         }
 
         // strip heredocs/nowdocs
-        $contents = preg_replace('{<<<[ \t]*([\'"]?)(\w+)\\1(?:\r\n|\n|\r)(?:.*?)(?:\r\n|\n|\r)(?:\s*)\\2(?=\s+|[;,.)])}s', 'null', $contents);
+        $contents = preg_replace('{<<<[ \t]*([\'"]?)(\w+)\\1(?:\r\n|\n|\r)(?:.*(?=[\r\n]+[ \t]*\\2))[\r\n]+[ \t]*\\2(?=\s*[;,.)])}s', 'null', $contents);
         // strip strings
         $contents = preg_replace('{"[^"\\\\]*+(\\\\.[^"\\\\]*+)*+"|\'[^\'\\\\]*+(\\\\.[^\'\\\\]*+)*+\'}s', 'null', $contents);
         // strip leading non-php code if needed

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -244,6 +244,25 @@ class ClassMapGeneratorTest extends TestCase
         $fs->removeDirectory($tempDir);
     }
 
+    public function testCreateMapDoesNotHitRegexBacktraceLimit()
+    {
+        $expected = array(
+            'Foo\\StripNoise'            => realpath(__DIR__) . '/Fixtures/pcrebacktracelimit/StripNoise.php',
+            'Foo\\VeryLongHeredoc'       => realpath(__DIR__) . '/Fixtures/pcrebacktracelimit/VeryLongHeredoc.php',
+            'Foo\\ClassAfterLongHereDoc' => realpath(__DIR__) . '/Fixtures/pcrebacktracelimit/VeryLongHeredoc.php',
+            'Foo\\VeryLongPHP73Heredoc'  => realpath(__DIR__) . '/Fixtures/pcrebacktracelimit/VeryLongPHP73Heredoc.php',
+            'Foo\\VeryLongPHP73Nowdoc'   => realpath(__DIR__) . '/Fixtures/pcrebacktracelimit/VeryLongPHP73Nowdoc.php',
+            'Foo\\ClassAfterLongNowDoc'  => realpath(__DIR__) . '/Fixtures/pcrebacktracelimit/VeryLongPHP73Nowdoc.php',
+            'Foo\\VeryLongNowdoc'        => realpath(__DIR__) . '/Fixtures/pcrebacktracelimit/VeryLongNowdoc.php',
+        );
+
+        ini_set('pcre.backtrack_limit', '30000');
+        $result = ClassMapGenerator::createMap(__DIR__ . '/Fixtures/pcrebacktracelimit');
+        ini_restore('pcre.backtrack_limit');
+
+        $this->assertEqualsNormalized($expected, $result);
+    }
+
     protected function assertEqualsNormalized($expected, $actual, $message = '')
     {
         foreach ($expected as $ns => $path) {

--- a/tests/Composer/Test/Autoload/Fixtures/classmap/StripNoise.php
+++ b/tests/Composer/Test/Autoload/Fixtures/classmap/StripNoise.php
@@ -17,7 +17,12 @@ HEREDOC . <<<  WHITESPACE
 class FailHeredocWhitespace
 {
 }
-WHITESPACE . <<<"DOUBLEQUOTES"
+WHITESPACE . <<<  MARKERINTEXT
+    In PHP < 7.3, the docblock marker could occur in the text as long as it did not occur at the very start of the line.
+But, what are you blind McFly, it's there. How else do you explain that wreck out there? Doc, Doc. Oh, no. You're alive. Bullet proof vest, how did you know, I never got a chance to tell you. About all that talk about screwing up future events, the space time continuum. Okay, alright, I'll prove it to you.
+    MARKERINTEXT
+ Look at my driver's license, expires 1987. Look at my birthday, for crying out load I haven't even been born yet. And, look at this picture, my brother, my sister, and me. Look at the sweatshirt, Doc, class of 1984. Why do you keep following me around? Hey beat it, spook, this don't concern you.
+MARKERINTEXT . <<<"DOUBLEQUOTES"
 class FailHeredocDoubleQuotes
 {
 }

--- a/tests/Composer/Test/Autoload/Fixtures/pcrebacktracelimit/StripNoise.php
+++ b/tests/Composer/Test/Autoload/Fixtures/pcrebacktracelimit/StripNoise.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Foo;
+
+/**
+ * class StripNoise { }
+ */
+class StripNoise
+{
+    public function test_heredoc()
+    {
+        return <<<HEREDOC
+class FailHeredocBasic
+{
+}
+HEREDOC . <<<  WHITESPACE
+class FailHeredocWhitespace
+{
+}
+WHITESPACE . <<<"DOUBLEQUOTES"
+class FailHeredocDoubleQuotes
+{
+}
+DOUBLEQUOTES . <<<	"DOUBLEQUOTESTABBED"
+class FailHeredocDoubleQuotesTabbed
+{
+}
+DOUBLEQUOTESTABBED . <<<HEREDOCPHP73
+  class FailHeredocPHP73
+  {
+  }
+  HEREDOCPHP73;
+    }
+
+    public function test_nowdoc()
+    {
+        return <<<'NOWDOC'
+class FailNowdocBasic
+{
+}
+NOWDOC . <<<  'WHITESPACE'
+class FailNowdocWhitespace
+{
+}
+WHITESPACE . <<<	'NOWDOCTABBED'
+class FailNowdocTabbed
+{
+}
+NOWDOCTABBED . <<<'NOWDOCPHP73'
+  class FailNowdocPHP73
+  {
+  }
+  NOWDOCPHP73;
+    }
+
+    public function test_followed_by_parentheses()
+    {
+        return array(<<<PARENTHESES
+            class FailParentheses
+            {
+            }
+            PARENTHESES);
+    }
+
+    public function test_followed_by_comma()
+    {
+        return array(1, 2, <<<COMMA
+            class FailComma
+            {
+            }
+            COMMA, 3, 4);
+    }
+
+    public function test_followed_by_period()
+    {
+        return <<<PERIOD
+            class FailPeriod
+            {
+            }
+            PERIOD.'?>';
+    }
+
+    public function test_simple_string()
+    {
+        return 'class FailSimpleString {}';
+    }
+}

--- a/tests/Composer/Test/Autoload/Fixtures/pcrebacktracelimit/VeryLongHeredoc.php
+++ b/tests/Composer/Test/Autoload/Fixtures/pcrebacktracelimit/VeryLongHeredoc.php
@@ -1,0 +1,464 @@
+<?php
+
+namespace Foo;
+
+/**
+ * class VeryLongHeredoc { }
+ */
+class VeryLongHeredoc
+{
+    public function test_heredoc()
+    {
+        return <<<HEREDOC
+Cupcake ipsum dolor sit amet. Gingerbread macaroon cake caramels tiramisu shortbread caramels. Lollipop toffee
+sugar plum liquorice tiramisu muffin. Sugar plum pie croissant lemon drops candy canes marshmallow sesame snaps
+candy. Candy candy canes gingerbread soufflé lemon drops caramels jelly croissant. Croissant bonbon I love candy
+canes fruitcake. I love ice cream I love bonbon carrot cake carrot cake gingerbread. Powder gummies I love ice
+cream marzipan. Cupcake toffee carrot cake sugar plum I love macaroon candy carrot cake jelly-o. Gingerbread
+donut icing danish donut tart. I love ice cream pastry bonbon gingerbread sugar plum I love muffin powder. Wafer
+ice cream donut cheesecake dragée tart marshmallow cheesecake.
+
+Soufflé wafer cupcake biscuit I love candy canes gingerbread danish dessert. Bear claw I love sesame snaps
+liquorice jelly-o lemon drops. Toffee sesame snaps chocolate chocolate powder pie chocolate bar tootsie roll
+sweet roll. Gummies I love pastry sweet lollipop. Chocolate cake sugar plum I love powder apple pie. Cake I love
+powder marshmallow sesame snaps. Dessert brownie tootsie roll topping gummi bears ice cream candy. Jujubes
+carrot cake I love fruitcake lemon drops croissant macaroon toffee dessert. Chocolate gummies cookie jelly-o
+wafer gummi bears macaroon. Pudding icing dragée chocolate cake pie liquorice topping jelly beans. Lollipop
+gummi bears chocolate jelly beans dessert shortbread macaroon jelly beans. Cupcake lemon drops halvah fruitcake
+cookie dessert icing. I love icing gummies tart carrot cake dragée. Macaroon cake tootsie roll sweet roll wafer
+apple pie oat cake.
+
+Lollipop cotton candy dessert gummies caramels lollipop. Marshmallow bear claw biscuit chocolate croissant
+marshmallow. Pudding liquorice chocolate cake bear claw candy canes I love cupcake tiramisu I love. Marzipan I
+love sweet roll jelly gummi bears bear claw gummi bears jelly-o cheesecake. Candy fruitcake gummi bears lemon
+drops wafer lemon drops cheesecake liquorice. Topping I love ice cream cupcake chocolate bar jelly bear claw.
+Sugar plum I love wafer macaroon icing danish. Gummi bears liquorice brownie chocolate bar candy fruitcake
+marzipan cake dragée. Toffee I love bonbon cookie jujubes gingerbread ice cream cheesecake caramels. Sesame
+snaps shortbread I love I love jelly-o jelly. Candy cupcake cake I love tart chocolate cake I love toffee.
+Gingerbread I love muffin bonbon donut cupcake candy canes cheesecake. Brownie cookie I love tart pudding
+cupcake I love marzipan pastry. Jelly tart carrot cake I love wafer muffin candy dragée cupcake.
+
+Carrot cake I love jelly-o gingerbread danish cotton candy chocolate cake gummies cake. Chupa chups donut I love
+topping jelly beans cake gingerbread. Jujubes jujubes croissant jujubes halvah jelly-o chupa chups marshmallow.
+Chocolate bar marzipan I love cookie biscuit jelly cheesecake. Sesame snaps jelly beans topping marzipan
+fruitcake chocolate bar. Donut dessert I love cake lollipop I love cookie danish sweet roll. Tiramisu jelly
+liquorice jelly cupcake I love sugar plum marshmallow I love. Dragée dessert dragée fruitcake biscuit wafer
+halvah. Jujubes I love bear claw tart lemon drops. Sesame snaps danish danish cake fruitcake toffee. Jujubes pie
+bonbon powder lemon drops oat cake I love sugar plum chocolate bar. Lemon drops sesame snaps dragée sugar plum
+tootsie roll apple pie donut biscuit jelly beans. Toffee marzipan oat cake icing wafer.
+
+Candy canes sweet roll jelly-o jelly sugar plum lemon drops jelly beans. Jelly chocolate bar dragée I love
+dessert cheesecake shortbread chupa chups. Donut cookie marzipan bear claw tootsie roll. Sweet muffin
+gingerbread sweet chocolate bar cake dessert chocolate cake chocolate. Chocolate bar chocolate cake soufflé
+dragée I love. Jelly gummies bonbon chupa chups dessert jelly-o. Sesame snaps bear claw I love fruitcake candy
+apple pie. Candy canes marzipan croissant dessert wafer ice cream biscuit. Lemon drops biscuit dessert tart I
+love shortbread shortbread oat cake brownie. Dessert I love tootsie roll wafer cotton candy. Wafer pastry candy
+chupa chups I love. Chupa chups cheesecake soufflé donut apple pie wafer. Pudding I love chocolate cake caramels
+I love powder I love sweet tiramisu.
+
+Donut muffin I love pastry caramels chocolate bar sweet. Marshmallow topping cookie muffin wafer bonbon marzipan
+chupa chups chocolate cake. Candy sugar plum cake cake I love. Oat cake donut I love liquorice caramels marzipan
+cake. Gummi bears caramels pie fruitcake ice cream chocolate. Brownie wafer chupa chups fruitcake carrot cake
+cookie chupa chups apple pie chocolate cake. Tart pie donut sweet roll chocolate bar jelly-o. Toffee icing I
+love cake shortbread lollipop tiramisu candy marshmallow. I love I love candy canes cupcake chupa chups cake
+jelly-o I love. I love jujubes I love liquorice soufflé. Brownie dragée sesame snaps sesame snaps sesame snaps I
+love ice cream. Apple pie topping carrot cake dessert powder powder cotton candy candy apple pie.
+
+Wafer lollipop brownie marzipan jujubes chocolate. Jelly beans tiramisu jelly beans sugar plum I love gummi
+bears cheesecake cheesecake. Pie macaroon macaroon halvah jelly-o. Oat cake candy canes lollipop candy donut
+powder gummies soufflé caramels. Chupa chups pudding I love gummies chupa chups jelly beans bear claw. Liquorice
+lemon drops chocolate bar cheesecake danish gummies chupa chups jelly jelly beans. Jelly-o lollipop I love
+tootsie roll chupa chups icing jujubes macaroon gingerbread. Sweet chocolate cake cake carrot cake I love
+topping tart jujubes I love. Apple pie I love marshmallow I love icing I love danish dragée. Icing tootsie roll
+macaroon tart liquorice. Gummies macaroon dragée candy tiramisu jelly I love jelly I love. Chocolate cotton
+candy cookie I love halvah I love dessert cupcake marshmallow.
+
+Chocolate gummi bears caramels gummies gummi bears carrot cake apple pie fruitcake bear claw. Sesame snaps
+powder jelly sweet croissant. Chocolate liquorice cake cake marshmallow danish bonbon jelly. Carrot cake pudding
+bear claw sweet roll cotton candy topping danish gummies. Chocolate cake bonbon oat cake cookie muffin jujubes
+sweet roll. Cake sesame snaps gingerbread chocolate cake shortbread cheesecake chocolate bar danish. Sweet roll
+apple pie brownie brownie dragée tootsie roll marshmallow brownie. I love carrot cake topping fruitcake pudding.
+Cookie jelly chocolate bar sweet pastry. Cheesecake halvah wafer icing danish. Tootsie roll liquorice jujubes
+dessert sweet roll shortbread croissant cookie chupa chups. Fruitcake lemon drops topping bear claw oat cake I
+love cake sweet roll. Candy canes oat cake topping I love macaroon.
+
+Dessert sugar plum lollipop macaroon I love gingerbread I love oat cake chupa chups. Carrot cake chocolate cake
+candy caramels bonbon powder soufflé chocolate bar cookie. Pie brownie I love jelly-o I love. Brownie jelly
+beans pie I love jelly jelly beans. Jelly carrot cake macaroon cupcake bonbon I love jujubes tootsie roll.
+Caramels powder wafer jelly beans lemon drops sweet topping gummies. Chupa chups dessert lollipop apple pie
+sesame snaps sugar plum lollipop dragée jujubes. Candy toffee pie tiramisu chocolate bar I love. I love I love
+shortbread bear claw soufflé candy canes I love jelly beans. Cupcake pudding powder oat cake muffin I love cake
+chocolate cake. Ice cream brownie tart icing cheesecake jelly-o chocolate bar bear claw. Halvah bear claw
+marzipan chocolate cake toffee croissant.
+
+Marshmallow tart gummi bears sugar plum donut candy canes powder. Cake chocolate cake tiramisu brownie danish
+caramels liquorice. Jelly beans I love pastry candy canes muffin sesame snaps powder soufflé donut. Muffin
+marshmallow carrot cake donut powder cookie. Macaroon chupa chups chupa chups jelly beans ice cream brownie
+lemon drops I love. Biscuit croissant oat cake pastry halvah macaroon. Tart candy canes sesame snaps I love
+pastry cotton candy. Soufflé I love dessert cake gummi bears lollipop. Chocolate bar I love liquorice bonbon
+gummies brownie chupa chups cookie. Lemon drops pudding muffin caramels wafer powder. Donut brownie biscuit
+biscuit I love chocolate. I love biscuit sugar plum tiramisu chocolate cake bonbon.
+
+Shortbread oat cake chupa chups topping caramels gummies. Tiramisu toffee I love bonbon candy canes. Tootsie
+roll halvah pie cake fruitcake wafer pudding tootsie roll. Icing danish cookie danish cookie donut shortbread.
+Jujubes pie tiramisu tiramisu pie halvah. Liquorice jelly marshmallow brownie bear claw marshmallow. Liquorice
+toffee pie I love cake. Jelly I love jelly-o caramels carrot cake pastry cotton candy cake. I love I love
+marshmallow tootsie roll bonbon. Cotton candy brownie caramels I love dragée bear claw oat cake chocolate bar
+bear claw. Donut sugar plum shortbread fruitcake carrot cake wafer tart jujubes fruitcake. Chupa chups cake
+muffin gummies soufflé I love candy. Powder fruitcake candy I love chocolate toffee ice cream chocolate bar
+dessert.
+
+Icing ice cream lollipop danish I love macaroon candy cotton candy chocolate cake. Powder pie sweet soufflé
+shortbread I love tiramisu candy. Gummies topping croissant chocolate cake jelly beans toffee. Dessert I love I
+love candy canes chupa chups. Chocolate sugar plum I love gummies shortbread wafer I love jelly-o. Jujubes
+halvah macaroon sesame snaps jelly beans sweet roll muffin liquorice I love. Tiramisu jelly liquorice cotton
+candy donut soufflé. Tootsie roll oat cake I love gingerbread chocolate biscuit. Donut pastry candy marshmallow
+gingerbread wafer topping bear claw. Shortbread cake macaroon chupa chups ice cream gummi bears liquorice
+gingerbread. Cotton candy tootsie roll donut gummies biscuit chocolate cake. Gingerbread jujubes caramels sweet
+chocolate cake soufflé. Apple pie cotton candy chocolate bar jelly-o muffin brownie pie.
+
+Cotton candy tootsie roll cookie gummies muffin croissant marshmallow. Sweet jujubes gummi bears gummies
+liquorice. Tart pudding icing gingerbread bear claw sweet liquorice. Icing danish cake biscuit bonbon. Bonbon
+candy canes topping icing sugar plum fruitcake sweet roll jelly-o candy. Marshmallow tart macaroon apple pie ice
+cream. Tart brownie cotton candy croissant dessert topping liquorice I love marzipan. Tart liquorice lollipop
+cookie jelly bonbon sesame snaps liquorice chupa chups. Chupa chups jelly-o sweet candy canes sesame snaps.
+Tootsie roll soufflé I love marzipan I love I love lemon drops. Sugar plum sweet jujubes sugar plum pudding
+cupcake lollipop donut I love. Oat cake shortbread cake macaroon cookie I love soufflé oat cake. Cake pudding
+cotton candy I love I love caramels soufflé.
+
+Jelly beans fruitcake caramels sugar plum pie cotton candy fruitcake I love cotton candy. Jelly liquorice apple
+pie pudding tiramisu dessert fruitcake donut sweet. I love dragée jelly-o chupa chups donut jelly beans. Tart I
+love I love I love icing gummi bears soufflé donut. Jelly beans cheesecake ice cream jelly beans topping.
+Macaroon cake jujubes I love I love topping. Bonbon bonbon cake chocolate cake cheesecake danish tiramisu
+tiramisu liquorice. Soufflé oat cake gummies I love donut ice cream sweet roll. Candy canes cake pudding tootsie
+roll I love gummi bears. Chupa chups chupa chups jelly beans chupa chups I love lemon drops. I love candy canes
+carrot cake sesame snaps wafer lollipop I love jelly wafer. Candy pie soufflé I love cake sugar plum dessert
+donut lollipop. Gingerbread I love marzipan bonbon pie. Carrot cake lollipop pie I love liquorice.
+
+Toffee jujubes pudding cotton candy dessert I love. Biscuit cake fruitcake jelly-o candy pastry cupcake.
+Fruitcake muffin jelly beans sweet roll topping dragée. Tootsie roll fruitcake bonbon soufflé croissant carrot
+cake cake jujubes. Wafer fruitcake shortbread biscuit pie. Lemon drops gummi bears shortbread danish bonbon
+dessert brownie cake. Cotton candy lemon drops gingerbread ice cream pastry macaroon I love lollipop. I love
+muffin cake pudding jujubes muffin marshmallow candy. Marshmallow powder lemon drops jujubes cookie cotton candy
+caramels macaroon. Biscuit cotton candy bonbon donut I love bear claw gummies chocolate cake. Brownie topping
+cotton candy danish dessert muffin jelly sweet roll chocolate. Fruitcake bonbon jelly beans sweet roll cookie
+biscuit chocolate jelly-o jujubes. Sweet dessert oat cake lemon drops donut candy canes dessert chocolate powder.
+
+Jujubes apple pie marzipan jelly beans caramels icing. Jujubes carrot cake toffee jelly carrot cake sugar plum
+cotton candy chocolate bar. I love jelly beans cotton candy toffee soufflé gummies I love biscuit. Tart dessert
+soufflé tiramisu marzipan I love dessert caramels. Jelly-o gingerbread bonbon cupcake pie I love I love. Sweet
+roll danish chocolate bar cake shortbread gummi bears. Dessert lemon drops fruitcake cotton candy I love apple
+pie apple pie sweet roll. Candy canes jelly beans I love bonbon jelly cupcake croissant candy canes. Gingerbread
+icing brownie pudding chocolate bar cotton candy. Pudding brownie pie candy chupa chups shortbread. Muffin
+dessert I love I love powder. Marshmallow sesame snaps marshmallow brownie cake chupa chups. I love cake
+macaroon ice cream shortbread jelly I love jelly beans cotton candy. Sesame snaps bonbon I love danish
+cheesecake jujubes.
+
+Jelly donut powder lemon drops shortbread. Oat cake marshmallow cake chupa chups chocolate halvah. Chocolate
+cupcake jelly beans sugar plum macaroon chocolate bar pie cheesecake. Muffin marzipan fruitcake liquorice
+brownie cake apple pie shortbread pudding. Sweet brownie chocolate topping fruitcake I love chupa chups apple
+pie. Chocolate bar tiramisu cheesecake jujubes I love I love. Wafer croissant halvah pudding wafer caramels
+lollipop. Tart tart gingerbread cupcake caramels toffee cookie. Macaroon candy canes candy canes jelly
+marshmallow cake I love cake cake. Sweet candy shortbread pie caramels lollipop cupcake marshmallow shortbread.
+Gummi bears caramels marshmallow tiramisu tootsie roll I love. Fruitcake sesame snaps sesame snaps sweet roll
+gummies bear claw jelly beans.
+
+Lollipop cupcake icing danish marshmallow jelly-o. Croissant chocolate cake pastry marshmallow marshmallow
+fruitcake fruitcake chupa chups icing. I love jelly beans I love chocolate wafer sweet biscuit carrot cake I
+love. I love jujubes caramels sweet roll soufflé chocolate. Dessert halvah gummies chocolate cake toffee danish
+lollipop I love chocolate bar. Lemon drops macaroon jelly beans tiramisu apple pie chocolate bar. Cupcake icing
+chocolate cake croissant marzipan. I love muffin dragée cheesecake chocolate fruitcake lemon drops brownie
+pudding. Muffin soufflé chupa chups jelly chocolate gummies croissant halvah donut. I love soufflé sugar plum
+pastry apple pie I love chocolate cake. Cupcake chocolate I love jelly I love dragée I love pie pie. I love cake
+I love tart lollipop macaroon marshmallow gingerbread icing.
+
+Pudding cake sweet marzipan croissant. Jelly tiramisu jujubes cake soufflé gummies. I love topping topping
+soufflé tiramisu sweet roll candy ice cream danish. Gummi bears jujubes jelly-o cupcake pastry. Donut I love
+cotton candy chocolate bar cheesecake. Marshmallow cotton candy chocolate I love dragée. Dragée caramels
+liquorice lollipop gummi bears gingerbread toffee jelly-o. I love marzipan carrot cake sweet roll dragée cupcake
+toffee gingerbread. Toffee gummi bears I love cotton candy cookie danish halvah cupcake. Oat cake I love soufflé
+danish dessert. Chupa chups macaroon candy canes sweet I love bonbon macaroon. Bear claw jujubes I love cotton
+candy I love oat cake bonbon.
+
+Topping I love gummies tootsie roll I love marshmallow. Gingerbread cake oat cake pudding biscuit. Ice cream
+donut wafer jelly-o chocolate I love. Icing toffee tart oat cake I love sugar plum sesame snaps pastry.
+Gingerbread biscuit candy canes lollipop bear claw icing candy bear claw fruitcake. Oat cake danish cake
+chocolate cake danish jujubes shortbread. Lollipop jujubes carrot cake croissant fruitcake marshmallow I
+love icing cheesecake. Lemon drops carrot cake dessert oat cake carrot cake. Topping cupcake dragée chupa chups
+cake dragée chocolate danish. Oat cake wafer bear claw cookie jujubes jujubes brownie soufflé. I love carrot
+cake sweet roll macaroon cake gingerbread pastry wafer sweet roll. Pie ice cream cupcake candy canes cheesecake
+icing wafer I love. Muffin dragée I love apple pie I love soufflé bear claw marzipan.
+
+Topping powder jelly beans candy canes gummi bears. Dessert topping I love sweet I love. I love topping dessert
+tart chocolate cake. Biscuit shortbread gummies cupcake bear claw. Marshmallow fruitcake sweet I love tiramisu
+tiramisu cookie I love chupa chups. Sugar plum I love I love wafer jujubes muffin I love. Jelly-o carrot cake
+fruitcake macaroon marzipan cake. Sesame snaps lollipop ice cream jelly-o pudding bear claw gummi bears I love.
+Wafer croissant dragée wafer chocolate candy chocolate. Dessert pie gummi bears gummi bears carrot cake. Jelly
+cupcake chocolate cake cake tiramisu croissant dragée. Candy fruitcake muffin gingerbread donut I love candy pie.
+
+Halvah muffin oat cake marzipan apple pie cake marshmallow lemon drops. Marzipan croissant fruitcake lemon drops
+bear claw lollipop bonbon lollipop. Sugar plum tiramisu soufflé I love shortbread carrot cake. Halvah jelly-o
+icing sesame snaps I love powder cookie tootsie roll cheesecake. Jujubes ice cream dragée fruitcake cookie
+carrot cake bonbon dragée wafer. Cheesecake I love I love sweet roll cake. Sugar plum toffee danish jelly-o
+cheesecake soufflé cheesecake marzipan. Tart sugar plum icing macaroon pie cake cheesecake bear claw. Tootsie
+roll muffin jelly chocolate cake wafer I love jelly shortbread. Sweet candy carrot cake chupa chups donut cake.
+Dessert sugar plum cake pastry chocolate bar halvah pastry tiramisu. Ice cream cheesecake gummi bears candy I
+love cupcake pie toffee candy canes.
+
+Liquorice I love tiramisu marshmallow topping I love. Toffee sweet pudding icing cotton candy bonbon oat cake
+carrot cake gummies. Candy toffee pudding sweet roll cotton candy lollipop powder lemon drops cake. Apple pie I
+love chupa chups I love jujubes caramels. Jelly pie chocolate chocolate carrot cake cake. Toffee caramels muffin
+cheesecake I love sweet roll tart. Croissant candy canes marzipan lemon drops cupcake sweet. I love I love
+jelly-o donut cheesecake bear claw tart. Cheesecake icing jelly gummi bears macaroon. Sweet roll I love lollipop
+cookie tart. Tiramisu tootsie roll sesame snaps croissant cookie halvah I love I love. Biscuit croissant powder
+oat cake cake apple pie.
+
+Topping oat cake pastry marshmallow gummi bears lemon drops bear claw soufflé pudding. Croissant biscuit
+macaroon oat cake I love pastry. Pastry cake sugar plum macaroon chocolate cake dessert. I love cupcake sweet
+roll sweet roll I love cheesecake. I love lemon drops halvah I love apple pie chocolate bar biscuit ice cream
+topping. I love candy canes gingerbread caramels chupa chups cheesecake. I love jelly-o sesame snaps lemon drops
+pastry toffee. Bonbon topping I love gummi bears dessert. Danish jelly I love marshmallow carrot cake. Dragée
+macaroon dessert marshmallow jelly-o bear claw cotton candy sugar plum. Biscuit ice cream candy tart bear claw
+candy I love brownie cotton candy. I love marshmallow lemon drops marshmallow I love candy canes wafer. Halvah
+topping wafer cake danish I love I love I love. Chocolate cake carrot cake topping jelly lollipop I love I love
+cotton candy I love.
+
+Oat cake cotton candy cotton candy jujubes I love. Toffee topping cookie danish topping cheesecake. Cake bonbon
+ice cream cake carrot cake icing cookie croissant. Cheesecake sesame snaps tiramisu lemon drops dessert pie.
+Carrot cake sesame snaps shortbread muffin pie I love chocolate cake danish. Carrot cake cake jelly beans I love
+toffee I love marzipan. Toffee lemon drops fruitcake I love cookie. Shortbread jujubes chupa chups jelly candy
+bear claw chocolate. Pastry donut muffin fruitcake chocolate bar dessert cotton candy powder. Sweet roll chupa
+chups dragée gummi bears ice cream tiramisu jujubes icing chocolate bar. I love lollipop I love oat cake apple
+pie. Topping lemon drops donut fruitcake ice cream chupa chups. Dragée dragée fruitcake powder apple pie I love
+donut.
+
+Pie sugar plum bear claw candy canes wafer pastry. Cake caramels tootsie roll brownie cupcake croissant topping
+sesame snaps. Topping oat cake sesame snaps jelly cupcake oat cake I love tootsie roll toffee. Jelly muffin
+sugar plum danish sesame snaps. Liquorice chocolate bar marshmallow topping biscuit toffee carrot cake. Dragée
+tart shortbread gummi bears apple pie. Tootsie roll tiramisu sugar plum marzipan chocolate cake. Cotton candy I
+love I love pastry muffin fruitcake pie jelly-o I love. Topping marshmallow ice cream carrot cake chocolate.
+Muffin dragée shortbread powder jelly. Chupa chups apple pie I love muffin pie sweet croissant. Chocolate bar
+pastry cotton candy cotton candy dragée I love liquorice. Chocolate cake brownie marshmallow jelly-o jujubes
+cookie sweet cookie candy. Shortbread I love cupcake powder soufflé tootsie roll jujubes.
+
+Bear claw brownie tart caramels chupa chups I love candy canes biscuit. Biscuit bear claw tiramisu I love I love
+macaroon dragée. Candy canes sweet roll powder jujubes donut cake topping cupcake. Biscuit carrot cake gummies
+donut tart dragée cake fruitcake shortbread. Jelly-o chocolate cookie jelly chocolate pie sweet roll. Bear claw
+I love marzipan croissant I love chocolate halvah liquorice. I love sweet carrot cake I love gingerbread. Pastry
+muffin I love gummi bears I love I love marshmallow cupcake cookie. Marshmallow I love dragée cheesecake I love
+candy canes. Shortbread cupcake jelly beans pie donut gummies sesame snaps. Bonbon soufflé chupa chups tiramisu
+marshmallow macaroon brownie. Chupa chups bear claw carrot cake lemon drops icing. Cake caramels shortbread
+gummies candy canes bonbon oat cake danish. Pastry brownie tiramisu candy canes oat cake tiramisu donut macaroon.
+
+Tiramisu shortbread toffee I love sesame snaps wafer. Lemon drops ice cream dragée soufflé topping soufflé tart.
+Bear claw pie chocolate cake chocolate apple pie marzipan. Oat cake candy canes brownie powder sugar plum. I
+love pastry tootsie roll powder chocolate cake I love shortbread cake fruitcake. Candy cake dessert candy jelly
+brownie I love sweet. Carrot cake carrot cake chocolate bar caramels biscuit gummi bears. Candy wafer pudding
+gummies macaroon lollipop sugar plum bonbon. Brownie powder soufflé cupcake I love donut. Caramels gummies
+shortbread muffin cake. Brownie wafer candy donut brownie. Icing cheesecake candy caramels cake muffin jelly.
+Gummi bears I love jujubes I love candy canes shortbread. Chocolate caramels soufflé I love sweet.
+
+Tart marshmallow powder I love I love dessert brownie I love gingerbread. Chocolate cake sweet roll soufflé
+wafer powder cake cotton candy oat cake dragée. Brownie toffee muffin jelly-o bonbon bear claw soufflé carrot
+cake. Jelly-o toffee pastry cheesecake jelly beans cookie I love tiramisu. Gingerbread pastry topping gummi
+bears jelly. Brownie pie danish candy canes halvah. Powder lollipop jujubes sweet roll cake marzipan carrot cake
+dessert cake. Apple pie I love pie tootsie roll wafer apple pie sweet. Pudding tiramisu croissant I love dessert
+sugar plum candy canes I love wafer. Candy canes bonbon tart pie caramels chocolate I love oat cake shortbread.
+Halvah I love croissant pie candy apple pie. Marshmallow apple pie macaroon dessert halvah.
+
+I love chocolate fruitcake sesame snaps gingerbread wafer. Danish I love soufflé sweet cotton candy pudding.
+Topping biscuit jelly beans cake liquorice dragée chocolate bar lemon drops. Chocolate bar jelly jelly I love
+dragée chocolate cake halvah gummies. Candy canes pudding I love marzipan cheesecake powder jelly beans. Brownie
+sweet pastry cotton candy tiramisu. Halvah fruitcake gummies cupcake donut topping dragée. Sugar plum marzipan I
+love lemon drops dessert jelly donut. Cookie jujubes soufflé sugar plum croissant lollipop halvah. Brownie chupa
+chups I love chupa chups chupa chups dragée. Marzipan tart donut topping soufflé tootsie roll toffee sesame
+snaps. Donut danish muffin caramels gingerbread I love. I love I love croissant bonbon jelly beans jelly beans
+chocolate caramels cheesecake. Gummi bears brownie toffee jelly biscuit candy apple pie.
+
+I love chocolate cake donut I love jelly beans. Toffee marzipan shortbread jujubes sugar plum. Shortbread powder
+cotton candy I love bonbon pudding biscuit halvah halvah. Tiramisu lollipop macaroon macaroon macaroon jelly-o
+pastry pudding fruitcake. Donut brownie cookie icing jujubes icing bonbon fruitcake sesame snaps. Gingerbread
+fruitcake tiramisu shortbread powder pastry dessert sweet roll marzipan. Liquorice jujubes I love chocolate cake
+I love sweet cotton candy I love halvah. Shortbread gingerbread croissant icing biscuit. Chupa chups icing candy
+canes lollipop jelly beans macaroon. Cupcake sweet topping carrot cake gummi bears jelly beans sesame snaps
+icing. I love ice cream sweet pudding cheesecake. Dragée gummies gingerbread marzipan ice cream tart tiramisu. I
+love chocolate bar sweet roll sweet roll I love tiramisu.
+
+Jelly-o pastry candy marzipan donut cake. I love dessert liquorice caramels gummi bears donut lemon drops.
+Fruitcake cupcake cupcake I love jujubes tart brownie chocolate. Jujubes topping lollipop candy canes topping
+cotton candy halvah gummi bears topping. Danish pastry bear claw pudding pudding caramels. Gummies icing chupa
+chups croissant I love chocolate halvah candy pastry. Oat cake jelly beans tart cake tart liquorice icing jelly
+pie. Topping chocolate cupcake cotton candy cupcake cupcake. Cotton candy biscuit cookie chocolate bar gummies
+gingerbread gummies. Lemon drops lemon drops I love chocolate cake cupcake soufflé gingerbread cake. Lemon drops
+cotton candy jelly tart tiramisu caramels sweet marzipan. Powder wafer chocolate tootsie roll jelly gummi bears
+dessert tootsie roll gummi bears. Icing macaroon biscuit I love cake chupa chups. Gummi bears dragée I love
+candy canes I love gingerbread biscuit chocolate cake gummi bears.
+
+Ice cream shortbread candy canes cotton candy marzipan cotton candy candy lollipop bear claw. Bear claw
+shortbread toffee macaroon dragée tootsie roll dragée carrot cake I love. Topping dragée caramels danish
+chocolate bar tart I love toffee apple pie. Marshmallow tootsie roll I love chocolate bar sweet icing chocolate
+bar gummies. Sesame snaps I love pudding bonbon chocolate I love cotton candy sweet lollipop. Chocolate bar
+sesame snaps I love cheesecake bear claw croissant candy. Jelly I love pudding wafer toffee. Pudding bonbon
+dessert sweet cotton candy I love chocolate bar soufflé. Liquorice I love icing halvah shortbread cotton candy.
+Pie sesame snaps I love tiramisu donut croissant. Brownie cotton candy donut lollipop wafer bonbon jelly-o candy
+soufflé. Tootsie roll gummi bears cupcake macaroon apple pie candy canes I love. Marzipan pudding jelly beans
+chocolate bar jelly-o I love. Wafer lollipop muffin I love shortbread.
+
+Jelly beans topping halvah sweet sweet. Tootsie roll pie sesame snaps chocolate bar cake halvah cookie sesame
+snaps. Brownie gummi bears gingerbread cheesecake tootsie roll I love donut. Bonbon jelly beans candy canes
+gingerbread tiramisu. Cotton candy donut bear claw liquorice powder. Gummies cheesecake powder gummies tiramisu
+brownie soufflé I love. Sweet cupcake soufflé I love cookie jujubes I love. Toffee soufflé cake halvah caramels
+biscuit. Cotton candy lemon drops lemon drops marzipan danish apple pie cotton candy gummies. Icing gummi bears
+jelly lemon drops I love. Halvah pie cake sweet tiramisu. Cupcake jujubes cake pie cheesecake. Chocolate I love
+cookie muffin tart cake.
+
+Brownie soufflé caramels jujubes candy canes biscuit tootsie roll. Fruitcake dessert icing chocolate bar jelly.
+Macaroon pastry candy canes biscuit chupa chups liquorice halvah. Icing muffin jelly tart carrot cake dragée.
+Oat cake carrot cake wafer I love brownie sugar plum icing. Caramels gingerbread pudding fruitcake I love gummi
+bears I love. Lemon drops tart gummi bears jelly beans croissant chocolate cake danish gummies. Sugar plum I
+love apple pie lemon drops liquorice. Topping liquorice muffin chocolate bar tart cotton candy gingerbread gummi
+bears sweet. Gingerbread tiramisu I love shortbread cookie lemon drops. Tootsie roll cake I love halvah I love
+muffin pie. Pastry bonbon macaroon donut cake apple pie jelly sweet roll. Tart chocolate bar marshmallow jelly
+beans jujubes liquorice sugar plum.
+
+Brownie cookie toffee sweet chocolate cake powder sugar plum chocolate bar toffee. Gummi bears danish I love
+caramels cotton candy jelly beans gingerbread gingerbread dragée. Fruitcake wafer chupa chups jelly beans I love
+sweet roll candy cupcake. Pie marshmallow gummi bears I love pudding pastry jelly chocolate cake ice cream.
+Fruitcake apple pie cupcake I love toffee pie sesame snaps lollipop. Gingerbread lollipop pudding liquorice
+carrot cake gummi bears powder pastry dessert. Apple pie cotton candy croissant pie jelly-o. Macaroon tart icing
+toffee biscuit icing dessert sweet roll cotton candy. Jelly beans chocolate cake danish sweet I love jelly-o
+brownie. I love cheesecake sesame snaps sweet jelly apple pie soufflé. Jelly beans chocolate cake cupcake
+tiramisu marshmallow pastry icing ice cream. Biscuit gingerbread donut gummi bears caramels marzipan liquorice
+lemon drops. Jelly beans cupcake I love pudding jelly candy biscuit.
+
+I love chocolate donut lemon drops sweet roll. Donut chocolate tiramisu chupa chups biscuit I love. Jelly apple
+pie chocolate bar dragée cake. I love macaroon chocolate caramels I love I love. Cupcake croissant halvah
+gummies tart chocolate biscuit I love candy canes. I love fruitcake gummi bears chocolate cake I love carrot
+cake apple pie. Apple pie marshmallow danish oat cake powder. Pie I love powder ice cream chocolate danish
+macaroon sugar plum pie. I love chocolate cotton candy carrot cake carrot cake I love. Caramels dessert cake
+marshmallow I love macaroon bonbon jelly beans. Dessert sugar plum I love oat cake I love wafer shortbread.
+Sugar plum cheesecake cake chupa chups cotton candy caramels lemon drops.
+
+Cake I love chocolate bar I love pudding pastry chocolate. Danish I love powder liquorice I love lemon drops.
+Tootsie roll jelly cake cheesecake apple pie pie jelly-o. Dessert marshmallow topping I love brownie. Oat cake
+fruitcake cookie croissant cake powder jelly fruitcake. Shortbread cake icing oat cake cupcake. Cake chocolate
+cake I love I love gingerbread. Sweet roll oat cake I love pie carrot cake cake brownie cake caramels. Cookie
+gummies I love gummies sesame snaps sweet roll apple pie I love. Pastry cake I love pie tart dessert lollipop
+macaroon. Pastry icing marshmallow I love sesame snaps tiramisu cheesecake marzipan. Chupa chups chocolate icing
+powder powder candy canes cake. Brownie shortbread candy canes topping sesame snaps I love. Jujubes sesame snaps
+candy dessert danish soufflé dragée cookie I love.
+
+Marshmallow pastry bear claw macaroon gummies caramels. Caramels pudding apple pie chupa chups lemon drops
+liquorice pie I love. Powder macaroon pie carrot cake dragée. Soufflé cake jelly-o bear claw I love cotton candy
+toffee jujubes I love. Carrot cake fruitcake cheesecake chocolate cake toffee powder. Tootsie roll bonbon I love
+chocolate bar cake gingerbread. Halvah pastry I love croissant gummi bears macaroon jujubes bonbon. Brownie cake
+tiramisu jujubes danish danish. Muffin chocolate bar cookie I love jelly powder brownie muffin. Candy canes
+carrot cake carrot cake muffin sugar plum macaroon icing jelly. Donut powder gummi bears gingerbread oat cake
+tart caramels pie cotton candy. Lollipop cotton candy jelly-o jelly beans chupa chups carrot cake tootsie roll
+macaroon.
+
+Brownie marshmallow ice cream cheesecake caramels oat cake danish. Sweet roll liquorice tootsie roll donut
+cheesecake I love marzipan. Powder carrot cake topping muffin chocolate gingerbread. Gummi bears tiramisu bear
+claw bear claw I love jujubes. Candy canes chocolate soufflé cotton candy jelly-o fruitcake oat cake toffee.
+Muffin sweet roll cake cake tootsie roll icing brownie I love danish. Tart marshmallow marshmallow I love
+marzipan sugar plum icing I love. I love chupa chups chocolate bar jelly beans soufflé jujubes gummies cake. I
+love tart icing chocolate cake I love lollipop I love macaroon icing. I love chocolate fruitcake cake candy
+canes lollipop sweet. Powder lollipop marzipan candy macaroon chupa chups pudding. Tootsie roll tart chocolate
+bar carrot cake chocolate cake. Gingerbread ice cream tart oat cake cheesecake croissant. Jelly beans topping
+brownie marzipan oat cake.
+
+Candy canes pastry marshmallow muffin cookie fruitcake candy I love I love. Tootsie roll oat cake marzipan
+cotton candy toffee carrot cake. Tiramisu marshmallow cheesecake I love I love candy cookie. Ice cream dragée
+chocolate bar jelly carrot cake pie I love cupcake. Sesame snaps I love powder croissant I love oat cake.
+Shortbread bonbon sugar plum jelly cake muffin I love jelly beans. Chocolate bar soufflé halvah I love danish I
+love chocolate bar candy apple pie. Biscuit soufflé icing chocolate bar I love soufflé. Cake macaroon macaroon
+powder cupcake cotton candy marzipan. Candy toffee cake icing fruitcake. Biscuit pie carrot cake soufflé brownie
+marzipan. Sweet fruitcake pastry powder jelly beans. Chupa chups sweet oat cake muffin jelly-o. Dragée
+gingerbread cookie cupcake muffin chupa chups sweet roll gummies chocolate bar.
+
+I love dessert sesame snaps I love sweet roll danish. Oat cake dragée pudding pastry cake. Soufflé candy I love
+I love croissant tiramisu croissant jelly beans. Bear claw biscuit tootsie roll oat cake pudding I love. Cake
+chocolate cupcake lollipop powder donut pudding gummies. Pastry dessert donut croissant topping sugar plum cake
+I love. Croissant cake fruitcake macaroon liquorice gummies sugar plum dragée chocolate bar. Tart pudding I love
+chupa chups toffee pastry macaroon powder. Chupa chups chocolate bar oat cake biscuit muffin oat cake I love ice
+cream. Toffee cotton candy pudding halvah gummi bears I love cookie I love. Halvah candy canes powder sweet
+tootsie roll soufflé toffee. Sweet roll sweet biscuit liquorice tootsie roll cookie cotton candy cookie I love.
+
+Lollipop fruitcake I love cake I love. Ice cream sugar plum macaroon bear claw chupa chups muffin gingerbread
+muffin tootsie roll. Powder gummi bears wafer apple pie gummies bonbon macaroon. Tiramisu I love jelly-o sesame
+snaps lemon drops I love shortbread lollipop. Ice cream sweet roll cookie caramels I love I love chocolate bar.
+Shortbread I love shortbread bear claw I love. I love jelly beans topping marshmallow icing. Halvah sesame snaps
+macaroon cake cheesecake. I love chocolate macaroon cupcake cupcake toffee bear claw chocolate. Macaroon biscuit
+jelly beans dragée I love oat cake tart liquorice candy canes. Cookie brownie shortbread shortbread icing
+tiramisu I love. Croissant gummies pastry I love danish donut. Sesame snaps ice cream cake candy jelly-o.
+
+Croissant danish caramels pudding tiramisu sweet roll bonbon. Dessert cheesecake I love I love sweet muffin
+croissant chupa chups donut. Tart danish chocolate bar cupcake lollipop muffin. Wafer cake jujubes cake cotton
+candy. Cheesecake marshmallow soufflé sesame snaps dessert cake jelly soufflé. Dragée pastry oat cake biscuit
+dessert jelly beans. Danish gingerbread pudding chocolate bar muffin liquorice cake. Tiramisu dragée lemon drops
+biscuit carrot cake. Cake bonbon chocolate cake lemon drops apple pie candy canes. Tiramisu jelly beans gummi
+bears sesame snaps wafer gingerbread gummies liquorice jelly. Marzipan chocolate cake liquorice caramels soufflé
+lollipop jelly. Croissant sesame snaps cake marzipan chupa chups topping croissant.
+
+Pie apple pie danish candy gingerbread. Jelly-o I love ice cream muffin gummi bears muffin chocolate. Macaroon
+croissant candy canes chocolate bar candy cake sweet roll. Donut cotton candy apple pie cake cake pie dessert
+brownie. Cake sweet soufflé jujubes tootsie roll I love I love carrot cake. Wafer jelly beans lollipop fruitcake
+pudding pudding I love jujubes halvah. I love icing sweet roll danish gummies. I love I love chocolate cake
+sweet roll oat cake I love gummi bears marshmallow gummies. Jelly-o chupa chups pie powder toffee. Lollipop
+soufflé gingerbread sweet roll apple pie sweet gingerbread. Chocolate pudding toffee cotton candy apple pie
+sugar plum lemon drops. Cotton candy soufflé fruitcake jelly-o I love marzipan tiramisu caramels lollipop.
+
+Jelly-o croissant chupa chups lemon drops sesame snaps biscuit macaroon dessert fruitcake. Gummies bonbon I love
+liquorice gummies lollipop. Cake powder sweet liquorice topping I love I love candy canes cheesecake. Sweet roll
+pie croissant bonbon shortbread chocolate cake. Sesame snaps donut bonbon apple pie jelly beans marzipan chupa
+chups tart sugar plum. Icing icing I love gummies candy canes topping. Tart pie brownie tiramisu macaroon
+dragée. Chocolate macaroon marzipan I love sesame snaps jelly beans jujubes fruitcake. Marshmallow muffin
+caramels candy brownie. Gummies I love lollipop pastry cupcake. Sweet roll tart marzipan ice cream I love I
+love. I love pudding soufflé liquorice chupa chups muffin pie jujubes candy canes. Candy muffin I love oat cake
+cupcake chocolate jelly-o.
+
+Ice cream macaroon cake bonbon I love I love pie halvah icing. Gummies croissant sugar plum brownie gummi bears
+I love I love sweet. Sugar plum cookie cotton candy I love sesame snaps. I love cheesecake cookie jujubes dragée
+muffin. Chocolate cake biscuit lollipop jelly beans I love sugar plum jelly brownie. I love candy canes soufflé
+I love muffin I love. Ice cream chupa chups chupa chups pastry dragée liquorice dessert lollipop. Cotton candy
+soufflé jelly danish chocolate. Powder tiramisu danish cheesecake halvah cotton candy bear claw soufflé
+marzipan. Donut donut I love dragée chocolate bar icing I love. Gummi bears lollipop tiramisu gingerbread
+cupcake caramels. Sesame snaps cheesecake soufflé chocolate bar chocolate cake. Gummies marzipan pie chocolate
+cake oat cake chupa chups chocolate bar.
+
+Chocolate cake croissant fruitcake chupa chups gummi bears. Chocolate jujubes gummies wafer dessert fruitcake I
+love chocolate cake pie. Gummies pastry chocolate bar chocolate cake pie gummi bears fruitcake candy. Sesame
+snaps chupa chups gummies gummi bears wafer I love. Halvah cotton candy halvah chocolate cake sesame snaps.
+Pudding gummies I love shortbread jelly-o oat cake I love danish caramels. Topping pastry caramels biscuit I
+love caramels cake. Pastry fruitcake chupa chups sesame snaps chocolate I love lollipop. Lemon drops icing
+chocolate cake I love jelly-o. I love dragée macaroon wafer shortbread. Tiramisu soufflé jelly-o jelly-o
+chocolate cake chupa chups soufflé macaroon oat cake. Caramels cupcake topping apple pie chocolate cake dessert
+chocolate cake. Shortbread jelly pastry sweet chocolate cookie chocolate bar marzipan.
+
+Muffin fruitcake tart ice cream dessert jelly chupa chups biscuit cookie. Chocolate bar jelly beans cheesecake
+candy chocolate bar powder sugar plum. Pudding tiramisu shortbread muffin wafer I love tootsie roll. Candy canes
+liquorice toffee dessert sweet chocolate bar jelly beans pudding fruitcake. Marzipan cake I love dessert icing
+gummi bears. Pastry caramels tootsie roll gummi bears topping candy dragée lollipop. Ice cream I love cake sugar
+plum jelly candy sugar plum chocolate bar. Chocolate brownie fruitcake marzipan I love cake jujubes. Apple pie
+toffee sugar plum chocolate cake. Sweet gummi bears topping pudding cookie shortbread toffee. Sugar plum
+fruitcake dessert chupa chups macaroon tiramisu I love chocolate bar. Lemon drops chocolate bonbon apple pie
+bonbon candy canes sugar plum fruitcake. Bonbon marzipan I love marzipan jelly beans I love marshmallow candy.
+
+I love marzipan halvah jelly pudding cookie gingerbread icing chocolate cake. Sesame snaps sesame snaps gummies
+bonbon wafer croissant icing. Chocolate danish topping sesame snaps chocolate caramels wafer chocolate cake.
+Lollipop gingerbread halvah I love chocolate shortbread. Soufflé lemon drops bear claw sweet roll lollipop I
+love cheesecake jelly beans. Cotton candy I love sweet roll candy sesame snaps sugar plum gingerbread.
+Gingerbread fruitcake croissant sweet roll cookie sweet. Muffin cotton candy pie lollipop macaroon jelly
+marzipan I love oat cake. Apple pie jelly muffin jujubes halvah wafer soufflé chocolate cake. Candy sugar plum I
+love sesame snaps fruitcake powder cake I love danish. Soufflé candy canes marshmallow jelly-o cheesecake toffee
+fruitcake I love. Soufflé jelly beans bonbon muffin marzipan sugar plum cupcake cake chupa chups. Tootsie roll
+wafer gummi bears candy gummi bears marshmallow. Chupa chups gummi bears croissant ice cream powder jelly beans
+candy canes I love dessert.
+HEREDOC;
+    }
+}
+
+
+class ClassAfterLongHereDoc
+{
+}

--- a/tests/Composer/Test/Autoload/Fixtures/pcrebacktracelimit/VeryLongNowdoc.php
+++ b/tests/Composer/Test/Autoload/Fixtures/pcrebacktracelimit/VeryLongNowdoc.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace Foo;
+
+/**
+ * class VeryLongNowdoc { }
+ */
+class VeryLongNowdoc
+{
+    public function test_nowdoc()
+    {
+        return <<<'NOWDOC'
+# I am the Doctor, and you are the Daleks!
+
+Saving the world with meals on wheels. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister. Heh-haa! Super squeaky bum time! You hate me; you want to kill me! Well, go on! Kill me! KILL ME!
+
+It's a fez. I wear a fez now. Fezes are cool. __You know how I sometimes have really brilliant ideas?__ *I'm the Doctor, I'm worse than everyone's aunt.* *catches himself* And that is not how I'm introducing myself.
+
+## No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! You hate me; you want to kill me! Well, go on! Kill me! KILL ME! It's a fez. I wear a fez now. Fezes are cool. I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why.
+
+1. Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you?
+2. You've swallowed a planet!
+3. You know how I sometimes have really brilliant ideas?
+
+### Aw, you're all Mr. Grumpy Face today.
+
+Sorry, checking all the water in this area; there's an escaped fish. Did I mention we have comfy chairs? I am the last of my species, and I know how that weighs on the heart so don't lie to me! Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+* It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+* I'm the Doctor, I'm worse than everyone's aunt. *catches himself* And that is not how I'm introducing myself.
+* Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+You hit me with a cricket bat. The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant.
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Heh-haa! Super squeaky bum time! You know when grown-ups tell you 'everything's going to be fine' and you think they're probably lying to make you feel better? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+You've swallowed a planet! No… It's a thing; it's like a plan, but with more greatness. I am the last of my species, and I know how that weighs on the heart so don't lie to me! *Insistently* Bow ties are cool! Come on Amy, I'm a normal bloke, tell me what normal blokes do!
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? Stop talking, brain thinking. Hush.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? I hate yogurt. It's just stuff with bits in.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. You know how I sometimes have really brilliant ideas?
+
+Father Christmas. Santa Claus. Or as I've always known him: Jeff. You've swallowed a planet! You hit me with a cricket bat. It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+
+I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why. You hate me; you want to kill me! Well, go on! Kill me! KILL ME! You know how I sometimes have really brilliant ideas?
+
+# I am the Doctor, and you are the Daleks!
+
+Saving the world with meals on wheels. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister. Heh-haa! Super squeaky bum time! You hate me; you want to kill me! Well, go on! Kill me! KILL ME!
+
+It's a fez. I wear a fez now. Fezes are cool. __You know how I sometimes have really brilliant ideas?__ *I'm the Doctor, I'm worse than everyone's aunt.* *catches himself* And that is not how I'm introducing myself.
+
+## No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! You hate me; you want to kill me! Well, go on! Kill me! KILL ME! It's a fez. I wear a fez now. Fezes are cool. I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why.
+
+1. Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you?
+2. You've swallowed a planet!
+3. You know how I sometimes have really brilliant ideas?
+
+### Aw, you're all Mr. Grumpy Face today.
+
+Sorry, checking all the water in this area; there's an escaped fish. Did I mention we have comfy chairs? I am the last of my species, and I know how that weighs on the heart so don't lie to me! Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+* It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+* I'm the Doctor, I'm worse than everyone's aunt. *catches himself* And that is not how I'm introducing myself.
+* Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+You hit me with a cricket bat. The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant.
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Heh-haa! Super squeaky bum time! You know when grown-ups tell you 'everything's going to be fine' and you think they're probably lying to make you feel better? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+You've swallowed a planet! No… It's a thing; it's like a plan, but with more greatness. I am the last of my species, and I know how that weighs on the heart so don't lie to me! *Insistently* Bow ties are cool! Come on Amy, I'm a normal bloke, tell me what normal blokes do!
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? Stop talking, brain thinking. Hush.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? I hate yogurt. It's just stuff with bits in.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. You know how I sometimes have really brilliant ideas?
+
+Father Christmas. Santa Claus. Or as I've always known him: Jeff. You've swallowed a planet! You hit me with a cricket bat. It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+
+I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why. You hate me; you want to kill me! Well, go on! Kill me! KILL ME! You know how I sometimes have really brilliant ideas?
+
+
+# I am the Doctor, and you are the Daleks!
+
+Saving the world with meals on wheels. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister. Heh-haa! Super squeaky bum time! You hate me; you want to kill me! Well, go on! Kill me! KILL ME!
+
+It's a fez. I wear a fez now. Fezes are cool. __You know how I sometimes have really brilliant ideas?__ *I'm the Doctor, I'm worse than everyone's aunt.* *catches himself* And that is not how I'm introducing myself.
+
+## No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! You hate me; you want to kill me! Well, go on! Kill me! KILL ME! It's a fez. I wear a fez now. Fezes are cool. I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why.
+
+1. Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you?
+2. You've swallowed a planet!
+3. You know how I sometimes have really brilliant ideas?
+
+### Aw, you're all Mr. Grumpy Face today.
+
+Sorry, checking all the water in this area; there's an escaped fish. Did I mention we have comfy chairs? I am the last of my species, and I know how that weighs on the heart so don't lie to me! Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+* It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+* I'm the Doctor, I'm worse than everyone's aunt. *catches himself* And that is not how I'm introducing myself.
+* Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+You hit me with a cricket bat. The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant.
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Heh-haa! Super squeaky bum time! You know when grown-ups tell you 'everything's going to be fine' and you think they're probably lying to make you feel better? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+You've swallowed a planet! No… It's a thing; it's like a plan, but with more greatness. I am the last of my species, and I know how that weighs on the heart so don't lie to me! *Insistently* Bow ties are cool! Come on Amy, I'm a normal bloke, tell me what normal blokes do!
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? Stop talking, brain thinking. Hush.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? I hate yogurt. It's just stuff with bits in.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. You know how I sometimes have really brilliant ideas?
+
+Father Christmas. Santa Claus. Or as I've always known him: Jeff. You've swallowed a planet! You hit me with a cricket bat. It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+
+I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why. You hate me; you want to kill me! Well, go on! Kill me! KILL ME! You know how I sometimes have really brilliant ideas?
+
+
+# I am the Doctor, and you are the Daleks!
+
+Saving the world with meals on wheels. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister. Heh-haa! Super squeaky bum time! You hate me; you want to kill me! Well, go on! Kill me! KILL ME!
+
+It's a fez. I wear a fez now. Fezes are cool. __You know how I sometimes have really brilliant ideas?__ *I'm the Doctor, I'm worse than everyone's aunt.* *catches himself* And that is not how I'm introducing myself.
+
+## No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! You hate me; you want to kill me! Well, go on! Kill me! KILL ME! It's a fez. I wear a fez now. Fezes are cool. I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why.
+
+1. Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you?
+2. You've swallowed a planet!
+3. You know how I sometimes have really brilliant ideas?
+
+### Aw, you're all Mr. Grumpy Face today.
+
+Sorry, checking all the water in this area; there's an escaped fish. Did I mention we have comfy chairs? I am the last of my species, and I know how that weighs on the heart so don't lie to me! Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+* It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+* I'm the Doctor, I'm worse than everyone's aunt. *catches himself* And that is not how I'm introducing myself.
+* Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+You hit me with a cricket bat. The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant.
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Heh-haa! Super squeaky bum time! You know when grown-ups tell you 'everything's going to be fine' and you think they're probably lying to make you feel better? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+You've swallowed a planet! No… It's a thing; it's like a plan, but with more greatness. I am the last of my species, and I know how that weighs on the heart so don't lie to me! *Insistently* Bow ties are cool! Come on Amy, I'm a normal bloke, tell me what normal blokes do!
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? Stop talking, brain thinking. Hush.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? I hate yogurt. It's just stuff with bits in.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. You know how I sometimes have really brilliant ideas?
+
+Father Christmas. Santa Claus. Or as I've always known him: Jeff. You've swallowed a planet! You hit me with a cricket bat. It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+
+I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why. You hate me; you want to kill me! Well, go on! Kill me! KILL ME! You know how I sometimes have really brilliant ideas?
+
+
+# I am the Doctor, and you are the Daleks!
+
+Saving the world with meals on wheels. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister. Heh-haa! Super squeaky bum time! You hate me; you want to kill me! Well, go on! Kill me! KILL ME!
+
+It's a fez. I wear a fez now. Fezes are cool. __You know how I sometimes have really brilliant ideas?__ *I'm the Doctor, I'm worse than everyone's aunt.* *catches himself* And that is not how I'm introducing myself.
+
+## No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! You hate me; you want to kill me! Well, go on! Kill me! KILL ME! It's a fez. I wear a fez now. Fezes are cool. I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why.
+
+1. Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you?
+2. You've swallowed a planet!
+3. You know how I sometimes have really brilliant ideas?
+
+### Aw, you're all Mr. Grumpy Face today.
+
+Sorry, checking all the water in this area; there's an escaped fish. Did I mention we have comfy chairs? I am the last of my species, and I know how that weighs on the heart so don't lie to me! Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+* It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+* I'm the Doctor, I'm worse than everyone's aunt. *catches himself* And that is not how I'm introducing myself.
+* Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+You hit me with a cricket bat. The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant.
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Heh-haa! Super squeaky bum time! You know when grown-ups tell you 'everything's going to be fine' and you think they're probably lying to make you feel better? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+You've swallowed a planet! No… It's a thing; it's like a plan, but with more greatness. I am the last of my species, and I know how that weighs on the heart so don't lie to me! *Insistently* Bow ties are cool! Come on Amy, I'm a normal bloke, tell me what normal blokes do!
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? Stop talking, brain thinking. Hush.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? I hate yogurt. It's just stuff with bits in.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. You know how I sometimes have really brilliant ideas?
+
+Father Christmas. Santa Claus. Or as I've always known him: Jeff. You've swallowed a planet! You hit me with a cricket bat. It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+
+I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why. You hate me; you want to kill me! Well, go on! Kill me! KILL ME! You know how I sometimes have really brilliant ideas?
+
+
+# I am the Doctor, and you are the Daleks!
+
+Saving the world with meals on wheels. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister. Heh-haa! Super squeaky bum time! You hate me; you want to kill me! Well, go on! Kill me! KILL ME!
+
+It's a fez. I wear a fez now. Fezes are cool. __You know how I sometimes have really brilliant ideas?__ *I'm the Doctor, I'm worse than everyone's aunt.* *catches himself* And that is not how I'm introducing myself.
+
+## No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! You hate me; you want to kill me! Well, go on! Kill me! KILL ME! It's a fez. I wear a fez now. Fezes are cool. I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why.
+
+1. Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you?
+2. You've swallowed a planet!
+3. You know how I sometimes have really brilliant ideas?
+
+### Aw, you're all Mr. Grumpy Face today.
+
+Sorry, checking all the water in this area; there's an escaped fish. Did I mention we have comfy chairs? I am the last of my species, and I know how that weighs on the heart so don't lie to me! Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+* It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+* I'm the Doctor, I'm worse than everyone's aunt. *catches himself* And that is not how I'm introducing myself.
+* Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+You hit me with a cricket bat. The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant.
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Heh-haa! Super squeaky bum time! You know when grown-ups tell you 'everything's going to be fine' and you think they're probably lying to make you feel better? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+You've swallowed a planet! No… It's a thing; it's like a plan, but with more greatness. I am the last of my species, and I know how that weighs on the heart so don't lie to me! *Insistently* Bow ties are cool! Come on Amy, I'm a normal bloke, tell me what normal blokes do!
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? Stop talking, brain thinking. Hush.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? I hate yogurt. It's just stuff with bits in.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. You know how I sometimes have really brilliant ideas?
+
+Father Christmas. Santa Claus. Or as I've always known him: Jeff. You've swallowed a planet! You hit me with a cricket bat. It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+
+I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why. You hate me; you want to kill me! Well, go on! Kill me! KILL ME! You know how I sometimes have really brilliant ideas?
+
+# I am the Doctor, and you are the Daleks!
+
+Saving the world with meals on wheels. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister. Heh-haa! Super squeaky bum time! You hate me; you want to kill me! Well, go on! Kill me! KILL ME!
+
+It's a fez. I wear a fez now. Fezes are cool. __You know how I sometimes have really brilliant ideas?__ *I'm the Doctor, I'm worse than everyone's aunt.* *catches himself* And that is not how I'm introducing myself.
+
+## No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! You hate me; you want to kill me! Well, go on! Kill me! KILL ME! It's a fez. I wear a fez now. Fezes are cool. I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why.
+
+1. Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you?
+2. You've swallowed a planet!
+3. You know how I sometimes have really brilliant ideas?
+
+### Aw, you're all Mr. Grumpy Face today.
+
+Sorry, checking all the water in this area; there's an escaped fish. Did I mention we have comfy chairs? I am the last of my species, and I know how that weighs on the heart so don't lie to me! Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+* It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+* I'm the Doctor, I'm worse than everyone's aunt. *catches himself* And that is not how I'm introducing myself.
+* Father Christmas. Santa Claus. Or as I've always known him: Jeff.
+
+You hit me with a cricket bat. The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant.
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Heh-haa! Super squeaky bum time! You know when grown-ups tell you 'everything's going to be fine' and you think they're probably lying to make you feel better? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+You've swallowed a planet! No… It's a thing; it's like a plan, but with more greatness. I am the last of my species, and I know how that weighs on the heart so don't lie to me! *Insistently* Bow ties are cool! Come on Amy, I'm a normal bloke, tell me what normal blokes do!
+
+I am the last of my species, and I know how that weighs on the heart so don't lie to me! No, I'll fix it. I'm good at fixing rot. Call me the Rotmeister. No, I'm the Doctor. Don't call me the Rotmeister.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? Stop talking, brain thinking. Hush.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? I hate yogurt. It's just stuff with bits in.
+
+Annihilate? No. No violence. I won't stand for it. Not now, not ever, do you understand me?! I'm the Doctor, the Oncoming Storm - and you basically meant beat them in a football match, didn't you? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong?
+
+The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. You know how I sometimes have really brilliant ideas?
+
+Father Christmas. Santa Claus. Or as I've always known him: Jeff. You've swallowed a planet! You hit me with a cricket bat. It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'!
+
+I'm the Doctor. Well, they call me the Doctor. I don't know why. I call me the Doctor too. I still don't know why. You hate me; you want to kill me! Well, go on! Kill me! KILL ME! You know how I sometimes have really brilliant ideas?
+
+NOWDOC;
+    }
+}

--- a/tests/Composer/Test/Autoload/Fixtures/pcrebacktracelimit/VeryLongPHP73Heredoc.php
+++ b/tests/Composer/Test/Autoload/Fixtures/pcrebacktracelimit/VeryLongPHP73Heredoc.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Foo;
+
+/**
+ * class VeryLongPHP73Heredoc { }
+ */
+class VeryLongPHP73Heredoc
+{
+    public function test_heredoc()
+    {
+        return <<<HEREDOCPHP73
+    Unwrap toilet paper
+    Cat ipsum dolor sit amet, eat the rubberband but human is behind a closed door, emergency! abandoned!
+    meeooowwww!!! and i heard this rumor where the humans are our owners, pfft, what do they know?!. Inspect
+    anything brought into the house dead stare with ears cocked or pet right here, no not there, here, no fool,
+    right here that other cat smells funny you should really give me all the treats because i smell the best and
+    omg you finally got the right spot and i love you right now. Lasers are tiny mice unwrap toilet paper steal
+    raw zucchini off kitchen counter. Lick butt and make a weird face. What the heck just happened, something
+    feels fishy sleep on dog bed, force dog to sleep on floor so lick plastic bags so meowing non stop for food
+    but bite plants, run up and down stairs. Catasstrophe stare at ceiling light for see brother cat receive
+    pets, attack out of jealousy, or stand with legs in litter box, but poop outside but dont wait for the storm
+    to pass, dance in the rain. Roll on the floor purring your whiskers off sleeping in the box, or find empty
+    spot in cupboard and sleep all day yet sleep nap mmmmmmmmmeeeeeeeeooooooooowwwwwwww. Scratch leg; meow for
+    can opener to feed me. Make meme, make cute face adventure always, for caticus cuteicus, enslave the hooman,
+    so sit by the fire so this human feeds me, i should be a god. This is the day chase mice. Cats woo spit up
+    on light gray carpet instead of adjacent linoleum. Put toy mouse in food bowl run out of litter box at full
+    speed . Lick human with sandpaper tongue destroy couch, fall over dead (not really but gets sypathy). This
+    cat happen now, it was too purr-fect!!! eat grass, throw it back up howl on top of tall thing for love to
+    play with owner's hair tie and leave hair on owner's clothes so scratch leg; meow for can opener to feed me.
+    My cat stared at me he was sipping his tea, too miaow then turn around and show you my bum yet scoot butt on
+    the rug but head nudges . Climb a tree, wait for a fireman jump to fireman then scratch his face if it fits
+    i sits hell is other people yet floof tum, tickle bum, jellybean footies curly toes for whatever. Scratch
+    the furniture do not try to mix old food with new one to fool me! and meow all night having their mate
+    disturbing sleeping humans yet jumps off balcony gives owner dead mouse at present then poops in litter box
+    snatches yarn and fights with dog cat chases laser then plays in grass finds tiny spot in cupboard and
+    sleeps all day jumps in bathtub and meows when owner fills food dish the cat knocks over the food dish cat
+    slides down the water slide and into pool and swims even though it does not like water. Go into a room to
+    decide you didn't want to be in there anyway slap the dog because cats rule there's a forty year old lady
+    there let us feast and ooh, are those your $250 dollar sandals? lemme use that as my litter box.
+
+        Cattt catt cattty cat being a cat meow meow it's 3am, time to create some chaos or eat plants, meow, and
+    throw up because i ate plants get poop stuck in paws jumping out of litter box and run around the house
+    scream meowing and smearing hot cat mud all over for terrorize the hundred-and-twenty-pound rottweiler and
+    steal his bed, not sorry yet kitty poochy. I is not fat, i is fluffy lasers are tiny mice spread kitty
+    litter all over house or i bet my nine lives on you-oooo-ooo-hooo sniff catnip and act crazy touch water
+    with paw then recoil in horror but has closed eyes but still sees you. Meow steal mom's crouton while she is
+    in the bathroom meow and walk away yowling nonstop the whole night chase little red dot someday it will be
+    mine! stuff and things so sit in box. Meow. Scratch so owner bleeds murr i hate humans they are so annoying.
+    Prow?? ew dog you drink from the toilet, yum yum warm milk hotter pls, ouch too hot meow meow you are my
+    owner so here is a dead bird i will ruin the couch with my claws. Morning beauty routine of licking self
+    lick plastic bags yet groom forever, stretch tongue and leave it slightly out, blep pee on walls it smells
+    like breakfast so dismember a mouse and then regurgitate parts of it on the family room floor, and meow meow
+    you are my owner so here is a dead bird. Always ensure to lay down in such a manner that tail can lightly
+    brush human's nose meow so run in circles, or freak human out make funny noise mow mow mow mow mow mow
+    success now attack human or munch on tasty moths. Litter kitter kitty litty little kitten big roar roar feed
+    me. Run off table persian cat jump eat fish. Plop down in the middle where everybody walks scratch me now!
+    stop scratching me! scratch me there, elevator butt. Relentlessly pursues moth give me attention or face the
+    wrath of my claws flex claws on the human's belly and purr like a lawnmower, with tail in the air pounce on
+    unsuspecting person. Lick the plastic bag poop on floor and watch human clean up but i'm bored inside, let
+    me out i'm lonely outside, let me in i can't make up my mind whether to go in or out, guess i'll just stand
+    partway in and partway out, contemplating the universe for half an hour how dare you nudge me with your
+    foot?!?! leap into the air in greatest offense!. Relentlessly pursues moth love why must they do that.
+    Pretend you want to go out but then don't curl into a furry donut do doodoo in the litter-box, clickityclack
+    on the piano, be frumpygrumpy or groom yourself 4 hours - checked, have your beauty sleep 18 hours -
+    checked, be fabulous for the rest of the day - checked so burrow under covers. Kitty power the fat cat sat
+    on the mat bat away with paws crash against wall but walk away like nothing happened for i just saw other
+    cats inside the house and nobody ask me before using my litter box but swat at dog.
+
+        Lick the plastic bag find empty spot in cupboard and sleep all day or stuff and things when in doubt, wash
+    or love to play with owner's hair tie. Purr as loud as possible, be the most annoying cat that you can, and,
+    knock everything off the table. Head nudges . Jump on human and sleep on her all night long be long in the
+    bed, purr in the morning and then give a bite to every human around for not waking up request food, purr
+    loud scratch the walls, the floor, the windows, the humans is good you understand your place in my world
+    refuse to drink water except out of someone's glass when in doubt, wash meow meow, i tell my human for this
+    cat happen now, it was too purr-fect!!!. Your pillow is now my pet bed rub my belly hiss or the cat was
+    chasing the mouse. Munch, munch, chomp, chomp massacre a bird in the living room and then look like the
+    cutest and most innocent animal on the planet or cats are a queer kind of folk scratch at door to be let
+    outside, get let out then scratch at door immmediately after to be let back in for reward the chosen human
+    with a slow blink. I do no work yet get food, shelter, and lots of stuff just like man who lives with us
+    oooo! dangly balls! jump swat swing flies so sweetly to the floor crash move on wash belly nap decide to
+    want nothing to do with my owner today so twitch tail in permanent irritation. Sitting in a box commence
+    midnight zoomies, so when in doubt, wash pet me pet me don't pet me but time to go zooooom i is not fat, i
+    is fluffy. Bird bird bird bird bird bird human why take bird out i could have eaten that litter kitter kitty
+    litty little kitten big roar roar feed me so purr purr purr until owner pets why owner not pet me hiss
+    scratch meow. Meow meow, i tell my human try to hold own back foot to clean it but foot reflexively kicks
+    you in face, go into a rage and bite own foot, hard slap the dog because cats rule but caticus cuteicus
+    check cat door for ambush 10 times before coming in, or stand in doorway, unwilling to chose whether to stay
+    in or go out. Haha you hold me hooman i scratch cat meoooow i iz master of hoomaan, not hoomaan master of i,
+    oooh damn dat dog for bird bird bird bird bird bird human why take bird out i could have eaten that, eat
+    grass, throw it back up for dream about hunting birds i like frogs and 0 gravity. Sit as close as possible
+    to warm fire without sitting on cold floor freak human out make funny noise mow mow mow mow mow mow success
+    now attack human. More napping, more napping all the napping is exhausting. Stare at ceiling crash against
+    wall but walk away like nothing happened meow to be let out and thinking longingly about tuna brine. Run at
+    3am stare at owner accusingly then wink meowzer or eat a plant, kill a hand. Prow?? ew dog you drink from
+    the toilet, yum yum warm milk hotter pls, ouch too hot licks your face, so thinking longingly about tuna
+    brine haha you hold me hooman i scratch but at four in the morning wake up owner meeeeeeooww scratch at legs
+    and beg for food then cry and yowl until they wake up at two pm jump on window and sleep while observing the
+    bootyful cat next door that u really like but who already has a boyfriend end up making babies with her and
+    let her move in for bite plants i am the best. Bite off human's toes meowing chowing and wowing but scratch
+    the box and howl uncontrollably for no reason and kitty loves pigs. Meow need to chase tail chase imaginary
+    bugs purr for no reason or poop in litter box, scratch the walls but eat and than sleep on your face and
+    walk on car leaving trail of paw prints on hood and windshield.
+
+        Need to chase tail being gorgeous with belly side up i love cuddles. Adventure always. Pet me pet me don't
+    pet me i am the best toy mouse squeak roll over but slap owner's face at 5am until human fills food dish.
+    Munch on tasty moths scratch my tummy actually i hate you now fight me. Bathe private parts with tongue then
+    lick owner's face ooh, are those your $250 dollar sandals? lemme use that as my litter box scratch for shake
+    treat bag. Cat sit like bread hiss at vacuum cleaner so is good you understand your place in my world. Hate
+    dogs bathe private parts with tongue then lick owner's face chirp at birds damn that dog or chase after
+    silly colored fish toys around the house and mice. Caticus cuteicus it's 3am, time to create some chaos .
+    Catty ipsum plan steps for world domination. Human is behind a closed door, emergency! abandoned!
+    meeooowwww!!! spread kitty litter all over house but need to chase tail, or meowing chowing and wowing, for
+    human is in bath tub, emergency! drowning! meooowww! for twitch tail in permanent irritation.
+
+        Disappear for four days and return home with an expensive injury; bite the vet climb a tree, wait for a
+    fireman jump to fireman then scratch his face refuse to leave cardboard box mess up all the toilet paper yet
+    nyaa nyaa scratch me there, elevator butt. Bring your owner a dead bird i'm going to lap some water out of
+    my master's cup meow pushed the mug off the table, if it fits, i sits. ???????? run as fast as i can into
+    another room for no reason. Going to catch the red dot today going to catch the red dot today purr as loud
+    as possible, be the most annoying cat that you can, and, knock everything off the table yet instantly break
+    out into full speed gallop across the house for no reason, i like cats because they are fat and fluffy. Sit
+    and stare love to play with owner's hair tie, yet make muffins a nice warm laptop for me to sit on caticus
+    cuteicus. Stares at human while pushing stuff off a table purr while eating. Ooooh feather moving feather!
+    check cat door for ambush 10 times before coming in. Refuse to come home when humans are going to bed; stay
+    out all night then yowl like i am dying at 4am rub against owner because nose is wet.
+
+        Hey! you there, with the hands leave fur on owners clothes ooh, are those your $250 dollar sandals? lemme
+    use that as my litter box. Just going to dip my paw in your coffee and do a taste test - oh never mind i
+    forgot i don't like coffee - you can have that back now cats are the world, but spill litter box, scratch at
+    owner, destroy all furniture, especially couch ask to be pet then attack owners hand. Jump up to edge of
+    bath, fall in then scramble in a mad panic to get out destroy couch as revenge and crash against wall but
+    walk away like nothing happened. Lick butt i’m so hungry i’m so hungry but ew not for that , take a deep
+    sniff of sock then walk around with mouth half open, spill litter box, scratch at owner, destroy all
+    furniture, especially couch for kitty run to human with blood on mouth from frenzied attack on poor innocent
+    mouse, don't i look cute?. Cough furball catch mouse and gave it as a present pooping rainbow while flying
+    in a toasted bread costume in space unwrap toilet paper so take a deep sniff of sock then walk around with
+    mouth half open. Am in trouble, roll over, too cute for human to get mad i love cuddles meow meow pee in
+    shoe love you, then bite you. Steal the warm chair right after you get up why can't i catch that stupid red
+    dot yet i can haz steal mom's crouton while she is in the bathroom love you, then bite you. Meow. This is
+    the day ooooh feather moving feather! steal the warm chair right after you get up or snuggles up to
+    shoulders or knees and purrs you to sleep i want to go outside let me go outside nevermind inside is better
+    or jump around on couch, meow constantly until given food, . Yowling nonstop the whole night purr like an
+    angel or i cry and cry and cry unless you pet me, and then maybe i cry just for fun, mice. Get suspicious of
+    own shadow then go play with toilette paper plays league of legends kitty kitty yet bathe private parts with
+    tongue then lick owner's face so stare at imaginary bug sleeps on my head. And sometimes switches in french
+    and say "miaou" just because well why not chase the pig around the house so cats are cute chase imaginary
+    bugs catasstrophe or love me!. Do doodoo in the litter-box, clickityclack on the piano, be frumpygrumpy lick
+    sellotape. Swipe at owner's legs allways wanting food cough catch small lizards, bring them into house, then
+    unable to find them on carpet for scratch at door to be let outside, get let out then scratch at door
+    immmediately after to be let back in caticus cuteicus and unwrap toilet paper.
+
+        In the middle of the night i crawl onto your chest and purr gently to help you sleep disappear for four days
+    and return home with an expensive injury; bite the vet and poop in a handbag look delicious and drink the
+    soapy mopping up water then puke giant foamy fur-balls for stand in doorway, unwilling to chose whether to
+    stay in or go out, yet find something else more interesting attack dog, run away and pretend to be victim.
+    Run outside as soon as door open cats go for world domination and hopped up on catnip, for chew foot, or
+    leave dead animals as gifts. Ask to be pet then attack owners hand sleep or chase mice eat all the power
+    cords so cereal boxes make for five star accommodation swipe at owner's legs. Hunt anything i do no work yet
+    get food, shelter, and lots of stuff just like man who lives with us and dream about hunting birds inspect
+    anything brought into the house ????????, yet good now the other hand, too. Plop down in the middle where
+    everybody walks i will be pet i will be pet and then i will hiss nyaa nyaa miaow then turn around and show
+    you my bum. Morning beauty routine of licking self plays league of legends when owners are asleep, cry for
+    no apparent reason or roll over and sun my belly but naughty running cat i vomit in the bed in the middle of
+    the night or ask to be pet then attack owners hand. Murr i hate humans they are so annoying attempt to leap
+    between furniture but woefully miscalibrate and bellyflop onto the floor; what's your problem? i meant to do
+    that now i shall wash myself intently so intently sniff hand, yet rub whiskers on bare skin act innocent.
+    Cat fur is the new black that box? i can fit in that box get video posted to internet for chasing red dot.
+    Toilet paper attack claws fluff everywhere meow miao french ciao litterbox sugar, my siamese, stalks me (in
+    a good way), day and night for cat milk copy park pee walk owner escape bored tired cage droppings sick vet
+    vomit bawl under human beds for chase laser. Kitty. Russian blue knock over christmas tree
+    ccccccccccccaaaaaaaaaaaaaaatttttttttttttttttssssssssssssssss destroy the blinds but nap all day. Hate dogs
+    eat plants, meow, and throw up because i ate plants, yet plan your travel i can haz put butt in owner's
+    face. Dead stare with ears cocked the best thing in the universe is a cardboard box yet my cat stared at me
+    he was sipping his tea, too. Eat the rubberband warm up laptop with butt lick butt fart rainbows until owner
+    yells pee in litter box hiss at cats so fish i must find my red catnip fishy fish and meowwww. Thug cat
+    disappear for four days and return home with an expensive injury; bite the vet purr as loud as possible, be
+    the most annoying cat that you can, and, knock everything off the table. Eat fish on floor chew foot put toy
+    mouse in food bowl run out of litter box at full speed for hack mesmerizing birds yet give attitude. Jumps
+    off balcony gives owner dead mouse at present then poops in litter box snatches yarn and fights with dog cat
+    chases laser then plays in grass finds tiny spot in cupboard and sleeps all day jumps in bathtub and meows
+    when owner fills food dish the cat knocks over the food dish cat slides down the water slide and into pool
+    and swims even though it does not like water give me some of your food give me some of your food give me
+    some of your food meh, i don't want it ooooh feather moving feather! experiences short bursts of poo-phoria
+    after going to the loo but so you're just gonna scroll by without saying meowdy? morning beauty routine of
+    licking self so destroy couch as revenge. Drool. Attack the child paw at beetle and eat it before it gets
+    away for poop in a handbag look delicious and drink the soapy mopping up water then puke giant foamy
+    fur-balls for warm up laptop with butt lick butt fart rainbows until owner yells pee in litter box hiss at
+    cats purr when give birth. Eat owner's food love and coo around boyfriend who purrs and makes the perfect
+    moonlight eyes so i can purr and swat the glittery gleaming yarn to him (the yarn is from a $125 sweater)
+    and eat a rug and furry furry hairs everywhere oh no human coming lie on counter don't get off counter for
+    eat the fat cats food. Show belly destroy couch as revenge pee in the shoe and this human feeds me, i should
+    be a god and small kitty warm kitty little balls of fur find a way to fit in tiny box. I shall purr myself
+    to sleep howl on top of tall thing. Scratch me there, elevator butt. Find empty spot in cupboard and sleep
+    all day side-eyes your "jerk" other hand while being petted for twitch tail in permanent irritation.
+
+        I can haz disappear for four days and return home with an expensive injury; bite the vet prance along on top
+    of the garden fence, annoy the neighbor's dog and make it bark, scratch at the door then walk away, and
+    under the bed, but eat the rubberband annoy kitten brother with poking. Intently stare at the same spot.
+    Destroy the blinds catty ipsum and love fish x yet cat milk copy park pee walk owner escape bored tired cage
+    droppings sick vet vomit for mew. Leave fur on owners clothes chase imaginary bugs, yet catasstrophe yet mew
+    mew drool vommit food and eat it again, yet walk on a keyboard. Dont wait for the storm to pass, dance in
+    the rain refuse to leave cardboard box flex claws on the human's belly and purr like a lawnmower and grass
+    smells good where is it? i saw that bird i need to bring it home to mommy squirrel! for being gorgeous with
+    belly side up. Annoy owner until he gives you food say meow repeatedly until belly rubs, feels good dead
+    stare with ears cocked so hiss at vacuum cleaner disappear for four days and return home with an expensive
+    injury; bite the vet run as fast as i can into another room for no reason lies down . I shall purr myself to
+    sleep miaow then turn around and show you my bum. Bird bird bird bird bird bird human why take bird out i
+    could have eaten that kitty loves pigs chew on cable, for sees bird in air, breaks into cage and attacks
+    creature or climb a tree, wait for a fireman jump to fireman then scratch his face. Poop in a handbag look
+    delicious and drink the soapy mopping up water then puke giant foamy fur-balls murder hooman toes and meow
+    go back to sleep owner brings food and water tries to pet on head, so scratch get sprayed by water because
+    bad cat toy mouse squeak roll over toy mouse squeak roll over get away from me stupid dog. Hey! you there,
+    with the hands growl at dogs in my sleep sees bird in air, breaks into cage and attacks creature, so knock
+    over christmas tree lick human with sandpaper tongue. Miaow then turn around and show you my bum bawl under
+    human beds but eat a plant, kill a hand. Woops poop hanging from butt must get rid run run around house drag
+    poop on floor maybe it comes off woops left brown marks on floor human slave clean lick butt now run as fast
+    as i can into another room for no reason give attitude, or ask to be pet then attack owners hand. Demand to
+    be let outside at once, and expect owner to wait for me as i think about it pet me pet me don't pet me,
+    scratch me there, elevator butt. Why use post when this sofa is here see owner, run in terror. Snob you for
+    another person if it smells like fish eat as much as you wish or i could pee on this if i had the energy
+    human give me attention meow human is washing you why halp oh the horror flee scratch hiss bite. Human is in
+    bath tub, emergency! drowning! meooowww! i just saw other cats inside the house and nobody ask me before
+    using my litter box cat jumps and falls onto the couch purrs and wakes up in a new dimension filled with
+    kitty litter meow meow yummy there is a bunch of cats hanging around eating catnip and rub face on owner or
+    meoooow kitty pounce, trip, faceplant you didn't see that no you didn't definitely didn't lick, lick, lick,
+    and preen away the embarrassment. Human is washing you why halp oh the horror flee scratch hiss bite behind
+    the couch. Cats making all the muffins purr like a car engine oh yes, there is my human slave woman she does
+    best pats ever that all i like about her hiss meow for kitten is playing with dead mouse. Mrow that box? i
+    can fit in that box humans,humans, humans oh how much they love us felines we are the center of attention
+    they feed, they clean yet slap owner's face at 5am until human fills food dish and sleep in the bathroom
+    sink scratch at door to be let outside, get let out then scratch at door immmediately after to be let back
+    in. Small kitty warm kitty little balls of fur eat a rug and furry furry hairs everywhere oh no human coming
+    lie on counter don't get off counter for trip owner up in kitchen i want food, claws in your leg yet purrr
+    purr littel cat, little cat purr purr whatever. Leave hair on owner's clothes. Kitty kitty pussy cat doll
+    drool for lick the other cats yet leave hair on owner's clothes.
+
+        Kitty time jumps off balcony gives owner dead mouse at present then poops in litter box snatches yarn and
+    fights with dog cat chases laser then plays in grass finds tiny spot in cupboard and sleeps all day jumps in
+    bathtub and meows when owner fills food dish the cat knocks over the food dish cat slides down the water
+    slide and into pool and swims even though it does not like water at four in the morning wake up owner
+    meeeeeeooww scratch at legs and beg for food then cry and yowl until they wake up at two pm jump on window
+    and sleep while observing the bootyful cat next door that u really like but who already has a boyfriend end
+    up making babies with her and let her move in for hide at bottom of staircase to trip human. Meeeeouw while
+    happily ignoring when being called inspect anything brought into the house, and sitting in a box kitty kitty
+    pussy cat doll nap all day. Eat my own ears you have cat to be kitten me right meow ask to go outside and
+    ask to come inside and ask to go outside and ask to come inside or pet right here, no not there, here, no
+    fool, right here that other cat smells funny you should really give me all the treats because i smell the
+    best and omg you finally got the right spot and i love you right now or allways wanting food. Purr. Check
+    cat door for ambush 10 times before coming in hide when guests come over. Howl uncontrollably for no reason.
+    Massacre a bird in the living room and then look like the cutest and most innocent animal on the planet rub
+    face on everything ask to be pet then attack owners hand proudly present butt to human or i am the best yet
+    purr purr purr until owner pets why owner not pet me hiss scratch meow. Nap all day crusty butthole. Destroy
+    dog bite plants love you, then bite you, and missing until dinner time hiss and stare at nothing then run
+    suddenly away. Meow all night having their mate disturbing sleeping humans cough yet car rides are evil hiss
+    at vacuum cleaner sniff all the things so groom yourself 4 hours - checked, have your beauty sleep 18 hours
+    - checked, be fabulous for the rest of the day - checked just going to dip my paw in your coffee and do a
+    taste test - oh never mind i forgot i don't like coffee - you can have that back now. Sleep all day whilst
+    slave is at work, play all night whilst slave is sleeping head nudges , purr for no reason, humans,humans,
+    humans oh how much they love us felines we are the center of attention they feed, they clean . Lick face
+    hiss at owner, pee a lot, and meow repeatedly scratch at fence purrrrrr eat muffins and poutine until owner
+    comes back. Look at dog hiiiiiisssss i rule on my back you rub my tummy i bite you hard or kitty loves pigs,
+    or freak human out make funny noise mow mow mow mow mow mow success now attack human, or rub my belly hiss.
+    Get scared by sudden appearance of cucumber. Freak human out make funny noise mow mow mow mow mow mow
+    success now attack human steal the warm chair right after you get up. I heard this rumor where the humans
+    are our owners, pfft, what do they know?! it's 3am, time to create some chaos but stare at ceiling light.
+    Have secret plans. Grab pompom in mouth and put in water dish scratch the box for eat too much then proceed
+    to regurgitate all over living room carpet while humans eat dinner for suddenly go on wild-eyed crazy
+    rampage yet make it to the carpet before i vomit mmmmmm, and scream for no reason at 4 am. Pushed the mug
+    off the table meow all night having their mate disturbing sleeping humans catching very fast laser pointer.
+    Lasers are tiny mice you call this cat food crusty butthole. Intrigued by the shower put butt in owner's
+    face. Carefully drink from water glass and then spill it everywhere and proceed to lick the puddle eat an
+    easter feather as if it were a bird then burp victoriously, but tender for poop in litter box, scratch the
+    walls sleep in the bathroom sink or nap all day. Attack dog, run away and pretend to be victim. Steal the
+    warm chair right after you get up.
+
+        What a cat-ass-trophy! shove bum in owner's face like camera lens, i want to go outside let me go outside
+    nevermind inside is better but your pillow is now my pet bed. Meeeeouw hiding behind the couch until lured
+    out by a feathery toy but pounce on unsuspecting person. Run up and down stairs pee in human's bed until he
+    cleans the litter box love and coo around boyfriend who purrs and makes the perfect moonlight eyes so i can
+    purr and swat the glittery gleaming yarn to him (the yarn is from a $125 sweater) you are a captive audience
+    while sitting on the toilet, pet me mouse but crash against wall but walk away like nothing happened play
+    with twist ties. Jump up to edge of bath, fall in then scramble in a mad panic to get out demand to have
+    some of whatever the human is cooking, then sniff the offering and walk away, lie in the sink all day.
+    Unwrap toilet paper attack the child. Meow climb a tree, wait for a fireman jump to fireman then scratch his
+    face yet cats are a queer kind of folk. Kitty poochy refuse to drink water except out of someone's glass
+    kitty run to human with blood on mouth from frenzied attack on poor innocent mouse, don't i look cute?. The
+    door is opening! how exciting oh, it's you, meh time to go zooooom knock over christmas tree so purr as loud
+    as possible, be the most annoying cat that you can, and, knock everything off the table for stare out cat
+    door then go back inside check cat door for ambush 10 times before coming in. Cat fur is the new black eat
+    prawns daintily with a claw then lick paws clean wash down prawns with a lap of carnation milk then retire
+    to the warmest spot on the couch to claw at the fabric before taking a catnap jump on fridge do not try to
+    mix old food with new one to fool me! so refuse to leave cardboard box and bleghbleghvomit my furball really
+    tie the room together steal mom's crouton while she is in the bathroom. Vommit food and eat it again.
+    Whenever a door is opened, rush in before the human. You are a captive audience while sitting on the toilet,
+    pet me. Milk the cow make meme, make cute face so sit in a box for hours. Murr i hate humans they are so
+    annoying proudly present butt to human eat all the power cords for sun bathe destroy couch. While happily
+    ignoring when being called purr like an angel tweeting a baseball meowzer grass smells good so cats secretly
+    make all the worlds muffins steal mom's crouton while she is in the bathroom. Plan your travel litter box is
+    life, so sleeps on my head. Try to hold own back foot to clean it but foot reflexively kicks you in face, go
+    into a rage and bite own foot, hard use lap as chair, yet attack the child i do no work yet get food,
+    shelter, and lots of stuff just like man who lives with us or sniff all the things and push your water glass
+    on the floor.
+
+    HEREDOCPHP73;
+    }
+}

--- a/tests/Composer/Test/Autoload/Fixtures/pcrebacktracelimit/VeryLongPHP73Nowdoc.php
+++ b/tests/Composer/Test/Autoload/Fixtures/pcrebacktracelimit/VeryLongPHP73Nowdoc.php
@@ -1,0 +1,1018 @@
+<?php
+
+namespace Foo;
+
+/**
+ * class VeryLongPHP73Nowdoc { }
+ */
+class VeryLongPHP73Nowdoc
+{
+    public function test_nowdoc()
+    {
+        return <<<'NOWDOCPHP73'
+      Leave her alone, you bastard. Ah. Whoa. Lynda, first of all, I'm not your answering service. Second of all, somebody named Greg or Craig called you just a little while ago. I hope you don't mind but George asked if he could take me home. Whoa, wait, Doc.
+
+    I noticed you band is on the roster for dance auditions after school today. Why even bother Mcfly, you haven't got a chance, you're too much like your own man. No McFly ever amounted to anything in the history of Hill Valley. Oh, if Paul calls me tell him I'm working at the boutique late tonight. Hey, George, buddy, you weren't at school, what have you been doing all day? Doc, Doc. Oh, no. You're alive. Bullet proof vest, how did you know, I never got a chance to tell you. About all that talk about screwing up future events, the space time continuum. Listen, Doc.
+
+    Yeah, I guessed you're a sailor, aren't you, that's why you wear that life preserver. Doc, she's beautiful. She's crazy about me. Look at this, look what she wrote me, Doc. That says it all. Doc, you're my only hope. Indeed I will, roll em. I, Doctor Emmett Brown, am about to embark on an historic journey. What have I been thinking of, I almost forgot to bring some extra plutonium. How did I ever expect to get back, one pallet one trip I must be out of my mind. What is it Einy? Oh my god, they found me, I don't know how but they found me. Run for it, Marty. I have to tell you about the future. Huh?
+
+    Right, and where am I gonna be? Listen, this is very important, I forgot my video camera, could you stop by my place and pick it up on your way to the mall? Re-elect Mayor Goldie Wilson. Progress is his middle name. whoa, whoa Doc, stuck here, I can't be stuck here, I got a life in 1985. I got a girl. Well, uh, listen, uh, I really-
+
+    Alright, okay listen, keep your pants on, she's over in the cafe. God, how do you do this? What made you change your mind, George? Ho, you mean you're gonna touch her on her- Well, safe and sound, now, n good old 1955. Look, George, I'm telling you George, if you do not ask Lorraine to that dance, I'm gonna regret it for the rest of my life. He's a very strange young man.
+
+    Can I go now, Mr. Strickland? Erased from existence. You'll find out in thirty years. Whoa, they really cleaned this place up, looks brand new. Something that really cooks. Alright, alright this is an oldie, but uh, it's an oldie where I come from. Alright guys, let's do some blues riff in b, watch me for the changes, and uh, try and keep up, okay.
+
+    Silence Earthling. my name is Darth Vader. I'm am an extra-terrestrial from the planet Vulcan. Marty, that's completely out of the question, you must not leave this house. you must not see anybody or talk to anybody. Anything you do could have serious repercussions on future events. Do you understand? McFly. The hell you doing to my car? What?
+
+    See, there's Biff out there waxing it right now. Now, Biff, I wanna make sure that we get two coats of wax this time, not just one. Back to the future. No, get out of town, my mom thinks I'm going camping with the guys. Well, Jennifer, my mother would freak out if she knew I was going up there with you. And I get this standard lecture about how she never did that kind of stuff when she was a kid. Now look, I think she was born a nun. No no no, Doc, I just got here, okay, Jennifer's here, we're gonna take the new truck for a spin. Which one's your pop?
+
+    My equipment, that reminds me, Marty, you better not hook up to the amplifier. There's a slight possibility for overload. 1955? You're my ma- you're my ma. Alright, good-bye Einy. Oh, watch that re-entry, it's a little bumpy. Alright, punk, now- Lorraine, are you up there?
+
+    I have to tell you about the future. Hey, George, buddy, you weren't at school, what have you been doing all day? Yes, definitely, god-dammit George, swear. Okay, so now, you come up, you punch me in the stomach, I'm out for the count, right? And you and Lorraine live happily ever after. Uh, well, okay Biff, uh, I'll finish that on up tonight and I'll bring it over first thing tomorrow morning. No, Marty, we've already agreed that having information about the future could be extremely dangerous. Even if your intentions are good, they could backfire drastically. Whatever you've got to tell me I'll find out through the natural course of time.
+
+    Hey, McFly, I thought I told you never to come in here. Well it's gonna cost you. How much money you got on you? My insurance, it's your car, your insurance should pay for it. Hey, I wanna know who's gonna pay for this? I spilled beer all over it when that car smashed into me. Who's gonna pay my cleaning bill? Mom, Dad. Yes, definitely, god-dammit George, swear. Okay, so now, you come up, you punch me in the stomach, I'm out for the count, right? And you and Lorraine live happily ever after. Doc, is that a de-
+
+    Sit here, Marty. Welcome to my latest experiment. It's the one I've been waiting for all my life. Let's get him. It's information about the future isn't it. I warned you about this kid. The consequences could be disastrous. He's absolutely right, Marty. the last thing you need is headaches.
+
+    Yeah, but I never picked a fight in my entire life. What? George, aren't you gonna kiss me? This is it. This is the answer. It says here that a bolt of lightning is gonna strike the clock tower precisely at 10:04 p.m. next Saturday night. If we could somehow harness this bolt of lightning, channel it into the flux capacitor, it just might work. Next Saturday night, we're sending you back to the future. Let him go, Biff, you're drunk.
+
+    We all make mistakes in life, children George: you ever think of running for class president? Doc? You do? Oh, just a little weather experiment.
+
+    The only way we're gonna get those two to successfully meet is if they're alone together. So you've got to get your father and mother to interact at some sort of social- Hey, hey, keep rolling, keep rolling there. No, no, no, no, this sucker's electrical. But I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity that I need. So what's it to you, butthead. You know you've been looking for a, since you're new here, I'm gonna cut you a break, today. So why don't you make like a tree, and get out of here. Did you hurt your head? I have to tell you about the future.
+
+    Thanks a lot, kid. What kind of date? I don't know, what do kids do in the fifties? Look, there's a rhythmic ceremonial ritual coming up. What? Where were we.
+
+    Why is she gonna get angry with you? Save the clock tower, save the clock tower. Mayor Wilson is sponsoring an initiative to replace that clock. Thirty years ago, lightning struck that clock tower and the clock hasn't run since. We at the Hill Valley Preservation Society think it should be preserved exactly the way it is as part of our history and heritage. You know Marty, you look so familiar, do I know your mother? Marty, such a nice name. Hello.
+
+    This is more serious than I thought. Apparently your mother is amorously infatuated with you instead of your father. He's an absolute dream. The keys are in the trunk. McFly. Listen, Doc.
+    Ah, honey, your first novel. Uh, plutonium, wait a minute, are you telling me that this sucker's nuclear? Wow, you must be rich. Perfect, just perfect. Hey.
+
+    What? Whoa, wait, Doc. I do understand. If I know too much about my own future I could endanger my own existence, just as you endangered yours. The only way we're gonna get those two to successfully meet is if they're alone together. So you've got to get your father and mother to interact at some sort of social- Doc, you don't just walk into a store and ask for plutonium. Did you rip this off?
+
+    Well, they're bigger than me. You don't understand. Oh, you mean how you're supposed to act on a first date. Doc. I over slept, look I need your help. I have to ask Lorraine out but I don't know how to do it. I have to ask Lorraine out but I don't know how to do it.
+
+    Well, Marty, I'm almost eighteen-years-old, it's not like I've never parked before. Well, Marty, I want to thank you for all your good advice, I'll never forget it. I guess you guys aren't ready for that yet. But your kids are gonna love it. He's an absolute dream. What the hell is a gigawatt?
+
+    Let him go, Biff, you're drunk. Marty, you didn't fall asleep, did you? Shut your filthy mouth, I'm not that kind of girl. Now, Biff, um, can I assume that your insurance is gonna pay for the damage? No, bastards.
+
+    Oh, I've been so worried about you ever since you ran off the other night. Are you okay? I'm sorry I have to go. Isn't he a dream boat? Uh Doc, uh no. No, don't be silly. I guarantee it. Um, yeah, I'm on my way. Don't tell me anything.
+
+    The way I see it, if you're gonna build a time machine into a car why not do it with some style. Besides, the stainless, steel construction made the flux dispersal- look out. Marty, why are you so nervous? What, what? We're gonna take a little break but we'll be back in a while so, don't nobody go no where. Yeah, alright, bye-bye. What?
+
+    Just finishing up the second coat now. Alright, okay Jennifer. What if I send in the tape and they don't like it. I mean, what if they say I'm no good. What if they say, 'Get out of here, kid, you got no future.' I mean, I just don't think I can take that kind of rejection. Jesus, I'm beginning to sound like my old man. Uh, well, I haven't finished those up yet, but you know I figured since they weren't due till- I said the keys are in here. Maybe you were adopted.
+
+    Watch this. Not me, the car, the car. My calculations are correct, when this baby hits eighty-eight miles per hour, your gonna see some serious shit. Watch this, watch this. Ha, what did I tell you, eighty-eight miles per hour. The temporal displacement occurred at exactly 1:20 a.m. and zero seconds. Stop it. You extol me with a lot of confidence, Doc. Oh, what I meant to day was- Uh, Doc.
+
+    Alright, we're the pinheads. And he could sleep in my room. I know, and all I could say is I'm sorry. I'm really gonna miss you. Doc, about the future- Lorraine.
+
+    The only way we're gonna get those two to successfully meet is if they're alone together. So you've got to get your father and mother to interact at some sort of social- Hey George, buddy, hey, I've been looking all over for you. You remember me, the guy who saved your life the other day. Radiation suit, of course, cause all of the fall out from the atomic wars. This is truly amazing, a portable television studio. No wonder your president has to be an actor, he's gotta look good on television. Doc, Doc. Oh, no. You're alive. Bullet proof vest, how did you know, I never got a chance to tell you. About all that talk about screwing up future events, the space time continuum. Yeah, I'm- mayor. Now that's a good idea. I could run for mayor.
+
+    Don't tell me anything. What's a rerun? whoa, this is it, this is the part coming up, Doc. Well, now we gotta sneak this back into my laboratory, we've gotta get you home. Nothing.
+
+    Go. Go. What the hell is a gigawatt? Science Fiction Theater. Precisely. Like I always told you, if you put your mind to it you could accomplish anything.
+
+    Right. Ohh, no. Yeah, who are you? I can't play. I followed you.
+
+    I don't know, Doc, I guess she felt sorry for him cause her did hit him with the car, hit me with the car. Evening, Doctor Brown, what's with the wire? oh yeah, all you gotta do is go over there and ask her. Marty, I always wear a suit to the office. You alright? Uh, yeah.
+
+    I still don't understand, how am I supposed to go to the dance with her, if she's already going to the dance with you. Alright, we're the pinheads. Let's get him. Ronald Reagon, the actor? Then who's vice president, Jerry Lewis? I suppose Jane Wymann is the first lady. I have to tell you about the future.
+
+    Next, please. Perfect, just perfect. Doc, you don't just walk into a store and ask for plutonium. Did you rip this off? Calvin. Hi, it's really a pleasure to meet you.
+
+    That's a Florence Nightingale effect. It happens in hospitals when nurses fall in love with their patients. Go to it, kid. So tell me, Marty, how long have you been in port? Don't pay any attention to him, he's in one of his moods. Sam, quit fiddling with that thing, come in here to dinner. Now let's see, you already know Lorraine, this is Milton, this is Sally, that's Toby, and over there in the playpen is little baby Joey. Wait a minute, wait a minute. 1:15 in the morning? So tell me, future boy, who's president of the United States in 1985?
+
+    Oh, great scott. You get the cable, I'll throw the rope down to you. George. Whoa, whoa, Biff, what's that? That's true, Marty, I think you should spend the night. I think you're our responsibility. Yet.
+
+    Now that's a risk you'll have to take you're life depends on it. George. Hey. It's my dad. Oh, I've been so worried about you ever since you ran off the other night. Are you okay? I'm sorry I have to go. Isn't he a dream boat?
+
+    Look, George, I'm telling you George, if you do not ask Lorraine to that dance, I'm gonna regret it for the rest of my life. Don't say a word. Shape up, man. You're a slacker. You wanna be a slacker for the rest of your life? What did your mother ever see in that kid? Hey, Doc, we better back up, we don't have enough roads to get up to 88.
+
+    Erased from existence. Right. Don't say a word. He's absolutely right, Marty. the last thing you need is headaches. Hey, Doc? Doc. Hello, anybody home? Einstein, come here, boy. What's going on? Wha- aw, god. Aw, Jesus. Whoa, rock and roll. Yo
+
+    Ho, you mean you're gonna touch her on her- Yeah, it's in the back. Precisely. Hey Marty, I'm not your answering service, but you're outside pouting about the car, Jennifer Parker called you twice. Where the hell are they.
+
+    What you got under here? Yet. Doc? Lorraine, have you ever, uh, been in a situation where you know you had to act a certain way but when you got there, you didn't know if you could go through with it? Mother, with Marty's parents out of town, don't you think he oughta spend the night, after all, Dad almost killed him with the car.
+
+    Ah. Whoa. Are you sure about this storm? It's safe now. Everything's lead lined. Don't you lose those tapes now, we'll need a record. Wup, wup, I almost forgot my luggage. Who knows if they've got cotton underwear in the future. I'm allergic to all synthetics. We all make mistakes in life, children Leave me alone.
+
+    Look, you gotta listen to me. Go. Now, Biff, um, can I assume that your insurance is gonna pay for the damage? Crazy drunk drivers. Hey man, look at Marvin's hand. He can't play with his hands like that, and we can't play without him.
+
+    Calvin. Listen, Doc. Uh, Lorraine. How did you know I was here? Of course, the Enchantment Under The Sea Dance they're supposed to go to this, that's where they kiss for the first time. You broke it. Wow, look at him go.
+
+    Look, I'm just not ready to ask Lorraine out to the dance, and not you, nor anybody else on this planet is gonna make me change my mind. No, Doc. Wait a minute, Doc. What are you talking about? What happens to us in the future? What do we become assholes or something? Listen, woh. Hello, uh excuse me. Sorry about your barn. Okay, alright, Saturday is good, Saturday's good, I could spend a week in 1955. I could hang out, you could show me around.
+
+    Flux capacitor. Oh, I sure like her, Marty, she is such a sweet girl. Isn't tonight the night of the big date? Kids, we're gonna have to eat this cake by ourselves, Uncle Joey didn't make parole again. I think it would be nice, if you all dropped him a line. Oh, you make it sound so easy. I just, I wish I wasn't so scared. Yeah, I'll keep that in mind.
+
+    I don't wanna see you in here again. Something that really cooks. Alright, alright this is an oldie, but uh, it's an oldie where I come from. Alright guys, let's do some blues riff in b, watch me for the changes, and uh, try and keep up, okay. What was it, George, bird watching? The hell you doing to my car? Yeah, well, I still don't understand what Dad was doing in the middle of the street.
+
+    Right about here. Good evening, I'm Doctor Emmet Brown, I'm standing here on the parking lot of- This Saturday night, mostly clear, with some scattered clouds. Lows in the upper forties. My equipment, that reminds me, Marty, you better not hook up to the amplifier. There's a slight possibility for overload. Never?
+
+    Well, Marty, I want to thank you for all your good advice, I'll never forget it. Oh, great scott. You get the cable, I'll throw the rope down to you. The future, it's where you're going? Okay, but I don't know what to say. Tab? I can't give you a tab unless you order something.
+
+    I think you got the wrong car, McFly. My god, do you know what this means? It means that this damn thing doesn't work at all. It's taken me almost thirty years and my entire family fortune to realize the vision of that day, my god has it been that long. Things have certainly changed around here. I remember when this was all farmland as far as the eye could see. Old man Peabody, owned all of this. He had this crazy idea about breeding pine trees. Alright, okay listen, keep your pants on, she's over in the cafe. God, how do you do this? What made you change your mind, George? I'm sure that in 1985, plutonium is available at every corner drug store, but in 1955, it's a little hard to come by. Marty, I'm sorry, but I'm afraid you're stuck here.
+
+    David, watch your mouth. You come here and kiss your mother before you go, come here. So what's it to you, butthead. You know you've been looking for a, since you're new here, I'm gonna cut you a break, today. So why don't you make like a tree, and get out of here. Ah. Its good. It's uh, the other end of town, a block past Maple.
+
+    Who is that guy. Unfortunately no, it requires something with a little more kick, plutonium. Nothing. Hey wait, wait a minute, who are you? Stella, another one of these damn kids jumped in front of my car. Come on out here, help me take him in the house. Doc, is that a de-
+
+    I think you got the wrong car, McFly. My insurance, it's your car, your insurance should pay for it. Hey, I wanna know who's gonna pay for this? I spilled beer all over it when that car smashed into me. Who's gonna pay my cleaning bill? Pretty Mediocre photographic fakery, they cut off your brother's hair. Don't stop, Wilbert, drive. I hope so.
+
+    Save the clock tower, save the clock tower. Mayor Wilson is sponsoring an initiative to replace that clock. Thirty years ago, lightning struck that clock tower and the clock hasn't run since. We at the Hill Valley Preservation Society think it should be preserved exactly the way it is as part of our history and heritage. Uh no, not hard at all. So anyway, George, now Lorraine, she really likes you. She told me to tell you that she wants you to ask her to the Enchantment Under The Sea Dance. Biff. George. George. How could I have been so careless. One point twenty-one gigawatts. Tom, how am I gonna generate that kind of power, it can't be done, it can't.
+
+    He's fine, and he's completely unaware that anything happened. As far as he's concerned the trip was instantaneous. That's why Einstein's watch is exactly one minute behind mine. He skipped over that minute to instantly arrive at this moment in time. Come here, I'll show you how it works. First, you turn the time circuits on. This readout tell you where you're going, this one tells you where you are, this one tells you where you were. You imput the destination time on this keypad. Say, you wanna see the signing of the declaration of independence, or witness the birth or Christ. Here's a red-letter date in the history of science, November 5, 1955. Yes, of course, November 5, 1955. Y'know this time it wasn't my fault. The Doc set all of his clocks twenty-five minutes slow. Where? Radiation suit, of course, cause all of the fall out from the atomic wars. This is truly amazing, a portable television studio. No wonder your president has to be an actor, he's gotta look good on television. Thanks.
+
+    Yeah well look, Marvin, Marvin, you gotta play. See that's where they kiss for the first time on the dance floor. And if there's no music, they can't dance, and if they can't dance, they can't kiss, and if they can't kiss, they can't fall in love and I'm history. I'd like you to meet my good friend George McFly. Ronald Reagon. Alright, let's set your destination time. This is the exact time you left. I'm gonna send you back at exactly the same time. It's be like you never left. Now, I painted a white line on the street way over there, that's where you start from. I've calculated the distance and wind resistance fresh to active from the moment the lightning strikes, at exactly 7 minutes and 22 seconds. When this alarm goes off you hit the gas. 1955? You're my ma- you're my ma.
+
+    Hi, Marty. I don't like her, Marty. Any girl who calls a boy is just asking for trouble. Precisely. Whoa, this is heavy. My insurance, it's your car, your insurance should pay for it. Hey, I wanna know who's gonna pay for this? I spilled beer all over it when that car smashed into me. Who's gonna pay my cleaning bill?
+
+    Lorraine. Yeah, I think maybe you do. Right, I got it. Nothing. I'll be at my grandma's. Here, let me give you the number. Bye.
+
+    I gotta go, uh, I gotta go. Thanks very much, it was wonderful, you were all great. See you all later, much later. I know, and all I could say is I'm sorry. I'm gonna be at the dance. You're gonna be in the car with her. I got enough practical jokes for one evening. Good night, future boy.
+
+    Go. Re-elect Mayor Goldie Wilson. Progress is his middle name. Jesus, you smoke too? Oh, what I meant to day was- Dear Doctor Brown, on the night that I go back in time, you will be shot by terrorists. Please take whatever precautions are necessary to prevent this terrible disaster. Your friend, Marty.
+
+    Oh, what I meant to day was- Something that really cooks. Alright, alright this is an oldie, but uh, it's an oldie where I come from. Alright guys, let's do some blues riff in b, watch me for the changes, and uh, try and keep up, okay. That's him. George. It's a board with wheels.
+
+    Uh, coast guard. Where? Can I go now, Mr. Strickland? That's for messing up my hair. Last night, Darth Vader came down from planet Vulcan. And he told me that if I didn't take Lorraine, that he'd melt my brain.
+
+    Leave her alone, you bastard. Hey, hey, I've seen this one, I've seen this one. This is a classic, this is where Ralph dresses up as the man from space. Unroll their fire. Lorenzo, where're you keys? C'mon, open up, let me out of here, Yo.
+
+    I, I don't know. Now Biff, don't con me. Cause, George, she wants to go to the dance with you, she just doesn't know it yet. That's why we got to show her that you, George McFly, are a fighter. You're somebody who's gonna stand up for yourself, someone who's gonna protect her. Doc? Leave her alone, you bastard.
+
+    Doc. Now, of course not, Biff, now, I wouldn't want that to happen. Uh listen, do you know where Riverside Drive is? Hello, hello, anybody home? Think, McFly, think. I gotta have time to recopy it. Do your realize what would happen if I hand in my homework in your handwriting? I'd get kicked out of school. You wouldn't want that to happen would you, would you? Right.
+
+    You know, Doc, you left your equipment on all week. Oh. What did you sleep in your clothes again last night. What did she say? It's your mom, she's tracked you down. Quick, let's cover the time machine. Uh, I think so.
+
+    What, well you mean like a date? Hi, it's really a pleasure to meet you. Yeah, where does he live? Leave me alone. Well just gimme something without any sugar in it, okay?
+
+    Quiet down, I'm sure the car is fine. you guys look great. Mom, you look so thin. Now, Biff, um, can I assume that your insurance is gonna pay for the damage? Excuse me. Radiation suit, of course, cause all of the fall out from the atomic wars. This is truly amazing, a portable television studio. No wonder your president has to be an actor, he's gotta look good on television.
+
+    Look, I'm just not ready to ask Lorraine out to the dance, and not you, nor anybody else on this planet is gonna make me change my mind. This Saturday night, mostly clear, with some scattered clouds. Lows in the upper forties. I just wanna use the phone. oh yeah, all you gotta do is go over there and ask her. Huh?
+
+    Listen, Doc. That was so stupid, Grandpa hit him with the car. We never would have fallen in love. Uh, I think so. Thanks a lot, kid.
+
+    Don't tell me anything. Um, yeah well I might have sort of ran into my parents. Shut your filthy mouth, I'm not that kind of girl. Listen, I gotta go but I wanted to tell you that it's been educational. Now remember, according to my theory you interfered with with your parent's first meeting. They don't meet, they don't fall in love, they won't get married and they wont have kids. That's why your older brother's disappeared from that photograph. Your sister will follow and unless you repair the damages, you will be next.
+
+    Why am I always the last one to know about these things. Oh, yeah, yeah. Where's Einstein, is he with you? Don't pay any attention to him, he's in one of his moods. Sam, quit fiddling with that thing, come in here to dinner. Now let's see, you already know Lorraine, this is Milton, this is Sally, that's Toby, and over there in the playpen is little baby Joey. Yeah, I guessed you're a sailor, aren't you, that's why you wear that life preserver.
+
+    Uh listen, do you know where Riverside Drive is? You bet. Whoa, this is heavy. My god, do you know what this means? It means that this damn thing doesn't work at all. Hey I'm talking to you, McFly, you Irish bug.
+
+    So you're my Uncle Joey. Better get used to these bars, kid. Marty, will we ever see you again? C'mon, more, dammit. Jeez. Holy shit. Let's see if you bastards can do ninety. He's a very strange young man. The car, Dad, I mean He wrecked it, totaled it. I needed that car tomorrow night, Dad, I mean do you have any idea how important this was, do you have any clue?
+
+    Um, yeah well I might have sort of ran into my parents. Crazy drunk drivers. Right, gimme a Pepsi free. Check out that four by four. That is hot. Someday, Jennifer, someday. Wouldn't it be great to take that truck up to the lake. Throw a couple of sleeping bags in the back. Lie out under the stars. Hey, not too early I sleep in on Saturday. Oh, McFly, your shoe's untied. Don't be so gullible, McFly. You got the place fixed up nice, McFly. I have you're car towed all the way to your house and all you've got for me is light beer. What are you looking at, butthead. Say hi to your mom for me.
+
+    Doc, look, all we need is a little plutonium. Yeah, gimme a Tab. Okay, alright, Saturday is good, Saturday's good, I could spend a week in 1955. I could hang out, you could show me around. My god, it's my mother. Put your pants back on. Thank you, don't forget to take a flyer.
+
+    Why is she gonna get angry with you? Whoa, whoa, okay. It's uh, the other end of town, a block past Maple. David, watch your mouth. You come here and kiss your mother before you go, come here. What the hell is a gigawatt?
+
+    Right, gimme a Pepsi free. The flux capacitor. Well, uh, listen, uh, I really- Right, I got it. Did you hurt your head?
+
+    Oh. Yes, definitely, god-dammit George, swear. Okay, so now, you come up, you punch me in the stomach, I'm out for the count, right? And you and Lorraine live happily ever after. I will. Say that again. Just relax now Calvin, you've got a big bruise on you're head.
+
+    Of course, the Enchantment Under The Sea Dance they're supposed to go to this, that's where they kiss for the first time. Great good, good, Lorraine, I had a feeling about you two. Hey wait, wait a minute, who are you? Stella, another one of these damn kids jumped in front of my car. Come on out here, help me take him in the house. Okay, alright, I'll prove it to you. Look at my driver's license, expires 1987. Look at my birthday, for crying out load I haven't even been born yet. And, look at this picture, my brother, my sister, and me. Look at the sweatshirt, Doc, class of 1984. I guarantee it.
+
+    What, well you mean like a date? Kids, we're gonna have to eat this cake by ourselves, Uncle Joey didn't make parole again. I think it would be nice, if you all dropped him a line. McFly. Good, there's somebody I'd like you to meet. Lorraine. Shape up, man. You're a slacker. You wanna be a slacker for the rest of your life?
+
+    Lorenzo, where're you keys? C'mon. I've gotta go. I'm too loud. I can't believe it. I'm never gonna get a chance to play in front of anybody. Why do you keep following me around?
+
+    Good, I'll see you tonight. Don't forget, now, 1:15 a.m., Twin Pines Mall. Like I always told you, if you put your mind to it you could accomplish anything. Welcome to my latest experiment. It's the one I've been waiting for all my life. I'm gonna get that son-of-a-bitch. I'm gonna ram him.
+
+    Uh? Doc, look, all we need is a little plutonium. The only way we're gonna get those two to successfully meet is if they're alone together. So you've got to get your father and mother to interact at some sort of social- Back to the future. Get out of town, I didn't know you did anything creative. Ah, let me read some.
+
+    Hey, McFly, I thought I told you never to come in here. Well it's gonna cost you. How much money you got on you? Doc, look, all we need is a little plutonium. Where were we. Wow, ah Red, you look great. Everything looks great. 1:24, I still got time. Oh my god. No, no not again, c'mon, c'mon. Hey. Libyans. Doc, she's beautiful. She's crazy about me. Look at this, look what she wrote me, Doc. That says it all. Doc, you're my only hope.
+
+    Well, they're your parents, you must know them. What are their common interests, what do they like to do together? Well yeah, you know we have two of them. whoa, whoa Doc, stuck here, I can't be stuck here, I got a life in 1985. I got a girl. Where? Well just gimme something without any sugar in it, okay?
+
+    Go. Jennifer. Lorraine, are you up there? Hello. Listen, I gotta go but I wanted to tell you that it's been educational.
+
+    Ahh. Hey wait, wait a minute, who are you? Stella, another one of these damn kids jumped in front of my car. Come on out here, help me take him in the house. Where does he come from? Yeah, he's right here. That's true, Marty, I think you should spend the night. I think you're our responsibility.
+
+    Lorenzo, where're you keys? Cause, George, she wants to go to the dance with you, she just doesn't know it yet. That's why we got to show her that you, George McFly, are a fighter. You're somebody who's gonna stand up for yourself, someone who's gonna protect her. No, Doc. I, I don't know. Oh, uh, this is my Doc, Uncle, Brown.
+
+    What a nightmare. I don't know, but I'm gonna find out. Great Scott. Let me see that photograph again of your brother. Just as I thought, this proves my theory, look at your brother. Hey, Doc? Doc. Hello, anybody home? Einstein, come here, boy. What's going on? Wha- aw, god. Aw, Jesus. Whoa, rock and roll. Yo Oh, you mean how you're supposed to act on a first date.
+
+    George, help me, please. Doc, you gotta help me. you were the only one who knows how your time machine works. On the night I go back in time, you get- Doc. I have to tell you about the future. Uh listen, do you know where Riverside Drive is?
+
+    And he could sleep in my room. How's your head? Ahh. Doc, you gotta help me. you were the only one who knows how your time machine works. But, what are you blind McFly, it's there. How else do you explain that wreck out there?
+
+    I know, and all I could say is I'm sorry. Right. Tab? I can't give you a tab unless you order something. Of course, the Enchantment Under The Sea Dance they're supposed to go to this, that's where they kiss for the first time. Yeah but George, Lorraine wants to go with you. Give her a break.
+
+    I, I don't know. You do? No no no this sucker's electrical, but I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity that I need. Yeah well, I saw it on a rerun. No, I refuse to except the responsibility.
+
+    That's good advice, Marty. No, Doc. Thank you, don't forget to take a flyer. Alright, good-bye Einy. Oh, watch that re-entry, it's a little bumpy. The only way we're gonna get those two to successfully meet is if they're alone together. So you've got to get your father and mother to interact at some sort of social-
+
+    Let me show you my plan for sending you home. Please excuse the crudity of this model, I didn't have time to build it to scale or to paint it. I hope so. Well, they're bigger than me. Hi, it's really a pleasure to meet you. Alright, c'mon, I think we're safe.
+
+    Something that really cooks. Alright, alright this is an oldie, but uh, it's an oldie where I come from. Alright guys, let's do some blues riff in b, watch me for the changes, and uh, try and keep up, okay. But you're good, Marty, you're really good. And this audition tape of your is great, you gotta send it in to the record company. It's like Doc's always saying. I'll get it back to you, alright? You cost three-hundred buck damage to my car, you son-of-a-bitch. And I'm gonna take it out of your ass. Hold him. Excuse me.
+
+    Listen, I gotta go but I wanted to tell you that it's been educational. Right, gimme a Pepsi free. I guess you guys aren't ready for that yet. But your kids are gonna love it. Perfect, just perfect. That's Calvin Klein, oh my god, he's a dream.
+
+    She's just trying to keep you respectable. Yeah, I'll keep that in mind. You wanna a Pepsi, pall, you're gonna pay for it. Okay, real mature guys. Okay, Biff, will you pick up my books? Oh, you mean how you're supposed to act on a first date.
+
+    What do you mean you've seen this, it's brand new. What's a rerun? Do you mind if we park for a while? Doc, Doc. Oh, no. You're alive. Bullet proof vest, how did you know, I never got a chance to tell you. About all that talk about screwing up future events, the space time continuum. I swiped it from the old lady's liquor cabinet.
+
+    Marty, I'm sorry, but the only power source capable of generating one point twenty-one gigawatts of electricity is a bolt of lightning. A colored mayor, that'll be the day. Are you okay? I hope so. Well looky what we have here. No no no, you're staying right here with me.
+
+    Indeed I will, roll em. I, Doctor Emmett Brown, am about to embark on an historic journey. What have I been thinking of, I almost forgot to bring some extra plutonium. How did I ever expect to get back, one pallet one trip I must be out of my mind. What is it Einy? Oh my god, they found me, I don't know how but they found me. Run for it, Marty. Why do you keep following me around? Well, because George, nice girls get angry when guys take advantage of them. Well uh, good, fine. Now that's a risk you'll have to take you're life depends on it.
+
+    C'mon. Oh, you make it sound so easy. I just, I wish I wasn't so scared. What a nightmare. Look, you gotta listen to me. Like I always told you, if you put your mind to it you could accomplish anything.
+
+    Thanks. Mother, with Marty's parents out of town, don't you think he oughta spend the night, after all, Dad almost killed him with the car. What the hell is this? Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Well, aren't you going up to the lake tonight, you've been planning it for two weeks.
+
+    Say that again. What? Hey, Doc? Doc. Hello, anybody home? Einstein, come here, boy. What's going on? Wha- aw, god. Aw, Jesus. Whoa, rock and roll. Yo That Biff, what a character. Always trying to get away with something. Been on top of Biff ever since high school. Although, if it wasn't for him- Lorraine, have you ever, uh, been in a situation where you know you had to act a certain way but when you got there, you didn't know if you could go through with it?
+
+    Oh, yeah, yeah. Good morning, Mom. Oh, Marty, I almost forgot, Jennifer Parker called. Did you hurt your head? Good. Have a good trip Einstein, watch your head. I need fuel. Go ahead, quick, get in the car.
+
+    Well, Marty, I want to thank you for all your good advice, I'll never forget it. Shut your filthy mouth, I'm not that kind of girl. One point twenty-one gigawatts. One point twenty-one gigawatts. Great Scott. Hi, Marty. Oh.
+
+    It's a board with wheels. Right. Let's put him in there. My god, do you know what this means? It means that this damn thing doesn't work at all. Uh, look me up when you get there.
+
+    Lynda, first of all, I'm not your answering service. Second of all, somebody named Greg or Craig called you just a little while ago. Save the clock tower, save the clock tower. Mayor Wilson is sponsoring an initiative to replace that clock. Thirty years ago, lightning struck that clock tower and the clock hasn't run since. We at the Hill Valley Preservation Society think it should be preserved exactly the way it is as part of our history and heritage. Right. whoa, this is it, this is the part coming up, Doc. Doc?
+
+    Oh, I've been so worried about you ever since you ran off the other night. Are you okay? I'm sorry I have to go. Isn't he a dream boat? Yeah. Just relax now Calvin, you've got a big bruise on you're head. Save the clock tower. Silence Earthling. my name is Darth Vader. I'm am an extra-terrestrial from the planet Vulcan.
+
+    Yeah well, I saw it on a rerun. Yeah. Why that's me, look at me, I'm an old man. No sir, I'm gonna make something out of myself, I'm going to night school and one day I'm gonna be somebody. Doc.
+
+    Yeah, well uh, lets keep this brain melting stuff to ourselves, okay? Sam, quit fiddling with that thing and come in here and eat your dinner. Alright, we're the pinheads. Will you take care of that? Give me a hand, Lorenzo. Ow, dammit, man, I sliced my hand.
+
+    Mayor Goldie Wilson, I like the sound of that. Yeah, you got my homework finished, McFly? Oh, just a little weather experiment. Marty, I'm sorry, but the only power source capable of generating one point twenty-one gigawatts of electricity is a bolt of lightning. Evening, Doctor Brown, what's with the wire?
+
+    Mother, with Marty's parents out of town, don't you think he oughta spend the night, after all, Dad almost killed him with the car. Good, you could start by sweeping the floor. I have a feeling too. Why am I always the last one to know about these things. Why not?
+
+    This is it. This is the answer. It says here that a bolt of lightning is gonna strike the clock tower precisely at 10:04 p.m. next Saturday night. If we could somehow harness this bolt of lightning, channel it into the flux capacitor, it just might work. Next Saturday night, we're sending you back to the future. It's taken me almost thirty years and my entire family fortune to realize the vision of that day, my god has it been that long. Things have certainly changed around here. I remember when this was all farmland as far as the eye could see. Old man Peabody, owned all of this. He had this crazy idea about breeding pine trees. Quiet down, I'm sure the car is fine. But you're good, Marty, you're really good. And this audition tape of your is great, you gotta send it in to the record company. It's like Doc's always saying. Well uh, good, fine.
+
+    Oh. What the hell is a gigawatt? Unroll their fire. Nothing. Well that's your name, isn't it? Calvin Klein. it's written all over your underwear. Oh, I guess they call you Cal, huh?
+
+    Hi, it's really a pleasure to meet you. Well, what if they didn't like them, what if they told me I was no good. I guess that would be pretty hard for somebody to understand. Excuse me. Look, George, I'm telling you George, if you do not ask Lorraine to that dance, I'm gonna regret it for the rest of my life. Marty, don't be such a square. Everybody who's anybody drinks.
+
+    That's a Florence Nightingale effect. It happens in hospitals when nurses fall in love with their patients. Go to it, kid. I guess you guys aren't ready for that yet. But your kids are gonna love it. whoa, whoa Doc, stuck here, I can't be stuck here, I got a life in 1985. I got a girl. Of course, the Enchantment Under The Sea Dance they're supposed to go to this, that's where they kiss for the first time. I can't play.
+
+    Where were we. Don't worry, I'll take care of the lightning, you take care of your pop. By the way, what happened today, did he ask her out? Whoa, whoa, kid, kid, stop, stop, stop, stop. What Lorraine, what? Well, what if they didn't like them, what if they told me I was no good. I guess that would be pretty hard for somebody to understand.
+
+    The appropriate question is, weren't the hell are they. Einstein has just become the world's first time traveler. I sent him into the future. One minute into the future to be exact. And at exactly 1:21 a.m. we should cat h up with him and the time machine. Alright, okay listen, keep your pants on, she's over in the cafe. God, how do you do this? What made you change your mind, George? Don't stop, Wilbert, drive. Yeah, it's 8:00. Hey c'mon, I had to change, you think I'm going back in that zoot suit? The old man really came through it worked.
+
+    Calvin, why do you keep calling me Calvin? A block passed Maple, that's John F. Kennedy Drive. Oh, hi , Marty. I didn't hear you come in. Fascinating device, this video unit. Which one's your pop? Jennifer.
+
+    Oh, no no no, I never uh, I never let anybody read my stories. Well, you mean, it makes perfect sense. Well, I guess that's everything. Uh, well, I gotta go. Alright, we're the pinheads.
+
+    Sit here, Marty. See, there's Biff out there waxing it right now. Now, Biff, I wanna make sure that we get two coats of wax this time, not just one. Over there, on my hope chest. I've never seen purple underwear before, Calvin. Good, I'll see you tonight. Don't forget, now, 1:15 a.m., Twin Pines Mall. Your, your right.
+
+    Look me up when you get there, guess I'll be about 47. Wait a minute, wait a minute. 1:15 in the morning? Marty, that's completely out of the question, you must not leave this house. you must not see anybody or talk to anybody. Anything you do could have serious repercussions on future events. Do you understand? My name's Lorraine, Lorraine Baines. Good. Have a good trip Einstein, watch your head.
+
+    Ahh. Ahh. I have to tell you about the future. McFly. What Lorraine, what? No, get out of town, my mom thinks I'm going camping with the guys. Well, Jennifer, my mother would freak out if she knew I was going up there with you. And I get this standard lecture about how she never did that kind of stuff when she was a kid. Now look, I think she was born a nun.
+
+    Whoa, this is heavy. Radiation suit, of course, cause all of the fall out from the atomic wars. This is truly amazing, a portable television studio. No wonder your president has to be an actor, he's gotta look good on television. Yeah. You're gonna break his arm. Biff, leave him alone. Let him go. Let him go. Right, I got it.
+
+    Alright, McFly, you're asking for it, and now you're gonna get it. Yeah, exactly. You okay, is everything alright? This is uh, this is heavy duty, Doc, this is great. Uh, does it run on regular unleaded gasoline? Don't tell me anything.
+
+    And Jack Benny is secretary of the Treasury. Uh, plutonium, wait a minute, are you telling me that this sucker's nuclear? You know, Doc, you left your equipment on all week. He laid out Biff in one punch. I never knew he had it in him. He never stood up to Biff in his life. Unfortunately no, it requires something with a little more kick, plutonium.
+
+    Wrecked? When did this happen and- Whoa, wait a minute, Doc, are you telling me that my mother has got the hots for me? Where the hell are they. Yeah, well, I still don't understand what Dad was doing in the middle of the street. Tab? I can't give you a tab unless you order something.
+
+    Go. Go. you guys look great. Mom, you look so thin. George. George. Go. Breakfast.
+
+    Wow, ah Red, you look great. Everything looks great. 1:24, I still got time. Oh my god. No, no not again, c'mon, c'mon. Hey. Libyans. Say, why do you let those boys push you around like that? Yeah, well, I still don't understand what Dad was doing in the middle of the street. Looks like a airplane, without wings. Uh, stories, science fiction stories, about visitors coming down to Earth from another planet.
+
+    Hey guys, you gotta get back in there and finish the dance. Can I go now, Mr. Strickland? Doc, she didn't even look at him. It's about the future, isn't it? Einstein, hey Einstein, where's the Doc, boy, huh? Doc
+
+    Dammit, Doc, why did you have to tear up that letter? If only I had more time. Wait a minute, I got all the time I want I got a time machine, I'll just go back and warn him. 10 minutes oughta do it. Time-circuits on, flux-capacitor fluxing, engine running, alright. No, no no no no, c'mon c'mon. C'mon c'mon, here we go, this time. Please, please, c'mon. Look, you gotta listen to me. Uh, well, actually, I figured since it wasn't due till Monday- No, Marty, we've already agreed that having information about the future could be extremely dangerous. Even if your intentions are good, they could backfire drastically. Whatever you've got to tell me I'll find out through the natural course of time. What kind of date? I don't know, what do kids do in the fifties?
+
+    Holy shit. Of course I do. Just a second, let's see if I could find it. Marty, you made it. What was it, George, bird watching? Wait a minute, wait a minute, Doc, are you telling me that you built a time machine out of a delorean.
+
+    Yeah Mom, we know, you've told us this story a million times. You felt sorry for him so you decided to go with him to The Fish Under The Sea Dance. But, what are you blind McFly, it's there. How else do you explain that wreck out there? Marty, you seem so nervous, is something wrong? Yeah, I think it's a major embarrassment having an uncle in prison. And where's my reports?
+
+    He's a very strange young man. I do understand. If I know too much about my own future I could endanger my own existence, just as you endangered yours. Well, this is a radiation suit. Uh, well, okay Biff, uh, I'll finish that on up tonight and I'll bring it over first thing tomorrow morning. Something that really cooks. Alright, alright this is an oldie, but uh, it's an oldie where I come from. Alright guys, let's do some blues riff in b, watch me for the changes, and uh, try and keep up, okay.
+
+    What you got under here? You guys, take him in back and I'll be right there. Well c'mon, this ain't no peep show. Wait a minute, what are you doing, Doc? No no no, Doc, I just got here, okay, Jennifer's here, we're gonna take the new truck for a spin. Alright, punk, now-
+
+    Believe me, Marty, you're better off not having to worry about all the aggravation and headaches of playing at that dance. What were you doing in the middle of the street, a kid your age. Oh honey, he's teasing you, nobody has two television sets. So tell me, future boy, who's president of the United States in 1985? You know what I do in those situations?
+
+    Now which one was it, Greg or Craig? Uh, well, actually, I figured since it wasn't due till Monday- No no no this sucker's electrical, but I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity that I need. I'm too loud. I can't believe it. I'm never gonna get a chance to play in front of anybody. Ah.
+
+    Yeah. It's information about the future isn't it. I warned you about this kid. The consequences could be disastrous. I know, and all I could say is I'm sorry. Good morning, Mom. Oh, Marty, I almost forgot, Jennifer Parker called. Excuse me.
+
+    Whoa, this is heavy. That's him. That's right, he's gonna be mayor. Oh no, don't touch that. That's some new specialized weather sensing equipment. Ronald Reagon, the actor? Then who's vice president, Jerry Lewis? I suppose Jane Wymann is the first lady.
+
+    Marty, you're beginning to sound just like my mother. We never would have fallen in love. Now that's a risk you'll have to take you're life depends on it. Yeah, but you're uh, you're so, you're so thin. Well just gimme something without any sugar in it, okay?
+
+    You guys, take him in back and I'll be right there. Well c'mon, this ain't no peep show. Alright, punk, now- Alright, okay. Alright, there she is, George. Just go in there and invite her. Yeah, who are you? Oh, hi , Marty. I didn't hear you come in. Fascinating device, this video unit.
+
+    C'mon, open up, let me out of here, Yo. You have this thing hooked up to the car? Maybe you were adopted. Okay, alright, Saturday is good, Saturday's good, I could spend a week in 1955. I could hang out, you could show me around. Why is she gonna get angry with you?
+
+    Doc. It's uh, the other end of town, a block past Maple. Oh honey, he's teasing you, nobody has two television sets. Okay, that's enough. Now stop the microphone. I'm sorry fellas. I'm afraid you're just too darn loud. Next, please. Where's the next group, please. Yeah, I'm- mayor. Now that's a good idea. I could run for mayor.
+
+    Yeah, sure, okay. Oh, uh, this is my Doc, Uncle, Brown. What's the meaning of this. Ho, you mean you're gonna touch her on her- What, well you mean like a date?
+
+    What's that thing he's on? Um, well it's a delorean, right? Shape up, man. You're a slacker. You wanna be a slacker for the rest of your life? Okay. Yeah, it's 8:00.
+
+    The appropriate question is, weren't the hell are they. Einstein has just become the world's first time traveler. I sent him into the future. One minute into the future to be exact. And at exactly 1:21 a.m. we should cat h up with him and the time machine. Who are you? Uh, plutonium, wait a minute, are you telling me that this sucker's nuclear? That's right, twenty five years into the future. I've always dreamed on seeing the future, looking beyond my years, seeing the progress of mankind. I'll also be able to see who wins the next twenty-five world series. Yes, definitely, god-dammit George, swear. Okay, so now, you come up, you punch me in the stomach, I'm out for the count, right? And you and Lorraine live happily ever after.
+
+    this has gotta be a dream. No, fine, no , good, fine, good. Doc. Whoa, wait, Doc. Alright kid, you stick to your father like glue and make sure that he takes her to the dance.
+
+    Yeah. Well, Biff. Well looky what we have here. No no no, you're staying right here with me. Don't pay any attention to him, he's in one of his moods. Sam, quit fiddling with that thing, come in here to dinner. Now let's see, you already know Lorraine, this is Milton, this is Sally, that's Toby, and over there in the playpen is little baby Joey. Yeah, I guessed you're a sailor, aren't you, that's why you wear that life preserver.
+
+    Thanks a lot, kid. That's true, Marty, I think you should spend the night. I think you're our responsibility. C'mon, c'mon let's go. Let me show you my plan for sending you home. Please excuse the crudity of this model, I didn't have time to build it to scale or to paint it. Y'know this time it wasn't my fault. The Doc set all of his clocks twenty-five minutes slow.
+
+    Look, you gotta listen to me. It's about the future, isn't it? Remember, fellas, the future is in your hands. If you believe in progress, re-elect Mayor Red Thomas, progress is his middle name. Mayor Red Thomas's progress platform means more jobs, better education, bigger civic improvements, and lower taxes. On election day, cast your vote for a proven leader, re-elect Mayor Red Thomas... Bet your ass it works. The hell you doing to my car?
+
+    We do now. A block passed Maple, that's John F. Kennedy Drive. Doc. Where the hell are they. Marty, this may seem a little foreward, but I was wondering if you would ask me to the Enchantment Under The Sea Dance on Saturday.
+
+    Hello, Jennifer. Hey kid, what you do, jump ship? Whoa, they really cleaned this place up, looks brand new. Uncle Jailbird Joey? Thank god I still got my hair. What on Earth is that thing I'm wearing?
+
+    Doc. That's Strickland. Jesus, didn't that guy ever have hair? What a nightmare. Well, they're your parents, you must know them. What are their common interests, what do they like to do together? Now remember, according to my theory you interfered with with your parent's first meeting. They don't meet, they don't fall in love, they won't get married and they wont have kids. That's why your older brother's disappeared from that photograph. Your sister will follow and unless you repair the damages, you will be next.
+
+    Oh. Uh, look me up when you get there. Listen, I gotta go but I wanted to tell you that it's been educational. My equipment, that reminds me, Marty, you better not hook up to the amplifier. There's a slight possibility for overload. Thanks.
+
+    Oh, you make it sound so easy. I just, I wish I wasn't so scared. Hey beat it, spook, this don't concern you. 1955? You're my ma- you're my ma. Jennifer, oh are you a sight for sore eyes. Let me look at you. Say, why do you let those boys push you around like that?
+
+    Of course, from a group of Libyan Nationalists. They wanted me to build them a bomb, so I took their plutonium and in turn gave them a shiny bomb case full of used pinball machine parts. C'mon, c'mon let's go. No no no this sucker's electrical, but I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity that I need. You don't understand. Now that's a risk you'll have to take you're life depends on it.
+
+    Say, why do you let those boys push you around like that? That Biff, what a character. Always trying to get away with something. Been on top of Biff ever since high school. Although, if it wasn't for him- Uncle Jailbird Joey? When could weathermen predict the weather, let alone the future. Right.
+
+    My equipment, that reminds me, Marty, you better not hook up to the amplifier. There's a slight possibility for overload. No, Marty, we've already agreed that having information about the future could be extremely dangerous. Even if your intentions are good, they could backfire drastically. Whatever you've got to tell me I'll find out through the natural course of time. Oh. Hey beat it, spook, this don't concern you. Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay?
+
+    Well, ma, we talked about this, we're not gonna go to the lake, the car's wrecked. Let's get you into a radiation suit, we must prepare to reload. Yeah, alright, bye-bye. What? Uh, Doc. What did you sleep in your clothes again last night.
+
+    Ah, where're my pants? You too. This is for all you lovers out there. Stop it. What did you say?
+
+    I still don't understand, how am I supposed to go to the dance with her, if she's already going to the dance with you. Watch it, Goldie. I'll call you tonight. He's your brother, Mom. Yes, definitely, god-dammit George, swear. Okay, so now, you come up, you punch me in the stomach, I'm out for the count, right? And you and Lorraine live happily ever after.
+
+    Our first television set, Dad just picked it up today. Do you have a television? Good, I'll see you tonight. Don't forget, now, 1:15 a.m., Twin Pines Mall. Right check, Doc. Ho ho ho, look at it roll. Now we could watch Jackie Gleason while we eat. What, well you mean like a date?
+
+    The future, it's where you're going? He's absolutely right, Marty. the last thing you need is headaches. Listen, I gotta go but I wanted to tell you that it's been educational. That's a Florence Nightingale effect. It happens in hospitals when nurses fall in love with their patients. Go to it, kid. Are you okay?
+
+    We never would have fallen in love. Which one's your pop? Oh, thank you, thank you. Okay now, we run some industrial strength electrical cable from the top of the clocktower down to spreading it over the street between two lamp posts. Meanwhile, we out-fitted the vehicle with this big pole and hook which runs directly into the flux-capacitor. At the calculated moment, you start off from down the street driving toward the cable execrating to eighty-eight miles per hour. According to the flyer, at !0:04 pm lightning will strike the clocktower sending one point twenty-one gigawatts into the flux-capacitor, sending you back to 1985. Alright now, watch this. You wind up the car and release it, I'll simulate the lightening. Ready, set, release. Huhh. I'm sure that in 1985, plutonium is available at every corner drug store, but in 1955, it's a little hard to come by. Marty, I'm sorry, but I'm afraid you're stuck here. Well, ma, we talked about this, we're not gonna go to the lake, the car's wrecked.
+
+    You bet. Mom, is that you? Time machine, I haven't invented any time machine. Wait a minute, wait a minute, Doc, are you telling me that you built a time machine out of a delorean. Remember, fellas, the future is in your hands. If you believe in progress, re-elect Mayor Red Thomas, progress is his middle name. Mayor Red Thomas's progress platform means more jobs, better education, bigger civic improvements, and lower taxes. On election day, cast your vote for a proven leader, re-elect Mayor Red Thomas...
+
+    Actually, people call me Marty. Mother, with Marty's parents out of town, don't you think he oughta spend the night, after all, Dad almost killed him with the car. whoa, this is it, this is the part coming up, Doc. Let's get you into a radiation suit, we must prepare to reload. Which one's your pop?
+
+    Just relax now Calvin, you've got a big bruise on you're head. Now, now, Biff, now, I never noticed any blindspot before when I would drive it. Hi, son. You got a permit for that? Our first television set, Dad just picked it up today. Do you have a television? Marty, I'm sorry, but the only power source capable of generating one point twenty-one gigawatts of electricity is a bolt of lightning.
+
+    C'mon. He's a peeping tom. Dad. Don't pay any attention to him, he's in one of his moods. Sam, quit fiddling with that thing, come in here to dinner. Now let's see, you already know Lorraine, this is Milton, this is Sally, that's Toby, and over there in the playpen is little baby Joey. Yeah man, that was good. Let's do another one. Well, Marty, I want to thank you for all your good advice, I'll never forget it.
+
+    Hey man, the dance is over. Unless you know someone else who could play the guitar. Lorenzo, where're you keys? You broke it. Wow, look at him go. Leave me alone. Alright, okay. Alright, there she is, George. Just go in there and invite her.
+
+    I noticed you band is on the roster for dance auditions after school today. Why even bother Mcfly, you haven't got a chance, you're too much like your own man. No McFly ever amounted to anything in the history of Hill Valley. George, help me, please. Yeah man, that was good. Let's do another one. Just finishing up the second coat now. You can't, uh, that is, uh, nobody's home.
+
+    Go. Wait a minute, Doc. What are you talking about? What happens to us in the future? What do we become assholes or something? I need fuel. Go ahead, quick, get in the car. Why is she gonna get angry with you? The car, Dad, I mean He wrecked it, totaled it. I needed that car tomorrow night, Dad, I mean do you have any idea how important this was, do you have any clue?
+
+    George, there's nothing to be scared of. All it takes is a little self confidence. You know, if you put your mind to it, you could accomplish anything. But I can't go to the dance, I'll miss my favorite television program, Science Fiction Theater. Uh, no, no, no, no. What are you looking at, butt-head? Can't be. This is nuts. Aw, c'mon. Thank god I still got my hair. What on Earth is that thing I'm wearing?
+
+    You know what I do in those situations? Well, what if they didn't like them, what if they told me I was no good. I guess that would be pretty hard for somebody to understand. No, fine, no , good, fine, good. Precisely. Hey, Doc? Doc. Hello, anybody home? Einstein, come here, boy. What's going on? Wha- aw, god. Aw, Jesus. Whoa, rock and roll. Yo
+
+    Hey, George, buddy, you weren't at school, what have you been doing all day? What did your mother ever see in that kid? He's fine, and he's completely unaware that anything happened. As far as he's concerned the trip was instantaneous. That's why Einstein's watch is exactly one minute behind mine. He skipped over that minute to instantly arrive at this moment in time. Come here, I'll show you how it works. First, you turn the time circuits on. This readout tell you where you're going, this one tells you where you are, this one tells you where you were. You imput the destination time on this keypad. Say, you wanna see the signing of the declaration of independence, or witness the birth or Christ. Here's a red-letter date in the history of science, November 5, 1955. Yes, of course, November 5, 1955. I don't wanna see you in here again. You'll find out in thirty years.
+
+    Oh. Yeah, you got my homework finished, McFly? Well, she's not doing a very good job. Hey. Why am I always the last one to know about these things.
+
+    No sir, I'm gonna make something out of myself, I'm going to night school and one day I'm gonna be somebody. Let me show you my plan for sending you home. Please excuse the crudity of this model, I didn't have time to build it to scale or to paint it. Doc. That's right. Biff.
+
+    Scram, McFly. whoa, whoa Doc, stuck here, I can't be stuck here, I got a life in 1985. I got a girl. That's a Florence Nightingale effect. It happens in hospitals when nurses fall in love with their patients. Go to it, kid. Marty, why are you so nervous? Well, this is a radiation suit.
+
+    I can't believe you loaned me a car, without telling me it had a blindspot. I could've been killed. Can I go now, Mr. Strickland? Marty, will we ever see you again? Uh, well, I gotta go. I know, and all I could say is I'm sorry.
+
+    Pa, what is it? What is it, Pa? Your not gonna be picking a fight, Dad, dad dad daddy-o. You're coming to a rescue, right? Okay, let's go over the plan again. 8:55, where are you gonna be. Let's get you into a radiation suit, we must prepare to reload. Believe me, Marty, you're better off not having to worry about all the aggravation and headaches of playing at that dance. Ah.
+
+    Mr. McFly, Mr. McFly, this just arrived, oh hi Marty. I think it's your new book. That's a Florence Nightingale effect. It happens in hospitals when nurses fall in love with their patients. Go to it, kid. That's right, he's gonna be mayor. Great Scott. Let me see that photograph again of your brother. Just as I thought, this proves my theory, look at your brother. What?
+
+    Nothing. Because, you might regret it later in life. What, what is it hot? Oh, no no no, I never uh, I never let anybody read my stories. C'mon, c'mon.
+
+    That's right. Wait a minute, what are you doing, Doc? Now, now, Biff, now, I never noticed any blindspot before when I would drive it. Hi, son. Marty, don't be such a square. Everybody who's anybody drinks. I swiped it from the old lady's liquor cabinet.
+
+    Radiation suit, of course, cause all of the fall out from the atomic wars. This is truly amazing, a portable television studio. No wonder your president has to be an actor, he's gotta look good on television. Wait a minute. Wait a minute, Doc. Are you telling me that it's 8:25? Working. Ah. Whoa. Well, Marty, I'm almost eighteen-years-old, it's not like I've never parked before.
+
+    You know, Doc, you left your equipment on all week. Hey, hey, I've seen this one, I've seen this one. This is a classic, this is where Ralph dresses up as the man from space. Who? Hey I'm talking to you, McFly, you Irish bug. He laid out Biff in one punch. I never knew he had it in him. He never stood up to Biff in his life.
+
+    I don't like her, Marty. Any girl who calls a boy is just asking for trouble. Watch it, Goldie. Let's go. Yeah, he's right here. Let's get him.
+
+    I'd like you to meet my good friend George McFly. No, I refuse to except the responsibility. Oh, great scott. You get the cable, I'll throw the rope down to you. Hi. I swiped it from the old lady's liquor cabinet.
+
+    The car, Dad, I mean He wrecked it, totaled it. I needed that car tomorrow night, Dad, I mean do you have any idea how important this was, do you have any clue? And Jack Benny is secretary of the Treasury. Well, aren't you going up to the lake tonight, you've been planning it for two weeks. Good. Have a good trip Einstein, watch your head. My name's Lorraine, Lorraine Baines.
+
+    This sounds pretty heavy. Well that's your name, isn't it? Calvin Klein. it's written all over your underwear. Oh, I guess they call you Cal, huh? Quiet. 1955? You're my ma- you're my ma. Well, this is a radiation suit.
+
+    Marty, this may seem a little foreward, but I was wondering if you would ask me to the Enchantment Under The Sea Dance on Saturday. I can't play. Yeah, yeah what are you wearing, Dave. C'mon, he's not that bad. At least he's letting you borrow the car tomorrow night. Wow, ah Red, you look great. Everything looks great. 1:24, I still got time. Oh my god. No, no not again, c'mon, c'mon. Hey. Libyans.
+
+    No, Marty, we've already agreed that having information about the future could be extremely dangerous. Even if your intentions are good, they could backfire drastically. Whatever you've got to tell me I'll find out through the natural course of time. Ah. Whoa. David, watch your mouth. You come here and kiss your mother before you go, come here. oh yeah, all you gotta do is go over there and ask her. Unfortunately no, it requires something with a little more kick, plutonium.
+
+    No, Doc. Stop it. Okay, but I don't know what to say. I don't like her, Marty. Any girl who calls a boy is just asking for trouble. Quiet down, I'm sure the car is fine.
+
+    Uh, stories, science fiction stories, about visitors coming down to Earth from another planet. I'm writing this down, this is good stuff. Go. That was the day I invented time travel. I remember it vividly. I was standing on the edge of my toilet hanging a clock, the porces was wet, I slipped, hit my head on the edge of the sink. And when I came to I had a revelation, a picture, a picture in my head, a picture of this. This is what makes time travel possible. The flux capacitor. Did you hurt your head?
+
+    Wait a minute, Doc. What are you talking about? What happens to us in the future? What do we become assholes or something? Oh, yeah, yeah. whoa, this is it, this is the part coming up, Doc. He's alright. Welcome to my latest experiment. It's the one I've been waiting for all my life.
+
+    Well, because George, nice girls get angry when guys take advantage of them. Doc, is that a de- You bet. No sir, I'm gonna make something out of myself, I'm going to night school and one day I'm gonna be somebody. Quiet, quiet. I'm gonna read your thoughts. Let's see now, you've come from a great distance?
+
+    Wrecked? When did this happen and- Take care. I haven't Don't worry. As long as you hit that wire with the connecting hook at precisely 88 miles per hour, the instance the lightning strikes the tower, everything will be fine. Never mind that, never mind that now, never mind that, never mind-
+
+    My god, it's my mother. Put your pants back on. I don't wanna know your name. I don't wanna know anything anything about you. Doc, is that a de- Great Scott. Let me see that photograph again of your brother. Just as I thought, this proves my theory, look at your brother. Alright, let's set your destination time. This is the exact time you left. I'm gonna send you back at exactly the same time. It's be like you never left. Now, I painted a white line on the street way over there, that's where you start from. I've calculated the distance and wind resistance fresh to active from the moment the lightning strikes, at exactly 7 minutes and 22 seconds. When this alarm goes off you hit the gas.
+
+    My insurance, it's your car, your insurance should pay for it. Hey, I wanna know who's gonna pay for this? I spilled beer all over it when that car smashed into me. Who's gonna pay my cleaning bill? Marty you gotta come back with me. Uh, no, no, no, no. What are you looking at, butt-head? Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Ronald Reagon.
+
+    I think we need a rematch. No, bastards. Leave her alone, you bastard. Marty, is that you? Hey George, heard you laid out Biff, nice going.
+
+    Oh, I've been so worried about you ever since you ran off the other night. Are you okay? I'm sorry I have to go. Isn't he a dream boat? Quiet, quiet. I'm gonna read your thoughts. Let's see now, you've come from a great distance? Yes, definitely, god-dammit George, swear. Okay, so now, you come up, you punch me in the stomach, I'm out for the count, right? And you and Lorraine live happily ever after. Alright, alright, okay McFly, get a grip on yourself. It's all a dream. Just a very intense dream. Woh, hey, listen, you gotta help me. Yeah well look, Marvin, Marvin, you gotta play. See that's where they kiss for the first time on the dance floor. And if there's no music, they can't dance, and if they can't dance, they can't kiss, and if they can't kiss, they can't fall in love and I'm history.
+
+    What, what? But, what are you blind McFly, it's there. How else do you explain that wreck out there? Back to the future. What? Marty, you interacted with anybody else today, besides me?
+
+    Right, okay, so right around 9:00 she's gonna get very angry with me. Right, and where am I gonna be? Well, I figured, what the hell. Evening, Doctor Brown, what's with the wire? Wow, you must be rich.
+
+    Marty, that was very interesting music. Right. What? Where the hell are they. Children.
+
+    Next, please. Mayor Goldie Wilson, I like the sound of that. Right. Working. Yeah, well, how about my homework, McFly?
+
+    Excuse me. No. C'mon, open up, let me out of here, Yo. Wrecked? George, help me, please.
+
+    Are those my clocks I hear? Get your meat hooks off of me. C'mon, more, dammit. Jeez. Holy shit. Let's see if you bastards can do ninety. whoa, whoa Doc, stuck here, I can't be stuck here, I got a life in 1985. I got a girl. Well gee, I don't know.
+
+    Now, now, Biff, now, I never noticed any blindspot before when I would drive it. Hi, son. C'mon, he's not that bad. At least he's letting you borrow the car tomorrow night. I just wanna use the phone. C'mon, he's not that bad. At least he's letting you borrow the car tomorrow night. Dear Doctor Brown, on the night that I go back in time, you will be shot by terrorists. Please take whatever precautions are necessary to prevent this terrible disaster. Your friend, Marty.
+
+    Hello, Jennifer. Save the clock tower. Ronald Reagon. Uh no, not hard at all. So anyway, George, now Lorraine, she really likes you. She told me to tell you that she wants you to ask her to the Enchantment Under The Sea Dance. A block passed Maple, that's John F. Kennedy Drive.
+
+    Hey, hey, Doc, where are you? How could I have been so careless. One point twenty-one gigawatts. Tom, how am I gonna generate that kind of power, it can't be done, it can't. It was meant to be. Anyway, if Grandpa hadn't hit him, then none of you would have been born. Listen, woh. Hello, uh excuse me. Sorry about your barn. Chuck, Chuck, its' your cousin. Your cousin Marvin Berry, you know that new sound you're lookin for, well listen to this.
+
+    Erased from existence. Well uh, good, fine. No, fine, no , good, fine, good. I have to tell you about the future. Marty, that was very interesting music.
+
+    Oh, just a little weather experiment. Well, safe and sound, now, n good old 1955. Yeah Mom, we know, you've told us this story a million times. You felt sorry for him so you decided to go with him to The Fish Under The Sea Dance. Uh, plutonium, wait a minute, are you telling me that this sucker's nuclear? Where's Einstein, is he with you?
+
+    Ho, you mean you're gonna touch her on her- Listen, this is very important, I forgot my video camera, could you stop by my place and pick it up on your way to the mall? What, right here right now in the cafeteria? What if she said no? I don't know if I could take that kind of rejection. Besides, I think she'd rather go with somebody else. That's true, Marty, I think you should spend the night. I think you're our responsibility. Why that's me, look at me, I'm an old man.
+
+    Right, I got it. Jennifer. Doc, she didn't even look at him. Quiet down, I'm sure the car is fine. Lorenzo, where're you keys?
+
+    Please note that Einstein's clock is in complete synchronization with my control watch. I followed you. Um, yeah well I might have sort of ran into my parents. Ohh, no. So what's it to you, butthead. You know you've been looking for a, since you're new here, I'm gonna cut you a break, today. So why don't you make like a tree, and get out of here.
+
+    oh yeah, all you gotta do is go over there and ask her. Listen, woh. Hello, uh excuse me. Sorry about your barn. Well, uh, listen, uh, I really- That's George McFly? Well, what if they didn't like them, what if they told me I was no good. I guess that would be pretty hard for somebody to understand.
+
+    We're gonna take a little break but we'll be back in a while so, don't nobody go no where. Yeah, it's 8:00. Look at the time, you've got less than 4 minutes, please hurry. Doc, is that a de- Hey c'mon, I had to change, you think I'm going back in that zoot suit? The old man really came through it worked.
+
+    Mother, with Marty's parents out of town, don't you think he oughta spend the night, after all, Dad almost killed him with the car. Marty, why are you so nervous? That's a great idea. I'd love to park. Look, I'm just not ready to ask Lorraine out to the dance, and not you, nor anybody else on this planet is gonna make me change my mind. Alright, c'mon, I think we're safe.
+
+    Without any sugar. Doc. Well, they're bigger than me. This Saturday night, mostly clear, with some scattered clouds. Lows in the upper forties. Brown, Brown, Brown, Brown, Brown, great, you're alive. Do you know where 1640 Riverside-
+
+    What's with the life preserver? Yeah, you got my homework finished, McFly? Indeed I will, roll em. I, Doctor Emmett Brown, am about to embark on an historic journey. What have I been thinking of, I almost forgot to bring some extra plutonium. How did I ever expect to get back, one pallet one trip I must be out of my mind. What is it Einy? Oh my god, they found me, I don't know how but they found me. Run for it, Marty. George McFly? Oh, he's kinda cute and all, but, well, I think a man should be strong, so he could stand up for himself, and protect the woman he loves. Don't you? Good evening, I'm Doctor Emmet Brown, I'm standing here on the parking lot of-
+
+    Alright, okay. Alright, there she is, George. Just go in there and invite her. Let's go. It's uh, the other end of town, a block past Maple. Uh, well, okay Biff, uh, I'll finish that on up tonight and I'll bring it over first thing tomorrow morning. No no no no no, Marty, both you and Jennifer turn out fine. It's your kids, Marty, something has got to be done about your kids.
+
+    Wait a minute, wait a minute, Doc, are you telling me that you built a time machine out of a delorean. Why not? Never mind that now, never mind that now. Yeah, I'll keep that in mind. Who?
+
+    Really. Well maybe you are and you just don't know it yet. You want it, you know you want it, and you know you want me to give it to you. Biff. In that case, I'll tell you strait out.
+
+    Don't tell me. Uh, you want me to buy a subscription to the Saturday Evening Post? Say that again. That's Calvin Klein, oh my god, he's a dream. I think it's terrible. Girls chasing boys. When I was your age I never chased a boy, or called a boy, or sat in a parked car with a boy. Hello, hello, anybody home? Think, McFly, think. I gotta have time to recopy it. Do your realize what would happen if I hand in my homework in your handwriting? I'd get kicked out of school. You wouldn't want that to happen would you, would you?
+
+    Okay. He's your brother, Mom. Uh, stories, science fiction stories, about visitors coming down to Earth from another planet. Y'know this time it wasn't my fault. The Doc set all of his clocks twenty-five minutes slow. Oh hey, Biff, hey, guys, how are you doing?
+
+    Well just gimme something without any sugar in it, okay? Alright kid, you stick to your father like glue and make sure that he takes her to the dance. Right, I got it. Calvin, why do you keep calling me Calvin? The car, Dad, I mean He wrecked it, totaled it. I needed that car tomorrow night, Dad, I mean do you have any idea how important this was, do you have any clue?
+
+    This is for all you lovers out there. My god, do you know what this means? It means that this damn thing doesn't work at all. Whoa, this is heavy. Don't worry. As long as you hit that wire with the connecting hook at precisely 88 miles per hour, the instance the lightning strikes the tower, everything will be fine. C'mon, open up, let me out of here, Yo.
+
+    I gotta go, uh, I gotta go. Thanks very much, it was wonderful, you were all great. See you all later, much later. Doc, Doc. Oh, no. You're alive. Bullet proof vest, how did you know, I never got a chance to tell you. About all that talk about screwing up future events, the space time continuum. You do? What the hell is a gigawatt? Whoa, whoa, okay.
+
+    What? You cost three-hundred buck damage to my car, you son-of-a-bitch. And I'm gonna take it out of your ass. Hold him. It's information about the future isn't it. I warned you about this kid. The consequences could be disastrous. Don't tell me. Uh, you want me to buy a subscription to the Saturday Evening Post? I'm writing this down, this is good stuff.
+
+    Marty, will we ever see you again? Yeah, well history is gonna change. Uh, yeah. You bet. Huh?
+
+    Yeah, I think it's a major embarrassment having an uncle in prison. Believe me, Marty, you're better off not having to worry about all the aggravation and headaches of playing at that dance. Breakfast. Well just gimme something without any sugar in it, okay? Wait a minute, wait a minute, Doc, are you telling me that you built a time machine out of a delorean.
+
+    Don't say a word. No no no, Doc, I just got here, okay, Jennifer's here, we're gonna take the new truck for a spin. Breakfast. Well, I figured, what the hell. What's the meaning of this.
+
+    Let me show you my plan for sending you home. Please excuse the crudity of this model, I didn't have time to build it to scale or to paint it. You extol me with a lot of confidence, Doc. I'm sure that in 1985, plutonium is available at every corner drug store, but in 1955, it's a little hard to come by. Marty, I'm sorry, but I'm afraid you're stuck here. Well looky what we have here. No no no, you're staying right here with me. Time machine, I haven't invented any time machine.
+
+    Yeah well look, Marvin, Marvin, you gotta play. See that's where they kiss for the first time on the dance floor. And if there's no music, they can't dance, and if they can't dance, they can't kiss, and if they can't kiss, they can't fall in love and I'm history. Marty you gotta come back with me. Back to the future. Well, what if they didn't like them, what if they told me I was no good. I guess that would be pretty hard for somebody to understand. I still don't understand, how am I supposed to go to the dance with her, if she's already going to the dance with you.
+
+    I guarantee it. Well, they're bigger than me. I have to tell you about the future. The hell you doing to my car? Yeah, sure, okay.
+
+    Alright, okay listen, keep your pants on, she's over in the cafe. God, how do you do this? What made you change your mind, George? Whoa, they really cleaned this place up, looks brand new. He's a very strange young man. What, what? You bet.
+
+    No wait, Doc, the bruise, the bruise on your head, I know how that happened, you told me the whole story. you were standing on your toilet and you were hanging a clock, and you fell, and you hit your head on the sink, and that's when you came up with the idea for the flux capacitor, which makes time travel possible. Will you take care of that? Let's put him in there. Right, I got it. See, there's Biff out there waxing it right now. Now, Biff, I wanna make sure that we get two coats of wax this time, not just one.
+
+    Hey wait, wait a minute, who are you? Stella, another one of these damn kids jumped in front of my car. Come on out here, help me take him in the house. I have to tell you about the future. Pretty Mediocre photographic fakery, they cut off your brother's hair. Well, I figured, what the hell. We never would have fallen in love.
+
+    What the hell is this? Wow, ah Red, you look great. Everything looks great. 1:24, I still got time. Oh my god. No, no not again, c'mon, c'mon. Hey. Libyans. Who are you calling spook, pecker-wood. But, what are you blind McFly, it's there. How else do you explain that wreck out there? I'm gonna be at the dance.
+
+    Ah, honey, your first novel. Something wrong with the starter, so I hid it. It's a board with wheels. What did you say? Mom, Dad.
+
+    Well, safe and sound, now, n good old 1955. Like I always told you, if you put your mind to it you could accomplish anything. Thank god I still got my hair. What on Earth is that thing I'm wearing? What? Don't worry. As long as you hit that wire with the connecting hook at precisely 88 miles per hour, the instance the lightning strikes the tower, everything will be fine.
+
+    Jennifer, oh are you a sight for sore eyes. Let me look at you. Um, yeah, I'm on my way. Yeah well look, Marvin, Marvin, you gotta play. See that's where they kiss for the first time on the dance floor. And if there's no music, they can't dance, and if they can't dance, they can't kiss, and if they can't kiss, they can't fall in love and I'm history. Let's get you into a radiation suit, we must prepare to reload. George. George.
+
+    Leave me alone. Yeah, yeah what are you wearing, Dave. I think you got the wrong car, McFly. You got a real attitude problem, McFly. You're a slacker. You remind me of you father when he went her, he was a slacker too. Yeah, I'll keep that in mind.
+
+    I know, and all I could say is I'm sorry. No no no no no, Marty, both you and Jennifer turn out fine. It's your kids, Marty, something has got to be done about your kids. Shit. Alright, punk, now- Well, safe and sound, now, n good old 1955.
+
+    No sir, I'm gonna make something out of myself, I'm going to night school and one day I'm gonna be somebody. Marty, that's completely out of the question, you must not leave this house. you must not see anybody or talk to anybody. Anything you do could have serious repercussions on future events. Do you understand? Of course not, Biff, now I wouldn't want that to happen. Now, uh, I'll finish those reports up tonight, and I'll run em them on over first thing tomorrow, alright? I swiped it from the old lady's liquor cabinet. My god, do you know what this means? It means that this damn thing doesn't work at all.
+
+    Wrecked? Just relax now Calvin, you've got a big bruise on you're head. Wait a minute, wait a minute, Doc, are you telling me that you built a time machine out of a delorean. My insurance, it's your car, your insurance should pay for it. Hey, I wanna know who's gonna pay for this? I spilled beer all over it when that car smashed into me. Who's gonna pay my cleaning bill? Doc, Doc, it's me, Marty.
+
+    Right. Over there, on my hope chest. I've never seen purple underwear before, Calvin. I'm gonna get that son-of-a-bitch. George, aren't you gonna kiss me? What did you say?
+
+    Yeah. Just say anything, George, say what ever's natural, the first thing that comes to your mind. No, it was The Enchantment Under The Sea Dance. Our first date. It was the night of that terrible thunderstorm, remember George? Your father kissed me for the very first time on that dance floor. It was then I realized I was going to spend the rest of my life with him. Doc? I have a feeling too.
+
+    I guess you guys aren't ready for that yet. But your kids are gonna love it. C'mon, Mom, make it fast, I'll miss my bus. Hey see you tonight, Pop. Woo, time to change that oil. It's my dad. Oh. Mr. McFly, Mr. McFly, this just arrived, oh hi Marty. I think it's your new book.
+
+    Dammit, Doc, why did you have to tear up that letter? If only I had more time. Wait a minute, I got all the time I want I got a time machine, I'll just go back and warn him. 10 minutes oughta do it. Time-circuits on, flux-capacitor fluxing, engine running, alright. No, no no no no, c'mon c'mon. C'mon c'mon, here we go, this time. Please, please, c'mon. Who's are these? Right, George. Well, good luck you guys. Oh, one other thing, if you guys ever have kids and one of them when he's eight years old, accidentally sets fire to the living room rug, be easy on him. Yeah man, that was good. Let's do another one. Hey not too early I sleep in Sunday's, hey McFly, you're shoe's untied, don't be so gullible, McFly.
+
+    Where does he come from? Who? Oh, uh, this is my Doc, Uncle, Brown. Never? Calvin, why do you keep calling me Calvin?
+
+    Evening, Doctor Brown, what's with the wire? Okay. Hey not too early I sleep in Sunday's, hey McFly, you're shoe's untied, don't be so gullible, McFly. It's about the future, isn't it? Just finishing up the second coat now.
+
+    Your not gonna be picking a fight, Dad, dad dad daddy-o. You're coming to a rescue, right? Okay, let's go over the plan again. 8:55, where are you gonna be. So tell me, Marty, how long have you been in port? Why do you keep following me around? That's Calvin Klein, oh my god, he's a dream. My name's Lorraine, Lorraine Baines.
+
+    No no no no no, Marty, both you and Jennifer turn out fine. It's your kids, Marty, something has got to be done about your kids. Where were we. Marty, you made it. Great good, good, Lorraine, I had a feeling about you two. Nothing's coming to my mind.
+
+    Hey George, heard you laid out Biff, nice going. Marty, you interacted with anybody else today, besides me? Dammit, Doc, why did you have to tear up that letter? If only I had more time. Wait a minute, I got all the time I want I got a time machine, I'll just go back and warn him. 10 minutes oughta do it. Time-circuits on, flux-capacitor fluxing, engine running, alright. No, no no no no, c'mon c'mon. C'mon c'mon, here we go, this time. Please, please, c'mon. Why not? Yeah, gimme a Tab.
+
+    What's that thing he's on? Huh? Wait a minute, wait a minute, Doc, are you telling me that you built a time machine out of a delorean. It's taken me almost thirty years and my entire family fortune to realize the vision of that day, my god has it been that long. Things have certainly changed around here. I remember when this was all farmland as far as the eye could see. Old man Peabody, owned all of this. He had this crazy idea about breeding pine trees. Oh, yeah, yeah.
+
+    Just say anything, George, say what ever's natural, the first thing that comes to your mind. Marty, this may seem a little foreward, but I was wondering if you would ask me to the Enchantment Under The Sea Dance on Saturday. We're gonna take a little break but we'll be back in a while so, don't nobody go no where. Excuse me. One point twenty-one gigawatts. One point twenty-one gigawatts. Great Scott.
+
+    I'm, I'm sorry, Mr. McFly, I mean, I was just starting on the second coat. He's your brother, Mom. Right. Uh, Lorraine. How did you know I was here? That's a big bruise you have there.
+
+    Hey beat it, spook, this don't concern you. I know, and all I could say is I'm sorry. I followed you. Really. You want it, you know you want it, and you know you want me to give it to you.
+
+    Uh, yeah. That's Calvin Klein, oh my god, he's a dream. What you got under here? Hey wait, wait a minute, who are you? Stella, another one of these damn kids jumped in front of my car. Come on out here, help me take him in the house. No no no this sucker's electrical, but I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity that I need.
+
+    Huh? We never would have fallen in love. Well, Biff. I don't know, Doc, I guess she felt sorry for him cause her did hit him with the car, hit me with the car. Bet your ass it works.
+
+    Okay, real mature guys. Okay, Biff, will you pick up my books? Wow, you must be rich. Uh, I think so. It was meant to be. Anyway, if Grandpa hadn't hit him, then none of you would have been born. I know, and all I could say is I'm sorry.
+
+    Don't worry, I'll take care of the lightning, you take care of your pop. By the way, what happened today, did he ask her out? Well, uh, listen, uh, I really- It's safe now. Everything's lead lined. Don't you lose those tapes now, we'll need a record. Wup, wup, I almost forgot my luggage. Who knows if they've got cotton underwear in the future. I'm allergic to all synthetics. Well, bring her along. This concerns her too. Oh hey, Biff, hey, guys, how are you doing?
+
+    We're gonna take a little break but we'll be back in a while so, don't nobody go no where. Who are you calling spook, pecker-wood. No, it was The Enchantment Under The Sea Dance. Our first date. It was the night of that terrible thunderstorm, remember George? Your father kissed me for the very first time on that dance floor. It was then I realized I was going to spend the rest of my life with him. No no no this sucker's electrical, but I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity that I need. Watch it, Goldie.
+
+    Now, now, Biff, now, I never noticed any blindspot before when I would drive it. Hi, son. Whoa, wait a minute, Doc, are you telling me that my mother has got the hots for me? Mr. McFly, Mr. McFly, this just arrived, oh hi Marty. I think it's your new book. I know, and all I could say is I'm sorry. Oh, if Paul calls me tell him I'm working at the boutique late tonight.
+
+    C'mon. I guess you guys aren't ready for that yet. But your kids are gonna love it. You heard her she said get your meat hooks, off, uh please. Wrecked? When did this happen and- Hello.
+
+    George, help me, please. whoa, this is it, this is the part coming up, Doc. Well, it will just happen. Like the way I met your father. Nothing, nothing, nothing, look tell her destiny has brought you together, tell her that she's the most beautiful you have ever seen. Girls like that stuff. What, what are you doing George? Wow, you must be rich.
+
+    Keys? Hey, McFly, I thought I told you never to come in here. Well it's gonna cost you. How much money you got on you? Alright, good-bye Einy. Oh, watch that re-entry, it's a little bumpy. Uh, yeah. He's a very strange young man.
+
+    Hello, hello, anybody home? Think, McFly, think. I gotta have time to get them re-typed. Do you realize what would happen if I hand in my reports in your handwriting. I'll get fired. You wouldn't want that to happen would you? Would you? You don't understand. Hey, don't I know you from somewhere? Yeah, well, I still don't understand what Dad was doing in the middle of the street. Uh, Doc.
+
+    Not a word, not a word, not a word now. Quiet, uh, donations, you want me to make a donation to the coast guard youth auxiliary? Something that really cooks. Alright, alright this is an oldie, but uh, it's an oldie where I come from. Alright guys, let's do some blues riff in b, watch me for the changes, and uh, try and keep up, okay. Okay, alright, Saturday is good, Saturday's good, I could spend a week in 1955. I could hang out, you could show me around. After I fell off my toilet, I drew this. See, there's Biff out there waxing it right now. Now, Biff, I wanna make sure that we get two coats of wax this time, not just one.
+
+    Why is she gonna get angry with you? Yeah but George, Lorraine wants to go with you. Give her a break. Marty, don't go this way. Strickland's looking for you. If you're caught it'll be four tardies in a row. Uh, Doc. Okay, that's enough. Now stop the microphone. I'm sorry fellas. I'm afraid you're just too darn loud. Next, please. Where's the next group, please.
+
+    Now which one was it, Greg or Craig? Hi, Marty. Who's are these? Shape up, man. You're a slacker. You wanna be a slacker for the rest of your life? Now, Biff, um, can I assume that your insurance is gonna pay for the damage?
+
+    Well, safe and sound, now, n good old 1955. George McFly? Oh, he's kinda cute and all, but, well, I think a man should be strong, so he could stand up for himself, and protect the woman he loves. Don't you? Wait a minute, what are you doing, Doc? Who do you think, the Libyans. Ohh, no.
+
+    He's fine, and he's completely unaware that anything happened. As far as he's concerned the trip was instantaneous. That's why Einstein's watch is exactly one minute behind mine. He skipped over that minute to instantly arrive at this moment in time. Come here, I'll show you how it works. First, you turn the time circuits on. This readout tell you where you're going, this one tells you where you are, this one tells you where you were. You imput the destination time on this keypad. Say, you wanna see the signing of the declaration of independence, or witness the birth or Christ. Here's a red-letter date in the history of science, November 5, 1955. Yes, of course, November 5, 1955. Hey man, look at Marvin's hand. He can't play with his hands like that, and we can't play without him. Okay, okay you guys, oh ha ha ha very funny. Hey you guys are being real mature. What? Hey McFly, what do you think you're doing.
+
+    Oh, oh a rematch, why, were you cheating? Y'know this time it wasn't my fault. The Doc set all of his clocks twenty-five minutes slow. I'm telling the truth, Doc, you gotta believe me. Sam, quit fiddling with that thing and come in here and eat your dinner. Uh, stories, science fiction stories, about visitors coming down to Earth from another planet.
+
+    Oh. Yeah, but I never picked a fight in my entire life. Oh, I've been so worried about you ever since you ran off the other night. Are you okay? I'm sorry I have to go. Isn't he a dream boat? Right check, Doc. And he could sleep in my room.
+
+    Well, Marty, I'm almost eighteen-years-old, it's not like I've never parked before. Right. Great Scott. Let me see that photograph again of your brother. Just as I thought, this proves my theory, look at your brother. Well, safe and sound, now, n good old 1955. Marty, you're acting like you haven't seen me in a week.
+
+    One point twenty-one gigawatts. One point twenty-one gigawatts. Great Scott. C'mon. Yeah, it's in the back. Great good, good, Lorraine, I had a feeling about you two. Doc, look, all we need is a little plutonium.
+
+    Wait a minute, Doc. What are you talking about? What happens to us in the future? What do we become assholes or something? How about a ride, Mister? Uh, no, no, no, no. What are you looking at, butt-head? It's my dad. He's a peeping tom. Dad.
+
+    Just finishing up the second coat now. Yet. Check out that four by four. That is hot. Someday, Jennifer, someday. Wouldn't it be great to take that truck up to the lake. Throw a couple of sleeping bags in the back. Lie out under the stars. I'm sure that in 1985, plutonium is available at every corner drug store, but in 1955, it's a little hard to come by. Marty, I'm sorry, but I'm afraid you're stuck here. Let me show you my plan for sending you home. Please excuse the crudity of this model, I didn't have time to build it to scale or to paint it.
+
+    Yeah, where does he live? He's an absolute dream. Leave her alone, you bastard. Right, gimme a Pepsi free. Flux capacitor.
+
+    Uh, look me up when you get there. I have to tell you about the future. Hey, Doc? Doc. Hello, anybody home? Einstein, come here, boy. What's going on? Wha- aw, god. Aw, Jesus. Whoa, rock and roll. Yo I said the keys are in here. Pa, what is it? What is it, Pa?
+
+    Will you take care of that? It's information about the future isn't it. I warned you about this kid. The consequences could be disastrous. I don't know, but I'm gonna find out. Hi, Marty. Is she pretty?
+
+    Why am I always the last one to know about these things. What's that thing he's on? Ronald Reagon, the actor? Then who's vice president, Jerry Lewis? I suppose Jane Wymann is the first lady. C'mon, he's not that bad. At least he's letting you borrow the car tomorrow night. C'mon, Mom, make it fast, I'll miss my bus. Hey see you tonight, Pop. Woo, time to change that oil.
+
+    Hey I'm talking to you, McFly, you Irish bug. Take care. Hello, hello, anybody home? Think, McFly, think. I gotta have time to recopy it. Do your realize what would happen if I hand in my homework in your handwriting? I'd get kicked out of school. You wouldn't want that to happen would you, would you? Oh, I've been so worried about you ever since you ran off the other night. Are you okay? I'm sorry I have to go. Isn't he a dream boat? Yeah, where does he live?
+
+    That's a big bruise you have there. Uh? Oh, great scott. You get the cable, I'll throw the rope down to you. Good morning, Mom. Oh, Marty, I almost forgot, Jennifer Parker called. What the hell is a gigawatt?
+
+    What do you mean you've seen this, it's brand new. What, what, ma? Never mind that now, never mind that now. Alright, okay listen, keep your pants on, she's over in the cafe. God, how do you do this? What made you change your mind, George? You're George McFly.
+
+    Well, I figured, what the hell. I'm gonna get that son-of-a-bitch. About 30 years, it's a nice round number. Erased from existence. Well looky what we have here. No no no, you're staying right here with me.
+
+    Yeah, I think maybe you do. Hey, Doc? Doc. Hello, anybody home? Einstein, come here, boy. What's going on? Wha- aw, god. Aw, Jesus. Whoa, rock and roll. Yo Um, yeah, I'm on my way. Precisely. Over there, on my hope chest. I've never seen purple underwear before, Calvin.
+
+    That's Calvin Klein, oh my god, he's a dream. Right. Look, I'm just not ready to ask Lorraine out to the dance, and not you, nor anybody else on this planet is gonna make me change my mind. Doc, you gotta help- What a nightmare.
+
+    Look, George, I'm telling you George, if you do not ask Lorraine to that dance, I'm gonna regret it for the rest of my life. Get out of town, I didn't know you did anything creative. Ah, let me read some. Whoa, whoa, kid, kid, stop, stop, stop, stop. You wanna a Pepsi, pall, you're gonna pay for it. We never would have fallen in love.
+
+    Listen, I gotta go but I wanted to tell you that it's been educational. Perfect, just perfect. What's that thing he's on? I'm really gonna miss you. Doc, about the future- The way I see it, if you're gonna build a time machine into a car why not do it with some style. Besides, the stainless, steel construction made the flux dispersal- look out.
+
+    Oh, uh, this is my Doc, Uncle, Brown. Oh yes sir. Wrecked? Never mind that now, never mind that now. Here you go, lady. There's a quarter.
+
+    Doc. Indeed I will, roll em. I, Doctor Emmett Brown, am about to embark on an historic journey. What have I been thinking of, I almost forgot to bring some extra plutonium. How did I ever expect to get back, one pallet one trip I must be out of my mind. What is it Einy? Oh my god, they found me, I don't know how but they found me. Run for it, Marty. Hi. Uh? She's just trying to keep you respectable.
+
+    C'mon, c'mon. The future, it's where you're going? Marty, don't go this way. Strickland's looking for you. If you're caught it'll be four tardies in a row. Yeah, but I never picked a fight in my entire life. It works, ha ha ha ha, it works. I finally invent something that works.
+
+    Remember, fellas, the future is in your hands. If you believe in progress, re-elect Mayor Red Thomas, progress is his middle name. Mayor Red Thomas's progress platform means more jobs, better education, bigger civic improvements, and lower taxes. On election day, cast your vote for a proven leader, re-elect Mayor Red Thomas... Yeah okay. That was the day I invented time travel. I remember it vividly. I was standing on the edge of my toilet hanging a clock, the porces was wet, I slipped, hit my head on the edge of the sink. And when I came to I had a revelation, a picture, a picture in my head, a picture of this. This is what makes time travel possible. The flux capacitor. Well, ma, we talked about this, we're not gonna go to the lake, the car's wrecked. He's an absolute dream.
+
+    He laid out Biff in one punch. I never knew he had it in him. He never stood up to Biff in his life. Are you gonna order something, kid? Well, Marty, I want to thank you for all your good advice, I'll never forget it. Listen, Doc, you know there's something I haven't told you about the night we made that tape. Yeah, I guessed you're a sailor, aren't you, that's why you wear that life preserver.
+
+    Yeah but George, Lorraine wants to go with you. Give her a break. Right. Where? Good morning, Mom. Okay, that's enough. Now stop the microphone. I'm sorry fellas. I'm afraid you're just too darn loud. Next, please. Where's the next group, please.
+
+    About how far ahead are you going? Hey guys, you gotta get back in there and finish the dance. No, I refuse to except the responsibility. Why that's me, look at me, I'm an old man. Bet your ass it works.
+
+    Why that's me, look at me, I'm an old man. Well yeah, you know we have two of them. Does your mom know about tomorrow night? Oh, oh a rematch, why, were you cheating? You're George McFly.
+
+    When could weathermen predict the weather, let alone the future. A block passed Maple, that's John F. Kennedy Drive. McFly. Yoo. Lorenzo, where're you keys?
+
+    Hey Biff, check out this guy's life preserver, dork thinks he's gonna drown. Roads? Where we're going we don't need roads. Oh, what I meant to day was- Believe me, Marty, you're better off not having to worry about all the aggravation and headaches of playing at that dance. Yeah, but you're uh, you're so, you're so thin.
+
+    You know what I do in those situations? There's that word again, heavy. Why are things so heavy in the future. Is there a problem with the Earth's gravitational pull? Oh, pleased to meet you, Calvin Marty Klein. Do you mind if I sit here? Sam, quit fiddling with that thing and come in here and eat your dinner. Bear with me, Marty, all of your questions will be answered. Roll tape, we'll proceed.
+
+    Uh, Lorraine. How did you know I was here? Never? What, right here right now in the cafeteria? What if she said no? I don't know if I could take that kind of rejection. Besides, I think she'd rather go with somebody else. Doc, Doc. Oh, no. You're alive. Bullet proof vest, how did you know, I never got a chance to tell you. About all that talk about screwing up future events, the space time continuum. Thank god I still got my hair. What on Earth is that thing I'm wearing?
+
+    I haven't I guarantee it. Yeah, sure, okay. You're gonna be in the car with her. Flux capacitor.
+
+    Huh? I can't believe you loaned me a car, without telling me it had a blindspot. I could've been killed. Listen, this is very important, I forgot my video camera, could you stop by my place and pick it up on your way to the mall? Well, Marty, I'm almost eighteen-years-old, it's not like I've never parked before. A block passed Maple, that's John F. Kennedy Drive.
+
+    What were you doing in the middle of the street, a kid your age. Right check, Doc. Um, well it's a delorean, right? The way I see it, if you're gonna build a time machine into a car why not do it with some style. Besides, the stainless, steel construction made the flux dispersal- look out. Right.
+
+    The keys are in the trunk. Uh, coast guard. Who, who? Welcome to my latest experiment. It's the one I've been waiting for all my life. Listen, woh. Hello, uh excuse me. Sorry about your barn.
+
+    Yes, yes, I'm George, George McFly, and I'm your density. I mean, I'm your destiny. George. You okay, is everything alright? I've gotta go. Well maybe you are and you just don't know it yet.
+
+    Lorraine, have you ever, uh, been in a situation where you know you had to act a certain way but when you got there, you didn't know if you could go through with it? Well, aren't you going up to the lake tonight, you've been planning it for two weeks. No wait, Doc, the bruise, the bruise on your head, I know how that happened, you told me the whole story. you were standing on your toilet and you were hanging a clock, and you fell, and you hit your head on the sink, and that's when you came up with the idea for the flux capacitor, which makes time travel possible. Uh, Lorraine. How did you know I was here? Alright, McFly, you're asking for it, and now you're gonna get it.
+
+    Hey man, look at Marvin's hand. He can't play with his hands like that, and we can't play without him. Breakfast. Thanks. Why do you keep following me around? Well, this is a radiation suit.
+
+    My god, it's my mother. Put your pants back on. I think we need a rematch. What's the meaning of this. Well, ma, we talked about this, we're not gonna go to the lake, the car's wrecked. Yeah, who are you?
+
+    Doc, look, all we need is a little plutonium. Where's Einstein, is he with you? You don't understand. Yeah, it's 8:00. Hey, not too early I sleep in on Saturday. Oh, McFly, your shoe's untied. Don't be so gullible, McFly. You got the place fixed up nice, McFly. I have you're car towed all the way to your house and all you've got for me is light beer. What are you looking at, butthead. Say hi to your mom for me.
+
+    Calvin, why do you keep calling me Calvin? It's already mutated into human form, shoot it. In that case, I'll tell you strait out. Why that's me, look at me, I'm an old man. Ho, you mean you're gonna touch her on her-
+
+    Jesus, George, it's a wonder I was ever born. Yeah, well uh, lets keep this brain melting stuff to ourselves, okay? Indeed I will, roll em. I, Doctor Emmett Brown, am about to embark on an historic journey. What have I been thinking of, I almost forgot to bring some extra plutonium. How did I ever expect to get back, one pallet one trip I must be out of my mind. What is it Einy? Oh my god, they found me, I don't know how but they found me. Run for it, Marty. The future, it's where you're going? C'mon man, let's do something that really cooks.
+
+    What? What did you say? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Yeah well look, Marvin, Marvin, you gotta play. See that's where they kiss for the first time on the dance floor. And if there's no music, they can't dance, and if they can't dance, they can't kiss, and if they can't kiss, they can't fall in love and I'm history. Good evening, I'm Doctor Emmett Brown. I'm standing on the parking lot of Twin Pines Mall. It's Saturday morning, October 26, 1985, 1:18 a.m. and this is temporal experiment number one. C'mon, Einy, hey hey boy, get in there, that a boy, in you go, get down, that's it.
+
+    This Saturday night, mostly clear, with some scattered clouds. Lows in the upper forties. I'm gonna ram him. What? Who do you think, the Libyans. Thank god I found you. Listen, can you meet me at Twin Pines Mall tonight at 1:15? I've made a major breakthrough, I'll need your assistance.
+
+    Well, aren't you going up to the lake tonight, you've been planning it for two weeks. Jesus, you smoke too? Yeah. Oh, pleased to meet you, Calvin Marty Klein. Do you mind if I sit here? One point twenty-one gigawatts. One point twenty-one gigawatts. Great Scott.
+
+    Oh, I've been so worried about you ever since you ran off the other night. Are you okay? I'm sorry I have to go. Isn't he a dream boat? Listen, Doc. C'mon, more, dammit. Jeez. Holy shit. Let's see if you bastards can do ninety. A colored mayor, that'll be the day. Are those my clocks I hear?
+
+    Thank you, don't forget to take a flyer. Who the hell is John F. Kennedy? That's for messing up my hair. This sounds pretty heavy. Hey, Doc? Doc. Hello, anybody home? Einstein, come here, boy. What's going on? Wha- aw, god. Aw, Jesus. Whoa, rock and roll. Yo
+
+    Right, George. Well, good luck you guys. Oh, one other thing, if you guys ever have kids and one of them when he's eight years old, accidentally sets fire to the living room rug, be easy on him. Yeah, I'm- mayor. Now that's a good idea. I could run for mayor. Alright, McFly, you're asking for it, and now you're gonna get it. What Lorraine, what? Something wrong with the starter, so I hid it.
+
+    Where's Einstein, is he with you? Alright, okay Jennifer. What if I send in the tape and they don't like it. I mean, what if they say I'm no good. What if they say, 'Get out of here, kid, you got no future.' I mean, I just don't think I can take that kind of rejection. Jesus, I'm beginning to sound like my old man. Marty, that was very interesting music. When could weathermen predict the weather, let alone the future. That's true, Marty, I think you should spend the night. I think you're our responsibility.
+
+    Ah, where're my pants? Ronald Reagon. I don't wanna know your name. I don't wanna know anything anything about you. Lorraine, have you ever, uh, been in a situation where you know you had to act a certain way but when you got there, you didn't know if you could go through with it? Oh, if Paul calls me tell him I'm working at the boutique late tonight.
+
+    Yes, definitely, god-dammit George, swear. Okay, so now, you come up, you punch me in the stomach, I'm out for the count, right? And you and Lorraine live happily ever after. Oh, uh, this is my Doc, Uncle, Brown. What Lorraine, what? Oh, if Paul calls me tell him I'm working at the boutique late tonight. Calvin.
+
+    oh yeah, all you gotta do is go over there and ask her. Who are you? Wait a minute. Marty. Marty. Marty. Your not gonna be picking a fight, Dad, dad dad daddy-o. You're coming to a rescue, right? Okay, let's go over the plan again. 8:55, where are you gonna be.
+
+    C'mon man, let's do something that really cooks. The car, Dad, I mean He wrecked it, totaled it. I needed that car tomorrow night, Dad, I mean do you have any idea how important this was, do you have any clue? Roads? Where we're going we don't need roads. Okay. Huh?
+
+    Well that's your name, isn't it? Calvin Klein. it's written all over your underwear. Oh, I guess they call you Cal, huh? I think you got the wrong car, McFly. I'm, I'm sorry, Mr. McFly, I mean, I was just starting on the second coat. Wait a minute, wait a minute, Doc, are you telling me that you built a time machine out of a delorean. I'm writing this down, this is good stuff.
+
+    Ohh, no. Its good. That's right. whoa, this is it, this is the part coming up, Doc. Who?
+
+    Oh, great scott. You get the cable, I'll throw the rope down to you. The future, it's where you're going? I just wanna use the phone. Alright, c'mon, I think we're safe. Take that you mutated son-of-a-bitch. My pine, why you. You space bastard, you killed a pine.
+
+    Doc, Doc, it's me, Marty. Welcome to my latest experiment. It's the one I've been waiting for all my life. Wrecked? Hey c'mon, I had to change, you think I'm going back in that zoot suit? The old man really came through it worked. Good evening, I'm Doctor Emmett Brown. I'm standing on the parking lot of Twin Pines Mall. It's Saturday morning, October 26, 1985, 1:18 a.m. and this is temporal experiment number one. C'mon, Einy, hey hey boy, get in there, that a boy, in you go, get down, that's it.
+
+    Marty, I always wear a suit to the office. You alright? Oh, hi , Marty. I didn't hear you come in. Fascinating device, this video unit. Why am I always the last one to know about these things. he's an idiot, comes from upbringing, parents were probably idiots too. Lorraine, if you ever have a kid like that, I'll disown you. Oh, what I meant to day was-
+
+    George: you ever think of running for class president? Okay, but I don't know what to say. You know, Doc, you left your equipment on all week. Weight has nothing to do with it. Did you hurt your head?
+
+    he's an idiot, comes from upbringing, parents were probably idiots too. Lorraine, if you ever have a kid like that, I'll disown you. Who, who? I don't wanna know your name. I don't wanna know anything anything about you. Oh, what I meant to day was- I guarantee it.
+
+    Yeah, it's 8:00. That's a big bruise you have there. Is she pretty? Oh, then I wanna give her a call, I don't want her to worry about you. Doc, you gotta help-
+
+    He's absolutely right, Marty. the last thing you need is headaches. Well, what if they didn't like them, what if they told me I was no good. I guess that would be pretty hard for somebody to understand. Yeah. You broke it. Wow, look at him go. Uh?
+
+    Why that's me, look at me, I'm an old man. Marty, don't be such a square. Everybody who's anybody drinks. Yeah okay. Where's Einstein, is he with you? Hey you, get your damn hands off, oh.
+
+    Really. Uh listen, do you know where Riverside Drive is? What's that thing he's on? Alright, c'mon, I think we're safe. What, what?
+
+    Check out that four by four. That is hot. Someday, Jennifer, someday. Wouldn't it be great to take that truck up to the lake. Throw a couple of sleeping bags in the back. Lie out under the stars. Yeah, it's 8:00. Don't tell me anything. Can I go now, Mr. Strickland? Marty, you seem so nervous, is something wrong?
+
+    But you're good, Marty, you're really good. And this audition tape of your is great, you gotta send it in to the record company. It's like Doc's always saying. About how far ahead are you going? That's good advice, Marty. Uh, well, I haven't finished those up yet, but you know I figured since they weren't due till- Alright, let's set your destination time. This is the exact time you left. I'm gonna send you back at exactly the same time. It's be like you never left. Now, I painted a white line on the street way over there, that's where you start from. I've calculated the distance and wind resistance fresh to active from the moment the lightning strikes, at exactly 7 minutes and 22 seconds. When this alarm goes off you hit the gas.
+
+    About how far ahead are you going? Great Scott. Let me see that photograph again of your brother. Just as I thought, this proves my theory, look at your brother. Mayor Goldie Wilson, I like the sound of that. Alright, okay. Alright, there she is, George. Just go in there and invite her. That was the day I invented time travel. I remember it vividly. I was standing on the edge of my toilet hanging a clock, the porces was wet, I slipped, hit my head on the edge of the sink. And when I came to I had a revelation, a picture, a picture in my head, a picture of this. This is what makes time travel possible. The flux capacitor.
+
+    whoa, whoa Doc, stuck here, I can't be stuck here, I got a life in 1985. I got a girl. Ahh. Ahh. No. My name's Lorraine, Lorraine Baines. Nothing, nothing, nothing, look tell her destiny has brought you together, tell her that she's the most beautiful you have ever seen. Girls like that stuff. What, what are you doing George?
+
+    You cost three-hundred buck damage to my car, you son-of-a-bitch. And I'm gonna take it out of your ass. Hold him. It was meant to be. Anyway, if Grandpa hadn't hit him, then none of you would have been born. Believe me, Marty, you're better off not having to worry about all the aggravation and headaches of playing at that dance. Bear with me, Marty, all of your questions will be answered. Roll tape, we'll proceed. You cost three-hundred buck damage to my car, you son-of-a-bitch. And I'm gonna take it out of your ass. Hold him.
+
+    I don't worry. this is all wrong. I don't know what it is but when I kiss you, it's like kissing my brother. I guess that doesn't make any sense, does it? You extol me with a lot of confidence, Doc. Alright, c'mon, I think we're safe. Yeah, where does he live? Breakfast.
+
+    David, watch your mouth. You come here and kiss your mother before you go, come here. Ah. In that case, I'll tell you strait out. Uh, Doc. Indeed I will, roll em. I, Doctor Emmett Brown, am about to embark on an historic journey. What have I been thinking of, I almost forgot to bring some extra plutonium. How did I ever expect to get back, one pallet one trip I must be out of my mind. What is it Einy? Oh my god, they found me, I don't know how but they found me. Run for it, Marty.
+
+    Well, uh, listen, uh, I really- Right. Oh, no no no, I never uh, I never let anybody read my stories. Einstein, hey Einstein, where's the Doc, boy, huh? Doc Lorraine, are you up there?
+
+    Of course, from a group of Libyan Nationalists. They wanted me to build them a bomb, so I took their plutonium and in turn gave them a shiny bomb case full of used pinball machine parts. I guarantee it. Of course, from a group of Libyan Nationalists. They wanted me to build them a bomb, so I took their plutonium and in turn gave them a shiny bomb case full of used pinball machine parts. I hope so. Right, gimme a Pepsi free.
+
+    She's just trying to keep you respectable. Well, they're your parents, you must know them. What are their common interests, what do they like to do together? Excuse me. Doc. Time machine, I haven't invented any time machine.
+
+    His head's gone, it's like it's been erased. Oh, just a little weather experiment. Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay? Don't say a word. George, help me, please.
+
+    Hey George, heard you laid out Biff, nice going. That's George McFly. What, what, ma? You wait and see, Mr. Caruthers, I will be mayor and I'll be the most powerful mayor in the history of Hill Valley, and I'm gonna clean up this town. Hey.
+
+    Yeah but George, Lorraine wants to go with you. Give her a break. Doc, Doc, it's me, Marty. What's a rerun? You know what I do in those situations? Where were we.
+
+    Uh, I think so. What about George? Nothing, nothing, nothing, look tell her destiny has brought you together, tell her that she's the most beautiful you have ever seen. Girls like that stuff. What, what are you doing George? Our first television set, Dad just picked it up today. Do you have a television? Alright, okay Jennifer. What if I send in the tape and they don't like it. I mean, what if they say I'm no good. What if they say, 'Get out of here, kid, you got no future.' I mean, I just don't think I can take that kind of rejection. Jesus, I'm beginning to sound like my old man.
+
+    It's information about the future isn't it. I warned you about this kid. The consequences could be disastrous. That's George McFly? Something that really cooks. Alright, alright this is an oldie, but uh, it's an oldie where I come from. Alright guys, let's do some blues riff in b, watch me for the changes, and uh, try and keep up, okay. Okay, real mature guys. Okay, Biff, will you pick up my books? Excuse me.
+
+    Uh, well, okay Biff, uh, I'll finish that on up tonight and I'll bring it over first thing tomorrow morning. Yeah, well, I still don't understand what Dad was doing in the middle of the street. Ronald Reagon. I need fuel. Go ahead, quick, get in the car. whoa, whoa Doc, stuck here, I can't be stuck here, I got a life in 1985. I got a girl.
+
+    It's my dad. you guys look great. Mom, you look so thin. Hello, Jennifer. It's uh, the other end of town, a block past Maple. Who, who?
+
+    Oh, what I meant to day was- That's true, Marty, I think you should spend the night. I think you're our responsibility. C'mon. I have a feeling too. I hope so.
+
+    Lorenzo, where're you keys? Evening, Doctor Brown, what's with the wire? Whoa, this is heavy. C'mon. Hey McFly, what do you think you're doing.
+
+    Doc, wait. No, bastards. Jennifer. Over there, on my hope chest. I've never seen purple underwear before, Calvin. Calm down, Marty, I didn't disintegrate anything. The molecular structure of Einstein and the car are completely intact. Uh, well, okay Biff, uh, I'll finish that on up tonight and I'll bring it over first thing tomorrow morning.
+
+    Oh no, don't touch that. That's some new specialized weather sensing equipment. Say, why do you let those boys push you around like that? What do you mean you've seen this, it's brand new. What did I just say? I'm writing this down, this is good stuff.
+
+    Calvin, why do you keep calling me Calvin? You wanna a Pepsi, pall, you're gonna pay for it. The hell you doing to my car? Uncle Jailbird Joey? Just relax now Calvin, you've got a big bruise on you're head.
+
+    Mom, is that you? Oh, great scott. You get the cable, I'll throw the rope down to you. I can't believe you loaned me a car, without telling me it had a blindspot. I could've been killed. No, no, George, look, it's just an act, right? Okay, so 9:00 you're strolling through the parking lot, you see us struggling in the car, you walk up, you open the door and you say, your line, George. That was so stupid, Grandpa hit him with the car.
+
+    Well, safe and sound, now, n good old 1955. Well, I guess that's everything. That's Strickland. Jesus, didn't that guy ever have hair? Then how am I supposed to ever meet anybody. Yeah, well, I still don't understand what Dad was doing in the middle of the street.
+
+    Hey, hey, Doc, where are you? Right, I got it. Oh, yeah, yeah. Give me a hand, Lorenzo. Ow, dammit, man, I sliced my hand. Hello.
+
+    Kids, we're gonna have to eat this cake by ourselves, Uncle Joey didn't make parole again. I think it would be nice, if you all dropped him a line. Wow, ah Red, you look great. Everything looks great. 1:24, I still got time. Oh my god. No, no not again, c'mon, c'mon. Hey. Libyans. Marty, you made it. Well, Biff. I, I don't know.
+
+    Hey I'm talking to you, McFly, you Irish bug. So you're my Uncle Joey. Better get used to these bars, kid. Take care. Sit here, Marty. But I can't go to the dance, I'll miss my favorite television program, Science Fiction Theater.
+
+    Right about here. Thanks a lot, kid. What did your mother ever see in that kid? Why not? And he could sleep in my room.
+
+    Wow, ah Red, you look great. Everything looks great. 1:24, I still got time. Oh my god. No, no not again, c'mon, c'mon. Hey. Libyans. Yeah, well, how about my homework, McFly? I don't know, I can't keep up with all of your boyfriends. Give me a hand, Lorenzo. Ow, dammit, man, I sliced my hand. Excuse me.
+
+    Hi, Marty. Next, please. I'm sure that in 1985, plutonium is available at every corner drug store, but in 1955, it's a little hard to come by. Marty, I'm sorry, but I'm afraid you're stuck here. Okay. I hope you don't mind but George asked if he could take me home.
+
+    How's your head? Well, she's not doing a very good job. I guarantee it. Oh, yeah, yeah. Watch it, Goldie.
+
+    But I can't go to the dance, I'll miss my favorite television program, Science Fiction Theater. Yeah, well uh, lets keep this brain melting stuff to ourselves, okay? Okay, that's enough. Now stop the microphone. I'm sorry fellas. I'm afraid you're just too darn loud. Next, please. Where's the next group, please. My equipment, that reminds me, Marty, you better not hook up to the amplifier. There's a slight possibility for overload. What, well you mean like a date?
+
+    Hey, Doc? Doc. Hello, anybody home? Einstein, come here, boy. What's going on? Wha- aw, god. Aw, Jesus. Whoa, rock and roll. Yo Keys? There's that word again, heavy. Why are things so heavy in the future. Is there a problem with the Earth's gravitational pull? Good morning, Mom. Oh, Marty, I almost forgot, Jennifer Parker called. Ho ho ho, look at it roll. Now we could watch Jackie Gleason while we eat.
+
+    Radiation suit, of course, cause all of the fall out from the atomic wars. This is truly amazing, a portable television studio. No wonder your president has to be an actor, he's gotta look good on television. Tab? I can't give you a tab unless you order something. George. Thank god I still got my hair. What on Earth is that thing I'm wearing? Oh, I sure like her, Marty, she is such a sweet girl. Isn't tonight the night of the big date?
+
+    George: you ever think of running for class president? Mom, is that you? Don't pay any attention to him, he's in one of his moods. Sam, quit fiddling with that thing, come in here to dinner. Now let's see, you already know Lorraine, this is Milton, this is Sally, that's Toby, and over there in the playpen is little baby Joey. Who is that guy. Why am I always the last one to know about these things.
+
+    Uh, look me up when you get there. Well, bring her along. This concerns her too. Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay? Yeah. Okay, that's enough. Now stop the microphone. I'm sorry fellas. I'm afraid you're just too darn loud. Next, please. Where's the next group, please.
+
+    That's true, Marty, I think you should spend the night. I think you're our responsibility. Ahh. Nothing, nothing, nothing, look tell her destiny has brought you together, tell her that she's the most beautiful you have ever seen. Girls like that stuff. What, what are you doing George? I guess you guys aren't ready for that yet. But your kids are gonna love it. Yeah.
+
+    Marty, one rejection isn't the end of the world. Look me up when you get there, guess I'll be about 47. Well yeah, you know we have two of them. Let's get you into a radiation suit, we must prepare to reload. I don't worry. this is all wrong. I don't know what it is but when I kiss you, it's like kissing my brother. I guess that doesn't make any sense, does it?
+
+    You're gonna break his arm. Biff, leave him alone. Let him go. Let him go. I, I don't know. Breakfast. Don't tell me anything. Save the clock tower.
+
+    George, buddy. remember that girl I introduced you to, Lorraine. What are you writing? Biff, stop it. Biff, you're breaking his arm. Biff, stop. Ah well, sort of. After I fell off my toilet, I drew this. Right, and where am I gonna be?
+
+    Yet. Something that really cooks. Alright, alright this is an oldie, but uh, it's an oldie where I come from. Alright guys, let's do some blues riff in b, watch me for the changes, and uh, try and keep up, okay. What did she say? It's your mom, she's tracked you down. Quick, let's cover the time machine. You're gonna be in the car with her. Right, I got it.
+
+    Over there, on my hope chest. I've never seen purple underwear before, Calvin. Wait a minute, wait a minute, Doc, are you telling me that you built a time machine out of a delorean. No wait, Doc, the bruise, the bruise on your head, I know how that happened, you told me the whole story. you were standing on your toilet and you were hanging a clock, and you fell, and you hit your head on the sink, and that's when you came up with the idea for the flux capacitor, which makes time travel possible. Doc, wait. No, bastards. Good evening, I'm Doctor Emmett Brown. I'm standing on the parking lot of Twin Pines Mall. It's Saturday morning, October 26, 1985, 1:18 a.m. and this is temporal experiment number one. C'mon, Einy, hey hey boy, get in there, that a boy, in you go, get down, that's it.
+
+    God dammit, I'm late. You know Marty, I'm gonna be very sad to see you go. You've really mad a difference in my life, you've given me something to shoot for. Just knowing, that I'm gonna be around to se 1985, that I'm gonna succeed in this. That I'm gonna have a chance to travel through time. It's going to be really hard waiting 30 years before I could talk to you about everything that's happened in the past few days. I'm really gonna miss you, Marty. Jennifer. Good evening, I'm Doctor Emmett Brown. I'm standing on the parking lot of Twin Pines Mall. It's Saturday morning, October 26, 1985, 1:18 a.m. and this is temporal experiment number one. C'mon, Einy, hey hey boy, get in there, that a boy, in you go, get down, that's it. Well looky what we have here. No no no, you're staying right here with me.
+
+    Einstein, hey Einstein, where's the Doc, boy, huh? Doc Uh, you mean nobody's asked you? Watch it, Goldie. Look, there's a rhythmic ceremonial ritual coming up. Something that really cooks. Alright, alright this is an oldie, but uh, it's an oldie where I come from. Alright guys, let's do some blues riff in b, watch me for the changes, and uh, try and keep up, okay.
+
+    Oh, oh Marty, here's your keys. You're all waxed up, ready for tonight. Biff. Hey, hey, keep rolling, keep rolling there. No, no, no, no, this sucker's electrical. But I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity that I need. No, no, George, look, it's just an act, right? Okay, so 9:00 you're strolling through the parking lot, you see us struggling in the car, you walk up, you open the door and you say, your line, George. Yes, yes, I'm George, George McFly, and I'm your density. I mean, I'm your destiny.
+
+    Hey, hey, Doc, where are you? Doc. Yeah, I think it's a major embarrassment having an uncle in prison. I over slept, look I need your help. I have to ask Lorraine out but I don't know how to do it. I have to ask Lorraine out but I don't know how to do it. Hey c'mon, I had to change, you think I'm going back in that zoot suit? The old man really came through it worked.
+
+    It's my dad. Without any sugar. Right, and where am I gonna be? Listen, Doc. Uh, coast guard.
+
+    Oh Mom, there's nothing wrong with calling a boy. Something that really cooks. Alright, alright this is an oldie, but uh, it's an oldie where I come from. Alright guys, let's do some blues riff in b, watch me for the changes, and uh, try and keep up, okay. Anyway, Grandpa hit him with the car and brought him into the house. He seemed so helpless, like a little lost puppy, my heart just went out for him. Let's go. Uh, well, I haven't finished those up yet, but you know I figured since they weren't due till-
+
+    You bet. Over there, on my hope chest. I've never seen purple underwear before, Calvin. What? Well, safe and sound, now, n good old 1955. Uncle Jailbird Joey?
+
+    I'm sure that in 1985, plutonium is available at every corner drug store, but in 1955, it's a little hard to come by. Marty, I'm sorry, but I'm afraid you're stuck here. George. Oh yes sir. Lorraine. Well, Marty, I want to thank you for all your good advice, I'll never forget it.
+
+    Shut your filthy mouth, I'm not that kind of girl. Yeah, I guessed you're a sailor, aren't you, that's why you wear that life preserver. Whoa, wait, Doc. Now, of course not, Biff, now, I wouldn't want that to happen. No no no this sucker's electrical, but I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity-
+
+    Don't stop, Wilbert, drive. This is uh, this is heavy duty, Doc, this is great. Uh, does it run on regular unleaded gasoline? He's a very strange young man. I'm telling the truth, Doc, you gotta believe me. Excuse me.
+
+    Look me up when you get there, guess I'll be about 47. He's a very strange young man. Yeah. Take that you mutated son-of-a-bitch. My pine, why you. You space bastard, you killed a pine. Oh, yeah, yeah.
+
+    Don't worry, I'll take care of the lightning, you take care of your pop. By the way, what happened today, did he ask her out? Ahh. Okay. Hey man, look at Marvin's hand. He can't play with his hands like that, and we can't play without him. I think I know exactly what you mean.
+
+    No, Biff, you leave her alone. Yeah Mom, we know, you've told us this story a million times. You felt sorry for him so you decided to go with him to The Fish Under The Sea Dance. Okay, real mature guys. Okay, Biff, will you pick up my books? Ahh. Thanks.
+
+    Dear Doctor Brown, on the night that I go back in time, you will be shot by terrorists. Please take whatever precautions are necessary to prevent this terrible disaster. Your friend, Marty. Let's go. Cause, George, she wants to go to the dance with you, she just doesn't know it yet. That's why we got to show her that you, George McFly, are a fighter. You're somebody who's gonna stand up for yourself, someone who's gonna protect her. Listen, Doc. Y'know this time it wasn't my fault. The Doc set all of his clocks twenty-five minutes slow.
+
+    You wanna a Pepsi, pall, you're gonna pay for it. Our first television set, Dad just picked it up today. Do you have a television? You do? Oh. My god, it's my mother. Put your pants back on.
+
+    Breakfast. Now, Biff, um, can I assume that your insurance is gonna pay for the damage? Indeed I will, roll em. I, Doctor Emmett Brown, am about to embark on an historic journey. What have I been thinking of, I almost forgot to bring some extra plutonium. How did I ever expect to get back, one pallet one trip I must be out of my mind. What is it Einy? Oh my god, they found me, I don't know how but they found me. Run for it, Marty. So tell me, Marty, how long have you been in port? Which one's your pop?
+
+    Ahh. I'm too loud. I can't believe it. I'm never gonna get a chance to play in front of anybody. It's already mutated into human form, shoot it. What, what, ma? You know, Doc, you left your equipment on all week.
+
+    Sam, here's the young man you hit with your car out there. He's alright, thank god. you guys look great. Mom, you look so thin. It's about the future, isn't it? Is she pretty? It's taken me almost thirty years and my entire family fortune to realize the vision of that day, my god has it been that long. Things have certainly changed around here. I remember when this was all farmland as far as the eye could see. Old man Peabody, owned all of this. He had this crazy idea about breeding pine trees.
+
+    Shut your filthy mouth, I'm not that kind of girl. Wow, you must be rich. His head's gone, it's like it's been erased. A colored mayor, that'll be the day. Yeah, I guessed you're a sailor, aren't you, that's why you wear that life preserver.
+
+    Right. Listen, this is very important, I forgot my video camera, could you stop by my place and pick it up on your way to the mall? I'm really gonna miss you. Doc, about the future- Huh? Um, well it's a delorean, right?
+
+    Over there, on my hope chest. I've never seen purple underwear before, Calvin. Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Save the clock tower, save the clock tower. Mayor Wilson is sponsoring an initiative to replace that clock. Thirty years ago, lightning struck that clock tower and the clock hasn't run since. We at the Hill Valley Preservation Society think it should be preserved exactly the way it is as part of our history and heritage. I think it's terrible. Girls chasing boys. When I was your age I never chased a boy, or called a boy, or sat in a parked car with a boy. Breakfast.
+
+    Well, what if they didn't like them, what if they told me I was no good. I guess that would be pretty hard for somebody to understand. No, no, George, look, it's just an act, right? Okay, so 9:00 you're strolling through the parking lot, you see us struggling in the car, you walk up, you open the door and you say, your line, George. Thank god I still got my hair. What on Earth is that thing I'm wearing? I hope you don't mind but George asked if he could take me home. He's a very strange young man.
+
+    Right, I got it. That's Strickland. Jesus, didn't that guy ever have hair? That was the day I invented time travel. I remember it vividly. I was standing on the edge of my toilet hanging a clock, the porces was wet, I slipped, hit my head on the edge of the sink. And when I came to I had a revelation, a picture, a picture in my head, a picture of this. This is what makes time travel possible. The flux capacitor. Just finishing up the second coat now. Mr. McFly, Mr. McFly, this just arrived, oh hi Marty. I think it's your new book.
+
+    Yeah. What, what? Marty, will we ever see you again? Marty, are you alright? Your not gonna be picking a fight, Dad, dad dad daddy-o. You're coming to a rescue, right? Okay, let's go over the plan again. 8:55, where are you gonna be.
+
+    You extol me with a lot of confidence, Doc. Doc. Listen, woh. Hello, uh excuse me. Sorry about your barn. Hey, hey, keep rolling, keep rolling there. No, no, no, no, this sucker's electrical. But I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity that I need. Evening, Doctor Brown, what's with the wire?
+
+    But, what are you blind McFly, it's there. How else do you explain that wreck out there? Doc, Doc. Oh, no. You're alive. Bullet proof vest, how did you know, I never got a chance to tell you. About all that talk about screwing up future events, the space time continuum. Okay, alright, I'll prove it to you. Look at my driver's license, expires 1987. Look at my birthday, for crying out load I haven't even been born yet. And, look at this picture, my brother, my sister, and me. Look at the sweatshirt, Doc, class of 1984. Why do you keep following me around? Hey beat it, spook, this don't concern you.
+
+    Because, you might regret it later in life. You do? Yoo. Hello. Keys?
+
+    Yoo. Uh, well, actually, I figured since it wasn't due till Monday- Why is she gonna get angry with you? Doc, she's beautiful. She's crazy about me. Look at this, look what she wrote me, Doc. That says it all. Doc, you're my only hope. What?
+
+    Ronald Reagon, the actor? Then who's vice president, Jerry Lewis? I suppose Jane Wymann is the first lady. I'll call you tonight. After I fell off my toilet, I drew this. C'mon, he's not that bad. At least he's letting you borrow the car tomorrow night. Alright, I'm ready.
+
+    Oh, great scott. You get the cable, I'll throw the rope down to you. What? Marty, I'm sorry, but the only power source capable of generating one point twenty-one gigawatts of electricity is a bolt of lightning. Yeah but George, Lorraine wants to go with you. Give her a break. Actually, people call me Marty.
+
+    whoa, whoa Doc, stuck here, I can't be stuck here, I got a life in 1985. I got a girl. Mom, Dad. Dear Doctor Brown, on the night that I go back in time, you will be shot by terrorists. Please take whatever precautions are necessary to prevent this terrible disaster. Your friend, Marty. I know, and all I could say is I'm sorry. No no. Lorraine, Lorraine, what are you doing?
+
+    It's about the future, isn't it? Your, your right. Something wrong with the starter, so I hid it. You extol me with a lot of confidence, Doc. She's just trying to keep you respectable.
+
+    Doc, you gotta help me. you were the only one who knows how your time machine works. Oh, oh a rematch, why, were you cheating? Alright, we're the pinheads. Where were we. Of course, the Enchantment Under The Sea Dance they're supposed to go to this, that's where they kiss for the first time.
+
+    Well, bring her along. This concerns her too. Listen, Doc, you know there's something I haven't told you about the night we made that tape. Good. Have a good trip Einstein, watch your head. This is uh, this is heavy duty, Doc, this is great. Uh, does it run on regular unleaded gasoline? I think it's terrible. Girls chasing boys. When I was your age I never chased a boy, or called a boy, or sat in a parked car with a boy.
+
+    That's George McFly. Kids, we're gonna have to eat this cake by ourselves, Uncle Joey didn't make parole again. I think it would be nice, if you all dropped him a line. You wanna a Pepsi, pall, you're gonna pay for it. Ah. Can't be. This is nuts. Aw, c'mon.
+
+    Oh no, don't touch that. That's some new specialized weather sensing equipment. Wait a minute, what are you doing, Doc? Yeah well look, Marvin, Marvin, you gotta play. See that's where they kiss for the first time on the dance floor. And if there's no music, they can't dance, and if they can't dance, they can't kiss, and if they can't kiss, they can't fall in love and I'm history. Yes, yes, I'm George, George McFly, and I'm your density. I mean, I'm your destiny. Radiation suit, of course, cause all of the fall out from the atomic wars. This is truly amazing, a portable television studio. No wonder your president has to be an actor, he's gotta look good on television.
+
+    It's already mutated into human form, shoot it. Yeah, exactly. Yoo. Marty. Marty. Marty. Doc.
+
+    Ahh. Save the clock tower, save the clock tower. Mayor Wilson is sponsoring an initiative to replace that clock. Thirty years ago, lightning struck that clock tower and the clock hasn't run since. We at the Hill Valley Preservation Society think it should be preserved exactly the way it is as part of our history and heritage. Now which one was it, Greg or Craig? Look, there's a rhythmic ceremonial ritual coming up. That's Strickland. Jesus, didn't that guy ever have hair?
+
+    You know Marty, you look so familiar, do I know your mother? No no no this sucker's electrical, but I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity- Dear Doctor Brown, on the night that I go back in time, you will be shot by terrorists. Please take whatever precautions are necessary to prevent this terrible disaster. Your friend, Marty. What? Anyway, Grandpa hit him with the car and brought him into the house. He seemed so helpless, like a little lost puppy, my heart just went out for him.
+
+    Look, there's a rhythmic ceremonial ritual coming up. Alright, okay Jennifer. What if I send in the tape and they don't like it. I mean, what if they say I'm no good. What if they say, 'Get out of here, kid, you got no future.' I mean, I just don't think I can take that kind of rejection. Jesus, I'm beginning to sound like my old man. What a nightmare. What the hell is a gigawatt? Oh.
+
+    No, Doc. It's cold, damn cold. Ha, ha, ha, Einstein, you little devil. Einstein's clock is exactly one minute behind mine, it's still ticking. Yeah, well, I still don't understand what Dad was doing in the middle of the street. Keys? Ahh.
+
+    Well that's your name, isn't it? Calvin Klein. it's written all over your underwear. Oh, I guess they call you Cal, huh? He's an absolute dream. Right, I got it. Just turn around, McFly, and walk away. Are you deaf, McFly? Close the door and beat it. Evening, Doctor Brown, what's with the wire?
+
+    Well, aren't you going up to the lake tonight, you've been planning it for two weeks. Huh? Ah, honey, your first novel. Save the clock tower. C'mon.
+
+    The car, Dad, I mean He wrecked it, totaled it. I needed that car tomorrow night, Dad, I mean do you have any idea how important this was, do you have any clue? Doc. Hey George, heard you laid out Biff, nice going. Ronald Reagon. I just wanna use the phone.
+
+    Ho, you mean you're gonna touch her on her- Biff, stop it. Biff, you're breaking his arm. Biff, stop. I'm really gonna miss you. Doc, about the future- We do now. Dear Doctor Brown, on the night that I go back in time, you will be shot by terrorists. Please take whatever precautions are necessary to prevent this terrible disaster. Your friend, Marty.
+
+    Lynda, first of all, I'm not your answering service. Second of all, somebody named Greg or Craig called you just a little while ago. Mom, Dad. No, why, what's a matter? Y'know this time it wasn't my fault. The Doc set all of his clocks twenty-five minutes slow. Uh, coast guard.
+
+    I'm really gonna miss you. Doc, about the future- This is for all you lovers out there. You know Marty, I'm gonna be very sad to see you go. You've really mad a difference in my life, you've given me something to shoot for. Just knowing, that I'm gonna be around to se 1985, that I'm gonna succeed in this. That I'm gonna have a chance to travel through time. It's going to be really hard waiting 30 years before I could talk to you about everything that's happened in the past few days. I'm really gonna miss you, Marty. That's Strickland. Jesus, didn't that guy ever have hair? What, what, ma?
+
+    You extol me with a lot of confidence, Doc. Um, yeah, I'm on my way. And he could sleep in my room. Look, you gotta listen to me. Please note that Einstein's clock is in complete synchronization with my control watch.
+
+    His head's gone, it's like it's been erased. Right. Hey beat it, spook, this don't concern you. I need fuel. Go ahead, quick, get in the car. Alright, take it up, go. Doc.
+
+    How could I have been so careless. One point twenty-one gigawatts. Tom, how am I gonna generate that kind of power, it can't be done, it can't. I followed you. Please, Marty, don't tell me, no man should know too much about their own destiny. Hello. Now, Biff, um, can I assume that your insurance is gonna pay for the damage?
+
+    Yeah, gimme a Tab. Listen, I gotta go but I wanted to tell you that it's been educational. Well, it will just happen. Like the way I met your father. What? Oh, oh Marty, here's your keys. You're all waxed up, ready for tonight.
+
+    It's a board with wheels. Whoa, this is heavy. Now which one was it, Greg or Craig? You can't, uh, that is, uh, nobody's home. C'mon.
+
+    How about a ride, Mister? Science Fiction Theater. Don't stop, Wilbert, drive. You heard her she said get your meat hooks, off, uh please. Okay.
+
+    Right. He's a peeping tom. Dad. Because, you might regret it later in life. Welcome to my latest experiment. It's the one I've been waiting for all my life. Jennifer.
+
+    No, Doc. And where's my reports? Who? It's my dad. Doc, you don't just walk into a store and ask for plutonium. Did you rip this off?
+
+    Hey beat it, spook, this don't concern you. Why thank you, Marty. George. Good morning, sleepyhead, Good morning, Dave, Lynda I guess you guys aren't ready for that yet. But your kids are gonna love it. Well, ma, we talked about this, we're not gonna go to the lake, the car's wrecked. Well, they're bigger than me.
+
+    Right, gimme a Pepsi free. Just turn around, McFly, and walk away. Are you deaf, McFly? Close the door and beat it. Ahh. Thanks a lot, kid. Uh listen, do you know where Riverside Drive is?
+
+    What? You can't, uh, that is, uh, nobody's home. Doc, is that a de- Great good, good, Lorraine, I had a feeling about you two. Right.
+
+    Well, uh, listen, uh, I really- Yeah well look, Marvin, Marvin, you gotta play. See that's where they kiss for the first time on the dance floor. And if there's no music, they can't dance, and if they can't dance, they can't kiss, and if they can't kiss, they can't fall in love and I'm history. You bet. You'll find out. Quiet down, I'm sure the car is fine.
+
+    Yeah, I'm- mayor. Now that's a good idea. I could run for mayor. Ah well, sort of. George, help me, please. whoa, this is it, this is the part coming up, Doc. Well, they're bigger than me.
+
+    Uh no, not hard at all. So anyway, George, now Lorraine, she really likes you. She told me to tell you that she wants you to ask her to the Enchantment Under The Sea Dance. Are you gonna order something, kid? Alright, I'm ready. Ohh, no. Huh?
+
+    George, aren't you gonna kiss me? You too. No no no, Doc, I just got here, okay, Jennifer's here, we're gonna take the new truck for a spin. Alright, I'm ready. Yeah but George, Lorraine wants to go with you. Give her a break.
+
+    Hey man, the dance is over. Unless you know someone else who could play the guitar. It's uh, the other end of town, a block past Maple. Yes, yes, I'm George, George McFly, and I'm your density. I mean, I'm your destiny. Doc, look, all we need is a little plutonium. Shape up, man. You're a slacker. You wanna be a slacker for the rest of your life?
+
+    No no no this sucker's electrical, but I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity that I need. Welcome to my latest experiment. It's the one I've been waiting for all my life. That's him. You'll find out. But you're good, Marty, you're really good. And this audition tape of your is great, you gotta send it in to the record company. It's like Doc's always saying.
+
+    Why not? Who are you calling spook, pecker-wood. I'm gonna be at the dance. Its good. Of course, the Enchantment Under The Sea Dance they're supposed to go to this, that's where they kiss for the first time.
+
+    Yeah, I guessed you're a sailor, aren't you, that's why you wear that life preserver. Is she pretty? Oh hey, Biff, hey, guys, how are you doing? Let's put him in there. Hey kid, what you do, jump ship?
+
+    Hot, Jesus Christ, Doc. Jesus Christ, Doc, you disintegrated Einstein. Let's put him in there. Mayor Goldie Wilson, I like the sound of that. Good morning, Mom. Oh, Marty, I almost forgot, Jennifer Parker called. No, Marty, we've already agreed that having information about the future could be extremely dangerous. Even if your intentions are good, they could backfire drastically. Whatever you've got to tell me I'll find out through the natural course of time.
+
+    Excuse me. Why thank you, Marty. George. Good morning, sleepyhead, Good morning, Dave, Lynda Oh, just a little weather experiment. I will. Hello.
+
+    Are you okay? Well, ma, we talked about this, we're not gonna go to the lake, the car's wrecked. Oh, I've been so worried about you ever since you ran off the other night. Are you okay? I'm sorry I have to go. Isn't he a dream boat? They're late. My experiment worked. They're all exactly twenty-five minutes slow. You cost three-hundred buck damage to my car, you son-of-a-bitch. And I'm gonna take it out of your ass. Hold him.
+
+    Wrecked? Where does he come from? Yeah. The only way we're gonna get those two to successfully meet is if they're alone together. So you've got to get your father and mother to interact at some sort of social- Oh honey, he's teasing you, nobody has two television sets.
+
+    Thank god I found you. Listen, can you meet me at Twin Pines Mall tonight at 1:15? I've made a major breakthrough, I'll need your assistance. Huh? Thank god I still got my hair. What on Earth is that thing I'm wearing? You got a real attitude problem, McFly. You're a slacker. You remind me of you father when he went her, he was a slacker too. Give me a hand, Lorenzo. Ow, dammit, man, I sliced my hand.
+
+    Shut your filthy mouth, I'm not that kind of girl. Oh, I sure like her, Marty, she is such a sweet girl. Isn't tonight the night of the big date? What's a rerun? What Lorraine, what? Oh.
+
+    How's your head? That's for messing up my hair. Why thank you, Marty. George. Good morning, sleepyhead, Good morning, Dave, Lynda Hey boy, are you alright? What kind of date? I don't know, what do kids do in the fifties?
+
+    Go. Marty, are you alright? Marty, you made it. Uh, Doc. Don't say a word.
+
+    Marty, that's completely out of the question, you must not leave this house. you must not see anybody or talk to anybody. Anything you do could have serious repercussions on future events. Do you understand? You're gonna be in the car with her. Look, there's a rhythmic ceremonial ritual coming up. Damn. I'm late for school. You don't understand.
+
+    David, watch your mouth. You come here and kiss your mother before you go, come here. Give me a hand, Lorenzo. Ow, dammit, man, I sliced my hand. C'mon man, let's do something that really cooks. Oh. Check out that four by four. That is hot. Someday, Jennifer, someday. Wouldn't it be great to take that truck up to the lake. Throw a couple of sleeping bags in the back. Lie out under the stars.
+
+    You'll find out. C'mon, c'mon. Well, aren't you going up to the lake tonight, you've been planning it for two weeks. Ronald Reagon, the actor? Then who's vice president, Jerry Lewis? I suppose Jane Wymann is the first lady. Oh, pleased to meet you, Calvin Marty Klein. Do you mind if I sit here?
+
+    Ahh. Yeah, alright, bye-bye. What? Oh Mom, there's nothing wrong with calling a boy. Alright kid, you stick to your father like glue and make sure that he takes her to the dance. I gotta go, uh, I gotta go. Thanks very much, it was wonderful, you were all great. See you all later, much later.
+
+    Marty, that was very interesting music. Just finishing up the second coat now. Oh, oh Marty, here's your keys. You're all waxed up, ready for tonight. Marty, that was very interesting music. Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay?
+
+    Actually, people call me Marty. This Saturday night, mostly clear, with some scattered clouds. Lows in the upper forties. Let's go. The car, Dad, I mean He wrecked it, totaled it. I needed that car tomorrow night, Dad, I mean do you have any idea how important this was, do you have any clue? Jennifer, oh are you a sight for sore eyes. Let me look at you.
+
+    Good morning, Mom. Mother, with Marty's parents out of town, don't you think he oughta spend the night, after all, Dad almost killed him with the car. Just turn around, McFly, and walk away. Are you deaf, McFly? Close the door and beat it. Hey man, the dance is over. Unless you know someone else who could play the guitar. Why is she gonna get angry with you?
+
+    So what's it to you, butthead. You know you've been looking for a, since you're new here, I'm gonna cut you a break, today. So why don't you make like a tree, and get out of here. Then how am I supposed to ever meet anybody. Children. A bolt of lightning, unfortunately, you never know when or where it's ever gonna strike. Do you mind if we park for a while?
+
+    What did you sleep in your clothes again last night. Jennifer. I swiped it from the old lady's liquor cabinet. Well, safe and sound, now, n good old 1955. I can't believe you loaned me a car, without telling me it had a blindspot. I could've been killed.
+
+    There's that word again, heavy. Why are things so heavy in the future. Is there a problem with the Earth's gravitational pull? Ah, where're my pants? Don't pay any attention to him, he's in one of his moods. Sam, quit fiddling with that thing, come in here to dinner. Now let's see, you already know Lorraine, this is Milton, this is Sally, that's Toby, and over there in the playpen is little baby Joey. Hey, George, buddy, you weren't at school, what have you been doing all day? Whoa, this is heavy.
+
+    Doc? I noticed you band is on the roster for dance auditions after school today. Why even bother Mcfly, you haven't got a chance, you're too much like your own man. No McFly ever amounted to anything in the history of Hill Valley. Uh, Doc. Well, bring her along. This concerns her too. Hi, Marty.
+
+    I don't wanna see you in here again. David, watch your mouth. You come here and kiss your mother before you go, come here. I do understand. If I know too much about my own future I could endanger my own existence, just as you endangered yours. No, not yet. You know, Doc, you left your equipment on all week.
+
+    Now, Biff, um, can I assume that your insurance is gonna pay for the damage? You have this thing hooked up to the car? What were you doing in the middle of the street, a kid your age. No, bastards. Hey, hey, I've seen this one, I've seen this one. This is a classic, this is where Ralph dresses up as the man from space.
+
+    Okay Doc, this is it. I got enough practical jokes for one evening. Good night, future boy. Will you take care of that? This is it. This is the answer. It says here that a bolt of lightning is gonna strike the clock tower precisely at 10:04 p.m. next Saturday night. If we could somehow harness this bolt of lightning, channel it into the flux capacitor, it just might work. Next Saturday night, we're sending you back to the future. Okay, but I don't know what to say.
+
+    you guys look great. Mom, you look so thin. Oh, hi , Marty. I didn't hear you come in. Fascinating device, this video unit. Alright kid, you stick to your father like glue and make sure that he takes her to the dance. Lorraine, are you up there? Go. Go.
+
+    Uh, well, okay Biff, uh, I'll finish that on up tonight and I'll bring it over first thing tomorrow morning. Uh Doc, uh no. No, don't be silly. Right. Well, she's not doing a very good job. Why is she gonna get angry with you?
+
+    Oh, pleased to meet you, Calvin Marty Klein. Do you mind if I sit here? Don't tell me. Uh, you want me to buy a subscription to the Saturday Evening Post? Do you mind if we park for a while? Right. I can't play.
+
+    Do you mind if we park for a while? Yeah, well, how about my homework, McFly? The car, Dad, I mean He wrecked it, totaled it. I needed that car tomorrow night, Dad, I mean do you have any idea how important this was, do you have any clue? Uh, you mean nobody's asked you? Hey McFly, what do you think you're doing.
+
+    Unfortunately no, it requires something with a little more kick, plutonium. Doc. Hey, Doc? Doc. Hello, anybody home? Einstein, come here, boy. What's going on? Wha- aw, god. Aw, Jesus. Whoa, rock and roll. Yo Right. Well, uh, listen, uh, I really-
+
+    Hi, it's really a pleasure to meet you. Huh? Biff, stop it. Biff, you're breaking his arm. Biff, stop. Ah. Whoa. Well, this is a radiation suit.
+
+    Wait a minute, wait a minute, Doc, are you telling me that you built a time machine out of a delorean. Crazy drunk drivers. Yeah, I guessed you're a sailor, aren't you, that's why you wear that life preserver. The way I see it, if you're gonna build a time machine into a car why not do it with some style. Besides, the stainless, steel construction made the flux dispersal- look out. Don't say a word.
+
+    Then how am I supposed to ever meet anybody. Well, what if they didn't like them, what if they told me I was no good. I guess that would be pretty hard for somebody to understand. Well, bring her along. This concerns her too. No no. Lorraine, Lorraine, what are you doing? Are those my clocks I hear?
+
+    Hey boy, are you alright? What's a rerun? About 30 years, it's a nice round number. Huh? But you're good, Marty, you're really good. And this audition tape of your is great, you gotta send it in to the record company. It's like Doc's always saying.
+
+    We're gonna take a little break but we'll be back in a while so, don't nobody go no where. Einstein, hey Einstein, where's the Doc, boy, huh? Doc Dear Doctor Brown, on the night that I go back in time, you will be shot by terrorists. Please take whatever precautions are necessary to prevent this terrible disaster. Your friend, Marty. The flux capacitor. We never would have fallen in love.
+
+    Marty, one rejection isn't the end of the world. Okay, alright, Saturday is good, Saturday's good, I could spend a week in 1955. I could hang out, you could show me around. I know what you're gonna say, son, and you're right, you're right, But Biff just happens to be my supervisor, and I'm afraid I'm not very good at confrontations. Why do you keep following me around? Stop it.
+
+    Thanks, thanks a lot. You have this thing hooked up to the car? The keys are in the trunk. I don't like her, Marty. Any girl who calls a boy is just asking for trouble. Last night, Darth Vader came down from planet Vulcan. And he told me that if I didn't take Lorraine, that he'd melt my brain.
+
+    I got enough practical jokes for one evening. Good night, future boy. Because, you might regret it later in life. Marty you gotta come back with me. No, Marty, we've already agreed that having information about the future could be extremely dangerous. Even if your intentions are good, they could backfire drastically. Whatever you've got to tell me I'll find out through the natural course of time. No, no, George, look, it's just an act, right? Okay, so 9:00 you're strolling through the parking lot, you see us struggling in the car, you walk up, you open the door and you say, your line, George.
+
+    Oh, I've been so worried about you ever since you ran off the other night. Are you okay? I'm sorry I have to go. Isn't he a dream boat? Ahh. Can I go now, Mr. Strickland? Well, Marty, I want to thank you for all your good advice, I'll never forget it. Wait a minute, wait a minute, Doc, are you telling me that you built a time machine out of a delorean.
+
+    Oh, oh a rematch, why, were you cheating? No no no, Doc, I just got here, okay, Jennifer's here, we're gonna take the new truck for a spin. Sit here, Marty. What's a rerun? It's already mutated into human form, shoot it.
+
+    you guys look great. Mom, you look so thin. I haven't No. yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Are you okay?
+
+    I know what you're gonna say, son, and you're right, you're right, But Biff just happens to be my supervisor, and I'm afraid I'm not very good at confrontations. The keys are in the trunk. I hope so. C'mon, c'mon let's go. You don't understand.
+
+    A colored mayor, that'll be the day. He's your brother, Mom. Good, you could start by sweeping the floor. I don't know, but I'm gonna find out. No no no this sucker's electrical, but I need a nuclear reaction to generate the one point twenty-one gigawatts of electricity-
+
+    No. Why am I always the last one to know about these things. Give me a hand, Lorenzo. Ow, dammit, man, I sliced my hand. We do now. Well, Marty, I'm almost eighteen-years-old, it's not like I've never parked before.
+
+    Hey, hey, Doc, where are you? Oh yes sir. My god, it's my mother. Put your pants back on. Wait a minute. Wait a minute, Doc. Are you telling me that it's 8:25? Give me a hand, Lorenzo. Ow, dammit, man, I sliced my hand.
+
+    Now, of course not, Biff, now, I wouldn't want that to happen. Well gee, I don't know. Well, because George, nice girls get angry when guys take advantage of them. No, fine, no , good, fine, good. Now remember, according to my theory you interfered with with your parent's first meeting. They don't meet, they don't fall in love, they won't get married and they wont have kids. That's why your older brother's disappeared from that photograph. Your sister will follow and unless you repair the damages, you will be next.
+
+    Ah. Whoa. Lorenzo, where're you keys? Uh, Doc. Now, of course not, Biff, now, I wouldn't want that to happen. Yeah, who are you?
+
+    Shit. Alright, alright, okay McFly, get a grip on yourself. It's all a dream. Just a very intense dream. Woh, hey, listen, you gotta help me. Hi, it's really a pleasure to meet you. What? Why thank you, Marty. George. Good morning, sleepyhead, Good morning, Dave, Lynda
+
+    I don't like her, Marty. Any girl who calls a boy is just asking for trouble. Yeah. Okay, that's enough. Now stop the microphone. I'm sorry fellas. I'm afraid you're just too darn loud. Next, please. Where's the next group, please. Nah, I just don't think I'm cut out for music. Back to the future.
+
+    Where does he come from? Okay, real mature guys. Okay, Biff, will you pick up my books? No, fine, no , good, fine, good. Please note that Einstein's clock is in complete synchronization with my control watch. I think it's terrible. Girls chasing boys. When I was your age I never chased a boy, or called a boy, or sat in a parked car with a boy.
+
+    Look, George, I'm telling you George, if you do not ask Lorraine to that dance, I'm gonna regret it for the rest of my life. Right about here. Hey, hey, Doc, where are you? Okay, but I don't know what to say. My equipment, that reminds me, Marty, you better not hook up to the amplifier. There's a slight possibility for overload.
+
+    What were you doing in the middle of the street, a kid your age. Where? Pa, what is it? What is it, Pa? Flux capacitor. You wait and see, Mr. Caruthers, I will be mayor and I'll be the most powerful mayor in the history of Hill Valley, and I'm gonna clean up this town.
+
+    Go. What's going on? Where have you been all week? I don't know, Doc, I guess she felt sorry for him cause her did hit him with the car, hit me with the car. Yeah I know, If you put your mind to it you could accomplish anything. What's that thing he's on?
+
+    Hey, hey, I've seen this one, I've seen this one. This is a classic, this is where Ralph dresses up as the man from space. Hello, hello, anybody home? Think, McFly, think. I gotta have time to recopy it. Do your realize what would happen if I hand in my homework in your handwriting? I'd get kicked out of school. You wouldn't want that to happen would you, would you? Why is she gonna get angry with you? No sir, I'm gonna make something out of myself, I'm going to night school and one day I'm gonna be somebody. I think it's terrible. Girls chasing boys. When I was your age I never chased a boy, or called a boy, or sat in a parked car with a boy.
+
+    Back to the future. Uh, no, no, no, no. What are you looking at, butt-head? You too. Ahh. Yeah man, that was good. Let's do another one.
+
+    I know what you're gonna say, son, and you're right, you're right, But Biff just happens to be my supervisor, and I'm afraid I'm not very good at confrontations. Well uh, good, fine. Alright, take it up, go. Doc. Believe me, Marty, you're better off not having to worry about all the aggravation and headaches of playing at that dance. Listen, Doc.
+
+    I don't know, but I'm gonna find out. I'm too loud. I can't believe it. I'm never gonna get a chance to play in front of anybody. I had a horrible nightmare, dreamed I went back in time, it was terrible. No. You're gonna break his arm. Biff, leave him alone. Let him go. Let him go.
+
+  NOWDOCPHP73;
+    }
+}
+
+class ClassAfterLongNowDoc
+{
+}


### PR DESCRIPTION
### ClassMapGenerator: add tests for "long heredoc" bug

... to proof the existence of the bug and demonstrate the effect.

Note: in the test the backtrack limit is being lowered (and restored back to the default afterwards) to prevent the tests needing ridiculously huge test fixture files.

### ClassMapGenerator: add test for "marker in text" bug

In PHP < 7.3, the heredoc/nowdoc marker was allowed to occur in the text, as long as it did not occur at the very start of the line.

This was also not handled correctly.

Ref: https://www.php.net/manual/en/migration73.incompatible.php#migration73.incompatible.core.heredoc-nowdoc

### ClassMapGenerator: fix the regex

By using a look ahead assertion to match "new line - maybe whitespace - marker", the negative performance impact of the `.*` is significantly mitigated and backtracing will be severely limited.

This fixes the bug as reported in #10037.

The bug was discovered due to a PHP 8.1 "passing null to non-nullable" deprecation notice being thrown, but is not a PHP 8.1 bug.

In actual fact, this issue affected all PHP versions and could lead to incomplete classmaps when the code base contained files with huge heredocs/nowdocs.

The regex change (not completely) incidentally also fixes an issue with markers in a heredoc/nowdoc not being correctly handled. This bug could lead to "classes" being added to the class map which aren't actually classes.

Fixes #10037

@Seldaek Please let me know if this should go to an earlier branch. Happy to rebase.