### PR TITLE
Clean up properly if self-update fails

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -468,6 +468,7 @@ TAGSPUBKEY
                 return $this->tryAsWindowsAdmin($localFilename, $newFilename);
             }
 
+            @unlink($newFilename);
             $action = 'Composer '.($backupTarget ? 'update' : 'rollback');
             throw new FilesystemException($action.' failed: "'.$localFilename.'" could not be written.'.PHP_EOL.$e->getMessage());
         }
@@ -620,7 +621,7 @@ EOT;
         exec('"'.$script.'"');
         @unlink($script);
 
-        // see if the file was moved and is still accessible
+        // see if the file was copied and is still accessible
         if ($result = Filesystem::isReadable($localFilename) && (hash_file('sha256', $localFilename) === $checksum)) {
             $io->writeError('<info>Operation succeeded.</info>');
             @unlink($newFilename);


### PR DESCRIPTION
If self-update fails because the downloaded file cannot be renamed or copied, it is left wherever it was downloaded to. Because it was always given the same name (`composer-temp.phar`), this didn't seem much of a problem - and could allow the user to manually move it if things got hairy.

However, it is now given a randomized name (3bb78fd1e) which produces multiple files, so this fix deletes the downloaded file on self-update failure.