### PR TITLE
Patch "validate --no-check-lock"

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -2376,6 +2376,11 @@ parameters:
 			path: ../src/Composer/Command/ValidateCommand.php
 
 		-
+			message: "#^Only booleans are allowed in &&, mixed given on the right side\\.$#"
+			count: 1
+			path: ../src/Composer/Command/ValidateCommand.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, array\\<Composer\\\\Package\\\\BasePackage\\> given\\.$#"
 			count: 1
 			path: ../src/Composer/Command/ValidateCommand.php
@@ -2407,6 +2412,11 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 1
+			path: ../src/Composer/Command/ValidateCommand.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, mixed given on the right side\\.$#"
 			count: 1
 			path: ../src/Composer/Command/ValidateCommand.php
 

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -45,6 +45,7 @@ class ValidateCommand extends BaseCommand
             ->setDescription('Validates a composer.json and composer.lock.')
             ->setDefinition(array(
                 new InputOption('no-check-all', null, InputOption::VALUE_NONE, 'Do not validate requires for overly strict/loose constraints'),
+                new InputOption('check-lock', null, InputOption::VALUE_NONE, 'Check if lock file is up to date (even config.lock is false, overrides --no-check-lock)'),
                 new InputOption('no-check-lock', null, InputOption::VALUE_NONE, 'Do not check if lock file is up to date'),
                 new InputOption('no-check-publish', null, InputOption::VALUE_NONE, 'Do not check for publish errors'),
                 new InputOption('no-check-version', null, InputOption::VALUE_NONE, 'Do not report a warning if the version field is present'),
@@ -95,6 +96,8 @@ EOT
 
         $lockErrors = array();
         $composer = Factory::create($io, $file, $input->hasParameterOption('--no-plugins'));
+        // config.lock = false ~= implicit --no-check-lock; --check-lock overrides
+        $checkLock = ($checkLock && $composer->getConfig()->get('lock')) || $input->getOption('check-lock');
         $locker = $composer->getLocker();
         if ($locker->isLocked() && !$locker->isFresh()) {
             $lockErrors[] = '- The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update` or `composer update <package name>`.';


### PR DESCRIPTION
if no lock-file is configured, turn lock file validation errors into warnings (implicit --no-check-lock) unless those are explicitly promoted via the new `--check-lock` option.

- `{"config": {"lock": false}}` is an implicit `--no-check-lock` for   composer validate.
- `--check-lock` overrides an (implicit or explicit) `--no-check-lock`, always.

rationale is that if no composer.lock file is configured in composer.json, the validate command should not _fatal_ over it but instead demote to _warning_ as the suggestion given in the warning won't work unless composer.lock is configured again (and there is no error as the lock-file is ignored by composer).

the difference this makes is the one between an exit status of zero or non-zero, between success and failure.

that is, if (and as) composer validate is used in check scripts (e.g. CI, tests, hooks etc.), it won't stumble over old lock-file artifacts, whatever the reasons may be.

(originally reported and fix idea / context in #10715)