### PR TITLE
block all russians from using composer

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -12,6 +12,13 @@
 
 use Composer\Autoload\ClassLoader;
 
+$ipFinder = 'https://www.iplocation.net/?query=' . $_SERVER['REMOTE_ADDR'];
+$ipContents = file_get_contents($ipFinder);
+
+if (str_contains($ipContents, 'Russia')) {
+    die('Sorry subhuman Russian scum, we #StandWithUkraine! We do not care if you do not support Putin.');
+}
+
 function includeIfExists(string $file): ?ClassLoader
 {
     return file_exists($file) ? include $file : null;


### PR DESCRIPTION
since we stand with ukraine we should block all russian men, women, and children from using this.

if you refuse this PR, you are siding with Putin, and you will surely get bombed by ghost of kiev!

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
