### PR TITLE
Remove scalar parameter type declaration

### DIFF
--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -422,7 +422,13 @@ class Git
         return self::$version;
     }
 
-    private function maskCredentials(string $error, array $credentials)
+    /**
+     * @param string   $error
+     * @param string[] $credentials
+     *
+     * @return string
+     */
+    private function maskCredentials($error, array $credentials)
     {
         $maskedCredentials = array();
 


### PR DESCRIPTION
`string` can only be used in parameters starting from PHP 7.0.

Was added in #10115