### PR TITLE
GitDownloader: add option for single use git clone to avoid --dissociate flag when cloning from local copy

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -92,8 +92,15 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
 
         if (!empty($this->cachedPackages[$package->getId()][$ref])) {
             $msg = "Cloning ".$this->getShortHash($ref).' from cache';
+
+            $cloneFlags = '--dissociate --reference %cachePath% ';
+            $transportOptions = $package->getTransportOptions();
+            if (isset($transportOptions['git']['single_use_clone']) && $transportOptions['git']['single_use_clone']) {
+                $cloneFlags = '';
+            }
+
             $command =
-                'git clone --no-checkout %cachePath% %path% --dissociate --reference %cachePath% '
+                'git clone --no-checkout %cachePath% %path% ' . $cloneFlags
                 . '&& cd '.$flag.'%path% '
                 . '&& git remote set-url origin -- %sanitizedUrl% && git remote add composer -- %sanitizedUrl%';
         } else {


### PR DESCRIPTION
Running `git clone` with the `--dissociate` flag can take several minutes for large git repositories. In certain scenarios, like creating archives, we don't need a fully working copy of the git repository that works independent of the local cache. The archiver removes the clone at the end anyway.

I moved the transport option into a `git` key instead of setting it in the root in case the transport options get passed to `StreamContextFactory::getContext` then this would throw a `Options should have the form ["wrappername"]["optionname"] = $value` error.