### PR TITLE
Fix #10366: Improve messaging when GitHub tokens need SSO authorization

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -92,6 +92,22 @@ class AuthHelper
             $message = "\n";
 
             $rateLimited = $gitHubUtil->isRateLimited($headers);
+            $requiresSso = $gitHubUtil->requiresSso($headers);
+
+            if ($requiresSso) {
+                $ssoUrl = $gitHubUtil->getSsoUrl($headers);
+                $message = sprintf(
+                        'GitHub API token requires SSO authorization. Authorize this token at ' . $ssoUrl,
+                        $ssoUrl
+                    ) . "\n";
+                $this->io->writeError($message);
+                if (!$this->io->isInteractive()) {
+                    throw new TransportException('Could not authenticate against ' . $origin, 403);
+                }
+                $this->io->ask('After authorizing your token, confirm that you would like to retry the request');
+                return ['retry' => TRUE, 'storeAuth' => $storeAuth];
+            }
+
             if ($rateLimited) {
                 $rateLimit = $gitHubUtil->getRateLimit($headers);
                 if ($this->io->hasAuthentication($origin)) {

--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -105,7 +105,8 @@ class AuthHelper
                     throw new TransportException('Could not authenticate against ' . $origin, 403);
                 }
                 $this->io->ask('After authorizing your token, confirm that you would like to retry the request');
-                return ['retry' => TRUE, 'storeAuth' => $storeAuth];
+
+                return array('retry' => true, 'storeAuth' => $storeAuth);
             }
 
             if ($rateLimited) {

--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -172,6 +172,27 @@ class GitHub
     }
 
     /**
+     * Extract SSO URL from response.
+     *
+     * @param string[] $headers Headers from Composer\Downloader\TransportException.
+     *
+     * @return string|null
+     */
+    public function getSsoUrl(array $headers)
+    {
+        foreach ($headers as $header) {
+            $header = trim($header);
+            if (false === strpos($header, 'x-github-sso: required')) {
+                continue;
+            }
+            list(, $url) = explode('=', $header, 2);
+            return $url;
+        }
+
+        return null;
+    }
+
+    /**
      * Finds whether a request failed due to rate limiting
      *
      * @param string[] $headers Headers from Composer\Downloader\TransportException.
@@ -182,6 +203,26 @@ class GitHub
     {
         foreach ($headers as $header) {
             if (Preg::isMatch('{^X-RateLimit-Remaining: *0$}i', trim($header))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Finds whether a request failed due to lacking SSO authorization
+     *
+     * @see https://docs.github.com/en/rest/overview/other-authentication-methods#authenticating-for-saml-sso
+     *
+     * @param string[] $headers Headers from Composer\Downloader\TransportException.
+     *
+     * @return bool
+     */
+    public function requiresSso(array $headers)
+    {
+        foreach ($headers as $header) {
+            if (Preg::isMatch('{^X-GitHub-SSO: required}i', trim($header))) {
                 return true;
             }
         }

--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -182,11 +182,12 @@ class GitHub
     {
         foreach ($headers as $header) {
             $header = trim($header);
-            if (false === strpos($header, 'x-github-sso: required')) {
+            if (false === stripos($header, 'x-github-sso: required')) {
                 continue;
             }
-            list(, $url) = explode('=', $header, 2);
-            return $url;
+            if (Preg::isMatch('{\burl=(?P<url>[^\s;]+)}', $header, $match)) {
+                return $match['url'];
+            }
         }
 
         return null;


### PR DESCRIPTION
Fix #10366

This might be a little rough, I tried to keep it consistent with the rest of the auth helper methods which I found a little hard to parse. But if you're happy with the overall approach and provide feedback, I'll clean it up.