### PR TITLE
Parallellize the branch comparisons to speed up bootstrapping/version guessing when on a feature branch

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -271,6 +271,16 @@ class ProcessExecutor
         }
     }
 
+    public function setMaxJobs(int $maxJobs): void
+    {
+        $this->maxJobs = $maxJobs;
+    }
+
+    public function resetMaxJobs(): void
+    {
+        $this->maxJobs = 10;
+    }
+
     /**
      * @param  ?int $index job id
      * @return void
@@ -278,7 +288,7 @@ class ProcessExecutor
     public function wait($index = null): void
     {
         while (true) {
-            if (!$this->countActiveJobs($index)) {
+            if (0 === $this->countActiveJobs($index)) {
                 return;
             }
 

--- a/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
@@ -20,6 +20,7 @@ use Composer\Package\RootPackage;
 use Composer\Package\Version\VersionGuesser;
 use Composer\Semver\VersionParser;
 use Composer\Test\TestCase;
+use Composer\Util\ProcessExecutor;
 
 class RootPackageLoaderTest extends TestCase
 {
@@ -36,8 +37,11 @@ class RootPackageLoaderTest extends TestCase
 
         $config = new Config;
         $config->merge(array('repositories' => array('packagist' => false)));
+        $processExecutor = new ProcessExecutor();
+        $processExecutor->enableAsync();
+        $guesser = new VersionGuesser($config, $processExecutor, new VersionParser());
 
-        $loader = new RootPackageLoader($manager, $config);
+        $loader = new RootPackageLoader($manager, $config, null, $guesser);
 
         return $loader->load($data);
     }

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -320,7 +320,7 @@ class GitHubDriverTest extends TestCase
             ->setConstructorArgs(array($io, $this->config))
             ->getMock();
 
-        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $httpDownloader, new ProcessExecutorMock);
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $httpDownloader, $this->getProcessExecutorMock());
         $gitHubDriver->initialize();
     }
 

--- a/tests/Composer/Test/TestCase.php
+++ b/tests/Composer/Test/TestCase.php
@@ -32,6 +32,7 @@ use Composer\Package\RootAliasPackage;
 use Composer\Package\CompletePackage;
 use Composer\Package\CompleteAliasPackage;
 use Composer\Package\Package;
+use Symfony\Component\Process\Process;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
@@ -256,7 +257,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     protected function getProcessExecutorMock(): ProcessExecutorMock
     {
-        $this->processExecutorMocks[] = $mock = new ProcessExecutorMock();
+        $this->processExecutorMocks[] = $mock = new ProcessExecutorMock($this->getMockBuilder(Process::class));
 
         return $mock;
     }


### PR DESCRIPTION
Fixes #10568

On a huge repo with many branches like symfony/symfony, this speeds up bootstrap for me from 9sec to 3sec which is quite nice.