### PR TITLE
fix phpdoc type in ProcessExecutorMock 

### DIFF
--- a/tests/Composer/Test/Mock/ProcessExecutorMock.php
+++ b/tests/Composer/Test/Mock/ProcessExecutorMock.php
@@ -66,7 +66,7 @@ class ProcessExecutorMock extends ProcessExecutor
      */
     public function expects(array $expectations, bool $strict = false, array $defaultHandler = array('return' => 0, 'stdout' => '', 'stderr' => '')): void
     {
-        /** @var array{cmd: string|list<string>, return?: int, stdout?: string, stderr?: string, callback?: callable} $default */
+        /** @var array{cmd: string|list<string>, return: int, stdout: string, stderr: string, callback: callable} $default */
         $default = array('cmd' => '', 'return' => 0, 'stdout' => '', 'stderr' => '', 'callback' => null);
         $this->expectations = array_map(function ($expect) use ($default): array {
             if (is_string($expect)) {


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
