### PR TITLE
Fixing the API version

### DIFF
--- a/doc/articles/plugins.md
+++ b/doc/articles/plugins.md
@@ -39,7 +39,7 @@ requirements:
 The required version of the `composer-plugin-api` follows the same [rules][7]
 as a normal package's rules.
 
-The current Composer plugin API version is `2.1.0`.
+The current Composer plugin API version is `2.2.0`.
 
 An example of a valid plugin `composer.json` file (with the autoloading
 part omitted and an optional require-dev dependency on `composer/composer` for IDE auto completion):


### PR DESCRIPTION
Fixing the API version in the documentation, to be concise with the change done in https://github.com/composer/composer/commit/1b5b5c48bf91f256745740b6b60e460180213d7d