### PR TITLE
Allow psr/log ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "composer/spdx-licenses": "^1.2",
         "composer/xdebug-handler": "^2.0",
         "justinrainbow/json-schema": "^5.2.11",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0",
         "seld/jsonlint": "^1.4",
         "seld/phar-utils": "^1.0",
         "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",


### PR DESCRIPTION
This PR allows `psr/log` version 2 which is essentially version 1 with PHP 8 syntax.

This is currently preventing packages that rely on `composer/composer` being installed in fresh Laravel projects, such as Larastan, Debug Bar etc.