### PR TITLE
Disable "composer/package-versions-deprecated" by default

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -699,6 +699,10 @@ class PluginManager
             }
         }
 
+        if ($package === 'composer/package-versions-deprecated') {
+            return false;
+        }
+
         if (!isset($warned[$package])) {
             if ($this->io->isInteractive()) {
                 $composer = $isGlobalPlugin && $this->globalComposer !== null ? $this->globalComposer : $this->composer;


### PR DESCRIPTION
Instead of  #10354

Inspired by @stof's comment at https://github.com/composer/composer/pull/10354#issuecomment-1013108766

The goal here is to free the ecosystem from having to reference a legacy plugin in their composer.json files.