### PR TITLE
Upgrade PHPStan to 1.0

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: "Install PHPStan"
         # Locked to phpunit 7.5 here as newer ones have void return types which break inheritance
-        run: "bin/composer require --dev phpstan/phpstan:^0.12.93 phpstan/phpstan-phpunit:^0.12.17 phpunit/phpunit:^7.5.20 --with-all-dependencies ${{ env.COMPOSER_FLAGS }}"
+        run: "bin/composer require --dev phpstan/phpstan:^1.0 phpstan/phpstan-phpunit:^1.0 phpunit/phpunit:^7.5.20 --with-all-dependencies ${{ env.COMPOSER_FLAGS }}"
 
       - name: "Run PHPStan"
         run: "vendor/bin/phpstan analyse --configuration=phpstan/config.neon"

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         "test": "simple-phpunit",
         "phpstan-setup": [
             "@composer config platform --unset",
-            "@php composer.phar update",
+            "@composer update",
             "@composer require --dev phpstan/phpstan:^1.0 phpstan/phpstan-phpunit:^1.0 phpunit/phpunit:^7.5.20 --with-all-dependencies",
             "git checkout composer.json composer.lock"
         ],

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "phpstan-setup": [
             "@composer config platform --unset",
             "@php composer.phar update",
-            "@composer require --dev phpstan/phpstan:^0.12.93 phpstan/phpstan-phpunit:^0.12.17 phpunit/phpunit:^7.5.20 --with-all-dependencies",
+            "@composer require --dev phpstan/phpstan:^1.0 phpstan/phpstan-phpunit:^1.0 phpunit/phpunit:^7.5.20 --with-all-dependencies",
             "git checkout composer.json composer.lock"
         ],
         "phpstan": "@php vendor/bin/phpstan analyse --configuration=phpstan/config.neon"

--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -1,5 +1,11 @@
 parameters:
     ignoreErrors:
+        # reported as https://github.com/phpstan/phpstan/issues/6008
+        -
+            message: "#^Offset 'curl_id' on array{curl_id:#"
+            count: 1
+            path: ../src/Composer/Util/HttpDownloader.php
+
         -
             message: "#^Parameter \\#1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\)\\: void, array\\{\\$this\\(Composer\\\\Autoload\\\\ClassLoader\\), 'loadClass'\\} given\\.$#"
             count: 1

--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -1,7 +1,7 @@
 parameters:
     ignoreErrors:
         -
-            message: "#^Parameter \\#1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\)\\: void, array\\(\\$this\\(Composer\\\\Autoload\\\\ClassLoader\\), 'loadClass'\\) given\\.$#"
+            message: "#^Parameter \\#1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\)\\: void, array\\{\\$this\\(Composer\\\\Autoload\\\\ClassLoader\\), 'loadClass'\\} given\\.$#"
             count: 1
             path: ../src/Composer/Autoload/ClassLoader.php
 

--- a/phpstan/config.neon
+++ b/phpstan/config.neon
@@ -40,8 +40,8 @@ parameters:
         - '~^Call to an undefined method (PHPUnit\\Framework\\MockObject\\MockObject|Prophecy\\Prophecy\\ObjectProphecy)::.*$~'
 
         # Ignore some irrelevant errors in test files
-        - '~Method Composer\\Test\\[^:]+::(setUp(BeforeClass)?|tearDown(AfterClass)?|test[^(]+)\(\) has no return typehint specified.~'
-        - '~Method Composer\\Test\\[^:]+::(data\w+|provide\w+|\w+?Provider)\(\) has no return typehint specified.~'
+        - '~Method Composer\\Test\\[^:]+::(setUp(BeforeClass)?|tearDown(AfterClass)?|test[^(]+)\(\) has no return type specified.~'
+        - '~Method Composer\\Test\\[^:]+::(data\w+|provide\w+|\w+?Provider)\(\) has no return type specified.~'
 
     bootstrapFiles:
         - ../tests/bootstrap.php

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -585,7 +585,7 @@ EOF;
     /**
      * Registers an autoloader based on an autoload-map returned by parseAutoloads
      *
-     * @param array<string, array> $autoloads see parseAutoloads return value
+     * @param array<string, mixed[]> $autoloads see parseAutoloads return value
      * @param ?string $vendorDir
      * @return ClassLoader
      */

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -149,7 +149,7 @@ class ClassLoader
 
     /**
      * @return string[] Array of classname => path
-     * @psalm-var array<string, string>
+     * @psalm-return array<string, string>
      */
     public function getClassMap()
     {

--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -244,7 +244,7 @@ abstract class BaseCommand extends Command
     }
 
     /**
-     * @param array<TableSeparator|array> $table
+     * @param array<TableSeparator|mixed[]> $table
      *
      * @return void
      */

