### PR TITLE
SplFileInfo: getRealPath can return false in ArchivableFilesFinder

### DIFF
--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -58,7 +58,7 @@ class ArchivableFilesFinder extends \FilterIterator
         $this->finder = new Finder();
 
         $filter = function (\SplFileInfo $file) use ($sources, $filters, $fs): bool {
-            if ($file->isLink() && strpos($file->getRealPath(), $sources) !== 0) {
+            if ($file->isLink() && ($file->getRealPath() === false || strpos($file->getRealPath(), $sources) !== 0)) {
                 return false;
             }
 


### PR DESCRIPTION
Fixes: `TypeError(code: 0): strpos(): Argument #1 ($haystack) must be of type string, bool given at src/Composer/Package/Archiver/ArchivableFilesFinder.php:61`

Happens for instance if files in the bin folder are pointing to the vendor directory and vendors are not installed