### PR TITLE
fix: Do not optimise away packages due to a requirement by a locked package that will be uninstalled

### DIFF
--- a/src/Composer/DependencyResolver/PoolOptimizer.php
+++ b/src/Composer/DependencyResolver/PoolOptimizer.php
@@ -420,14 +420,15 @@ class PoolOptimizer
         foreach ($request->getLockedPackages() as $package) {
             // If this locked package is no longer required by root or anything in the pool, it may get uninstalled so do not apply its requirements
             // In a case where a requirement WERE to appear in the pool by a package that would not be used, it would've been unlocked and so not filtered still
-            $ignoreUnusedPackage = false;
+            $isUnusedPackage = true;
             foreach ($package->getNames(false) as $packageName) {
-                if (!isset($this->requireConstraintsPerPackage[$packageName])) {
-                    $ignoreUnusedPackage = true;
+                if (isset($this->requireConstraintsPerPackage[$packageName])) {
+                    $isUnusedPackage = false;
+                    break;
                 }
             }
 
-            if ($ignoreUnusedPackage) {
+            if ($isUnusedPackage) {
                 continue;
             }
 

--- a/src/Composer/DependencyResolver/PoolOptimizer.php
+++ b/src/Composer/DependencyResolver/PoolOptimizer.php
@@ -418,6 +418,19 @@ class PoolOptimizer
         }
 
         foreach ($request->getLockedPackages() as $package) {
+            // If this locked package is no longer required by root or anything in the pool, it may get uninstalled so do not apply its requirements
+            // In a case where a requirement WERE to appear in the pool by a package that would not be used, it would've been unlocked and so not filtered still
+            $ignoreUnusedPackage = false;
+            foreach ($package->getNames(false) as $packageName) {
+                if (!isset($this->requireConstraintsPerPackage[$packageName])) {
+                    $ignoreUnusedPackage = true;
+                }
+            }
+
+            if ($ignoreUnusedPackage) {
+                continue;
+            }
+
             foreach ($package->getRequires() as $link) {
                 $require = $link->getTarget();
                 if (!isset($packageIndex[$require])) {

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-locked-replacer.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-locked-replacer.test
@@ -1,0 +1,60 @@
+--TEST--
+Do not load packages into the pool that cannot meet the fixed/locked requirements, when a loose requirement is encountered during update
+(The locked replacer/pkg should restrict dependencies even though it is only referenced by its replaced name)
+
+--REQUEST--
+{
+    "require": {
+        "first/pkg": "*",
+        "second/pkg": "*",
+        "replacer/dep": "*"
+    },
+    "locked": [
+        {"name": "first/pkg", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}},
+        {"name": "second/pkg", "version": "1.0.0"},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}, "require": {"replacer/dep": "1.*"}},
+        {"name": "replacer/dep", "version": "1.0.0"}
+    ],
+    "allowList": [
+        "second/pkg",
+        "replacer/dep"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name": "first/pkg", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}},
+        {"name": "first/pkg", "version": "1.1.0", "require": {"replaced/pkg": "2.0.0"}},
+        {"name": "second/pkg", "version": "1.0.0"},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}, "require": {"replacer/dep": "1.*"}},
+        {"name": "replacer/pkg", "version": "1.1.0", "replace": {"replaced/pkg": "2.0.0"}, "require": {"replacer/dep": "1.*"}},
+        {"name": "replacer/pkg", "version": "1.2.0", "replace": {"replaced/pkg": "3.0.0"}, "require": {"replacer/dep": "1.*"}},
+        {"name": "replacer/dep", "version": "1.0.0"},
+        {"name": "replacer/dep", "version": "1.0.1"},
+        {"name": "replacer/dep", "version": "2.0.0"}
+    ]
+]
+
+--EXPECT--
+[
+    "first/pkg-1.0.0.0 (locked)",
+    "replacer/pkg-1.0.0.0 (locked)",
+    "second/pkg-1.0.0.0",
+    "replacer/dep-1.0.0.0",
+    "replacer/dep-1.0.1.0",
+    "replacer/dep-2.0.0.0"
+]
+
+--EXPECT-OPTIMIZED--
+[
+    "first/pkg-1.0.0.0 (locked)",
+    "replacer/pkg-1.0.0.0 (locked)",
+    "second/pkg-1.0.0.0",
+    "replacer/dep-1.0.1.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-only-required-provides.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-only-required-provides.test
@@ -1,0 +1,58 @@
+--TEST--
+When filtering packages from the pool that cannot meet the fixed/locked requirements, ensure that the requirements for a package that is not required anywhere is not used to filter, as it will be ultimately be removed.
+(Variant where the requirement is on a provided package, the locked third/pkg must not restrict the provider)
+(NOTE: We are not optimising this scenario currently)
+
+--REQUEST--
+{
+    "require": {
+        "first/pkg": "*",
+        "second/pkg": "1.1.0",
+        "provider/pkg": "*"
+    },
+    "locked": [
+        {"name": "first/pkg", "version": "1.0.0", "require": {"second/pkg": "^1.0"}},
+        {"name": "second/pkg", "version": "1.0.0", "require": {"third/pkg": "1.0.0"}},
+        {"name": "third/pkg", "version": "1.0.0", "require": {"provided/pkg": "1.0.0"}},
+        {"name": "provider/pkg", "version": "1.0.0", "provide": {"provided/pkg": "1.0.0"}}
+    ],
+    "allowList": [
+        "first/pkg",
+        "provider/pkg"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name": "first/pkg", "version": "1.0.0", "require": {"second/pkg": "*"}},
+        {"name": "second/pkg", "version": "1.0.0", "require": {"third/pkg": "1.0.0"}},
+        {"name": "second/pkg", "version": "1.1.0", "require": {"provided/pkg": "2.0.0"}},
+        {"name": "third/pkg", "version": "1.0.0", "require": {"provided/pkg": "1.0.0"}},
+        {"name": "provider/pkg", "version": "1.0.0", "provide": {"provided/pkg": "1.0.0"}},
+        {"name": "provider/pkg", "version": "2.0.0", "provide": {"provided/pkg": "2.0.0"}}
+    ]
+]
+
+--EXPECT--
+[
+    "third/pkg-1.0.0.0 (locked)",
+    "first/pkg-1.0.0.0",
+    "provider/pkg-1.0.0.0",
+    "provider/pkg-2.0.0.0",
+    "second/pkg-1.1.0.0"
+]
+
+--EXPECT-OPTIMIZED--
+[
+    "third/pkg-1.0.0.0 (locked)",
+    "first/pkg-1.0.0.0",
+    "provider/pkg-1.0.0.0",
+    "provider/pkg-2.0.0.0",
+    "second/pkg-1.1.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-only-required-replaces.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-only-required-replaces.test
@@ -1,18 +1,20 @@
 --TEST--
 When filtering packages from the pool that cannot meet the fixed/locked requirements, ensure that the requirements for a package that is not required anywhere is not used to filter, as it will be ultimately be removed.
-(The locked third/pkg is not required by any package so will be removed, so should not restrict the versions of fourth/pkg)
+(Variant where the requirement is on a replaced package, the locked third/pkg must not restrict the replacer)
+(NOTE: We are not optimising this scenario currently)
 
 --REQUEST--
 {
     "require": {
         "first/pkg": "*",
-        "second/pkg": "1.1.0"
+        "second/pkg": "1.1.0",
+        "replacer/pkg": "*"
     },
     "locked": [
         {"name": "first/pkg", "version": "1.0.0", "require": {"second/pkg": "^1.0"}},
         {"name": "second/pkg", "version": "1.0.0", "require": {"third/pkg": "1.0.0"}},
-        {"name": "third/pkg", "version": "1.0.0", "require": {"fourth/pkg": "1.0.0"}},
-        {"name": "fourth/pkg", "version": "1.0.0"}
+        {"name": "third/pkg", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}}
     ],
     "allowList": [
         "first/pkg"
@@ -29,10 +31,10 @@ When filtering packages from the pool that cannot meet the fixed/locked requirem
     [
         {"name": "first/pkg", "version": "1.0.0", "require": {"second/pkg": "*"}},
         {"name": "second/pkg", "version": "1.0.0", "require": {"third/pkg": "1.0.0"}},
-        {"name": "second/pkg", "version": "1.1.0", "require": {"fourth/pkg": "2.0.0"}},
-        {"name": "third/pkg", "version": "1.0.0", "require": {"fourth/pkg": "1.0.0"}},
-        {"name": "fourth/pkg", "version": "1.0.0"},
-        {"name": "fourth/pkg", "version": "2.0.0"}
+        {"name": "second/pkg", "version": "1.1.0", "require": {"replaced/pkg": "2.0.0"}},
+        {"name": "third/pkg", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}},
+        {"name": "replacer/pkg", "version": "2.0.0", "replace": {"replaced/pkg": "2.0.0"}}
     ]
 ]
 
@@ -41,8 +43,8 @@ When filtering packages from the pool that cannot meet the fixed/locked requirem
     "third/pkg-1.0.0.0 (locked)",
     "first/pkg-1.0.0.0",
     "second/pkg-1.1.0.0",
-    "fourth/pkg-1.0.0.0",
-    "fourth/pkg-2.0.0.0"
+    "replacer/pkg-1.0.0.0",
+    "replacer/pkg-2.0.0.0"
 ]
 
 --EXPECT-OPTIMIZED--
