### PR TITLE
Add abandoned flag to show/outdated commands package lists

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -461,6 +461,7 @@ EOT
                             $packageViewData['path'] = strtok(realpath($composer->getInstallationManager()->getInstallPath($package)), "\r\n");
                         }
 
+                        $packageIsAbandoned = false;
                         if ($latestPackage instanceof CompletePackageInterface && $latestPackage->isAbandoned()) {
                             $replacement = is_string($latestPackage->getReplacementPackage())
                                 ? 'Use ' . $latestPackage->getReplacementPackage() . ' instead'
@@ -471,7 +472,10 @@ EOT
                                 $replacement
                             );
                             $packageViewData['warning'] = $packageWarning;
+                            $packageIsAbandoned = true;
                         }
+
+                        $packageViewData['abandoned'] = $packageIsAbandoned;
                     } else {
                         $packageViewData['name'] = $package;
                         $nameLength = max($nameLength, strlen($package));

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -463,7 +463,8 @@ EOT
 
                         $packageIsAbandoned = false;
                         if ($latestPackage instanceof CompletePackageInterface && $latestPackage->isAbandoned()) {
-                            $replacement = is_string($latestPackage->getReplacementPackage())
+                            $replacementPackageName = $latestPackage->getReplacementPackage();
+                            $replacement = $replacementPackageName !== null
                                 ? 'Use ' . $latestPackage->getReplacementPackage() . ' instead'
                                 : 'No replacement was suggested';
                             $packageWarning = sprintf(
@@ -472,7 +473,7 @@ EOT
                                 $replacement
                             );
                             $packageViewData['warning'] = $packageWarning;
-                            $packageIsAbandoned = true;
+                            $packageIsAbandoned = $replacementPackageName ?? true;
                         }
 
                         $packageViewData['abandoned'] = $packageIsAbandoned;


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->

Hey there,

we are using the `composer outdated --format=json` output to create scheduled JSON files we can use to notify us when projects needs some maintenance. I'd love to have some `abandoned` flag in there so we do not have to parse the `warning` string. 

I'm open for additional changes but this flag would definitely help us and maybe others who are consuming this JSON.
Feedback welcome.