### PR TITLE
VcsDriverInterface: fix return type for getComposerInformation

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -6351,7 +6351,7 @@ parameters:
 			path: ../src/Composer/Repository/VcsRepository.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array given\\.$#"
+			message: "#^Only booleans are allowed in a negated boolean, array\\|null given\\.$#"
 			count: 2
 			path: ../src/Composer/Repository/VcsRepository.php
 

--- a/src/Composer/Repository/Vcs/VcsDriverInterface.php
+++ b/src/Composer/Repository/Vcs/VcsDriverInterface.php
@@ -31,7 +31,7 @@ interface VcsDriverInterface
      * Return the composer.json file information
      *
      * @param  string  $identifier Any identifier to a specific branch/tag/commit
-     * @return mixed[] containing all infos from the composer.json file
+     * @return null|array<mixed> containing all infos from the composer.json file
      */
     public function getComposerInformation($identifier);
 

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -217,6 +217,7 @@ class GitHubDriverTest extends TestCase
 
         $data = $gitHubDriver->getComposerInformation($identifier);
 
+        $this->assertNotNull($data);
         $this->assertArrayNotHasKey('abandoned', $data);
     }
 
@@ -267,6 +268,7 @@ class GitHubDriverTest extends TestCase
 
         $data = $gitHubDriver->getComposerInformation($sha);
 
+        $this->assertNotNull($data);
         $this->assertTrue($data['abandoned']);
     }
 


### PR DESCRIPTION
`VcsDriverInterface::getComposerInformation` can return null