### PR TITLE
Refactor ignore platform reqs checks

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -14,7 +14,9 @@ namespace Composer\Autoload;
 
 use Composer\Config;
 use Composer\EventDispatcher\EventDispatcher;
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\IgnoreAllPlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterInterface;
 use Composer\Installer\InstallationManager;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
@@ -70,7 +72,7 @@ class AutoloadGenerator
     private $runScripts = false;
 
     /**
-     * @var PlatformRequirementFilter
+     * @var PlatformRequirementFilterInterface
      */
     private $platformRequirementFilter;
 
@@ -79,7 +81,7 @@ class AutoloadGenerator
         $this->eventDispatcher = $eventDispatcher;
         $this->io = $io;
 
-        $this->platformRequirementFilter = PlatformRequirementFilter::ignoreNothing();
+        $this->platformRequirementFilter = PlatformRequirementFilterFactory::ignoreNothing();
     }
 
     /**
@@ -142,13 +144,13 @@ class AutoloadGenerator
     {
         trigger_error('AutoloadGenerator::setIgnorePlatformRequirements is deprecated since Composer 2.2, use setPlatformRequirementFilter instead.', E_USER_DEPRECATED);
 
-        $this->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
+        $this->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
     }
 
     /**
      * @return void
      */
-    public function setPlatformRequirementFilter(PlatformRequirementFilter $platformRequirementFilter)
+    public function setPlatformRequirementFilter(PlatformRequirementFilterInterface $platformRequirementFilter)
     {
         $this->platformRequirementFilter = $platformRequirementFilter;
     }
@@ -399,7 +401,7 @@ EOF;
             unlink($includeFilesFilePath);
         }
         $filesystem->filePutContentsIfModified($targetDir.'/autoload_static.php', $this->getStaticFile($suffix, $targetDir, $vendorPath, $basePath, $staticPhpVersion));
-        $checkPlatform = $config->get('platform-check') && !$this->platformRequirementFilter->isAllIgnored();
+        $checkPlatform = $config->get('platform-check') && !($this->platformRequirementFilter instanceof IgnoreAllPlatformRequirementFilter);
         $platformCheckContent = null;
         if ($checkPlatform) {
             $platformCheckContent = $this->getPlatformCheck($packageMap, $config->get('platform-check'), $devPackageNames);

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -771,7 +771,7 @@ EOF;
             }
 
             foreach ($package->getRequires() as $link) {
-                if ($this->platformRequirementFilter->isReqIgnored($link->getTarget())) {
+                if ($this->platformRequirementFilter->isIgnored($link->getTarget())) {
                     continue;
                 }
 

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Command;
 
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Symfony\Component\Console\Input\InputInterface;
@@ -97,7 +98,7 @@ EOT
         $generator->setClassMapAuthoritative($authoritative);
         $generator->setRunScripts(true);
         $generator->setApcu($apcu, $apcuPrefix);
-        $generator->setIgnorePlatformRequirements($ignorePlatformReqs);
+        $generator->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
         $numberOfClasses = $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
 
         if ($authoritative) {

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -12,7 +12,7 @@
 
 namespace Composer\Command;
 
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Symfony\Component\Console\Input\InputInterface;
@@ -98,7 +98,7 @@ EOT
         $generator->setClassMapAuthoritative($authoritative);
         $generator->setRunScripts(true);
         $generator->setApcu($apcu, $apcuPrefix);
-        $generator->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
+        $generator->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
         $numberOfClasses = $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
 
         if ($authoritative) {

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -903,7 +903,7 @@ EOT
         if (!$package) {
             // platform packages can not be found in the pool in versions other than the local platform's has
             // so if platform reqs are ignored we just take the user's word for it
-            if ($platformRequirementFilter->isReqIgnored($name)) {
+            if ($platformRequirementFilter->isIgnored($name)) {
                 return array($name, $requiredVersion ?: '*');
             }
 

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -12,7 +12,7 @@
 
 namespace Composer\Command;
 
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Installer;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
@@ -131,7 +131,7 @@ EOT
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)
             ->setApcuAutoloader($apcu, $apcuPrefix)
-            ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs))
+            ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs))
         ;
 
         if ($input->getOption('no-plugins')) {

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Command;
 
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
 use Composer\Installer;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
@@ -130,7 +131,7 @@ EOT
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)
             ->setApcuAutoloader($apcu, $apcuPrefix)
-            ->setIgnorePlatformRequirements($ignorePlatformReqs)
+            ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs))
         ;
 
         if ($input->getOption('no-plugins')) {

--- a/src/Composer/Command/ReinstallCommand.php
+++ b/src/Composer/Command/ReinstallCommand.php
@@ -15,7 +15,7 @@ namespace Composer\Command;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Transaction;
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
 use Composer\Plugin\CommandEvent;
@@ -159,7 +159,7 @@ EOT
             $generator = $composer->getAutoloadGenerator();
             $generator->setClassMapAuthoritative($authoritative);
             $generator->setApcu($apcu, $apcuPrefix);
-            $generator->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
+            $generator->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
             $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
         }
 

--- a/src/Composer/Command/ReinstallCommand.php
+++ b/src/Composer/Command/ReinstallCommand.php
@@ -15,6 +15,7 @@ namespace Composer\Command;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Transaction;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
 use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
 use Composer\Plugin\CommandEvent;
@@ -158,7 +159,7 @@ EOT
             $generator = $composer->getAutoloadGenerator();
             $generator->setClassMapAuthoritative($authoritative);
             $generator->setApcu($apcu, $apcuPrefix);
-            $generator->setIgnorePlatformRequirements($ignorePlatformReqs);
+            $generator->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
             $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
         }
 

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -14,6 +14,7 @@ namespace Composer\Command;
 
 use Composer\Config\JsonConfigSource;
 use Composer\DependencyResolver\Request;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
 use Composer\Installer;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
@@ -265,7 +266,7 @@ EOT
             ->setUpdate(true)
             ->setInstall(!$input->getOption('no-install'))
             ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
