### PR TITLE
restore --version output to pre-2.3

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -557,17 +557,18 @@ class Application extends BaseApplication
 
     public function getLongVersion(): string
     {
+        $branchAliasString = '';
         if (Composer::BRANCH_ALIAS_VERSION && Composer::BRANCH_ALIAS_VERSION !== '@package_branch_alias_version'.'@') {
-            return sprintf(
-                '<info>%s</info> version <comment>%s (%s)</comment> %s',
-                $this->getName(),
-                Composer::BRANCH_ALIAS_VERSION,
-                $this->getVersion(),
-                Composer::RELEASE_DATE
-            );
+            $branchAliasString = sprintf(' (%s)', Composer::BRANCH_ALIAS_VERSION);
         }
 
-        return parent::getLongVersion() . ' ' . Composer::RELEASE_DATE;
+        return sprintf(
+            '<info>%s</info> version <comment>%s%s</comment> %s',
+            $this->getName(),
+            $this->getVersion(),
+            $branchAliasString,
+            Composer::RELEASE_DATE
+        );
     }
 
     protected function getDefaultInputDefinition(): InputDefinition


### PR DESCRIPTION
Symfony Console 2.8 used to print 'version ' in between name and version, and Composer 2.3 still does for -dev snapshots, so we're going back to the old formatting for consistency (and anyone out there who parses the version output of Composer)

Fixes #10683