### PR TITLE
PHP 8.1: prevent a "null to non-nullable" deprecation notice [2] (test only fix)

### DIFF
--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -50,7 +50,7 @@ class InstallerTest extends TestCase
     public function tearDown()
     {
         chdir($this->prevCwd);
-        if (is_dir($this->tempComposerHome)) {
+        if (isset($this->tempComposerHome) && is_dir($this->tempComposerHome)) {
             $fs = new Filesystem;
             $fs->removeDirectory($this->tempComposerHome);
         }


### PR DESCRIPTION
Not all tests in the `InstallerTest` class actually create a temporary directory and set the `$this->tempComposerHome` property.

Those tests which didn't, throw a notice in PHP 8.1.

Fixes 3 notices along the lines of:
```
Deprecation triggered by Composer\Test\InstallerTest::tearDown:
is_dir(): Passing null to parameter #1 ($filename) of type string is deprecated

Stack trace:
0 [internal function]: Symfony\Bridge\PhpUnit\DeprecationErrorHandler->handleError(8192, '...', '...', 53)
1 tests/Composer/Test/InstallerTest.php(53): is_dir(NULL)
...
```