### PR TITLE
Limit GitHub token scope when authorizing interactively

### DIFF
--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -90,9 +90,15 @@ class GitHub
         }
         $note .= ' ' . date('Y-m-d Hi');
 
-        $url = 'https://'.$originUrl.'/settings/tokens/new?scopes=repo:status,public_repo&description=' . str_replace('%20', '+', rawurlencode($note));
-        $this->io->writeError(sprintf('Head to %s', $url));
-        $this->io->writeError(sprintf('to retrieve a token. It will be stored in "%s" for future use by Composer.', $this->config->getAuthConfigSource()->getName()));
+        $url = 'https://'.$originUrl.'/settings/tokens/new?scopes=&description=' . str_replace('%20', '+', rawurlencode($note));
+        $this->io->writeError(sprintf('When working with _public_ GitHub repositories only, head to %s to retrieve a token.', $url));
+        $this->io->writeError('This token will have read-only permission for public information only.');
+
+        $url = 'https://'.$originUrl.'/settings/tokens/new?scopes=repo&description=' . str_replace('%20', '+', rawurlencode($note));
+        $this->io->writeError(sprintf('When you need to access _private_ GitHub repositories as well, go to %s', $url));
+        $this->io->writeError('Note that such tokens have broad read/write permissions on your behalf, even if not needed by Composer.');
+        $this->io->writeError(sprintf('Tokens will be stored in plain text in "%s" for future use by Composer.', $this->config->getAuthConfigSource()->getName()));
+        $this->io->writeError('For additional information, check https://getcomposer.org/doc/articles/authentication-for-private-packages.md#github-oauth.');
 
         $token = trim($this->io->askAndHideAnswer('Token (hidden): '));
 

--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -90,7 +90,7 @@ class GitHub
         }
         $note .= ' ' . date('Y-m-d Hi');
 
-        $url = 'https://'.$originUrl.'/settings/tokens/new?scopes=repo&description=' . str_replace('%20', '+', rawurlencode($note));
+        $url = 'https://'.$originUrl.'/settings/tokens/new?scopes=repo:status,public_repo&description=' . str_replace('%20', '+', rawurlencode($note));
         $this->io->writeError(sprintf('Head to %s', $url));
         $this->io->writeError(sprintf('to retrieve a token. It will be stored in "%s" for future use by Composer.', $this->config->getAuthConfigSource()->getName()));
 

--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -98,7 +98,7 @@ class GitHub
         $this->io->writeError(sprintf('When you need to access _private_ GitHub repositories as well, go to %s', $url));
         $this->io->writeError('Note that such tokens have broad read/write permissions on your behalf, even if not needed by Composer.');
         $this->io->writeError(sprintf('Tokens will be stored in plain text in "%s" for future use by Composer.', $this->config->getAuthConfigSource()->getName()));
-        $this->io->writeError('For additional information, check https://getcomposer.org/doc/articles/authentication-for-private-packages.md#github-oauth.');
+        $this->io->writeError('For additional information, check https://getcomposer.org/doc/articles/authentication-for-private-packages.md#github-oauth');
 
         $token = trim($this->io->askAndHideAnswer('Token (hidden): '));
 


### PR DESCRIPTION
When the documentation at https://getcomposer.org/doc/articles/authentication-for-private-packages.md#github-oauth is accurate, only limited token scopes are needed:

> For public repositories when rate limited, the public_repo scope is required, for private repositories the repo:status scope is needed. 

This can be indicated in the URL to create tokens with limited capabilities.

### Update

It turns out the documentation is not accurate, #10257 updates it.

This PR has been amended to better explain to the user what options they have and to provide different URLs.

