### PR TITLE
ComposerRepository: fix array_keys(): Argument #1 () must be of type array, null given

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -657,7 +657,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             return array();
         }
 
-        if ($this->providersUrl && null !== $this->providerListing) {
+        if (null !== $this->providersUrl && null !== $this->providerListing) {
             return array_keys($this->providerListing);
         }
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -657,7 +657,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             return array();
         }
 
-        if ($this->providersUrl) {
+        if ($this->providersUrl && null !== $this->providerListing) {
             return array_keys($this->providerListing);
         }
 


### PR DESCRIPTION
There is no guarantee that `ComposerRepository::providerListing` is ever initialized. For instance, if the root response doesn't include a `provider-includes` key or the value is an empty array. This currently results in:

```
TypeError: array_keys(): Argument #1 ($array) must be of type array, null given at path/to/composer/src/Composer/Repository/ComposerRepository.php:661
```
