### PR TITLE
Install full binaries on Windows by default

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -103,7 +103,7 @@ class BinaryInstaller
                 $binCompat = 'full';
             }
 
-            if ($this->binCompat === "full") {
+            if ($binCompat === "full") {
                 $this->installFullBinaries($binPath, $link, $bin, $package);
             } else {
                 $this->installUnixyProxyBinaries($binPath, $link);


### PR DESCRIPTION
A bug was introduced in #10137 that leads
to the situation that by default .bat binaries
are not installed on Windows any more.

Check the correct variable to install .bat
files on Windows by default again.