### PR TITLE
phpstan: update tests/Composer/Test/Installer/* to level 6 standard

### DIFF
--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -21,8 +21,19 @@ use Composer\Test\TestCase;
 
 class InstallationManagerTest extends TestCase
 {
+    /**
+     * @var \Composer\Repository\InstalledRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
     protected $repository;
+
+    /**
+     * @var \Composer\Util\Loop&\PHPUnit\Framework\MockObject\MockObject
+     */
     protected $loop;
+
+    /**
+     * @var \Composer\IO\IOInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
     protected $io;
 
     public function setUp()
@@ -282,12 +293,18 @@ class InstallationManagerTest extends TestCase
         $manager->ensureBinariesPresence($package);
     }
 
+    /**
+     * @return \Composer\Installer\InstallerInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
     private function createInstallerMock()
     {
         return $this->getMockBuilder('Composer\Installer\InstallerInterface')
             ->getMock();
     }
 
+    /**
+     * @return \Composer\Package\PackageInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
     private function createPackageMock()
     {
         $mock = $this->getMockBuilder('Composer\Package\PackageInterface')

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -20,14 +20,49 @@ use Composer\Config;
 
 class LibraryInstallerTest extends TestCase
 {
+    /**
+     * @var \Composer\Composer
+     */
     protected $composer;
+
+    /**
+     * @var \Composer\Config
+     */
     protected $config;
+
+    /**
+     * @var string
+     */
     protected $rootDir;
+
+    /**
+     * @var string
+     */
     protected $vendorDir;
+
+    /**
+     * @var string
+     */
     protected $binDir;
+
+    /**
+     * @var \Composer\Downloader\DownloadManager&\PHPUnit\Framework\MockObject\MockObject
+     */
     protected $dm;
+
+    /**
+     * @var \Composer\Repository\InstalledRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
     protected $repository;
+
+    /**
+     * @var \Composer\IO\IOInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
     protected $io;
+
+    /**
+     * @var \Composer\Util\Filesystem
+     */
     protected $fs;
 
     protected function setUp()
@@ -285,6 +320,9 @@ class LibraryInstallerTest extends TestCase
         $library->ensureBinariesPresence($package);
     }
 
+    /**
+     * @return \Composer\Package\PackageInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
     protected function createPackageMock()
     {
         return $this->getMockBuilder('Composer\Package\Package')

--- a/tests/Composer/Test/Installer/MetapackageInstallerTest.php
+++ b/tests/Composer/Test/Installer/MetapackageInstallerTest.php
@@ -107,6 +107,9 @@ class MetapackageInstallerTest extends TestCase
         $this->installer->uninstall($this->repository, $package);
     }
 
+    /**
+     * @return \Composer\Package\PackageInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
     private function createPackageMock()
     {
         return $this->getMockBuilder('Composer\Package\Package')

--- a/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
+++ b/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
@@ -20,7 +20,14 @@ use Composer\Test\TestCase;
  */
 class SuggestedPackagesReporterTest extends TestCase
 {
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
     private $io;
+
+    /**
+     * @var \Composer\Installer\SuggestedPackagesReporter
+     */
     private $suggestedPackagesReporter;
 
     protected function setUp()
@@ -267,6 +274,9 @@ class SuggestedPackagesReporterTest extends TestCase
         $this->suggestedPackagesReporter->output(SuggestedPackagesReporter::MODE_BY_PACKAGE, $repository);
     }
 
+    /**
+     * @return array<string, string>
+     */
     private function getSuggestedPackageArray()
     {
         return array(
@@ -276,6 +286,9 @@ class SuggestedPackagesReporterTest extends TestCase
         );
     }
 
+    /**
+     * @return \Composer\Package\PackageInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
     private function createPackageMock()
     {
         return $this->getMockBuilder('Composer\Package\Package')


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. 2.1 or similar if such a branch exists, or 1.10 if it is a critical fix that should be fixed in Composer 1)

For new features and everything else, use the main branch. -->

Relates #10159 
