### PR TITLE
Fix minor spelling & grammar issues in docs

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -53,7 +53,7 @@ or review it on [GitHub](https://github.com/composer/getcomposer.org/blob/main/w
 if you wish to know more about the inner workings of the installer. The source
 is plain PHP.
 
-There are in short, two ways to install Composer. Locally as part of your
+There are, in short, two ways to install Composer. Locally as part of your
 project, or globally as a system wide executable.
 
 #### Locally

--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -243,7 +243,7 @@ Composer will register a [PSR-4](https://www.php-fig.org/psr/psr-4/) autoloader
 for the `Acme` namespace.
 
 You define a mapping from namespaces to directories. The `src` directory would
-be in your project root, on the same level as `vendor` directory is. An example
+be in your project root, on the same level as the `vendor` directory. An example
 filename would be `src/Foo.php` containing an `Acme\Foo` class.
 
 After adding the [`autoload`](04-schema.md#autoload) field, you have to re-run

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -422,7 +422,7 @@ You can also search for more than one term by passing multiple arguments.
 
 * **--only-name (-N):** Search only in package names.
 * **--only-vendor (-O):** Search only for vendor / organization names, returns only "vendor"
-  as result.
+  as a result.
 * **--type (-t):** Search for a specific package type.
 * **--format (-f):** Lets you pick between text (default) or json output format.
   Note that in the json, only the name and description keys are guaranteed to be
@@ -542,7 +542,7 @@ in your browser.
 
 ## suggests
 
-Lists all packages suggested by currently installed set of packages. You can
+Lists all packages suggested by the currently installed set of packages. You can
 optionally pass one or multiple package names in the format of `vendor/package`
 to limit output to suggestions made by those packages only.
 
@@ -730,7 +730,7 @@ php composer.phar config --list
 
 `setting-key` is a configuration option name and `setting-value1` is a
 configuration value.  For settings that can take an array of values (like
-`github-protocols`), more than one setting-value arguments are allowed.
+`github-protocols`), multiple setting-value arguments are allowed.
 
 You can also edit the values of the following properties:
 
@@ -809,7 +809,7 @@ There are several applications for this:
 
 To create a new project using Composer you can use the `create-project` command.
 Pass it a package name, and the directory to create the project in. You can also
-provide a version as third argument, otherwise the latest version is used.
+provide a version as a third argument, otherwise the latest version is used.
 
 If the directory does not currently exist, it will be created during installation.
 
@@ -839,7 +839,7 @@ By default the command checks for the packages on packagist.org.
   JSON string which similar to what the [repositories](04-schema.md#repositories)
   key accepts. You can use this multiple times to configure multiple repositories.
 * **--add-repository:** Add the custom repository in the composer.json. If a lock
-  file is present it will be deleted and an update will be run instead of install.
+  file is present, it will be deleted and an update will be run instead of an install.
 * **--dev:** Install packages listed in `require-dev`.
 * **--no-dev:** Disables installation of require-dev packages.
 * **--no-scripts:** Disables the execution of the scripts defined in the root
@@ -861,7 +861,7 @@ By default the command checks for the packages on packagist.org.
 * **--ignore-platform-req:** ignore a specific platform requirement(`php`,
   `hhvm`, `lib-*` and `ext-*`) and force the installation even if the local machine
   does not fulfill it. Multiple requirements can be ignored via wildcard.
-* **--ask:** Ask user to provide target directory for new project.
+* **--ask:** Ask the user to provide a target directory for the new project.
 
 ## dump-autoload (dumpautoload)
 
@@ -877,7 +877,7 @@ using this option you can still use PSR-0/4 for convenience and classmaps for
 performance.
 
 ### Options
-* **--no-scripts:** Skips the execution of all scripts defined in `composer.json` file.
+* **--no-scripts:** Skips the execution of all scripts defined in the `composer.json` file.
 * **--optimize (-o):** Convert PSR-0/4 autoloading to classmap to get a faster
   autoloader. This is recommended especially for production, but can take
   a bit of time to run, so it is currently not done by default.
@@ -997,7 +997,7 @@ The generated lock file will use the same name: `composer-other.lock` in this ex
 
 If set to 1, this env disables the warning about running commands as root/super user.
 It also disables automatic clearing of sudo sessions, so you should really only set this
-if you use Composer as super user at all times like in docker containers.
+if you use Composer as a super user at all times like in docker containers.
 
 ### COMPOSER_ALLOW_XDEBUG
 
@@ -1148,7 +1148,7 @@ from setting the request_fulluri option.
 
 ### COMPOSER_SELF_UPDATE_TARGET
 
-If set, makes the self-update command write the new Composer phar file into that path instead of overwriting itself. Useful for updating Composer on read-only filesystem.
+If set, makes the self-update command write the new Composer phar file into that path instead of overwriting itself. Useful for updating Composer on a read-only filesystem.
 
 ### no_proxy or NO_PROXY
 
@@ -1177,5 +1177,5 @@ useful for plugin authors to identify what is firing when exactly.
 
 ### COMPOSER_NO_DEV
 
-If set to `1`, it is the equivalent of passing the `--no-dev` arguement to `install` or
+If set to `1`, it is the equivalent of passing the `--no-dev` argument to `install` or
 `update`. You can override this for a single command by setting `COMPOSER_NO_DEV=0`.

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -34,7 +34,7 @@ separated by `/`. Examples:
 * monolog/monolog
 * igorw/event-source
 
-The name must be lowercased and consist of words separated by `-`, `.` or `_`.
+The name must be lowercase and consist of words separated by `-`, `.` or `_`.
 The complete name should match `^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$`.
 
 The `name` property is required for published packages (libraries).
@@ -171,7 +171,7 @@ An Example:
 ```
 
 For a package, when there is a choice between licenses ("disjunctive license"),
-multiple can be specified as array.
+multiple can be specified as an array.
 
 An Example for disjunctive licenses:
 
@@ -675,7 +675,7 @@ for more details on how to reduce this impact.
 
 ### autoload-dev <span>([root-only](04-schema.md#root-package))</span>
 
-This section allows to define autoload rules for development purposes.
+This section allows defining autoload rules for development purposes.
 
 Classes needed to run the test suite should not be included in the main autoload
 rules to avoid polluting the autoloader in production and when other people use
@@ -941,7 +941,7 @@ It can be boolean or a package name/URL pointing to a recommended alternative.
 
 Examples:
 
-Use `"abandoned": true` to indicates this package is abandoned.
+Use `"abandoned": true` to indicate this package is abandoned.
 Use `"abandoned": "monolog/monolog"` to indicates this package is abandoned, and the
 recommended alternative is  `monolog/monolog`.
 
@@ -962,7 +962,7 @@ version of the parent branch or at least master or something.
 
 To handle non-numeric named branches as versions instead of searching for a parent branch
 with a valid version or special branch name like master, you can set patterns for branch
-names, that should be handled as dev version branches.
+names that should be handled as dev version branches.
 
 This is really helpful when you have dependencies using "self.version", so that not dev-master,
 but the same branch is installed (in the example: latest-testing).

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -197,7 +197,7 @@ Avoid redirects to alternative 404 pages.
 If your repository only has a small number of packages, and you want to avoid
 the 404-requests, you can also specify an `"available-packages"` key in
 `packages.json` which should be an array with all the package names that your
-repository contain. Alternatively you can specify an
+repository contains. Alternatively you can specify an
 `"available-package-patterns"` key which is an array of package name patterns
 (with `*` matching any string, e.g. `vendor/*` would make Composer look up
 every matching package name in this repository).
@@ -468,7 +468,7 @@ repository like this:
 If you have no branches or tags directory you can disable them entirely by
 setting the `branches-path` or `tags-path` to `false`.
 
-If the package is in a sub-directory, e.g. `/trunk/foo/bar/composer.json` and
+If the package is in a subdirectory, e.g. `/trunk/foo/bar/composer.json` and
 `/tags/1.0/foo/bar/composer.json`, then you can make Composer access it by
 setting the `"package-path"` option to the sub-directory, in this example it
 would be `"package-path": "foo/bar/"`.

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -101,7 +101,7 @@ is one present in a directory above Composer will by default ask you whether
 you want to use that directory's composer.json instead.
 
 If you always want to answer yes to this prompt, you can set this config value
-to `true`. To never be prompted set it to `false`. The default is `"prompt"`.
+to `true`. To never be prompted, set it to `false`. The default is `"prompt"`.
 
 > **Note:** This config must be set in your global user-wide config for it
 > to work. Use for example `php composer.phar config --global use-parent-dir true`

--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -224,7 +224,7 @@ php composer.phar config [--global] --editor --auth
 > [`gitlab-domains`](../06-config.md#gitlab-domains) section should also contain the url.
 
 To create a new access token, go to your [access tokens section on GitLab](https://gitlab.com/-/profile/personal_access_tokens)
-(or the equivalent URL on your private instance) and create a new token. See also [the GitLab access token documentation](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#creating-a-personal-access-token) for more informations.
+(or the equivalent URL on your private instance) and create a new token. See also [the GitLab access token documentation](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#creating-a-personal-access-token) for more information.
 
 When creating a gitlab token manually, make sure it has either the `read_api` or `api` scope.
 

--- a/doc/articles/custom-installers.md
+++ b/doc/articles/custom-installers.md
@@ -78,7 +78,7 @@ requirements:
 1. the [type][1] attribute must be `composer-plugin`.
 2. the [extra][2] attribute must contain an element `class` defining the
    class name of the plugin (including namespace). If a package contains
-   multiple plugins this can be array of class names.
+   multiple plugins, this can be an array of class names.
 
 Example:
 

--- a/doc/articles/plugins.md
+++ b/doc/articles/plugins.md
@@ -27,17 +27,17 @@ requirements:
 1. The [type][1] attribute must be `composer-plugin`.
 2. The [extra][2] attribute must contain an element `class` defining the
    class name of the plugin (including namespace). If a package contains
-   multiple plugins, this can be array of class names.
+   multiple plugins, this can be an array of class names.
 3. You must require the special package called `composer-plugin-api`
    to define which Plugin API versions your plugin is compatible with.
    Requiring this package doesn't actually include any extra dependencies,
    it only specifies which version of the plugin API to use.
 
 > **Note:** When developing a plugin, although not required, it's useful to add
-> a require-dev dependency on `composer/composer` to have IDE auto completion on Composer classes.
+> a require-dev dependency on `composer/composer` to have IDE autocompletion on Composer classes.
 
 The required version of the `composer-plugin-api` follows the same [rules][7]
-as a normal package's.
+as a normal package's rules.
 
 The current Composer plugin API version is `2.1.0`.
 

--- a/doc/articles/repository-priorities.md
+++ b/doc/articles/repository-priorities.md
@@ -13,17 +13,17 @@ goes on to the next one, until one repository contains it and the process ends.
 Canonical repositories are better for a few reasons:
 
 - Performance wise, it is more efficient to stop looking for a package once it
-has been found somewhere. It also avoids loading duplicate packages in case
-the same package is present in several of your repositories.
+  has been found somewhere. It also avoids loading duplicate packages in case
+  the same package is present in several of your repositories.
 - Security wise, it is safer to treat them canonically as it means that packages you
-expect to come from your most important repositories will never be loaded from
-another repository instead. Let's
-say you have a private repository which is not canonical, and you require your
-private package `foo/bar ^2.0` for example. Now if someone publishes
-`foo/bar 2.999` to packagist.org, suddenly Composer will pick that package as it
-has a higher version than your latest release (say 2.4.3), and you end up installing
-something you may not have meant to. If the private repository is canonical
-however, that 2.999 version from packagist.org will not be considered at all.
+  expect to come from your most important repositories will never be loaded from
+  another repository instead. Let's
+  say you have a private repository which is not canonical, and you require your
+  private package `foo/bar ^2.0` for example. Now if someone publishes
+  `foo/bar 2.999` to packagist.org, suddenly Composer will pick that package as it
+  has a higher version than your latest release (say 2.4.3), and you end up installing
+  something you may not have meant to. However, if the private repository is canonical,
+  that 2.999 version from packagist.org will not be considered at all.
 
 There are however a few cases where you may want to specifically load some packages
 from a given repository, but not all. Or you may want a given repository to not be
@@ -92,4 +92,4 @@ we may not want to load in this project.
 ```
 
 Both `only` and `exclude` should be arrays of package names, which can also
-contain wildcards (`*`) which will match any characters.
+contain wildcards (`*`), which will match any character.

--- a/doc/articles/resolving-merge-conflicts.md
+++ b/doc/articles/resolving-merge-conflicts.md
@@ -49,8 +49,8 @@ php composer.phar install [--dry-run]
 
 ## Important considerations
 
-Keep in mind that whenever merge conflicts occur on the lock file, the information about the exact version
-new packages were locked on for one of the branches gets lost. When package A in branch 1 is constrained
+Keep in mind that whenever merge conflicts occur on the lock file, the information, about the exact version
+new packages were locked on for one of the branches, is lost. When package A in branch 1 is constrained
 as `^1.2.0` and locked as `1.2.0`, it might get updated when branch 2 is used as baseline and a new
 `composer require package/A:^1.2.0` is executed, as that will use the most recent version that the
 constraint allows when possible. There might be a version 1.3.0 for that package available by now, which

--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -71,7 +71,7 @@ Composer fires the following named events during its execution process:
   manipulate the `InputInterface` object's options and arguments to tweak
   a command's behavior.
 - **pre-pool-create**: occurs before the Pool of packages is created, and lets
-  you filter the list of packages which is going to enter the Solver.
+  you filter the list of packages that is going to enter the Solver.
 
 > **Note:** Composer makes no assumptions about the state of your dependencies
 > prior to `install` or `update`. Therefore, you should not specify scripts
@@ -166,7 +166,7 @@ class MyClass
 `COMPOSER_DEV_MODE` will be added to the environment. If the command was run
 with the `--no-dev` flag, this variable will be set to 0, otherwise it will be
 set to 1. The variable is also available while `dump-autoload` runs, and it
-will be set to same as the last `install` or `update` was run in.
+will be set to the same as the last `install` or `update` was run in.
 
 ## Event classes
 

--- a/doc/articles/troubleshooting.md
+++ b/doc/articles/troubleshooting.md
@@ -200,7 +200,7 @@ please report this [issue](https://github.com/composer/composer/issues).
 2. Search for an `AutoRun` key inside `HKEY_LOCAL_MACHINE\Software\Microsoft\Command Processor`,
    `HKEY_CURRENT_USER\Software\Microsoft\Command Processor`
    or `HKEY_LOCAL_MACHINE\Software\Wow6432Node\Microsoft\Command Processor`.
-3. Check if it contains any path to non-existent file, if it's the case, remove them.
+3. Check if it contains any path to a non-existent file, if it's the case, remove them.
 
 
 ## API rate limit and OAuth tokens
@@ -293,7 +293,7 @@ following workarounds:
 **Workaround Linux:**
 
 On linux, it seems that running this command helps to make ipv4 traffic have a
-higher prio than ipv6, which is a better alternative than disabling ipv6 entirely:
+higher priority than ipv6, which is a better alternative than disabling ipv6 entirely:
 
 ```bash
 sudo sh -c "echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf"
@@ -326,7 +326,7 @@ networksetup -setv6automatic Wi-Fi
 ```
 
 That said, if this fixes your problem, please talk to your ISP about it to
-try and resolve the routing errors. That's the best way to get things resolved
+try to resolve the routing errors. That's the best way to get things resolved
 for everyone.
 
 

--- a/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md
+++ b/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md
@@ -30,7 +30,7 @@ for your package.
 As a **package consumer** you can set or override the install path for a package
 that requires composer/installers by configuring the `installer-paths` extra. A
 useful example would be for a Drupal multisite setup where the package should be
-installed into your sites subdirectory. Here we are overriding the install path
+installed into your site's subdirectory. Here we are overriding the install path
 for a module that uses composer/installers, as well as putting all packages of type
 `drupal-theme` into a themes folder:
 


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. 2.1 or similar if such a branch exists, or 1.10 if it is a critical fix that should be fixed in Composer 1)

For new features and everything else, use the main branch. -->
