### PR TITLE
fix typo

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -356,12 +356,12 @@ EOF;
             }
         }
 
-        foreach ($ambiguousClasses as $className => $ambigiousPaths) {
+        foreach ($ambiguousClasses as $className => $ambiguousPaths) {
             $cleanPath = str_replace(array('$vendorDir . \'', '$baseDir . \'', "',\n"), array($vendorPath, $basePath, ''), $classMap[$className]);
 
             $this->io->writeError(
                 '<warning>Warning: Ambiguous class resolution, "'.$className.'"'.
-                ' was found '. (count($ambigiousPaths) + 1) .'x: in "'.$cleanPath.'" and "'. implode('", "', $ambigiousPaths) .'", the first will be used.</warning>'
+                ' was found '. (count($ambiguousPaths) + 1) .'x: in "'.$cleanPath.'" and "'. implode('", "', $ambiguousPaths) .'", the first will be used.</warning>'
             );
         }
 

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -414,7 +414,7 @@ class PoolBuilder
             }
         }
 
-        // if propogateUpdate is false we are loading a fixed or locked package, root aliases do not apply as they are
+        // if propagateUpdate is false we are loading a fixed or locked package, root aliases do not apply as they are
         // manually loaded as separate packages in this case
         if ($propagateUpdate && isset($this->rootAliases[$name][$package->getVersion()])) {
             $alias = $this->rootAliases[$name][$package->getVersion()];

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -176,7 +176,7 @@ class Filesystem
      * @param string $directory
      * @param bool   $fallbackToPhp
      *
-     * @return bool|null Returns null, when no edge case was hit. Otherwise a bool whether removal was successfull
+     * @return bool|null Returns null, when no edge case was hit. Otherwise a bool whether removal was successful
      */
     private function removeEdgeCases($directory, $fallbackToPhp = true)
     {


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. 2.1 or similar if such a branch exists, or 1.10 if it is a critical fix that should be fixed in Composer 1)

For new features and everything else, use the main branch. -->

Hello!

I found typos, using [typos-cli](https://github.com/crate-ci/typos).