### PR TITLE
Improve installed.php meta information

### DIFF
--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -269,7 +269,13 @@ class FilesystemRepository extends WritableArrayRepository
                     $replaced = $package->getPrettyVersion();
                 }
                 if (!isset($versions['versions'][$replace->getTarget()]['replaced']) || !in_array($replaced, $versions['versions'][$replace->getTarget()]['replaced'], true)) {
+
+                    // This does not give enough information about what package(s) replace the current package!
+                    // SHOULD be deprecated! We keep it to avoid breaking changes in composer 2.x
                     $versions['versions'][$replace->getTarget()]['replaced'][] = $replaced;
+
+                    // This ensures to that the replacement's source is available in the data structure.
+                    $versions['versions'][$replace->getTarget()]['replaced_by'][$replace->getSource()][] = $replaced;
                 }
             }
             foreach ($package->getProvides() as $provide) {
@@ -287,7 +293,13 @@ class FilesystemRepository extends WritableArrayRepository
                     $provided = $package->getPrettyVersion();
                 }
                 if (!isset($versions['versions'][$provide->getTarget()]['provided']) || !in_array($provided, $versions['versions'][$provide->getTarget()]['provided'], true)) {
+
+                    // This does not give enough information about what package(s) provide for the current package!
+                    // SHOULD be deprecated! We keep it to avoid breaking changes in composer 2.x
                     $versions['versions'][$provide->getTarget()]['provided'][] = $provided;
+
+                    // This ensures to that the provided package's source is available in the data structure.
+                    $versions['versions'][$provide->getTarget()]['provided_by'][$provide->getSource()][] = $provided;
                 }
             }
         }

--- a/tests/Composer/Test/Repository/Fixtures/installed.php
+++ b/tests/Composer/Test/Repository/Fixtures/installed.php
@@ -86,21 +86,48 @@ return array(
                 '1.4',
                 '2.0',
             ),
+            'provided_by' => array(
+                'a/provider' => array(
+                    '^1.1'
+                ),
+                'a/provider2' => array(
+                    '1.2',
+                    '1.4',
+                ),
+                '__root__' => array(
+                    '2.0',
+                )
+            )
         ),
         'foo/impl2' => array(
             'dev_requirement' => false,
             'provided' => array(
                 '2.0',
             ),
+            'provided_by' => array(
+                'a/provider' => array(
+                    '2.0',
+                )
+            ),
             'replaced' => array(
                 '2.2',
             ),
+            'replaced_by' => array(
+                'b/replacer' => array(
+                    '2.2'
+                )
+            )
         ),
         'foo/replaced' => array(
             'dev_requirement' => false,
             'replaced' => array(
                 '^3.0',
             ),
+            'replaced_by' => array(
+                'b/replacer' => array(
+                    '^3.0'
+                )
+            )
         ),
         'meta/package' => array(
             'pretty_version' => '3.0',


### PR DESCRIPTION
This adds two new entries (`replaced_by` and `provided_by`) in the `installed.php` data structure. These entries contain the source package name, along with the pretty versions.

### Additional Information

Please see  #10478 for additional background information about this PR.