### PR TITLE
Add COMPOSER_NO_DEV environment variable

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1147,3 +1147,8 @@ If set to `1`, outputs information about events being dispatched, which can be
 useful for plugin authors to identify what is firing when exactly.
 
 &larr; [Libraries](02-libraries.md)  |  [Schema](04-schema.md) &rarr;
+
+### COMPOSER_NO_DEV
+
+If set to `1`, it is the equivalent of passing the `--no-dev` arguement to `install` or
+`update`. You can override this for a single command by setting `COMPOSER_NO_DEV=0`.

--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -154,7 +154,7 @@ abstract class BaseCommand extends Command
         }
 
         if (true == $input->hasOption('no-dev')) {
-            if (!$input->getOption('no-dev') && true == getenv('COMPOSER_NO_DEV')) {
+            if (!$input->getOption('no-dev') && true == Platform::getEnv('COMPOSER_NO_DEV')) {
                 $input->setOption('no-dev', true);
             }
         }

--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -153,6 +153,12 @@ abstract class BaseCommand extends Command
             $input->setOption('no-progress', true);
         }
 
+        if (true == $input->hasOption('no-dev')) {
+            if (!$input->getOption('no-dev') && true == getenv('COMPOSER_NO_DEV')) {
+                $input->setOption('no-dev', true);
+            }
+        }
+
         parent::initialize($input, $output);
     }
 


### PR DESCRIPTION
This works fine in practice, but the tests fail because it doesn't call the initialization function, so the setup isn't done. I don't see how to fix that.

As discussed in https://github.com/composer/composer/discussions/9974