--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -132,7 +132,7 @@ class BaseDependencyCommand extends BaseCommand
     /**
      * Assembles and prints a bottom-up table of the dependencies.
      *
-     * @param array[]         $results
+     * @param array{PackageInterface, Link, mixed}[] $results
      *
      * @return void
      */
@@ -191,7 +191,7 @@ class BaseDependencyCommand extends BaseCommand
     /**
      * Recursively prints a tree of the selected results.
      *
-     * @param array[] $results Results to be printed at this level.
+     * @param array{PackageInterface, Link, mixed[]|bool}[] $results Results to be printed at this level.
      * @param string  $prefix  Prefix of the current tree level.
      * @param int     $level   Current level of recursion.
      *
@@ -202,11 +202,6 @@ class BaseDependencyCommand extends BaseCommand
         $count = count($results);
         $idx = 0;
         foreach ($results as $result) {
-            /**
-             * @var PackageInterface $package
-             * @var Link             $link
-             * @var mixed[]|bool     $children
-             */
             list($package, $link, $children) = $result;
 
             $color = $this->colors[$level % count($this->colors)];

--- a/src/Composer/Command/CheckPlatformReqsCommand.php
+++ b/src/Composer/Command/CheckPlatformReqsCommand.php
@@ -173,7 +173,7 @@ EOT
     }
 
     /**
-     * @param array[] $results
+     * @param mixed[] $results
      *
      * @return void
      */

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -826,10 +826,10 @@ EOT
     /**
      * Display the contents of the file in a pretty formatted way
      *
-     * @param array<array|bool|string> $contents
-     * @param array<array|string>      $rawContents
-     * @param string|null              $k
-     * @param bool                     $showSource
+     * @param array<mixed[]|bool|string> $contents
+     * @param array<mixed[]|string>      $rawContents
+     * @param string|null                $k
+     * @param bool                       $showSource
      *
      * @return void
      */

--- a/src/Composer/Command/FundCommand.php
+++ b/src/Composer/Command/FundCommand.php
@@ -132,8 +132,8 @@ class FundCommand extends BaseCommand
     }
 
     /**
-     * @param array[] $fundings
-     * @return array[]
+     * @param mixed[] $fundings
+     * @return mixed[]
      */
     private function insertFundingData(array $fundings, CompletePackageInterface $package)
     {

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -490,15 +490,6 @@ EOT
     }
 
     /**
-     * @param string $name
-     * @return list<array{name: string, description: ?string}>
-     */
-    protected function findPackages($name)
-    {
-        return $this->getRepos()->search($name);
-    }
-
-    /**
      * @return CompositeRepository
      */
     protected function getRepos()
