### PR TITLE
Disable files autoloading for scripts to avoid untrusted code execution at runtime

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -509,10 +509,6 @@ class EventDispatcher
         $this->loader = $generator->createLoader($map, $this->composer->getConfig()->get('vendor-dir'));
         $this->loader->register(false);
 
-        foreach ($map['files'] as $fileIdentifier => $file) {
-            \Composer\Autoload\composerRequire($fileIdentifier, $file);
-        }
-
         return $scripts[$event->getName()];
     }
 


### PR DESCRIPTION
Plugin dependencies still get files autoloaded, but for scripts we keep the old restrictions which is documented at https://getcomposer.org/doc/articles/scripts.md#defining-scripts

> Callbacks can only autoload classes from psr-0, psr-4 and classmap definitions. If a defined callback relies on functions defined outside of a class, the callback itself is responsible for loading the file containing these functions.

Otherwise defining any PHP-callback script would automatically load all `files` from all packages installed, not giving you a chance to review what's present before they execute code, which goes against the new allow-plugin model.

cc @helhum @nicolas-grekas 