### PR TITLE
Fix run-script not setting Path correctly on Windows

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -571,6 +571,10 @@ class EventDispatcher
     private function ensureBinDirIsInPath(): void
     {
         $pathEnv = 'PATH';
+
+        // checking if only Path and not PATH is set then we probably need to update the Path env
+        // on Windows getenv is case-insensitive so we cannot check it via Platform::getEnv and
+        // we need to check in $_SERVER directly
         if (!isset($_SERVER[$pathEnv]) && isset($_SERVER['Path'])) {
             $pathEnv = 'Path';
         }

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -571,7 +571,7 @@ class EventDispatcher
     private function ensureBinDirIsInPath(): void
     {
         $pathEnv = 'PATH';
-        if (false === Platform::getEnv('PATH') && false !== Platform::getEnv('Path')) {
+        if (!isset($_SERVER[$pathEnv]) && isset($_SERVER['Path'])) {
             $pathEnv = 'Path';
         }
 


### PR DESCRIPTION
Fixes #10699.

`getenv` is case-insensitive as far as I understand it, which makes it not work correctly.

Not entirely sure why it works on 2.2, because the same code should be there.

It was changed here: https://github.com/composer/composer/commit/bd4d624cc7468623b29e56fa800b1750886b04c7#diff-4ec8bee1b3bdbc03e2097675b4586f3bb92ff70afff4e6ee5e4cc25847816e97L569