### PR TITLE
Add support for ignoring the upper bound of platform requirements using "name+" notation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
     ],
     "scripts": {
         "compile": "@php -dphar.readonly=0 bin/compile",
-        "test": "simple-phpunit",
+        "test": "@php simple-phpunit",
         "phpstan-setup": [
             "@composer config platform --unset",
             "@composer update",

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -117,7 +117,10 @@ resolution.
   See also the [`platform`](06-config.md#platform) config option.
 * **--ignore-platform-req:** ignore a specific platform requirement(`php`,
   `hhvm`, `lib-*` and `ext-*`) and force the installation even if the local machine
-  does not fulfill it. Multiple requirements can be ignored via wildcard.
+  does not fulfill it. Multiple requirements can be ignored via wildcard. Appending
+  a `+` makes it only ignore the upper-bound of the requirements. For example, if a package
+  requires `php: ^7`, then the option `--ignore-platform-req=php+` would allow installing on PHP8,
+  but installation on PHP 5.6 would still fail.
 
 ## update / u
 
@@ -202,7 +205,10 @@ php composer.phar update vendor/package:2.0.1 vendor/package2:3.0.*
   See also the [`platform`](06-config.md#platform) config option.
 * **--ignore-platform-req:** ignore a specific platform requirement(`php`,
   `hhvm`, `lib-*` and `ext-*`) and force the installation even if the local machine
-  does not fulfill it. Multiple requirements can be ignored via wildcard.
+  does not fulfill it. Multiple requirements can be ignored via wildcard. Appending
+  a `+` makes it only ignore the upper-bound of the requirements. For example, if a package
+  requires `php: ^7`, then the option `--ignore-platform-req=php+` would allow installing on PHP8,
+  but installation on PHP 5.6 would still fail.
 * **--prefer-stable:** Prefer stable versions of dependencies.
 * **--prefer-lowest:** Prefer lowest versions of dependencies. Useful for testing minimal
   versions of requirements, generally used with `--prefer-stable`.

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -12,6 +12,7 @@
 
 namespace Composer\DependencyResolver;
 
+use Composer\Filter\PlatformRequirementFilter\IgnoreListPlatformRequirementFilter;
 use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterInterface;
 use Composer\IO\IOInterface;
@@ -174,6 +175,8 @@ class Solver
         foreach ($request->getRequires() as $packageName => $constraint) {
             if ($platformRequirementFilter->isIgnored($packageName)) {
                 continue;
+            } elseif ($platformRequirementFilter instanceof IgnoreListPlatformRequirementFilter) {
+                $constraint = $platformRequirementFilter->filterConstraint($packageName, $constraint);
             }
 
             if (!$this->pool->whatProvides($packageName, $constraint)) {

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
@@ -5,20 +5,40 @@ namespace Composer\Filter\PlatformRequirementFilter;
 use Composer\Package\BasePackage;
 use Composer\Pcre\Preg;
 use Composer\Repository\PlatformRepository;
+use Composer\Semver\Constraint\Constraint;
+use Composer\Semver\Constraint\ConstraintInterface;
+use Composer\Semver\Constraint\MatchAllConstraint;
+use Composer\Semver\Constraint\MultiConstraint;
+use Composer\Semver\Interval;
+use Composer\Semver\Intervals;
 
 final class IgnoreListPlatformRequirementFilter implements PlatformRequirementFilterInterface
 {
     /**
      * @var string
      */
-    private $regexp;
+    private $ignoreRegex;
+
+    /**
+     * @var string
+     */
+    private $ignoreUpperBoundRegex;
 
     /**
      * @param string[] $reqList
      */
     public function __construct(array $reqList)
     {
-        $this->regexp = BasePackage::packageNamesToRegexp($reqList);
+        $ignoreAll = $ignoreUpperBound = array();
+        foreach ($reqList as $req) {
+            if (substr($req, -1) === '+') {
+                $ignoreUpperBound[] = substr($req, 0, -1);
+            } else {
+                $ignoreAll[] = $req;
+            }
+        }
+        $this->ignoreRegex = BasePackage::packageNamesToRegexp($ignoreAll);
+        $this->ignoreUpperBoundRegex = BasePackage::packageNamesToRegexp($ignoreUpperBound);
     }
 
     /**
@@ -31,6 +51,33 @@ final class IgnoreListPlatformRequirementFilter implements PlatformRequirementFi
             return false;
         }
 
-        return Preg::isMatch($this->regexp, $req);
+        return Preg::isMatch($this->ignoreRegex, $req);
+    }
+
+    /**
+     * @param string $req
+     * @return ConstraintInterface
+     */
+    public function filterConstraint($req, ConstraintInterface $constraint)
+    {
+        if (!PlatformRepository::isPlatformPackage($req)) {
+            return $constraint;
+        }
+
+        if (!Preg::isMatch($this->ignoreUpperBoundRegex, $req)) {
+            return $constraint;
+        }
+
+        if (Preg::isMatch($this->ignoreRegex, $req)) {
+            return new MatchAllConstraint;
+        }
+
+        $intervals = Intervals::get($constraint);
+        $last = end($intervals['numeric']);
+        if ($last !== false && (string) $last->getEnd() !== (string) Interval::untilPositiveInfinity()) {
+            $constraint = new MultiConstraint(array($constraint, new Constraint('>=', $last->getEnd()->getVersion())), false);
+        }
+
+        return $constraint;
     }
 }

--- a/tests/Composer/Test/Fixtures/installer/platform-ext-solver-problems.test
+++ b/tests/Composer/Test/Fixtures/installer/platform-ext-solver-problems.test
@@ -47,7 +47,7 @@ Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
     - Root composer.json requires a/a * -> satisfiable by a/a[1.0.0].
-    - a/a 1.0.0 requires ext-filter 2.0.0 -> it has the wrong version (7.4.0; overridden via config.platform, actual: %s) installed. Install or enable PHP's filter extension.
+    - a/a 1.0.0 requires ext-filter 2.0.0 -> it has the wrong version installed (7.4.0; overridden via config.platform, actual: %s).
 
 To enable extensions, verify that they are enabled in your .ini files:
 __inilist__

--- a/tests/Composer/Test/Fixtures/installer/solver-problems.test
+++ b/tests/Composer/Test/Fixtures/installer/solver-problems.test
@@ -119,7 +119,7 @@ Your requirements could not be resolved to an installable set of packages.
   Problem 6
     - Root composer.json requires linked library lib-icu 1001.* but it has the wrong version installed, try upgrading the intl extension.
   Problem 7
-    - Root composer.json requires PHP extension ext-xml 1002.* but it has the wrong version (%s) installed. Install or enable PHP's xml extension.
+    - Root composer.json requires PHP extension ext-xml 1002.* but it has the wrong version installed (%s).
   Problem 8
     - Root composer.json requires php 1 but your php version (%s) does not satisfy that requirement.
   Problem 9
@@ -161,4 +161,3 @@ Alternatively, you can run Composer with `--ignore-platform-req=ext-xml` to temp
 Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
 
 --EXPECT--
-

--- a/tests/Composer/Test/Fixtures/installer/update-ignore-platform-package-requirement-list-upper-bounds.test
+++ b/tests/Composer/Test/Fixtures/installer/update-ignore-platform-package-requirement-list-upper-bounds.test
@@ -40,7 +40,7 @@ Your requirements could not be resolved to an installable set of packages.
     - Root composer.json requires PHP extension ext-foo-baz [== 9.0.0.0 || >= 9.0.0.0] but it is missing from your system. Install or enable PHP's foo-baz extension.
   Problem 2
     - Root composer.json requires b/b 1.0.* -> satisfiable by b/b[1.0.1].
-    - b/b 1.0.1 requires ext-foo-bar 10.* -> it has the wrong version (5.0.3 provided by __root__ 1.0.0+no-version-set) installed. Install or enable PHP's foo-bar extension.
+    - b/b 1.0.1 requires ext-foo-bar 10.* -> it has the wrong version installed (5.0.3 provided by __root__ 1.0.0+no-version-set).
 
 To enable extensions, verify that they are enabled in your .ini files:
 __inilist__

--- a/tests/Composer/Test/Fixtures/installer/update-ignore-platform-package-requirement-list-upper-bounds.test
+++ b/tests/Composer/Test/Fixtures/installer/update-ignore-platform-package-requirement-list-upper-bounds.test
@@ -1,0 +1,50 @@
+--TEST--
+Update with ignore-platform-req list ignoring upper bound of a dependency
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "a/a", "version": "1.0.1", "require": { "ext-foo-bar": "3.*" } },
+                { "name": "b/b", "version": "1.0.1", "require": { "ext-foo-bar": "10.*" } }
+            ]
+        }
+    ],
+    "require": {
+        "a/a": "1.0.*",
+        "b/b": "1.0.*",
+        "php": "^4.3",
+        "ext-foo-baz": "9.0.0"
+    },
+    "provide": {
+        "ext-foo-bar": "5.0.3"
+    }
+}
+--INSTALLED--
+[
+    { "name": "a/a", "version": "1.0.0" }
+]
+--RUN--
+update --ignore-platform-req=php+ --ignore-platform-req=ext-foo-bar+ --ignore-platform-req=ext-foo-baz+
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires PHP extension ext-foo-baz [== 9.0.0.0 || >= 9.0.0.0] but it is missing from your system. Install or enable PHP's foo-baz extension.
+  Problem 2
+    - Root composer.json requires b/b 1.0.* -> satisfiable by b/b[1.0.1].
+    - b/b 1.0.1 requires ext-foo-bar 10.* -> it has the wrong version (5.0.3 provided by __root__ 1.0.0+no-version-set) installed. Install or enable PHP's foo-bar extension.
+
+To enable extensions, verify that they are enabled in your .ini files:
+__inilist__
+You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
+Alternatively, you can run Composer with `--ignore-platform-req=ext-foo-baz --ignore-platform-req=ext-foo-bar` to temporarily ignore these required extensions.
+
+--EXPECT--

--- a/tests/deprecations-8.1.json
+++ b/tests/deprecations-8.1.json
@@ -77,12 +77,12 @@
     {
         "location": "Composer\\Test\\InstallerTest::testIntegrationWithRawPool",
         "message": "preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated",
-        "count": 1800
+        "count": 1820
     },
     {
         "location": "Composer\\Test\\InstallerTest::testIntegrationWithPoolOptimizer",
         "message": "preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated",
-        "count": 1800
+        "count": 1820
     },
     {
         "location": "Composer\\Test\\Package\\Archiver\\ArchivableFilesFinderTest::testManualExcludes",


### PR DESCRIPTION
e.g. `--ignore-platform-req=php+` ignores the upper bound of the php requirements.

- [x] TODO docs but would like to hear if anyone has objections to the idea/impl first

Fixes https://github.com/composer/composer/issues/9534
