### PR TITLE
ArrayLoader: handle none string values for version/version_normalized

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -113,12 +113,12 @@ class ArrayLoader implements LoaderInterface
         if (!isset($config['name'])) {
             throw new \UnexpectedValueException('Unknown package has no name defined ('.json_encode($config).').');
         }
-        if (!isset($config['version'])) {
+        if (!isset($config['version']) || !is_scalar($config['version'])) {
             throw new \UnexpectedValueException('Package '.$config['name'].' has no version defined.');
         }
 
         // handle already normalized versions
-        if (isset($config['version_normalized'])) {
+        if (isset($config['version_normalized']) && is_string($config['version_normalized'])) {
             $version = $config['version_normalized'];
 
             // handling of existing repos which need to remain composer v1 compatible, in case the version_normalized contained VersionParser::DEFAULT_BRANCH_ALIAS, we renormalize it
@@ -129,7 +129,7 @@ class ArrayLoader implements LoaderInterface
             $version = $this->versionParser->normalize($config['version']);
         }
 
-        return new $class($config['name'], $version, $config['version']);
+        return new $class($config['name'], $version, (string) $config['version']);
     }
 
     /**

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -116,6 +116,9 @@ class ArrayLoader implements LoaderInterface
         if (!isset($config['version']) || !is_scalar($config['version'])) {
             throw new \UnexpectedValueException('Package '.$config['name'].' has no version defined.');
         }
+        if (!is_string($config['version'])) {
+            $config['version'] = (string) $config['version'];
+        }
 
         // handle already normalized versions
         if (isset($config['version_normalized']) && is_string($config['version_normalized'])) {
@@ -129,7 +132,7 @@ class ArrayLoader implements LoaderInterface
             $version = $this->versionParser->normalize($config['version']);
         }
 
-        return new $class($config['name'], $version, (string) $config['version']);
+        return new $class($config['name'], $version, $config['version']);
     }
 
     /**

--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -71,11 +71,15 @@ class ValidatingArrayLoader implements LoaderInterface
         }
 
         if (!empty($this->config['version'])) {
-            try {
-                $this->versionParser->normalize($this->config['version']);
-            } catch (\Exception $e) {
-                $this->errors[] = 'version : invalid value ('.$this->config['version'].'): '.$e->getMessage();
-                unset($this->config['version']);
+            if (!is_scalar($this->config['version'])) {
+                $this->validateString('version');
+            } else {
+                try {
+                    $this->versionParser->normalize($this->config['version']);
+                } catch (\Exception $e) {
+                    $this->errors[] = 'version : invalid value ('.$this->config['version'].'): '.$e->getMessage();
+                    unset($this->config['version']);
+                }
             }
         }
 

--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -74,6 +74,9 @@ class ValidatingArrayLoader implements LoaderInterface
             if (!is_scalar($this->config['version'])) {
                 $this->validateString('version');
             } else {
+                if (!is_string($this->config['version'])) {
+                    $this->config['version'] = (string) $this->config['version'];
+                }
                 try {
                     $this->versionParser->normalize($this->config['version']);
                 } catch (\Exception $e) {

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -314,4 +314,15 @@ class ArrayLoaderTest extends TestCase
         $this->assertArrayHasKey('composer-plugin-api', $links);
         $this->assertSame('6.6.6', $links['composer-plugin-api']->getConstraint()->getPrettyString());
     }
+
+    public function testNoneStringVersion()
+    {
+        $config = array(
+            'name' => 'acme/package',
+            'version' => 1,
+        );
+
+        $package = $this->loader->load($config);
+        $this->assertSame('1', $package->getPrettyVersion());
+    }
 }


### PR DESCRIPTION
Asserting that `Package::getVersion/Package::getPrettyVersion` always return a string. Currently this can return bool/int/float/string.

Additionally catching cases where version is not an array/object which currently throws a `TypeError : trim(): Argument #1 ($string) must be of type string, array given` 