### PR TITLE
Fix GithubDriver nextPage deprecation notice with no link header

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -575,6 +575,10 @@ class GitHubDriver extends VcsDriver
     protected function getNextPage(Response $response)
     {
         $header = $response->getHeader('link');
+        
+        if (!$header) {
+            return;
+        }
 
         $links = explode(',', $header);
         foreach ($links as $link) {


### PR DESCRIPTION
Currently getting 2 notices on PHP 8.1 (on preview and snapshot channel) Dont get confused by the version number in the path its come from brew but the tested version is `Composer version 2.1.6 2021-08-19 17:11:08` and `Composer version 2.1-dev (2.1-dev+5b16d61762579fcd86507292789f1c92432d9e8b) 2021-09-02 15:22:14`:

> `Deprecation Notice: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in phar:///usr/local/Cellar/composer/2.0.8/bin/composer/vendor/symfony/console/Descriptor/TextDescriptor.php:120`

This one I think was already fixed by the symfony team.

> `Deprecation Notice: explode(): Passing null to parameter #2 ($string) of type string is deprecated in phar:///usr/local/Cellar/composer/2.0.8/bin/composer/src/Composer/Repository/Vcs/GitHubDriver.php:579`

This check if link is actually returning something if not it is ignored.


Reproducable `composer.json`:

```json
{
    "name": "sulu/sulu",
    "description": "Test",
    "license": "MIT",
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/derrabus/laminas-code.git"
        }
    ],
    "require-dev": {
        "laminas/laminas-code": "dev-bugfix/return-type-will-change as 4.4.3"
    }
}
```