### PR TITLE
Replaced package is not installed if its replacer is updated to a version that no longer replaces

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -640,6 +640,8 @@ class PoolBuilder
                     // make sure that any requirements for this package by other locked or fixed packages are now
                     // also loaded, as they were previously ignored because the locked (now unlocked) package already
                     // satisfied their requirements
+                    // and if this package is replacing another that is required by a locked or fixed package, ensure
+                    // that we load that replaced package in case an update to this package removes the replacement
                     foreach ($request->getFixedOrLockedPackages() as $fixedOrLockedPackage) {
                         if ($fixedOrLockedPackage === $lockedPackage) {
                             continue;
@@ -649,6 +651,12 @@ class PoolBuilder
                             $requires = $fixedOrLockedPackage->getRequires();
                             if (isset($requires[$lockedPackage->getName()])) {
                                 $this->markPackageNameForLoading($request, $lockedPackage->getName(), $requires[$lockedPackage->getName()]->getConstraint());
+                            }
+                            foreach ($lockedPackage->getReplaces() as $replace) {
+                                if (isset($requires[$replace->getTarget()], $this->skippedLoad[$replace->getTarget()])) {
+                                    $this->unlockPackage($request, $repositories, $replace->getTarget());
+                                    $this->markPackageNameForLoading($request, $replace->getTarget(), $requires[$replace->getTarget()]->getConstraint());
+                                }
                             }
                         }
                     }

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/load-replaced-package-if-replacer-dropped.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/load-replaced-package-if-replacer-dropped.test
@@ -1,0 +1,50 @@
+--TEST--
+Ensure that a package gets loaded which was previously skipped due to replacement
+
+--REQUEST--
+{
+    "require": {
+        "root/dep": "*",
+        "root/no-update": "*"
+    },
+    "locked": [
+        {"name": "root/dep", "version": "1.1.0", "require": {"replacer/pkg": "1.*"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}},
+        {"name": "root/no-update", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}}
+    ],
+    "allowList": [
+        "root/dep"
+    ],
+    "allowTransitiveDepsNoRootRequire": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name": "root/dep", "version": "1.2.0", "require": {"replacer/pkg": ">=1.1.0"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}},
+        {"name": "replacer/pkg", "version": "1.1.0"},
+        {"name": "replaced/pkg", "version": "1.0.0"},
+        {"name": "root/no-update", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}}
+    ]
+]
+
+--EXPECT--
+[
+    "root/no-update-1.0.0.0 (locked)",
+    "root/dep-1.2.0.0",
+    "replaced/pkg-1.0.0.0",
+    "replacer/pkg-1.1.0.0"
+]
+
+--EXPECT-OPTIMIZED--
+[
+    "root/no-update-1.0.0.0 (locked)",
+    "root/dep-1.2.0.0",
+    "replaced/pkg-1.0.0.0",
+    "replacer/pkg-1.1.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
@@ -136,10 +136,14 @@ class PoolBuilderTest extends TestCase
 
         $result = $this->getPackageResultSet($pool, $packageIds);
 
+        sort($expect);
+        sort($result);
         $this->assertSame($expect, $result, 'Unoptimized pool does not match expected package set');
 
         $optimizer = new PoolOptimizer(new DefaultPolicy());
         $result = $this->getPackageResultSet($optimizer->optimize($request, $pool), $packageIds);
+        sort($expectOptimized);
+        sort($result);
         $this->assertSame($expectOptimized, $result, 'Optimized pool does not match expected package set');
 
         chdir($oldCwd);


### PR DESCRIPTION
During discussion in #9619 @naderman discovered a failing test. This PR adds the test as it was proposed along with a possible fix for it. In summary, if a package (A) that replaces another (B) is updated to a new version that no longer replaces package B, then package B does not get unlocked and added to the pool, therefore the update would presumedly fail unless the package B was also added to the update allow list.

I believe from the discussion in #9619 the replaced package should get loaded and added automatically.