### PR TITLE
ArrayLoader: fix integer index of branch alias

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -421,6 +421,8 @@ class ArrayLoader implements LoaderInterface
 
         if (isset($config['extra']['branch-alias']) && \is_array($config['extra']['branch-alias'])) {
             foreach ($config['extra']['branch-alias'] as $sourceBranch => $targetBranch) {
+                $sourceBranch = (string) $sourceBranch;
+
                 // ensure it is an alias to a -dev package
                 if ('-dev' !== substr($targetBranch, -4)) {
                     continue;

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -347,4 +347,23 @@ class ArrayLoaderTest extends TestCase
         $this->assertSame('2019', $package->getSourceReference());
         $this->assertSame('2019', $package->getDistReference());
     }
+
+    public function testBranchAliasIntegerIndex(): void
+    {
+        $config = array(
+            'name' => 'acme/package',
+            'version' => 'dev-1',
+            'extra' => [
+                'branch-alias' => [
+                    '1' => '1.3-dev',
+                ],
+            ],
+            'dist' => [
+                'type' => 'zip',
+                'url' => 'https://example.org/',
+            ],
+        );
+
+        $this->assertNull($this->loader->getBranchAlias($config));
+    }
 }


### PR DESCRIPTION
Fixes `Console Exception: strtolower(): Argument #1 ($string) must be of type string, int given in ArrayLoader.php:440`

For example, happens for package "silverstripe/crontask" from packagist.org which has an `extra` key with value `{"branch-alias":{"1":"1.3.x-dev"}}` in version `1.x-dev`