### PR TITLE
Fix phpstan return type in `SvnTest::urlProvider`

### DIFF
--- a/tests/Composer/Test/Util/SvnTest.php
+++ b/tests/Composer/Test/Util/SvnTest.php
@@ -36,11 +36,6 @@ class SvnTest extends TestCase
         $this->assertEquals($expect, $reflMethod->invoke($svn));
     }
 
-    /**
-     * Provide some examples for {@self::testCredentials()}.
-     *
-     * @return array
-     */
     public function urlProvider()
     {
         return array(


### PR DESCRIPTION
Missed that in #10228 after reverting a file and phpstan caching problems I guess..

The type needs to be either fully specified or not at all. This halfway solution makes phpstan unhappy.