### PR TITLE
Support ignore-platform-reqs in `composer outdated`

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -485,6 +485,13 @@ php composer.phar show monolog/monolog 1.0.2
 * **--direct (-D):** Restricts the list of packages to your direct dependencies.
 * **--strict:** Return a non-zero exit code when there are outdated packages.
 * **--format (-f):** Lets you pick between text (default) or json output format.
+* **--ignore-platform-reqs:** ignore all platform requirements (`php`, `hhvm`,
+  `lib-*` and `ext-*`) and force the installation even if the local machine does
+  not fulfill these. Use with the --outdated option.
+* **--ignore-platform-req:** ignore a specific platform requirement(`php`,
+  `hhvm`, `lib-*` and `ext-*`) and force the installation even if the local machine
+  does not fulfill it. Multiple requirements can be ignored via wildcard. Use with
+  the --outdated option.
 
 ## outdated
 
@@ -508,6 +515,12 @@ The color coding is as such:
 * **--format (-f):** Lets you pick between text (default) or json output format.
 * **--no-dev:** Do not show outdated dev dependencies.
 * **--locked:** Shows updates for packages from the lock file, regardless of what is currently in vendor dir.
+* **--ignore-platform-reqs:** ignore all platform requirements (`php`, `hhvm`,
+  `lib-*` and `ext-*`) and force the installation even if the local machine does
+  not fulfill these.
+* **--ignore-platform-req:** ignore a specific platform requirement(`php`,
+  `hhvm`, `lib-*` and `ext-*`) and force the installation even if the local machine
+  does not fulfill it. Multiple requirements can be ignored via wildcard.
 
 ## browse / home
 

--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -42,6 +42,8 @@ class OutdatedCommand extends ShowCommand
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
                 new InputOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore specified package(s). Use it with the --outdated option if you don\'t want to be informed about new versions of some packages.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),
+                new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages). Use with the --outdated option'),
+                new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages). Use with the --outdated option'),
             ))
             ->setHelp(
                 <<<EOT
@@ -87,6 +89,12 @@ EOT
         }
         if ($input->getOption('no-dev')) {
             $args['--no-dev'] = true;
+        }
+        if ($input->getOption('ignore-platform-req')) {
+            $args['--ignore-platform-req'] = $input->getOption('ignore-platform-req');
+        }
+        if ($input->getOption('ignore-platform-reqs')) {
+            $args['--ignore-platform-reqs'] = true;
         }
         $args['--format'] = $input->getOption('format');
         $args['--ignore'] = $input->getOption('ignore');


### PR DESCRIPTION
This allows users to also find libraries that require major platform
changes to unlock updates.

Closes #10291.

