### PR TITLE
[ISSUE - #10147] Add "help" in the list of command that need plugins

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -196,10 +196,10 @@ class Application extends BaseApplication
                 // not a composer command, so try loading plugin ones
                 false === $commandName
                 // list command requires plugin commands to show them
-                || in_array($commandName, array('', 'list'), true)
+                || in_array($commandName, array('', 'list', 'help'), true)
             );
 
-        if ($mayNeedPluginCommand && !$this->disablePluginsByDefault && !$this->hasPluginCommands && 'global' !== $commandName) {
+        if ($mayNeedPluginCommand && !$this->disablePluginsByDefault && !$this->hasPluginCommands) {
             try {
                 foreach ($this->getPluginCommands() as $command) {
                     if ($this->has($command->getName())) {


### PR DESCRIPTION
[See issue](https://github.com/composer/composer/issues/10147)
- Add 'help' in the list of commands that need plugin command ($mayNeedPluginCommand)
- Remove `'global' !== $commandName` because `$mayNeedPluginCommand` ensure that `$commandName` is one of `false`, `empty`, `list` or `help` (so never 'global')

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. 2.1 or similar if such a branch exists, or 1.10 if it is a critical fix that should be fixed in Composer 1)

For new features and everything else, use the master branch. -->