-            ->setIgnorePlatformRequirements($ignorePlatformReqs)
+            ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs))
             ->setDryRun($dryRun)
         ;
 

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -14,7 +14,7 @@ namespace Composer\Command;
 
 use Composer\Config\JsonConfigSource;
 use Composer\DependencyResolver\Request;
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Installer;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
@@ -266,7 +266,7 @@ EOT
             ->setUpdate(true)
             ->setInstall(!$input->getOption('no-install'))
             ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
-            ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs))
+            ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs))
             ->setDryRun($dryRun)
         ;
 

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -13,6 +13,7 @@
 namespace Composer\Command;
 
 use Composer\DependencyResolver\Request;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
 use Composer\Util\Filesystem;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -413,7 +414,7 @@ EOT
             ->setUpdate(true)
             ->setInstall(!$input->getOption('no-install'))
             ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
-            ->setIgnorePlatformRequirements($ignorePlatformReqs)
+            ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs))
             ->setPreferStable($input->getOption('prefer-stable'))
             ->setPreferLowest($input->getOption('prefer-lowest'))
         ;

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -13,7 +13,7 @@
 namespace Composer\Command;
 
 use Composer\DependencyResolver\Request;
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Util\Filesystem;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -414,7 +414,7 @@ EOT
             ->setUpdate(true)
             ->setInstall(!$input->getOption('no-install'))
             ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
-            ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs))
+            ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs))
             ->setPreferStable($input->getOption('prefer-stable'))
             ->setPreferLowest($input->getOption('prefer-lowest'))
         ;

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -14,7 +14,7 @@ namespace Composer\Command;
 
 use Composer\Composer;
 use Composer\DependencyResolver\Request;
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Installer;
 use Composer\IO\IOInterface;
 use Composer\Package\Loader\RootPackageLoader;
@@ -237,7 +237,7 @@ EOT
             ->setUpdateMirrors($updateMirrors)
             ->setUpdateAllowList($packages)
             ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
-            ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs))
+            ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs))
             ->setPreferStable($input->getOption('prefer-stable'))
             ->setPreferLowest($input->getOption('prefer-lowest'))
         ;

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -14,6 +14,7 @@ namespace Composer\Command;
 
 use Composer\Composer;
 use Composer\DependencyResolver\Request;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
 use Composer\Installer;
 use Composer\IO\IOInterface;
 use Composer\Package\Loader\RootPackageLoader;
@@ -236,7 +237,7 @@ EOT
             ->setUpdateMirrors($updateMirrors)
             ->setUpdateAllowList($packages)
             ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
