### PR TITLE
Correctly resolve promises when package type changes

### DIFF
--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -511,7 +511,7 @@ class InstallationManager
             }
 
             $installer = $this->getInstaller($targetType);
-            $promise->then(function () use ($installer, $repo, $target) {
+            $promise = $promise->then(function () use ($installer, $repo, $target) {
                 return $installer->install($repo, $target);
             });
         }


### PR DESCRIPTION
This fixes https://github.com/composer/composer/issues/10069

When the type of a package changes, Composer does an uninstall and install instead of an update. 78d7792eb810319f86421071bf795ce41eca24f2 added support for handling promises of the installer, but because it returns the `uninstall` promise instead of the resulting `install` promise, the `cleanup` operation in https://github.com/composer/composer/blob/master/src/Composer/Installer/InstallationManager.php#L420 runs before `install` is executed.

---

FYI instead of setting `$promise = $promise->then(…)` we could also just `return $promise->then(…)`