### PR TITLE
Add allow-plugins config value

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -26,14 +26,15 @@ helper is available:
 
 ## allow-plugins
 
-Defaults to `null` (allow all plugins implicitly) for backwards compatibility.
+Defaults to `null` (allow all plugins implicitly) for backwards compatibility until July 2022.
+At that point the default will become `{}` and plugins will not load anymore unless allowed.
 
 As of Composer 2.2.0, the `allow-plugins` option adds a layer of security
 allowing you to restrict which Composer plugins are able to execute code during
 a Composer run.
 
 When a new plugin is first activated, which is not yet listed in the config option,
-Composer will print a warning. If you run Composer interactively it will 
+Composer will print a warning. If you run Composer interactively it will
 prompt you to decide if you want to execute the plugin or not.
 
 Use this setting to allow only packages you trust to execute code. Set it to

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -24,6 +24,36 @@ helper is available:
 }
 ```
 
+## allow-plugins
+
+Defaults to `null` (allow all plugins implicitly) for backwards compatibility.
+
+As of Composer 2.2.0, the `allow-plugins` option adds a layer of security by
+allowing you to restrict which Composer plugins are able to execute code during
+a Composer run.
+
+When a new plugin which is not listed in the config option is first activated,
+Composer will warn you and prompt you (if run interactively) to know if you
+want to execute it or not.
+
+The best way to use this is to allow packages you trust to execute. Set it to
+a hash of package name patterns where the values are true to allow and false to
+disallow and suppress warnings/prompts.
+
+```json
+{
+    "config": {
+        "allow-plugins": {
+            "third-party/required-plugin": true,
+            "my-organization/*": true,
+            "unnecessary/plugin": false
+        }
+    }
+}
+```
+
+You can also set this to `false` to disallow all plugins, or `true` to allow all plugins to run (NOT recommended).
+
 ## use-include-path
 
 Defaults to `false`. If `true`, the Composer autoloader will also look for classes
@@ -33,7 +63,7 @@ in the PHP include path.
 
 Defaults to `dist` and can be any of `source`, `dist` or `auto`. This option
 allows you to set the install method Composer will prefer to use. Can
-optionally be a hash of patterns for more granular install preferences.
+optionally be a hash of package name patterns for more granular install preferences.
 
 ```json
 {

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -28,17 +28,17 @@ helper is available:
 
 Defaults to `null` (allow all plugins implicitly) for backwards compatibility.
 
-As of Composer 2.2.0, the `allow-plugins` option adds a layer of security by
+As of Composer 2.2.0, the `allow-plugins` option adds a layer of security
 allowing you to restrict which Composer plugins are able to execute code during
 a Composer run.
 
-When a new plugin which is not listed in the config option is first activated,
-Composer will warn you and prompt you (if run interactively) to know if you
-want to execute it or not.
+When a new plugin is first activated, which is not yet listed in the config option,
+Composer will print a warning. If you run Composer interactively it will 
+prompt you to decide if you want to execute the plugin or not.
 
-The best way to use this is to allow packages you trust to execute. Set it to
-a hash of package name patterns where the values are true to allow and false to
-disallow and suppress warnings/prompts.
+Use this setting to allow only packages you trust to execute code. Set it to
+an object with package name patterns as keys. The values are **true** to allow
+and **false** to disallow while suppressing further warnings and prompts.
 
 ```json
 {
@@ -52,7 +52,7 @@ disallow and suppress warnings/prompts.
 }
 ```
 
-You can also set this to `false` to disallow all plugins, or `true` to allow all plugins to run (NOT recommended).
+You can also set the config option itself to `false` to disallow all plugins, or `true` to allow all plugins to run (NOT recommended).
 
 ## use-include-path
 
@@ -63,7 +63,7 @@ in the PHP include path.
 
 Defaults to `dist` and can be any of `source`, `dist` or `auto`. This option
 allows you to set the install method Composer will prefer to use. Can
-optionally be a hash of package name patterns for more granular install preferences.
+optionally be an object with package name patterns for keys for more granular install preferences.
 
 ```json
 {

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -138,42 +138,42 @@
         },
         "require": {
             "type": "object",
-            "description": "This is a hash of package name (keys) and version constraints (values) that are required to run this package.",
+            "description": "This is an object of package name (keys) and version constraints (values) that are required to run this package.",
             "additionalProperties": {
                 "type": "string"
             }
         },
         "require-dev": {
             "type": "object",
-            "description": "This is a hash of package name (keys) and version constraints (values) that this package requires for developing it (testing tools and such).",
+            "description": "This is an object of package name (keys) and version constraints (values) that this package requires for developing it (testing tools and such).",
             "additionalProperties": {
                 "type": "string"
             }
         },
         "replace": {
             "type": "object",
-            "description": "This is a hash of package name (keys) and version constraints (values) that can be replaced by this package.",
+            "description": "This is an object of package name (keys) and version constraints (values) that can be replaced by this package.",
             "additionalProperties": {
                 "type": "string"
             }
         },
         "conflict": {
             "type": "object",
-            "description": "This is a hash of package name (keys) and version constraints (values) that conflict with this package.",
+            "description": "This is an object of package name (keys) and version constraints (values) that conflict with this package.",
             "additionalProperties": {
                 "type": "string"
             }
         },
         "provide": {
             "type": "object",
-            "description": "This is a hash of package name (keys) and version constraints (values) that this package provides in addition to this package's name.",
+            "description": "This is an object of package name (keys) and version constraints (values) that this package provides in addition to this package's name.",
             "additionalProperties": {
                 "type": "string"
             }
         },
         "suggest": {
             "type": "object",
-            "description": "This is a hash of package name (keys) and descriptions (values) that this package suggests work well with it (this will be suggested to the user during installation).",
+            "description": "This is an object of package name (keys) and descriptions (values) that this package suggests work well with it (this will be suggested to the user during installation).",
             "additionalProperties": {
                 "type": "string"
             }
@@ -217,7 +217,7 @@
             "properties": {
                 "psr-0": {
                     "type": "object",
-                    "description": "This is a hash of namespaces (keys) and the directories they can be found into (values, can be arrays of paths) by the autoloader.",
+                    "description": "This is an object of namespaces (keys) and the directories they can be found into (values, can be arrays of paths) by the autoloader.",
                     "additionalProperties": {
                         "type": ["string", "array"],
                         "items": {
@@ -227,7 +227,7 @@
                 },
                 "psr-4": {
                     "type": "object",
-                    "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
+                    "description": "This is an object of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
                     "additionalProperties": {
                         "type": ["string", "array"],
                         "items": {
@@ -283,7 +283,7 @@
             "properties": {
                 "platform": {
                     "type": "object",
-                    "description": "This is a hash of package name (keys) and version (values) that will be used to mock the platform packages on this machine.",
+                    "description": "This is an object of package name (keys) and version (values) that will be used to mock the platform packages on this machine.",
                     "additionalProperties": {
                         "type": ["string", "boolean"]
                     }
@@ -327,21 +327,21 @@
                 },
                 "github-oauth": {
                     "type": "object",
-                    "description": "A hash of domain name => github API oauth tokens, typically {\"github.com\":\"<token>\"}.",
+                    "description": "An object of domain name => github API oauth tokens, typically {\"github.com\":\"<token>\"}.",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "gitlab-oauth": {
                     "type": "object",
-                    "description": "A hash of domain name => gitlab API oauth tokens, typically {\"gitlab.com\":\"<token>\"}.",
+                    "description": "An object of domain name => gitlab API oauth tokens, typically {\"gitlab.com\":\"<token>\"}.",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "gitlab-token": {
                     "type": "object",
-                    "description": "A hash of domain name => gitlab private tokens, typically {\"gitlab.com\":\"<token>\"}.",
+                    "description": "An object of domain name => gitlab private tokens, typically {\"gitlab.com\":\"<token>\"}.",
                     "additionalProperties": {
                         "type": "string"
                     }
@@ -352,7 +352,7 @@
                 },
                 "bearer": {
                     "type": "object",
-                    "description": "A hash of domain name => bearer authentication token, for example {\"example.com\":\"<token>\"}.",
+                    "description": "An object of domain name => bearer authentication token, for example {\"example.com\":\"<token>\"}.",
                     "additionalProperties": {
                         "type": "string"
                     }
@@ -382,7 +382,7 @@
                 },
                 "http-basic": {
                     "type": "object",
-                    "description": "A hash of domain name => {\"username\": \"...\", \"password\": \"...\"}.",
+                    "description": "An object of domain name => {\"username\": \"...\", \"password\": \"...\"}.",
                     "additionalProperties": {
                         "type": "object",
                         "required": ["username", "password"],
@@ -641,7 +641,7 @@
             "properties": {
                 "psr-0": {
                     "type": "object",
-                    "description": "This is a hash of namespaces (keys) and the directories they can be found in (values, can be arrays of paths) by the autoloader.",
+                    "description": "This is an object of namespaces (keys) and the directories they can be found in (values, can be arrays of paths) by the autoloader.",
                     "additionalProperties": {
                         "type": ["string", "array"],
                         "items": {
@@ -651,7 +651,7 @@
                 },
                 "psr-4": {
                     "type": "object",
-                    "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
+                    "description": "This is an object of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
                     "additionalProperties": {
                         "type": ["string", "array"],
                         "items": {

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -311,7 +311,7 @@
                     "type": ["string", "object"],
                     "description": "The install method Composer will prefer to use, defaults to auto and can be any of source, dist, auto, or an object of {\"pattern\": \"preference\"}.",
                     "additionalProperties": {
-                        "type": ["boolean"]
+                        "type": ["string"]
                     }
                 },
                 "notify-on-install": {

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -290,7 +290,7 @@
                 },
                 "allow-plugins": {
                     "type": ["object", "boolean"],
-                    "description": "This is an array of package names which are allowed to be loaded as plugins, or true to allow all, false to allow none, defaults to true.",
+                    "description": "This is an object of {\"pattern\": true|false} with packages which are allowed to be loaded as plugins, or true to allow all, false to allow none. Defaults to {} which prompts when an unknown plugin is added.",
                     "additionalProperties": {
                         "type": ["boolean"]
                     }
@@ -309,7 +309,7 @@
                 },
                 "preferred-install": {
                     "type": ["string", "object"],
-                    "description": "The install method Composer will prefer to use, defaults to auto and can be any of source, dist, auto, or a hash of {\"pattern\": \"preference\"}.",
+                    "description": "The install method Composer will prefer to use, defaults to auto and can be any of source, dist, auto, or an object of {\"pattern\": \"preference\"}.",
                     "additionalProperties": {
                         "type": ["boolean"]
                     }

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -288,6 +288,13 @@
                         "type": ["string", "boolean"]
                     }
                 },
+                "allow-plugins": {
+                    "type": ["array", "boolean"],
+                    "description": "This is an array of package names which are allowed to be loaded as plugins, or true to allow all, false to allow none, defaults to true.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "process-timeout": {
                     "type": "integer",
                     "description": "The timeout in seconds for process executions, defaults to 300 (5mins)."

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -289,10 +289,10 @@
                     }
                 },
                 "allow-plugins": {
-                    "type": ["array", "boolean"],
+                    "type": ["object", "boolean"],
                     "description": "This is an array of package names which are allowed to be loaded as plugins, or true to allow all, false to allow none, defaults to true.",
-                    "items": {
-                        "type": "string"
+                    "additionalProperties": {
+                        "type": ["boolean"]
                     }
                 },
                 "process-timeout": {
@@ -309,7 +309,10 @@
                 },
                 "preferred-install": {
                     "type": ["string", "object"],
-                    "description": "The install method Composer will prefer to use, defaults to auto and can be any of source, dist, auto, or a hash of {\"pattern\": \"preference\"}."
+                    "description": "The install method Composer will prefer to use, defaults to auto and can be any of source, dist, auto, or a hash of {\"pattern\": \"preference\"}.",
+                    "additionalProperties": {
+                        "type": ["boolean"]
+                    }
                 },
                 "notify-on-install": {
                     "type": "boolean",

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -562,12 +562,7 @@ EOT
                 return 0;
             }
 
-            $pluginPattern = $matches[1];
-            if ($input->getOption('unset')) {
-                $values[0] = 'false';
-            }
-
-            if (true !== $validation = $booleanValidator($values[0])) {
+            if (true !== $booleanValidator($values[0])) {
                 throw new \RuntimeException(sprintf(
                     '"%s" is an invalid value',
                     $values[0]

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -214,7 +214,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         // Open file in editor
-        if ($input->getOption('editor')) {
+        if (true === $input->getOption('editor')) {
             $editor = escapeshellcmd(Platform::getEnv('EDITOR'));
             if (!$editor) {
                 if (Platform::isWindows()) {
@@ -235,20 +235,20 @@ EOT
             return 0;
         }
 
-        if (!$input->getOption('global')) {
+        if (false === $input->getOption('global')) {
             $this->config->merge($this->configFile->read(), $this->configFile->getPath());
             $this->config->merge(array('config' => $this->authConfigFile->exists() ? $this->authConfigFile->read() : array()), $this->authConfigFile->getPath());
         }
 
         // List the configuration of the file settings
-        if ($input->getOption('list')) {
+        if (true === $input->getOption('list')) {
             $this->listConfiguration($this->config->all(), $this->config->raw(), $output, null, (bool) $input->getOption('source'));
 
             return 0;
         }
 
         $settingKey = $input->getArgument('setting-key');
-        if (!$settingKey || !is_string($settingKey)) {
+        if (!is_string($settingKey)) {
             return 0;
         }
 
@@ -555,7 +555,7 @@ EOT
         }
 
         // handle allow-plugins config setting elements true or false to add/remove
-        if (preg_match('{^allow-plugins\.([a-zA-Z0-9/*-]+)}', $settingKey, $matches)) {
+        if (Preg::isMatch('{^allow-plugins\.([a-zA-Z0-9/*-]+)}', $settingKey, $matches)) {
             if ($input->getOption('unset')) {
                 $this->configSource->removeConfigSetting($settingKey);
 

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -178,6 +178,11 @@ class Config
                 if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic', 'bearer')) && isset($this->config[$key])) {
                     $this->config[$key] = array_merge($this->config[$key], $val);
                     $this->setSourceOfConfigValue($val, $key, $source);
+                } elseif (in_array($key, array('allow-plugins')) && isset($this->config[$key]) && is_array($this->config[$key])) {
+                    // merging $val first to get the local config on top of the global one, then appending the global config,
+                    // then merging local one again to make sure the values from local win over global ones for keys present in both
+                    $this->config[$key] = array_merge($val, $this->config[$key], $val);
+                    $this->setSourceOfConfigValue($val, $key, $source);
                 } elseif (in_array($key, array('gitlab-domains', 'github-domains')) && isset($this->config[$key])) {
                     $this->config[$key] = array_unique(array_merge($this->config[$key], $val));
                     $this->setSourceOfConfigValue($val, $key, $source);

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -172,7 +172,7 @@ class Config
     /**
      * Merges new config values with the existing ones (overriding)
      *
-     * @param array<string, mixed> $config
+     * @param array<string, array{config?: array<string, mixed>, repositories?: array<string, mixed>}> $config
      * @param string $source
      *
      * @return void
@@ -182,15 +182,15 @@ class Config
         // override defaults with given config
         if (!empty($config['config']) && is_array($config['config'])) {
             foreach ($config['config'] as $key => $val) {
-                if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic', 'bearer')) && isset($this->config[$key])) {
+                if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic', 'bearer'), true) && isset($this->config[$key])) {
                     $this->config[$key] = array_merge($this->config[$key], $val);
                     $this->setSourceOfConfigValue($val, $key, $source);
-                } elseif (in_array($key, array('allow-plugins')) && isset($this->config[$key]) && is_array($this->config[$key])) {
+                } elseif (in_array($key, array('allow-plugins'), true) && isset($this->config[$key]) && is_array($this->config[$key])) {
                     // merging $val first to get the local config on top of the global one, then appending the global config,
                     // then merging local one again to make sure the values from local win over global ones for keys present in both
                     $this->config[$key] = array_merge($val, $this->config[$key], $val);
                     $this->setSourceOfConfigValue($val, $key, $source);
-                } elseif (in_array($key, array('gitlab-domains', 'github-domains')) && isset($this->config[$key])) {
+                } elseif (in_array($key, array('gitlab-domains', 'github-domains'), true) && isset($this->config[$key])) {
                     $this->config[$key] = array_unique(array_merge($this->config[$key], $val));
                     $this->setSourceOfConfigValue($val, $key, $source);
                 } elseif ('preferred-install' === $key && isset($this->config[$key])) {

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -172,7 +172,7 @@ class Config
     /**
      * Merges new config values with the existing ones (overriding)
      *
-     * @param array<string, array{config?: array<string, mixed>, repositories?: array<string, mixed>}> $config
+     * @param array{config?: array<string, mixed>, repositories?: array<mixed>} $config
      * @param string $source
      *
      * @return void

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -34,6 +34,7 @@ class Config
     public static $defaultConfig = array(
         'process-timeout' => 300,
         'use-include-path' => false,
+        'allow-plugins' => null, // null for BC for now, will become array() after July 2022
         'use-parent-dir' => 'prompt',
         'preferred-install' => 'dist',
         'notify-on-install' => true,
@@ -117,6 +118,12 @@ class Config
     {
         // load defaults
         $this->config = static::$defaultConfig;
+
+        // TODO after July 2022 remove this and update the default value above in self::$defaultConfig + remove note from 06-config.md
+        if (strtotime('2022-07-01') < time()) {
+            $this->config['allow-plugins'] = array();
+        }
+
         $this->repositories = static::$defaultRepositories;
         $this->useEnvironment = (bool) $useEnvironment;
         $this->baseDir = $baseDir;

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -287,7 +287,7 @@ class JsonConfigSource implements ConfigSourceInterface
         } catch (JsonValidationException $e) {
             // restore contents to the original state
             file_put_contents($this->file->getPath(), $contents);
-            throw new \RuntimeException('Failed to update composer.json with a valid format, reverting to the original content. Please report an issue to us with details (command you run and a copy of your composer.json).', 0, $e);
+            throw new \RuntimeException('Failed to update composer.json with a valid format, reverting to the original content. Please report an issue to us with details (command you run and a copy of your composer.json). '.PHP_EOL.implode(PHP_EOL, $e->getErrors()), 0, $e);
         }
 
         if ($newFile) {

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -628,7 +628,7 @@ class PluginManager
 
     /**
      * @param  array<string, bool>|bool|null $allowPluginsConfig
-     * @return ?string
+     * @return array<string, bool>|null
      */
     private function parseAllowedPlugins($allowPluginsConfig)
     {

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -687,7 +687,7 @@ class PluginManager
             if ($this->io->isInteractive()) {
                 $composer = $isGlobalPlugin ? $this->globalComposer : $this->composer;
 
-                $this->io->writeError('<warning>'.$package.' contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins</warning>');
+                $this->io->writeError('<warning>'.$package.($isGlobalPlugin ? ' (installed globally)' : '').' contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins</warning>');
                 while (true) {
                     switch ($answer = $this->io->ask('<warning>Do you trust "'.$package.'" to execute code and wish to enable the plugin now? [y,n,d,?]</warning> ', '?')) {
                         case 'y':
@@ -721,8 +721,8 @@ class PluginManager
                     }
                 }
             } else {
-                $this->io->writeError('<warning>'.$package.' contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe. See https://getcomposer.org/allow-plugins</warning>');
-                $this->io->writeError('<warning>You can run "composer config allow-plugins.'.$package.' [true|false]" to enable it (true) or keep it disabled and suppress this warning (false)</warning>');
+                $this->io->writeError('<warning>'.$package.($isGlobalPlugin ? ' (installed globally)' : '').' contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe. See https://getcomposer.org/allow-plugins</warning>');
+                $this->io->writeError('<warning>You can run "composer '.($isGlobalPlugin ? 'global ' : '').'config --no-plugins allow-plugins.'.$package.' [true|false]" to enable it (true) or keep it disabled and suppress this warning (false)</warning>');
             }
             $warned[$package] = true;
         }

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -376,6 +376,10 @@ class PluginManager
      */
     public function addPlugin(PluginInterface $plugin, $isGlobalPlugin = false, PackageInterface $sourcePackage = null)
     {
+        if (!$sourcePackage) {
+            trigger_error('Calling PluginManager::addPlugin without $sourcePackage is deprecated, if you are using this please get in touch with us to explain the use case', E_USER_DEPRECATED);
+        }
+
         if ($sourcePackage && !$this->isPluginAllowed($sourcePackage->getName(), $isGlobalPlugin)) {
             $this->io->writeError('Skipped loading "'.get_class($plugin).' from '.$sourcePackage->getName() . '" '.($isGlobalPlugin ? '(installed globally) ' : '').' as it is not in config.allow-plugins', true, IOInterface::DEBUG);
             return;

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -165,7 +165,7 @@ class PluginManager
         }
 
         if (!$this->isPluginAllowed($package->getName(), $isGlobalPlugin)) {
-            $this->io->writeError('Skipped loading "'.$package->getName() . '" '.($isGlobalPlugin ? '(installed globally) ' : '').' as it is not in config.allow-plugins', true, IOInterface::DEBUG);
+            $this->io->writeError('Skipped loading "'.$package->getName() . '" '.($isGlobalPlugin ? '(installed globally) ' : '').'as it is not in config.allow-plugins', true, IOInterface::DEBUG);
             return;
         }
 
@@ -666,6 +666,7 @@ class PluginManager
             if (!$this->io->isInteractive()) {
                 if (!isset($warned['all'])) {
                     $this->io->writeError('<warning>For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins</warning>');
+                    $this->io->writeError('<warning>You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins.</warning>');
                     $warned['all'] = true;
                 }
 

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -688,7 +688,7 @@ class PluginManager
 
                 $this->io->writeError('<warning>'.$package.($isGlobalPlugin ? ' (installed globally)' : '').' contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins</warning>');
                 while (true) {
-                    switch ($answer = $this->io->ask('<warning>Do you trust "'.$package.'" to execute code and wish to enable the plugin now? [y,n,d,?]</warning> ', '?')) {
+                    switch ($answer = $this->io->ask('<warning>Do you trust "'.$package.'" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]</warning> ', '?')) {
                         case 'y':
                         case 'n':
                         case 'd':

--- a/tests/Composer/Test/Fixtures/functional/installed-versions/composer.json
+++ b/tests/Composer/Test/Fixtures/functional/installed-versions/composer.json
@@ -17,5 +17,8 @@
     },
     "autoload": {
         "classmap": ["Hooks.php"]
+    },
+    "config": {
+        "allow-plugins": true
     }
 }

--- a/tests/Composer/Test/Fixtures/functional/installed-versions2/composer.json
+++ b/tests/Composer/Test/Fixtures/functional/installed-versions2/composer.json
@@ -17,5 +17,8 @@
     },
     "autoload": {
         "classmap": ["Hooks.php"]
+    },
+    "config": {
+        "allow-plugins": true
     }
 }

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -114,16 +114,17 @@ class PluginInstallerTest extends TestCase
         $this->composer->setEventDispatcher(new EventDispatcher($this->composer, $this->io));
         $this->composer->setPackage(new RootPackage('dummy/root', '1.0.0.0', '1.0.0'));
 
-        $this->pm = new PluginManager($this->io, $this->composer);
-        $this->composer->setPluginManager($this->pm);
-
         $config->merge(array(
             'config' => array(
                 'vendor-dir' => $this->directory.'/Fixtures/',
                 'home' => $this->directory.'/Fixtures',
                 'bin-dir' => $this->directory.'/Fixtures/bin',
+                'allow-plugins' => true,
             ),
         ));
+
+        $this->pm = new PluginManager($this->io, $this->composer);
+        $this->composer->setPluginManager($this->pm);
     }
 
     protected function tearDown()
@@ -146,7 +147,6 @@ class PluginInstallerTest extends TestCase
         $plugins = $this->pm->getPlugins();
         $this->assertEquals('installer-v1', $plugins[0]->version);  // @phpstan-ignore-line
         $this->assertEquals(
-            '<warning>For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins</warning>'.PHP_EOL.
             'activate v1'.PHP_EOL,
             $this->io->getOutput()
         );

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -145,7 +145,11 @@ class PluginInstallerTest extends TestCase
 
         $plugins = $this->pm->getPlugins();
         $this->assertEquals('installer-v1', $plugins[0]->version);  // @phpstan-ignore-line
-        $this->assertEquals('activate v1'.PHP_EOL, $this->io->getOutput());
+        $this->assertEquals(
+            '<warning>For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins</warning>'.PHP_EOL.
+            'activate v1'.PHP_EOL,
+            $this->io->getOutput()
+        );
     }
 
     public function testInstallMultiplePlugins()


### PR DESCRIPTION
Fixes #5659

Still a few TODOs / open questions

- [x] Currently this warns on every operation once you have a plugin which is not enabled, I am not sure if this gets annoying or not. Are there cases where you want to have plugins installed but not enable them? Or is this only a safety net?
![image](https://user-images.githubusercontent.com/183678/143499308-e99636e4-f547-4067-ba78-70a220e7606c.png)
- [x] Probably would be nicer if it instead prompted the user if the plugin should be added or not when something doesn't match the allow-plugins rules. Default to no of course.. Then we could modify the config in band and proceed activating the plugin if desired. Otherwise store it in a disallow-plugins list to make explicit those you don't wanna hear about again?
- [x] Docs
- [x] add the new `/allow-plugins` shortlink on getcomposer.org