### PR TITLE
Output deprecations in CI results

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,7 @@
          bootstrap="tests/bootstrap.php"
 >
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0"/>
         <env name="COMPOSER_TEST_SUITE" value="1"/>
     </php>
     <testsuites>

--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -36,9 +36,9 @@ class ConsoleIO extends BaseIO
     /** @var HelperSet */
     protected $helperSet;
     /** @var string */
-    protected $lastMessage;
+    protected $lastMessage = '';
     /** @var string */
-    protected $lastMessageErr;
+    protected $lastMessageErr = '';
 
     /** @var float */
     private $startTime;

--- a/src/Composer/Json/JsonValidationException.php
+++ b/src/Composer/Json/JsonValidationException.php
@@ -24,7 +24,7 @@ class JsonValidationException extends Exception
     public function __construct($message, $errors = array(), Exception $previous = null)
     {
         $this->errors = $errors;
-        parent::__construct($message, 0, $previous);
+        parent::__construct((string) $message, 0, $previous);
     }
 
     public function getErrors()

--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -88,7 +88,7 @@ class ArchiveManager
         }
         $nameParts = array($baseName);
 
-        if (preg_match('{^[a-f0-9]{40}$}', $package->getDistReference())) {
+        if (null !== $package->getDistReference() && preg_match('{^[a-f0-9]{40}$}', $package->getDistReference())) {
             array_push($nameParts, $package->getDistReference(), $package->getDistType());
         } else {
             array_push($nameParts, $package->getPrettyVersion(), $package->getDistReference());

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -217,6 +217,10 @@ abstract class BasePackage implements PackageInterface
                 throw new \UnexpectedValueException('Display mode '.$displayMode.' is not supported');
         }
 
+        if (null === $reference) {
+            return $this->getPrettyVersion();
+        }
+
         // if source reference is a sha1 hash -- truncate
         if ($truncate && \strlen($reference) === 40 && $this->getSourceType() !== 'svn') {
             return $this->getPrettyVersion() . ' ' . substr($reference, 0, 7);

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -27,11 +27,14 @@ class Package extends BasePackage
     protected $installationSource;
     protected $sourceType;
     protected $sourceUrl;
+    /** @var ?string */
     protected $sourceReference;
     protected $sourceMirrors;
     protected $distType;
     protected $distUrl;
+    /** @var ?string */
     protected $distReference;
+    /** @var ?string */
     protected $distSha1Checksum;
     protected $distMirrors;
     protected $version;

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -131,7 +131,7 @@ interface PackageInterface
     /**
      * Returns the repository reference of this package, e.g. master, 1.0.0 or a commit hash for git
      *
-     * @return string The repository reference
+     * @return ?string The repository reference
      */
     public function getSourceReference();
 
@@ -172,14 +172,14 @@ interface PackageInterface
     /**
      * Returns the reference of the distribution archive of this version, e.g. master, 1.0.0 or a commit hash for git
      *
-     * @return string
+     * @return ?string
      */
     public function getDistReference();
 
     /**
      * Returns the sha1 checksum for the distribution archive of this version
      *
-     * @return string
+     * @return ?string
      */
     public function getDistSha1Checksum();
 

--- a/src/Composer/Util/Bitbucket.php
+++ b/src/Composer/Util/Bitbucket.php
@@ -151,7 +151,7 @@ class Bitbucket
         $this->io->writeError(sprintf('to create a consumer. It will be stored in "%s" for future use by Composer.', $this->config->getAuthConfigSource()->getName()));
         $this->io->writeError('Ensure you enter a "Callback URL" (http://example.com is fine) or it will not be possible to create an Access Token (this callback url will not be used by composer)');
 
-        $consumerKey = trim($this->io->askAndHideAnswer('Consumer Key (hidden): '));
+        $consumerKey = trim((string) $this->io->askAndHideAnswer('Consumer Key (hidden): '));
 
         if (!$consumerKey) {
             $this->io->writeError('<warning>No consumer key given, aborting.</warning>');
@@ -160,7 +160,7 @@ class Bitbucket
             return false;
         }
 
-        $consumerSecret = trim($this->io->askAndHideAnswer('Consumer Secret (hidden): '));
+        $consumerSecret = trim((string) $this->io->askAndHideAnswer('Consumer Secret (hidden): '));
 
         if (!$consumerSecret) {
             $this->io->writeError('<warning>No consumer secret given, aborting.</warning>');

--- a/src/Composer/Util/Perforce.php
+++ b/src/Composer/Util/Perforce.php
@@ -160,7 +160,7 @@ class Perforce
 
     public function isStream()
     {
-        return (strcmp($this->p4DepotType, 'stream') === 0);
+        return is_string($this->p4DepotType) && (strcmp($this->p4DepotType, 'stream') === 0);
     }
 
     public function getStream()
@@ -204,11 +204,11 @@ class Perforce
     public function queryP4User()
     {
         $this->getUser();
-        if (strlen($this->p4User) > 0) {
+        if (strlen((string) $this->p4User) > 0) {
             return;
         }
         $this->p4User = $this->getP4variable('P4USER');
-        if (strlen($this->p4User) > 0) {
+        if (strlen((string) $this->p4User) > 0) {
             return;
         }
         $this->p4User = $this->io->ask('Enter P4 User:');
@@ -262,7 +262,7 @@ class Perforce
             return $this->p4Password;
         }
         $password = $this->getP4variable('P4PASSWD');
-        if (strlen($password) <= 0) {
+        if (strlen((string) $password) <= 0) {
             $password = $this->io->askAndHideAnswer('Enter password for Perforce user ' . $this->getUser() . ': ');
         }
         $this->p4Password = $password;

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -371,6 +371,9 @@ class ProcessExecutor
         return $this->errorOutput;
     }
 
+    /**
+     * @private
+     */
     public function outputHandler($type, $buffer)
     {
         if ($this->captureOutput) {

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -356,9 +356,9 @@ class ProcessExecutor
      */
     public function splitLines($output)
     {
-        $output = trim($output);
+        $output = trim((string) $output);
 
-        return ((string) $output === '') ? array() : preg_split('{\r?\n}', $output);
+        return $output === '' ? array() : preg_split('{\r?\n}', $output);
     }
 
     /**

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -18,6 +18,7 @@ use Composer\EventDispatcher\EventDispatcher;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PreFileDownloadEvent;
 use Composer\Test\TestCase;
+use Composer\Test\Mock\ProcessExecutorMock;
 use Composer\Util\Filesystem;
 use Composer\Util\Http\Response;
 use Composer\Util\Loop;
@@ -194,7 +195,7 @@ class FileDownloaderTest extends TestCase
         $dispatcher = new EventDispatcher(
             $composerMock,
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
-            $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock()
+            new ProcessExecutorMock
         );
         $dispatcher->addListener(PluginEvents::PRE_FILE_DOWNLOAD, function (PreFileDownloadEvent $event) use ($expectedUrl) {
             $event->setProcessedUrl($expectedUrl);
@@ -288,7 +289,7 @@ class FileDownloaderTest extends TestCase
         $dispatcher = new EventDispatcher(
             $composerMock,
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
-            $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock()
+            new ProcessExecutorMock
         );
         $dispatcher->addListener(PluginEvents::PRE_FILE_DOWNLOAD, function (PreFileDownloadEvent $event) use ($customCacheKey) {
             $event->setCustomCacheKey($customCacheKey);

--- a/tests/Composer/Test/Downloader/FossilDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FossilDownloaderTest.php
@@ -132,7 +132,11 @@ class FossilDownloaderTest extends TestCase
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($expectedFossilCommand))
-            ->will($this->returnValue(0));
+            ->will($this->returnCallback(function ($cmd, &$output, $path) {
+                $output = '';
+
+                return 0;
+            }));
         $expectedFossilCommand = $this->getCmd("fossil pull && fossil up 'trunk'");
         $processExecutor->expects($this->at(1))
             ->method('execute')

--- a/tests/Composer/Test/Downloader/FossilDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FossilDownloaderTest.php
@@ -16,6 +16,7 @@ use Composer\Downloader\FossilDownloader;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Util\Platform;
+use Composer\Test\Mock\ProcessExecutorMock;
 
 class FossilDownloaderTest extends TestCase
 {
@@ -39,7 +40,7 @@ class FossilDownloaderTest extends TestCase
     {
         $io = $io ?: $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $config = $config ?: $this->getMockBuilder('Composer\Config')->getMock();
-        $executor = $executor ?: $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $executor = $executor ?: new ProcessExecutorMock;
         $filesystem = $filesystem ?: $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
 
         return new FossilDownloader($io, $config, $executor, $filesystem);
@@ -67,28 +68,18 @@ class FossilDownloaderTest extends TestCase
         $packageMock->expects($this->once())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('http://fossil.kd2.org/kd2fw/')));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
-        $expectedFossilCommand = $this->getCmd('fossil clone -- \'http://fossil.kd2.org/kd2fw/\' \'repo.fossil\'');
-        $processExecutor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->equalTo($expectedFossilCommand))
-            ->will($this->returnValue(0));
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->getCmd('fossil clone -- \'http://fossil.kd2.org/kd2fw/\' \'repo.fossil\''),
+            $this->getCmd('fossil open --nested -- \'repo.fossil\''),
+            $this->getCmd('fossil update -- \'trunk\''),
+        ), true);
 
-        $expectedFossilCommand = $this->getCmd('fossil open --nested -- \'repo.fossil\'');
-        $processExecutor->expects($this->at(1))
-            ->method('execute')
-            ->with($this->equalTo($expectedFossilCommand))
-            ->will($this->returnValue(0));
-
-        $expectedFossilCommand = $this->getCmd('fossil update -- \'trunk\'');
-        $processExecutor->expects($this->at(2))
-            ->method('execute')
-            ->with($this->equalTo($expectedFossilCommand))
-            ->will($this->returnValue(0));
-
-        $downloader = $this->getDownloaderMock(null, null, $processExecutor);
+        $downloader = $this->getDownloaderMock(null, null, $process);
         $downloader->install($packageMock, 'repo');
+
+        $process->assertComplete($this);
     }
 
     public function testUpdateforPackageWithoutSourceReference()
@@ -126,46 +117,46 @@ class FossilDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getVersion')
             ->will($this->returnValue('1.0.0.0'));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
-        $expectedFossilCommand = $this->getCmd("fossil changes");
-        $processExecutor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->equalTo($expectedFossilCommand))
-            ->will($this->returnCallback(function ($cmd, &$output, $path) {
-                $output = '';
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->getCmd("fossil changes"),
+            $this->getCmd("fossil pull && fossil up 'trunk'"),
+        ), true);
 
-                return 0;
-            }));
-        $expectedFossilCommand = $this->getCmd("fossil pull && fossil up 'trunk'");
-        $processExecutor->expects($this->at(1))
-            ->method('execute')
-            ->with($this->equalTo($expectedFossilCommand))
-            ->will($this->returnValue(0));
-
-        $downloader = $this->getDownloaderMock(null, null, $processExecutor);
+        $downloader = $this->getDownloaderMock(null, null, $process);
         $downloader->prepare('update', $packageMock, $this->workingDir, $packageMock);
         $downloader->update($packageMock, $packageMock, $this->workingDir);
         $downloader->cleanup('update', $packageMock, $this->workingDir, $packageMock);
+
+        $process->assertComplete($this);
     }
 
     public function testRemove()
     {
-        $expectedResetCommand = $this->getCmd('cd \'composerPath\' && fossil status');
+        // Ensure file exists
+        $file = $this->workingDir . '/.fslckout';
+        touch($file);
 
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
-        $processExecutor->expects($this->any())
-            ->method('execute')
-            ->with($this->equalTo($expectedResetCommand));
+
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->getCmd('fossil changes'),
+        ), true);
+
         $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $filesystem->expects($this->once())
             ->method('removeDirectoryAsync')
-            ->with($this->equalTo('composerPath'))
+            ->with($this->equalTo($this->workingDir))
             ->will($this->returnValue(\React\Promise\resolve(true)));
 
-        $downloader = $this->getDownloaderMock(null, null, $processExecutor, $filesystem);
-        $downloader->remove($packageMock, 'composerPath');
+        $downloader = $this->getDownloaderMock(null, null, $process, $filesystem);
+        $downloader->prepare('uninstall', $packageMock, $this->workingDir);
+        $downloader->remove($packageMock, $this->workingDir);
+        $downloader->cleanup('uninstall', $packageMock, $this->workingDir);
+
+        $process->assertComplete($this);
     }
 
     public function testGetInstallationSource()

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -69,7 +69,7 @@ class GitDownloaderTest extends TestCase
     protected function getDownloaderMock($io = null, $config = null, $executor = null, $filesystem = null)
     {
         $io = $io ?: $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
-        $executor = $executor ?: $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $executor = $executor ?: $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
         $filesystem = $filesystem ?: $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $config = $this->setupConfig($config);
 
@@ -107,7 +107,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('dev-master'));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
 
         $expectedGitCommand = $this->winCompat("git clone --no-checkout -- 'https://example.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://example.com/composer/composer' && git fetch composer && git remote set-url origin -- 'https://example.com/composer/composer' && git remote set-url composer -- 'https://example.com/composer/composer'");
         $processExecutor->expects($this->at(0))
@@ -147,7 +147,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('dev-master'));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
 
         $this->initGitVersion('2.17.0');
 
@@ -219,7 +219,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('1.0.0'));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute', 'getErrorOutput'))->getMock();
 
         $expectedGitCommand = $this->winCompat("git clone --no-checkout -- 'https://github.com/mirrors/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://github.com/mirrors/composer' && git fetch composer && git remote set-url origin -- 'https://github.com/mirrors/composer' && git remote set-url composer -- 'https://github.com/mirrors/composer'");
         $processExecutor->expects($this->at(0))
@@ -297,7 +297,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('1.0.0'));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
 
         $expectedGitCommand = $this->winCompat("git clone --no-checkout -- '{$url}' 'composerPath' && cd 'composerPath' && git remote add composer -- '{$url}' && git fetch composer && git remote set-url origin -- '{$url}' && git remote set-url composer -- '{$url}'");
         $processExecutor->expects($this->at(0))
@@ -335,7 +335,7 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('https://example.com/composer/composer')));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($expectedGitCommand))
@@ -423,7 +423,7 @@ class GitDownloaderTest extends TestCase
             ->method('getVersion')
             ->will($this->returnValue('1.0.0.0'));
 
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
         $processExecutor->expects($this->at(0))
             ->method('execute')
             ->with($this->equalTo($this->winCompat("git show-ref --head -d")))
@@ -589,7 +589,7 @@ composer https://github.com/old/url (push)
             ->method('getFullPrettyVersion')
             ->will($this->returnValue('1.0.0'));
 
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
         $processExecutor->expects($this->any())
             ->method('execute')
             ->will($this->returnValue(0));
@@ -631,7 +631,7 @@ composer https://github.com/old/url (push)
             ->method('getVersion')
             ->will($this->returnValue('dev-ref2'));
 
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
         $processExecutor->expects($this->any())
             ->method('execute')
             ->will($this->returnValue(0));
@@ -654,7 +654,7 @@ composer https://github.com/old/url (push)
         $expectedGitResetCommand = $this->winCompat("cd 'composerPath' && git status --porcelain --untracked-files=no");
 
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
         $processExecutor->expects($this->any())
             ->method('execute')
             ->with($this->equalTo($expectedGitResetCommand))

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -18,8 +18,6 @@ use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Util\Platform;
 use Composer\Test\Mock\ProcessExecutorMock;
-use DateTime;
-use Prophecy\Argument;
 
 class GitDownloaderTest extends TestCase
 {
@@ -71,7 +69,7 @@ class GitDownloaderTest extends TestCase
     protected function getDownloaderMock($io = null, $config = null, $executor = null, $filesystem = null)
     {
         $io = $io ?: $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
-        $executor = $executor ?: $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
+        $executor = $executor ?: new ProcessExecutorMock;
         $filesystem = $filesystem ?: $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $config = $this->setupConfig($config);
 
@@ -109,33 +107,21 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('dev-master'));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
 
-        $expectedGitCommand = $this->winCompat("git clone --no-checkout -- 'https://example.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://example.com/composer/composer' && git fetch composer && git remote set-url origin -- 'https://example.com/composer/composer' && git remote set-url composer -- 'https://example.com/composer/composer'");
-        $processExecutor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand))
-            ->will($this->returnValue(0));
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->winCompat("git clone --no-checkout -- 'https://example.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://example.com/composer/composer' && git fetch composer && git remote set-url origin -- 'https://example.com/composer/composer' && git remote set-url composer -- 'https://example.com/composer/composer'"),
+            $this->winCompat("git branch -r"),
+            $this->winCompat("(git checkout 'master' -- || git checkout -B 'master' 'composer/master' --) && git reset --hard '1234567890123456789012345678901234567890' --"),
+        ), true);
 
-        $processExecutor->expects($this->at(1))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("git branch -r")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
-            ->will($this->returnCallback(function ($cmd, &$output) {
-                $output = '';
-
-                return 0;
-            }));
-
-        $processExecutor->expects($this->at(2))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("(git checkout 'master' -- || git checkout -B 'master' 'composer/master' --) && git reset --hard '1234567890123456789012345678901234567890' --")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
-            ->will($this->returnValue(0));
-
-        $downloader = $this->getDownloaderMock(null, null, $processExecutor);
+        $downloader = $this->getDownloaderMock(null, null, $process);
         $downloader->download($packageMock, 'composerPath');
         $downloader->prepare('install', $packageMock, 'composerPath');
         $downloader->install($packageMock, 'composerPath');
         $downloader->cleanup('install', $packageMock, 'composerPath');
+
+        $process->assertComplete($this);
     }
 
     public function testDownloadWithCache()
@@ -153,7 +139,6 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('dev-master'));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
 
         $this->initGitVersion('2.17.0');
 
@@ -164,54 +149,24 @@ class GitDownloaderTest extends TestCase
         $filesystem = new \Composer\Util\Filesystem;
         $filesystem->removeDirectory($cachePath);
 
-        $expectedGitCommand = $this->winCompat(sprintf("git clone --mirror -- 'https://example.com/composer/composer' '%s'", $cachePath));
-        $processExecutor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand))
-            ->will($this->returnCallback(function () use ($cachePath) {
-                @mkdir($cachePath, 0777, true);
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            array('cmd' => $this->winCompat(sprintf("git clone --mirror -- 'https://example.com/composer/composer' '%s'", $cachePath)), 'callback' => function () use ($cachePath) { @mkdir($cachePath, 0777, true); }),
+            array('cmd' => 'git rev-parse --git-dir', 'stdout' => '.'),
+            $this->winCompat('git rev-parse --quiet --verify \'1234567890123456789012345678901234567890^{commit}\''),
+            $this->winCompat(sprintf("git clone --no-checkout '%1\$s' 'composerPath' --dissociate --reference '%1\$s' && cd 'composerPath' && git remote set-url origin -- 'https://example.com/composer/composer' && git remote add composer -- 'https://example.com/composer/composer'", $cachePath)),
+            'git branch -r',
+            $this->winCompat("(git checkout 'master' -- || git checkout -B 'master' 'composer/master' --) && git reset --hard '1234567890123456789012345678901234567890' --")
+        ), true);
 
-                return 0;
-            }));
-        $processExecutor->expects($this->at(1))
-            ->method('execute')
-            ->with($this->equalTo('git rev-parse --git-dir'), $this->anything(), $this->equalTo($this->winCompat($cachePath)))
-            ->will($this->returnCallback(function ($command, &$output = null) {
-                $output = '.';
-
-                return 0;
-            }));
-        $processExecutor->expects($this->at(2))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat('git rev-parse --quiet --verify \'1234567890123456789012345678901234567890^{commit}\'')), $this->equalTo(null), $this->equalTo($this->winCompat($cachePath)))
-            ->will($this->returnValue(0));
-
-        $expectedGitCommand = $this->winCompat(sprintf("git clone --no-checkout '%1\$s' 'composerPath' --dissociate --reference '%1\$s' && cd 'composerPath' && git remote set-url origin -- 'https://example.com/composer/composer' && git remote add composer -- 'https://example.com/composer/composer'", $cachePath));
-        $processExecutor->expects($this->at(3))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand))
-            ->will($this->returnValue(0));
-
-        $processExecutor->expects($this->at(4))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("git branch -r")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
-            ->will($this->returnCallback(function ($cmd, &$output, $path) {
-                $output = '';
-
-                return 0;
-            }));
-
-        $processExecutor->expects($this->at(5))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("(git checkout 'master' -- || git checkout -B 'master' 'composer/master' --) && git reset --hard '1234567890123456789012345678901234567890' --")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
-            ->will($this->returnValue(0));
-
-        $downloader = $this->getDownloaderMock(null, $config, $processExecutor);
+        $downloader = $this->getDownloaderMock(null, $config, $process);
         $downloader->download($packageMock, 'composerPath');
         $downloader->prepare('install', $packageMock, 'composerPath');
         $downloader->install($packageMock, 'composerPath');
         $downloader->cleanup('install', $packageMock, 'composerPath');
         @rmdir($cachePath);
+
+        $process->assertComplete($this);
     }
 
     public function testDownloadUsesVariousProtocolsAndSetsPushUrlForGithub()
@@ -229,56 +184,28 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('1.0.0'));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute', 'getErrorOutput'))->getMock();
 
-        $expectedGitCommand = $this->winCompat("git clone --no-checkout -- 'https://github.com/mirrors/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://github.com/mirrors/composer' && git fetch composer && git remote set-url origin -- 'https://github.com/mirrors/composer' && git remote set-url composer -- 'https://github.com/mirrors/composer'");
-        $processExecutor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand))
-            ->will($this->returnValue(1));
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            array(
+                'cmd' => $this->winCompat("git clone --no-checkout -- 'https://github.com/mirrors/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://github.com/mirrors/composer' && git fetch composer && git remote set-url origin -- 'https://github.com/mirrors/composer' && git remote set-url composer -- 'https://github.com/mirrors/composer'"),
+                'return' => 1,
+                'stderr' => 'Error1',
+            ),
+            $this->winCompat("git clone --no-checkout -- 'git@github.com:mirrors/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'git@github.com:mirrors/composer' && git fetch composer && git remote set-url origin -- 'git@github.com:mirrors/composer' && git remote set-url composer -- 'git@github.com:mirrors/composer'"),
+            $this->winCompat("git remote set-url origin -- 'https://github.com/composer/composer'"),
+            $this->winCompat("git remote set-url --push origin -- 'git@github.com:composer/composer.git'"),
+            'git branch -r',
+            $this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"),
+        ), true);
 
-        $processExecutor->expects($this->at(1))
-            ->method('getErrorOutput')
-            ->with()
-            ->will($this->returnValue('Error1'));
-
-        $expectedGitCommand = $this->winCompat("git clone --no-checkout -- 'git@github.com:mirrors/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'git@github.com:mirrors/composer' && git fetch composer && git remote set-url origin -- 'git@github.com:mirrors/composer' && git remote set-url composer -- 'git@github.com:mirrors/composer'");
-        $processExecutor->expects($this->at(2))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand))
-            ->will($this->returnValue(0));
-
-        $expectedGitCommand = $this->winCompat("git remote set-url origin -- 'https://github.com/composer/composer'");
-        $processExecutor->expects($this->at(3))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
-            ->will($this->returnValue(0));
-
-        $expectedGitCommand = $this->winCompat("git remote set-url --push origin -- 'git@github.com:composer/composer.git'");
-        $processExecutor->expects($this->at(4))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
-            ->will($this->returnValue(0));
-
-        $processExecutor->expects($this->at(5))
-            ->method('execute')
-            ->with($this->equalTo('git branch -r'))
-            ->will($this->returnCallback(function ($cmd, &$output, $path) {
-                $output = '';
-
-                return 0;
-            }));
-
-        $processExecutor->expects($this->at(6))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
-            ->will($this->returnValue(0));
-
-        $downloader = $this->getDownloaderMock(null, new Config(), $processExecutor);
+        $downloader = $this->getDownloaderMock(null, new Config(), $process);
         $downloader->download($packageMock, 'composerPath');
         $downloader->prepare('install', $packageMock, 'composerPath');
         $downloader->install($packageMock, 'composerPath');
         $downloader->cleanup('install', $packageMock, 'composerPath');
+
+        $process->assertComplete($this);
     }
 
     public function pushUrlProvider()
@@ -501,25 +428,35 @@ composer https://github.com/old/url (push)
             ->method('getVersion')
             ->will($this->returnValue('1.0.0.0'));
 
-        $process = $this->prophesize('Composer\Util\ProcessExecutor');
-        $process->execute($this->winCompat('git --version'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git show-ref --head -d'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git status --porcelain --untracked-files=no'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git remote -v'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git branch -r'), Argument::cetera())->willReturn(0);
-        $process->execute($expectedGitUpdateCommand, null, $this->winCompat($this->workingDir))->willReturn(1)->shouldBeCalled();
-        $process->execute($expectedGitUpdateCommand2, null, $this->winCompat($this->workingDir))->willReturn(1)->shouldBeCalled();
-        $process->getErrorOutput()->willReturn('');
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->winCompat('git show-ref --head -d'),
+            $this->winCompat('git status --porcelain --untracked-files=no'),
+            $this->winCompat('git remote -v'),
+            array(
+                'cmd' => $expectedGitUpdateCommand,
+                'return' => 1,
+            ),
+            array(
+                'cmd' => $expectedGitUpdateCommand2,
+                'return' => 1,
+            ),
+            $this->winCompat('git --version'),
+            $this->winCompat('git branch -r'),
+        ), true);
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
 
         // not using PHPUnit's expected exception because Prophecy exceptions extend from RuntimeException too so it is not safe
         try {
-            $downloader = $this->getDownloaderMock(null, new Config(), $process->reveal());
+            $downloader = $this->getDownloaderMock(null, new Config(), $process);
             $downloader->download($packageMock, $this->workingDir, $packageMock);
             $downloader->prepare('update', $packageMock, $this->workingDir, $packageMock);
             $downloader->update($packageMock, $packageMock, $this->workingDir);
             $downloader->cleanup('update', $packageMock, $this->workingDir, $packageMock);
+
+            $process->assertComplete($this);
+
             $this->fail('This test should throw');
         } catch (\RuntimeException $e) {
             if ('RuntimeException' !== get_class($e)) {
@@ -544,24 +481,38 @@ composer https://github.com/old/url (push)
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array(Platform::isWindows() ? 'C:\\' : '/', 'https://github.com/composer/composer')));
+        $packageMock->expects($this->any())
+            ->method('getPrettyVersion')
+            ->will($this->returnValue('1.0.0'));
 
-        $process = $this->prophesize('Composer\Util\ProcessExecutor');
-        $process->execute($this->winCompat('git --version'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git show-ref --head -d'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git status --porcelain --untracked-files=no'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git remote -v'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git branch -r'), Argument::cetera())->willReturn(0);
-        $process->execute($expectedFirstGitUpdateCommand, Argument::cetera())->willReturn(1)->shouldBeCalled();
-        $process->execute($expectedSecondGitUpdateCommand, Argument::cetera())->willReturn(0)->shouldBeCalled();
-        $process->execute($this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"), null, $this->winCompat($this->workingDir))->willReturn(0)->shouldBeCalled();
-        $process->getErrorOutput()->willReturn('');
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->winCompat('git show-ref --head -d'),
+            $this->winCompat('git status --porcelain --untracked-files=no'),
+            $this->winCompat('git remote -v'),
+            array(
+                'cmd' => $expectedFirstGitUpdateCommand,
+                'return' => 1,
+            ),
+            $this->winCompat('git --version'),
+            $this->winCompat('git remote -v'),
+            array(
+                'cmd' => $expectedSecondGitUpdateCommand,
+                'return' => 0,
+            ),
+            $this->winCompat('git branch -r'),
+            $this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"),
+            $this->winCompat('git remote -v'),
+        ), true);
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
-        $downloader = $this->getDownloaderMock(null, new Config(), $process->reveal());
+        $downloader = $this->getDownloaderMock(null, new Config(), $process);
         $downloader->download($packageMock, $this->workingDir, $packageMock);
         $downloader->prepare('update', $packageMock, $this->workingDir, $packageMock);
         $downloader->update($packageMock, $packageMock, $this->workingDir);
         $downloader->cleanup('update', $packageMock, $this->workingDir, $packageMock);
+
+        $process->assertComplete($this);
     }
 
     public function testDowngradeShowsAppropriateMessage()
@@ -591,13 +542,13 @@ composer https://github.com/old/url (push)
             ->method('getVersion')
             ->will($this->returnValue('1.0.0.0'));
         $newPackage->expects($this->any())
+            ->method('getPrettyVersion')
+            ->will($this->returnValue('1.0.0'));
+        $newPackage->expects($this->any())
             ->method('getFullPrettyVersion')
             ->will($this->returnValue('1.0.0'));
 
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
-        $processExecutor->expects($this->any())
-            ->method('execute')
-            ->will($this->returnValue(0));
+        $process = new ProcessExecutorMock;
 
         $ioMock = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $ioMock->expects($this->at(0))
@@ -605,7 +556,7 @@ composer https://github.com/old/url (push)
             ->with($this->stringContains('Downgrading'));
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
-        $downloader = $this->getDownloaderMock($ioMock, null, $processExecutor);
+        $downloader = $this->getDownloaderMock($ioMock, null, $process);
         $downloader->download($newPackage, $this->workingDir, $oldPackage);
         $downloader->prepare('update', $newPackage, $this->workingDir, $oldPackage);
         $downloader->update($oldPackage, $newPackage, $this->workingDir);
@@ -635,11 +586,11 @@ composer https://github.com/old/url (push)
         $newPackage->expects($this->any())
             ->method('getVersion')
             ->will($this->returnValue('dev-ref2'));
+        $newPackage->expects($this->any())
+            ->method('getPrettyVersion')
+            ->will($this->returnValue('dev-ref2'));
 
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
-        $processExecutor->expects($this->any())
-            ->method('execute')
-            ->will($this->returnValue(0));
+        $process = new ProcessExecutorMock;
 
         $ioMock = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $ioMock->expects($this->at(0))
@@ -647,7 +598,7 @@ composer https://github.com/old/url (push)
             ->with($this->stringContains('Upgrading'));
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
-        $downloader = $this->getDownloaderMock($ioMock, null, $processExecutor);
+        $downloader = $this->getDownloaderMock($ioMock, null, $process);
         $downloader->download($newPackage, $this->workingDir, $oldPackage);
         $downloader->prepare('update', $newPackage, $this->workingDir, $oldPackage);
         $downloader->update($oldPackage, $newPackage, $this->workingDir);
@@ -656,24 +607,29 @@ composer https://github.com/old/url (push)
 
     public function testRemove()
     {
-        $expectedGitResetCommand = $this->winCompat("cd 'composerPath' && git status --porcelain --untracked-files=no");
+        $expectedGitResetCommand = $this->winCompat("git status --porcelain --untracked-files=no");
 
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
-        $processExecutor->expects($this->any())
-            ->method('execute')
-            ->with($this->equalTo($expectedGitResetCommand))
-            ->will($this->returnValue(0));
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            'git show-ref --head -d',
+            $expectedGitResetCommand,
+        ), true);
+
+        $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
+
         $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $filesystem->expects($this->once())
             ->method('removeDirectoryAsync')
-            ->with($this->equalTo('composerPath'))
+            ->with($this->equalTo($this->workingDir))
             ->will($this->returnValue(\React\Promise\resolve(true)));
 
-        $downloader = $this->getDownloaderMock(null, null, $processExecutor, $filesystem);
-        $downloader->prepare('uninstall', $packageMock, 'composerPath');
-        $downloader->remove($packageMock, 'composerPath');
-        $downloader->cleanup('uninstall', $packageMock, 'composerPath');
+        $downloader = $this->getDownloaderMock(null, null, $process, $filesystem);
+        $downloader->prepare('uninstall', $packageMock, $this->workingDir);
+        $downloader->remove($packageMock, $this->workingDir);
+        $downloader->cleanup('uninstall', $packageMock, $this->workingDir);
+
+        $process->assertComplete($this);
     }
 
     public function testGetInstallationSource()

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -17,6 +17,8 @@ use Composer\Config;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Util\Platform;
+use Composer\Test\Mock\ProcessExecutorMock;
+use DateTime;
 use Prophecy\Argument;
 
 class GitDownloaderTest extends TestCase
@@ -118,7 +120,11 @@ class GitDownloaderTest extends TestCase
         $processExecutor->expects($this->at(1))
             ->method('execute')
             ->with($this->equalTo($this->winCompat("git branch -r")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
-            ->will($this->returnValue(0));
+            ->will($this->returnCallback(function ($cmd, &$output) {
+                $output = '';
+
+                return 0;
+            }));
 
         $processExecutor->expects($this->at(2))
             ->method('execute')
@@ -189,7 +195,11 @@ class GitDownloaderTest extends TestCase
         $processExecutor->expects($this->at(4))
             ->method('execute')
             ->with($this->equalTo($this->winCompat("git branch -r")), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
-            ->will($this->returnValue(0));
+            ->will($this->returnCallback(function ($cmd, &$output, $path) {
+                $output = '';
+
+                return 0;
+            }));
 
         $processExecutor->expects($this->at(5))
             ->method('execute')
@@ -253,7 +263,11 @@ class GitDownloaderTest extends TestCase
         $processExecutor->expects($this->at(5))
             ->method('execute')
             ->with($this->equalTo('git branch -r'))
-            ->will($this->returnValue(0));
+            ->will($this->returnCallback(function ($cmd, &$output, $path) {
+                $output = '';
+
+                return 0;
+            }));
 
         $processExecutor->expects($this->at(6))
             ->method('execute')
@@ -297,37 +311,29 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getPrettyVersion')
             ->will($this->returnValue('1.0.0'));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
 
-        $expectedGitCommand = $this->winCompat("git clone --no-checkout -- '{$url}' 'composerPath' && cd 'composerPath' && git remote add composer -- '{$url}' && git fetch composer && git remote set-url origin -- '{$url}' && git remote set-url composer -- '{$url}'");
-        $processExecutor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand))
-            ->will($this->returnValue(0));
-
-        $expectedGitCommand = $this->winCompat("git remote set-url --push origin -- '{$pushUrl}'");
-        $processExecutor->expects($this->at(1))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand), $this->equalTo(null), $this->equalTo($this->winCompat('composerPath')))
-            ->will($this->returnValue(0));
-
-        $processExecutor->expects($this->exactly(4))
-            ->method('execute')
-            ->will($this->returnValue(0));
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->winCompat("git clone --no-checkout -- '{$url}' 'composerPath' && cd 'composerPath' && git remote add composer -- '{$url}' && git fetch composer && git remote set-url origin -- '{$url}' && git remote set-url composer -- '{$url}'"),
+            $this->winCompat("git remote set-url --push origin -- '{$pushUrl}'"),
+            'git branch -r',
+            $this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"),
+        ), true);
 
         $config = new Config();
         $config->merge(array('config' => array('github-protocols' => $protocols)));
 
-        $downloader = $this->getDownloaderMock(null, $config, $processExecutor);
+        $downloader = $this->getDownloaderMock(null, $config, $process);
         $downloader->download($packageMock, 'composerPath');
         $downloader->prepare('install', $packageMock, 'composerPath');
         $downloader->install($packageMock, 'composerPath');
         $downloader->cleanup('install', $packageMock, 'composerPath');
+
+        $process->assertComplete($this);
     }
 
     public function testDownloadThrowsRuntimeExceptionIfGitCommandFails()
     {
-        $expectedGitCommand = $this->winCompat("git clone --no-checkout -- 'https://example.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://example.com/composer/composer' && git fetch composer && git remote set-url origin -- 'https://example.com/composer/composer' && git remote set-url composer -- 'https://example.com/composer/composer'");
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
@@ -335,19 +341,31 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('https://example.com/composer/composer')));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
-        $processExecutor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand))
-            ->will($this->returnValue(1));
+        $packageMock->expects($this->any())
+            ->method('getSourceUrl')
+            ->will($this->returnValue('https://example.com/composer/composer'));
+        $packageMock->expects($this->any())
+            ->method('getPrettyVersion')
+            ->will($this->returnValue('1.0.0'));
+
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            array(
+                'cmd' => $this->winCompat("git clone --no-checkout -- 'https://example.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://example.com/composer/composer' && git fetch composer && git remote set-url origin -- 'https://example.com/composer/composer' && git remote set-url composer -- 'https://example.com/composer/composer'"),
+                'return' => 1,
+            ),
+        ));
 
         // not using PHPUnit's expected exception because Prophecy exceptions extend from RuntimeException too so it is not safe
         try {
-            $downloader = $this->getDownloaderMock(null, null, $processExecutor);
+            $downloader = $this->getDownloaderMock(null, null, $process);
             $downloader->download($packageMock, 'composerPath');
             $downloader->prepare('install', $packageMock, 'composerPath');
             $downloader->install($packageMock, 'composerPath');
             $downloader->cleanup('install', $packageMock, 'composerPath');
+
+            $process->assertComplete($this);
+
             $this->fail('This test should throw');
         } catch (\RuntimeException $e) {
             if ('RuntimeException' !== get_class($e)) {
@@ -388,21 +406,29 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getVersion')
             ->will($this->returnValue('1.0.0.0'));
+        $packageMock->expects($this->any())
+            ->method('getPrettyVersion')
+            ->will($this->returnValue('1.0.0'));
 
-        $process = $this->prophesize('Composer\Util\ProcessExecutor');
-        $process->execute($this->winCompat('git show-ref --head -d'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git status --porcelain --untracked-files=no'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git remote -v'), Argument::cetera())->willReturn(0);
-        $process->execute($this->winCompat('git branch -r'), Argument::cetera())->willReturn(0);
-        $process->execute($expectedGitUpdateCommand, null, $this->winCompat($this->workingDir))->willReturn(0)->shouldBeCalled();
-        $process->execute($this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"), null, $this->winCompat($this->workingDir))->willReturn(0)->shouldBeCalled();
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->winCompat('git show-ref --head -d'),
+            $this->winCompat('git status --porcelain --untracked-files=no'),
+            $this->winCompat('git remote -v'),
+            $expectedGitUpdateCommand,
+            $this->winCompat('git branch -r'),
+            $this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"),
+            $this->winCompat('git remote -v'),
+        ), true);
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
-        $downloader = $this->getDownloaderMock(null, new Config(), $process->reveal());
+        $downloader = $this->getDownloaderMock(null, new Config(), $process);
         $downloader->download($packageMock, $this->workingDir, $packageMock);
         $downloader->prepare('update', $packageMock, $this->workingDir, $packageMock);
         $downloader->update($packageMock, $packageMock, $this->workingDir);
         $downloader->cleanup('update', $packageMock, $this->workingDir, $packageMock);
+
+        $process->assertComplete($this);
     }
 
     public function testUpdateWithNewRepoUrl()
@@ -422,59 +448,38 @@ class GitDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getVersion')
             ->will($this->returnValue('1.0.0.0'));
+        $packageMock->expects($this->any())
+            ->method('getPrettyVersion')
+            ->will($this->returnValue('1.0.0'));
 
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->setMethods(array('execute'))->getMock();
-        $processExecutor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("git show-ref --head -d")))
-            ->will($this->returnValue(0));
-        $processExecutor->expects($this->at(1))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("git status --porcelain --untracked-files=no")))
-            ->will($this->returnValue(0));
-        $processExecutor->expects($this->at(2))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("git remote -v")))
-            ->will($this->returnValue(0));
-        $processExecutor->expects($this->at(3))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat($expectedGitUpdateCommand)), $this->equalTo(null), $this->equalTo($this->winCompat($this->workingDir)))
-            ->will($this->returnValue(0));
-        $processExecutor->expects($this->at(4))
-            ->method('execute')
-            ->with($this->equalTo('git branch -r'))
-            ->will($this->returnValue(0));
-        $processExecutor->expects($this->at(5))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --")), $this->equalTo(null), $this->equalTo($this->winCompat($this->workingDir)))
-            ->will($this->returnValue(0));
-        $processExecutor->expects($this->at(6))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("git remote -v")))
-            ->will($this->returnCallback(function ($cmd, &$output, $cwd) {
-                $output = 'origin https://github.com/old/url (fetch)
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->winCompat("git show-ref --head -d"),
+            $this->winCompat("git status --porcelain --untracked-files=no"),
+            $this->winCompat("git remote -v"),
+            $this->winCompat($expectedGitUpdateCommand),
+            'git branch -r',
+            $this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"),
+            array(
+                'cmd' => $this->winCompat("git remote -v"),
+                'stdout' => 'origin https://github.com/old/url (fetch)
 origin https://github.com/old/url (push)
 composer https://github.com/old/url (fetch)
 composer https://github.com/old/url (push)
-';
-
-                return 0;
-            }));
-        $processExecutor->expects($this->at(7))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("git remote set-url origin -- 'https://github.com/composer/composer'")), $this->equalTo(null), $this->equalTo($this->winCompat($this->workingDir)))
-            ->will($this->returnValue(0));
-        $processExecutor->expects($this->at(8))
-            ->method('execute')
-            ->with($this->equalTo($this->winCompat("git remote set-url --push origin -- 'git@github.com:composer/composer.git'")), $this->equalTo(null), $this->equalTo($this->winCompat($this->workingDir)))
-            ->will($this->returnValue(0));
+',
+            ),
+            $this->winCompat("git remote set-url origin -- 'https://github.com/composer/composer'"),
+            $this->winCompat("git remote set-url --push origin -- 'git@github.com:composer/composer.git'"),
+        ), true);
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
-        $downloader = $this->getDownloaderMock(null, new Config(), $processExecutor);
+        $downloader = $this->getDownloaderMock(null, new Config(), $process);
         $downloader->download($packageMock, $this->workingDir, $packageMock);
         $downloader->prepare('update', $packageMock, $this->workingDir, $packageMock);
         $downloader->update($packageMock, $packageMock, $this->workingDir);
         $downloader->cleanup('update', $packageMock, $this->workingDir, $packageMock);
+
+        $process->assertComplete($this);
     }
 
     /**

--- a/tests/Composer/Test/Downloader/HgDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/HgDownloaderTest.php
@@ -16,6 +16,7 @@ use Composer\Downloader\HgDownloader;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Util\Platform;
+use Composer\Test\Mock\ProcessExecutorMock;
 
 class HgDownloaderTest extends TestCase
 {
@@ -39,7 +40,7 @@ class HgDownloaderTest extends TestCase
     {
         $io = $io ?: $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $config = $config ?: $this->getMockBuilder('Composer\Config')->getMock();
-        $executor = $executor ?: $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $executor = $executor ?: new ProcessExecutorMock;
         $filesystem = $filesystem ?: $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
 
         return new HgDownloader($io, $config, $executor, $filesystem);
@@ -67,22 +68,17 @@ class HgDownloaderTest extends TestCase
         $packageMock->expects($this->once())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('https://mercurial.dev/l3l0/composer')));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
-        $expectedGitCommand = $this->getCmd('hg clone -- \'https://mercurial.dev/l3l0/composer\' \'composerPath\'');
-        $processExecutor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand))
-            ->will($this->returnValue(0));
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->getCmd('hg clone -- \'https://mercurial.dev/l3l0/composer\' \'composerPath\''),
+            $this->getCmd('hg up -- \'ref\''),
+        ), true);
 
-        $expectedGitCommand = $this->getCmd('hg up -- \'ref\'');
-        $processExecutor->expects($this->at(1))
-            ->method('execute')
-            ->with($this->equalTo($expectedGitCommand))
-            ->will($this->returnValue(0));
-
-        $downloader = $this->getDownloaderMock(null, null, $processExecutor);
+        $downloader = $this->getDownloaderMock(null, null, $process);
         $downloader->install($packageMock, 'composerPath');
+
+        $process->assertComplete($this);
     }
 
     public function testUpdateforPackageWithoutSourceReference()
@@ -115,44 +111,44 @@ class HgDownloaderTest extends TestCase
         $packageMock->expects($this->any())
             ->method('getSourceUrls')
             ->will($this->returnValue(array('https://github.com/l3l0/composer')));
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
-        $expectedHgCommand = $this->getCmd("hg st");
-        $processExecutor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->equalTo($expectedHgCommand))
-            ->will($this->returnValue(0));
-        $expectedHgCommand = $this->getCmd("hg pull -- 'https://github.com/l3l0/composer' && hg up -- 'ref'");
-        $processExecutor->expects($this->at(1))
-            ->method('execute')
-            ->with($this->equalTo($expectedHgCommand))
-            ->will($this->returnValue(0));
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->getCmd('hg st'),
+            $this->getCmd("hg pull -- 'https://github.com/l3l0/composer' && hg up -- 'ref'"),
+        ), true);
 
-        $downloader = $this->getDownloaderMock(null, null, $processExecutor);
+        $downloader = $this->getDownloaderMock(null, null, $process);
         $downloader->prepare('update', $packageMock, $this->workingDir, $packageMock);
         $downloader->update($packageMock, $packageMock, $this->workingDir);
         $downloader->cleanup('update', $packageMock, $this->workingDir, $packageMock);
+
+        $process->assertComplete($this);
     }
 
     public function testRemove()
     {
-        $expectedResetCommand = $this->getCmd('cd \'composerPath\' && hg st');
-
+        $fs = new Filesystem;
+        $fs->ensureDirectoryExists($this->workingDir.'/.hg');
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
-        $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
-        $processExecutor->expects($this->any())
-            ->method('execute')
-            ->with($this->equalTo($expectedResetCommand));
+
+        $process = new ProcessExecutorMock;
+        $process->expects(array(
+            $this->getCmd('hg st'),
+        ), true);
+
         $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();
         $filesystem->expects($this->once())
             ->method('removeDirectoryAsync')
-            ->with($this->equalTo('composerPath'))
+            ->with($this->equalTo($this->workingDir))
             ->will($this->returnValue(\React\Promise\resolve(true)));
 
-        $downloader = $this->getDownloaderMock(null, null, $processExecutor, $filesystem);
-        $downloader->prepare('uninstall', $packageMock, 'composerPath');
-        $downloader->remove($packageMock, 'composerPath');
-        $downloader->cleanup('uninstall', $packageMock, 'composerPath');
+        $downloader = $this->getDownloaderMock(null, null, $process, $filesystem);
+        $downloader->prepare('uninstall', $packageMock, $this->workingDir);
+        $downloader->remove($packageMock, $this->workingDir);
+        $downloader->cleanup('uninstall', $packageMock, $this->workingDir);
+
+        $process->assertComplete($this);
     }
 
     public function testGetInstallationSource()

--- a/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/PerforceDownloaderTest.php
@@ -19,6 +19,7 @@ use Composer\IO\IOInterface;
 use Composer\Test\TestCase;
 use Composer\Factory;
 use Composer\Util\Filesystem;
+use Composer\Test\Mock\ProcessExecutorMock;
 
 /**
  * @author Matt Whittom <Matt.Whittom@veteransunited.com>
@@ -41,7 +42,7 @@ class PerforceDownloaderTest extends TestCase
         $this->repoConfig = $this->getRepoConfig();
         $this->config = $this->getConfig();
         $this->io = $this->getMockIoInterface();
-        $this->processExecutor = $this->getMockProcessExecutor();
+        $this->processExecutor = new ProcessExecutorMock;
         $this->repository = $this->getMockRepository($this->repoConfig, $this->io, $this->config);
         $this->package = $this->getMockPackageInterface($this->repository);
         $this->downloader = new PerforceDownloader($this->io, $this->config, $this->processExecutor);
@@ -59,11 +60,6 @@ class PerforceDownloaderTest extends TestCase
             $fs = new Filesystem;
             $fs->removeDirectory($this->testPath);
         }
-    }
-
-    protected function getMockProcessExecutor()
-    {
-        return $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
     }
 
     protected function getConfig()

--- a/tests/Composer/Test/Fixtures/installer/update-installed-reference.test
+++ b/tests/Composer/Test/Fixtures/installer/update-installed-reference.test
@@ -28,4 +28,4 @@ Updating a dev package forcing it's reference should not do anything if the refe
 --RUN--
 update
 --EXPECT--
-Upgrading a/a (dev-master def000 => dev-master )
+Upgrading a/a (dev-master def000 => dev-master)

--- a/tests/Composer/Test/InstalledVersionsTest.php
+++ b/tests/Composer/Test/InstalledVersionsTest.php
@@ -205,6 +205,9 @@ class InstalledVersionsTest extends TestCase
         ), InstalledVersions::getRootPackage());
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetRawData()
     {
         $dir = $this->root;

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -67,6 +67,21 @@ class InstallerTest extends TestCase
             ->setConstructorArgs(array($io))
             ->getMock();
         $config = $this->getMockBuilder('Composer\Config')->getMock();
+        $config->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function ($key) {
+                switch ($key) {
+                    case 'vendor-dir':
+                        return 'foo';
+                    case 'lock';
+                    case 'notify-on-install';
+                        return true;
+                    case 'platform';
+                        return array();
+                }
+
+                throw new \UnexpectedValueException('Unknown key '.$key);
+            }));
 
         $eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
         $httpDownloader = $this->getMockBuilder('Composer\Util\HttpDownloader')->disableOriginalConstructor()->getMock();

--- a/tests/Composer/Test/Mock/ProcessExecutorMock.php
+++ b/tests/Composer/Test/Mock/ProcessExecutorMock.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Mock;
+
+use Composer\Util\ProcessExecutor;
+use Composer\Util\Platform;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+use React\Promise\Promise;
+
+/**
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class ProcessExecutorMock extends ProcessExecutor
+{
+    private $expectations = array();
+    private $strict = false;
+    private $defaultHandler = array('return' => 0, 'stdout' => '', 'stderr' => '');
+    private $log = array();
+
+    /**
+     * @param array<string|array{cmd: string, return: int, stdout?: string, stderr?: string}> $expectations
+     * @param bool                                                                            $strict         set to true if you want to provide *all* expected commands, and not just a subset you are interested in testing
+     * @param array{return: int, stdout?: string, stderr?: string}                            $defaultHandler default command handler for undefined commands if not in strict mode
+     */
+    public function expects(array $expectations, $strict = false, array $defaultHandler = array('return' => 0, 'stdout' => '', 'stderr' => ''))
+    {
+        $default = array('return' => 0, 'stdout' => '', 'stderr' => '');
+        $this->expectations = array_map(function ($expect) use ($default) {
+            if (is_string($expect)) {
+                $expect = array('cmd' => $expect);
+            }
+
+            return array_merge($default, $expect);
+        }, $expectations);
+        $this->strict = $strict;
+        $this->defaultHandler = array_merge($default, $defaultHandler);
+    }
+
+    public function assertComplete(TestCase $testCase)
+    {
+        if ($this->expectations) {
+            $expectations = array_map(function ($expect) {
+                return $expect['cmd'];
+            }, $this->expectations);
+            throw new \LogicException(
+                'There are still '.count($this->expectations).' expected process calls which have not been consumed:'.PHP_EOL.
+                implode(PHP_EOL, $expectations).PHP_EOL.PHP_EOL.
+                'Received calls:'.PHP_EOL.implode(PHP_EOL, $this->log)
+            );
+        }
+
+        $testCase->assertTrue(true);
+    }
+
+    public function execute($command, &$output = null, $cwd = null)
+    {
+        if (func_num_args() > 1) {
+            return $this->doExecute($command, $cwd, false, $output);
+        }
+
+        return $this->doExecute($command, $cwd, false);
+    }
+
+    public function executeTty($command, $cwd = null)
+    {
+        if (Platform::isTty()) {
+            return $this->doExecute($command, $cwd, true);
+        }
+
+        return $this->doExecute($command, $cwd, false);
+    }
+
+    private function doExecute($command, $cwd, $tty, &$output = null)
+    {
+        $this->captureOutput = func_num_args() > 3;
+        $this->errorOutput = '';
+
+        $callback = is_callable($output) ? $output : array($this, 'outputHandler');
+
+        if ($this->expectations && $command === $this->expectations[0]['cmd']) {
+            $expect = array_shift($this->expectations);
+            $stdout = $expect['stdout'];
+            $stderr = $expect['stderr'];
+            $return = $expect['return'];
+        } elseif (!$this->strict) {
+            $stdout = $this->defaultHandler['stdout'];
+            $stderr = $this->defaultHandler['stderr'];
+            $return = $this->defaultHandler['return'];
+        } else {
+            throw new \LogicException(
+                'Received unexpected command "'.$command.'" in "'.$cwd.'"'.PHP_EOL.
+                ($this->expectations ? 'Expected "'.$this->expectations[0]['cmd'].'" at this point.' : 'Expected no more calls at this point.')
+            );
+        }
+
+        if ($stdout) {
+            call_user_func($callback, Process::STDOUT, $stdout);
+        }
+        if ($stderr) {
+            call_user_func($callback, Process::ERR, $stderr);
+        }
+
+        if ($this->captureOutput && !is_callable($output)) {
+            $output = $stdout;
+        }
+
+        $this->log[] = $command;
+
+        $this->errorOutput = $stderr;
+
+        return $return;
+    }
+
+    public function executeAsync($command, $cwd = null)
+    {
+        $resolver = function ($resolve, $reject) {
+            // TODO strictly speaking this should resolve with a mock Process instance here
+            $resolve();
+        };
+
+        $canceler = function () {
+            throw new \RuntimeException('Aborted process');
+        };
+
+        return new Promise($resolver, $canceler);
+    }
+
+    public function getErrorOutput()
+    {
+        return $this->errorOutput;
+    }
+}

--- a/tests/Composer/Test/Repository/Vcs/PerforceDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/PerforceDriverTest.php
@@ -17,6 +17,7 @@ use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Config;
 use Composer\Util\Perforce;
+use Composer\Test\Mock\ProcessExecutorMock;
 
 /**
  * @author Matt Whittom <Matt.Whittom@veteransunited.com>
@@ -42,7 +43,7 @@ class PerforceDriverTest extends TestCase
         $this->config = $this->getTestConfig($this->testPath);
         $this->repoConfig = $this->getTestRepoConfig();
         $this->io = $this->getMockIOInterface();
-        $this->process = $this->getMockProcessExecutor();
+        $this->process = new ProcessExecutorMock;
         $this->httpDownloader = $this->getMockHttpDownloader();
         $this->perforce = $this->getMockPerforce();
         $this->driver = new PerforceDriver($this->repoConfig, $this->io, $this->config, $this->httpDownloader, $this->process);
@@ -92,11 +93,6 @@ class PerforceDriverTest extends TestCase
     protected function getMockIOInterface()
     {
         return $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
-    }
-
-    protected function getMockProcessExecutor()
-    {
-        return $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
     }
 
     protected function getMockHttpDownloader()

--- a/tests/Composer/Test/Util/BitbucketTest.php
+++ b/tests/Composer/Test/Util/BitbucketTest.php
@@ -15,6 +15,7 @@ namespace Composer\Test\Util;
 use Composer\Util\Bitbucket;
 use Composer\Util\Http\Response;
 use Composer\Test\TestCase;
+use Composer\Test\Mock\ProcessExecutorMock;
 
 /**
  * @author Paul Wenke <wenke.paul@gmail.com>
@@ -456,10 +457,8 @@ class BitbucketTest extends TestCase
 
     public function testAuthorizeOAuthWithoutAvailableGitConfigToken()
     {
-        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
-        $process->expects($this->once())
-            ->method('execute')
-            ->willReturn(-1);
+        $process = new ProcessExecutorMock;
+        $process->expects(array(), false, array('return' => -1));
 
         $bitbucket = new Bitbucket($this->io, $this->config, $process, $this->httpDownloader, $this->time);
 
@@ -468,10 +467,7 @@ class BitbucketTest extends TestCase
 
     public function testAuthorizeOAuthWithAvailableGitConfigToken()
     {
-        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
-        $process->expects($this->once())
-            ->method('execute')
-            ->willReturn(0);
+        $process = new ProcessExecutorMock;
 
         $bitbucket = new Bitbucket($this->io, $this->config, $process, $this->httpDownloader, $this->time);
 

--- a/tests/Composer/Test/Util/GitLabTest.php
+++ b/tests/Composer/Test/Util/GitLabTest.php
@@ -93,8 +93,9 @@ class GitLabTest extends TestCase
         $httpDownloader
             ->expects($this->exactly(5))
             ->method('get')
-            ->will($this->throwException(new TransportException('', 401)))
+            ->will($this->throwException($e = new TransportException('', 401)))
         ;
+        $e->setResponse('{}');
 
         $config = $this->getConfigMock();
         $config

--- a/tests/Composer/Test/Util/MetadataMinifierTest.php
+++ b/tests/Composer/Test/Util/MetadataMinifierTest.php
@@ -12,7 +12,7 @@
 
 namespace Composer\Test\Util;
 
-use Composer\Util\MetadataMinifier;
+use Composer\MetadataMinifier\MetadataMinifier;
 use Composer\Package\CompletePackage;
 use Composer\Package\Dumper\ArrayDumper;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
This should get us the deprecations right on the CI for PHP 8.1, so easy to keep an eye out for more.

Fixes #10038

/cc @jrfnl