### PR TITLE
Restore the ability to list the scripts in the 'run-script' command without providing a script

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -6056,6 +6056,11 @@ parameters:
 		-
 			message: "#^Dynamic call to static method Composer\\\\Test\\\\TestCase\\:\\:getUniqueTmpDirectory\\(\\)\\.$#"
 			count: 1
+			path: ../tests/Composer/Test/Command/RunScriptCommandTest.php
+
+		-
+			message: "#^Dynamic call to static method Composer\\\\Test\\\\TestCase\\:\\:getUniqueTmpDirectory\\(\\)\\.$#"
+			count: 1
 			path: ../tests/Composer/Test/Config/JsonConfigSourceTest.php
 
 		-

--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -54,7 +54,7 @@ class RunScriptCommand extends BaseCommand
             ->setAliases(array('run'))
             ->setDescription('Runs the scripts defined in composer.json.')
             ->setDefinition(array(
-                new InputArgument('script', InputArgument::REQUIRED, 'Script name to run.'),
+                new InputArgument('script', InputArgument::OPTIONAL, 'Script name to run.'),
                 new InputArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, ''),
                 new InputOption('timeout', null, InputOption::VALUE_REQUIRED, 'Sets script timeout in seconds, or 0 for never.'),
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Sets the dev mode.'),
@@ -80,6 +80,10 @@ EOT
         }
 
         $script = $input->getArgument('script');
+        if ($script === null) {
+            throw new \RuntimeException('Missing required argument "script"');
+        }
+
         if (!in_array($script, $this->scriptEvents)) {
             if (defined('Composer\Script\ScriptEvents::'.str_replace('-', '_', strtoupper($script)))) {
                 throw new \InvalidArgumentException(sprintf('Script "%s" cannot be run with this command', $script));


### PR DESCRIPTION
Fixes #10705
Fixes #10707

After #10476 the ability to list scripts from the `run-script` command without passing a script name (i.e. `composer run-script -l`) was lost because the `script` argument was made required.  This restores the ability to list the scripts without needing to pass something to fill the `script` argument while also failing if not listing scripts and a script name wasn't provided.