### PR TITLE
Explicitly deprecate misuse of the link setters to enforce the fact they expect maps

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -364,7 +364,8 @@ class ArrayLoader implements LoaderInterface
     {
         $res = array();
         foreach ($links as $target => $constraint) {
-            $res[strtolower($target)] = $this->createLink($source, $sourceVersion, $description, $target, $constraint);
+            $target = strtolower($target);
+            $res[$target] = $this->createLink($source, $sourceVersion, $description, $target, $constraint);
         }
 
         return $res;

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -456,6 +456,10 @@ class Package extends BasePackage
      */
     public function setRequires(array $requires)
     {
+        if (isset($requires[0])) {
+            $requires = $this->convertLinksToMap($requires, 'setRequires');
+        }
+
         $this->requires = $requires;
     }
 
@@ -476,6 +480,10 @@ class Package extends BasePackage
      */
     public function setConflicts(array $conflicts)
     {
+        if (isset($conflicts[0])) {
+            $conflicts = $this->convertLinksToMap($conflicts, 'setConflicts');
+        }
+
         $this->conflicts = $conflicts;
     }
 
@@ -497,6 +505,10 @@ class Package extends BasePackage
      */
     public function setProvides(array $provides)
     {
+        if (isset($provides[0])) {
+            $provides = $this->convertLinksToMap($provides, 'setProvides');
+        }
+
         $this->provides = $provides;
     }
 
@@ -518,6 +530,10 @@ class Package extends BasePackage
      */
     public function setReplaces(array $replaces)
     {
+        if (isset($replaces[0])) {
+            $replaces = $this->convertLinksToMap($replaces, 'setReplaces');
+        }
+
         $this->replaces = $replaces;
     }
 
@@ -539,6 +555,10 @@ class Package extends BasePackage
      */
     public function setDevRequires(array $devRequires)
     {
+        if (isset($devRequires[0])) {
+            $devRequires = $this->convertLinksToMap($devRequires, 'setDevRequires');
+        }
+
         $this->devRequires = $devRequires;
     }
 
@@ -751,5 +771,21 @@ class Package extends BasePackage
         }
 
         return $urls;
+    }
+
+    /**
+     * @param  array<int, Link> $links
+     * @param  string $source
+     * @return array<string, Link>
+     */
+    private function convertLinksToMap(array $links, $source)
+    {
+        trigger_error('Package::'.$source.' must be called with a map of lowercased package name => Link object, got a indexed array, this is deprecated and you should fix your usage.');
+        $newLinks = array();
+        foreach ($links as $link) {
+            $newLinks[$link->getTarget()] = $link;
+        }
+
+        return $newLinks;
     }
 }

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -249,7 +249,7 @@ interface PackageInterface
      * Returns a set of links to packages which need to be installed before
      * this package can be installed
      *
-     * @return array<string, Link> An array of package links defining required packages
+     * @return array<string, Link> A map of package links defining required packages, indexed by the require package's name
      */
     public function getRequires();
 
@@ -281,7 +281,7 @@ interface PackageInterface
      * Returns a set of links to packages which are required to develop
      * this package. These are installed if in dev mode.
      *
-     * @return array<string, Link> An array of package links defining packages required for development
+     * @return array<string, Link> A map of package links defining packages required for development, indexed by the require package's name
      */
     public function getDevRequires();
 

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -616,11 +616,18 @@ class PlatformRepository extends ArrayRepository
         $lib = new CompletePackage('lib-'.$name, $version, $prettyVersion);
         $lib->setDescription($description);
 
