### PR TITLE
Fix validator, commit-ref must warn only for non-dev packages

### DIFF
--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -158,13 +158,11 @@ class ConfigValidator
         }
 
         // check for commit references
-        $require = isset($manifest['require']) ? $manifest['require'] : array();
-        $requireDev = isset($manifest['require-dev']) ? $manifest['require-dev'] : array();
-        $packages = array_merge($require, $requireDev);
-        foreach ($packages as $package => $version) {
+        $packagesNonDev = isset($manifest['require']) ? $manifest['require'] : array();
+        foreach ($packagesNonDev as $package => $version) {
             if (preg_match('/#/', $version) === 1) {
                 $warnings[] = sprintf(
-                    'The package "%s" is pointing to a commit-ref, this is bad practice and can cause unforeseen issues.',
+                    'The package "%s" is pointing to a commit-ref which is root package feature only and it will be ignored in dependent packages.',
                     $package
                 );
             }

--- a/tests/Composer/Test/Util/ConfigValidatorTest.php
+++ b/tests/Composer/Test/Util/ConfigValidatorTest.php
@@ -30,7 +30,11 @@ class ConfigValidatorTest extends TestCase
         list(, , $warnings) = $configValidator->validate(__DIR__ . '/Fixtures/composer_commit-ref.json');
 
         $this->assertContains(
-            'The package "some/package" is pointing to a commit-ref, this is bad practice and can cause unforeseen issues.',
+            'The package "some/package" is pointing to a commit-ref which is root package feature only and it will be ignored in dependent packages.',
+            $warnings
+        );
+        $this->assertNotContains(
+            '"some/package2"',
             $warnings
         );
     }

--- a/tests/Composer/Test/Util/Fixtures/composer_commit-ref.json
+++ b/tests/Composer/Test/Util/Fixtures/composer_commit-ref.json
@@ -1,5 +1,8 @@
 {
     "require": {
         "some/package": "dev-master#fgb42d"
+    },
+    "require-dev": {
+        "some/package2": "dev-master#fgb42d"
     }
 }


### PR DESCRIPTION
fixes #10175