### PR TITLE
Update the Composer plugin API version to 2.1.0

### DIFF
--- a/doc/articles/plugins.md
+++ b/doc/articles/plugins.md
@@ -39,7 +39,7 @@ requirements:
 The required version of the `composer-plugin-api` follows the same [rules][7]
 as a normal package's.
 
-The current Composer plugin API version is `2.0.0`.
+The current Composer plugin API version is `2.1.0`.
 
 An example of a valid plugin `composer.json` file (with the autoloading
 part omitted and an optional require-dev dependency on `composer/composer` for IDE auto completion):


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. 2.1 or similar if such a branch exists, or 1.10 if it is a critical fix that should be fixed in Composer 1)

For new features and everything else, use the master branch. -->
