### PR TITLE
Add ability check for ZipArchive

### DIFF
--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -51,6 +51,7 @@ class ZipArchiver implements ArchiverInterface
 
                 /**
                  * ZipArchive::setExternalAttributesName is available from >= PHP 5.6
+                 * setExternalAttributesName() is only available with libzip 0.11.2 or above
                  */
                 if (PHP_VERSION_ID >= 50600 && method_exists($zip, 'setExternalAttributesName')) {
                     $perms = fileperms($filepath);

--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -52,7 +52,7 @@ class ZipArchiver implements ArchiverInterface
                 /**
                  * ZipArchive::setExternalAttributesName is available from >= PHP 5.6
                  */
-                if (PHP_VERSION_ID >= 50600) {
+                if (PHP_VERSION_ID >= 50600 && method_exists($zip, 'setExternalAttributesName')) {
                     $perms = fileperms($filepath);
 
                     /**


### PR DESCRIPTION
ZipArchive::setExternalAttributesName() is only available when libzip 0.11.2 or higher is present. 
This is not the case with at least SUSE SLES 12, so a simple PHP version check will not work here.

As stated in #8330 and fixed in #8331, Composer is adding the file permissions to ZIPs, but the version check is insufficient to detect if the zip extension is powered by a recent enough libzip version. The extension will transparently not provide the called method if libzip is too old, so the `method_exists()` check has to be added.

Should be able to fix the underlying issue in https://github.com/composer/satis/issues/653 