### PR TITLE
Rename COMPOSER_BIN_DIR (in bin proxies) to COMPOSER_RUNTIME_BIN_DIR 

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -235,14 +235,14 @@ class BinaryInstaller
             return "@ECHO OFF\r\n".
                 "setlocal DISABLEDELAYEDEXPANSION\r\n".
                 "SET BIN_TARGET=%~dp0/".trim(ProcessExecutor::escape(basename($link, '.bat')), '"\'')."\r\n".
-                "SET COMPOSER_BIN_DIR=%~dp0\r\n".
+                "SET COMPOSER_RUNTIME_BIN_DIR=%~dp0\r\n".
                 "{$caller} \"%BIN_TARGET%\" %*\r\n";
         }
 
         return "@ECHO OFF\r\n".
             "setlocal DISABLEDELAYEDEXPANSION\r\n".
             "SET BIN_TARGET=%~dp0/".trim(ProcessExecutor::escape($binPath), '"\'')."\r\n".
-            "SET COMPOSER_BIN_DIR=%~dp0\r\n".
+            "SET COMPOSER_RUNTIME_BIN_DIR=%~dp0\r\n".
             "{$caller} \"%BIN_TARGET%\" %*\r\n";
     }
 
@@ -434,7 +434,7 @@ if [ -d /proc/cygdrive ]; then
     esac
 fi
 
-export COMPOSER_BIN_DIR=\$(cd "\${self%[/\\\\]*}" > /dev/null; pwd)
+export COMPOSER_RUNTIME_BIN_DIR=\$(cd "\${self%[/\\\\]*}" > /dev/null; pwd)
 
 # If bash is sourcing this file, we have to source the target as well
 bashSource="\$BASH_SOURCE"


### PR DESCRIPTION
This fixes a regression introduced in 2.2.2 due to a name clash (as COMPOSER_BIN_DIR already existed and is read by Composer's Config to override the default bin-dir parameter)

Fixes #10504

I'm open to feedback on the new name, and I still need to update the docs to clarify all this, but in principle the fix should work and as the COMPOSER_BIN_DIR var for bin proxies has been available for just over a month it's a small BC break I'm ok making.. I doubt it's in much use if at all.