### PR TITLE
Add warning if host is accessed via verify_peer or verify_peer_name disabled

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -168,7 +168,7 @@ class CurlDownloader
 
         // check URL can be accessed (i.e. is not insecure), but allow insecure Packagist calls to $hashed providers as file integrity is verified with sha256
         if (!Preg::isMatch('{^http://(repo\.)?packagist\.org/p/}', $url) || (false === strpos($url, '$') && false === strpos($url, '%24'))) {
-            $this->config->prohibitUrlByConfig($url, $this->io);
+            $this->config->prohibitUrlByConfig($url, $this->io, $options);
         }
 
         $curlHandle = curl_init();

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -13,6 +13,9 @@
 namespace Composer\Test;
 
 use Composer\Config;
+use Composer\IO\BaseIO;
+use Composer\IO\IOInterface;
+use Composer\IO\NullIO;
 use Composer\Util\Platform;
 
 class ConfigTest extends TestCase
@@ -306,6 +309,24 @@ class ConfigTest extends TestCase
         return array_combine($urls, array_map(function ($e): array {
             return array($e);
         }, $urls));
+    }
+
+    public function testProhibitedUrlsWarningVerifyPeer(): void
+    {
+        $io = $this->getMockBuilder(IOInterface::class)->disableOriginalConstructor()->getMock();
+
+        $io
+            ->expects($this->once())
+            ->method('writeError')
+            ->with($this->equalTo('<warning>Warning: Accessing example.org with verify_peer and verify_peer_name disabled.</warning>'));
+
+        $config = new Config(false);
+        $config->prohibitUrlByConfig('https://example.org', $io, [
+            'ssl' => [
+                'verify_peer' => false,
+                'verify_peer_name' => false,
+            ]
+        ]);
     }
 
     /**


### PR DESCRIPTION
Similar to the warning about accessing a host via insecure protocol, this adds a warning about accessing a host with verify_peer or verify_peer_name disabled.

```
composer update
Loading composer repositories with package information
Warning: Accessing api.github.com with verify_peer disabled.
```