### PR TITLE
Expanding home diretory in vcs url for private repositories

### DIFF
--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -17,6 +17,7 @@ use Composer\IO\IOInterface;
 use Composer\Config;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\Util\HttpDownloader;
+use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Composer\Json\JsonFile;
 
@@ -163,6 +164,7 @@ class RepositoryFactory
             if ($repo['type'] === 'filesystem') {
                 $repos[$name] = new FilesystemRepository($repo['json']);
             } else {
+                $repo['url'] = Platform::expandPath($repo['url']);
                 $repos[$name] = $rm->createRepository($repo['type'], $repo, $index);
             }
         }

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -164,7 +164,9 @@ class RepositoryFactory
             if ($repo['type'] === 'filesystem') {
                 $repos[$name] = new FilesystemRepository($repo['json']);
             } else {
-                $repo['url'] = Platform::expandPath($repo['url']);
+                if(isset($repo['url'])) {
+                    $repo['url'] = Platform::expandPath($repo['url']);
+                }
                 $repos[$name] = $rm->createRepository($repo['type'], $repo, $index);
             }
         }

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -301,6 +301,7 @@ class Git
         $this->filesystem->removeDirectory($dir);
 
         $commandCallable = function ($url) use ($dir) {
+            $url = Platform::expandPath($url);
             return sprintf('git clone --mirror -- %s %s', ProcessExecutor::escape($url), ProcessExecutor::escape($dir));
         };
 

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -301,7 +301,6 @@ class Git
         $this->filesystem->removeDirectory($dir);
 
         $commandCallable = function ($url) use ($dir) {
-            $url = Platform::expandPath($url);
             return sprintf('git clone --mirror -- %s %s', ProcessExecutor::escape($url), ProcessExecutor::escape($dir));
         };
 


### PR DESCRIPTION
Hi,

I would like to propose the ability to expand the "~" (home) folder for private repositories.

For example in a composer.json :
```json
{
    "repositories": [
        {
            "type": "git",
            "url": "~/repositories/project"
        }
    ]
}
```
