### PR TITLE
Fix usage of spaces for package names in `composer search`/`composer require` commands

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -540,7 +540,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         $this->loadRootServerFile(600);
 
         if ($this->searchUrl && $mode === self::SEARCH_FULLTEXT) {
-            $url = str_replace(array('%query%', '%type%'), array($query, $type), $this->searchUrl);
+            $url = str_replace(array('%query%', '%type%'), array(urlencode($query), $type), $this->searchUrl);
 
             $search = $this->httpDownloader->get($url, $this->options)->decodeJson();
 

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -202,6 +202,36 @@ class ComposerRepositoryTest extends TestCase
         );
     }
 
+    public function testSearchWithSpecialChars()
+    {
+        $repoConfig = array(
+            'url' => 'http://example.org',
+        );
+
+        $result = array(
+            'results' => array(
+                array(
+                    'name' => 'foo',
+                    'description' => null,
+                ),
+            ),
+        );
+
+        $httpDownloader = new HttpDownloaderMock(array(
+            'http://example.org/packages.json' => JsonFile::encode(array('search' => '/search.json?q=%query%&type=%type%')),
+            'http://example.org/search.json?q=foo+bar&type=' => JsonFile::encode(array()),
+        ));
+        $eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $repository = new ComposerRepository($repoConfig, new NullIO, FactoryMock::createConfig(), $httpDownloader, $eventDispatcher);
+
+        $this->assertEmpty(
+            $repository->search('foo bar', RepositoryInterface::SEARCH_FULLTEXT)
+        );
+    }
+
     public function testSearchWithAbandonedPackages()
     {
         $repoConfig = array(


### PR DESCRIPTION
Hello there :vulcan_salute: 

I found out while using `composer search` that I can not search for two words with a space in between:
```bash
$ composer search ramsey commits

[Composer\Downloader\TransportException]
curl error 3 while downloading https://packagist.org/search.json?q=ramsey commits&type=: URL using bad/illegal format or missing URL

search [-N|--only-name] [-t|--type TYPE] [-f|--format FORMAT] [--] <tokens> (<tokens>)...
```
Same is true for using `composer require`:
```bash
$ composer require
Search for a package: ramsey commits

[Composer\Downloader\TransportException]
curl error 3 while downloading https://packagist.org/search.json?q=ramsey commits&type=: URL using bad/illegal format or missing URL
```
I do not know for the `composre require` command, but for the `composer search` command such a usage is documented via the `composer help search` command, so I assumed it is the expected behavior for this to work.

With this PR applied those two commands behave as following:
```bash
$ ./bin/composer require
Search for a package: ramsey commits

Found 1 packages matching ramsey commits

   [0] ramsey/conventional-commits

Enter package # to add, or the complete package name if it is not listed:
[...]
```
and
```bash
./bin/composer search ramsey commits
ramsey/conventional-commits A PHP library for creating and validating commit messages according to the Conventional Commits specification. In...
```

What do you think?

Kind regards
Florian