### PR TITLE
ArrayLoader: handle links where target is invalid numeric package name

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -357,10 +357,10 @@ class ArrayLoader implements LoaderInterface
     }
 
     /**
-     * @param  string                $source        source package name
-     * @param  string                $sourceVersion source package version (pretty version ideally)
-     * @param  string                $description   link description (e.g. requires, replaces, ..)
-     * @param  array<string, string> $links         array of package name => constraint mappings
+     * @param  string                    $source        source package name
+     * @param  string                    $sourceVersion source package version (pretty version ideally)
+     * @param  string                    $description   link description (e.g. requires, replaces, ..)
+     * @param  array<string|int, string> $links         array of package name => constraint mappings
      *
      * @return Link[]
      *
@@ -370,7 +370,7 @@ class ArrayLoader implements LoaderInterface
     {
         $res = array();
         foreach ($links as $target => $constraint) {
-            $target = strtolower($target);
+            $target = strtolower((string) $target);
             $res[$target] = $this->createLink($source, $sourceVersion, $description, $target, $constraint);
         }
 

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -315,6 +315,13 @@ class ArrayLoaderTest extends TestCase
         $this->assertSame('6.6.6', $links['composer-plugin-api']->getConstraint()->getPrettyString());
     }
 
+    public function testParseLinksIntegerTarget(): void
+    {
+        $links = $this->loader->parseLinks('Plugin', '9.9.9', Link::TYPE_REQUIRE, array('1' => 'dev-main'));
+
+        $this->assertArrayHasKey('1', $links);
+    }
+
     public function testNoneStringVersion(): void
     {
         $config = array(


### PR DESCRIPTION
Resolves: `Uncaught Console Exception: strtolower(): Argument #1 ($string) must be of type string, int given in ArrayLoader.php:373`

Traces:
```
src/Composer/Package/Loader/ArrayLoader.php:373",
src/Composer/Package/Loader/ArrayLoader.php:68",
src/Composer/Repository/VcsRepository.php:306",
src/Composer/Repository/ArrayRepository.php:311",
```