### PR TITLE
Add back abandoned key in repository search results

### DIFF
--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -166,6 +166,10 @@ class ArrayRepository implements RepositoryInterface
                     'name' => $package->getPrettyName(),
                     'description' => $package instanceof CompletePackageInterface ? $package->getDescription() : null,
                 );
+
+                if ($package instanceof CompletePackageInterface && $package->isAbandoned()) {
+                    $matches[$name]['abandoned'] = $package->getReplacementPackage() ?: true;
+                }
             }
         }
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -482,11 +482,6 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     continue;
                 }
 
-                if (isset($result['abandoned']) && '' === $result['abandoned']) {
-                    // The API returns '' in case a package is abandoned but does not have a replacement
-                    $result['abandoned'] = true;
-                }
-
                 $results[] = $result;
             }
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -482,8 +482,9 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     continue;
                 }
 
-                if (isset($result['abandoned'])) {
-                    $result['abandoned'] = $result['abandoned'] ?: true;
+                if (isset($result['abandoned']) && '' === $result['abandoned']) {
+                    // The API returns '' in case a package is abandoned but does not have a replacement
+                    $result['abandoned'] = true;
                 }
 
                 $results[] = $result;

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -478,9 +478,15 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             $results = array();
             foreach ($search['results'] as $result) {
                 // do not show virtual packages in results as they are not directly useful from a composer perspective
-                if (empty($result['virtual'])) {
-                    $results[] = array('name' => $result['name'], 'description' => $result['description']);
+                if (!empty($result['virtual'])) {
+                    continue;
                 }
+
+                if (isset($result['abandoned'])) {
+                    $result['abandoned'] = $result['abandoned'] ?: true;
+                }
+
+                $results[] = $result;
             }
 
             return $results;

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -90,7 +90,7 @@ interface RepositoryInterface extends \Countable
      * @param string $type  The type of package to search for. Defaults to all types of packages
      *
      * @return array[] an array of array('name' => '...', 'description' => '...'|null)
-     * @phpstan-return list<array{name: string, description: ?string}>
+     * @phpstan-return list<array{name: string, description: ?string, abandoned?: string|true}>
      */
     public function search($query, $mode = 0, $type = null);
 

--- a/tests/Composer/Test/Repository/ArrayRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ArrayRepositoryTest.php
@@ -131,4 +131,24 @@ class ArrayRepositoryTest extends TestCase
             $repo->search('foo', 0, 'composer-plugin')
         );
     }
+
+    public function testSearchWithAbandonedPackages()
+    {
+        $repo = new ArrayRepository();
+
+        $package1 = $this->getPackage('foo1', '1');
+        $package1->setAbandoned(true);
+        $repo->addPackage($package1);
+        $package2 = $this->getPackage('foo2', '1');
+        $package2->setAbandoned('bar');
+        $repo->addPackage($package2);
+
+        $this->assertSame(
+            array(
+                array('name' => 'foo1', 'description' => null, 'abandoned' => true),
+                array('name' => 'foo2', 'description' => null, 'abandoned' => 'bar'),
+            ),
+            $repo->search('foo')
+        );
+    }
 }

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -227,7 +227,7 @@ class ComposerRepositoryTest extends TestCase
                 array(
                     'name' => 'foo1',
                     'description' => null,
-                    'abandoned' => '',
+                    'abandoned' => true,
                 ),
                 array(
                     'name' => 'foo2',


### PR DESCRIPTION
This also fixes the abandoned info via interactive search in the init command.

Was mistakenly removed in https://github.com/composer/composer/commit/4940009f8377d06b9fb48df0cbe67193e0989830#diff-fcfc43da4ed67efe626640158c4aa49d5a162efd01e8844f0fbbc655fcffbddeL431-R433 in the ComposerRepository and apparently never implemented in the ArrayRepository

Noticed via https://github.com/Seldaek/composer/pull/5 

Test case for the init command: add deps interactively and search for e.g. "faker", which should list "fzaninotto/faker" as being abandoned.