### PR TITLE
Harden isWindowsSubsystemForLinux check

### DIFF
--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -108,7 +108,7 @@ class Platform
                 return self::$isWindowsSubsystemForLinux = false;
             }
 
-            if (!ini_get('open_basedir') && is_readable('/proc/version') && false !== stripos(file_get_contents('/proc/version'), 'microsoft')) {
+            if (!ini_get('open_basedir') && is_readable('/proc/version') && false !== stripos(@file_get_contents('/proc/version') ?: '', 'microsoft')) {
                 return self::$isWindowsSubsystemForLinux = true;
             }
         }


### PR DESCRIPTION
Recently we discovered that there is a very specific problem with the `isWindowsSubsystemForLinux` check in certain server environments. Particularly it happens on environments of the Alfahosting hosting provider, but only when Composer is executed via the web process (which is the case when Composer gets executed via the Contao Manager for example, as a sub process of the web server process).

The error is the following: 

```
    Update of symfony/yaml failed

In Platform.php line 111:
                                                                              
  file_get_contents(/proc/version): failed to open stream: Permission denied
```

In theory, this error should never happen, because `is_readable('/proc/version')` here

https://github.com/composer/composer/blob/5e750171666c1f2b859c9a124e4275b5b10ced9c/src/Composer/Util/Platform.php#L111

should return false. However, in certain circumstances, the result of the permission check in `is_readable` might not be as expected. See the [PHP doc](https://www.php.net/manual/en/function.is-readable.php) notes:

> Keep in mind that PHP may be accessing the file as the user id that the web server runs as (often 'nobody'). 

>  The check is done using the real UID/GID instead of the effective one.

May be this is something either the Hoster or PHP needs to change. But in any case, I think it may be makes sense to harden the check within Composer against such errors.

Though may be there is a better way for hardening, rather than using the silence operator? wdyt?