### PR TITLE
Introduce phpstan-type about autoload array type to be DRY

### DIFF
--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -21,7 +21,8 @@ use Composer\Util\ComposerMirror;
  *
  * @author Nils Adermann <naderman@naderman.de>
  *
- * @phpstan-import-type ComposerAudoload from PackageInterface
+ * @phpstan-import-type AutoloadRules from PackageInterface
+ * @phpstan-import-type DevAutoloadRules from PackageInterface
  */
 class Package extends BasePackage
 {
@@ -81,9 +82,15 @@ class Package extends BasePackage
     protected $devRequires = array();
     /** @var array<string, string> */
     protected $suggests = array();
-    /** @var ComposerAudoload */
+    /**
+     * @var array
+     * @phpstan-var AutoloadRules
+     */
     protected $autoload = array();
-    /** @var ComposerAudoload */
+    /**
+     * @var array
+     * @phpstan-var DevAutoloadRules
+     */
     protected $devAutoload = array();
     /** @var string[] */
     protected $includePaths = array();
@@ -600,7 +607,7 @@ class Package extends BasePackage
      *
      * @return void
      *
-     * @phpstan-param ComposerAudoload $autoload
+     * @phpstan-param AutoloadRules $autoload
      */
     public function setAutoload(array $autoload)
     {
@@ -622,7 +629,7 @@ class Package extends BasePackage
      *
      * @return void
      *
-     * @phpstan-param ComposerAudoload $devAutoload
+     * @phpstan-param DevAutoloadRules $devAutoload
      */
     public function setDevAutoload(array $devAutoload)
     {

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -20,6 +20,8 @@ use Composer\Util\ComposerMirror;
  * Core package definitions that are needed to resolve dependencies and install packages
  *
  * @author Nils Adermann <naderman@naderman.de>
+ *
+ * @phpstan-import-type AutoloadMapping from \Composer\Package\PackageInterface
  */
 class Package extends BasePackage
 {
@@ -79,9 +81,9 @@ class Package extends BasePackage
     protected $devRequires = array();
     /** @var array<string, string> */
     protected $suggests = array();
-    /** @var array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>} */
+    /** @var AutoloadMapping */
     protected $autoload = array();
-    /** @var array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>} */
+    /** @var AutoloadMapping */
     protected $devAutoload = array();
     /** @var string[] */
     protected $includePaths = array();
@@ -598,7 +600,7 @@ class Package extends BasePackage
      *
      * @return void
      *
-     * @phpstan-param array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>} $autoload
+     * @phpstan-param AutoloadMapping $autoload
      */
     public function setAutoload(array $autoload)
     {
@@ -620,7 +622,7 @@ class Package extends BasePackage
      *
      * @return void
      *
-     * @phpstan-param array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>} $devAutoload
+     * @phpstan-param AutoloadMapping $devAutoload
      */
     public function setDevAutoload(array $devAutoload)
     {

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -21,7 +21,7 @@ use Composer\Util\ComposerMirror;
  *
  * @author Nils Adermann <naderman@naderman.de>
  *
- * @phpstan-import-type AutoloadMapping from \Composer\Package\PackageInterface
+ * @phpstan-import-type AutoloadMapping from PackageInterface
  */
 class Package extends BasePackage
 {

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -21,7 +21,7 @@ use Composer\Util\ComposerMirror;
  *
  * @author Nils Adermann <naderman@naderman.de>
  *
- * @phpstan-import-type AutoloadMapping from PackageInterface
+ * @phpstan-import-type ComposerAudoload from PackageInterface
  */
 class Package extends BasePackage
 {
@@ -81,9 +81,9 @@ class Package extends BasePackage
     protected $devRequires = array();
     /** @var array<string, string> */
     protected $suggests = array();
-    /** @var AutoloadMapping */
+    /** @var ComposerAudoload */
     protected $autoload = array();
-    /** @var AutoloadMapping */
+    /** @var ComposerAudoload */
     protected $devAutoload = array();
     /** @var string[] */
     protected $includePaths = array();
@@ -600,7 +600,7 @@ class Package extends BasePackage
      *
      * @return void
      *
-     * @phpstan-param AutoloadMapping $autoload
+     * @phpstan-param ComposerAudoload $autoload
      */
     public function setAutoload(array $autoload)
     {
@@ -622,7 +622,7 @@ class Package extends BasePackage
      *
      * @return void
      *
-     * @phpstan-param AutoloadMapping $devAutoload
+     * @phpstan-param ComposerAudoload $devAutoload
      */
     public function setDevAutoload(array $devAutoload)
     {

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -18,6 +18,8 @@ use Composer\Repository\RepositoryInterface;
  * Defines the essential information a package has that is used during solving/installation
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @phpstan-type AutoloadMapping array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>}
  */
 interface PackageInterface
 {
@@ -303,7 +305,7 @@ interface PackageInterface
      * directories for autoloading using the type specified.
      *
      * @return array Mapping of autoloading rules
-     * @phpstan-return array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>}
+     * @phpstan-return AutoloadMapping
      */
     public function getAutoload();
 
@@ -316,7 +318,7 @@ interface PackageInterface
      * directories for autoloading using the type specified.
      *
      * @return array Mapping of dev autoloading rules
-     * @phpstan-return array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>}
+     * @phpstan-return AutoloadMapping
      */
     public function getDevAutoload();
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -19,7 +19,7 @@ use Composer\Repository\RepositoryInterface;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  *
- * @phpstan-type AutoloadMapping array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
+ * @phpstan-type ComposerAudoload array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
  */
 interface PackageInterface
 {
@@ -305,7 +305,7 @@ interface PackageInterface
      * directories for autoloading using the type specified.
      *
      * @return array Mapping of autoloading rules
-     * @phpstan-return AutoloadMapping
+     * @phpstan-return ComposerAudoload
      */
     public function getAutoload();
 
@@ -318,7 +318,7 @@ interface PackageInterface
      * directories for autoloading using the type specified.
      *
      * @return array Mapping of dev autoloading rules
-     * @phpstan-return AutoloadMapping
+     * @phpstan-return ComposerAudoload
      */
     public function getDevAutoload();
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -19,7 +19,7 @@ use Composer\Repository\RepositoryInterface;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  *
- * @phpstan-type AutoloadMapping array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>}
+ * @phpstan-type AutoloadMapping array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
  */
 interface PackageInterface
 {

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -19,7 +19,8 @@ use Composer\Repository\RepositoryInterface;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  *
- * @phpstan-type ComposerAudoload array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
+ * @phpstan-type AutoloadRules    array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
+ * @phpstan-type DevAutoloadRules array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>}
  */
 interface PackageInterface
 {
@@ -305,7 +306,7 @@ interface PackageInterface
      * directories for autoloading using the type specified.
      *
      * @return array Mapping of autoloading rules
-     * @phpstan-return ComposerAudoload
+     * @phpstan-return AutoloadRules
      */
     public function getAutoload();
 
@@ -318,7 +319,7 @@ interface PackageInterface
      * directories for autoloading using the type specified.
      *
      * @return array Mapping of dev autoloading rules
-     * @phpstan-return ComposerAudoload
+     * @phpstan-return DevAutoloadRules
      */
     public function getDevAutoload();
 

--- a/src/Composer/Package/RootPackageInterface.php
+++ b/src/Composer/Package/RootPackageInterface.php
@@ -16,6 +16,9 @@ namespace Composer\Package;
  * Defines additional fields that are only needed for the root package
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @phpstan-import-type AutoloadRules from PackageInterface
+ * @phpstan-import-type DevAutoloadRules from PackageInterface
  */
 interface RootPackageInterface extends CompletePackageInterface
 {
@@ -122,7 +125,8 @@ interface RootPackageInterface extends CompletePackageInterface
     /**
      * Set the autoload mapping
      *
-     * @param array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>} $autoload Mapping of autoloading rules
+     * @param array $autoload Mapping of autoloading rules
+     * @phpstan-param AutoloadRules $autoload
      *
      * @return void
      */
@@ -131,7 +135,8 @@ interface RootPackageInterface extends CompletePackageInterface
     /**
      * Set the dev autoload mapping
      *
-     * @param array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>} $devAutoload Mapping of dev autoloading rules
+     * @param array $devAutoload Mapping of dev autoloading rules
+     * @phpstan-param DevAutoloadRules $devAutoload
      *
      * @return void
      */


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:
For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)
For new features and everything else, use the main branch. -->

To be clear, and to be DRY.
I propose refactor autoload ~~mapping array~~ array type with type alias.

NOTES: `exclude-from-classmap` key is defined in composer-schema, but current array type does not have it. I don't know what to do it. 
https://github.com/composer/composer/blob/main/res/composer-schema.json#L670

In additionally, first of all, there are some duplicates in BetterReflection too. Therefore, I do this PR for clarification about autoload mapping array.
https://github.com/Roave/BetterReflection/blob/5.1.x/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php