### PR TITLE
(Probable) typo fix

### DIFF
--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -273,7 +273,7 @@ If you have been pointed to this page, you want to check a few things:
 - If you are using IPv6, try disabling it. If that solves your issues, get in touch
   with your ISP or server host, the problem is not at the Packagist level but in the
   routing rules between you and Packagist (i.e. the internet at large). The best way to get
-  these fixed is raise awareness to the network engineers that have the power to fix it.
+  these fixed is to raise awareness to the network engineers that have the power to fix it.
   Take a look at the next section for IPv6 workarounds.
 - If none of the above helped, please report the error.
 


### PR DESCRIPTION
Isn't "to" missing before "raise awareness" ?

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. 2.1 or similar if such a branch exists, or 1.10 if it is a critical fix that should be fixed in Composer 1)

For new features and everything else, use the main branch. -->
