### PR TITLE
RemoteFilesystem: fix result length check

### DIFF
--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -526,7 +526,7 @@ class RemoteFilesystem
         } catch (\Throwable $e) {
         }
 
-        if ($maxFileSize !== null && Platform::strlen($result) >= $maxFileSize) {
+        if ($result !== false && $maxFileSize !== null && Platform::strlen($result) >= $maxFileSize) {
             throw new MaxFileSizeExceededException('Maximum allowed download size reached. Downloaded ' . Platform::strlen($result) . ' of allowed ' .  $maxFileSize . ' bytes');
         }
 


### PR DESCRIPTION
Fixes: `Uncaught Error: Composer\Util\Platform::strlen(): Argument #1 ($str) must be of type string, bool given, called in src/Composer/Util/RemoteFilesystem.php on line 529`