### PR TITLE
Fix issues in require/init when dealing with virtual packages which do not exist

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -543,12 +543,6 @@ EOT
                         $requirement['version'],
                         $requirement['name']
                     ));
-                } else {
-                    // check that the specified version/constraint exists before we proceed
-                    list($name) = $this->findBestVersionAndNameForPackage($input, $requirement['name'], $platformRepo, $preferredStability, $checkProvidedVersions ? $requirement['version'] : null, 'dev', $fixed);
-
-                    // replace package name from packagist.org
-                    $requirement['name'] = $name;
                 }
 
                 $result[] = $requirement['name'] . ' ' . $requirement['version'];

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -577,21 +577,9 @@ EOT
                 }
                 $matches = array_values($matches);
 
-                $exactMatch = null;
-                $choices = array();
-                foreach ($matches as $position => $foundPackage) {
-                    $abandoned = '';
-                    if (isset($foundPackage['abandoned'])) {
-                        if (is_string($foundPackage['abandoned'])) {
-                            $replacement = sprintf('Use %s instead', $foundPackage['abandoned']);
-                        } else {
-                            $replacement = 'No replacement was suggested';
-                        }
-                        $abandoned = sprintf('<warning>Abandoned. %s.</warning>', $replacement);
-                    }
-
-                    $choices[] = sprintf(' <info>%5s</info> %s %s', "[$position]", $foundPackage['name'], $abandoned);
-                    if ($foundPackage['name'] === $package) {
+                $exactMatch = false;
+                foreach ($matches as $match) {
+                    if ($match['name'] === $package) {
                         $exactMatch = true;
                         break;
                     }
@@ -599,6 +587,26 @@ EOT
 
                 // no match, prompt which to pick
                 if (!$exactMatch) {
+                    $providers = $this->getRepos()->getProviders($package);
+                    if (count($providers) > 0) {
+                        array_unshift($matches, array('name' => $package, 'description' => ''));
+                    }
+
+                    $choices = array();
+                    foreach ($matches as $position => $foundPackage) {
+                        $abandoned = '';
+                        if (isset($foundPackage['abandoned'])) {
+                            if (is_string($foundPackage['abandoned'])) {
+                                $replacement = sprintf('Use %s instead', $foundPackage['abandoned']);
+                            } else {
+                                $replacement = 'No replacement was suggested';
+                            }
+                            $abandoned = sprintf('<warning>Abandoned. %s.</warning>', $replacement);
+                        }
+
+                        $choices[] = sprintf(' <info>%5s</info> %s %s', "[$position]", $foundPackage['name'], $abandoned);
+                    }
+
                     $io->writeError(array(
                         '',
                         sprintf('Found <info>%s</info> packages matching <info>%s</info>', count($matches), $package),
@@ -893,7 +901,8 @@ EOT
         $platformRequirementFilter = PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs);
 
         // find the latest version allowed in this repo set
-        $versionSelector = new VersionSelector($this->getRepositorySet($input, $minimumStability), $platformRepo);
+        $repoSet = $this->getRepositorySet($input, $minimumStability);
+        $versionSelector = new VersionSelector($repoSet, $platformRepo);
         $effectiveMinimumStability = $minimumStability ?: $this->getMinimumStability($input);
 
         $package = $versionSelector->findBestCandidate($name, $requiredVersion, $preferredStability, $platformRequirementFilter);
@@ -903,6 +912,22 @@ EOT
             // so if platform reqs are ignored we just take the user's word for it
             if ($platformRequirementFilter->isIgnored($name)) {
                 return array($name, $requiredVersion ?: '*');
+            }
+
+            // Check if it is a virtual package provided by others
+            $providers = $repoSet->getProviders($name);
+            if (count($providers) > 0) {
+                $constraint = '*';
+                if ($input->isInteractive()) {
+                    $constraint = $this->getIO()->askAndValidate('Package "<info>'.$name.'</info>" does not exist but is provided by '.count($providers).' packages. Which version constraint would you like to use? [<info>*</info>] ', function ($value) {
+                        $parser = new VersionParser();
+                        $parser->parseConstraints($value);
+
+                        return $value;
+                    }, 3, '*');
+                }
+
+                return array($name, $constraint);
             }
 
             // Check whether the package requirements were the problem


### PR DESCRIPTION
Fixes #10489 

- `composer require psr/log-implementation:*` now works
- `composer require psr/log-implementation` (without constraint) prompts for a version:

```
$ c req psr/log-implementation
Package "psr/log-implementation" does not exist but is provided by 124 packages. Which version constraint would you like to use? [*] ^2
Using version ^2 for psr/log-implementation
./composer.json has been updated
Running composer update psr/log-implementation
```

- `composer init` when searching for virtual packages also checks for providers and if one is found the provided name is added to the list of matches from the package search (previously only `xxnoobmanxx/psrlogger` was suggested here)

```
Define your dependencies.


Would you like to define your dependencies (require) interactively [yes]? Search for a package:
Would you like to define your dev dependencies (require-dev) interactively [yes]?
Search for a package: psr/log-implementation

Found 2 packages matching psr/log-implementation

   [0] psr/log-implementation
   [1] xxnoobmanxx/psrlogger

Enter package # to add, or the complete package name if it is not listed:
```

cc @dzuelke 
