### PR TITLE
Fix strict types - bool passed to dirname

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -185,7 +185,7 @@ EOT
 
         $authConfigFile = $input->getOption('global')
             ? ($this->config->get('home') . '/auth.json')
-            : dirname(realpath($configFile)) . '/auth.json';
+            : dirname(realpath($configFile) !== false ? realpath($configFile) : '') . '/auth.json';
 
         $this->authConfigFile = new JsonFile($authConfigFile, null, $io);
         $this->authConfigSource = new JsonConfigSource($this->authConfigFile, true);


### PR DESCRIPTION
fix `composer config platform.php 8.1` strict types error on PHP 8.2 (php-src master) when run on empty dir /wo composer.json file