### PR TITLE
phpstan: update tests/Composer/Test/DependencyResolver/* to level 6 standard

### DIFF
--- a/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
@@ -140,6 +140,9 @@ class PoolBuilderTest extends TestCase
         $this->assertSame($expect, $result);
     }
 
+    /**
+     * @return array<string, array<string>>
+     */
     public function getIntegrationTests()
     {
         $fixturesDir = realpath(__DIR__.'/Fixtures/poolbuilder/');
@@ -173,6 +176,11 @@ class PoolBuilderTest extends TestCase
         return $tests;
     }
 
+    /**
+     * @param \SplFileInfo $file
+     * @param string $fixturesDir
+     * @return array<string, string>
+     */
     protected function readTestFile(\SplFileInfo $file, $fixturesDir)
     {
         $tokens = preg_split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file->getRealPath()), -1, PREG_SPLIT_DELIM_CAPTURE);

--- a/tests/Composer/Test/DependencyResolver/PoolTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolTest.php
@@ -57,7 +57,11 @@ class PoolTest extends TestCase
         $this->assertEquals(array(), $pool->whatProvides('foo'));
     }
 
-    protected function createPool(array $packages = array())
+    /**
+     * @param array<\Composer\Package\BasePackage>|null $packages
+     * @return \Composer\DependencyResolver\Pool
+     */
+    protected function createPool($packages = array())
     {
         return new Pool($packages);
     }

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -200,7 +200,7 @@ class SolverTest extends TestCase
      *
      * This is not something that can happen with packages on e.g. Packagist, but custom installers with custom repositories might do something like this;
      * in fact, some PaaSes do the exact thing above, installing binary builds of PHP and extensions as Composer packages with a custom installer in a separate step before the "userland" `composer install`.
-     * 
+     *
      * If version selectors are sufficiently permissive (e.g. "ourcustom/php":"*", "ourcustom/ext-foobar":"*"), then it may happen that the Solver won't pick the highest possible PHP version, as it has already settled on an "ext-foobar" (they're all the same version to the Solver, it doesn't know about the different requirements in each of the otherwise identical packages) if that was listed in "require" before "php".
      * That's "unfixable", and not even broken, behavior (what if the "ext-foobar" has higher versions for the lower "PHP"? who wins then? any combination of the packages is "correct"), but it shouldn't randomly change.
      * This test asserts this behavior to prevent regressions.
@@ -1039,12 +1039,18 @@ class SolverTest extends TestCase
         $this->assertTrue($this->solver->testFlagLearnedPositiveLiteral);
     }
 
+    /**
+     * @return void
+     */
     protected function reposComplete()
     {
         $this->repoSet->addRepository($this->repo);
         $this->repoSet->addRepository($this->repoLocked);
     }
 
+    /**
+     * @return void
+     */
     protected function createSolver()
     {
         $io = new NullIO();
@@ -1052,6 +1058,10 @@ class SolverTest extends TestCase
         $this->solver = new Solver($this->policy, $this->pool, $io);
     }
 
+    /**
+     * @param array<array<string, string>> $expected
+     * @return void
+     */
     protected function checkSolverResult(array $expected)
     {
         $this->createSolver();

--- a/tests/Composer/Test/DependencyResolver/TransactionTest.php
+++ b/tests/Composer/Test/DependencyResolver/TransactionTest.php
@@ -98,6 +98,11 @@ class TransactionTest extends TestCase
         $this->checkTransactionOperations($transaction, $expectedOperations);
     }
 
+    /**
+     * @param \Composer\DependencyResolver\Transaction $transaction
+     * @param array<array<string, string>> $expected
+     * @return void
+     */
     protected function checkTransactionOperations(Transaction $transaction, array $expected)
     {
         $result = array();


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. 2.1 or similar if such a branch exists, or 1.10 if it is a critical fix that should be fixed in Composer 1)

For new features and everything else, use the main branch. -->

Relates #10159 
