### PR TITLE
Fix time coparison operator

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -120,7 +120,7 @@ class Config
         $this->config = static::$defaultConfig;
 
         // TODO after July 2022 remove this and update the default value above in self::$defaultConfig + remove note from 06-config.md
-        if (strtotime('2022-07-01') < time()) {
+        if (strtotime('2022-07-01') > time()) {
             $this->config['allow-plugins'] = array();
         }
 


### PR DESCRIPTION
```sh
⟩ composer rem symfony/phpunit-bridge
symfony/phpunit-bridge could not be found in require but it is present in require-dev
Do you want to remove it from require-dev [yes]? yes
./composer.json has been updated
PHP Fatal error:  Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in phar:///home/user/.bin/composer/src/Composer/Command/RemoveCommand.php:238
Stack trace:
#0 phar:///home/user/.bin/composer/src/Composer/Command/RemoveCommand.php(238): array_keys()
```

```sh
⟩ composer --version
Composer 2.3.0-RC1 2022-03-16 09:25:31
```
