### PR TITLE
BitbucketDriver: remove unnecessary HTTP call to fetch the root identifier

### DIFF
--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -48,6 +48,8 @@ class GitBitbucketDriver extends VcsDriver
     private $website = '';
     /** @var string */
     private $cloneHttpsUrl = '';
+    /** @var array<string, mixed> */
+    private $repoData;
 
     /**
      * @var ?VcsDriver
@@ -124,6 +126,8 @@ class GitBitbucketDriver extends VcsDriver
         $this->homeUrl = $repoData['links']['html']['href'];
         $this->website = $repoData['website'];
         $this->vcsType = $repoData['scm'];
+
+        $this->repoData = $repoData;
 
         return true;
     }
@@ -473,25 +477,6 @@ class GitBitbucketDriver extends VcsDriver
     }
 
     /**
-     * @return (array{name: string}&mixed[])|null
-     */
-    protected function getMainBranchData(): ?array
-    {
-        $resource = sprintf(
-            'https://api.bitbucket.org/2.0/repositories/%s/%s?fields=mainbranch',
-            $this->owner,
-            $this->repository
-        );
-
-        $data = $this->fetchWithOAuthCredentials($resource)->decodeJson();
-        if (isset($data['mainbranch'])) {
-            return $data['mainbranch'];
-        }
-
-        return null;
-    }
-
-    /**
      * @inheritDoc
      */
     public function getRootIdentifier(): string
@@ -517,8 +502,7 @@ class GitBitbucketDriver extends VcsDriver
                 );
             }
 
-            $mainBranchData = $this->getMainBranchData();
-            $this->rootIdentifier = !empty($mainBranchData['name']) ? $mainBranchData['name'] : 'master';
+            $this->rootIdentifier = $this->repoData['mainbranch']['name'] ?? 'master';
         }
 
         return $this->rootIdentifier;

--- a/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
@@ -105,11 +105,10 @@ class GitBitbucketDriverTest extends TestCase
 
         $urls = array(
             'https://api.bitbucket.org/2.0/repositories/user/repo?fields=-project%2C-owner',
-            'https://api.bitbucket.org/2.0/repositories/user/repo?fields=mainbranch',
             'https://api.bitbucket.org/2.0/repositories/user/repo/refs/tags?pagelen=100&fields=values.name%2Cvalues.target.hash%2Cnext&sort=-target.date',
             'https://api.bitbucket.org/2.0/repositories/user/repo/refs/branches?pagelen=100&fields=values.name%2Cvalues.target.hash%2Cvalues.heads%2Cnext&sort=-target.date',
-            'https://api.bitbucket.org/2.0/repositories/user/repo/src/master/composer.json',
-            'https://api.bitbucket.org/2.0/repositories/user/repo/commit/master?fields=date',
+            'https://api.bitbucket.org/2.0/repositories/user/repo/src/main/composer.json',
+            'https://api.bitbucket.org/2.0/repositories/user/repo/commit/main?fields=date',
         );
         $this->httpDownloader->expects($this->any())
             ->method('get')