@@ -573,7 +564,7 @@ EOT
 
         $io = $this->getIO();
         while (null !== $package = $io->ask('Search for a package: ')) {
-            $matches = $this->findPackages($package);
+            $matches = $this->getRepos()->search($package);
 
             if (count($matches)) {
                 // Remove existing packages from search results.

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -1005,7 +1005,7 @@ EOT
     /**
      * Display the tree
      *
-     * @param array<int, array<string, string|array>> $arrayTree
+     * @param array<int, array<string, string|mixed[]>> $arrayTree
      * @return void
      */
     protected function displayPackageTree(array $arrayTree)
@@ -1051,7 +1051,7 @@ EOT
     /**
      * Generate the package tree
      *
-     * @return array<string, array<int, array<string, array|string>>|string|null>
+     * @return array<string, array<int, array<string, mixed[]|string>>|string|null>
      */
     protected function generatePackageTree(
         PackageInterface $package,
@@ -1093,8 +1093,8 @@ EOT
     /**
      * Display a package tree
      *
-     * @param array<string, array<int, array<string, array|string>>|string|null>|string $package
-     * @param array<int, string|array> $packagesInTree
+     * @param array<string, array<int, array<string, mixed[]|string>>|string|null>|string $package
+     * @param array<int, string|mixed[]> $packagesInTree
      * @param string $previousTreeBar
      * @param int $level
      *

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -299,7 +299,9 @@ EOT
         if ($input->getOption('tree')) {
             $rootRequires = $this->getRootRequires();
             $packages = $installedRepo->getPackages();
-            usort($packages, 'strcmp');
+            usort($packages, function (BasePackage $a, BasePackage $b) {
+                return strcmp((string) $a, (string) $b);
+            });
             $arrayTree = array();
             foreach ($packages as $package) {
                 if (in_array($package->getName(), $rootRequires, true)) {
@@ -704,7 +706,8 @@ EOT
 
         if ($package->getAutoload()) {
             $io->write("\n<info>autoload</info>");
-            foreach ($package->getAutoload() as $type => $autoloads) {
+            $autoloadConfig = $package->getAutoload();
+            foreach ($autoloadConfig as $type => $autoloads) {
                 $io->write('<comment>' . $type . '</comment>');
 
                 if ($type === 'psr-0' || $type === 'psr-4') {
@@ -712,7 +715,7 @@ EOT
                         $io->write(($name ?: '*') . ' => ' . (is_array($path) ? implode(', ', $path) : ($path ?: '.')));
                     }
                 } elseif ($type === 'classmap') {
-                    $io->write(implode(', ', $autoloads));
+                    $io->write(implode(', ', $autoloadConfig[$type]));
                 }
             }
             if ($package->getIncludePaths()) {

--- a/src/Composer/Console/HtmlOutputFormatter.php
+++ b/src/Composer/Console/HtmlOutputFormatter.php
@@ -82,12 +82,12 @@ class HtmlOutputFormatter extends OutputFormatter
     {
         $out = '<span style="';
         foreach (explode(';', $matches[1]) as $code) {
-            if (isset(self::$availableForegroundColors[$code])) {
-                $out .= 'color:'.self::$availableForegroundColors[$code].';';
-            } elseif (isset(self::$availableBackgroundColors[$code])) {
-                $out .= 'background-color:'.self::$availableBackgroundColors[$code].';';
-            } elseif (isset(self::$availableOptions[$code])) {
-                switch (self::$availableOptions[$code]) {
+            if (isset(self::$availableForegroundColors[(int) $code])) {
+                $out .= 'color:'.self::$availableForegroundColors[(int) $code].';';
+            } elseif (isset(self::$availableBackgroundColors[(int) $code])) {
+                $out .= 'background-color:'.self::$availableBackgroundColors[(int) $code].';';
+            } elseif (isset(self::$availableOptions[(int) $code])) {
+                switch (self::$availableOptions[(int) $code]) {
                     case 'bold':
                         $out .= 'font-weight:bold;';
                         break;

--- a/src/Composer/Console/HtmlOutputFormatter.php
+++ b/src/Composer/Console/HtmlOutputFormatter.php
@@ -60,7 +60,7 @@ class HtmlOutputFormatter extends OutputFormatter
     }
 
     /**
-     * @param string $message
+     * @param ?string $message
      *
      * @return string
      */

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -444,7 +444,7 @@ class PoolBuilder
                     if ($request->getUpdateAllowTransitiveRootDependencies() || !$this->isRootRequire($request, $this->skippedLoad[$replace])) {
                         $this->unlockPackage($request, $replace);
                         $this->markPackageNameForLoading($request, $replace, $link->getConstraint());
-                    } elseif (!$request->getUpdateAllowTransitiveRootDependencies() && $this->isRootRequire($request, $replace) && !isset($this->updateAllowWarned[$replace])) {
+                    } elseif ($this->isRootRequire($request, $replace) && !isset($this->updateAllowWarned[$replace])) {
                         $this->updateAllowWarned[$replace] = true;
                         $this->io->writeError('<warning>Dependency "'.$replace.'" is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>');
                     }

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -384,6 +384,8 @@ class Problem
                 $hasDefaultBranch[$package->getName()] = true;
             }
         }
+
+        $preparedStrings = array();
         foreach ($prepared as $name => $package) {
             // remove the implicit default branch alias to avoid cruft in the display
             if (isset($package['versions'][VersionParser::DEFAULT_BRANCH_ALIAS], $hasDefaultBranch[$name])) {
@@ -395,10 +397,10 @@ class Problem
             if (!$isVerbose) {
                 $package['versions'] = self::condenseVersionList($package['versions'], 4);
             }
-            $prepared[$name] = $package['name'].'['.implode(', ', $package['versions']).']';
+            $preparedStrings[] = $package['name'].'['.implode(', ', $package['versions']).']';
         }
 
-        return implode(', ', $prepared);
+        return implode(', ', $preparedStrings);
     }
 
     /**

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -42,7 +42,7 @@ class Solver
 
     /** @var int */
     protected $propagateIndex;
-    /** @var array[] */
+    /** @var mixed[] */
     protected $branches = array();
     /** @var Problem[] */
     protected $problems = array();

--- a/src/Composer/Downloader/PerforceDownloader.php
+++ b/src/Composer/Downloader/PerforceDownloader.php
@@ -21,7 +21,7 @@ use Composer\Util\Perforce;
  */
 class PerforceDownloader extends VcsDownloader
 {
-    /** @var Perforce */
+    /** @var Perforce|null */
     protected $perforce;
 
     /**

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -33,7 +33,7 @@ class ZipDownloader extends ArchiveDownloader
     private static $isWindows;
 
     /** @var ZipArchive|null */
-    private $zipArchiveObject;
+    private $zipArchiveObject; // @phpstan-ignore-line helper property that is set via reflection for testing purposes
 
     /**
      * @inheritDoc

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -508,10 +508,8 @@ class EventDispatcher
         $this->loader = $generator->createLoader($map, $this->composer->getConfig()->get('vendor-dir'));
         $this->loader->register(false);
 
-        if (isset($map['files'])) {
-            foreach ($map['files'] as $fileIdentifier => $file) {
-                \Composer\Autoload\composerRequire($fileIdentifier, $file);
-            }
+        foreach ($map['files'] as $fileIdentifier => $file) {
+            \Composer\Autoload\composerRequire($fileIdentifier, $file);
         }
 
         return $scripts[$event->getName()];

--- a/src/Composer/Installer/SuggestedPackagesReporter.php
+++ b/src/Composer/Installer/SuggestedPackagesReporter.php
@@ -180,7 +180,7 @@ class SuggestedPackagesReporter
     /**
      * @param  InstalledRepository|null $installedRepo    If passed in, suggested packages which are installed already will be skipped
      * @param  PackageInterface|null    $onlyDependentsOf If passed in, only the suggestions from direct dependents of that package, or from the package itself, will be shown
-     * @return array[]
+     * @return mixed[]
      */
     private function getFilteredSuggestions(InstalledRepository $installedRepo = null, PackageInterface $onlyDependentsOf = null)
     {

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -456,7 +456,7 @@ class Package extends BasePackage
      */
     public function setRequires(array $requires)
     {
-        if (isset($requires[0])) {
+        if (isset($requires[0])) { // @phpstan-ignore-line
             $requires = $this->convertLinksToMap($requires, 'setRequires');
         }
 
@@ -480,7 +480,7 @@ class Package extends BasePackage
      */
     public function setConflicts(array $conflicts)
     {
-        if (isset($conflicts[0])) {
+        if (isset($conflicts[0])) { // @phpstan-ignore-line
             $conflicts = $this->convertLinksToMap($conflicts, 'setConflicts');
         }
 
@@ -505,7 +505,7 @@ class Package extends BasePackage
      */
     public function setProvides(array $provides)
     {
-        if (isset($provides[0])) {
+        if (isset($provides[0])) { // @phpstan-ignore-line
             $provides = $this->convertLinksToMap($provides, 'setProvides');
         }
 
@@ -530,7 +530,7 @@ class Package extends BasePackage
      */
     public function setReplaces(array $replaces)
     {
-        if (isset($replaces[0])) {
+        if (isset($replaces[0])) { // @phpstan-ignore-line
             $replaces = $this->convertLinksToMap($replaces, 'setReplaces');
         }
 
@@ -555,7 +555,7 @@ class Package extends BasePackage
      */
     public function setDevRequires(array $devRequires)
     {
-        if (isset($devRequires[0])) {
+        if (isset($devRequires[0])) { // @phpstan-ignore-line
             $devRequires = $this->convertLinksToMap($devRequires, 'setDevRequires');
         }
 

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -201,10 +201,8 @@ class PluginManager
         $classLoader = $generator->createLoader($map, $this->composer->getConfig()->get('vendor-dir'));
         $classLoader->register(false);
 
-        if (isset($map['files'])) {
-            foreach ($map['files'] as $fileIdentifier => $file) {
-                \Composer\Autoload\composerRequire($fileIdentifier, $file);
-            }
+        foreach ($map['files'] as $fileIdentifier => $file) {
+            \Composer\Autoload\composerRequire($fileIdentifier, $file);
         }
 
         foreach ($classes as $class) {

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1045,7 +1045,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     }
 
     /**
-     * @return array[]
+     * @return mixed[]
      */
     private function loadDataFromServer()
     {
@@ -1067,7 +1067,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     }
 
     /**
-     * @param array{providers?: array, provider-includes?: array} $data
+     * @param array{providers?: mixed[], provider-includes?: mixed[]} $data
      *
      * @return void
      */
@@ -1097,9 +1097,9 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     }
 
     /**
-     * @param array[] $data
+     * @param mixed[] $data
      *
-     * @return array[]
+     * @return mixed[]
      */
     private function loadIncludes($data)
     {
@@ -1144,7 +1144,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      * TODO v3 should make this private once we can drop PHP 5.3 support
      * @private
      *
-     * @param array[] $packages
+     * @param mixed[] $packages
      * @param string|null $source
      *
      * @return list<CompletePackage|CompleteAliasPackage>

--- a/src/Composer/Repository/PackageRepository.php
+++ b/src/Composer/Repository/PackageRepository.php
@@ -28,7 +28,7 @@ class PackageRepository extends ArrayRepository
     /**
      * Initializes filesystem repository.
      *
-     * @param array{package: array} $config package definition
+     * @param array{package: mixed[]} $config package definition
      */
     public function __construct(array $config)
     {

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -95,7 +95,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
     /**
      * Initializes path repository.
      *
-     * @param array{url: string, options?: array{symlink?: bool, relative?: bool, versions?: array<string, string>}} $repoConfig
+     * @param array{url?: string, options?: array{symlink?: bool, relative?: bool, versions?: array<string, string>}} $repoConfig
      * @param IOInterface $io
      * @param Config      $config
      */

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -81,7 +81,7 @@ class RepositoryFactory
         if (!$rm) {
             $rm = static::manager($io, $config, Factory::createHttpDownloader($io, $config));
         }
-        $repos = static::createRepos($rm, array($repoConfig));
+        $repos = self::createRepos($rm, array($repoConfig));
 
         return reset($repos);
     }
@@ -107,7 +107,7 @@ class RepositoryFactory
             $rm = static::manager($io, $config, Factory::createHttpDownloader($io, $config));
         }
 
-        return static::createRepos($rm, $config->getRepositories());
+        return self::createRepos($rm, $config->getRepositories());
     }
 
     /**

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -286,10 +286,10 @@ class CurlDownloader
      */
     public function abortRequest($id)
     {
-        if (isset($this->jobs[$id], $this->jobs[$id]['handle'])) {
+        if (isset($this->jobs[$id], $this->jobs[$id]['curlHandle'])) {
             $job = $this->jobs[$id];
-            curl_multi_remove_handle($this->multiHandle, $job['handle']);
-            curl_close($job['handle']);
+            curl_multi_remove_handle($this->multiHandle, $job['curlHandle']);
+            curl_close($job['curlHandle']);
             if (is_resource($job['headerHandle'])) {
                 fclose($job['headerHandle']);
             }

--- a/src/Composer/Util/Http/ProxyHelper.php
+++ b/src/Composer/Util/Http/ProxyHelper.php
@@ -156,8 +156,8 @@ class ProxyHelper
     /**
      * Formats a url from its component parts
      *
-     * @param  array{scheme: string, host: string, port?: int, user?: string, pass?: string} $proxy
-     * @param  bool                                                                          $includeAuth
+     * @param  array{scheme?: string, host: string, port?: int, user?: string, pass?: string} $proxy
+     * @param  bool                                                                           $includeAuth
      *
      * @return string The formatted value
      */

--- a/src/Composer/Util/Http/ProxyManager.php
+++ b/src/Composer/Util/Http/ProxyManager.php
@@ -34,8 +34,6 @@ class ProxyManager
     private $hasProxy;
     /** @var ?string */
     private $info = null;
-    /** @var ?string */
-    private $lastProxy = null;
     /** @var ?NoProxyPattern */
     private $noProxyHandler = null;
 
@@ -188,14 +186,6 @@ class ProxyManager
      */
     private function noProxy($requestUrl)
     {
-        if ($this->noProxyHandler) {
-            if ($this->noProxyHandler->test($requestUrl)) {
-                $this->lastProxy = 'excluded by no_proxy';
-
-                return true;
-            }
-        }
-
-        return false;
+        return $this->noProxyHandler && $this->noProxyHandler->test($requestUrl);
     }
 }

--- a/src/Composer/Util/Http/Response.php
+++ b/src/Composer/Util/Http/Response.php
@@ -37,7 +37,7 @@ class Response
      */
     public function __construct(array $request, $code, array $headers, $body)
     {
-        if (!isset($request['url'])) {
+        if (!isset($request['url'])) { // @phpstan-ignore-line
             throw new \LogicException('url key missing from request array');
         }
         $this->request = $request;

--- a/src/Composer/Util/Perforce.php
+++ b/src/Composer/Util/Perforce.php
@@ -26,7 +26,7 @@ class Perforce
     protected $path;
     /** @var ?string */
     protected $p4Depot;
-    /** @var string */
+    /** @var ?string */
     protected $p4Client;
     /** @var ?string */
     protected $p4User;
@@ -34,7 +34,7 @@ class Perforce
     protected $p4Password;
     /** @var string */
     protected $p4Port;
-    /** @var string */
+    /** @var ?string */
     protected $p4Stream;
     /** @var string */
     protected $p4ClientSpec;
@@ -54,7 +54,7 @@ class Perforce
     /** @var IOInterface */
     protected $io;
 
-    /** @var Filesystem */
+    /** @var ?Filesystem */
     protected $filesystem;
 
     /**
@@ -743,7 +743,7 @@ class Perforce
      */
     public function getFilesystem()
     {
-        if (empty($this->filesystem)) {
+        if (null === $this->filesystem) {
             $this->filesystem = new Filesystem($this->process);
         }
 

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -60,7 +60,7 @@ final class StreamContextFactory
      * @param string  $url
      * @param mixed[] $options
      * @param bool    $forCurl When true, will not add proxy values as these are handled separately
-     * @phpstan-return array{http: array{header: string[], proxy?: string, request_fulluri: bool}, ssl: array}
+     * @phpstan-return array{http: array{header: string[], proxy?: string, request_fulluri: bool}, ssl?: mixed[]}
      * @return array formatted as a stream context array
      */
     public static function initOptions($url, array $options, $forCurl = false)

--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -283,7 +283,7 @@ class Svn
             throw new \LogicException("No svn auth detected.");
         }
 
-        return isset($this->credentials['password']) ? $this->credentials['password'] : '';
+        return $this->credentials['password'];
     }
 
     /**
@@ -366,9 +366,7 @@ class Svn
         }
 
         $this->credentials['username'] = $uri['user'];
-        if (!empty($uri['pass'])) {
-            $this->credentials['password'] = $uri['pass'];
-        }
+        $this->credentials['password'] = !empty($uri['pass']) ? $uri['pass'] : '';
 
         return $this->hasAuth = true;
     }

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -151,7 +151,7 @@ class EventDispatcherTest extends TestCase
             ->will($this->returnValue(array()));
         $generator
             ->method('parseAutoloads')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue(array('psr-0' => array(), 'psr-4' => array(), 'classmap' => array(), 'files' => array(), 'exclude-from-classmap' => array(),)));
         $generator
             ->method('createLoader')
             ->will($this->returnValue($this->getMockBuilder('Composer\Autoload\ClassLoader')->getMock()));

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -70,7 +70,7 @@ class InstallerTest extends TestCase
      * @dataProvider provideInstaller
      * @param RootPackageInterface&BasePackage $rootPackage
      * @param RepositoryInterface[] $repositories
-     * @param array[] $options
+     * @param mixed[] $options
      */
     public function testInstaller(RootPackageInterface $rootPackage, $repositories, array $options)
     {

--- a/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
@@ -32,8 +32,6 @@ class GitBitbucketDriverTest extends TestCase
     private $httpDownloader;
     /** @var string */
     private $home;
-    /** @var string */
-    private $originUrl = 'bitbucket.org';
 
     protected function setUp()
     {


### PR DESCRIPTION
Still WIP for now, need to fix a few errors which are newly reported in 1.0 (if anyone wants to help feel free to send a PR against my PR branch, I won't have time to wrap this up in the next few days/weeks I think).

I am not sure what's up with all the ClassLoader failures though. I am thinking it may be a loading issue whereas the ClassLoader that is shipped with PHPStan is used and not the one from the Composer repo. Seemed to work fine in 0.12 though. @ondrejmirtes any clue about this? If not I can also just ignore these in baseline, it's not a huge deal as this class is pretty much written in stone.