-        $links = function ($alias) use ($name, $version, $lib) {
-            return new Link('lib-'.$name, 'lib-'.$alias, new Constraint('=', $version), Link::TYPE_REPLACE, $lib->getPrettyVersion());
-        };
-        $lib->setReplaces(array_map($links, $replaces));
-        $lib->setProvides(array_map($links, $provides));
+        $replaceLinks = array();
+        foreach ($replaces as $replace) {
+            $replace = strtolower($replace);
+            $replaceLinks[$replace] = new Link('lib-'.$name, 'lib-'.$replace, new Constraint('=', $version), Link::TYPE_REPLACE, $lib->getPrettyVersion());
+        }
+        $provideLinks = array();
+        foreach ($provides as $provide) {
+            $provide = strtolower($provide);
+            $provideLinks[$provide] = new Link('lib-'.$name, 'lib-'.$provide, new Constraint('=', $version), Link::TYPE_PROVIDE, $lib->getPrettyVersion());
+        }
+        $lib->setReplaces($replaceLinks);
+        $lib->setProvides($provideLinks);
 
         $this->addPackage($lib);
     }

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -1754,42 +1754,42 @@ EOF;
         return array(
             'Typical project requirements' => array(
                 array(
-                    new Link('a', 'php', $versionParser->parseConstraints('^7.2')),
-                    new Link('a', 'ext-xml', $versionParser->parseConstraints('*')),
-                    new Link('a', 'ext-json', $versionParser->parseConstraints('*')),
+                    'php' => new Link('a', 'php', $versionParser->parseConstraints('^7.2')),
+                    'ext-xml' => new Link('a', 'ext-xml', $versionParser->parseConstraints('*')),
+                    'ext-json' => new Link('a', 'ext-json', $versionParser->parseConstraints('*')),
                 ),
                 'typical',
             ),
             'No PHP lower bound' => array(
                 array(
-                    new Link('a', 'php', $versionParser->parseConstraints('< 8')),
+                    'php' => new Link('a', 'php', $versionParser->parseConstraints('< 8')),
                 ),
                 null,
             ),
             'No PHP upper bound' => array(
                 array(
-                    new Link('a', 'php', $versionParser->parseConstraints('>= 7.2')),
+                    'php' => new Link('a', 'php', $versionParser->parseConstraints('>= 7.2')),
                 ),
                 'no_php_upper_bound',
             ),
             'Specific PHP release version' => array(
                 array(
-                    new Link('a', 'php', $versionParser->parseConstraints('^7.2.8')),
+                    'php' => new Link('a', 'php', $versionParser->parseConstraints('^7.2.8')),
                 ),
                 'specific_php_release',
             ),
             'No PHP required' => array(
                 array(
-                    new Link('a', 'ext-xml', $versionParser->parseConstraints('*')),
-                    new Link('a', 'ext-json', $versionParser->parseConstraints('*')),
+                    'ext-xml' => new Link('a', 'ext-xml', $versionParser->parseConstraints('*')),
+                    'ext-json' => new Link('a', 'ext-json', $versionParser->parseConstraints('*')),
                 ),
                 'no_php_required',
             ),
             'Ignoring all platform requirements skips check completely' => array(
                 array(
-                    new Link('a', 'php', $versionParser->parseConstraints('^7.2')),
-                    new Link('a', 'ext-xml', $versionParser->parseConstraints('*')),
-                    new Link('a', 'ext-json', $versionParser->parseConstraints('*')),
+                    'php' => new Link('a', 'php', $versionParser->parseConstraints('^7.2')),
+                    'ext-xml' => new Link('a', 'ext-xml', $versionParser->parseConstraints('*')),
+                    'ext-json' => new Link('a', 'ext-json', $versionParser->parseConstraints('*')),
                 ),
                 null,
                 array(),
@@ -1798,10 +1798,10 @@ EOF;
             ),
             'Ignored platform requirements are not checked for' => array(
                 array(
-                    new Link('a', 'php', $versionParser->parseConstraints('^7.2.8')),
-                    new Link('a', 'ext-xml', $versionParser->parseConstraints('*')),
-                    new Link('a', 'ext-json', $versionParser->parseConstraints('*')),
-                    new Link('a', 'ext-pdo', $versionParser->parseConstraints('*')),
+                    'php' => new Link('a', 'php', $versionParser->parseConstraints('^7.2.8')),
+                    'ext-xml' => new Link('a', 'ext-xml', $versionParser->parseConstraints('*')),
+                    'ext-json' => new Link('a', 'ext-json', $versionParser->parseConstraints('*')),
+                    'ext-pdo' => new Link('a', 'ext-pdo', $versionParser->parseConstraints('*')),
                 ),
                 'no_php_required',
                 array(),
@@ -1810,12 +1810,12 @@ EOF;
             ),
             'Via wildcard ignored platform requirements are not checked for' => array(
                 array(
-                    new Link('a', 'php', $versionParser->parseConstraints('^7.2.8')),
-                    new Link('a', 'ext-xml', $versionParser->parseConstraints('*')),
-                    new Link('a', 'ext-json', $versionParser->parseConstraints('*')),
-                    new Link('a', 'ext-fileinfo', $versionParser->parseConstraints('*')),
-                    new Link('a', 'ext-filesystem', $versionParser->parseConstraints('*')),
-                    new Link('a', 'ext-filter', $versionParser->parseConstraints('*')),
+                    'php' => new Link('a', 'php', $versionParser->parseConstraints('^7.2.8')),
+                    'ext-xml' => new Link('a', 'ext-xml', $versionParser->parseConstraints('*')),
+                    'ext-json' => new Link('a', 'ext-json', $versionParser->parseConstraints('*')),
+                    'ext-fileinfo' => new Link('a', 'ext-fileinfo', $versionParser->parseConstraints('*')),
+                    'ext-filesystem' => new Link('a', 'ext-filesystem', $versionParser->parseConstraints('*')),
+                    'ext-filter' => new Link('a', 'ext-filter', $versionParser->parseConstraints('*')),
                 ),
                 'no_php_required',
                 array(),
@@ -1824,26 +1824,26 @@ EOF;
             ),
             'No extensions required' => array(
                 array(
-                    new Link('a', 'php', $versionParser->parseConstraints('^7.2')),
+                    'php' => new Link('a', 'php', $versionParser->parseConstraints('^7.2')),
                 ),
                 'no_extensions_required',
             ),
             'Replaced/provided extensions are not checked for + checking case insensitivity' => array(
                 array(
-                    new Link('a', 'ext-xml', $versionParser->parseConstraints('^7.2')),
-                    new Link('a', 'ext-Pdo', $versionParser->parseConstraints('^7.2')),
-                    new Link('a', 'ext-bcMath', $versionParser->parseConstraints('^7.2')),
+                    'ext-xml' => new Link('a', 'ext-xml', $versionParser->parseConstraints('^7.2')),
+                    'ext-pdo' => new Link('a', 'ext-Pdo', $versionParser->parseConstraints('^7.2')),
+                    'ext-bcmath' => new Link('a', 'ext-bcMath', $versionParser->parseConstraints('^7.2')),
                 ),
                 'replaced_provided_exts',
                 array(
                     // constraint does not satisfy all the ^7.2 requirement so we do not accept it as being replaced
-                    new Link('a', 'ext-PDO', $versionParser->parseConstraints('7.1.*')),
+                    'ext-pdo' => new Link('a', 'ext-PDO', $versionParser->parseConstraints('7.1.*')),
                     // valid replace of bcmath so no need to check for it
-                    new Link('a', 'ext-BCMath', $versionParser->parseConstraints('^7.1')),
+                    'ext-bcmath' => new Link('a', 'ext-BCMath', $versionParser->parseConstraints('^7.1')),
                 ),
                 array(
                     // valid provide of ext-xml so no need to check for it
-                    new Link('a', 'ext-XML', $versionParser->parseConstraints('*')),
+                    'ext-xml' => new Link('a', 'ext-XML', $versionParser->parseConstraints('*')),
                 ),
             ),
         );

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -215,13 +215,13 @@ class SolverTest extends TestCase
         $this->repo->addPackage($extForPhp80 = $this->getPackage('ourcustom/ext-foobar', '1.0'));
 
         $extForPhp74->setRequires(array(
-            'php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint(array(
+            'ourcustom/php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint(array(
                 $this->getVersionConstraint('>=', '7.4.0'),
                 $this->getVersionConstraint('<', '7.5.0'),
             )), Link::TYPE_REQUIRE),
         ));
         $extForPhp80->setRequires(array(
-            'php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint(array(
+            'ourcustom/php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint(array(
                 $this->getVersionConstraint('>=', '8.0.0'),
                 $this->getVersionConstraint('<', '8.1.0'),
             )), Link::TYPE_REQUIRE),
@@ -264,13 +264,13 @@ class SolverTest extends TestCase
         $this->repo->addPackage($extForPhp74 = $this->getPackage('ourcustom/ext-foobar', '1.0'));
 
         $extForPhp80->setRequires(array(
-            'php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint(array(
+            'ourcustom/php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint(array(
                 $this->getVersionConstraint('>=', '8.0.0'),
                 $this->getVersionConstraint('<', '8.1.0'),
             )), Link::TYPE_REQUIRE),
         ));
         $extForPhp74->setRequires(array(
-            'php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint(array(
+            'ourcustom/php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint(array(
                 $this->getVersionConstraint('>=', '7.4.0'),
                 $this->getVersionConstraint('<', '7.5.0'),
             )), Link::TYPE_REQUIRE),


### PR DESCRIPTION
This is already relied on in a few places for getRequires at least, so IMO good thing to codify it.