### PR TITLE
Search improvements

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -420,7 +420,9 @@ You can also search for more than one term by passing multiple arguments.
 
 ### Options
 
-* **--only-name (-N):** Search only in name.
+* **--only-name (-N):** Search only in package names.
+* **--only-vendor (-O):** Search only for vendor / organization names, returns only "vendor"
+  as result.
 * **--type (-t):** Search for a specific package type.
 * **--format (-f):** Lets you pick between text (default) or json output format.
   Note that in the json, only the name and description keys are guaranteed to be

--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -287,6 +287,23 @@ class Cache
     }
 
     /**
+     * @param string $file
+     * @return int|false
+     * @phpstan-return int<0, max>|false
+     */
+    public function getAge($file)
+    {
+        if ($this->isEnabled()) {
+            $file = Preg::replace('{[^'.$this->allowlist.']}i', '-', $file);
+            if (file_exists($this->root . $file) && ($mtime = filemtime($this->root . $file)) !== false) {
+                return abs(time() - $mtime);
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param int $ttl
      * @param int $maxSize
      *

--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -38,7 +38,8 @@ class SearchCommand extends BaseCommand
             ->setName('search')
             ->setDescription('Searches for packages.')
             ->setDefinition(array(
-                new InputOption('only-name', 'N', InputOption::VALUE_NONE, 'Search only in name'),
+                new InputOption('only-name', 'N', InputOption::VALUE_NONE, 'Search only in package names'),
+                new InputOption('only-vendor', 'O', InputOption::VALUE_NONE, 'Search only for vendor / organization names, returns only "vendor" as result'),
                 new InputOption('type', 't', InputOption::VALUE_REQUIRED, 'Search for a specific package type'),
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
                 new InputArgument('tokens', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'tokens to search for'),
@@ -77,11 +78,24 @@ EOT
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'search', $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
 
-        $onlyName = $input->getOption('only-name');
-        $type = $input->getOption('type') ?: null;
+        $mode = RepositoryInterface::SEARCH_FULLTEXT;
+        if ($input->getOption('only-name') === true) {
+            if ($input->getOption('only-vendor') === true) {
+                throw new \InvalidArgumentException('--only-name and --only-vendor cannot be used together');
+            }
+            $mode = RepositoryInterface::SEARCH_NAME;
+        } elseif ($input->getOption('only-vendor') === true) {
+            $mode = RepositoryInterface::SEARCH_VENDOR;
+        }
 
-        $flags = $onlyName ? RepositoryInterface::SEARCH_NAME : RepositoryInterface::SEARCH_FULLTEXT;
-        $results = $repos->search(implode(' ', $input->getArgument('tokens')), $flags, $type);
+        $type = $input->getOption('type');
+
+        $query = implode(' ', $input->getArgument('tokens'));
+        if ($mode !== RepositoryInterface::SEARCH_FULLTEXT) {
+            $query = preg_quote($query);
+        }
+
+        $results = $repos->search($query, $mode, $type);
 
         if ($results && $format === 'text') {
             $width = $this->getTerminalWidth();

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -727,4 +727,14 @@ class PlatformRepository extends ArrayRepository
     {
         return self::$lastSeenPlatformPhp;
     }
+
+    public function search($query, $mode = 0, $type = null)
+    {
+        // suppress vendor search as there are no vendors to match in platform packages
+        if ($mode === self::SEARCH_VENDOR) {
+            return array();
+        }
+
+        return parent::search($query, $mode, $type);
+    }
 }

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -27,6 +27,7 @@ interface RepositoryInterface extends \Countable
 {
     const SEARCH_FULLTEXT = 0;
     const SEARCH_NAME = 1;
+    const SEARCH_VENDOR = 2;
 
     /**
      * Checks if specified package registered (installed).
@@ -85,11 +86,11 @@ interface RepositoryInterface extends \Countable
     /**
      * Searches the repository for packages containing the query
      *
-     * @param string $query search query
-     * @param int    $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only
+     * @param string $query search query, for SEARCH_NAME and SEARCH_VENDOR regular expressions metacharacters are supported by implementations, and user input should be escaped through preg_quote by callers
+     * @param int    $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only, default is SEARCH_FULLTEXT
      * @param string $type  The type of package to search for. Defaults to all types of packages
      *
-     * @return array[] an array of array('name' => '...', 'description' => '...'|null)
+     * @return array[] an array of array('name' => '...', 'description' => '...'|null, 'abandoned' => 'string'|true|unset) For SEARCH_VENDOR the name will be in "vendor" form
      * @phpstan-return list<array{name: string, description: ?string, abandoned?: string|true}>
      */
     public function search($query, $mode = 0, $type = null);


### PR DESCRIPTION
- Performance improvements by caching the /packages.json (only when searching) and /packages/list.json responses for up to 600 seconds and optimizing some code (fixes #10123)
- Add SEARCH_VENDOR search type (fixes #10325)
- Fixes and documents regex searchability at API level, preg_quote user content in search cmd (fixes #10324)

This lays groundwork to be able to further speed up #10320 