@@ -128,22 +127,18 @@ class GitBitbucketDriverTest extends TestCase
                 ),
                 array(
                     $urls[4], array(),
-                ),
-                array(
-                    $urls[5], array(),
                 )
             )
             ->willReturnOnConsecutiveCalls(
-                new Response(array('url' => $urls[0]), 200, array(), '{"scm":"git","website":"","has_wiki":false,"name":"repo","links":{"branches":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/branches"},"tags":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/tags"},"clone":[{"href":"https:\/\/user@bitbucket.org\/user\/repo.git","name":"https"},{"href":"ssh:\/\/git@bitbucket.org\/user\/repo.git","name":"ssh"}],"html":{"href":"https:\/\/bitbucket.org\/user\/repo"}},"language":"php","created_on":"2015-02-18T16:22:24.688+00:00","updated_on":"2016-05-17T13:20:21.993+00:00","is_private":true,"has_issues":false}'),
-                new Response(array('url' => $urls[1]), 200, array(), '{"mainbranch": {"name": "master"}}'),
-                new Response(array('url' => $urls[2]), 200, array(), '{"values":[{"name":"1.0.1","target":{"hash":"9b78a3932143497c519e49b8241083838c8ff8a1"}},{"name":"1.0.0","target":{"hash":"d3393d514318a9267d2f8ebbf463a9aaa389f8eb"}}]}'),
-                new Response(array('url' => $urls[3]), 200, array(), '{"values":[{"name":"master","target":{"hash":"937992d19d72b5116c3e8c4a04f960e5fa270b22"}}]}'),
-                new Response(array('url' => $urls[4]), 200, array(), '{"name": "user/repo","description": "test repo","license": "GPL","authors": [{"name": "Name","email": "local@domain.tld"}],"require": {"creator/package": "^1.0"},"require-dev": {"phpunit/phpunit": "~4.8"}}'),
-                new Response(array('url' => $urls[5]), 200, array(), '{"date": "2016-05-17T13:19:52+00:00"}')
+                new Response(array('url' => $urls[0]), 200, array(), '{"mainbranch": {"name": "main"}, "scm":"git","website":"","has_wiki":false,"name":"repo","links":{"branches":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/branches"},"tags":{"href":"https:\/\/api.bitbucket.org\/2.0\/repositories\/user\/repo\/refs\/tags"},"clone":[{"href":"https:\/\/user@bitbucket.org\/user\/repo.git","name":"https"},{"href":"ssh:\/\/git@bitbucket.org\/user\/repo.git","name":"ssh"}],"html":{"href":"https:\/\/bitbucket.org\/user\/repo"}},"language":"php","created_on":"2015-02-18T16:22:24.688+00:00","updated_on":"2016-05-17T13:20:21.993+00:00","is_private":true,"has_issues":false}'),
+                new Response(array('url' => $urls[1]), 200, array(), '{"values":[{"name":"1.0.1","target":{"hash":"9b78a3932143497c519e49b8241083838c8ff8a1"}},{"name":"1.0.0","target":{"hash":"d3393d514318a9267d2f8ebbf463a9aaa389f8eb"}}]}'),
+                new Response(array('url' => $urls[2]), 200, array(), '{"values":[{"name":"main","target":{"hash":"937992d19d72b5116c3e8c4a04f960e5fa270b22"}}]}'),
+                new Response(array('url' => $urls[3]), 200, array(), '{"name": "user/repo","description": "test repo","license": "GPL","authors": [{"name": "Name","email": "local@domain.tld"}],"require": {"creator/package": "^1.0"},"require-dev": {"phpunit/phpunit": "~4.8"}}'),
+                new Response(array('url' => $urls[4]), 200, array(), '{"date": "2016-05-17T13:19:52+00:00"}')
             );
 
         $this->assertEquals(
-            'master',
+            'main',
             $driver->getRootIdentifier()
         );
 
@@ -157,7 +152,7 @@ class GitBitbucketDriverTest extends TestCase
 
         $this->assertEquals(
             array(
-                'master' => '937992d19d72b5116c3e8c4a04f960e5fa270b22',
+                'main' => '937992d19d72b5116c3e8c4a04f960e5fa270b22',
             ),
             $driver->getBranches()
         );
@@ -181,11 +176,11 @@ class GitBitbucketDriverTest extends TestCase
                 ),
                 'time' => '2016-05-17T13:19:52+00:00',
                 'support' => array(
-                    'source' => 'https://bitbucket.org/user/repo/src/937992d19d72b5116c3e8c4a04f960e5fa270b22/?at=master',
+                    'source' => 'https://bitbucket.org/user/repo/src/937992d19d72b5116c3e8c4a04f960e5fa270b22/?at=main',
                 ),
                 'homepage' => 'https://bitbucket.org/user/repo',
             ),
-            $driver->getComposerInformation('master')
+            $driver->getComposerInformation('main')
         );
 
         return $driver;


### PR DESCRIPTION
The `mainbranch` information is already available when fetching the repo data. The HTTP call in `getMainBranchData` was calling the same endpoint as `getRepoData` but only fetch the `mainbranch` data.

Windows test failing with a random timeout