-            ->setIgnorePlatformRequirements($ignorePlatformReqs)
+            ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs))
             ->setPreferStable($input->getOption('prefer-stable'))
             ->setPreferLowest($input->getOption('prefer-lowest'))
         ;

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -197,7 +197,7 @@ class RuleSetGenerator
             }
 
             foreach ($package->getRequires() as $link) {
-                if ($platformRequirementFilter->isReqIgnored($link->getTarget())) {
+                if ($platformRequirementFilter->isIgnored($link->getTarget())) {
                     continue;
                 }
 
@@ -225,7 +225,7 @@ class RuleSetGenerator
                     continue;
                 }
 
-                if ($platformRequirementFilter->isReqIgnored($link->getTarget())) {
+                if ($platformRequirementFilter->isIgnored($link->getTarget())) {
                     continue;
                 }
 
@@ -275,7 +275,7 @@ class RuleSetGenerator
         }
 
         foreach ($request->getRequires() as $packageName => $constraint) {
-            if ($platformRequirementFilter->isReqIgnored($packageName)) {
+            if ($platformRequirementFilter->isIgnored($packageName)) {
                 continue;
             }
 

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -12,7 +12,8 @@
 
 namespace Composer\DependencyResolver;
 
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterInterface;
 use Composer\Package\BasePackage;
 use Composer\Package\AliasPackage;
 use Composer\Repository\PlatformRepository;
@@ -163,7 +164,7 @@ class RuleSetGenerator
     /**
      * @return void
      */
-    protected function addRulesForPackage(BasePackage $package, PlatformRequirementFilter $platformRequirementFilter)
+    protected function addRulesForPackage(BasePackage $package, PlatformRequirementFilterInterface $platformRequirementFilter)
     {
         /** @var \SplQueue<BasePackage> */
         $workQueue = new \SplQueue;
@@ -214,7 +215,7 @@ class RuleSetGenerator
     /**
      * @return void
      */
-    protected function addConflictRules(PlatformRequirementFilter $platformRequirementFilter)
+    protected function addConflictRules(PlatformRequirementFilterInterface $platformRequirementFilter)
     {
         /** @var BasePackage $package */
         foreach ($this->addedMap as $package) {
@@ -252,7 +253,7 @@ class RuleSetGenerator
     /**
      * @return void
      */
-    protected function addRulesForRequest(Request $request, PlatformRequirementFilter $platformRequirementFilter)
+    protected function addRulesForRequest(Request $request, PlatformRequirementFilterInterface $platformRequirementFilter)
     {
         foreach ($request->getFixedPackages() as $package) {
             if ($package->id == -1) {
@@ -296,7 +297,7 @@ class RuleSetGenerator
     /**
      * @return void
      */
-    protected function addRulesForRootAliases(PlatformRequirementFilter $platformRequirementFilter)
+    protected function addRulesForRootAliases(PlatformRequirementFilterInterface $platformRequirementFilter)
     {
         foreach ($this->pool->getPackages() as $package) {
             // ensure that rules for root alias packages and aliases of packages which were loaded are also loaded
@@ -314,9 +315,9 @@ class RuleSetGenerator
     /**
      * @return RuleSet
      */
-    public function getRulesFor(Request $request, PlatformRequirementFilter $platformRequirementFilter = null)
+    public function getRulesFor(Request $request, PlatformRequirementFilterInterface $platformRequirementFilter = null)
     {
-        $platformRequirementFilter = $platformRequirementFilter ?: PlatformRequirementFilter::ignoreNothing();
+        $platformRequirementFilter = $platformRequirementFilter ?: PlatformRequirementFilterFactory::ignoreNothing();
 
         $this->addRulesForRequest($request, $platformRequirementFilter);
 

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -172,7 +172,7 @@ class Solver
     protected function checkForRootRequireProblems(Request $request, PlatformRequirementFilterInterface $platformRequirementFilter)
     {
         foreach ($request->getRequires() as $packageName => $constraint) {
-            if ($platformRequirementFilter->isReqIgnored($packageName)) {
+            if ($platformRequirementFilter->isIgnored($packageName)) {
                 continue;
             }
 

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -12,7 +12,8 @@
 
 namespace Composer\DependencyResolver;
 
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterInterface;
 use Composer\IO\IOInterface;
 use Composer\Package\BasePackage;
 
@@ -168,7 +169,7 @@ class Solver
     /**
      * @return void
      */
-    protected function checkForRootRequireProblems(Request $request, PlatformRequirementFilter $platformRequirementFilter)
+    protected function checkForRootRequireProblems(Request $request, PlatformRequirementFilterInterface $platformRequirementFilter)
     {
         foreach ($request->getRequires() as $packageName => $constraint) {
             if ($platformRequirementFilter->isReqIgnored($packageName)) {
@@ -186,9 +187,9 @@ class Solver
     /**
      * @return LockTransaction
      */
-    public function solve(Request $request, PlatformRequirementFilter $platformRequirementFilter = null)
+    public function solve(Request $request, PlatformRequirementFilterInterface $platformRequirementFilter = null)
     {
-        $platformRequirementFilter = $platformRequirementFilter ?: PlatformRequirementFilter::ignoreNothing();
+        $platformRequirementFilter = $platformRequirementFilter ?: PlatformRequirementFilterFactory::ignoreNothing();
 
         $this->setupFixedMap($request);
 

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilter.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Composer\Filter\PlatformRequirementFilter;
+
+use Composer\Repository\PlatformRepository;
+
+final class IgnoreAllPlatformRequirementFilter extends PlatformRequirementFilter
+{
+    /**
+     * @param string $req
+     * @return bool
+     */
+    public function isReqIgnored($req)
+    {
+        return PlatformRepository::isPlatformPackage($req);
+    }
+}

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilter.php
@@ -4,7 +4,7 @@ namespace Composer\Filter\PlatformRequirementFilter;
 
 use Composer\Repository\PlatformRepository;
 
-final class IgnoreAllPlatformRequirementFilter extends PlatformRequirementFilter
+final class IgnoreAllPlatformRequirementFilter implements PlatformRequirementFilterInterface
 {
     /**
      * @param string $req

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilter.php
@@ -10,7 +10,7 @@ final class IgnoreAllPlatformRequirementFilter implements PlatformRequirementFil
      * @param string $req
      * @return bool
      */
-    public function isReqIgnored($req)
+    public function isIgnored($req)
     {
         return PlatformRepository::isPlatformPackage($req);
     }

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Composer\Filter\PlatformRequirementFilter;
+
+use Composer\Repository\PlatformRepository;
+
+final class IgnoreListPlatformRequirementFilter extends PlatformRequirementFilter
+{
+    /**
+     * @var string[]
+     */
+    private $reqList;
+
+    /**
+     * @param string[] $reqList
+     */
+    public function __construct(array $reqList)
+    {
+        $this->reqList = $reqList;
+    }
+
+    /**
+     * @param string $req
+     * @return bool
+     */
+    public function isReqIgnored($req)
+    {
+        if (!PlatformRepository::isPlatformPackage($req)) {
+            return false;
+        }
+
+        return in_array($req, $this->reqList, true);
+    }
+}

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
@@ -4,7 +4,7 @@ namespace Composer\Filter\PlatformRequirementFilter;
 
 use Composer\Repository\PlatformRepository;
 
-final class IgnoreListPlatformRequirementFilter extends PlatformRequirementFilter
+final class IgnoreListPlatformRequirementFilter implements PlatformRequirementFilterInterface
 {
     /**
      * @var string[]

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
@@ -23,7 +23,7 @@ final class IgnoreListPlatformRequirementFilter implements PlatformRequirementFi
      * @param string $req
      * @return bool
      */
-    public function isReqIgnored($req)
+    public function isIgnored($req)
     {
         if (!PlatformRepository::isPlatformPackage($req)) {
             return false;

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Composer\Filter\PlatformRequirementFilter;
+
+final class IgnoreNothingPlatformRequirementFilter extends PlatformRequirementFilter
+{
+    /**
+     * @param string $req
+     * @return false
+     */
+    public function isReqIgnored($req)
+    {
+        return false;
+    }
+}

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilter.php
@@ -2,7 +2,7 @@
 
 namespace Composer\Filter\PlatformRequirementFilter;
 
-final class IgnoreNothingPlatformRequirementFilter extends PlatformRequirementFilter
+final class IgnoreNothingPlatformRequirementFilter implements PlatformRequirementFilterInterface
 {
     /**
      * @param string $req

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilter.php
@@ -8,7 +8,7 @@ final class IgnoreNothingPlatformRequirementFilter implements PlatformRequiremen
      * @param string $req
      * @return false
      */
-    public function isReqIgnored($req)
+    public function isIgnored($req)
     {
         return false;
     }

--- a/src/Composer/Filter/PlatformRequirementFilter/PlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/PlatformRequirementFilter.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Composer\Filter\PlatformRequirementFilter;
+
+abstract class PlatformRequirementFilter
+{
+    /**
+     * @param string $req
+     * @return bool
+     */
+    abstract public function isReqIgnored($req);
+
+    /**
+     * @param mixed $boolOrList
+     *
+     * @return PlatformRequirementFilter
+     */
+    public static function fromBoolOrList($boolOrList)
+    {
+        if (is_bool($boolOrList)) {
+            return $boolOrList ? self::ignoreAll() : self::ignoreNothing();
+        }
+
+        if (is_array($boolOrList)) {
+            return new IgnoreListPlatformRequirementFilter($boolOrList);
+        }
+
+        throw new \InvalidArgumentException(
+            sprintf(
+                'PlatformRequirementFilter: Unknown $boolOrList parameter %s. Please report at https://github.com/composer/composer/issues/new.',
+                gettype($boolOrList)
+            )
+        );
+    }
+
+    /**
+     * @return PlatformRequirementFilter
+     */
+    public static function ignoreAll()
+    {
+        return new IgnoreAllPlatformRequirementFilter();
+    }
+
+    /**
+     * @return PlatformRequirementFilter
+     */
+    public static function ignoreNothing()
+    {
+        return new IgnoreNothingPlatformRequirementFilter();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAllIgnored()
+    {
+        return $this instanceof IgnoreAllPlatformRequirementFilter;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNothingIgnored()
+    {
+        return $this instanceof IgnoreNothingPlatformRequirementFilter;
+    }
+}

--- a/src/Composer/Filter/PlatformRequirementFilter/PlatformRequirementFilterFactory.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/PlatformRequirementFilterFactory.php
@@ -2,18 +2,12 @@
 
 namespace Composer\Filter\PlatformRequirementFilter;
 
-abstract class PlatformRequirementFilter
+final class PlatformRequirementFilterFactory
 {
-    /**
-     * @param string $req
-     * @return bool
-     */
-    abstract public function isReqIgnored($req);
-
     /**
      * @param mixed $boolOrList
      *
-     * @return PlatformRequirementFilter
+     * @return PlatformRequirementFilterInterface
      */
     public static function fromBoolOrList($boolOrList)
     {
@@ -34,7 +28,7 @@ abstract class PlatformRequirementFilter
     }
 
     /**
-     * @return PlatformRequirementFilter
+     * @return PlatformRequirementFilterInterface
      */
     public static function ignoreAll()
     {
@@ -42,26 +36,10 @@ abstract class PlatformRequirementFilter
     }
 
     /**
-     * @return PlatformRequirementFilter
+     * @return PlatformRequirementFilterInterface
      */
     public static function ignoreNothing()
     {
         return new IgnoreNothingPlatformRequirementFilter();
-    }
-
-    /**
-     * @return bool
-     */
-    public function isAllIgnored()
-    {
-        return $this instanceof IgnoreAllPlatformRequirementFilter;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isNothingIgnored()
-    {
-        return $this instanceof IgnoreNothingPlatformRequirementFilter;
     }
 }

--- a/src/Composer/Filter/PlatformRequirementFilter/PlatformRequirementFilterInterface.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/PlatformRequirementFilterInterface.php
@@ -8,5 +8,5 @@ interface PlatformRequirementFilterInterface
      * @param string $req
      * @return bool
      */
-    public function isReqIgnored($req);
+    public function isIgnored($req);
 }

--- a/src/Composer/Filter/PlatformRequirementFilter/PlatformRequirementFilterInterface.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/PlatformRequirementFilterInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Composer\Filter\PlatformRequirementFilter;
+
+interface PlatformRequirementFilterInterface
+{
+    /**
+     * @param string $req
+     * @return bool
+     */
+    public function isReqIgnored($req);
+}

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -27,7 +27,8 @@ use Composer\DependencyResolver\SolverProblemsException;
 use Composer\DependencyResolver\PolicyInterface;
 use Composer\Downloader\DownloadManager;
 use Composer\EventDispatcher\EventDispatcher;
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterInterface;
 use Composer\Installer\InstallationManager;
 use Composer\Installer\InstallerEvents;
 use Composer\Installer\SuggestedPackagesReporter;
@@ -177,7 +178,7 @@ class Installer
     protected $suggestedPackagesReporter;
 
     /**
-     * @var PlatformRequirementFilter
+     * @var PlatformRequirementFilterInterface
      */
     protected $platformRequirementFilter;
 
@@ -211,7 +212,7 @@ class Installer
         $this->eventDispatcher = $eventDispatcher;
         $this->autoloadGenerator = $autoloadGenerator;
         $this->suggestedPackagesReporter = new SuggestedPackagesReporter($this->io);
-        $this->platformRequirementFilter = PlatformRequirementFilter::ignoreNothing();
+        $this->platformRequirementFilter = PlatformRequirementFilterFactory::ignoreNothing();
 
         $this->writeLock = $config->get('lock');
     }
@@ -1254,14 +1255,14 @@ class Installer
     {
         trigger_error('Installer::setIgnorePlatformRequirements is deprecated since Composer 2.2, use setPlatformRequirementFilter instead.', E_USER_DEPRECATED);
 
-        return $this->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
+        return $this->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
     }
 
     /**
-     * @param PlatformRequirementFilter $platformRequirementFilter
+     * @param PlatformRequirementFilterInterface $platformRequirementFilter
      * @return Installer
      */
-    public function setPlatformRequirementFilter(PlatformRequirementFilter $platformRequirementFilter)
+    public function setPlatformRequirementFilter(PlatformRequirementFilterInterface $platformRequirementFilter)
     {
         $this->platformRequirementFilter = $platformRequirementFilter;
 

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -27,6 +27,7 @@ use Composer\DependencyResolver\SolverProblemsException;
 use Composer\DependencyResolver\PolicyInterface;
 use Composer\Downloader\DownloadManager;
 use Composer\EventDispatcher\EventDispatcher;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
 use Composer\Installer\InstallationManager;
 use Composer\Installer\InstallerEvents;
 use Composer\Installer\SuggestedPackagesReporter;
@@ -150,8 +151,6 @@ class Installer
     protected $dumpAutoloader = true;
     /** @var bool */
     protected $runScripts = true;
-    /** @var bool|string[] */
-    protected $ignorePlatformReqs = false;
     /** @var bool */
     protected $preferStable = false;
     /** @var bool */
@@ -176,6 +175,11 @@ class Installer
      * @var SuggestedPackagesReporter
      */
     protected $suggestedPackagesReporter;
+
+    /**
+     * @var PlatformRequirementFilter
+     */
+    protected $platformRequirementFilter;
 
     /**
      * @var ?RepositoryInterface
@@ -207,6 +211,7 @@ class Installer
         $this->eventDispatcher = $eventDispatcher;
         $this->autoloadGenerator = $autoloadGenerator;
         $this->suggestedPackagesReporter = new SuggestedPackagesReporter($this->io);
+        $this->platformRequirementFilter = PlatformRequirementFilter::ignoreNothing();
 
         $this->writeLock = $config->get('lock');
     }
@@ -329,7 +334,7 @@ class Installer
             $this->autoloadGenerator->setClassMapAuthoritative($this->classMapAuthoritative);
             $this->autoloadGenerator->setApcu($this->apcuAutoloader, $this->apcuAutoloaderPrefix);
             $this->autoloadGenerator->setRunScripts($this->runScripts);
-            $this->autoloadGenerator->setIgnorePlatformRequirements($this->ignorePlatformReqs);
+            $this->autoloadGenerator->setPlatformRequirementFilter($this->platformRequirementFilter);
             $this->autoloadGenerator->dump($this->config, $localRepo, $this->package, $this->installationManager, 'composer', $this->optimizeAutoloader);
         }
 
@@ -431,7 +436,7 @@ class Installer
         // solve dependencies
         $solver = new Solver($policy, $pool, $this->io);
         try {
-            $lockTransaction = $solver->solve($request, $this->ignorePlatformReqs);
+            $lockTransaction = $solver->solve($request, $this->platformRequirementFilter);
             $ruleSetSize = $solver->getRuleSetSize();
             $solver = null;
         } catch (SolverProblemsException $e) {
@@ -609,7 +614,7 @@ class Installer
 
         $solver = new Solver($policy, $pool, $this->io);
         try {
-            $nonDevLockTransaction = $solver->solve($request, $this->ignorePlatformReqs);
+            $nonDevLockTransaction = $solver->solve($request, $this->platformRequirementFilter);
             $solver = null;
         } catch (SolverProblemsException $e) {
             $err = 'Unable to find a compatible set of packages based on your non-dev requirements alone.';
@@ -674,7 +679,7 @@ class Installer
             // solve dependencies
             $solver = new Solver($policy, $pool, $this->io);
             try {
-                $lockTransaction = $solver->solve($request, $this->ignorePlatformReqs);
+                $lockTransaction = $solver->solve($request, $this->platformRequirementFilter);
                 $solver = null;
 
                 // installing the locked packages on this platform resulted in lock modifying operations, there wasn't a conflict, but the lock file as-is seems to not work on this system
@@ -799,7 +804,7 @@ class Installer
         $rootRequires = array();
         foreach ($requires as $req => $constraint) {
             // skip platform requirements from the root package to avoid filtering out existing platform packages
-            if ((true === $this->ignorePlatformReqs || (is_array($this->ignorePlatformReqs) && in_array($req, $this->ignorePlatformReqs, true))) && PlatformRepository::isPlatformPackage($req)) {
+            if ($this->platformRequirementFilter->isReqIgnored($req)) {
                 continue;
             }
             if ($constraint instanceof Link) {
@@ -1242,16 +1247,23 @@ class Installer
      * @param  bool|string[] $ignorePlatformReqs
      *
      * @return Installer
+     *
+     * @deprecated use setPlatformRequirementFilter instead
      */
     public function setIgnorePlatformRequirements($ignorePlatformReqs)
     {
-        if (is_array($ignorePlatformReqs)) {
-            $this->ignorePlatformReqs = array_filter($ignorePlatformReqs, function ($req) {
-                return PlatformRepository::isPlatformPackage($req);
-            });
-        } else {
-            $this->ignorePlatformReqs = (bool) $ignorePlatformReqs;
-        }
+        trigger_error('Installer::setIgnorePlatformRequirements is deprecated since Composer 2.2, use setPlatformRequirementFilter instead.', E_USER_DEPRECATED);
+
+        return $this->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
+    }
+
+    /**
+     * @param PlatformRequirementFilter $platformRequirementFilter
+     * @return Installer
+     */
+    public function setPlatformRequirementFilter(PlatformRequirementFilter $platformRequirementFilter)
+    {
+        $this->platformRequirementFilter = $platformRequirementFilter;
 
         return $this;
     }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -805,7 +805,7 @@ class Installer
         $rootRequires = array();
         foreach ($requires as $req => $constraint) {
             // skip platform requirements from the root package to avoid filtering out existing platform packages
-            if ($this->platformRequirementFilter->isReqIgnored($req)) {
+            if ($this->platformRequirementFilter->isIgnored($req)) {
                 continue;
             }
             if ($constraint instanceof Link) {

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -90,7 +90,7 @@ class VersionSelector
                 $reqs = $pkg->getRequires();
 
                 foreach ($reqs as $name => $link) {
-                    if (!$platformRequirementFilter->isReqIgnored($name)) {
+                    if (!$platformRequirementFilter->isIgnored($name)) {
                         if (isset($platformConstraints[$name])) {
                             foreach ($platformConstraints[$name] as $constraint) {
                                 if ($link->getConstraint()->matches($constraint)) {

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test\Autoload;
 
 use Composer\Autoload\AutoloadGenerator;
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Package\Link;
 use Composer\Package\Version\VersionParser;
 use Composer\Semver\Constraint\Constraint;
@@ -1732,7 +1732,7 @@ EOF;
             ->method('getCanonicalPackages')
             ->will($this->returnValue(array()));
 
-        $this->generator->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
+        $this->generator->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', true, '_1');
 
         if (null === $expectedFixture) {

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\Autoload;
 
 use Composer\Autoload\AutoloadGenerator;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
 use Composer\Package\Link;
 use Composer\Package\Version\VersionParser;
 use Composer\Semver\Constraint\Constraint;
@@ -1731,7 +1732,7 @@ EOF;
             ->method('getCanonicalPackages')
             ->will($this->returnValue(array()));
 
-        $this->generator->setIgnorePlatformRequirements($ignorePlatformReqs);
+        $this->generator->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', true, '_1');
 
         if (null === $expectedFixture) {

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilterTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Composer\Test\Filter\PlatformRequirementFilter;
+
+use Composer\Filter\PlatformRequirementFilter\IgnoreAllPlatformRequirementFilter;
+use Composer\Test\TestCase;
+
+final class IgnoreAllPlatformRequirementFilterTest extends TestCase
+{
+    /**
+     * @dataProvider dataIsReqIgnored
+     *
+     * @param string $req
+     * @param bool $expectIgnored
+     */
+    public function testIsReqIgnored($req, $expectIgnored)
+    {
+        $platformRequirementFilter = new IgnoreAllPlatformRequirementFilter();
+
+        $this->assertSame($expectIgnored, $platformRequirementFilter->isReqIgnored($req));
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    public function dataIsReqIgnored()
+    {
+        return array(
+            'php is ignored' => array('php', true),
+            'monolog/monolog is not ignored' => array('monolog/monolog', false),
+        );
+    }
+}

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilterTest.php
@@ -8,22 +8,22 @@ use Composer\Test\TestCase;
 final class IgnoreAllPlatformRequirementFilterTest extends TestCase
 {
     /**
-     * @dataProvider dataIsReqIgnored
+     * @dataProvider dataIsIgnored
      *
      * @param string $req
      * @param bool $expectIgnored
      */
-    public function testIsReqIgnored($req, $expectIgnored)
+    public function testIsIgnored($req, $expectIgnored)
     {
         $platformRequirementFilter = new IgnoreAllPlatformRequirementFilter();
 
-        $this->assertSame($expectIgnored, $platformRequirementFilter->isReqIgnored($req));
+        $this->assertSame($expectIgnored, $platformRequirementFilter->isIgnored($req));
     }
 
     /**
      * @return array<string, mixed[]>
      */
-    public function dataIsReqIgnored()
+    public function dataIsIgnored()
     {
         return array(
             'php is ignored' => array('php', true),

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Composer\Test\Filter\PlatformRequirementFilter;
+
+use Composer\Filter\PlatformRequirementFilter\IgnoreListPlatformRequirementFilter;
+use Composer\Test\TestCase;
+
+final class IgnoreListPlatformRequirementFilterTest extends TestCase
+{
+    /**
+     * @dataProvider dataIsReqIgnored
+     *
+     * @param string[] $reqList
+     * @param string $req
+     * @param bool $expectIgnored
+     */
+    public function testIsReqIgnored(array $reqList, $req, $expectIgnored)
+    {
+        $platformRequirementFilter = new IgnoreListPlatformRequirementFilter($reqList);
+
+        $this->assertSame($expectIgnored, $platformRequirementFilter->isReqIgnored($req));
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    public function dataIsReqIgnored()
+    {
+        return array(
+            'ext-json is ignored if listed' => array(array('ext-json', 'monolog/monolog'), 'ext-json', true),
+            'php is not ignored if not listed' => array(array('ext-json', 'monolog/monolog'), 'php', false),
+            'monolog/monolog is not ignored even if listed' => array(array('ext-json', 'monolog/monolog'), 'monolog/monolog', false),
+        );
+    }
+}

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilterTest.php
@@ -8,23 +8,23 @@ use Composer\Test\TestCase;
 final class IgnoreListPlatformRequirementFilterTest extends TestCase
 {
     /**
-     * @dataProvider dataIsReqIgnored
+     * @dataProvider dataIsIgnored
      *
      * @param string[] $reqList
      * @param string $req
      * @param bool $expectIgnored
      */
-    public function testIsReqIgnored(array $reqList, $req, $expectIgnored)
+    public function testIsIgnored(array $reqList, $req, $expectIgnored)
     {
         $platformRequirementFilter = new IgnoreListPlatformRequirementFilter($reqList);
 
-        $this->assertSame($expectIgnored, $platformRequirementFilter->isReqIgnored($req));
+        $this->assertSame($expectIgnored, $platformRequirementFilter->isIgnored($req));
     }
 
     /**
      * @return array<string, mixed[]>
      */
-    public function dataIsReqIgnored()
+    public function dataIsIgnored()
     {
         return array(
             'ext-json is ignored if listed' => array(array('ext-json', 'monolog/monolog'), 'ext-json', true),

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Composer\Test\Filter\PlatformRequirementFilter;
+
+use Composer\Filter\PlatformRequirementFilter\IgnoreNothingPlatformRequirementFilter;
+use Composer\Test\TestCase;
+
+final class IgnoreNothingPlatformRequirementFilterTest extends TestCase
+{
+    /**
+     * @dataProvider dataIsReqIgnored
+     *
+     * @param string $req
+     */
+    public function testIsReqIgnored($req)
+    {
+        $platformRequirementFilter = new IgnoreNothingPlatformRequirementFilter();
+
+        $this->assertFalse($platformRequirementFilter->isReqIgnored($req));
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    public function dataIsReqIgnored()
+    {
+        return array(
+            'php is not ignored' => array('php'),
+            'monolog/monolog is not ignored' => array('monolog/monolog'),
+        );
+    }
+}

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilterTest.php
@@ -8,21 +8,21 @@ use Composer\Test\TestCase;
 final class IgnoreNothingPlatformRequirementFilterTest extends TestCase
 {
     /**
-     * @dataProvider dataIsReqIgnored
+     * @dataProvider dataIsIgnored
      *
      * @param string $req
      */
-    public function testIsReqIgnored($req)
+    public function testIsIgnored($req)
     {
         $platformRequirementFilter = new IgnoreNothingPlatformRequirementFilter();
 
-        $this->assertFalse($platformRequirementFilter->isReqIgnored($req));
+        $this->assertFalse($platformRequirementFilter->isIgnored($req));
     }
 
     /**
      * @return array<string, mixed[]>
      */
-    public function dataIsReqIgnored()
+    public function dataIsIgnored()
     {
         return array(
             'php is not ignored' => array('php'),

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/PlatformRequirementFilterFactoryTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/PlatformRequirementFilterFactoryTest.php
@@ -2,10 +2,10 @@
 
 namespace Composer\Test\Filter\PlatformRequirementFilter;
 
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Test\TestCase;
 
-final class PlatformRequirementFilterTest extends TestCase
+final class PlatformRequirementFilterFactoryTest extends TestCase
 {
     /**
      * @dataProvider dataFromBoolOrList
@@ -15,7 +15,7 @@ final class PlatformRequirementFilterTest extends TestCase
      */
     public function testFromBoolOrList($boolOrList, $expectedInstance)
     {
-        $this->assertInstanceOf($expectedInstance, PlatformRequirementFilter::fromBoolOrList($boolOrList));
+        $this->assertInstanceOf($expectedInstance, PlatformRequirementFilterFactory::fromBoolOrList($boolOrList));
     }
 
     /**
@@ -34,32 +34,20 @@ final class PlatformRequirementFilterTest extends TestCase
     {
         $this->setExpectedException('InvalidArgumentException', 'PlatformRequirementFilter: Unknown $boolOrList parameter NULL. Please report at https://github.com/composer/composer/issues/new.');
 
-        PlatformRequirementFilter::fromBoolOrList(null);
+        PlatformRequirementFilterFactory::fromBoolOrList(null);
     }
 
     public function testIgnoreAll()
     {
-        $platformRequirementFilter = PlatformRequirementFilter::ignoreAll();
+        $platformRequirementFilter = PlatformRequirementFilterFactory::ignoreAll();
 
         $this->assertInstanceOf('Composer\Filter\PlatformRequirementFilter\IgnoreAllPlatformRequirementFilter', $platformRequirementFilter);
     }
 
     public function testIgnoreNothing()
     {
-        $platformRequirementFilter = PlatformRequirementFilter::ignoreNothing();
+        $platformRequirementFilter = PlatformRequirementFilterFactory::ignoreNothing();
 
         $this->assertInstanceOf('Composer\Filter\PlatformRequirementFilter\IgnoreNothingPlatformRequirementFilter', $platformRequirementFilter);
-    }
-
-    public function testIsAllIgnored()
-    {
-        $this->assertTrue(PlatformRequirementFilter::ignoreAll()->isAllIgnored());
-        $this->assertFalse(PlatformRequirementFilter::ignoreNothing()->isAllIgnored());
-    }
-
-    public function testIsNothingIgnored()
-    {
-        $this->assertTrue(PlatformRequirementFilter::ignoreNothing()->isNothingIgnored());
-        $this->assertFalse(PlatformRequirementFilter::ignoreAll()->isNothingIgnored());
     }
 }

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/PlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/PlatformRequirementFilterTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Composer\Test\Filter\PlatformRequirementFilter;
+
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Test\TestCase;
+
+final class PlatformRequirementFilterTest extends TestCase
+{
+    /**
+     * @dataProvider dataFromBoolOrList
+     *
+     * @param mixed $boolOrList
+     * @param class-string $expectedInstance
+     */
+    public function testFromBoolOrList($boolOrList, $expectedInstance)
+    {
+        $this->assertInstanceOf($expectedInstance, PlatformRequirementFilter::fromBoolOrList($boolOrList));
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    public function dataFromBoolOrList()
+    {
+        return array(
+            'true creates IgnoreAllFilter' => array(true, 'Composer\Filter\PlatformRequirementFilter\IgnoreAllPlatformRequirementFilter'),
+            'false creates IgnoreNothingFilter' => array(false, 'Composer\Filter\PlatformRequirementFilter\IgnoreNothingPlatformRequirementFilter'),
+            'list creates IgnoreListFilter' => array(array('php', 'ext-json'), 'Composer\Filter\PlatformRequirementFilter\IgnoreListPlatformRequirementFilter'),
+        );
+    }
+
+    public function testFromBoolThrowsExceptionIfTypeIsUnknown()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'PlatformRequirementFilter: Unknown $boolOrList parameter NULL. Please report at https://github.com/composer/composer/issues/new.');
+
+        PlatformRequirementFilter::fromBoolOrList(null);
+    }
+
+    public function testIgnoreAll()
+    {
+        $platformRequirementFilter = PlatformRequirementFilter::ignoreAll();
+
+        $this->assertInstanceOf('Composer\Filter\PlatformRequirementFilter\IgnoreAllPlatformRequirementFilter', $platformRequirementFilter);
+    }
+
+    public function testIgnoreNothing()
+    {
+        $platformRequirementFilter = PlatformRequirementFilter::ignoreNothing();
+
+        $this->assertInstanceOf('Composer\Filter\PlatformRequirementFilter\IgnoreNothingPlatformRequirementFilter', $platformRequirementFilter);
+    }
+
+    public function testIsAllIgnored()
+    {
+        $this->assertTrue(PlatformRequirementFilter::ignoreAll()->isAllIgnored());
+        $this->assertFalse(PlatformRequirementFilter::ignoreNothing()->isAllIgnored());
+    }
+
+    public function testIsNothingIgnored()
+    {
+        $this->assertTrue(PlatformRequirementFilter::ignoreNothing()->isNothingIgnored());
+        $this->assertFalse(PlatformRequirementFilter::ignoreAll()->isNothingIgnored());
+    }
+}

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -13,7 +13,7 @@
 namespace Composer\Test;
 
 use Composer\DependencyResolver\Request;
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Installer;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -341,7 +341,7 @@ class InstallerTest extends TestCase
             $installer
                 ->setDevMode(!$input->getOption('no-dev'))
                 ->setDryRun($input->getOption('dry-run'))
-                ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
+                ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
 
             return $installer->run();
         });
@@ -386,7 +386,7 @@ class InstallerTest extends TestCase
                 ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
                 ->setPreferStable($input->getOption('prefer-stable'))
                 ->setPreferLowest($input->getOption('prefer-lowest'))
-                ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
+                ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
 
             return $installer->run();
         });

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test;
 
 use Composer\DependencyResolver\Request;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
 use Composer\Installer;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -340,7 +341,7 @@ class InstallerTest extends TestCase
             $installer
                 ->setDevMode(!$input->getOption('no-dev'))
                 ->setDryRun($input->getOption('dry-run'))
-                ->setIgnorePlatformRequirements($ignorePlatformReqs);
+                ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
 
             return $installer->run();
         });
@@ -385,7 +386,7 @@ class InstallerTest extends TestCase
                 ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
                 ->setPreferStable($input->getOption('prefer-stable'))
                 ->setPreferLowest($input->getOption('prefer-lowest'))
-                ->setIgnorePlatformRequirements($ignorePlatformReqs);
+                ->setPlatformRequirementFilter(PlatformRequirementFilter::fromBoolOrList($ignorePlatformReqs));
 
             return $installer->run();
         });

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -12,7 +12,7 @@
 
 namespace Composer\Test\Package\Version;
 
-use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Package\Version\VersionSelector;
 use Composer\Package\Package;
 use Composer\Package\Link;
@@ -71,7 +71,7 @@ class VersionSelectorTest extends TestCase
 
         $best = $versionSelector->findBestCandidate($packageName);
         $this->assertSame($package1, $best, 'Latest version supporting php 5.5 should be returned (1.0.0)');
-        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilter::ignoreAll());
+        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilterFactory::ignoreAll());
         $this->assertSame($package2, $best, 'Latest version should be returned when ignoring platform reqs (2.0.0)');
     }
 
@@ -97,7 +97,7 @@ class VersionSelectorTest extends TestCase
 
         $best = $versionSelector->findBestCandidate($packageName);
         $this->assertSame($package1, $best, 'Latest version supporting ext-zip 5.3.0 should be returned (1.0.0)');
-        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilter::ignoreAll());
+        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilterFactory::ignoreAll());
         $this->assertSame($package2, $best, 'Latest version should be returned when ignoring platform reqs (2.0.0)');
     }
 
@@ -122,7 +122,7 @@ class VersionSelectorTest extends TestCase
 
         $best = $versionSelector->findBestCandidate($packageName);
         $this->assertSame($package1, $best, 'Latest version not requiring ext-barfoo should be returned (1.0.0)');
-        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilter::ignoreAll());
+        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilterFactory::ignoreAll());
         $this->assertSame($package2, $best, 'Latest version should be returned when ignoring platform reqs (2.0.0)');
     }
 
@@ -148,7 +148,7 @@ class VersionSelectorTest extends TestCase
 
         $best = $versionSelector->findBestCandidate($packageName);
         $this->assertSame($package1, $best, 'Latest version supporting composer 1 should be returned (1.0.0)');
-        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilter::ignoreAll());
+        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilterFactory::ignoreAll());
         $this->assertSame($package2, $best, 'Latest version should be returned when ignoring platform reqs (1.1.0)');
     }
 

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\Package\Version;
 
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilter;
 use Composer\Package\Version\VersionSelector;
 use Composer\Package\Package;
 use Composer\Package\Link;
@@ -70,7 +71,7 @@ class VersionSelectorTest extends TestCase
 
         $best = $versionSelector->findBestCandidate($packageName);
         $this->assertSame($package1, $best, 'Latest version supporting php 5.5 should be returned (1.0.0)');
-        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', true);
+        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilter::ignoreAll());
         $this->assertSame($package2, $best, 'Latest version should be returned when ignoring platform reqs (2.0.0)');
     }
 
@@ -96,7 +97,7 @@ class VersionSelectorTest extends TestCase
 
         $best = $versionSelector->findBestCandidate($packageName);
         $this->assertSame($package1, $best, 'Latest version supporting ext-zip 5.3.0 should be returned (1.0.0)');
-        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', true);
+        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilter::ignoreAll());
         $this->assertSame($package2, $best, 'Latest version should be returned when ignoring platform reqs (2.0.0)');
     }
 
@@ -121,7 +122,7 @@ class VersionSelectorTest extends TestCase
 
         $best = $versionSelector->findBestCandidate($packageName);
         $this->assertSame($package1, $best, 'Latest version not requiring ext-barfoo should be returned (1.0.0)');
-        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', true);
+        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilter::ignoreAll());
         $this->assertSame($package2, $best, 'Latest version should be returned when ignoring platform reqs (2.0.0)');
     }
 
@@ -147,7 +148,7 @@ class VersionSelectorTest extends TestCase
 
         $best = $versionSelector->findBestCandidate($packageName);
         $this->assertSame($package1, $best, 'Latest version supporting composer 1 should be returned (1.0.0)');
-        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', true);
+        $best = $versionSelector->findBestCandidate($packageName, null, 'stable', PlatformRequirementFilter::ignoreAll());
         $this->assertSame($package2, $best, 'Latest version should be returned when ignoring platform reqs (1.1.0)');
     }
 


### PR DESCRIPTION
Introduces a `PlatformRequirementFilter` with methods that help to decide if a requirement is ignored or not as discussed in #10045 but without changing behaviour.
The idea behind this is to be able to adapt simple wildcard or regex ignores in a follow-up.

I changed as much as needed so that the filter and its logic is used everywhere where the `bool|string[]` config was before, because it felt inconsistent otherwise. But I also tried to change as less as possible which is the reason the argument is nullable in some cases and falls back to the nothing filter then or is defined like that in the constructor.
Initially I only had one filter class, but this became already too complex and mixed regarding types in my opinion, so I split responsibilities into dedicated filter classes, which is of course more code/classes but way simpler to read/understand/test.