### PR TITLE
Move "packagist.org" to named property

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -181,10 +181,12 @@
         "repositories": {
             "type": ["object", "array"],
             "description": "A set of additional repositories where packages can be found.",
+            "properties": {
+                "packagist.org": { "type": "boolean", "enum": [false] }
+            },
             "additionalProperties": {
                 "anyOf": [
-                    { "$ref": "#/definitions/repository" },
-                    { "type": "boolean", "enum": [false] }
+                    { "$ref": "#/definitions/repository" }
                 ]
             },
             "items": {
@@ -192,7 +194,9 @@
                     { "$ref": "#/definitions/repository" },
                     {
                         "type": "object",
-                        "additionalProperties": { "type": "boolean", "enum": [false] },
+                        "properties": {
+                            "packagist.org": { "type": "boolean", "enum": [false] }
+                        },
                         "minProperties": 1,
                         "maxProperties": 1
                     }


### PR DESCRIPTION
This is the only allowed syntax according to the https://getcomposer.org/doc/05-repositories.md#disabling-packagist-org and existence of property name will enable code assistance for tools that are work based on this schema, for example IDE that provide code completion
