### PR TITLE
Docs: Place general troubleshooting steps in a more logical order

### DIFF
--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -7,21 +7,21 @@ This is a list of common pitfalls on using Composer, and how to avoid them.
 
 ## General
 
-1. Before asking anyone, run [`composer diagnose`](../03-cli.md#diagnose) to check
-   for common problems. If it all checks out, proceed to the next steps.
-
-2. When facing any kind of problems using Composer, be sure to **work with the
+1. When facing any kind of problems using Composer, be sure to **work with the
    latest version**. See [self-update](../03-cli.md#self-update) for details.
+   
+2. Before asking anyone, run [`composer diagnose`](../03-cli.md#diagnose) to check
+   for common problems. If it all checks out, proceed to the next steps.
 
 3. Make sure you have no problems with your setup by running the installer's
    checks via `curl -sS https://getcomposer.org/installer | php -- --check`.
 
-4. Ensure you're **installing vendors straight from your `composer.json`** via
+4. Try clearing Composer's cache by running `composer clear-cache`.
+
+5. Ensure you're **installing vendors straight from your `composer.json`** via
    `rm -rf vendor && composer update -v` when troubleshooting, excluding any
    possible interferences with existing vendor installations or `composer.lock`
    entries.
-
-5. Try clearing Composer's cache by running `composer clear-cache`.
 
 ## Package not found
 


### PR DESCRIPTION
* `self-update` should be run first, because it may affect the results of `diagnose`. 
* `clear-cache` should be run before `update`, otherwise `update` would need to be run again after clearing the cache.
