### PR TITLE
ComposerRepository: handle packages.json with null value for package

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1038,7 +1038,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         // legacy repo handling
         if (!isset($data['packages']) && !isset($data['includes'])) {
             foreach ($data as $pkg) {
-                if (is_array($pkg['versions'])) {
+                if (isset($pkg['versions']) && is_array($pkg['versions'])) {
                     foreach ($pkg['versions'] as $metadata) {
                         $packages[] = $metadata;
                     }


### PR DESCRIPTION
Found mirrored repository returning for package.json
```
{
    "notify-batch": "https://example.org/download/notify/",
    "cached": false,
    "packages": null
}
```

Resulting in `TypeError: Cannot access offset of type string on string in composer\/composer\/src\/Composer\/Repository\/ComposerRepository.php:1041`

