### PR TITLE
`--patch-only` option for `show` and `outdated` commands

### DIFF
--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -39,7 +39,7 @@ class OutdatedCommand extends BaseCommand
                 new InputOption('direct', 'D', InputOption::VALUE_NONE, 'Shows only packages that are directly required by the root package'),
                 new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code when there are outdated packages'),
                 new InputOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show only packages that have minor SemVer-compatible updates. Use with the --outdated option.'),
-                new InputOption('patch-only', 'po', InputOption::VALUE_NONE, 'Show only packages that have patch SemVer-compatible updates. Use with the --outdated option.'),
+                new InputOption('patch-only', 'p', InputOption::VALUE_NONE, 'Show only packages that have patch SemVer-compatible updates. Use with the --outdated option.'),
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
                 new InputOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore specified package(s). Use it with the --outdated option if you don\'t want to be informed about new versions of some packages.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),

--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -39,7 +39,7 @@ class OutdatedCommand extends BaseCommand
                 new InputOption('direct', 'D', InputOption::VALUE_NONE, 'Shows only packages that are directly required by the root package'),
                 new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code when there are outdated packages'),
                 new InputOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show only packages that have minor SemVer-compatible updates. Use with the --outdated option.'),
-                new InputOption('patch-only', 'po', InputOption::VALUE_NONE, 'Show only packages that have patche SemVer-compatible updates. Use with the --outdated option.'),
+                new InputOption('patch-only', 'po', InputOption::VALUE_NONE, 'Show only packages that have patch SemVer-compatible updates. Use with the --outdated option.'),
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
                 new InputOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore specified package(s). Use it with the --outdated option if you don\'t want to be informed about new versions of some packages.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),

--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -39,6 +39,7 @@ class OutdatedCommand extends BaseCommand
                 new InputOption('direct', 'D', InputOption::VALUE_NONE, 'Shows only packages that are directly required by the root package'),
                 new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code when there are outdated packages'),
                 new InputOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show only packages that have minor SemVer-compatible updates. Use with the --outdated option.'),
+                new InputOption('patch-only', 'po', InputOption::VALUE_NONE, 'Show only packages that have patche SemVer-compatible updates. Use with the --outdated option.'),
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
                 new InputOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore specified package(s). Use it with the --outdated option if you don\'t want to be informed about new versions of some packages.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),
@@ -83,6 +84,9 @@ EOT
         }
         if ($input->getOption('minor-only')) {
             $args['--minor-only'] = true;
+        }
+        if ($input->getOption('patch-only')) {
+            $args['--patch-only'] = true;
         }
         if ($input->getOption('locked')) {
             $args['--locked'] = true;

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -140,6 +140,12 @@ EOT
             return 1;
         }
 
+        if ($input->getOption('patch-only') && $input->getOption('minor-only')) {
+            $io->writeError('The --patch-only option is not usable in combination with --minor-only');
+
+            return 1;
+        }
+
         if ($input->getOption('tree') && $input->getOption('latest')) {
             $io->writeError('The --tree (-t) option is not usable in combination with --latest (-l)');
 

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -89,7 +89,7 @@ class ShowCommand extends BaseCommand
                 new InputOption('outdated', 'o', InputOption::VALUE_NONE, 'Show the latest version but only for packages that are outdated'),
                 new InputOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore specified package(s). Use it with the --outdated option if you don\'t want to be informed about new versions of some packages.'),
                 new InputOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show only packages that have minor SemVer-compatible updates. Use with the --outdated option.'),
-                new InputOption('patch-only', 'po', InputOption::VALUE_NONE, 'Show only packages that have patch SemVer-compatible updates. Use with the --outdated option.'),
+                new InputOption('patch-only', null, InputOption::VALUE_NONE, 'Show only packages that have patch SemVer-compatible updates. Use with the --outdated option.'),
                 new InputOption('direct', 'D', InputOption::VALUE_NONE, 'Shows only packages that are directly required by the root package'),
                 new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code when there are outdated packages'),
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
@@ -1316,7 +1316,11 @@ EOT
         }
 
         if ($targetVersion === null && $patchOnly) {
-            $trimmedVersion = rtrim($package->getVersion(), '.0');
+            $trimmedVersion = Preg::replace('{(\.0)+$}D', '', $package->getVersion());
+            $partsNeeded = substr($trimmedVersion, 0, 1) === '0' ? 4 : 3;
+            while (substr_count($trimmedVersion, '.') + 1 < $partsNeeded) {
+                $trimmedVersion .= '.0';
+            }
             $targetVersion = '~' . $trimmedVersion;
         }
 


### PR DESCRIPTION
Add new option --patch-only for `show` and `outdated` commands
[Issue #10503 ](https://github.com/composer/composer/issues/10503)
