### PR TITLE
Drivers: avoid early initialize of tags and branches

### DIFF
--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -293,7 +293,7 @@ class GitBitbucketDriver extends VcsDriver
         }
 
         if (null === $this->tags) {
-            $this->tags = array();
+            $tags = array();
             $resource = sprintf(
                 '%s?%s',
                 $this->tagsUrl,
@@ -311,7 +311,7 @@ class GitBitbucketDriver extends VcsDriver
             while ($hasNext) {
                 $tagsData = $this->fetchWithOAuthCredentials($resource)->decodeJson();
                 foreach ($tagsData['values'] as $data) {
-                    $this->tags[$data['name']] = $data['target']['hash'];
+                    $tags[$data['name']] = $data['target']['hash'];
                 }
                 if (empty($tagsData['next'])) {
                     $hasNext = false;
@@ -319,6 +319,8 @@ class GitBitbucketDriver extends VcsDriver
                     $resource = $tagsData['next'];
                 }
             }
+
+            $this->tags = $tags;
         }
 
         return $this->tags;
@@ -334,7 +336,7 @@ class GitBitbucketDriver extends VcsDriver
         }
 
         if (null === $this->branches) {
-            $this->branches = array();
+            $branches = array();
             $resource = sprintf(
                 '%s?%s',
                 $this->branchesUrl,
@@ -352,7 +354,7 @@ class GitBitbucketDriver extends VcsDriver
             while ($hasNext) {
                 $branchData = $this->fetchWithOAuthCredentials($resource)->decodeJson();
                 foreach ($branchData['values'] as $data) {
-                    $this->branches[$data['name']] = $data['target']['hash'];
+                    $branches[$data['name']] = $data['target']['hash'];
                 }
                 if (empty($branchData['next'])) {
                     $hasNext = false;
@@ -360,6 +362,8 @@ class GitBitbucketDriver extends VcsDriver
                     $resource = $branchData['next'];
                 }
             }
+
+            $this->branches = $branches;
         }
 
         return $this->branches;

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -322,18 +322,20 @@ class GitHubDriver extends VcsDriver
             return $this->gitDriver->getTags();
         }
         if (null === $this->tags) {
-            $this->tags = array();
+            $tags = array();
             $resource = $this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/tags?per_page=100';
 
             do {
                 $response = $this->getContents($resource);
                 $tagsData = $response->decodeJson();
                 foreach ($tagsData as $tag) {
-                    $this->tags[$tag['name']] = $tag['commit']['sha'];
+                    $tags[$tag['name']] = $tag['commit']['sha'];
                 }
 
                 $resource = $this->getNextPage($response);
             } while ($resource);
+
+            $this->tags = $tags;
         }
 
         return $this->tags;
@@ -348,7 +350,7 @@ class GitHubDriver extends VcsDriver
             return $this->gitDriver->getBranches();
         }
         if (null === $this->branches) {
-            $this->branches = array();
+            $branches = array();
             $resource = $this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/git/refs/heads?per_page=100';
 
             do {
@@ -357,12 +359,14 @@ class GitHubDriver extends VcsDriver
                 foreach ($branchData as $branch) {
                     $name = substr($branch['ref'], 11);
                     if ($name !== 'gh-pages') {
-                        $this->branches[$name] = $branch['object']['sha'];
+                        $branches[$name] = $branch['object']['sha'];
                     }
                 }
 
                 $resource = $this->getNextPage($response);
             } while ($resource);
+
+            $this->branches = $branches;
         }
 
         return $this->branches;

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -222,7 +222,7 @@ class SvnDriver extends VcsDriver
     public function getTags()
     {
         if (null === $this->tags) {
-            $this->tags = array();
+            $tags = array();
 
             if ($this->tagsPath !== false) {
                 $output = $this->execute('svn ls --verbose', $this->baseUrl . '/' . $this->tagsPath);
@@ -231,7 +231,7 @@ class SvnDriver extends VcsDriver
                         $line = trim($line);
                         if ($line && preg_match('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
                             if (isset($match[1], $match[2]) && $match[2] !== './') {
-                                $this->tags[rtrim($match[2], '/')] = $this->buildIdentifier(
+                                $tags[rtrim($match[2], '/')] = $this->buildIdentifier(
                                     '/' . $this->tagsPath . '/' . $match[2],
                                     $match[1]
                                 );
@@ -240,6 +240,8 @@ class SvnDriver extends VcsDriver
                     }
                 }
             }
+
+            $this->tags = $tags;
         }
 
         return $this->tags;
@@ -251,7 +253,7 @@ class SvnDriver extends VcsDriver
     public function getBranches()
     {
         if (null === $this->branches) {
-            $this->branches = array();
+            $branches = array();
 
             if (false === $this->trunkPath) {
                 $trunkParent = $this->baseUrl . '/';
@@ -265,11 +267,11 @@ class SvnDriver extends VcsDriver
                     $line = trim($line);
                     if ($line && preg_match('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
                         if (isset($match[1], $match[2]) && $match[2] === './') {
-                            $this->branches['trunk'] = $this->buildIdentifier(
+                            $branches['trunk'] = $this->buildIdentifier(
                                 '/' . $this->trunkPath,
                                 $match[1]
                             );
-                            $this->rootIdentifier = $this->branches['trunk'];
+                            $this->rootIdentifier = $branches['trunk'];
                             break;
                         }
                     }
@@ -284,7 +286,7 @@ class SvnDriver extends VcsDriver
                         $line = trim($line);
                         if ($line && preg_match('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
                             if (isset($match[1], $match[2]) && $match[2] !== './') {
-                                $this->branches[rtrim($match[2], '/')] = $this->buildIdentifier(
+                                $branches[rtrim($match[2], '/')] = $this->buildIdentifier(
                                     '/' . $this->branchesPath . '/' . $match[2],
                                     $match[1]
                                 );
@@ -293,6 +295,8 @@ class SvnDriver extends VcsDriver
                     }
                 }
             }
+
+            $this->branches = $branches;
         }
 
         return $this->branches;


### PR DESCRIPTION
Initializing `$this->branches` and `$this->tags` before the data is fetched can lead to wrong/inconsistent data

Example:
calling `$this->getBranches()` once while it throw a 5XX error on the first request (including retries) and then catching that exception here https://github.com/composer/composer/blob/012556d/src/Composer/Repository/VcsRepository.php#L214 results in the driver having an empty branches array stored. Calling it further down will then just return an empty array.

In addition to this PR, I am not sure the VcsRepository should just catch any kind of exception here and ignore it. I feel at least 5XX responses, request timeouts, network errors and such should be thrown again https://github.com/composer/composer/blob/012556d/src/Composer/Repository/VcsRepository.php#L214