### PR TITLE
Expose path to autoload in a global var for binaries

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -884,8 +884,8 @@ Optional.
 
 ### bin
 
-A set of files that should be treated as binaries and symlinked into the `bin-dir`
-(from config).
+A set of files that should be treated as binaries and made available
+into the `bin-dir` (from config).
 
 See [Vendor Binaries](articles/vendor-binaries.md) for more details.
 

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -257,8 +257,8 @@ If it is `auto` then Composer only installs .bat proxy files when on Windows or 
 set to `full` then both .bat files for Windows and scripts for Unix-based
 operating systems will be installed for each binary. This is mainly useful if you
 run Composer inside a linux VM but still want the `.bat` proxies available for use
-in the Windows host OS. If set to `symlink` Composer will always symlink even on
-Windows/WSL.
+in the Windows host OS. If set to `proxy` Composer will only create bash/Unix-style
+proxy files and no .bat files even on Windows/WSL.
 
 ## prepend-autoloader
 

--- a/doc/07-runtime.md
+++ b/doc/07-runtime.md
@@ -152,4 +152,10 @@ not its exact version.
 
 `lib-*` requirements are never supported/checked by the platform check feature.
 
+## Autoloader path in binaries
+
+composer-runtime-api 2.2 introduced a new `$_composer_autoload_path` global
+variable set when running binaries installed with Composer. Read more
+about this [on the vendor binaries docs](articles/vendor-binaries.md#finding-the-composer-autoloader-from-a-binary).
+
 &larr; [Config](06-config.md)  |  [Community](08-community.md) &rarr;

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -251,8 +251,8 @@
                     "description": "Whether to use the Composer cache in read-only mode."
                 },
                 "bin-compat": {
-                    "enum": ["auto", "full", "symlink"],
-                    "description": "The compatibility of the binaries, defaults to \"auto\" (automatically guessed), can be \"full\" (compatible with both Windows and Unix-based systems) and \"symlink\" (symlink also for WSL)."
+                    "enum": ["auto", "full", "proxy", "symlink"],
+                    "description": "The compatibility of the binaries, defaults to \"auto\" (automatically guessed), can be \"full\" (compatible with both Windows and Unix-based systems) and \"proxy\" (only bash-style proxy)."
                 },
                 "discard-changes": {
                     "type": ["string", "boolean"],

--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -65,7 +65,7 @@ class Composer
      *
      * @var string
      */
-    const RUNTIME_API_VERSION = '2.1.0';
+    const RUNTIME_API_VERSION = '2.2.0';
 
     /**
      * @return string

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -367,10 +367,14 @@ class Config
             case 'bin-compat':
                 $value = $this->getComposerEnv('COMPOSER_BIN_COMPAT') ?: $this->config[$key];
 
-                if (!in_array($value, array('auto', 'full', 'symlink'))) {
+                if (!in_array($value, array('auto', 'full', 'proxy', 'symlink'))) {
                     throw new \RuntimeException(
-                        "Invalid value for 'bin-compat': {$value}. Expected auto, full or symlink"
+                        "Invalid value for 'bin-compat': {$value}. Expected auto, full or proxy"
                     );
+                }
+
+                if ($value === 'symlink') {
+                    trigger_error('config.bin-compat "symlink" is deprecated since Composer 2.2, use auto, full (for Windows compatibility) or proxy instead.', E_USER_DEPRECATED);
                 }
 
                 return $value;

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -594,7 +594,7 @@ class Factory
     protected function createDefaultInstallers(Installer\InstallationManager $im, Composer $composer, IOInterface $io, ProcessExecutor $process = null)
     {
         $fs = new Filesystem($process);
-        $binaryInstaller = new Installer\BinaryInstaller($io, rtrim($composer->getConfig()->get('bin-dir'), '/'), $composer->getConfig()->get('bin-compat'), $fs);
+        $binaryInstaller = new Installer\BinaryInstaller($io, rtrim($composer->getConfig()->get('bin-dir'), '/'), $composer->getConfig()->get('bin-compat'), $fs, rtrim($composer->getConfig()->get('vendor-dir'), '/'));
 
         $im->addInstaller(new Installer\LibraryInstaller($io, $composer, null, $fs, $binaryInstaller));
         $im->addInstaller(new Installer\PluginInstaller($io, $composer, $fs, $binaryInstaller));

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -63,7 +63,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
 
         $this->filesystem = $filesystem ?: new Filesystem();
         $this->vendorDir = rtrim($composer->getConfig()->get('vendor-dir'), '/');
-        $this->binaryInstaller = $binaryInstaller ?: new BinaryInstaller($this->io, rtrim($composer->getConfig()->get('bin-dir'), '/'), $composer->getConfig()->get('bin-compat'), $this->filesystem);
+        $this->binaryInstaller = $binaryInstaller ?: new BinaryInstaller($this->io, rtrim($composer->getConfig()->get('bin-dir'), '/'), $composer->getConfig()->get('bin-compat'), $this->filesystem, $this->vendorDir);
     }
 
     /**


### PR DESCRIPTION
For binaries of packages to be able include the autoload file,
a global variable is now exposed and a proxy file now generated
by default, which exposes the path and includes the original
binary file.

Additionally it is now checked on binary creation whether
the reference binary has a shebang and if not, generates
a much simple proxy code with no magic and eval involved.

Fixes: #10119

* [x] Decide whether we can rely on `vendor-dir` being injected, or what to do when the object is created by other installers not providing it.
* [x] Should symlink creation for binaries remain or be removed?
* [x] Depending on the decision above, maybe add code to migrate from symlinks to proxies, when symlinks are found