### PR TITLE
ErrorHandler PHP 8.1 compatibility

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -10,6 +10,7 @@ require __DIR__.'/../src/bootstrap.php';
 
 use Composer\Console\Application;
 use Composer\XdebugHandler\XdebugHandler;
+use Composer\Util\ErrorHandler;
 
 error_reporting(-1);
 
@@ -56,6 +57,8 @@ if (function_exists('ini_set')) {
 }
 
 putenv('COMPOSER_BINARY='.realpath($_SERVER['argv'][0]));
+
+ErrorHandler::register();
 
 // run the command application
 $application = new Application();

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -127,6 +127,8 @@ class Application extends BaseApplication
         $io = $this->io = new ConsoleIO($input, $output, new HelperSet(array(
             new QuestionHelper(),
         )));
+
+        // Register error handler again to pass it the IO instance
         ErrorHandler::register($io);
 
         if ($input->hasParameterOption('--no-cache')) {

--- a/src/Composer/Util/ErrorHandler.php
+++ b/src/Composer/Util/ErrorHandler.php
@@ -57,6 +57,9 @@ class ErrorHandler
             if (preg_match('{^Return type of (Symfony|Composer)\\\\.*ReturnTypeWillChange}is', $message)) {
                 return true;
             }
+            if (strpos(strtr($file, '\\', '/'), 'vendor/symfony/') !== false) {
+                return true;
+            }
 
             self::$io->writeError('<warning>Deprecation Notice: '.$message.' in '.$file.':'.$line.'</warning>');
             if (self::$io->isVerbose()) {

--- a/src/Composer/Util/ErrorHandler.php
+++ b/src/Composer/Util/ErrorHandler.php
@@ -52,6 +52,12 @@ class ErrorHandler
         }
 
         if (self::$io) {
+            // ignore symfony/* deprecation warnings about return types
+            // also ignore them from the Composer namespace, as 1.x won't get all that fixed anymore
+            if (preg_match('{^Return type of (Symfony|Composer)\\\\.*ReturnTypeWillChange}is', $message)) {
+                return true;
+            }
+
             self::$io->writeError('<warning>Deprecation Notice: '.$message.' in '.$file.':'.$line.'</warning>');
             if (self::$io->isVerbose()) {
                 self::$io->writeError('<warning>Stack trace:</warning>');


### PR DESCRIPTION
Ports changes from 2.1/main that load `ErrorHandler` early, ignore all deprecation warnings from `vendor/symfony/`, and ignores all return type related deprecation warnings for both the `Symfony` and `Composer` namespaces.

As discussed in #10008.

Broken before:

```
~ $ php -v
PHP 8.1.0 (cli) (built: Dec  8 2021 20:43:30) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.0, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.0, Copyright (c), by Zend Technologies
    with blackfire v1.71.0~linux-x64-non_zts81, https://blackfire.io, by Blackfire


~ $ composer --version
PHP Deprecated:  Return type of Symfony\Component\Console\Helper\HelperSet::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/console/Helper/HelperSet.php on line 112

Deprecated: Return type of Symfony\Component\Console\Helper\HelperSet::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/console/Helper/HelperSet.php on line 112
Deprecation Notice: Return type of Composer\Repository\ArrayRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/ArrayRepository.php:206
Deprecation Notice: Return type of Composer\Repository\ArrayRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/ArrayRepository.php:206
Deprecation Notice: Return type of Composer\Repository\ArrayRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/ArrayRepository.php:206
Composer version 1.10.23 2021-10-05 09:44:27


~ $ composer config bin-dir
PHP Deprecated:  Return type of Symfony\Component\Console\Helper\HelperSet::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/console/Helper/HelperSet.php on line 112

Deprecated: Return type of Symfony\Component\Console\Helper\HelperSet::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/console/Helper/HelperSet.php on line 112
Deprecation Notice: Return type of Composer\Repository\ArrayRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/ArrayRepository.php:206
Deprecation Notice: Return type of Composer\Repository\ArrayRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/ArrayRepository.php:206
Deprecation Notice: Return type of Composer\Repository\ArrayRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/ArrayRepository.php:206
Deprecation Notice: Return type of Symfony\Component\Finder\Finder::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Finder.php:675
Deprecation Notice: Return type of Symfony\Component\Finder\Finder::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Finder.php:732
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\FilterIterator::rewind() should either be compatible with FilterIterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/FilterIterator.php:30
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\FileTypeFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/FileTypeFilterIterator.php:42
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator::getChildren() should either be compatible with RecursiveDirectoryIterator::getChildren(): RecursiveDirectoryIterator, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/RecursiveDirectoryIterator.php:85
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator::rewind() should either be compatible with FilesystemIterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/RecursiveDirectoryIterator.php:113
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator::current() should either be compatible with FilesystemIterator::current(): SplFileInfo|FilesystemIterator|string, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/RecursiveDirectoryIterator.php:65
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\ExcludeDirectoryFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/ExcludeDirectoryFilterIterator.php:55
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\ExcludeDirectoryFilterIterator::hasChildren() should either be compatible with RecursiveIterator::hasChildren(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/ExcludeDirectoryFilterIterator.php:71
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\ExcludeDirectoryFilterIterator::getChildren() should either be compatible with RecursiveIterator::getChildren(): ?RecursiveIterator, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/ExcludeDirectoryFilterIterator.php:76
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\FilterIterator::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/FilterIterator.php:30
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\DateRangeFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/DateRangeFilterIterator.php:41
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\PathFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/PathFilterIterator.php:27
vendor/bin
```

Set up this PR branch:

```
~ $ git clone https://github.com/dzuelke/composer
Cloning into 'composer'...
remote: Enumerating objects: 77820, done.
remote: Counting objects: 100% (29/29), done.
remote: Compressing objects: 100% (25/25), done.
remote: Total 77820 (delta 9), reused 12 (delta 4), pack-reused 77791
Receiving objects: 100% (77820/77820), 19.12 MiB | 25.42 MiB/s, done.
Resolving deltas: 100% (48237/48237), done.


~ $ cd composer


~/composer $ git checkout origin/errorhandler-php81-compat
Note: checking out 'origin/errorhandler-php81-compat'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at be273491c Ignore all symfony deprecations


~/composer $ composer install
PHP Deprecated:  Return type of Symfony\Component\Console\Helper\HelperSet::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/console/Helper/HelperSet.php on line 112

Deprecated: Return type of Symfony\Component\Console\Helper\HelperSet::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/console/Helper/HelperSet.php on line 112
Deprecation Notice: Return type of Composer\Repository\ArrayRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/ArrayRepository.php:206
Deprecation Notice: Return type of Composer\Repository\ArrayRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/ArrayRepository.php:206
Deprecation Notice: Return type of Composer\Repository\ArrayRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/ArrayRepository.php:206
Deprecation Notice: Return type of Symfony\Component\Finder\Finder::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Finder.php:675
Deprecation Notice: Return type of Symfony\Component\Finder\Finder::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Finder.php:732
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\FilterIterator::rewind() should either be compatible with FilterIterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/FilterIterator.php:30
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\FileTypeFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/FileTypeFilterIterator.php:42
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator::getChildren() should either be compatible with RecursiveDirectoryIterator::getChildren(): RecursiveDirectoryIterator, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/RecursiveDirectoryIterator.php:85
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator::rewind() should either be compatible with FilesystemIterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/RecursiveDirectoryIterator.php:113
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator::current() should either be compatible with FilesystemIterator::current(): SplFileInfo|FilesystemIterator|string, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/RecursiveDirectoryIterator.php:65
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\ExcludeDirectoryFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/ExcludeDirectoryFilterIterator.php:55
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\ExcludeDirectoryFilterIterator::hasChildren() should either be compatible with RecursiveIterator::hasChildren(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/ExcludeDirectoryFilterIterator.php:71
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\ExcludeDirectoryFilterIterator::getChildren() should either be compatible with RecursiveIterator::getChildren(): ?RecursiveIterator, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/ExcludeDirectoryFilterIterator.php:76
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\FilterIterator::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/FilterIterator.php:30
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\DateRangeFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/DateRangeFilterIterator.php:41
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\PathFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/PathFilterIterator.php:27
Deprecation Notice: Return type of Composer\Repository\ArrayRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/ArrayRepository.php:206
Deprecation Notice: Return type of Composer\Repository\CompositeRepository::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/Repository/CompositeRepository.php:139
Loading composer repositories with package information
Deprecation Notice: Return type of Composer\DependencyResolver\Pool::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/Pool.php:175
Installing dependencies (including require-dev) from lock file
Deprecation Notice: Return type of Composer\DependencyResolver\RuleSet::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/RuleSet.php:114
Deprecation Notice: Return type of Composer\DependencyResolver\RuleSet::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/RuleSet.php:99
Deprecation Notice: Return type of Composer\DependencyResolver\Decisions::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/Decisions.php:155
Deprecation Notice: Return type of Composer\DependencyResolver\Decisions::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/Decisions.php:165
Deprecation Notice: Return type of Composer\DependencyResolver\Decisions::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/Decisions.php:160
Deprecation Notice: Return type of Composer\DependencyResolver\Decisions::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/Decisions.php:170
Deprecation Notice: Return type of Composer\DependencyResolver\Decisions::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/Decisions.php:150
Deprecation Notice: Return type of Composer\DependencyResolver\Decisions::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/Decisions.php:145
Deprecation Notice: Return type of Composer\DependencyResolver\RuleSetIterator::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/RuleSetIterator.php:36
Deprecation Notice: Return type of Composer\DependencyResolver\RuleSetIterator::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/RuleSetIterator.php:46
Deprecation Notice: Return type of Composer\DependencyResolver\RuleSetIterator::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/RuleSetIterator.php:41
Deprecation Notice: Return type of Composer\DependencyResolver\RuleSetIterator::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/RuleSetIterator.php:89
Deprecation Notice: Return type of Composer\DependencyResolver\RuleSetIterator::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/src/Composer/DependencyResolver/RuleSetIterator.php:70
Package operations: 23 installs, 0 updates, 0 removals
  - Installing composer/ca-bundle (1.2.11): Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\DepthRangeFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/DepthRangeFilterIterator.php:41
Downloading (100%)         
Deprecation Notice: Return type of Symfony\Component\Finder\Iterator\FilenameFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///app/.heroku/php/bin/composer/vendor/symfony/finder/Iterator/FilenameFilterIterator.php:28
  - Installing composer/semver (1.7.2): Downloading (100%)         
  - Installing composer/spdx-licenses (1.5.5): Downloading (100%)         
  - Installing psr/log (1.1.4): Downloading (100%)         
  - Installing composer/xdebug-handler (1.4.6): Downloading (100%)         
  - Installing justinrainbow/json-schema (5.2.11): Downloading (100%)         
  - Installing seld/jsonlint (1.8.3): Downloading (100%)         
  - Installing seld/phar-utils (1.1.2): Downloading (100%)         
  - Installing symfony/polyfill-mbstring (v1.19.0): Downloading (100%)         
  - Installing symfony/debug (v2.8.52): Downloading (100%)         
  - Installing symfony/console (v2.8.52): Downloading (100%)         
  - Installing symfony/polyfill-ctype (v1.19.0): Downloading (100%)         
  - Installing symfony/filesystem (v2.8.52): Downloading (100%)         
  - Installing symfony/finder (v2.8.52): Downloading (100%)         
  - Installing symfony/process (v2.8.52): Downloading (100%)         
  - Installing sebastian/recursion-context (2.0.0): Downloading (100%)         
  - Installing sebastian/exporter (2.0.0): Downloading (100%)         
  - Installing sebastian/diff (1.4.3): Downloading (100%)         
  - Installing sebastian/comparator (1.2.4): Downloading (100%)         
  - Installing phpdocumentor/reflection-docblock (2.0.5): Downloading (100%)      - Installing doctrine/instantiator (1.0.5): Downloading (100%)         
  - Installing phpspec/prophecy (v1.10.3): Downloading (100%)         
  - Installing symfony/phpunit-bridge (v4.2.12): Downloading (100%)         
symfony/console suggests installing psr/log-implementation (For using the console logger)
symfony/console suggests installing symfony/event-dispatcher
phpdocumentor/reflection-docblock suggests installing dflydev/markdown (~1.0)
phpdocumentor/reflection-docblock suggests installing erusev/parsedown (~1.0)
Generating autoload files
7 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

The sound of silence:

```
~/composer $ bin/composer --version
Composer version 1.10-dev+source @release_date@


~/composer $ bin/composer config bin-dir
vendor/bin


~/composer $ bin/composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files
7 packages you are using are looking for funding.
Use the `composer fund` command to find out more!


~/composer $ bin/composer update 
Loading composer repositories with package information
Warning from https://repo.packagist.org: Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/
Updating dependencies (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Updating composer/ca-bundle (1.2.11 => 1.3.1): Downloading (100%)         
  - Updating composer/spdx-licenses (1.5.5 => 1.5.6): Downloading (100%)        Writing lock file
Generating autoload files
7 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

🙃