### PR TITLE
Handle missing license when showing license summary

### DIFF
--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -125,7 +125,8 @@ EOT
                 $usedLicenses = array();
                 foreach ($packages as $package) {
                     $license = $package instanceof CompletePackageInterface ? $package->getLicense() : array();
-                    $licenseName = $license[0];
+                    $licenseName =  array_key_exists(0, $license) ? $license[0] : 'none';
+
                     if (!isset($usedLicenses[$licenseName])) {
                         $usedLicenses[$licenseName] = 0;
                     }


### PR DESCRIPTION
Currently the LicensesCommand fails, when getting the summary (-f summary) and one of the packages is missing the license information.
This fixes the issue by simply using 'none' as the license, as is used in the text output already.
