### PR TITLE
Remove codeblocks for php 5 compatibilities

### DIFF
--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -293,7 +293,7 @@ class ClassMapGenerator
     {
         static $extraTypes = null;
         if (null === $extraTypes) {
-            $extraTypes = PHP_VERSION_ID < 50400 ? '' : '|trait';
+            $extraTypes = '|trait';
             if (PHP_VERSION_ID >= 80100 || (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>='))) {
                 $extraTypes .= '|enum';
             }

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -292,13 +292,12 @@ class ClassMapGenerator
     private static function getExtraTypes()
     {
         static $extraTypes = null;
-        if (null === $extraTypes) {
-            $extraTypes = '|trait';
-            if (PHP_VERSION_ID >= 80100 || (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>='))) {
-                $extraTypes .= '|enum';
-            }
-            PhpFileCleaner::setTypeConfig(array_merge(array('class', 'interface'), array_filter(explode('|', $extraTypes))));
+
+        if (PHP_VERSION_ID >= 80100 || (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>='))) {
+            $extraTypes .= '|enum';
         }
+
+        PhpFileCleaner::setTypeConfig(array_merge(['trait', 'class', 'interface'], array_filter(explode('|', $extraTypes))));
 
         return $extraTypes;
     }

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -241,7 +241,7 @@ class ClassMapGenerator
         }
 
         // return early if there is no chance of matching anything in this file
-        Preg::matchAll('{\b(?:class|interface'.$extraTypes.')\s}i', $contents, $matches);
+        Preg::matchAll('{\b(?:class|interface|trait'.$extraTypes.')\s}i', $contents, $matches);
         if (!$matches) {
             return array();
         }
@@ -252,7 +252,7 @@ class ClassMapGenerator
 
         Preg::matchAll('{
             (?:
-                 \b(?<![\$:>])(?P<type>class|interface'.$extraTypes.') \s++ (?P<name>[a-zA-Z_\x7f-\xff:][a-zA-Z0-9_\x7f-\xff:\-]*+)
+                 \b(?<![\$:>])(?P<type>class|interface|trait'.$extraTypes.') \s++ (?P<name>[a-zA-Z_\x7f-\xff:][a-zA-Z0-9_\x7f-\xff:\-]*+)
                | \b(?<![\$:>])(?P<ns>namespace) (?P<nsname>\s++[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\s*+\\\\\s*+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+)? \s*+ [\{;]
             )
         }ix', $contents, $matches);
@@ -293,11 +293,14 @@ class ClassMapGenerator
     {
         static $extraTypes = null;
 
-        if (PHP_VERSION_ID >= 80100 || (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>='))) {
-            $extraTypes .= '|enum';
-        }
+        if (null === $extraTypes) {
+            $extraTypes = '';
+            if (PHP_VERSION_ID >= 80100 || (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.3', '>='))) {
+                $extraTypes .= '|enum';
+            }
 
-        PhpFileCleaner::setTypeConfig(array_merge(['trait', 'class', 'interface'], array_filter(explode('|', $extraTypes))));
+            PhpFileCleaner::setTypeConfig(array_merge(['class', 'interface', 'trait'], array_filter(explode('|', $extraTypes))));
+        }
 
         return $extraTypes;
     }

--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -248,11 +248,7 @@ class Cache
             return false;
         }
 
-        if (PHP_VERSION_ID > 70000) {
-            return !random_int(0, 50);
-        }
-
-        return !mt_rand(0, 50);
+        return !random_int(0, 50);
     }
 
     /**

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -626,7 +626,7 @@ EOT
                         break;
 
                     case 'php':
-                        $text = PHP_EOL."Your PHP ({$current}) is too old, you must upgrade to PHP 5.3.2 or higher.";
+                        $text = PHP_EOL."Your PHP ({$current}) is too old, you must upgrade to PHP 7.2.5 or higher.";
                         break;
 
                     case 'allow_url_fopen':
@@ -685,8 +685,8 @@ EOT
                         break;
 
                     case 'php':
-                        $text = "Your PHP ({$current}) is quite old, upgrading to PHP 5.3.4 or higher is recommended.".PHP_EOL;
-                        $text .= " Composer works with 5.3.2+ for most people, but there might be edge case issues.";
+                        $text = "Your PHP ({$current}) is quite old, upgrading to PHP 7.2.5 or higher is recommended.".PHP_EOL;
+                        $text .= " Composer works with 7.2.5+ for most people, but there might be edge case issues.";
                         break;
 
                     case 'openssl_version':

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -553,6 +553,14 @@ EOT
             $errors['ioncube'] = ioncube_loader_version();
         }
 
+        if (PHP_VERSION_ID < 70205) {
+            $errors['php'] = PHP_VERSION;
+        }
+
+        if (!isset($errors['php']) && PHP_VERSION_ID < 70205) {
+            $warnings['php'] = PHP_VERSION;
+        }
+
         if (!extension_loaded('openssl')) {
             $errors['openssl'] = true;
         }

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -553,14 +553,6 @@ EOT
             $errors['ioncube'] = ioncube_loader_version();
         }
 
-        if (PHP_VERSION_ID < 50302) {
-            $errors['php'] = PHP_VERSION;
-        }
-
-        if (!isset($errors['php']) && PHP_VERSION_ID < 50304) {
-            $warnings['php'] = PHP_VERSION;
-        }
-
         if (!extension_loaded('openssl')) {
             $errors['openssl'] = true;
         }

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -557,10 +557,6 @@ EOT
             $errors['php'] = PHP_VERSION;
         }
 
-        if (!isset($errors['php']) && PHP_VERSION_ID < 70205) {
-            $warnings['php'] = PHP_VERSION;
-        }
-
         if (!extension_loaded('openssl')) {
             $errors['openssl'] = true;
         }
@@ -690,11 +686,6 @@ EOT
                     case 'curlwrappers':
                         $text = "PHP was compiled with --with-curlwrappers which will cause issues with HTTP authentication and GitHub.".PHP_EOL;
                         $text .= " Recompile it without this flag if possible";
-                        break;
-
-                    case 'php':
-                        $text = "Your PHP ({$current}) is quite old, upgrading to PHP 7.2.5 or higher is recommended.".PHP_EOL;
-                        $text .= " Composer works with 7.2.5+ for most people, but there might be edge case issues.";
                         break;
 
                     case 'openssl_version':

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -819,11 +819,6 @@ EOT
             return true;
         }
 
-        // php <5.3.3 has a very broken email validator, so bypass checks
-        if (PHP_VERSION_ID < 50303) {
-            return true;
-        }
-
         return false !== filter_var($email, FILTER_VALIDATE_EMAIL);
     }
 

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -252,8 +252,8 @@ class Application extends BaseApplication
                 function_exists('php_uname') ? php_uname('s') . ' / ' . php_uname('r') : 'Unknown OS'
             ), true, IOInterface::DEBUG);
 
-            if (PHP_VERSION_ID < 50302) {
-                $io->writeError('<warning>Composer only officially supports PHP 5.3.2 and above, you will most likely encounter problems with your PHP '.PHP_VERSION.', upgrading is strongly recommended.</warning>');
+            if (PHP_VERSION_ID < 70205) {
+                $io->writeError('<warning>Composer only officially supports PHP 7.2.5 and above, you will most likely encounter problems with your PHP '.PHP_VERSION.', upgrading is strongly recommended.</warning>');
             }
 
             if (XdebugHandler::isXdebugActive() && !Platform::getEnv('COMPOSER_DISABLE_XDEBUG_WARN')) {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -253,7 +253,7 @@ class Application extends BaseApplication
             ), true, IOInterface::DEBUG);
 
             if (PHP_VERSION_ID < 70205) {
-                $io->writeError('<warning>Composer only officially supports PHP 7.2.5 and above, you will most likely encounter problems with your PHP '.PHP_VERSION.', upgrading is strongly recommended.</warning>');
+                $io->writeError('<warning>Composer supports PHP 7.2.5 and above, you will most likely encounter problems with your PHP '.PHP_VERSION.'. Upgrading is strongly recommended but you can use Composer 2.2.x LTS as a fallback.</warning>');
             }
 
             if (XdebugHandler::isXdebugActive() && !Platform::getEnv('COMPOSER_DISABLE_XDEBUG_WARN')) {

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -685,9 +685,6 @@ class Factory
             if (false !== strpos($e->getMessage(), 'cafile')) {
                 $io->write('<error>Unable to locate a valid CA certificate file. You must set a valid \'cafile\' option.</error>');
                 $io->write('<error>A valid CA certificate file is required for SSL/TLS protection.</error>');
-                if (PHP_VERSION_ID < 50600) {
-                    $io->write('<error>It is recommended you upgrade to PHP 5.6+ which can detect your system CA file automatically.</error>');
-                }
                 $io->write('<error>You can disable this error, at your own risk, by setting the \'disable-tls\' option to true.</error>');
             }
             throw $e;

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -238,35 +238,12 @@ class JsonFile
      */
     public static function encode($data, $options = 448)
     {
-        if (PHP_VERSION_ID >= 50400) {
-            $json = json_encode($data, $options);
-            if (false === $json) {
-                self::throwEncodeError(json_last_error());
-            }
-
-            //  compact brackets to follow recent php versions
-            if (PHP_VERSION_ID < 50428 || (PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 50512) || (defined('JSON_C_VERSION') && version_compare(phpversion('json'), '1.3.6', '<'))) {
-                $json = Preg::replace('/\[\s+\]/', '[]', $json);
-                $json = Preg::replace('/\{\s+\}/', '{}', $json);
-            }
-
-            return $json;
-        }
-
-        $json = json_encode($data);
+        $json = json_encode($data, $options);
         if (false === $json) {
             self::throwEncodeError(json_last_error());
         }
 
-        $prettyPrint = (bool) ($options & self::JSON_PRETTY_PRINT);
-        $unescapeUnicode = (bool) ($options & self::JSON_UNESCAPED_UNICODE);
-        $unescapeSlashes = (bool) ($options & self::JSON_UNESCAPED_SLASHES);
-
-        if (!$prettyPrint && !$unescapeUnicode && !$unescapeSlashes) {
-            return $json;
-        }
-
-        return JsonFormatter::format($json, $unescapeUnicode, $unescapeSlashes);
+        return $json;
     }
 
     /**

--- a/src/Composer/Json/JsonFormatter.php
+++ b/src/Composer/Json/JsonFormatter.php
@@ -22,7 +22,7 @@ use Composer\Pcre\Preg;
  * @author Konstantin Kudryashiv <ever.zet@gmail.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
  *
- * @abandoned
+ * @abandoned Use json_encode or JsonFile::encode() with modern JSON_* flags to configure formatting - this class will be removed in 3.0
  */
 class JsonFormatter
 {

--- a/src/Composer/Json/JsonFormatter.php
+++ b/src/Composer/Json/JsonFormatter.php
@@ -21,6 +21,8 @@ use Composer\Pcre\Preg;
  *
  * @author Konstantin Kudryashiv <ever.zet@gmail.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @abandoned
  */
 class JsonFormatter
 {

--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -51,10 +51,9 @@ class ZipArchiver implements ArchiverInterface
                 }
 
                 /**
-                 * ZipArchive::setExternalAttributesName is available from >= PHP 5.6
                  * setExternalAttributesName() is only available with libzip 0.11.2 or above
                  */
-                if (PHP_VERSION_ID >= 50600 && method_exists($zip, 'setExternalAttributesName')) {
+                if (method_exists($zip, 'setExternalAttributesName')) {
                     $perms = fileperms($filepath);
 
                     /**

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -397,10 +397,6 @@ class Git
      */
     public static function cleanEnv()
     {
-        if (PHP_VERSION_ID < 50400 && ini_get('safe_mode') && false === strpos(ini_get('safe_mode_allowed_env_vars'), 'GIT_ASKPASS')) {
-            throw new \RuntimeException('safe_mode is enabled and safe_mode_allowed_env_vars does not contain GIT_ASKPASS, can not set env var. You can disable safe_mode with "-dsafe_mode=0" when running composer');
-        }
-
         // added in git 1.7.1, prevents prompting the user for username/password
         if (Platform::getEnv('GIT_ASKPASS') !== 'echo') {
             Platform::putEnv('GIT_ASKPASS', 'echo');

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -669,17 +669,6 @@ class RemoteFilesystem
         if ($this->disableTls === false && PHP_VERSION_ID < 50600 && !stream_is_local($this->fileUrl)) {
             $host = parse_url($this->fileUrl, PHP_URL_HOST);
 
-            if (PHP_VERSION_ID < 50304) {
-                // PHP < 5.3.4 does not support follow_location, for those people
-                // do some really nasty hard coded transformations. These will
-                // still breakdown if the site redirects to a domain we don't
-                // expect.
-
-                if ($host === 'github.com' || $host === 'api.github.com') {
-                    $host = '*.github.com';
-                }
-            }
-
             $tlsOptions['ssl']['CN_match'] = $host;
             $tlsOptions['ssl']['SNI_server_name'] = $host;
 
@@ -879,12 +868,7 @@ class RemoteFilesystem
             $decode = $contentEncoding && 'gzip' === strtolower($contentEncoding);
 
             if ($decode) {
-                if (PHP_VERSION_ID >= 50400) {
-                    $result = zlib_decode($result);
-                } else {
-                    // work around issue with gzuncompress & co that do not work with all gzip checksums
-                    $result = file_get_contents('compress.zlib://data:application/octet-stream;base64,'.base64_encode($result));
-                }
+                $result = zlib_decode($result);
 
                 if ($result === false) {
                     throw new TransportException('Failed to decode zlib stream');

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -332,18 +332,6 @@ class RemoteFilesystem
 
                 throw $e;
             }
-
-            if (PHP_VERSION_ID < 50600 && !empty($options['ssl']['peer_fingerprint'])) {
-                // Emulate fingerprint validation on PHP < 5.6
-                $params = stream_context_get_params($ctx);
-                $expectedPeerFingerprint = $options['ssl']['peer_fingerprint'];
-                $peerFingerprint = TlsHelper::getCertificateFingerprint($params['options']['ssl']['peer_certificate']);
-
-                // Constant time compare??!
-                if ($expectedPeerFingerprint !== $peerFingerprint) {
-                    throw new TransportException('Peer fingerprint did not match');
-                }
-            }
         } catch (\Exception $e) {
             if ($e instanceof TransportException && !empty($http_response_header[0])) {
                 $e->setHeaders($http_response_header);

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -222,12 +222,11 @@ final class StreamContextFactory
             throw new TransportException('The configured capath was not valid or could not be read.');
         }
 
+
         /**
          * Disable TLS compression to prevent CRIME attacks where supported.
          */
-        if (PHP_VERSION_ID >= 50413) {
-            $defaults['ssl']['disable_compression'] = true;
-        }
+        $defaults['ssl']['disable_compression'] = true;
 
         return $defaults;
     }

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -222,7 +222,6 @@ final class StreamContextFactory
             throw new TransportException('The configured capath was not valid or could not be read.');
         }
 
-
         /**
          * Disable TLS compression to prevent CRIME attacks where supported.
          */

--- a/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/ClassMapGeneratorTest.php
@@ -40,10 +40,6 @@ class ClassMapGeneratorTest extends TestCase
      */
     public function getTestCreateMapTests()
     {
-        if (PHP_VERSION_ID == 50303) {
-            $this->markTestSkipped('Test segfaults on travis 5.3.3 due to ClassMap\LongString');
-        }
-
         $classmap = array(
             'Foo\\Bar\\A' => realpath(__DIR__) . '/Fixtures/classmap/sameNsMultipleClasses.php',
             'Foo\\Bar\\B' => realpath(__DIR__) . '/Fixtures/classmap/sameNsMultipleClasses.php',

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -298,9 +298,6 @@ class JsonFileTest extends TestCase
 
     public function testUnicode()
     {
-        if (!function_exists('mb_convert_encoding')) {
-            $this->markTestSkipped('Test requires the mbstring extension');
-        }
 
         $data = array("Žluťoučký \" kůň" => "úpěl ďábelské ódy za €");
         $json = '{
@@ -312,9 +309,6 @@ class JsonFileTest extends TestCase
 
     public function testOnlyUnicode()
     {
-        if (!function_exists('mb_convert_encoding')) {
-            $this->markTestSkipped('Test requires the mbstring extension');
-        }
 
         $data = "\\/ƌ";
 

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -298,7 +298,7 @@ class JsonFileTest extends TestCase
 
     public function testUnicode()
     {
-        if (!function_exists('mb_convert_encoding') && PHP_VERSION_ID < 50400) {
+        if (!function_exists('mb_convert_encoding')) {
             $this->markTestSkipped('Test requires the mbstring extension');
         }
 
@@ -312,7 +312,7 @@ class JsonFileTest extends TestCase
 
     public function testOnlyUnicode()
     {
-        if (!function_exists('mb_convert_encoding') && PHP_VERSION_ID < 50400) {
+        if (!function_exists('mb_convert_encoding')) {
             $this->markTestSkipped('Test requires the mbstring extension');
         }
 

--- a/tests/Composer/Test/Platform/HhvmDetectorTest.php
+++ b/tests/Composer/Test/Platform/HhvmDetectorTest.php
@@ -45,9 +45,6 @@ class HhvmDetectorTest extends TestCase
         if (defined('HHVM_VERSION_ID')) {
             self::markTestSkipped('Running with HHVM');
         }
-        if (PHP_VERSION_ID < 50400) {
-            self::markTestSkipped('Test only works on PHP 5.4+');
-        }
         if (Platform::isWindows()) {
             self::markTestSkipped('Test does not run on Windows');
         }

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -252,10 +252,6 @@ class RemoteFilesystemTest extends TestCase
         $this->assertTrue($res['ssl']['verify_peer']);
         $this->assertTrue($res['ssl']['SNI_enabled']);
         $this->assertEquals(7, $res['ssl']['verify_depth']);
-        if (PHP_VERSION_ID < 50600) {
-            $this->assertEquals('www.example.org', $res['ssl']['CN_match']);
-            $this->assertEquals('www.example.org', $res['ssl']['SNI_server_name']);
-        }
         $this->assertEquals('/some/path/file.crt', $res['ssl']['cafile']);
         if (version_compare(PHP_VERSION, '5.4.13') >= 0) {
             $this->assertTrue($res['ssl']['disable_compression']);


### PR DESCRIPTION
This PR removes a couple of codeblocks that exists just to keep the codebase compatible with deprecated php versions.
Let me know if a different behaviour is needed anywhere instead of removal, I'll be happy to update the PR!