### PR TITLE
Add types to `Package/Dumper`

### DIFF
--- a/src/Composer/Package/Dumper/ArrayDumper.php
+++ b/src/Composer/Package/Dumper/ArrayDumper.php
@@ -23,6 +23,9 @@ use Composer\Package\RootPackageInterface;
  */
 class ArrayDumper
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function dump(PackageInterface $package)
     {
         $keys = array(
@@ -139,6 +142,12 @@ class ArrayDumper
         return $data;
     }
 
+    /**
+     * @param array<int|string, string> $keys
+     * @param array<string, mixed>      $data
+     *
+     * @return array<string, mixed>
+     */
     private function dumpValues(PackageInterface $package, array $keys, array $data)
     {
         foreach ($keys as $method => $key) {


### PR DESCRIPTION
Contribution for #10159

I thought of defining the dump data array shape but this would end up in some mad thing with more than 25 keys, many of them being optional and nested. I could still try to do that though if wanted and it could be shared as a phpstan type. On the other hand, maybe it would make more sense to refactor that to some value object at some point..