### PR TITLE
Document archive --format=tar.gz

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -931,8 +931,8 @@ php composer.phar archive vendor/package 2.0.21 --format=zip
 
 ### Options
 
-* **--format (-f):** Format of the resulting archive: tar or zip (default:
-  "tar")
+* **--format (-f):** Format of the resulting archive: tar, tar.gz or zip
+  (default: "tar")
 * **--dir:** Write the archive to this directory (default: ".")
 * **--file:** Write the archive with the given file name.
 


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. 2.1 or similar if such a branch exists, or 1.10 if it is a critical fix that should be fixed in Composer 1)

For new features and everything else, use the master branch. -->

I see that if `extension=bz2` is enabled in php.ini, then archive --format=tar.bz2 works as well.