### PR TITLE
Fix discrepancy between documentation and code in package's dist reference configuration

### DIFF
--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -62,7 +62,7 @@ use Composer\Util\Git as GitUtil;
  *         "type": "path",
  *         "url": "../../relative/path/to/package/",
  *         "options": {
- *             "reference": "none"
+ *             "reference": "null"
  *         }
  *     },
  * ]
@@ -182,7 +182,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
                 'url' => $url,
             );
             $reference = $this->options['reference'] ?? 'auto';
-            if ('none' === $reference) {
+            if ('none' === $reference  || 'null' === $reference) {
                 $package['dist']['reference'] = null;
             } elseif ('config' === $reference || 'auto' === $reference) {
                 $package['dist']['reference'] = sha1($json . serialize($this->options));

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -156,6 +156,9 @@ class PathRepositoryTest extends TestCase
         $this->assertSame($relativeUrl, $package->getDistUrl());
     }
 
+    /**
+     * @deprecated Should be removed when config value "none" will be removed
+     */
     public function testReferenceNone(): void
     {
         $ioInterface = $this->getMockBuilder('Composer\IO\IOInterface')
@@ -165,6 +168,27 @@ class PathRepositoryTest extends TestCase
 
         $options = array(
             'reference' => 'none',
+        );
+        $repositoryUrl = implode(DIRECTORY_SEPARATOR, array(__DIR__, 'Fixtures', 'path', '*'));
+        $repository = new PathRepository(array('url' => $repositoryUrl, 'options' => $options), $ioInterface, $config);
+        $packages = $repository->getPackages();
+
+        $this->assertGreaterThanOrEqual(2, $repository->count());
+
+        foreach ($packages as $package) {
+            $this->assertEquals($package->getDistReference(), null);
+        }
+    }
+
+    public function testReferenceNull(): void
+    {
+        $ioInterface = $this->getMockBuilder('Composer\IO\IOInterface')
+            ->getMock();
+
+        $config = new \Composer\Config();
+
+        $options = array(
+            'reference' => 'null',
         );
         $repositoryUrl = implode(DIRECTORY_SEPARATOR, array(__DIR__, 'Fixtures', 'path', '*'));
         $repository = new PathRepository(array('url' => $repositoryUrl, 'options' => $options), $ioInterface, $config);


### PR DESCRIPTION
https://github.com/composer/composer/pull/10488 in this pull request there is a mistake. In code used none for nullable reference configuration, in documentation used "null". I add "null" as possible value in code. 'none' config value should be removed in future.