### PR TITLE
Correction the function getComposerInformation in SvnDriver.php.

### DIFF
--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -148,7 +148,7 @@ class SvnDriver extends VcsDriver
                     throw $e;
                 }
                 // remember a not-existent composer.json
-                $composer = '';
+                $composer = [];
             }
 
             if ($this->shouldCache($identifier)) {


### PR DESCRIPTION
Sometimes the getBaseComposerInformation had an exception so we write in the cache a string value but the funtion want to return null or Array value.
Now we write a empty string value if it happened

Bug in the 2.3
It's the fix about the issues 10680