### PR TITLE
PHP 8.1: prevent a "null to non-nullable" deprecation notice [1]

### DIFF
--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -594,7 +594,10 @@ class Package extends BasePackage
 
         // only bitbucket, github and gitlab have auto generated dist URLs that easily allow replacing the reference in the dist URL
         // TODO generalize this a bit for self-managed/on-prem versions? Some kind of replace token in dist urls which allow this?
-        if (preg_match('{^https?://(?:(?:www\.)?bitbucket\.org|(api\.)?github\.com|(?:www\.)?gitlab\.com)/}i', $this->getDistUrl())) {
+        if (
+            $this->getDistUrl() !== null
+            && preg_match('{^https?://(?:(?:www\.)?bitbucket\.org|(api\.)?github\.com|(?:www\.)?gitlab\.com)/}i', $this->getDistUrl())
+        ) {
             $this->setDistReference($reference);
             $this->setDistUrl(preg_replace('{(?<=/|sha=)[a-f0-9]{40}(?=/|$)}i', $reference, $this->getDistUrl()));
         } elseif ($this->getDistReference()) { // update the dist reference if there was one, but if none was provided ignore it


### PR DESCRIPTION
Discovered while running the existing unit tests on PHP 8.1.

The default state of the protected `$distUrl` property is "not set" and the property may not be set when the `Package::setSourceDistReferences()` method gets called.

Fixes a total of 9 deprecation notices along the lines of:
```
Deprecation triggered by Composer\Test\DependencyResolver\PoolBuilderTest::testPoolBuilder:
preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated

Stack trace:
0 [internal function]: Symfony\Bridge\PhpUnit\DeprecationErrorHandler->handleError(8192, '...', '...', 597)
1 src/Composer/Package/Package.php(597): preg_match('...', NULL)
2 src/Composer/DependencyResolver/PoolBuilder.php(360): Composer\Package\Package->setSourceDistReferences('...')
3 src/Composer/DependencyResolver/PoolBuilder.php(338): Composer\DependencyResolver\PoolBuilder->loadPackage(Object(Composer\DependencyResolver\Request), Object(Composer\Package\CompletePackage))
4 src/Composer/DependencyResolver/PoolBuilder.php(195): Composer\DependencyResolver\PoolBuilder->loadPackagesMarkedForLoading(Object(Composer\DependencyResolver\Request), Array)
5 src/Composer/Repository/RepositorySet.php(229): Composer\DependencyResolver\PoolBuilder->buildPool(Array, Object(Composer\DependencyResolver\Request))
6 tests/Composer/Test/DependencyResolver/PoolBuilderTest.php(110): Composer\Repository\RepositorySet->createPool(Object(Composer\DependencyResolver\Request), Object(Composer\IO\NullIO))
...
```

👉🏻 Side-note: I'm wondering why `$this->getDistUrl()` is used instead of using the `$distUrl` property. It is a property within the same class after all. Haven't changed it, but did want to raise the question.

Refs:
* https://www.php.net/manual/en/function.preg-match.php
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg