### PR TITLE
Fix unlocking of replacers when a replaced package is unlocked

### DIFF
--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace-partial-update-all.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace-partial-update-all.test
@@ -1,5 +1,5 @@
 --TEST--
-Check that replacers from additional repositories are loaded when doing a partial update
+Check that replacers from additional repositories are loaded when doing a partial update allowing all transitive deps
 
 --REQUEST--
 {
@@ -15,7 +15,7 @@ Check that replacers from additional repositories are loaded when doing a partia
     "allowList": [
         "indirect/replacer"
     ],
-    "allowTransitiveDepsNoRootRequire": true
+    "allowTransitiveDeps": true
 }
 
 --FIXED--

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-replacers.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-replacers.test
@@ -1,0 +1,102 @@
+--TEST--
+Partially updating with deps a root requirement which depends on packages should load all available versions for the path repo packages' dependencies.
+
+--REQUEST--
+{
+    "require": {
+        "root/update": "*",
+        "root-required/replacer": "*",
+        "replacer/pkg": "*",
+        "root/noupdate": "*"
+    },
+    "locked": [
+        {
+            "name": "replacer/pkg",
+            "version": "1.0.0",
+            "require": {
+                "root-required/replacer-replaced": "1.*",
+                "transitive/dep-of-replacer": "1.*",
+                "transitive/replacer-replaced": "1.*"
+            },
+            "replace": {
+                "replaced/pkg": "1.0.0"
+            }
+        },
+        {
+            "name": "pkg/with-replaced-deps",
+            "version": "1.0.0",
+            "require": {
+                "transitive/dep": "1.*",
+                "root-required/replacer-replaced": "1.*",
+                "transitive/replacer-replaced": "1.*"
+            }
+        },
+        {"name": "root/update", "version": "1.0.1", "require": {"pkg/with-replaced-deps": ">=1.0.1", "replaced/pkg": "*"}},
+        {"name": "root/noupdate", "version": "1.0.1", "require": {"transitive/replacer": "^2"}},
+        {"name": "transitive/dep", "version": "1.0.0"},
+        {"name": "root-required/replacer", "version": "1.0.0", "replace": {"root-required/replacer-replaced": "1.0.0"}},
+        {"name": "transitive/dep-of-replacer", "version": "1.0.0"},
+        {"name": "transitive/replacer", "version": "1.0.0", "replace": {"transitive/replacer-replaced": "1.0.0"}}
+    ],
+    "allowList": [
+        "root/update"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {
+            "name": "replacer/pkg",
+            "version": "2.0.0",
+            "require": {
+                "root-required/replacer-replaced": ">=1.0.3",
+                "transitive/dep-of-replacer": "2.*",
+                "transitive/replacer-replaced": "2.*"
+            },
+            "replace": {
+                "replaced/pkg": "2.0.0"
+            }
+        },
+        {
+            "name": "pkg/with-replaced-deps",
+            "version": "2.0.0",
+            "require": {
+                "transitive/dep": "2.*",
+                "root-required/replacer-replaced": "2.*",
+                "transitive/replacer-replaced": ">=1.0.3"
+            }
+        },
+        {"name": "root/update", "version": "1.0.4", "require": {"pkg/with-replaced-deps": ">=1.0.1", "replaced/pkg": "*"}},
+        {"name": "root/noupdate", "version": "1.0.1", "require": {"transitive/replacer": "^2"}},
+        {"name": "transitive/dep", "version": "1.0.0"},
+        {"name": "transitive/dep", "version": "2.0.2"},
+        {"name": "root-required/replacer", "version": "1.0.0", "replace": {"root-required/replacer-replaced": "1.0.0"}},
+        {"name": "root-required/replacer", "version": "1.0.3", "replace": {"root-required/replacer-replaced": "1.0.3"}},
+        {"name": "root-required/replacer", "version": "2.0.4", "replace": {"root-required/replacer-replaced": "2.0.4"}},
+        {"name": "transitive/dep-of-replacer", "version": "1.0.0"},
+        {"name": "transitive/dep-of-replacer", "version": "2.0.2"},
+        {"name": "transitive/replacer", "version": "1.0.0", "replace": {"transitive/replacer-replaced": "1.0.0"}},
+        {"name": "transitive/replacer", "version": "1.0.3", "replace": {"transitive/replacer-replaced": "1.0.3"}},
+        {"name": "transitive/replacer", "version": "2.0.4", "replace": {"transitive/replacer-replaced": "2.0.4"}}
+    ]
+]
+
+--EXPECT--
+[
+   "root/noupdate-1.0.1.0 (locked)",
+   "root/update-1.0.4.0",
+   "replacer/pkg-2.0.0.0",
+   "pkg/with-replaced-deps-2.0.0.0",
+   "transitive/dep-2.0.2.0",
+   "root-required/replacer-1.0.0.0",
+   "root-required/replacer-1.0.3.0",
+   "root-required/replacer-2.0.4.0",
+   "transitive/dep-of-replacer-2.0.2.0",
+   "transitive/replacer-2.0.4.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-with-replacers-providers.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-with-replacers-providers.test
@@ -1,0 +1,87 @@
+--TEST--
+Check that replacers/providers which replace/provide a root requirement do not get unlocked
+
+--REQUEST--
+{
+    "require": {
+        "base/package": "^1.0",
+        "base/package2": "^1.0",
+        "indirect/replacer": "^1.0"
+    },
+    "locked": [
+        {"name": "shared/dep", "version": "1.2.0", "id": 1},
+        {"name": "shared/dep2", "version": "1.2.0", "id": 2},
+        {"name": "indirect/replacer", "version": "1.2.0", "require": {"replacer/package": "^1.2", "provider/package": "^1.2"}, "id": 3},
+        {"name": "replacer/package", "version": "1.2.0", "require": {"shared/dep": "^1.1"}, "replace": {"base/package": "1.2.0"}, "id": 4},
+        {"name": "provider/package", "version": "1.2.0", "require": {"shared/dep2": "^1.1"}, "provide": {"base/package2": "1.2.0"}, "id": 5}
+    ],
+    "allowList": [
+        "indirect/replacer"
+    ],
+    "allowTransitiveDepsNoRootRequire": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {
+            "name": "base/package",
+            "version": "1.0.0",
+            "require": {
+                "shared/dep": "^1.2"
+            }
+        },
+        {
+            "name": "base/package2",
+            "version": "1.0.0",
+            "require": {
+                "shared/dep2": "^1.2"
+            }
+        },
+        {
+            "name": "shared/dep",
+            "version": "1.0.0"
+        },
+        {
+            "name": "shared/dep",
+            "version": "1.2.0"
+        },
+        {
+            "name": "shared/dep2",
+            "version": "1.0.0"
+        },
+        {
+            "name": "shared/dep2",
+            "version": "1.2.0"
+        },
+        {
+            "name": "indirect/replacer",
+            "version": "1.2.0",
+            "require": {
+                "replacer/package": "^1.2"
+            }
+        },
+        {
+            "name": "indirect/replacer",
+            "version": "1.0.0",
+            "require": {
+                "replacer/package": "^1.0"
+            }
+        }
+    ]
+]
+
+--EXPECT--
+[
+    1,
+    4,
+    5,
+    "base/package2-1.0.0.0",
+    "indirect/replacer-1.2.0.0",
+    "indirect/replacer-1.0.0.0",
+    "shared/dep2-1.2.0.0"
+]

--- a/tests/Composer/Test/Fixtures/installer/github-issues-4795.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-4795.test
@@ -50,7 +50,7 @@ update b/b --with-dependencies
 
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
-<warning>Dependency "a/a" is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>
+<warning>Dependency a/a is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>
 Updating dependencies
 Nothing to modify in lock file
 Writing lock file

--- a/tests/Composer/Test/Fixtures/installer/partial-update-with-dependencies-provide.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-with-dependencies-provide.test
@@ -1,0 +1,65 @@
+--TEST--
+Ensure a partial update of a dependency updates dependencies which provide its requirements.
+
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {"name": "root/req1", "version": "1.0.0", "require": {"virtual/pkg1": "1.*"}},
+                {"name": "root/req1", "version": "2.0.0", "require": {"virtual/pkg1": "2.*"}},
+                {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg1": "1.*", "dep/pkg2": "1.*"}},
+                {"name": "dep/pkg1", "version": "1.0.0", "provide": {"virtual/pkg1": "1.0.0"}},
+                {"name": "dep/pkg1", "version": "1.2.0", "provide": {"virtual/pkg1": "2.0.0"}},
+                {"name": "dep/pkg2", "version": "1.0.0", "provide": {"virtual/pkg1": "1.0.0"}},
+                {"name": "dep/pkg2", "version": "1.2.0", "provide": {"virtual/pkg1": "2.0.0"}}
+            ]
+        }
+    ],
+    "require": {
+        "root/req1": "*",
+        "root/req2": "*"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        {"name": "dep/pkg1", "version": "1.0.0", "type": "library", "provide": {"virtual/pkg1": "1.0.0"}},
+        {"name": "dep/pkg2", "version": "1.0.0", "type": "library", "provide": {"virtual/pkg1": "1.0.0"}},
+        {"name": "root/req1", "version": "1.0.0", "type": "library", "require": {"virtual/pkg1": "1.*"}},
+        {"name": "root/req2", "version": "1.0.0", "type": "library", "require": {"dep/pkg1": "1.*", "dep/pkg2": "1.*"}}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--RUN--
+update root/req1 --with-dependencies
+--EXPECT-LOCK--
+{
+    "packages": [
+        {"name": "dep/pkg1", "version": "1.2.0", "type": "library", "provide": {"virtual/pkg1": "2.0.0"}},
+        {"name": "dep/pkg2", "version": "1.2.0", "type": "library", "provide": {"virtual/pkg1": "2.0.0"}},
+        {"name": "root/req1", "version": "2.0.0", "type": "library", "require": {"virtual/pkg1": "2.*"}},
+        {"name": "root/req2", "version": "1.0.0", "type": "library", "require": {"dep/pkg1": "1.*", "dep/pkg2": "1.*"}}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--EXPECT--
+Installing dep/pkg1 (1.2.0)
+Installing dep/pkg2 (1.2.0)
+Installing root/req1 (2.0.0)
+Installing root/req2 (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/partial-update-with-dependencies-provide.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-with-dependencies-provide.test
@@ -1,5 +1,5 @@
 --TEST--
-Ensure a partial update of a dependency updates dependencies which provide its requirements.
+Ensure a partial update of a dependency does NOT update dependencies which provide its requirements.
 
 --COMPOSER--
 {
@@ -44,9 +44,9 @@ update root/req1 --with-dependencies
 --EXPECT-LOCK--
 {
     "packages": [
-        {"name": "dep/pkg1", "version": "1.2.0", "type": "library", "provide": {"virtual/pkg1": "2.0.0"}},
-        {"name": "dep/pkg2", "version": "1.2.0", "type": "library", "provide": {"virtual/pkg1": "2.0.0"}},
-        {"name": "root/req1", "version": "2.0.0", "type": "library", "require": {"virtual/pkg1": "2.*"}},
+        {"name": "dep/pkg1", "version": "1.0.0", "type": "library", "provide": {"virtual/pkg1": "1.0.0"}},
+        {"name": "dep/pkg2", "version": "1.0.0", "type": "library", "provide": {"virtual/pkg1": "1.0.0"}},
+        {"name": "root/req1", "version": "1.0.0", "type": "library", "require": {"virtual/pkg1": "1.*"}},
         {"name": "root/req2", "version": "1.0.0", "type": "library", "require": {"dep/pkg1": "1.*", "dep/pkg2": "1.*"}}
     ],
     "packages-dev": [],
@@ -59,7 +59,7 @@ update root/req1 --with-dependencies
     "platform-dev": []
 }
 --EXPECT--
-Installing dep/pkg1 (1.2.0)
-Installing dep/pkg2 (1.2.0)
-Installing root/req1 (2.0.0)
+Installing dep/pkg1 (1.0.0)
+Installing dep/pkg2 (1.0.0)
+Installing root/req1 (1.0.0)
 Installing root/req2 (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/partial-update-with-dependencies-replace.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-with-dependencies-replace.test
@@ -1,0 +1,62 @@
+--TEST--
+Ensure a partial update of a dependency updates dependencies which replace one of its requirements.
+
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {"name": "root/req1", "version": "1.0.0", "require": {"replaced/pkg1": "1.*"}},
+                {"name": "root/req1", "version": "2.0.0", "require": {"replaced/pkg1": "2.*"}},
+                {"name": "root/req2", "version": "1.0.0", "require": {"dep/pkg1": "1.*"}},
+                {"name": "replaced/pkg1", "version": "1.0.0"},
+                {"name": "replaced/pkg1", "version": "2.0.0"},
+                {"name": "dep/pkg1", "version": "1.0.0", "replace": {"replaced/pkg1": "1.0.0"}},
+                {"name": "dep/pkg1", "version": "1.2.0", "replace": {"replaced/pkg1": "2.0.0"}}
+            ]
+        }
+    ],
+    "require": {
+        "root/req1": "*",
+        "root/req2": "*"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        {"name": "dep/pkg1", "version": "1.0.0", "type": "library", "replace": {"replaced/pkg1": "1.0.0"}},
+        {"name": "root/req1", "version": "1.0.0", "type": "library", "require": {"replaced/pkg1": "1.*"}},
+        {"name": "root/req2", "version": "1.0.0", "type": "library", "require": {"dep/pkg1": "1.*"}}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--RUN--
+update root/req1 --with-dependencies
+--EXPECT-LOCK--
+{
+    "packages": [
+        {"name": "dep/pkg1", "version": "1.2.0", "type": "library", "replace": {"replaced/pkg1": "2.0.0"}},
+        {"name": "root/req1", "version": "2.0.0", "type": "library", "require": {"replaced/pkg1": "2.*"}},
+        {"name": "root/req2", "version": "1.0.0", "type": "library", "require": {"dep/pkg1": "1.*"}}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--EXPECT--
+Installing dep/pkg1 (1.2.0)
+Installing root/req1 (2.0.0)
+Installing root/req2 (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/partial-update-with-deps-warns-root.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-with-deps-warns-root.test
@@ -110,8 +110,6 @@ update update/pkg1 --with-dependencies
 --EXPECT-OUTPUT--
 Loading composer repositories with package information
 <warning>Dependency root/pkg3 is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>
-<warning>Dependency dep/pkg5 (via provide of root/provided-pkg4) is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>
-<warning>Dependency dep/pkg6 (via provide of root/provided-pkg4) is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>
 <warning>Dependency dep/pkg9 (via replace of root/replaced-pkg8) is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>
 Updating dependencies
 Lock file operations: 0 installs, 2 updates, 0 removals

--- a/tests/Composer/Test/Fixtures/installer/partial-update-with-deps-warns-root.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-with-deps-warns-root.test
@@ -1,0 +1,133 @@
+--TEST--
+Ensure that a partial update of a dependency does not conflict if the only way to proceed is using an old locked version.
+
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "update/pkg1", "version": "1.0.0", "require": {
+                        "dep/pkg2": "*",
+                        "root/pkg3": "*",
+                        "root/provided-pkg4": "*",
+                        "root/replaced-pkg8": "*"
+                    }
+                },
+                {
+                    "name": "update/pkg1", "version": "2.0.0", "require": {
+                        "dep/pkg2": "*",
+                        "root/pkg3": "*",
+                        "root/provided-pkg4": "*",
+                        "root/replaced-pkg8": "*"
+                    }
+                },
+                {"name": "dep/pkg2", "version": "1.0.0"},
+                {"name": "dep/pkg2", "version": "2.0.0"},
+                {"name": "root/pkg3", "version": "1.0.0"},
+                {"name": "root/pkg3", "version": "2.0.0"},
+                {"name": "dep/pkg5", "version": "1.0.0", "provide": {"root/provided-pkg4": "1.0.0"}},
+                {"name": "dep/pkg5", "version": "2.0.0", "provide": {"root/provided-pkg4": "2.0.0"}},
+                {"name": "dep/pkg6", "version": "1.0.0", "provide": {"root/provided-pkg4": "1.0.0"}},
+                {"name": "dep/pkg6", "version": "2.0.0", "provide": {"root/provided-pkg4": "2.0.0"}},
+                {"name": "root/pkg7", "version": "1.0.0", "require": {"dep/pkg5": "*", "dep/pkg6": "*"}},
+                {"name": "dep/pkg9", "version": "1.0.0", "replace": {"root/replaced-pkg8": "1.0.0"}},
+                {"name": "dep/pkg9", "version": "2.0.0", "replace": {"root/replaced-pkg8": "2.0.0"}},
+                {"name": "root/replaced-pkg8", "version": "1.0.0"},
+                {"name": "root/replaced-pkg8", "version": "2.0.0"},
+                {"name": "root/pkg10", "version": "1.0.0", "require": {"dep/pkg9": "*"}}
+            ]
+        }
+    ],
+    "require": {
+        "update/pkg1": "*",
+        "root/pkg3": "*",
+        "root/provided-pkg4": "*",
+        "root/pkg7": "*",
+        "root/replaced-pkg8": "*",
+        "root/pkg10": "*"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "update/pkg1", "version": "1.0.0", "type": "library", "require": {
+                "dep/pkg2": "*",
+                "root/pkg3": "*",
+                "root/provided-pkg4": "*",
+                "root/replaced-pkg8": "*"
+            }
+        },
+        {"name": "dep/pkg2", "version": "1.0.0", "type": "library"},
+        {"name": "root/pkg3", "version": "1.0.0", "type": "library"},
+        {"name": "dep/pkg5", "version": "1.0.0", "type": "library", "provide": {"root/provided-pkg4": "1.0.0"}},
+        {"name": "dep/pkg6", "version": "1.0.0", "type": "library", "provide": {"root/provided-pkg4": "1.0.0"}},
+        {"name": "root/pkg7", "version": "1.0.0", "type": "library", "require": {"dep/pkg5": "*", "dep/pkg6": "*"}},
+        {"name": "dep/pkg9", "version": "1.0.0", "type": "library", "replace": {"root/replaced-pkg8": "1.0.0"}},
+        {"name": "root/pkg10", "version": "1.0.0", "type": "library", "require": {"dep/pkg9": "*"}}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--RUN--
+update update/pkg1 --with-dependencies
+--EXPECT-LOCK--
+{
+    "packages": [
+        {"name": "dep/pkg2", "version": "2.0.0", "type": "library"},
+        {"name": "dep/pkg5", "version": "1.0.0", "type": "library", "provide": {"root/provided-pkg4": "1.0.0"}},
+        {"name": "dep/pkg6", "version": "1.0.0", "type": "library", "provide": {"root/provided-pkg4": "1.0.0"}},
+        {"name": "dep/pkg9", "version": "1.0.0", "type": "library", "replace": {"root/replaced-pkg8": "1.0.0"}},
+        {"name": "root/pkg10", "version": "1.0.0", "type": "library", "require": {"dep/pkg9": "*"}},
+        {"name": "root/pkg3", "version": "1.0.0", "type": "library"},
+        {"name": "root/pkg7", "version": "1.0.0", "type": "library", "require": {"dep/pkg5": "*", "dep/pkg6": "*"}},
+        {
+            "name": "update/pkg1", "version": "2.0.0", "type": "library", "require": {
+                "dep/pkg2": "*",
+                "root/pkg3": "*",
+                "root/provided-pkg4": "*",
+                "root/replaced-pkg8": "*"
+            }
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+<warning>Dependency root/pkg3 is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>
+<warning>Dependency dep/pkg5 (via provide of root/provided-pkg4) is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>
+<warning>Dependency dep/pkg6 (via provide of root/provided-pkg4) is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>
+<warning>Dependency dep/pkg9 (via replace of root/replaced-pkg8) is also a root requirement. Package has not been listed as an update argument, so keeping locked at old version. Use --with-all-dependencies (-W) to include root dependencies.</warning>
+Updating dependencies
+Lock file operations: 0 installs, 2 updates, 0 removals
+  - Upgrading dep/pkg2 (1.0.0 => 2.0.0)
+  - Upgrading update/pkg1 (1.0.0 => 2.0.0)
+Writing lock file
+Installing dependencies from lock file (including require-dev)
+Package operations: 8 installs, 0 updates, 0 removals
+Generating autoload files
+
+--EXPECT--
+Installing dep/pkg9 (1.0.0)
+Installing root/pkg10 (1.0.0)
+Installing dep/pkg6 (1.0.0)
+Installing dep/pkg5 (1.0.0)
+Installing root/pkg7 (1.0.0)
+Installing root/pkg3 (1.0.0)
+Installing dep/pkg2 (2.0.0)
+Installing update/pkg1 (2.0.0)

--- a/tests/deprecations-8.1.json
+++ b/tests/deprecations-8.1.json
@@ -77,12 +77,12 @@
     {
         "location": "Composer\\Test\\InstallerTest::testIntegrationWithRawPool",
         "message": "preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated",
-        "count": 1728
+        "count": 1776
     },
     {
         "location": "Composer\\Test\\InstallerTest::testIntegrationWithPoolOptimizer",
         "message": "preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated",
-        "count": 1728
+        "count": 1776
     },
     {
         "location": "Composer\\Test\\Package\\Archiver\\ArchivableFilesFinderTest::testManualExcludes",


### PR DESCRIPTION
Note that the only relevant test is the added one (which failed before by adding way too few packages to the pool).

The other test changes are simply output order changes due to https://github.com/composer/composer/commit/ad4c9671432bad61661ed90d53b627beac16c985