### PR TITLE
Log when COMPOSER_AUTH environment variable is malformed, but do not throw an error

### DIFF
--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -230,13 +230,15 @@ class Factory
             $authData = json_decode($composerAuthEnv, true);
 
             if (null === $authData) {
-                throw new \UnexpectedValueException('COMPOSER_AUTH environment variable is malformed, should be a valid JSON object');
+                if ($io) {
+                    $io->writeError('<error>COMPOSER_AUTH environment variable is malformed, should be a valid JSON object</error>');
+                }
+            } else {
+                if ($io && $io->isDebug()) {
+                    $io->writeError('Loading auth config from COMPOSER_AUTH');
+                }
+                $config->merge(array('config' => $authData));
             }
-
-            if ($io && $io->isDebug()) {
-                $io->writeError('Loading auth config from COMPOSER_AUTH');
-            }
-            $config->merge(array('config' => $authData));
         }
 
         return $config;


### PR DESCRIPTION
I opened this PR as a potential fix for #10208.