### PR TITLE
$home -> $COMPOSER_HOME (doc: config)

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -253,8 +253,8 @@ into this directory.
 
 Defaults to `C:\Users\<user>\AppData\Roaming\Composer` on Windows,
 `$XDG_DATA_HOME/composer` on unix systems that follow the XDG Base Directory
-Specifications, and `$home` on other unix systems. Right now it is only
-used for storing past composer.phar files to be able to rollback to older
+Specifications, and `$COMPOSER_HOME` on other unix systems. Right now it is only
+used for storing past composer.phar files to be able to roll back to older
 versions. See also [COMPOSER_HOME](03-cli.md#composer-home).
 
 ## cache-dir
@@ -262,8 +262,8 @@ versions. See also [COMPOSER_HOME](03-cli.md#composer-home).
 Defaults to `C:\Users\<user>\AppData\Local\Composer` on Windows,
 `/Users/<user>/Library/Caches/composer` on macOS, `$XDG_CACHE_HOME/composer`
 on unix systems that follow the XDG Base Directory Specifications, and
-`$home/cache` on other unix systems. Stores all the caches used by Composer.
-See also [COMPOSER_HOME](03-cli.md#composer-home).
+`$COMPOSER_HOME/cache` on other unix systems. Stores all the caches used by
+Composer. See also [COMPOSER_HOME](03-cli.md#composer-home).
 
 ## cache-files-dir
 


### PR DESCRIPTION
for conclusion of the change please see discussion in PR comments below.

* [x] conclude the way of change (`$COMPOSER_HOME` variant)
* [ ] get review on `$home` for `data-dir` section, too.
* [ ] find the correct branch to PR against.

---
<details>
  <summary>original description (outdated)</summary>


the HOME environment parameter is upper-case in most of all systems.

> HOME
>
> The system will initialise this variable at the time of login to be a pathname of the user's home directory. See <pwd.h>.

(from: https://pubs.opengroup.org/onlinepubs/7908799/xbd/envvar.html)

change case to upper-case (US-ASCII; ref RFC 4790  9.2.1.  ASCII Casemap Collation Description)
</details>

---

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. 2.1 or similar if such a branch exists, or 1.10 if it is a critical fix that should be fixed in Composer 1)

For new features and everything else, use the main branch. -->
