### PR TITLE
Make it explicitly clear that `dev-` shouldn't be in the actual branch name

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -342,8 +342,9 @@ project to use the patched version. If the library is on GitHub (this is the
 case most of the time), you can fork it there and push your changes to
 your fork. After that you update the project's `composer.json`. All you have
 to do is add your fork as a repository and update the version constraint to
-point to your custom branch. In `composer.json`, you should prefix your custom
-branch name with `"dev-"`. For version constraint naming conventions see
+point to your custom branch. In `composer.json` only, you should prefix your
+custom branch name with `"dev-"` (without making it part of the actual branch
+name). For version constraint naming conventions see
 [Libraries](02-libraries.md) for more information.
 
 Example assuming you patched monolog to fix a bug in the `bugfix` branch:


### PR DESCRIPTION
According to https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository, "you should prefix your custom branch name with 'dev-'", but doing so doesn't work.  It needs to be stated that this should only happen in `composer.json`, not the actual branch name.

I've been confused by this [along with many others](https://stackoverflow.com/questions/13498519/how-to-require-a-fork-with-composer#comment82782412_13500676).

Please update the docs with the request to save others some trouble.  Thanks!

I chose the `main` branch because there were too many unrelated changed, but feel free to cherry-pick for 2.1 .