### PR TITLE
Note in docs about how single pipes are treated

### DIFF
--- a/doc/articles/versions.md
+++ b/doc/articles/versions.md
@@ -124,6 +124,11 @@ will be treated as a **logical OR**. AND has higher precedence than OR.
 > unexpectedly installing versions that break backwards compatibility.
 > Consider using the [caret](#caret-version-range-) operator instead for safety.
 
+<!--blank line followed by comment markup to separate the block quotes-->
+> **Note:** In older versions of Composer the single pipe (`|`) was the
+> recommended alternative to the **logical OR**. Thus for backwards compatibility
+> the single pipe (`|`) will still be treated as a **logical OR**.
+
 Examples:
 
 * `>=1.0`


### PR DESCRIPTION
The single pipe (the old alternative to logical OR) is treated as a logical OR but is not currently documented. This can be confusing to developers new to composer who encounter a single pipe and look to the docs for an explaination.

See this issue for more detail: https://github.com/composer/composer/issues/6755#issuecomment-898537753

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. 2.1 or similar if such a branch exists, or 1.10 if it is a critical fix that should be fixed in Composer 1)

For new features and everything else, use the master branch. -->
