### PR TITLE
Bitbucket: handle missing authentication response from API returning 404 status code

### DIFF
--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -390,7 +390,7 @@ class GitBitbucketDriver extends VcsDriver
         } catch (TransportException $e) {
             $bitbucketUtil = new Bitbucket($this->io, $this->config, $this->process, $this->httpDownloader);
 
-            if (403 === $e->getCode() || (401 === $e->getCode() && strpos($e->getMessage(), 'Could not authenticate against') === 0)) {
+            if (in_array($e->getCode(), array(403, 404), true) || (401 === $e->getCode() && strpos($e->getMessage(), 'Could not authenticate against') === 0)) {
                 if (!$this->io->hasAuthentication($this->originUrl)
                     && $bitbucketUtil->authorizeOAuth($this->originUrl)
                 ) {


### PR DESCRIPTION
Bitbucket now seems to return a 404 status code with the below body if you access a repository you don't have access to
```
{"type": "error", "error": {"message": "The requested repository either does not exist or you do not have access. If you believe this repository exists and you have access, make sure you're authenticated."}}
```