### PR TITLE
ArrayLoader: assert that source/dist reference are string values

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -185,7 +185,7 @@ class ArrayLoader implements LoaderInterface
             }
             $package->setSourceType($config['source']['type']);
             $package->setSourceUrl($config['source']['url']);
-            $package->setSourceReference($config['source']['reference'] ?? null);
+            $package->setSourceReference(isset($config['source']['reference']) ? (string) $config['source']['reference'] : null);
             if (isset($config['source']['mirrors'])) {
                 $package->setSourceMirrors($config['source']['mirrors']);
             }
@@ -202,7 +202,7 @@ class ArrayLoader implements LoaderInterface
             }
             $package->setDistType($config['dist']['type']);
             $package->setDistUrl($config['dist']['url']);
-            $package->setDistReference($config['dist']['reference'] ?? null);
+            $package->setDistReference(isset($config['dist']['reference']) ? (string) $config['dist']['reference'] : null);
             $package->setDistSha1Checksum($config['dist']['shasum'] ?? null);
             if (isset($config['dist']['mirrors'])) {
                 $package->setDistMirrors($config['dist']['mirrors']);

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -325,4 +325,26 @@ class ArrayLoaderTest extends TestCase
         $package = $this->loader->load($config);
         $this->assertSame('1', $package->getPrettyVersion());
     }
+
+    public function testNoneStringSourceDistReference(): void
+    {
+        $config = array(
+            'name' => 'acme/package',
+            'version' => 'dev-main',
+            'source' => [
+                'type' => 'svn',
+                'url' => 'https://example.org/',
+                'reference' => 2019,
+            ],
+            'dist' => [
+                'type' => 'zip',
+                'url' => 'https://example.org/',
+                'reference' => 2019,
+            ],
+        );
+
+        $package = $this->loader->load($config);
+        $this->assertSame('2019', $package->getSourceReference());
+        $this->assertSame('2019', $package->getDistReference());
+    }
 }


### PR DESCRIPTION
Source and dist reference from third party repositories can contain int values. Example in wpackagist: https://wpackagist.org/p/wpackagist-theme/blankslate%2491eb3d60b45cca3c230a8bbb96e88b06ce3d7ea22a4af26caeaeaaab2f16869d.json