### PR TITLE
Config: add source option for command to show where a config value is loaded from

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -736,6 +736,8 @@ See the [Config](06-config.md) chapter for valid configuration options.
   instead of relative.
 * **--json:** JSON decode the setting value, to be used with `extra.*` keys.
 * **--merge:** Merge the setting value with the current value, to be used with `extra.*` keys in combination with `--json`.
+* **--append:** When adding a repository, append it (lowest priority) to the existing ones instead of prepending it (highest priority).
+* **--source:** Display where the config value is loaded from.
 
 ### Modifying Repositories
 

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -351,7 +351,7 @@ EOT
     protected function installRootPackage(IOInterface $io, Config $config, $packageName, $directory = null, $packageVersion = null, $stability = 'stable', $preferSource = false, $preferDist = false, $installDevPackages = false, array $repositories = null, $disablePlugins = false, $noScripts = false, $noProgress = false, $ignorePlatformReqs = false, $secureHttp = true)
     {
         if (!$secureHttp) {
-            $config->merge(array('config' => array('secure-http' => false)));
+            $config->merge(array('config' => array('secure-http' => false)), Config::SOURCE_COMMAND);
         }
 
         $parser = new VersionParser();

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -90,7 +90,7 @@ EOT
             $config = Factory::createConfig();
         }
 
-        $config->merge(array('config' => array('secure-http' => false)));
+        $config->merge(array('config' => array('secure-http' => false)), Config::SOURCE_COMMAND);
         $config->prohibitUrlByConfig('http://repo.packagist.org', new NullIO);
 
         $this->httpDownloader = Factory::createHttpDownloader($io, $config);

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -340,4 +340,26 @@ class ConfigTest extends TestCase
         $this->assertEquals(0, $config->get('htaccess-protect'));
         putenv('COMPOSER_HTACCESS_PROTECT');
     }
+
+    public function testGetSourceOfValue()
+    {
+        $config = new Config;
+
+        $this->assertSame(Config::SOURCE_DEFAULT, $config->getSourceOfValue('process-timeout'));
+
+        $config->merge(
+            array('config' => array('process-timeout' => 1)),
+            'phpunit-test'
+        );
+
+        $this->assertSame('phpunit-test', $config->getSourceOfValue('process-timeout'));
+    }
+
+    public function testGetSourceOfValueEnvVariables()
+    {
+        putenv('COMPOSER_HTACCESS_PROTECT=0');
+        $config = new Config;
+        $this->assertEquals('COMPOSER_HTACCESS_PROTECT', $config->getSourceOfValue('htaccess-protect'));
+        putenv('COMPOSER_HTACCESS_PROTECT');
+    }
 }


### PR DESCRIPTION
Implements: https://github.com/composer/composer/issues/10085

Can be used either to output a specific config e.g.
```
composer config http-basic.repo.example.org.username --source
glaubinix (/Users/glaubinix/.composer/auth.json)
```

or can be used with listing the entire configuration e.g. 
```
composer config -l --source
[process-timeout] 300 (default)
[use-include-path] false (default)
[preferred-install] dist (default)
[notify-on-install] true (default)
[github-protocols] [https, ssh] (default)
[gitlab-protocol]  (default)
[vendor-dir] vendor (/Users/glaubinix/Projects/example/vendor) (default)
[bin-dir] bin (/Users/glaubinix/Projects/example/bin) (./composer.json)
```