### PR TITLE
VcsRepository: do not continue when receiving 429 rate limit exception

### DIFF
--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -282,7 +282,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
                     if ($e->getCode() === 404) {
                         $this->emptyReferences[] = $identifier;
                     }
-                    if ($e->getCode() === 401 || $e->getCode() === 403) {
+                    if (in_array($e->getCode(), array(401, 403, 429), true)) {
                         throw $e;
                     }
                 }
@@ -371,7 +371,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
                 if ($e->getCode() === 404) {
                     $this->emptyReferences[] = $identifier;
                 }
-                if ($e->getCode() === 401 || $e->getCode() === 403) {
+                if (in_array($e->getCode(), array(401, 403, 429), true)) {
                     throw $e;
                 }
                 if ($isVeryVerbose) {


### PR DESCRIPTION
Currently Composer ignores all TransportExceptions (except 401 and 403) while fetching composer.json files to import all available versions and then skips those versions.

This pull request changes this behaviour for rate limit errors with a 429 status code. After a rate limit error response was received all future requests to that resource will most likely receive the same error status code which make it unlikely that Composer is able to finish the command.

Sample Composer output for such a scenario:
```
Reading composer.json of acme/package (2.0.0) 
Downloading https://api.bitbucket.org/2.0/repositories/acme/package/src/hash/composer.json
[429] https://api.bitbucket.org/2.0/repositories/acme/package/src/hash/composer.json
Skipped tag 2.0.0, no composer file was found (429 HTTP status code)
Reading composer.json of acme/package (2.0.1) 
Downloading https://api.bitbucket.org/2.0/repositories/acme/package/src/hash/composer.json
[429] https://api.bitbucket.org/2.0/repositories/acme/package/src/hash/composer.json
Skipped tag 2.0.1, no composer file was found (429 HTTP status code)
Reading composer.json of acme/package (2.0.2) 
Downloading https://api.bitbucket.org/2.0/repositories/acme/package/src/hash/composer.json
[429] https://api.bitbucket.org/2.0/repositories/acme/package/src/hash/composer.json
Skipped tag 2.0.2, no composer file was found (429 HTTP status code)
```

I do wonder whether the behaviour in the VcsRepository should be changed in general and abort for most errors including 5XX errors and curl errors. A VcsRepository that doesn't receive all available versions can lead to an unexpected result of a Composer command e.g. composer update might unexpectedly downgrade a package because the request to fetch the composer.json file of the latest tag returned a 500 response.