### PR TITLE
Fixed documentation for cache-dir location in case of XDG

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -997,8 +997,11 @@ directory to something other than `vendor/bin`.
 The `COMPOSER_CACHE_DIR` var allows you to change the Composer cache directory,
 which is also configurable via the [`cache-dir`](06-config.md#cache-dir) option.
 
-By default, it points to `$COMPOSER_HOME/cache` on \*nix and macOS, and
-`C:\Users\<user>\AppData\Local\Composer` (or `%LOCALAPPDATA%/Composer`) on Windows.
+By default, it points to `C:\Users\<user>\AppData\Local\Composer` (or `%LOCALAPPDATA%/Composer`) on Windows.
+On \*nix systems that follow the [XDG Base
+Directory Specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html),
+it points to `$XDG_CACHE_HOME/composer`. On other \*nix systems and on macOS, it points to
+`$COMPOSER_HOME/cache`.
 
 ### COMPOSER_CAFILE
 


### PR DESCRIPTION
This is fix for #8625 