@@ -50,6 +52,6 @@ When filtering packages from the pool that cannot meet the fixed/locked requirem
     "third/pkg-1.0.0.0 (locked)",
     "first/pkg-1.0.0.0",
     "second/pkg-1.1.0.0",
-    "fourth/pkg-1.0.0.0",
-    "fourth/pkg-2.0.0.0"
+    "replacer/pkg-1.0.0.0",
+    "replacer/pkg-2.0.0.0"
 ]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-only-required.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-only-required.test
@@ -1,0 +1,54 @@
+--TEST--
+When filtering packages from the pool that cannot meet the fixed/locked requirements, ensure that the requirements for a package that is not required anywhere is not used to filter, as it will be ultimately be removed.
+
+--REQUEST--
+{
+    "require": {
+        "first/pkg": "*",
+        "second/pkg": "1.1.0"
+    },
+    "locked": [
+        {"name": "first/pkg", "version": "1.0.0", "require": {"second/pkg": "^1.0"}},
+        {"name": "second/pkg", "version": "1.0.0", "require": {"third/pkg": "1.0.0"}},
+        {"name": "third/pkg", "version": "1.0.0", "require": {"fourth/pkg": "1.0.0"}},
+        {"name": "fourth/pkg", "version": "1.0.0"}
+    ],
+    "allowList": [
+        "first/pkg"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name": "first/pkg", "version": "1.0.0", "require": {"second/pkg": "*"}},
+        {"name": "second/pkg", "version": "1.0.0", "require": {"third/pkg": "1.0.0"}},
+        {"name": "second/pkg", "version": "1.1.0", "require": {"fourth/pkg": "2.0.0"}},
+        {"name": "third/pkg", "version": "1.0.0", "require": {"fourth/pkg": "1.0.0"}},
+        {"name": "fourth/pkg", "version": "1.0.0"},
+        {"name": "fourth/pkg", "version": "2.0.0"}
+    ]
+]
+
+--EXPECT--
+[
+    "third/pkg-1.0.0.0 (locked)",
+    "first/pkg-1.0.0.0",
+    "second/pkg-1.1.0.0",
+    "fourth/pkg-1.0.0.0",
+    "fourth/pkg-2.0.0.0"
+]
+
+--EXPECT-OPTIMIZED--
+[
+    "third/pkg-1.0.0.0 (locked)",
+    "first/pkg-1.0.0.0",
+    "second/pkg-1.1.0.0",
+    "fourth/pkg-1.0.0.0",
+    "fourth/pkg-2.0.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-provides.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-provides.test
@@ -1,0 +1,59 @@
+--TEST--
+Do not load packages into the pool that cannot meet the fixed/locked requirements, when a loose requirement is encountered during update
+(Variant where requirement is on a provided package, the locked second package should restrict the provider to those that provide < 3.0.0)
+(NOTE: We are not optimising this scenario currently)
+
+--REQUEST--
+{
+    "require": {
+        "first/pkg": "*",
+        "second/pkg": "*",
+        "provider/pkg": "*"
+    },
+    "locked": [
+        {"name": "first/pkg", "version": "1.0.0", "require": {"provided/pkg": "1.0.0"}},
+        {"name": "second/pkg", "version": "1.0.0", "require": {"provided/pkg": "< 3.0.0"}},
+        {"name": "provider/pkg", "version": "1.0.0", "provide": {"provided/pkg": "1.0.0"}}
+    ],
+    "allowList": [
+        "first/pkg",
+        "provider/pkg"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name": "first/pkg", "version": "1.0.0", "require": {"provided/pkg": "1.0.0"}},
+        {"name": "first/pkg", "version": "1.1.0", "require": {"provided/pkg": "2.0.0"}},
+        {"name": "second/pkg", "version": "1.0.0", "require": {"provided/pkg": "*"}},
+        {"name": "provider/pkg", "version": "1.0.0", "provide": {"provided/pkg": "1.0.0"}},
+        {"name": "provider/pkg", "version": "1.1.0", "provide": {"provided/pkg": "2.0.0"}},
+        {"name": "provider/pkg", "version": "1.2.0", "provide": {"provided/pkg": "3.0.0"}}
+    ]
+]
+
+--EXPECT--
+[
+    "second/pkg-1.0.0.0 (locked)",
+    "first/pkg-1.0.0.0",
+    "first/pkg-1.1.0.0",
+    "provider/pkg-1.0.0.0",
+    "provider/pkg-1.1.0.0",
+    "provider/pkg-1.2.0.0"
+]
+
+--EXPECT-OPTIMIZED--
+[
+    "second/pkg-1.0.0.0 (locked)",
+    "first/pkg-1.0.0.0",
+    "first/pkg-1.1.0.0",
+    "provider/pkg-1.0.0.0",
+    "provider/pkg-1.1.0.0",
+    "provider/pkg-1.2.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-replaces.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-replaces.test
@@ -1,0 +1,58 @@
+--TEST--
+Do not load packages into the pool that cannot meet the fixed/locked requirements, when a loose requirement is encountered during update
+(Variant where requirement is on a replaced package, the locked second package should restrict the replacer to those that replace < 3.0.0)
+(NOTE: We are not optimising this scenario currently)
+
+--REQUEST--
+{
+    "require": {
+        "first/pkg": "*",
+        "second/pkg": "*",
+        "replacer/pkg": "*"
+    },
+    "locked": [
+        {"name": "first/pkg", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}},
+        {"name": "second/pkg", "version": "1.0.0", "require": {"replaced/pkg": "< 3.0.0"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}}
+    ],
+    "allowList": [
+        "first/pkg"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name": "first/pkg", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}},
+        {"name": "first/pkg", "version": "1.1.0", "require": {"replaced/pkg": "2.0.0"}},
+        {"name": "second/pkg", "version": "1.0.0", "require": {"replaced/pkg": "*"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}},
+        {"name": "replacer/pkg", "version": "1.1.0", "replace": {"replaced/pkg": "2.0.0"}},
+        {"name": "replacer/pkg", "version": "1.2.0", "replace": {"replaced/pkg": "3.0.0"}}
+    ]
+]
+
+--EXPECT--
+[
+    "second/pkg-1.0.0.0 (locked)",
+    "first/pkg-1.0.0.0",
+    "first/pkg-1.1.0.0",
+    "replacer/pkg-1.0.0.0",
+    "replacer/pkg-1.1.0.0",
+    "replacer/pkg-1.2.0.0"
+]
+
+--EXPECT-OPTIMIZED--
+[
+    "second/pkg-1.0.0.0 (locked)",
+    "first/pkg-1.0.0.0",
+    "first/pkg-1.1.0.0",
+    "replacer/pkg-1.0.0.0",
+    "replacer/pkg-1.1.0.0",
+    "replacer/pkg-1.2.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages.test
@@ -1,5 +1,6 @@
 --TEST--
 Do not load packages into the pool that cannot meet the fixed/locked requirements, when a loose requirement is encountered during update
+(The locked root/req package should restrict dep/dep to only 2.* versions)
 
 --REQUEST--
 {


### PR DESCRIPTION
Fixes #10394, introduced by #9620

As explained in that issue when I did the optimisation to filter out packages from the pool that would ultimately never be installed due to a locked packages requirements, I hadn't considered that when packages are removed... they may still be in the set of locked packages.

This PR updates the optimisation to ignore any locked package which isn't required by any package in the pool - as that will, as I understand, mean the package is going to be removed and it's requirements will be moot. I have considered the case where a package IS required somewhere in the pool, or even an older version for example, and in those cases the package would have been unlocked when using `-W` anyway. So I believe this is the correct fix.

I tested it against the scenario in #10394 and when running the second command in the following set:

```
composer require --dev phpunit/phpunit:"^7.5" --no-update --ignore-platform-req=php
composer update yoast/wp-test-utils --with-dependencies --ignore-platform-req=php
```

You then get an error about PHPUnit is locked.

When then running the second command with `-W` then before this fix (2.2.1), you get the following:

```
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - phpunit/phpunit[7.5.0, ..., 7.5.20] require sebastian/exporter ^3.1 -> found sebastian/exporter[3.1.0, ..., 3.1.4] but these were not loaded, likely because it conflicts with another require.
    - Root composer.json requires phpunit/phpunit ^7.5 -> satisfiable by phpunit/phpunit[7.5.0, ..., 7.5.20].

```

With this PR merged it is now successful.

I will run the same timing/memory tests I did with the original PR to make sure the update is not making the optimisation useless...

@Seldaek thanks for bringing it to my attention - this will definitely need scrutiny to make sure the approach is right!