### PR TITLE
Always allow plugin "composer/package-versions-deprecated"

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -657,6 +657,10 @@ class PluginManager
      */
     private function isPluginAllowed($package, $isGlobalPlugin)
     {
+        if ($package === 'composer/package-versions-deprecated') {
+            return true;
+        }
+
         static $warned = array();
         $rules = $isGlobalPlugin ? $this->allowGlobalPluginRules : $this->allowPluginRules;
 


### PR DESCRIPTION
I propose to not annoy ppl with allowing this plugin since it's managed by the same team that makes composer.
