### PR TITLE
Add config option for update reference in path repository

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -755,6 +755,25 @@ variables are parsed in both Windows and Linux/Mac notations. For example
 > **Note:** Repository paths can also contain wildcards like `*` and `?`.
 > For details, see the [PHP glob function](https://php.net/glob).
 
+You can configure the behavior of reference building for a package. Field reference showing when something changed in package.
+There are the following options:
+- null - reference will be always null
+- config - reference is building basing on hash of composer.json and repo config
+- auto (used by default) - reference is building basing on hash of composer.json and repo config, but if the package folder contain git repository, then reference will be equal to the last commit hash in this folder
+```json
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../packages/my-package",
+            "options": {
+                "reference": "auto"
+            }
+        }
+    ]
+}
+```
+
 ## Disabling Packagist.org
 
 You can disable the default Packagist.org repository by adding this to your

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -755,11 +755,17 @@ variables are parsed in both Windows and Linux/Mac notations. For example
 > **Note:** Repository paths can also contain wildcards like `*` and `?`.
 > For details, see the [PHP glob function](https://php.net/glob).
 
-You can configure the behavior of reference building for a package. Field reference showing when something changed in package.
+You can configure the way the package's dist reference (which appears in
+the composer.lock file) is built.
+
 There are the following options:
-- null - reference will be always null
-- config - reference is building basing on hash of composer.json and repo config
-- auto (used by default) - reference is building basing on hash of composer.json and repo config, but if the package folder contain git repository, then reference will be equal to the last commit hash in this folder
+- `null` - reference will be always null. This can help reduce lock file conflicts
+  in the lock file but reduces clarity as to when the last update happened and whether
+  the package is in the latest state.
+- `config` - reference is built based on a hash of the package's composer.json and repo config
+- `auto` (used by default) - reference is built basing on the hash like with `config`, but if
+  the package folder contains a git repository, the HEAD commit's hash is used as reference instead.
+
 ```json
 {
     "repositories": [
@@ -767,7 +773,7 @@ There are the following options:
             "type": "path",
             "url": "../../packages/my-package",
             "options": {
-                "reference": "auto"
+                "reference": "config"
             }
         }
     ]

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -98,7 +98,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
     private $process;
 
     /**
-     * @var array{symlink?: bool, reference?: string, relative: bool, versions?: array<string, string>}
+     * @var array{symlink?: bool, reference?: string, relative?: bool, versions?: array<string, string>}
      */
     private $options;
 

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -154,4 +154,50 @@ class PathRepositoryTest extends TestCase
         $relativeUrl = str_replace(DIRECTORY_SEPARATOR, '/', $relativeUrl);
         $this->assertSame($relativeUrl, $package->getDistUrl());
     }
+
+    public function testReferenceNone()
+    {
+        $ioInterface = $this->getMockBuilder('Composer\IO\IOInterface')
+            ->getMock();
+
+        $config = new \Composer\Config();
+
+        $options = array(
+            'reference' => 'none',
+        );
+        $repositoryUrl = implode(DIRECTORY_SEPARATOR, array(__DIR__, 'Fixtures', 'path', '*'));
+        $repository = new PathRepository(array('url' => $repositoryUrl, 'options' => $options), $ioInterface, $config);
+        $packages = $repository->getPackages();
+
+        $this->assertGreaterThanOrEqual(2, $repository->count());
+
+        foreach ($packages as $package) {
+            $this->assertEquals($package->getDistReference(), null);
+        }
+    }
+
+    public function testReferenceConfig()
+    {
+        $ioInterface = $this->getMockBuilder('Composer\IO\IOInterface')
+            ->getMock();
+
+        $config = new \Composer\Config();
+
+        $options = array(
+            'reference' => 'config',
+            'relative' => true,
+        );
+        $repositoryUrl = implode(DIRECTORY_SEPARATOR, array(__DIR__, 'Fixtures', 'path', '*'));
+        $repository = new PathRepository(array('url' => $repositoryUrl, 'options' => $options), $ioInterface, $config);
+        $packages = $repository->getPackages();
+
+        $this->assertGreaterThanOrEqual(2, $repository->count());
+
+        foreach ($packages as $package) {
+            $this->assertEquals(
+                $package->getDistReference(),
+                sha1(file_get_contents($package->getDistUrl() . '/composer.json') . serialize($options))
+            );
+        }
+    }
 }


### PR DESCRIPTION
Example of composer.json
```
{
  "name": "example/example",
  "require": {
    "pathExample/example": "^1.0"
  },
  "repositories": [
    {
      "type": "path",
      "url": "./pathExample"
    }
  ]  
}
```
Source code in folder pathExample is under git version control and offently updated by developers, and after each update "reference" in composer.lock for this package is update, but it caused a conflict between different branches. So it will be great to have opportunity to configure reference updating like this

```
{
  "name": "example/example",
  "require": {
    "pathExample/example": "^1.0"
  },
  "repositories": [
    {
      "type": "path",
      "url": "./pathExample",
      "reference": "none"
    }
  ]  
}
```

Related to https://github.com/composer/composer/issues/10482