### PR TITLE
Changed GitLab's applications URL

### DIFF
--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -118,7 +118,7 @@ class GitLab
         }
 
         $this->io->writeError(sprintf('A token will be created and stored in "%s", your password will never be stored', $this->config->getAuthConfigSource()->getName()));
-        $this->io->writeError('To revoke access to this token you can visit '.$scheme.'://'.$originUrl.'/-/profile/applications');
+        $this->io->writeError('To revoke access to this token you can visit '.$scheme.'://'.$originUrl.'/-/profile/personal_access_tokens');
 
         $attemptCounter = 0;
 

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -118,7 +118,7 @@ class GitLab
         }
 
         $this->io->writeError(sprintf('A token will be created and stored in "%s", your password will never be stored', $this->config->getAuthConfigSource()->getName()));
-        $this->io->writeError('To revoke access to this token you can visit '.$scheme.'://'.$originUrl.'/profile/applications');
+        $this->io->writeError('To revoke access to this token you can visit '.$scheme.'://'.$originUrl.'/-/profile/applications');
 
         $attemptCounter = 0;
 


### PR DESCRIPTION
Currently, Composer shows the following text:
```
To revoke access to this token you can visit https://gitlab.com/profile/applications
```
But this URL returns 404. The correct URL is https://gitlab.com/-/profile/applications

There is another way to get needed credentials in GitLab - [Personal Access Tokens](https://gitlab.com/-/profile/personal_access_tokens) - maybe we should display that URL instead?