### PR TITLE
Prevent uncaught exception when iconv/mbstring are missing; fixes #10168

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -24,6 +24,12 @@ if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '4.0', '>=')) {
     echo 'HHVM 4.0 has dropped support for Composer, please use PHP instead. Aborting.'.PHP_EOL;
     exit(1);
 }
+if (!extension_loaded('iconv') && !extension_loaded('mbstring')) {
+    echo 'The iconv OR mbstring extension is required and both are missing.'
+        .PHP_EOL.'Install either of them or recompile php without --disable-iconv.'
+        .PHP_EOL.'Aborting.'.PHP_EOL;
+    exit(1);
+}
 
 if (function_exists('ini_set')) {
     @ini_set('display_errors', '1');


### PR DESCRIPTION
Properly handle missing iconv/mbstring extensions, to prevent displaying an unhelpful obscure stack trace.

With this fix:
```
$ docker run --rm -v $(pwd):/app -w /app php:8.0-cli-without-iconv bin/composer
The iconv OR mbstring extension is required and both are missing.
Install either of them or recompile php without --disable-iconv.
Aborting.
```

Without this fix:
```
$ docker run --rm -v $(pwd):/app -w /app php:8.0-cli-without-iconv php composer.phar
   ______
  / ____/___  ____ ___  ____  ____  ________  _____
 / /   / __ \/ __ `__ \/ __ \/ __ \/ ___/ _ \/ ___/
/ /___/ /_/ / / / / / / /_/ / /_/ (__  )  __/ /
\____/\____/_/ /_/ /_/ .___/\____/____/\___/_/
                    /_/
Composer version 2.1.9 2021-10-05 09:47:38

Usage:
  command [options] [arguments]


Fatal error: Uncaught Error: Call to undefined function Symfony\Polyfill\Mbstring\iconv() in phar:///app/composer.phar/vendor/symfony/polyfill-mbstring/Mbstring.php:714
Stack trace:
...
```