### PR TITLE
Prevent auto-unlocked path repo packages from also unlocking their transitive deps when -w/-W is used

### DIFF
--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/mirrored-path-repo/composer.json
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/mirrored-path-repo/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "mirrored/path-pkg",
+    "version": "2.0.0",
+    "require": {
+        "mirrored/transitive": "2.*",
+        "mirrored/transitive2": "2.*"
+    }
+}

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repo-replacer-with-transitive-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repo-replacer-with-transitive-deps.test
@@ -1,0 +1,82 @@
+--TEST--
+Partially updating with deps a root requirement which depends on packages in a symlinked path repo should load all available versions for the path repo packages' dependencies.
+
+--REQUEST--
+{
+    "require": {
+        "root/update": "*",
+        "symlinked/transitive3": "*",
+        "symlinked/transitive5": "*"
+    },
+    "locked": [
+        {"name": "root/update", "version": "1.0.1", "require": {"symlinked/path-pkg": ">=1.0.1", "symlinked/replaced-pkg": "*"}},
+        {"name": "symlinked/transitive", "version": "1.0.0"},
+        {"name": "symlinked/transitive3", "version": "1.0.0", "replace": {"symlinked/transitive3-replaced": "1.0.0"}},
+        {
+            "name": "symlinked/path-pkg",
+            "version": "1.0.0",
+            "require": {
+                "symlinked/transitive": "1.*",
+                "symlinked/transitive3-replaced": "1.*",
+                "symlinked/transitive5-replaced": "1.*"
+            },
+            "dist": {"type": "path", "url": "./symlinked-path-repo-with-replaced-deps", "reference": "abcd"}, "transport-options": {}
+        },
+        {"name": "symlinked/transitive4", "version": "1.0.0"},
+        {"name": "symlinked/transitive5", "version": "1.0.0", "replace": {"symlinked/transitive5-replaced": "1.0.0"}},
+        {
+            "name": "symlinked/path-pkg-replace",
+            "version": "1.0.0",
+            "require": {
+                "symlinked/transitive3-replaced": "1.*",
+                "symlinked/transitive4": "1.*",
+                "symlinked/transitive5-replaced": "1.*"
+            },
+            "replace": {
+                "symlinked/replaced-pkg": "1.0.0"
+            },
+            "dist": {"type": "path", "url": "./symlinked-path-repo-replacer", "reference": "abcd"}, "transport-options": {}
+        }
+    ],
+    "allowList": [
+        "root/update"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    {"type": "path", "url": "./symlinked-path-repo-with-replaced-deps"},
+    {"type": "path", "url": "./symlinked-path-repo-replacer"},
+    [
+        {"name": "root/update", "version": "1.0.4", "require": {"symlinked/path-pkg": ">=1.0.1", "symlinked/replaced-pkg": "*"}},
+        {"name": "symlinked/transitive", "version": "1.0.0"},
+        {"name": "symlinked/transitive", "version": "2.0.2"},
+        {"name": "symlinked/transitive3", "version": "1.0.0", "replace": {"symlinked/transitive3-replaced": "1.0.0"}},
+        {"name": "symlinked/transitive3", "version": "1.0.3", "replace": {"symlinked/transitive3-replaced": "1.0.3"}},
+        {"name": "symlinked/transitive3", "version": "2.0.4", "replace": {"symlinked/transitive3-replaced": "2.0.4"}},
+        {"name": "symlinked/transitive4", "version": "1.0.0"},
+        {"name": "symlinked/transitive4", "version": "2.0.2"},
+        {"name": "symlinked/transitive5", "version": "1.0.0", "replace": {"symlinked/transitive5-replaced": "1.0.0"}},
+        {"name": "symlinked/transitive5", "version": "1.0.3", "replace": {"symlinked/transitive5-replaced": "1.0.3"}},
+        {"name": "symlinked/transitive5", "version": "2.0.4", "replace": {"symlinked/transitive5-replaced": "2.0.4"}}
+    ]
+]
+
+--EXPECT--
+[
+   "symlinked/transitive-1.0.0.0",
+   "symlinked/transitive-2.0.2.0",
+   "symlinked/path-pkg-2.0.0.0",
+   "root/update-1.0.4.0",
+   "symlinked/transitive3-1.0.3.0",
+   "symlinked/transitive3-2.0.4.0",
+   "symlinked/transitive4-1.0.0.0",
+   "symlinked/transitive4-2.0.2.0",
+   "symlinked/transitive5-1.0.3.0",
+   "symlinked/transitive5-2.0.4.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repo-replacer-with-transitive-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repo-replacer-with-transitive-deps.test
@@ -6,7 +6,8 @@ Partially updating with deps a root requirement which depends on packages in a s
     "require": {
         "root/update": "*",
         "symlinked/transitive3": "*",
-        "symlinked/transitive5": "*"
+        "symlinked/transitive5": "*",
+        "symlinked/path-pkg-replace": "*"
     },
     "locked": [
         {"name": "root/update", "version": "1.0.1", "require": {"symlinked/path-pkg": ">=1.0.1", "symlinked/replaced-pkg": "*"}},
@@ -69,14 +70,15 @@ Partially updating with deps a root requirement which depends on packages in a s
 
 --EXPECT--
 [
-   "symlinked/transitive-1.0.0.0",
-   "symlinked/transitive-2.0.2.0",
-   "symlinked/path-pkg-2.0.0.0",
    "root/update-1.0.4.0",
+   "symlinked/path-pkg-2.0.0.0",
+   "symlinked/path-pkg-replace-2.0.0.0",
+   "symlinked/transitive-2.0.2.0",
+   "symlinked/transitive3-1.0.0.0",
    "symlinked/transitive3-1.0.3.0",
    "symlinked/transitive3-2.0.4.0",
-   "symlinked/transitive4-1.0.0.0",
    "symlinked/transitive4-2.0.2.0",
+   "symlinked/transitive5-1.0.0.0",
    "symlinked/transitive5-1.0.3.0",
    "symlinked/transitive5-2.0.4.0"
 ]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repos-always-but-not-their-transitive-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repos-always-but-not-their-transitive-deps.test
@@ -77,3 +77,15 @@ Partially updating one root requirement with transitive deps fully updates trans
    "mirrored/transitive2-1.0.7.0",
    "mirrored/transitive2-2.0.8.0"
 ]
+
+--EXPECT-OPTIMIZED--
+[
+   "symlinked/transitive-1.0.0.0 (locked)",
+   "mirrored/transitive-1.0.0.0 (locked)",
+   "mirrored/path-pkg-1.0.0.0 (locked)",
+   "symlinked/path-pkg-2.0.0.0",
+   "root/update-1.0.4.0",
+   "symlinked/transitive2-2.0.4.0",
+   "mirrored/transitive2-1.0.7.0",
+   "mirrored/transitive2-2.0.8.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repos-always-but-not-their-transitive-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repos-always-but-not-their-transitive-deps.test
@@ -1,0 +1,79 @@
+--TEST--
+Partially updating one root requirement with transitive deps fully updates transitive deps, and always updates symlinked path repos, but not the transitive deps of the path repos.
+
+--REQUEST--
+{
+    "require": {
+        "root/update": "*",
+        "symlinked/path-pkg": "*",
+        "mirrored/path-pkg": "*"
+    },
+    "locked": [
+        {"name": "root/update", "version": "1.0.1", "require": {"symlinked/transitive2": ">=1.0.1", "mirrored/transitive2": ">=1.0.1"}},
+        {"name": "symlinked/transitive", "version": "1.0.0"},
+        {"name": "symlinked/transitive2", "version": "1.0.0"},
+        {"name": "mirrored/transitive", "version": "1.0.0"},
+        {"name": "mirrored/transitive2", "version": "1.0.0"},
+        {
+            "name": "symlinked/path-pkg",
+            "version": "1.0.0",
+            "require": {
+                "symlinked/transitive": "1.*",
+                "symlinked/transitive2": "1.*"
+            },
+            "dist": {"type": "path", "url": "./symlinked-path-repo", "reference": "abcd"}, "transport-options": {}
+        },
+        {
+            "name": "mirrored/path-pkg",
+            "version": "1.0.0",
+            "require": {
+                "mirrored/transitive": "1.*",
+                "mirrored/transitive2": "1.*"
+            },
+            "dist": {"type": "path", "url": "./mirrored-path-repo", "reference": "abcd"}, "transport-options": {"symlink": false}
+        }
+    ],
+    "allowList": [
+        "root/update"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    {"type": "path", "url": "./symlinked-path-repo"},
+    {"type": "path", "url": "./mirrored-path-repo", "options": {"symlink": false}},
+    [
+        {"name": "root/update", "version": "1.0.4", "require": {"symlinked/transitive2": ">=1.0.1", "mirrored/transitive2": ">=1.0.1"}},
+        {"name": "symlinked/transitive", "version": "1.0.0"},
+        {"name": "symlinked/transitive", "version": "1.0.1"},
+        {"name": "symlinked/transitive", "version": "2.0.2"},
+        {"name": "symlinked/transitive2", "version": "1.0.0"},
+        {"name": "symlinked/transitive2", "version": "1.0.3"},
+        {"name": "symlinked/transitive2", "version": "2.0.4"},
+        {"name": "mirrored/transitive", "version": "1.0.0"},
+        {"name": "mirrored/transitive", "version": "1.0.5"},
+        {"name": "mirrored/transitive", "version": "2.0.6"},
+        {"name": "mirrored/transitive2", "version": "1.0.0"},
+        {"name": "mirrored/transitive2", "version": "1.0.7"},
+        {"name": "mirrored/transitive2", "version": "2.0.8"}
+    ]
+]
+
+--EXPECT--
+[
+   "symlinked/transitive-1.0.0.0 (locked)",
+   "mirrored/transitive-1.0.0.0 (locked)",
+   "mirrored/path-pkg-1.0.0.0 (locked)",
+   "symlinked/path-pkg-2.0.0.0",
+   "root/update-1.0.4.0",
+   "symlinked/transitive2-1.0.3.0",
+   "symlinked/transitive2-2.0.4.0",
+   "mirrored/transitive2-1.0.0.0",
+   "mirrored/transitive2-1.0.7.0",
+   "mirrored/transitive2-2.0.8.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/symlinked-path-repo-replacer/composer.json
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/symlinked-path-repo-replacer/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "symlinked/path-pkg-replace",
+    "version": "2.0.0",
+    "require": {
+        "symlinked/transitive3-replaced": ">=1.0.3",
+        "symlinked/transitive4": "2.*",
+        "symlinked/transitive5-replaced": "2.*"
+    },
+    "replace": {
+        "symlinked/replaced-pkg": "2.0.0"
+    }
+}

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/symlinked-path-repo-with-replaced-deps/composer.json
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/symlinked-path-repo-with-replaced-deps/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "symlinked/path-pkg",
+    "version": "2.0.0",
+    "require": {
+        "symlinked/transitive": "2.*",
+        "symlinked/transitive3-replaced": "2.*",
+        "symlinked/transitive5-replaced": ">=1.0.3"
+    }
+}

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/symlinked-path-repo/composer.json
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/symlinked-path-repo/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "symlinked/path-pkg",
+    "version": "2.0.0",
+    "require": {
+        "symlinked/transitive": "2.*",
+        "symlinked/transitive2": "2.*"
+    }
+}

--- a/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
@@ -140,6 +140,8 @@ class PoolBuilderTest extends TestCase
         $optimizer = new PoolOptimizer(new DefaultPolicy());
         $result = $this->getPackageResultSet($optimizer->optimize($request, $pool), $packageIds);
         $this->assertSame($expectOptimized, $result, 'Optimized pool does not match expected package set');
+
+        chdir($oldCwd);
     }
 
     /**
@@ -152,8 +154,6 @@ class PoolBuilderTest extends TestCase
         for ($i = 1, $count = count($pool); $i <= $count; $i++) {
             $result[] = $pool->packageById($i);
         }
-
-        chdir($oldCwd);
 
         return array_map(function (BasePackage $package) use ($packageIds) {
             if ($id = array_search($package, $packageIds, true)) {

--- a/tests/Composer/Test/Fixtures/installer/partial-update-with-symlinked-path-repos.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-with-symlinked-path-repos.test
@@ -29,6 +29,7 @@ Partially updating one root requirement with transitive deps fully updates trans
         "mirrored/path-pkg": "*"
     }
 }
+
 --LOCK--
 {
     "packages": [
@@ -66,13 +67,7 @@ Partially updating one root requirement with transitive deps fully updates trans
     "platform": [],
     "platform-dev": []
 }
---INSTALLED--
-[
-    { "name": "a/old", "version": "0.9.0" },
-    { "name": "b/unstable", "version": "1.1.0-alpha", "require": {"f/dependency": "1.*"} },
-    { "name": "c/uptodate", "version": "2.0.0" },
-    { "name": "f/dependency", "version": "1.0.0" }
-]
+
 --RUN--
 update --with-all-dependencies root/update
 

--- a/tests/Composer/Test/Fixtures/installer/partial-update-with-symlinked-path-repos.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-with-symlinked-path-repos.test
@@ -1,0 +1,91 @@
+--TEST--
+Partially updating one root requirement with transitive deps fully updates transitive deps, and always updates symlinked path repos, but not the transitive deps of the path repos.
+
+--COMPOSER--
+{
+    "repositories": [
+        {"type": "path", "url": "./DependencyResolver/Fixtures/poolbuilder/symlinked-path-repo"},
+        {"type": "path", "url": "./DependencyResolver/Fixtures/poolbuilder/mirrored-path-repo", "options": {"symlink": false}},
+        {
+            "type": "package",
+            "package": [
+                {"name": "root/update", "version": "1.0.4", "require": {"symlinked/transitive2": ">=1.0.1", "mirrored/transitive2": ">=1.0.1"}},
+                {"name": "symlinked/transitive", "version": "1.0.0"},
+                {"name": "symlinked/transitive", "version": "1.0.1"},
+                {"name": "symlinked/transitive", "version": "2.0.3"},
+                {"name": "symlinked/transitive2", "version": "1.0.0"},
+                {"name": "symlinked/transitive2", "version": "1.0.3"},
+                {"name": "symlinked/transitive2", "version": "2.0.3"},
+                {"name": "mirrored/transitive", "version": "1.0.0"},
+                {"name": "mirrored/transitive", "version": "1.0.5"},
+                {"name": "mirrored/transitive2", "version": "1.0.0"},
+                {"name": "mirrored/transitive2", "version": "1.0.7"}
+            ]
+        }
+    ],
+    "require": {
+        "root/update": "*",
+        "symlinked/path-pkg": "*",
+        "mirrored/path-pkg": "*"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        {"name": "root/update", "version": "1.0.1", "require": {"symlinked/transitive2": ">=1.0.1", "mirrored/transitive2": ">=1.0.1"}},
+        {"name": "symlinked/transitive", "version": "1.0.0"},
+        {"name": "symlinked/transitive2", "version": "1.0.0"},
+        {"name": "mirrored/transitive", "version": "1.0.0"},
+        {"name": "mirrored/transitive2", "version": "1.0.0"},
+        {
+            "name": "symlinked/path-pkg",
+            "version": "1.0.0",
+            "require": {
+                "symlinked/transitive": "1.*",
+                "symlinked/transitive2": "1.*"
+            },
+            "dist": {"type": "path", "url": "./symlinked-path-repo", "reference": "abcd"}, "transport-options": {}
+        },
+        {
+            "name": "mirrored/path-pkg",
+            "version": "1.0.0",
+            "require": {
+                "mirrored/transitive": "1.*",
+                "mirrored/transitive2": "1.*"
+            },
+            "dist": {"type": "path", "url": "./mirrored-path-repo", "reference": "abcd"}, "transport-options": {"symlink": false}
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--INSTALLED--
+[
+    { "name": "a/old", "version": "0.9.0" },
+    { "name": "b/unstable", "version": "1.1.0-alpha", "require": {"f/dependency": "1.*"} },
+    { "name": "c/uptodate", "version": "2.0.0" },
+    { "name": "f/dependency", "version": "1.0.0" }
+]
+--RUN--
+update --with-all-dependencies root/update
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires symlinked/path-pkg * -> satisfiable by symlinked/path-pkg[2.0.0].
+    - symlinked/path-pkg 2.0.0 requires symlinked/transitive 2.* -> found symlinked/transitive[2.0.3] but the package is fixed to 1.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
+
+--EXPECT--

--- a/tests/deprecations-8.1.json
+++ b/tests/deprecations-8.1.json
@@ -77,12 +77,12 @@
     {
         "location": "Composer\\Test\\InstallerTest::testIntegrationWithRawPool",
         "message": "preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated",
-        "count": 1784
+        "count": 1800
     },
     {
         "location": "Composer\\Test\\InstallerTest::testIntegrationWithPoolOptimizer",
         "message": "preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated",
-        "count": 1784
+        "count": 1800
     },
     {
         "location": "Composer\\Test\\Package\\Archiver\\ArchivableFilesFinderTest::testManualExcludes",


### PR DESCRIPTION
Refs https://github.com/composer/composer/discussions/10093

As @stof said: 

> @Seldaek maybe this forced inclusion of path packages should be done after building the whitelist with -w/-W, so that the path packages don't automatically whitelist their dependencies when this option are used (they would still whitelist their dependencies if the path packages are explicitly marked for update in the whitelist in the command)

