### PR TITLE
Fix symlink resolution in shell proxy

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -397,9 +397,8 @@ PROXY;
         return <<<PROXY
 #!/usr/bin/env sh
 
-self=\$(realpath \$0 >/dev/null 2>&1)
-if [ -z "\$self" ]
-then
+self=\$(realpath \$0 2> /dev/null)
+if [ -z "\$self" ]; then
     self="\$0"
 fi
 


### PR DESCRIPTION
Fixes ```self=$(realpath $0 >/dev/null 2>&1)```, which pipes stdout to /dev/null (and is obviously not the intention).
