### PR TITLE
GitLab: detect repository functionality disabled in Driver

### DIFF
--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -504,6 +504,11 @@ class GitLabDriver extends VcsDriver
 
                 // force auth as the unauthenticated version of the API is broken
                 if (!isset($json['default_branch'])) {
+                    // GitLab allows you to disable the repository inside a project to use a project only for issues and wiki
+                    if (isset($json['repository_access_level']) && $json['repository_access_level'] === 'disabled') {
+                        throw new TransportException('The GitLab repository is disabled in the project', 400);
+                    }
+
                     if (!empty($json['id'])) {
                         $this->isPrivate = false;
                     }


### PR DESCRIPTION
Can otherwise cause `Warning: Undefined array key "default_branch" /src/Composer/Repository/Vcs/GitLabDriver.php:287`