### PR TITLE
Use web URL for Gitlab support metadata

### DIFF
--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -163,8 +163,12 @@ class GitLabDriver extends VcsDriver
 
             if ($composer) {
                 // specials for gitlab (this data is only available if authentication is provided)
-                if (!isset($composer['support']['issues']) && isset($this->project['_links']['issues'])) {
-                    $composer['support']['issues'] = $this->project['_links']['issues'];
+                if (!isset($composer['support']['source']) && isset($this->project['web_url'])) {
+                    $label = array_search($identifier, $this->getTags(), true) ?: array_search($identifier, $this->getBranches(), true) ?: $identifier;
+                    $composer['support']['source'] = sprintf('%s/-/tree/%s', $this->project['web_url'], $label);
+                }
+                if (!isset($composer['support']['issues']) && !empty($this->project['issues_enabled']) && isset($this->project['web_url'])) {
+                    $composer['support']['issues'] = sprintf('%s/-/issues', $this->project['web_url']);
                 }
                 if (!isset($composer['abandoned']) && !empty($this->project['archived'])) {
                     $composer['abandoned'] = true;

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -95,6 +95,8 @@ class GitLabDriverTest extends TestCase
     "id": 17,
     "default_branch": "mymaster",
     "visibility": "private",
+    "issues_enabled": true,
+    "archived": false,
     "http_url_to_repo": "https://gitlab.com/mygroup/myproject.git",
     "ssh_url_to_repo": "git@gitlab.com:mygroup/myproject.git",
     "last_activity_at": "2014-12-01T09:17:51.000+01:00",


### PR DESCRIPTION
Currently, when using Gitlab VCS, the **support.issues** provides an API endpoint. That was added in a PR related to an other topic (#8510).

Before, with this sample project : https://packagist.org/packages/codingpaws/gitlab-feature
```json
    "support": {
        "issues": "https://gitlab.com/api/v4/projects/28361162/issues"
    }
```

This PR provide web UI URL, inspired by the `GitHubDriver`:
```json
    "support": {
        "source": "https://gitlab.com/codingpaws/gitlab-feature/-/tree/1.3",
        "issues": "https://gitlab.com/codingpaws/gitlab-feature/-/issues"
    },
```