### PR TITLE
Rule::getRequiredPackage(): always return a string

### DIFF
--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -91,6 +91,8 @@ abstract class Rule
         if ($reason === self::RULE_PACKAGE_REQUIRES) {
             return $this->reasonData->getTarget();
         }
+
+        return '';
     }
 
     public function setType($type)


### PR DESCRIPTION
The return type of the `Rule::getRequiredPackage()` method effectively was `?string` as, if no matching reason was found, the function wasn't returning anything.

In PHP 8.1, this results in 97 notices along the lines of the below from existing tests:
```
Deprecation triggered by Composer\Test\DependencyResolver\SolverTest::testConflictResultEmpty:
strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated

Stack trace:
0 [internal function]: Symfony\Bridge\PhpUnit\DeprecationErrorHandler->handleError(8192, '...', '...', 111)
1 src/Composer/DependencyResolver/SolverProblemsException.php(111): strpos(NULL, '...')
2 src/Composer/DependencyResolver/SolverProblemsException.php(44): Composer\DependencyResolver\SolverProblemsException->hasExtensionProblems(Array)
3 tests/Composer/Test/DependencyResolver/SolverTest.php(659): Composer\DependencyResolver\SolverProblemsException->getPrettyString(Object(Composer\Repository\RepositorySet), Object(Composer\DependencyResolver\Request), Object(Composer\DependencyResolver\Pool), false)
....
```

Fixed by returning an empty string if no reason was matched.

👉🏻 I'm actually a little surprised this wasn't being flagged by PHPStan. Couldn't find an issue for it in the baseline either.