### PR TITLE
PHP 8.1: prevent a "null to non-nullable" deprecation notice [3]

### DIFF
--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -336,6 +336,10 @@ class Git
         );
 
         $errorOutput = $this->process->getErrorOutput();
+        if (null === $errorOutput) {
+            return false;
+        }
+
         foreach ($authFailures as $authFailure) {
             if (strpos($errorOutput, $authFailure) !== false) {
                 return true;

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -361,7 +361,7 @@ class ProcessExecutor
     /**
      * Get any error output from the last command
      *
-     * @return string
+     * @return ?string
      */
     public function getErrorOutput()
     {


### PR DESCRIPTION
The default state for the `ProcessExecutor::$errorOutput` property is "not set" and if there has been no error during the execution of the process, it may well still be, resulting in the return value of `$this->process->getErrorOutput()` being `null`.

In that case, we may as well bypass the whole `foreach` as it will never match any of the recognized authentication failure messages.

Includes correcting the return type for the `ProcessExecutor::getErrorOutput()` method.

👉🏻 There are several alternative solutions possible here:
* Set a default value for the `ProcessExecutor::$errorOutput` property of an empty string.
* Check within the `ProcessExecutor::getErrorOutput()` method whether the property is set and if not, return an empty string.

Not sure what is the best solution, please provide guidance.

Fixes a total of 5 deprecation notices along the lines of:
```
Deprecation triggered by Composer\Test\Downloader\GitDownloaderTest::testDownloadThrowsRuntimeExceptionIfGitCommandFails:
strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated

Stack trace:
0 [internal function]: Symfony\Bridge\PhpUnit\DeprecationErrorHandler->handleError(8192, '...', '...', 340)
1 src/Composer/Util/Git.php(340): strpos(NULL, '...')
2 src/Composer/Util/Git.php(200): Composer\Util\Git->isAuthenticationFailure('...', Array)
3 src/Composer/Downloader/GitDownloader.php(121): Composer\Util\Git->runCommand(Object(Closure), '...', NULL, true)
4 src/Composer/Downloader/VcsDownloader.php(137): Composer\Downloader\GitDownloader->doInstall(Object(Mock_PackageInterface_f8be9ebd), '...', '...')
5 tests/Composer/Test/Downloader/GitDownloaderTest.php(349): Composer\Downloader\VcsDownloader->install(Object(Mock_PackageInterface_f8be9ebd), '...')
...
```