### PR TITLE
Switch to LazyCommand implementations to improve bootstrap speed

### DIFF
--- a/src/Composer/Command/AboutCommand.php
+++ b/src/Composer/Command/AboutCommand.php
@@ -21,14 +21,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class AboutCommand extends BaseCommand
 {
+    public static $defaultName = 'about';
+    public static $defaultDescription = 'Shows a short information about Composer.';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
         $this
-            ->setName('about')
-            ->setDescription('Shows a short information about Composer.')
             ->setHelp(
                 <<<EOT
 <info>php composer.phar about</info>

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -39,14 +39,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ArchiveCommand extends BaseCommand
 {
+    public static $defaultName = 'archive';
+    public static $defaultDescription = 'Creates an archive of this composer package.';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
         $this
-            ->setName('archive')
-            ->setDescription('Creates an archive of this composer package.')
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'The package to archive instead of the current project'),
                 new InputArgument('version', InputArgument::OPTIONAL, 'A version constraint to find the package to archive'),

--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -34,7 +34,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
  */
-class BaseDependencyCommand extends BaseCommand
+abstract class BaseDependencyCommand extends BaseCommand
 {
     protected const ARGUMENT_PACKAGE = 'package';
     protected const ARGUMENT_CONSTRAINT = 'version';

--- a/src/Composer/Command/CheckPlatformReqsCommand.php
+++ b/src/Composer/Command/CheckPlatformReqsCommand.php
@@ -23,14 +23,15 @@ use Composer\Repository\InstalledRepository;
 
 class CheckPlatformReqsCommand extends BaseCommand
 {
+    public static $defaultName = 'check-platform-reqs';
+    public static $defaultDescription = 'Check that platform requirements are satisfied.';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
-        $this->setName('check-platform-reqs')
-            ->setDescription('Check that platform requirements are satisfied.')
-            ->setDefinition(array(
+        $this->setDefinition(array(
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables checking of require-dev packages requirements.'),
                 new InputOption('lock', null, InputOption::VALUE_NONE, 'Checks requirements only from the lock file, not from installed packages.'),
             ))

--- a/src/Composer/Command/ClearCacheCommand.php
+++ b/src/Composer/Command/ClearCacheCommand.php
@@ -22,15 +22,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ClearCacheCommand extends BaseCommand
 {
+    public static $defaultName = 'clear-cache,clearcache,cc';
+    public static $defaultDescription = 'Clears composer\'s internal package cache.';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
         $this
-            ->setName('clear-cache')
-            ->setAliases(array('clearcache', 'cc'))
-            ->setDescription('Clears composer\'s internal package cache.')
             ->setHelp(
                 <<<EOT
 The <info>clear-cache</info> deletes all cached packages from composer's

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -34,6 +34,9 @@ use Composer\Package\BasePackage;
  */
 class ConfigCommand extends BaseCommand
 {
+    public static $defaultName = 'config';
+    public static $defaultDescription = 'Sets config options.';
+
     /**
      * @var Config
      */
@@ -65,8 +68,6 @@ class ConfigCommand extends BaseCommand
     protected function configure(): void
     {
         $this
-            ->setName('config')
-            ->setDescription('Sets config options.')
             ->setDefinition(array(
                 new InputOption('global', 'g', InputOption::VALUE_NONE, 'Apply command to the global config file'),
                 new InputOption('editor', 'e', InputOption::VALUE_NONE, 'Open editor'),

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -55,6 +55,9 @@ use Composer\Package\Version\VersionParser;
  */
 class CreateProjectCommand extends BaseCommand
 {
+    public static $defaultName = 'create-project';
+    public static $defaultDescription = 'Creates new project from a package into given directory.';
+
     /**
      * @var SuggestedPackagesReporter
      */
@@ -66,8 +69,6 @@ class CreateProjectCommand extends BaseCommand
     protected function configure(): void
     {
         $this
-            ->setName('create-project')
-            ->setDescription('Creates new project from a package into given directory.')
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package name to be installed'),
                 new InputArgument('directory', InputArgument::OPTIONAL, 'Directory where the files should be created'),

--- a/src/Composer/Command/DependsCommand.php
+++ b/src/Composer/Command/DependsCommand.php
@@ -22,6 +22,9 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class DependsCommand extends BaseDependencyCommand
 {
+    public static $defaultName = 'depends,why';
+    public static $defaultDescription = 'Shows which packages cause the given package to be installed.';
+
     /**
      * Configure command metadata.
      *
@@ -30,9 +33,6 @@ class DependsCommand extends BaseDependencyCommand
     protected function configure(): void
     {
         $this
-            ->setName('depends')
-            ->setAliases(array('why'))
-            ->setDescription('Shows which packages cause the given package to be installed.')
             ->setDefinition(array(
                 new InputArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect'),
                 new InputOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package'),

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -40,6 +40,9 @@ use Symfony\Component\Process\ExecutableFinder;
  */
 class DiagnoseCommand extends BaseCommand
 {
+    public static $defaultName = 'diagnose';
+    public static $defaultDescription = 'Diagnoses the system to identify common errors.';
+
     /** @var HttpDownloader */
     protected $httpDownloader;
 
@@ -55,8 +58,6 @@ class DiagnoseCommand extends BaseCommand
     protected function configure(): void
     {
         $this
-            ->setName('diagnose')
-            ->setDescription('Diagnoses the system to identify common errors.')
             ->setHelp(
                 <<<EOT
 The <info>diagnose</info> command checks common errors to help debugging problems.

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -23,15 +23,17 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DumpAutoloadCommand extends BaseCommand
 {
+    public static $defaultName = 'dump-autoload,dumpautoload';
+    public static $defaultDescription = 'Dumps the autoloader.';
+
     /**
      * @return void
      */
     protected function configure()
     {
         $this
-            ->setName('dump-autoload')
-            ->setAliases(array('dumpautoload'))
-            ->setDescription('Dumps the autoloader.')
+            ->setName((string) static::$defaultName)
+            ->setDescription((string) static::$defaultDescription)
             ->setDefinition(array(
                 new InputOption('optimize', 'o', InputOption::VALUE_NONE, 'Optimizes PSR0 and PSR4 packages to be loaded with classmaps too, good for production.'),
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.'),

--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -22,14 +22,17 @@ use Symfony\Component\Console\Input\InputArgument;
  */
 class ExecCommand extends BaseCommand
 {
+    public static $defaultName = 'exec';
+    public static $defaultDescription = 'Executes a vendored binary/script.';
+
     /**
      * @return void
      */
     protected function configure()
     {
         $this
-            ->setName('exec')
-            ->setDescription('Executes a vendored binary/script.')
+            ->setName((string) static::$defaultName)
+            ->setDescription((string) static::$defaultDescription)
             ->setDefinition(array(
                 new InputOption('list', 'l', InputOption::VALUE_NONE),
                 new InputArgument('binary', InputArgument::OPTIONAL, 'The binary to run, e.g. phpunit'),

--- a/src/Composer/Command/FundCommand.php
+++ b/src/Composer/Command/FundCommand.php
@@ -30,13 +30,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class FundCommand extends BaseCommand
 {
+    public static $defaultName = 'fund';
+    public static $defaultDescription = 'Discover how to help fund the maintenance of your dependencies.';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
-        $this->setName('fund')
-            ->setDescription('Discover how to help fund the maintenance of your dependencies.')
+        $this
             ->setDefinition(array(
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
             ))

--- a/src/Composer/Command/GlobalCommand.php
+++ b/src/Composer/Command/GlobalCommand.php
@@ -26,14 +26,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GlobalCommand extends BaseCommand
 {
+    public static $defaultName = 'global';
+    public static $defaultDescription = 'Allows running commands in the global composer dir ($COMPOSER_HOME).';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
         $this
-            ->setName('global')
-            ->setDescription('Allows running commands in the global composer dir ($COMPOSER_HOME).')
             ->setDefinition(array(
                 new InputArgument('command-name', InputArgument::REQUIRED, ''),
                 new InputArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, ''),

--- a/src/Composer/Command/HomeCommand.php
+++ b/src/Composer/Command/HomeCommand.php
@@ -28,6 +28,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class HomeCommand extends BaseCommand
 {
+    public static $defaultName = 'browse,home';
+    public static $defaultDescription = 'Opens the package\'s repository URL or homepage in your browser.';
+
     /**
      * @inheritDoc
      *
@@ -36,9 +39,6 @@ class HomeCommand extends BaseCommand
     protected function configure(): void
     {
         $this
-            ->setName('browse')
-            ->setAliases(array('home'))
-            ->setDescription('Opens the package\'s repository URL or homepage in your browser.')
             ->setDefinition(array(
                 new InputArgument('packages', InputArgument::IS_ARRAY, 'Package(s) to browse to.'),
                 new InputOption('homepage', 'H', InputOption::VALUE_NONE, 'Open the homepage instead of the repository URL.'),

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -39,6 +39,9 @@ class InitCommand extends BaseCommand
 {
     use PackageDiscoveryTrait;
 
+    public static $defaultName = 'init';
+    public static $defaultDescription = 'Creates a basic composer.json file in current directory.';
+
     /** @var array<string, string> */
     private $gitConfig;
 
@@ -50,8 +53,8 @@ class InitCommand extends BaseCommand
     protected function configure()
     {
         $this
-            ->setName('init')
-            ->setDescription('Creates a basic composer.json file in current directory.')
+            ->setName((string) static::$defaultName)
+            ->setDescription((string) static::$defaultDescription)
             ->setDefinition(array(
                 new InputOption('name', null, InputOption::VALUE_REQUIRED, 'Name of the package'),
                 new InputOption('description', null, InputOption::VALUE_REQUIRED, 'Description of package'),

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -29,15 +29,17 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class InstallCommand extends BaseCommand
 {
+    public static $defaultName = 'install,i';
+    public static $defaultDescription = 'Installs the project dependencies from the composer.lock file if present, or falls back on the composer.json.';
+
     /**
      * @return void
      */
     protected function configure()
     {
         $this
-            ->setName('install')
-            ->setAliases(array('i'))
-            ->setDescription('Installs the project dependencies from the composer.lock file if present, or falls back on the composer.json.')
+            ->setName((string) static::$defaultName)
+            ->setDescription((string) static::$defaultDescription)
             ->setDefinition(array(
                 new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),
                 new InputOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).'),

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -31,14 +31,15 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class LicensesCommand extends BaseCommand
 {
+    public static $defaultName = 'licenses';
+    public static $defaultDescription = 'Shows information about licenses of dependencies.';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
         $this
-            ->setName('licenses')
-            ->setDescription('Shows information about licenses of dependencies.')
             ->setDefinition(array(
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text, json or summary', 'text'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),

--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -23,14 +23,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class OutdatedCommand extends BaseCommand
 {
+    public static $defaultName = 'outdated';
+    public static $defaultDescription = 'Shows a list of installed packages that have updates available, including their latest version.';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
         $this
-            ->setName('outdated')
-            ->setDescription('Shows a list of installed packages that have updates available, including their latest version.')
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.'),
                 new InputOption('outdated', 'o', InputOption::VALUE_NONE, 'Show only packages that are outdated (this is the default, but present here for compat with `show`'),

--- a/src/Composer/Command/ProhibitsCommand.php
+++ b/src/Composer/Command/ProhibitsCommand.php
@@ -22,6 +22,9 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class ProhibitsCommand extends BaseDependencyCommand
 {
+    public static $defaultName = 'prohibits,why-not';
+    public static $defaultDescription = 'Shows which packages prevent the given package from being installed.';
+
     /**
      * Configure command metadata.
      *
@@ -30,9 +33,6 @@ class ProhibitsCommand extends BaseDependencyCommand
     protected function configure(): void
     {
         $this
-            ->setName('prohibits')
-            ->setAliases(array('why-not'))
-            ->setDescription('Shows which packages prevent the given package from being installed.')
             ->setDefinition(array(
                 new InputArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect'),
                 new InputArgument(self::ARGUMENT_CONSTRAINT, InputArgument::REQUIRED, 'Version constraint, which version you expected to be installed'),

--- a/src/Composer/Command/ReinstallCommand.php
+++ b/src/Composer/Command/ReinstallCommand.php
@@ -32,14 +32,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ReinstallCommand extends BaseCommand
 {
+    public static $defaultName = 'reinstall';
+    public static $defaultDescription = 'Uninstalls and reinstalls the given package names';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
         $this
-            ->setName('reinstall')
-            ->setDescription('Uninstalls and reinstalls the given package names')
             ->setDefinition(array(
                 new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),
                 new InputOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).'),

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -32,14 +32,17 @@ use Composer\Package\BasePackage;
  */
 class RemoveCommand extends BaseCommand
 {
+    public static $defaultName = 'remove';
+    public static $defaultDescription = 'Removes a package from the require or require-dev.';
+
     /**
      * @return void
      */
     protected function configure()
     {
         $this
-            ->setName('remove')
-            ->setDescription('Removes a package from the require or require-dev.')
+            ->setName((string) static::$defaultName)
+            ->setDescription((string) static::$defaultDescription)
             ->setDefinition(array(
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Packages that should be removed.'),
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Removes a package from the require-dev section.'),

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -41,6 +41,9 @@ class RequireCommand extends BaseCommand
 {
     use PackageDiscoveryTrait;
 
+    public static $defaultName = 'require';
+    public static $defaultDescription = 'Adds required packages to your composer.json and installs them.';
+
     /** @var bool */
     private $newlyCreated;
     /** @var bool */
@@ -64,8 +67,8 @@ class RequireCommand extends BaseCommand
     protected function configure()
     {
         $this
-            ->setName('require')
-            ->setDescription('Adds required packages to your composer.json and installs them.')
+            ->setName((string) static::$defaultName)
+            ->setDescription((string) static::$defaultDescription)
             ->setDefinition(array(
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Optional package name can also include a version constraint, e.g. foo/bar or foo/bar:1.0.0 or foo/bar=1.0.0 or "foo/bar 1.0.0"'),
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Add requirement to require-dev.'),

--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -26,6 +26,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class RunScriptCommand extends BaseCommand
 {
+    public static $defaultName = 'run-script,run';
+    public static $defaultDescription = 'Runs the scripts defined in composer.json.';
+
     /**
      * @var string[] Array with command events
      */
@@ -50,9 +53,6 @@ class RunScriptCommand extends BaseCommand
     protected function configure(): void
     {
         $this
-            ->setName('run-script')
-            ->setAliases(array('run'))
-            ->setDescription('Runs the scripts defined in composer.json.')
             ->setDefinition(array(
                 new InputArgument('script', InputArgument::REQUIRED, 'Script name to run.'),
                 new InputArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, ''),

--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -30,14 +30,15 @@ use Composer\Plugin\PluginEvents;
  */
 class SearchCommand extends BaseCommand
 {
+    public static $defaultName = 'search';
+    public static $defaultDescription = 'Searches for packages.';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
         $this
-            ->setName('search')
-            ->setDescription('Searches for packages.')
             ->setDefinition(array(
                 new InputOption('only-name', 'N', InputOption::VALUE_NONE, 'Search only in package names'),
                 new InputOption('only-vendor', 'O', InputOption::VALUE_NONE, 'Search only for vendor / organization names, returns only "vendor" as result'),

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -36,6 +36,9 @@ use Symfony\Component\Finder\Finder;
  */
 class SelfUpdateCommand extends BaseCommand
 {
+    public static $defaultName = 'self-update,selfupdate';
+    public static $defaultDescription = 'Updates composer.phar to the latest version.';
+
     private const HOMEPAGE = 'getcomposer.org';
     private const OLD_INSTALL_EXT = '-old.phar';
 
@@ -45,9 +48,6 @@ class SelfUpdateCommand extends BaseCommand
     protected function configure(): void
     {
         $this
-            ->setName('self-update')
-            ->setAliases(array('selfupdate'))
-            ->setDescription('Updates composer.phar to the latest version.')
             ->setDefinition(array(
                 new InputOption('rollback', 'r', InputOption::VALUE_NONE, 'Revert to an older installation of composer'),
                 new InputOption('clean-backups', null, InputOption::VALUE_NONE, 'Delete old backups during an update. This makes the current version of composer the only backup available after the update'),

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -56,6 +56,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ShowCommand extends BaseCommand
 {
+    public static $defaultName = 'show,info';
+    public static $defaultDescription = 'Shows information about packages.';
+
     /** @var VersionParser */
     protected $versionParser;
     /** @var string[] */
@@ -70,9 +73,8 @@ class ShowCommand extends BaseCommand
     protected function configure()
     {
         $this
-            ->setName('show')
-            ->setAliases(array('info'))
-            ->setDescription('Shows information about packages.')
+            ->setName((string) static::$defaultName)
+            ->setDescription((string) static::$defaultDescription)
             ->setDefinition(array(
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.'),
                 new InputArgument('version', InputArgument::OPTIONAL, 'Version or version constraint to inspect'),

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -32,6 +32,9 @@ use Composer\Util\ProcessExecutor;
  */
 class StatusCommand extends BaseCommand
 {
+    public static $defaultName = 'status';
+    public static $defaultDescription = 'Shows a list of locally modified packages.';
+
     private const EXIT_CODE_ERRORS = 1;
     private const EXIT_CODE_UNPUSHED_CHANGES = 2;
     private const EXIT_CODE_VERSION_CHANGES = 4;
@@ -43,8 +46,6 @@ class StatusCommand extends BaseCommand
     protected function configure(): void
     {
         $this
-            ->setName('status')
-            ->setDescription('Shows a list of locally modified packages.')
             ->setDefinition(array(
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Show modified files for each directory that contains changes.'),
             ))

--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -23,14 +23,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SuggestsCommand extends BaseCommand
 {
+    public static $defaultName = 'suggests';
+    public static $defaultDescription = 'Shows package suggestions.';
+
     /**
      * @return void
      */
     protected function configure(): void
     {
         $this
-            ->setName('suggests')
-            ->setDescription('Shows package suggestions.')
             ->setDefinition(array(
                 new InputOption('by-package', null, InputOption::VALUE_NONE, 'Groups output by suggesting package (default)'),
                 new InputOption('by-suggestion', null, InputOption::VALUE_NONE, 'Groups output by suggested package'),

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -37,15 +37,17 @@ use Symfony\Component\Console\Question\Question;
  */
 class UpdateCommand extends BaseCommand
 {
+    public static $defaultName = 'update,u,upgrade';
+    public static $defaultDescription = 'Updates your dependencies to the latest version according to composer.json, and updates the composer.lock file.';
+
     /**
      * @return void
      */
     protected function configure()
     {
         $this
-            ->setName('update')
-            ->setAliases(array('u', 'upgrade'))
-            ->setDescription('Upgrades your dependencies to the latest version according to composer.json, and updates the composer.lock file.')
+            ->setName((string) static::$defaultName)
+            ->setDescription((string) static::$defaultDescription)
             ->setDefinition(array(
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that should be updated, if not provided all packages are.'),
                 new InputOption('with', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Temporary version constraint to add, e.g. foo/bar:1.0.0 or foo/bar=1.0.0'),

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -34,6 +34,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ValidateCommand extends BaseCommand
 {
+    public static $defaultName = 'validate';
+    public static $defaultDescription = 'Validates a composer.json and composer.lock.';
+
     /**
      * configure
      * @return void
@@ -41,8 +44,6 @@ class ValidateCommand extends BaseCommand
     protected function configure(): void
     {
         $this
-            ->setName('validate')
-            ->setDescription('Validates a composer.json and composer.lock.')
             ->setDefinition(array(
                 new InputOption('no-check-all', null, InputOption::VALUE_NONE, 'Do not validate requires for overly strict/loose constraints'),
                 new InputOption('no-check-lock', null, InputOption::VALUE_NONE, 'Do not check if lock file is up to date'),

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -17,6 +17,7 @@ use Composer\Util\Filesystem;
 use Composer\Util\Platform;
 use Composer\Util\Silencer;
 use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -489,39 +490,46 @@ class Application extends BaseApplication
      */
     protected function getDefaultCommands(): array
     {
-        $commands = array_merge(parent::getDefaultCommands(), array(
-            new Command\AboutCommand(),
-            new Command\ConfigCommand(),
-            new Command\DependsCommand(),
-            new Command\ProhibitsCommand(),
-            new Command\InitCommand(),
-            new Command\InstallCommand(),
-            new Command\CreateProjectCommand(),
-            new Command\UpdateCommand(),
-            new Command\SearchCommand(),
-            new Command\ValidateCommand(),
-            new Command\ShowCommand(),
-            new Command\SuggestsCommand(),
-            new Command\RequireCommand(),
-            new Command\DumpAutoloadCommand(),
-            new Command\StatusCommand(),
-            new Command\ArchiveCommand(),
-            new Command\DiagnoseCommand(),
-            new Command\RunScriptCommand(),
-            new Command\LicensesCommand(),
-            new Command\GlobalCommand(),
-            new Command\ClearCacheCommand(),
-            new Command\RemoveCommand(),
-            new Command\HomeCommand(),
-            new Command\ExecCommand(),
-            new Command\OutdatedCommand(),
-            new Command\CheckPlatformReqsCommand(),
-            new Command\FundCommand(),
-            new Command\ReinstallCommand(),
-        ));
+        $commands = parent::getDefaultCommands();
 
+        $classes = [
+            Command\AboutCommand::class,
+            Command\ArchiveCommand::class,
+            Command\CheckPlatformReqsCommand::class,
+            Command\ClearCacheCommand::class,
+            Command\ConfigCommand::class,
+            Command\CreateProjectCommand::class,
+            Command\DependsCommand::class,
+            Command\DiagnoseCommand::class,
+            Command\DumpAutoloadCommand::class,
+            Command\ExecCommand::class,
+            Command\FundCommand::class,
+            Command\GlobalCommand::class,
+            Command\HomeCommand::class,
+            Command\InitCommand::class,
+            Command\InstallCommand::class,
+            Command\LicensesCommand::class,
+            Command\OutdatedCommand::class,
+            Command\ProhibitsCommand::class,
+            Command\ReinstallCommand::class,
+            Command\RemoveCommand::class,
+            Command\RequireCommand::class,
+            Command\RunScriptCommand::class,
+            Command\SearchCommand::class,
+            Command\ShowCommand::class,
+            Command\StatusCommand::class,
+            Command\SuggestsCommand::class,
+            Command\UpdateCommand::class,
+            Command\ValidateCommand::class,
+        ];
         if (strpos(__FILE__, 'phar:') === 0) {
-            $commands[] = new Command\SelfUpdateCommand();
+            $classes[] = Command\SelfUpdateCommand::class;
+        }
+
+        foreach ($classes as $commandClass) {
+            $aliases = explode(',', $commandClass::$defaultName);
+            $name = array_shift($aliases);
+            $commands[] = new LazyCommand($name, $aliases, $commandClass::$defaultDescription, false, function () use ($commandClass) { return new $commandClass; });
         }
 
         return $commands;


### PR DESCRIPTION
Makes use of https://symfony.com/blog/new-in-symfony-5-3-lazy-command-description - TBH kind of micro-optimization level I guess as running the configure of most of those commands isn't a whole lot of code that runs, but if it saves a few ms it's a win I guess especially in the context of #10320

If someone with a profiler setup at hand and some free time wants to check the result, please do :)