### PR TITLE
PHP 8.1/LibraryInstallerTest: add missing mock expectation

### DIFF
--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -201,6 +201,10 @@ class LibraryInstallerTest extends TestCase
             ->expects($this->any())
             ->method('getPrettyName')
             ->will($this->returnValue('pkg'));
+        $package
+            ->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('pkg'));
 
         $this->repository
             ->expects($this->exactly(2))


### PR DESCRIPTION
The `LibraryInstallerTest::testUninstall()` method mocks a `Package` object, but did not set an expectation for a call to `getName()`, while that method _is_ called in the `LibraryInstaller::uninstall()` method.

Without expectation, the mock returns `null`, which was subsequently being passed on to `strpos()` leading to the below error.

Fixes:
```
Deprecation triggered by Composer\Test\Installer\LibraryInstallerTest::testUninstall:
strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated

Stack trace:
0 [internal function]: Symfony\Bridge\PhpUnit\DeprecationErrorHandler->handleError(8192, '...', '...', 202)
1 src/Composer/Installer/LibraryInstaller.php(202): strpos(NULL, '...')
2 vendor/react/promise/src/FulfilledPromise.php(28): Composer\Installer\LibraryInstaller->Composer\Installer\{closure}(NULL)
3 src/Composer/Installer/LibraryInstaller.php(208): React\Promise\FulfilledPromise->then(Object(Closure))
4 tests/Composer/Test/Installer/LibraryInstallerTest.php(221): Composer\Installer\LibraryInstaller->uninstall(Object(Mock_InstalledRepositoryInterface_e3699f95), Object(Mock_Package_e4571076))
...
```