### PR TITLE
Clarify that autoloader-suffix should be a non-empty-string

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -315,8 +315,8 @@ with other autoloaders.
 
 ## autoloader-suffix
 
-Defaults to `null`. String to be used as a suffix for the generated Composer
-autoloader. When null a random one will be generated.
+Defaults to `null`. Non-empty string to be used as a suffix for the generated
+Composer autoloader. When null a random one will be generated.
 
 ## optimize-autoloader
 

--- a/phpstan/config.neon
+++ b/phpstan/config.neon
@@ -16,6 +16,7 @@ parameters:
        - '../src/Composer/Console/HtmlOutputFormatter.php'
 
     reportUnmatchedIgnoredErrors: false
+    treatPhpDocTypesAsCertain: false
 
     ignoreErrors:
         # unused parameters

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -159,12 +159,12 @@ class AutoloadGenerator
     /**
      * @param string $targetDir
      * @param bool $scanPsrPackages
-     * @param string $suffix
+     * @param string|null $suffix
      * @return int
      * @throws \Seld\JsonLint\ParsingException
      * @throws \RuntimeException
      */
-    public function dump(Config $config, InstalledRepositoryInterface $localRepo, RootPackageInterface $rootPackage, InstallationManager $installationManager, $targetDir, $scanPsrPackages = false, $suffix = '')
+    public function dump(Config $config, InstalledRepositoryInterface $localRepo, RootPackageInterface $rootPackage, InstallationManager $installationManager, $targetDir, $scanPsrPackages = false, $suffix = null)
     {
         if ($this->classMapAuthoritative) {
             // Force scanPsrPackages when classmap is authoritative
@@ -374,16 +374,23 @@ EOF;
         }
         $classmapFile .= ");\n";
 
-        if (!$suffix) {
-            if (!$config->get('autoloader-suffix') && Filesystem::isReadable($vendorPath.'/autoload.php')) {
+        if ('' === $suffix) {
+            $suffix = null;
+        }
+        if (null === $suffix) {
+            $suffix = $config->get('autoloader-suffix');
+
+            // carry over existing autoload.php's suffix if possible and none is configured
+            if (null === $suffix && Filesystem::isReadable($vendorPath.'/autoload.php')) {
                 $content = file_get_contents($vendorPath.'/autoload.php');
                 if (Preg::isMatch('{ComposerAutoloaderInit([^:\s]+)::}', $content, $match)) {
                     $suffix = $match[1];
                 }
             }
 
-            if (!$suffix) {
-                $suffix = $config->get('autoloader-suffix') ?: md5(uniqid('', true));
+            // generate one if we still haven't got a suffix
+            if (null === $suffix) {
+                $suffix = md5(uniqid('', true));
             }
         }
 

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -427,6 +427,13 @@ class Config
 
                 return $protos;
 
+            case 'autoloader-suffix':
+                if ($this->config[$key] === '') { // we need to guarantee null or non-empty-string
+                    return null;
+                }
+
+                return $this->process($this->config[$key], $flags);
+
             default:
                 if (!isset($this->config[$key])) {
                     return null;


### PR DESCRIPTION
Fixes #10720
