### PR TITLE
report error if binary is a directory

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -77,6 +77,10 @@ class BinaryInstaller
                 $this->io->writeError('    <warning>Skipped installation of bin '.$bin.' for package '.$package->getName().': file not found in package</warning>');
                 continue;
             }
+            if (is_dir($binPath)) {
+                $this->io->writeError('    <warning>Skipped installation of bin '.$bin.' for package '.$package->getName().': found a directory at that path</warning>');
+                continue;
+            }
             if (!$this->filesystem->isAbsolutePath($binPath)) {
                 // in case a custom installer returned a relative path for the
                 // $package, we can now safely turn it into a absolute path (as we


### PR DESCRIPTION
file_exists is true also for directory and symlink. but later in generateUnixyProxyCode we call `file_get_contents` on the binary, which fails with `file_get_contents(): read of 8192 bytes failed with errno=21 Is a directory` if the binary is a directory.

maybe we can just change file_exists to is_file, but that would probably mess with symlinks.

this problem only started to occur with composer 2.2, in 2.1.16, the problem was silently ignored. because the error in 2.2 is a fatal error, we get no context about the composer package that causes the problem, nor the path that is a directory instead of a file.