### PR TITLE
Improve performance of DefaultPolicy

### DIFF
--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -77,7 +77,6 @@ class DefaultPolicy implements PolicyInterface
 
         $packages = $this->groupLiteralsByName($pool, $literals);
 
-
         foreach ($packages as &$nameLiterals) {
             usort($nameLiterals, function ($a, $b) use ($pool, $requiredPackage, $poolId): int {
                 $cacheKey = 'i'.$a.'.'.$b.$requiredPackage; // i prefix -> ignoreReplace = true

--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -27,7 +27,7 @@ class DefaultPolicy implements PolicyInterface
     private $preferStable;
     /** @var bool */
     private $preferLowest;
-    /** @var array<int, array<string, array>> */
+    /** @var array<int, array<string, array<int, int>>> */
     private $preferredPackageResultCachePerPool;
     /** @var array<int, array<string, int>> */
     private $sortingCachePerPool;
@@ -71,8 +71,8 @@ class DefaultPolicy implements PolicyInterface
         $resultCacheKey = implode(',', $literals).$requiredPackage;
         $poolId = spl_object_id($pool);
 
-        if (isset($this->preferredPackageResultCachePerPool[$resultCacheKey])) {
-            return $this->preferredPackageResultCachePerPool[$resultCacheKey];
+        if (isset($this->preferredPackageResultCachePerPool[$poolId][$resultCacheKey])) {
+            return $this->preferredPackageResultCachePerPool[$poolId][$resultCacheKey];
         }
 
         $packages = $this->groupLiteralsByName($pool, $literals);
@@ -108,7 +108,7 @@ class DefaultPolicy implements PolicyInterface
             return $this->sortingCachePerPool[$poolId][$cacheKey] = $this->compareByPriority($pool, $pool->literalToPackage($a), $pool->literalToPackage($b), $requiredPackage);
         });
 
-        return $this->preferredPackageResultCachePerPool[$resultCacheKey] = $selected;
+        return $this->preferredPackageResultCachePerPool[$poolId][$resultCacheKey] = $selected;
     }
 
     /**
@@ -195,7 +195,7 @@ class DefaultPolicy implements PolicyInterface
             if ($link->getTarget() === $target->getName()
 //                && (null === $link->getConstraint() ||
 //                $link->getConstraint()->matches(new Constraint('==', $target->getVersion())))) {
-            ) {
+                ) {
                 return true;
             }
         }


### PR DESCRIPTION
The `$policy->selectPreferredPackages()` is another bottleneck in the `PoolOptimizer` as we call it for every dependency group which can easily happen for 10 000+ times on medium size projects. Most packages match to a lot of dependency groups so we actually compare the same packages over and over again to sort them within one `selectPreferredPackages()` call. The respective 2 `usort()` calls were actually responsible for up to 25% of the whole `PoolOptimizer::optimize()` process.

With this PR we're now caching the result so the sorting can be way faster (another 0.5 - 1 seconds down on the `PoolOptimizer`).

Because we're using the `PolicyInterface` and `Pool $pool` is an argument, we have to make sure the cache is specific to the `$pool` instance. Thanks to the new PHP 7.2 requirement, we can use the faster `spl_object_id()` for that 😎 