### PR TITLE
PHPUnit: move environment variable into PHPUnit config file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,9 +42,17 @@ To achieve this, you need to acquire the Composer source code:
 3. Run Composer to get the dependencies: `cd composer && php ../composer.phar install`
 
 You can run the test suite by executing `vendor/bin/simple-phpunit` when inside the
-composer directory, and run Composer by executing the `bin/composer`. To test
-your modified Composer code against another project, run `php
-/path/to/composer/bin/composer` inside that project's directory.
+composer directory, and run Composer by executing the `bin/composer`.
+
+For running the tests against the most recent PHP versions (PHP 8.0/8.1), you will
+need to run `composer config platform.php --unset && composer update --ignore-platform-reqs`
+before running the `vendor/bin/simple-phpunit` command.
+If that still doesn't work, try running
+`composer require --dev "symfony/phpunit-bridge:~5.2" --update-with-dependencies` and
+then running the `vendor/bin/simple-phpunit` command again.
+
+To test your modified Composer code against another project, run
+`php /path/to/composer/bin/composer` inside that project's directory.
 
 Contributing policy
 -------------------

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,11 +45,8 @@ You can run the test suite by executing `vendor/bin/simple-phpunit` when inside 
 composer directory, and run Composer by executing the `bin/composer`.
 
 For running the tests against the most recent PHP versions (PHP 8.0/8.1), you will
-need to run `composer config platform.php --unset && composer update --ignore-platform-reqs`
-before running the `vendor/bin/simple-phpunit` command.
-If that still doesn't work, try running
-`composer require --dev "symfony/phpunit-bridge:~5.2" --update-with-dependencies` and
-then running the `vendor/bin/simple-phpunit` command again.
+need to run `composer update --ignore-platform-reqs && git checkout composer.lock`  before running 
+the `vendor/bin/simple-phpunit` command.
 
 To test your modified Composer code against another project, run
 `php /path/to/composer/bin/composer` inside that project's directory.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,6 @@ env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
   COMPOSER_UPDATE_FLAGS: ""
   COMPOSER_TESTS_ARE_RUNNING: "1"
-  SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT: "1"
 
 jobs:
   tests:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /composer.phar
 /vendor
 /nbproject
+.phpunit.result.cache
 phpunit.xml
 .vagrant
 Vagrantfile

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,7 @@
 >
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1"/>
         <env name="COMPOSER_TEST_SUITE" value="1"/>
     </php>
     <testsuites>

--- a/tests/complete.phpunit.xml
+++ b/tests/complete.phpunit.xml
@@ -16,6 +16,7 @@
 >
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1"/>
     </php>
     <testsuites>
         <testsuite name="Full Composer Test Suite">


### PR DESCRIPTION
... to make it easier on contributors to get the tests running locally with the current setup.

Also includes:
* Adding the typical PHPUnit 8/9 cache file to `.gitignore`.
* Adding information on how to get the tests running locally on PHP 8.0/8.1 to the CONTRIBUTING file.

Related to #10038