### PR TITLE
Use `addOption` and `addArgument` for command input definition

### DIFF
--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -47,15 +47,13 @@ class ArchiveCommand extends BaseCommand
         $this
             ->setName('archive')
             ->setDescription('Creates an archive of this composer package.')
-            ->setDefinition(array(
-                new InputArgument('package', InputArgument::OPTIONAL, 'The package to archive instead of the current project'),
-                new InputArgument('version', InputArgument::OPTIONAL, 'A version constraint to find the package to archive'),
-                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the resulting archive: tar, tar.gz, tar.bz2 or zip (default tar)'),
-                new InputOption('dir', null, InputOption::VALUE_REQUIRED, 'Write the archive to this directory'),
-                new InputOption('file', null, InputOption::VALUE_REQUIRED, 'Write the archive with the given file name.'
-                    .' Note that the format will be appended.'),
-                new InputOption('ignore-filters', null, InputOption::VALUE_NONE, 'Ignore filters when saving package'),
-            ))
+            ->addArgument('package', InputArgument::OPTIONAL, 'The package to archive instead of the current project')
+            ->addArgument('version', InputArgument::OPTIONAL, 'A version constraint to find the package to archive')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the resulting archive: tar, tar.gz, tar.bz2 or zip (default tar)')
+            ->addOption('dir', null, InputOption::VALUE_REQUIRED, 'Write the archive to this directory')
+            ->addOption('file', null, InputOption::VALUE_REQUIRED, 'Write the archive with the given file name.'
+                    .' Note that the format will be appended.')
+            ->addOption('ignore-filters', null, InputOption::VALUE_NONE, 'Ignore filters when saving package')
             ->setHelp(
                 <<<EOT
 The <info>archive</info> command creates an archive of the specified format

--- a/src/Composer/Command/CheckPlatformReqsCommand.php
+++ b/src/Composer/Command/CheckPlatformReqsCommand.php
@@ -30,10 +30,8 @@ class CheckPlatformReqsCommand extends BaseCommand
     {
         $this->setName('check-platform-reqs')
             ->setDescription('Check that platform requirements are satisfied.')
-            ->setDefinition(array(
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables checking of require-dev packages requirements.'),
-                new InputOption('lock', null, InputOption::VALUE_NONE, 'Checks requirements only from the lock file, not from installed packages.'),
-            ))
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Disables checking of require-dev packages requirements.')
+            ->addOption('lock', null, InputOption::VALUE_NONE, 'Checks requirements only from the lock file, not from installed packages.')
             ->setHelp(
                 <<<EOT
 Checks that your PHP and extensions versions match the platform requirements of the installed packages.

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -67,21 +67,19 @@ class ConfigCommand extends BaseCommand
         $this
             ->setName('config')
             ->setDescription('Sets config options.')
-            ->setDefinition(array(
-                new InputOption('global', 'g', InputOption::VALUE_NONE, 'Apply command to the global config file'),
-                new InputOption('editor', 'e', InputOption::VALUE_NONE, 'Open editor'),
-                new InputOption('auth', 'a', InputOption::VALUE_NONE, 'Affect auth config file (only used for --editor)'),
-                new InputOption('unset', null, InputOption::VALUE_NONE, 'Unset the given setting-key'),
-                new InputOption('list', 'l', InputOption::VALUE_NONE, 'List configuration settings'),
-                new InputOption('file', 'f', InputOption::VALUE_REQUIRED, 'If you want to choose a different composer.json or config.json'),
-                new InputOption('absolute', null, InputOption::VALUE_NONE, 'Returns absolute paths when fetching *-dir config values instead of relative'),
-                new InputOption('json', 'j', InputOption::VALUE_NONE, 'JSON decode the setting value, to be used with extra.* keys'),
-                new InputOption('merge', 'm', InputOption::VALUE_NONE, 'Merge the setting value with the current value, to be used with extra.* keys in combination with --json'),
-                new InputOption('append', null, InputOption::VALUE_NONE, 'When adding a repository, append it (lowest priority) to the existing ones instead of prepending it (highest priority)'),
-                new InputOption('source', null, InputOption::VALUE_NONE, 'Display where the config value is loaded from'),
-                new InputArgument('setting-key', null, 'Setting key'),
-                new InputArgument('setting-value', InputArgument::IS_ARRAY, 'Setting value'),
-            ))
+            ->addOption('global', 'g', InputOption::VALUE_NONE, 'Apply command to the global config file')
+            ->addOption('editor', 'e', InputOption::VALUE_NONE, 'Open editor')
+            ->addOption('auth', 'a', InputOption::VALUE_NONE, 'Affect auth config file (only used for --editor)')
+            ->addOption('unset', null, InputOption::VALUE_NONE, 'Unset the given setting-key')
+            ->addOption('list', 'l', InputOption::VALUE_NONE, 'List configuration settings')
+            ->addOption('file', 'f', InputOption::VALUE_REQUIRED, 'If you want to choose a different composer.json or config.json')
+            ->addOption('absolute', null, InputOption::VALUE_NONE, 'Returns absolute paths when fetching *-dir config values instead of relative')
+            ->addOption('json', 'j', InputOption::VALUE_NONE, 'JSON decode the setting value, to be used with extra.* keys')
+            ->addOption('merge', 'm', InputOption::VALUE_NONE, 'Merge the setting value with the current value, to be used with extra.* keys in combination with --json')
+            ->addOption('append', null, InputOption::VALUE_NONE, 'When adding a repository, append it (lowest priority) to the existing ones instead of prepending it (highest priority)')
+            ->addOption('source', null, InputOption::VALUE_NONE, 'Display where the config value is loaded from')
+            ->addArgument('setting-key', null, 'Setting key')
+            ->addArgument('setting-value', InputArgument::IS_ARRAY, 'Setting value')
             ->setHelp(
                 <<<EOT
 This command allows you to edit composer config settings and repositories

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -68,30 +68,28 @@ class CreateProjectCommand extends BaseCommand
         $this
             ->setName('create-project')
             ->setDescription('Creates new project from a package into given directory.')
-            ->setDefinition(array(
-                new InputArgument('package', InputArgument::OPTIONAL, 'Package name to be installed'),
-                new InputArgument('directory', InputArgument::OPTIONAL, 'Directory where the files should be created'),
-                new InputArgument('version', InputArgument::OPTIONAL, 'Version, will default to latest'),
-                new InputOption('stability', 's', InputOption::VALUE_REQUIRED, 'Minimum-stability allowed (unless a version is specified).'),
-                new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),
-                new InputOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).'),
-                new InputOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).'),
-                new InputOption('repository', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add custom repositories to look the package up, either by URL or using JSON arrays'),
-                new InputOption('repository-url', null, InputOption::VALUE_REQUIRED, 'DEPRECATED: Use --repository instead.'),
-                new InputOption('add-repository', null, InputOption::VALUE_NONE, 'Add the custom repository in the composer.json. If a lock file is present it will be deleted and an update will be run instead of install.'),
-                new InputOption('dev', null, InputOption::VALUE_NONE, 'Enables installation of require-dev packages (enabled by default, only present for BC).'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables installation of require-dev packages.'),
-                new InputOption('no-custom-installers', null, InputOption::VALUE_NONE, 'DEPRECATED: Use no-plugins instead.'),
-                new InputOption('no-scripts', null, InputOption::VALUE_NONE, 'Whether to prevent execution of all defined scripts in the root package.'),
-                new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
-                new InputOption('no-secure-http', null, InputOption::VALUE_NONE, 'Disable the secure-http config option temporarily while installing the root package. Use at your own risk. Using this flag is a bad idea.'),
-                new InputOption('keep-vcs', null, InputOption::VALUE_NONE, 'Whether to prevent deleting the vcs folder.'),
-                new InputOption('remove-vcs', null, InputOption::VALUE_NONE, 'Whether to force deletion of the vcs folder without prompting.'),
-                new InputOption('no-install', null, InputOption::VALUE_NONE, 'Whether to skip installation of the package dependencies.'),
-                new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
-                new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
-                new InputOption('ask', null, InputOption::VALUE_NONE, 'Whether to ask for project directory.'),
-            ))
+            ->addArgument('package', InputArgument::OPTIONAL, 'Package name to be installed')
+            ->addArgument('directory', InputArgument::OPTIONAL, 'Directory where the files should be created')
+            ->addArgument('version', InputArgument::OPTIONAL, 'Version, will default to latest')
+            ->addOption('stability', 's', InputOption::VALUE_REQUIRED, 'Minimum-stability allowed (unless a version is specified).')
+            ->addOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.')
+            ->addOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).')
+            ->addOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).')
+            ->addOption('repository', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add custom repositories to look the package up, either by URL or using JSON arrays')
+            ->addOption('repository-url', null, InputOption::VALUE_REQUIRED, 'DEPRECATED: Use --repository instead.')
+            ->addOption('add-repository', null, InputOption::VALUE_NONE, 'Add the custom repository in the composer.json. If a lock file is present it will be deleted and an update will be run instead of install.')
+            ->addOption('dev', null, InputOption::VALUE_NONE, 'Enables installation of require-dev packages (enabled by default, only present for BC).')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Disables installation of require-dev packages.')
+            ->addOption('no-custom-installers', null, InputOption::VALUE_NONE, 'DEPRECATED: Use no-plugins instead.')
+            ->addOption('no-scripts', null, InputOption::VALUE_NONE, 'Whether to prevent execution of all defined scripts in the root package.')
+            ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.')
+            ->addOption('no-secure-http', null, InputOption::VALUE_NONE, 'Disable the secure-http config option temporarily while installing the root package. Use at your own risk. Using this flag is a bad idea.')
+            ->addOption('keep-vcs', null, InputOption::VALUE_NONE, 'Whether to prevent deleting the vcs folder.')
+            ->addOption('remove-vcs', null, InputOption::VALUE_NONE, 'Whether to force deletion of the vcs folder without prompting.')
+            ->addOption('no-install', null, InputOption::VALUE_NONE, 'Whether to skip installation of the package dependencies.')
+            ->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).')
+            ->addOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).')
+            ->addOption('ask', null, InputOption::VALUE_NONE, 'Whether to ask for project directory.')
             ->setHelp(
                 <<<EOT
 The <info>create-project</info> command creates a new project from a given

--- a/src/Composer/Command/DependsCommand.php
+++ b/src/Composer/Command/DependsCommand.php
@@ -33,11 +33,9 @@ class DependsCommand extends BaseDependencyCommand
             ->setName('depends')
             ->setAliases(array('why'))
             ->setDescription('Shows which packages cause the given package to be installed.')
-            ->setDefinition(array(
-                new InputArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect'),
-                new InputOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package'),
-                new InputOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree'),
-            ))
+            ->addArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect')
+            ->addOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package')
+            ->addOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree')
             ->setHelp(
                 <<<EOT
 Displays detailed information about where a package is referenced.

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -32,16 +32,14 @@ class DumpAutoloadCommand extends BaseCommand
             ->setName('dump-autoload')
             ->setAliases(array('dumpautoload'))
             ->setDescription('Dumps the autoloader.')
-            ->setDefinition(array(
-                new InputOption('optimize', 'o', InputOption::VALUE_NONE, 'Optimizes PSR0 and PSR4 packages to be loaded with classmaps too, good for production.'),
-                new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.'),
-                new InputOption('apcu', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
-                new InputOption('apcu-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu'),
-                new InputOption('dev', null, InputOption::VALUE_NONE, 'Enables autoload-dev rules. Composer will by default infer this automatically according to the last install or update --no-dev state.'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables autoload-dev rules. Composer will by default infer this automatically according to the last install or update --no-dev state.'),
-                new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
-                new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
-            ))
+            ->addOption('optimize', 'o', InputOption::VALUE_NONE, 'Optimizes PSR0 and PSR4 packages to be loaded with classmaps too, good for production.')
+            ->addOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.')
+            ->addOption('apcu', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.')
+            ->addOption('apcu-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu')
+            ->addOption('dev', null, InputOption::VALUE_NONE, 'Enables autoload-dev rules. Composer will by default infer this automatically according to the last install or update --no-dev state.')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Disables autoload-dev rules. Composer will by default infer this automatically according to the last install or update --no-dev state.')
+            ->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).')
+            ->addOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).')
             ->setHelp(
                 <<<EOT
 <info>php composer.phar dump-autoload</info>

--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -30,15 +30,13 @@ class ExecCommand extends BaseCommand
         $this
             ->setName('exec')
             ->setDescription('Executes a vendored binary/script.')
-            ->setDefinition(array(
-                new InputOption('list', 'l', InputOption::VALUE_NONE),
-                new InputArgument('binary', InputArgument::OPTIONAL, 'The binary to run, e.g. phpunit'),
-                new InputArgument(
-                    'args',
-                    InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
-                    'Arguments to pass to the binary. Use <info>--</info> to separate from composer arguments'
-                ),
-            ))
+            ->addOption('list', 'l', InputOption::VALUE_NONE)
+            ->addArgument('binary', InputArgument::OPTIONAL, 'The binary to run, e.g. phpunit')
+            ->addArgument(
+                'args',
+                InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
+                'Arguments to pass to the binary. Use <info>--</info> to separate from composer arguments'
+            )
             ->setHelp(
                 <<<EOT
 Executes a vendored binary/script.

--- a/src/Composer/Command/FundCommand.php
+++ b/src/Composer/Command/FundCommand.php
@@ -37,9 +37,7 @@ class FundCommand extends BaseCommand
     {
         $this->setName('fund')
             ->setDescription('Discover how to help fund the maintenance of your dependencies.')
-            ->setDefinition(array(
-                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
-            ))
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text')
         ;
     }
 

--- a/src/Composer/Command/GlobalCommand.php
+++ b/src/Composer/Command/GlobalCommand.php
@@ -34,10 +34,8 @@ class GlobalCommand extends BaseCommand
         $this
             ->setName('global')
             ->setDescription('Allows running commands in the global composer dir ($COMPOSER_HOME).')
-            ->setDefinition(array(
-                new InputArgument('command-name', InputArgument::REQUIRED, ''),
-                new InputArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, ''),
-            ))
+            ->addArgument('command-name', InputArgument::REQUIRED, '')
+            ->addArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, '')
             ->setHelp(
                 <<<EOT
 Use this command as a wrapper to run other Composer commands

--- a/src/Composer/Command/HomeCommand.php
+++ b/src/Composer/Command/HomeCommand.php
@@ -39,11 +39,9 @@ class HomeCommand extends BaseCommand
             ->setName('browse')
             ->setAliases(array('home'))
             ->setDescription('Opens the package\'s repository URL or homepage in your browser.')
-            ->setDefinition(array(
-                new InputArgument('packages', InputArgument::IS_ARRAY, 'Package(s) to browse to.'),
-                new InputOption('homepage', 'H', InputOption::VALUE_NONE, 'Open the homepage instead of the repository URL.'),
-                new InputOption('show', 's', InputOption::VALUE_NONE, 'Only show the homepage or repository URL.'),
-            ))
+            ->addArgument('packages', InputArgument::IS_ARRAY, 'Package(s) to browse to.')
+            ->addOption('homepage', 'H', InputOption::VALUE_NONE, 'Open the homepage instead of the repository URL.')
+            ->addOption('show', 's', InputOption::VALUE_NONE, 'Only show the homepage or repository URL.')
             ->setHelp(
                 <<<EOT
 The home command opens or shows a package's repository URL or

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -52,19 +52,17 @@ class InitCommand extends BaseCommand
         $this
             ->setName('init')
             ->setDescription('Creates a basic composer.json file in current directory.')
-            ->setDefinition(array(
-                new InputOption('name', null, InputOption::VALUE_REQUIRED, 'Name of the package'),
-                new InputOption('description', null, InputOption::VALUE_REQUIRED, 'Description of package'),
-                new InputOption('author', null, InputOption::VALUE_REQUIRED, 'Author name of package'),
-                new InputOption('type', null, InputOption::VALUE_OPTIONAL, 'Type of package (e.g. library, project, metapackage, composer-plugin)'),
-                new InputOption('homepage', null, InputOption::VALUE_REQUIRED, 'Homepage of package'),
-                new InputOption('require', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Package to require with a version constraint, e.g. foo/bar:1.0.0 or foo/bar=1.0.0 or "foo/bar 1.0.0"'),
-                new InputOption('require-dev', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Package to require for development with a version constraint, e.g. foo/bar:1.0.0 or foo/bar=1.0.0 or "foo/bar 1.0.0"'),
-                new InputOption('stability', 's', InputOption::VALUE_REQUIRED, 'Minimum stability (empty or one of: '.implode(', ', array_keys(BasePackage::$stabilities)).')'),
-                new InputOption('license', 'l', InputOption::VALUE_REQUIRED, 'License of package'),
-                new InputOption('repository', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add custom repositories, either by URL or using JSON arrays'),
-                new InputOption('autoload', 'a', InputOption::VALUE_REQUIRED, 'Add PSR-4 autoload mapping. Maps your package\'s namespace to the provided directory. (Expects a relative path, e.g. src/)'),
-            ))
+            ->addOption('name', null, InputOption::VALUE_REQUIRED, 'Name of the package')
+            ->addOption('description', null, InputOption::VALUE_REQUIRED, 'Description of package')
+            ->addOption('author', null, InputOption::VALUE_REQUIRED, 'Author name of package')
+            ->addOption('type', null, InputOption::VALUE_OPTIONAL, 'Type of package (e.g. library, project, metapackage, composer-plugin)')
+            ->addOption('homepage', null, InputOption::VALUE_REQUIRED, 'Homepage of package')
+            ->addOption('require', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Package to require with a version constraint, e.g. foo/bar:1.0.0 or foo/bar=1.0.0 or "foo/bar 1.0.0"')
+            ->addOption('require-dev', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Package to require for development with a version constraint, e.g. foo/bar:1.0.0 or foo/bar=1.0.0 or "foo/bar 1.0.0"')
+            ->addOption('stability', 's', InputOption::VALUE_REQUIRED, 'Minimum stability (empty or one of: '.implode(', ', array_keys(BasePackage::$stabilities)).')')
+            ->addOption('license', 'l', InputOption::VALUE_REQUIRED, 'License of package')
+            ->addOption('repository', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add custom repositories, either by URL or using JSON arrays')
+            ->addOption('autoload', 'a', InputOption::VALUE_REQUIRED, 'Add PSR-4 autoload mapping. Maps your package\'s namespace to the provided directory. (Expects a relative path, e.g. src/)')
             ->setHelp(
                 <<<EOT
 The <info>init</info> command creates a basic composer.json file

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -38,26 +38,24 @@ class InstallCommand extends BaseCommand
             ->setName('install')
             ->setAliases(array('i'))
             ->setDescription('Installs the project dependencies from the composer.lock file if present, or falls back on the composer.json.')
-            ->setDefinition(array(
-                new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),
-                new InputOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).'),
-                new InputOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).'),
-                new InputOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything (implicitly enables --verbose).'),
-                new InputOption('dev', null, InputOption::VALUE_NONE, 'DEPRECATED: Enables installation of require-dev packages (enabled by default, only present for BC).'),
-                new InputOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables installation of require-dev packages.'),
-                new InputOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation'),
-                new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
-                new InputOption('no-install', null, InputOption::VALUE_NONE, 'Do not use, only defined here to catch misuse of the install command.'),
-                new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
-                new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
-                new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
-                new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
-                new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
-                new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
-                new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
-                new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Should not be provided, use composer require instead to add a given package to composer.json.'),
-            ))
+            ->addOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.')
+            ->addOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).')
+            ->addOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything (implicitly enables --verbose).')
+            ->addOption('dev', null, InputOption::VALUE_NONE, 'DEPRECATED: Enables installation of require-dev packages (enabled by default, only present for BC).')
+            ->addOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Disables installation of require-dev packages.')
+            ->addOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation')
+            ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.')
+            ->addOption('no-install', null, InputOption::VALUE_NONE, 'Do not use, only defined here to catch misuse of the install command.')
+            ->addOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.')
+            ->addOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump')
+            ->addOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.')
+            ->addOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.')
+            ->addOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader')
+            ->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).')
+            ->addOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).')
+            ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Should not be provided, use composer require instead to add a given package to composer.json.')
             ->setHelp(
                 <<<EOT
 The <info>install</info> command reads the composer.lock file from

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -39,10 +39,8 @@ class LicensesCommand extends BaseCommand
         $this
             ->setName('licenses')
             ->setDescription('Shows information about licenses of dependencies.')
-            ->setDefinition(array(
-                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text, json or summary', 'text'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),
-            ))
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text, json or summary', 'text')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.')
             ->setHelp(
                 <<<EOT
 The license command displays detailed information about the licenses of

--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -31,21 +31,19 @@ class OutdatedCommand extends BaseCommand
         $this
             ->setName('outdated')
             ->setDescription('Shows a list of installed packages that have updates available, including their latest version.')
-            ->setDefinition(array(
-                new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.'),
-                new InputOption('outdated', 'o', InputOption::VALUE_NONE, 'Show only packages that are outdated (this is the default, but present here for compat with `show`'),
-                new InputOption('all', 'a', InputOption::VALUE_NONE, 'Show all installed packages with their latest versions'),
-                new InputOption('locked', null, InputOption::VALUE_NONE, 'Shows updates for packages from the lock file, regardless of what is currently in vendor dir'),
-                new InputOption('direct', 'D', InputOption::VALUE_NONE, 'Shows only packages that are directly required by the root package'),
-                new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code when there are outdated packages'),
-                new InputOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show only packages that have minor SemVer-compatible updates. Use with the --outdated option.'),
-                new InputOption('patch-only', 'p', InputOption::VALUE_NONE, 'Show only packages that have patch SemVer-compatible updates. Use with the --outdated option.'),
-                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
-                new InputOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore specified package(s). Use it with the --outdated option if you don\'t want to be informed about new versions of some packages.'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),
-                new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages). Use with the --outdated option'),
-                new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages). Use with the --outdated option'),
-            ))
+            ->addArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.')
+            ->addOption('outdated', 'o', InputOption::VALUE_NONE, 'Show only packages that are outdated (this is the default, but present here for compat with `show`')
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Show all installed packages with their latest versions')
+            ->addOption('locked', null, InputOption::VALUE_NONE, 'Shows updates for packages from the lock file, regardless of what is currently in vendor dir')
+            ->addOption('direct', 'D', InputOption::VALUE_NONE, 'Shows only packages that are directly required by the root package')
+            ->addOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code when there are outdated packages')
+            ->addOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show only packages that have minor SemVer-compatible updates. Use with the --outdated option.')
+            ->addOption('patch-only', 'p', InputOption::VALUE_NONE, 'Show only packages that have patch SemVer-compatible updates. Use with the --outdated option.')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text')
+            ->addOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore specified package(s). Use it with the --outdated option if you don\'t want to be informed about new versions of some packages.')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.')
+            ->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages). Use with the --outdated option')
+            ->addOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages). Use with the --outdated option')
             ->setHelp(
                 <<<EOT
 The outdated command is just a proxy for `composer show -l`

--- a/src/Composer/Command/ProhibitsCommand.php
+++ b/src/Composer/Command/ProhibitsCommand.php
@@ -33,12 +33,10 @@ class ProhibitsCommand extends BaseDependencyCommand
             ->setName('prohibits')
             ->setAliases(array('why-not'))
             ->setDescription('Shows which packages prevent the given package from being installed.')
-            ->setDefinition(array(
-                new InputArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect'),
-                new InputArgument(self::ARGUMENT_CONSTRAINT, InputArgument::REQUIRED, 'Version constraint, which version you expected to be installed'),
-                new InputOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package'),
-                new InputOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree'),
-            ))
+            ->addArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect')
+            ->addArgument(self::ARGUMENT_CONSTRAINT, InputArgument::REQUIRED, 'Version constraint, which version you expected to be installed')
+            ->addOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package')
+            ->addOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree')
             ->setHelp(
                 <<<EOT
 Displays detailed information about why a package cannot be installed.

--- a/src/Composer/Command/ReinstallCommand.php
+++ b/src/Composer/Command/ReinstallCommand.php
@@ -40,20 +40,18 @@ class ReinstallCommand extends BaseCommand
         $this
             ->setName('reinstall')
             ->setDescription('Uninstalls and reinstalls the given package names')
-            ->setDefinition(array(
-                new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),
-                new InputOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).'),
-                new InputOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).'),
-                new InputOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation'),
-                new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
-                new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
-                new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
-                new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
-                new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
-                new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
-                new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
-                new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'List of package names to reinstall, can include a wildcard (*) to match any substring.'),
-            ))
+            ->addOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.')
+            ->addOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).')
+            ->addOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).')
+            ->addOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation')
+            ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.')
+            ->addOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump')
+            ->addOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.')
+            ->addOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.')
+            ->addOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader')
+            ->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).')
+            ->addOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).')
+            ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'List of package names to reinstall, can include a wildcard (*) to match any substring.')
             ->setHelp(
                 <<<EOT
 The <info>reinstall</info> command looks up installed packages by name,

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -40,26 +40,24 @@ class RemoveCommand extends BaseCommand
         $this
             ->setName('remove')
             ->setDescription('Removes a package from the require or require-dev.')
-            ->setDefinition(array(
-                new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Packages that should be removed.'),
-                new InputOption('dev', null, InputOption::VALUE_NONE, 'Removes a package from the require-dev section.'),
-                new InputOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything (implicitly enables --verbose).'),
-                new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
-                new InputOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies (implies --no-install).'),
-                new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
-                new InputOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.'),
-                new InputOption('update-with-dependencies', 'w', InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated with explicit dependencies. (Deprecrated, is now default behavior)'),
-                new InputOption('update-with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.'),
-                new InputOption('with-all-dependencies', null, InputOption::VALUE_NONE, 'Alias for --update-with-all-dependencies'),
-                new InputOption('no-update-with-dependencies', null, InputOption::VALUE_NONE, 'Does not allow inherited dependencies to be updated with explicit dependencies.'),
-                new InputOption('unused', null, InputOption::VALUE_NONE, 'Remove all packages which are locked but not required by any other package.'),
-                new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
-                new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
-                new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
-                new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
-                new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
-                new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
-            ))
+            ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Packages that should be removed.')
+            ->addOption('dev', null, InputOption::VALUE_NONE, 'Removes a package from the require-dev section.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything (implicitly enables --verbose).')
+            ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.')
+            ->addOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies (implies --no-install).')
+            ->addOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.')
+            ->addOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.')
+            ->addOption('update-with-dependencies', 'w', InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated with explicit dependencies. (Deprecrated, is now default behavior)')
+            ->addOption('update-with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.')
+            ->addOption('with-all-dependencies', null, InputOption::VALUE_NONE, 'Alias for --update-with-all-dependencies')
+            ->addOption('no-update-with-dependencies', null, InputOption::VALUE_NONE, 'Does not allow inherited dependencies to be updated with explicit dependencies.')
+            ->addOption('unused', null, InputOption::VALUE_NONE, 'Remove all packages which are locked but not required by any other package.')
+            ->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).')
+            ->addOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).')
+            ->addOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump')
+            ->addOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.')
+            ->addOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.')
+            ->addOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader')
             ->setHelp(
                 <<<EOT
 The <info>remove</info> command removes a package from the current

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -66,33 +66,31 @@ class RequireCommand extends BaseCommand
         $this
             ->setName('require')
             ->setDescription('Adds required packages to your composer.json and installs them.')
-            ->setDefinition(array(
-                new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Optional package name can also include a version constraint, e.g. foo/bar or foo/bar:1.0.0 or foo/bar=1.0.0 or "foo/bar 1.0.0"'),
-                new InputOption('dev', null, InputOption::VALUE_NONE, 'Add requirement to require-dev.'),
-                new InputOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything (implicitly enables --verbose).'),
-                new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),
-                new InputOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).'),
-                new InputOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).'),
-                new InputOption('fixed', null, InputOption::VALUE_NONE, 'Write fixed version to the composer.json.'),
-                new InputOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.'),
-                new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
-                new InputOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies (implies --no-install).'),
-                new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
-                new InputOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.'),
-                new InputOption('update-with-dependencies', 'w', InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated, except those that are root requirements.'),
-                new InputOption('update-with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.'),
-                new InputOption('with-dependencies', null, InputOption::VALUE_NONE, 'Alias for --update-with-dependencies'),
-                new InputOption('with-all-dependencies', null, InputOption::VALUE_NONE, 'Alias for --update-with-all-dependencies'),
-                new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
-                new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
-                new InputOption('prefer-stable', null, InputOption::VALUE_NONE, 'Prefer stable versions of dependencies.'),
-                new InputOption('prefer-lowest', null, InputOption::VALUE_NONE, 'Prefer lowest versions of dependencies.'),
-                new InputOption('sort-packages', null, InputOption::VALUE_NONE, 'Sorts packages when adding/updating a new dependency'),
-                new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
-                new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
-                new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
-                new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
-            ))
+            ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Optional package name can also include a version constraint, e.g. foo/bar or foo/bar:1.0.0 or foo/bar=1.0.0 or "foo/bar 1.0.0"')
+            ->addOption('dev', null, InputOption::VALUE_NONE, 'Add requirement to require-dev.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything (implicitly enables --verbose).')
+            ->addOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.')
+            ->addOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).')
+            ->addOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).')
+            ->addOption('fixed', null, InputOption::VALUE_NONE, 'Write fixed version to the composer.json.')
+            ->addOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.')
+            ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.')
+            ->addOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies (implies --no-install).')
+            ->addOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.')
+            ->addOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.')
+            ->addOption('update-with-dependencies', 'w', InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated, except those that are root requirements.')
+            ->addOption('update-with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.')
+            ->addOption('with-dependencies', null, InputOption::VALUE_NONE, 'Alias for --update-with-dependencies')
+            ->addOption('with-all-dependencies', null, InputOption::VALUE_NONE, 'Alias for --update-with-all-dependencies')
+            ->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).')
+            ->addOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).')
+            ->addOption('prefer-stable', null, InputOption::VALUE_NONE, 'Prefer stable versions of dependencies.')
+            ->addOption('prefer-lowest', null, InputOption::VALUE_NONE, 'Prefer lowest versions of dependencies.')
+            ->addOption('sort-packages', null, InputOption::VALUE_NONE, 'Sorts packages when adding/updating a new dependency')
+            ->addOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump')
+            ->addOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.')
+            ->addOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.')
+            ->addOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader')
             ->setHelp(
                 <<<EOT
 The require command adds required packages to your composer.json and installs them.

--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -53,14 +53,12 @@ class RunScriptCommand extends BaseCommand
             ->setName('run-script')
             ->setAliases(array('run'))
             ->setDescription('Runs the scripts defined in composer.json.')
-            ->setDefinition(array(
-                new InputArgument('script', InputArgument::OPTIONAL, 'Script name to run.'),
-                new InputArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, ''),
-                new InputOption('timeout', null, InputOption::VALUE_REQUIRED, 'Sets script timeout in seconds, or 0 for never.'),
-                new InputOption('dev', null, InputOption::VALUE_NONE, 'Sets the dev mode.'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables the dev mode.'),
-                new InputOption('list', 'l', InputOption::VALUE_NONE, 'List scripts.'),
-            ))
+            ->addArgument('script', InputArgument::OPTIONAL, 'Script name to run.')
+            ->addArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, '')
+            ->addOption('timeout', null, InputOption::VALUE_REQUIRED, 'Sets script timeout in seconds, or 0 for never.')
+            ->addOption('dev', null, InputOption::VALUE_NONE, 'Sets the dev mode.')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Disables the dev mode.')
+            ->addOption('list', 'l', InputOption::VALUE_NONE, 'List scripts.')
             ->setHelp(
                 <<<EOT
 The <info>run-script</info> command runs scripts defined in composer.json:

--- a/src/Composer/Command/ScriptAliasCommand.php
+++ b/src/Composer/Command/ScriptAliasCommand.php
@@ -43,11 +43,9 @@ class ScriptAliasCommand extends BaseCommand
         $this
             ->setName($this->script)
             ->setDescription($this->description)
-            ->setDefinition(array(
-                new InputOption('dev', null, InputOption::VALUE_NONE, 'Sets the dev mode.'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables the dev mode.'),
-                new InputArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, ''),
-            ))
+            ->addOption('dev', null, InputOption::VALUE_NONE, 'Sets the dev mode.')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Disables the dev mode.')
+            ->addArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, '')
             ->setHelp(
                 <<<EOT
 The <info>run-script</info> command runs scripts defined in composer.json:

--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -38,13 +38,11 @@ class SearchCommand extends BaseCommand
         $this
             ->setName('search')
             ->setDescription('Searches for packages.')
-            ->setDefinition(array(
-                new InputOption('only-name', 'N', InputOption::VALUE_NONE, 'Search only in package names'),
-                new InputOption('only-vendor', 'O', InputOption::VALUE_NONE, 'Search only for vendor / organization names, returns only "vendor" as result'),
-                new InputOption('type', 't', InputOption::VALUE_REQUIRED, 'Search for a specific package type'),
-                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
-                new InputArgument('tokens', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'tokens to search for'),
-            ))
+            ->addOption('only-name', 'N', InputOption::VALUE_NONE, 'Search only in package names')
+            ->addOption('only-vendor', 'O', InputOption::VALUE_NONE, 'Search only for vendor / organization names, returns only "vendor" as result')
+            ->addOption('type', 't', InputOption::VALUE_REQUIRED, 'Search for a specific package type')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text')
+            ->addArgument('tokens', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'tokens to search for')
             ->setHelp(
                 <<<EOT
 The search command searches for packages by its name

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -48,20 +48,18 @@ class SelfUpdateCommand extends BaseCommand
             ->setName('self-update')
             ->setAliases(array('selfupdate'))
             ->setDescription('Updates composer.phar to the latest version.')
-            ->setDefinition(array(
-                new InputOption('rollback', 'r', InputOption::VALUE_NONE, 'Revert to an older installation of composer'),
-                new InputOption('clean-backups', null, InputOption::VALUE_NONE, 'Delete old backups during an update. This makes the current version of composer the only backup available after the update'),
-                new InputArgument('version', InputArgument::OPTIONAL, 'The version to update to'),
-                new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
-                new InputOption('update-keys', null, InputOption::VALUE_NONE, 'Prompt user for a key update'),
-                new InputOption('stable', null, InputOption::VALUE_NONE, 'Force an update to the stable channel'),
-                new InputOption('preview', null, InputOption::VALUE_NONE, 'Force an update to the preview channel'),
-                new InputOption('snapshot', null, InputOption::VALUE_NONE, 'Force an update to the snapshot channel'),
-                new InputOption('1', null, InputOption::VALUE_NONE, 'Force an update to the stable channel, but only use 1.x versions'),
-                new InputOption('2', null, InputOption::VALUE_NONE, 'Force an update to the stable channel, but only use 2.x versions'),
-                new InputOption('2.2', null, InputOption::VALUE_NONE, 'Force an update to the stable channel, but only use 2.2.x LTS versions'),
-                new InputOption('set-channel-only', null, InputOption::VALUE_NONE, 'Only store the channel as the default one and then exit'),
-            ))
+            ->addOption('rollback', 'r', InputOption::VALUE_NONE, 'Revert to an older installation of composer')
+            ->addOption('clean-backups', null, InputOption::VALUE_NONE, 'Delete old backups during an update. This makes the current version of composer the only backup available after the update')
+            ->addArgument('version', InputArgument::OPTIONAL, 'The version to update to')
+            ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.')
+            ->addOption('update-keys', null, InputOption::VALUE_NONE, 'Prompt user for a key update')
+            ->addOption('stable', null, InputOption::VALUE_NONE, 'Force an update to the stable channel')
+            ->addOption('preview', null, InputOption::VALUE_NONE, 'Force an update to the preview channel')
+            ->addOption('snapshot', null, InputOption::VALUE_NONE, 'Force an update to the snapshot channel')
+            ->addOption('1', null, InputOption::VALUE_NONE, 'Force an update to the stable channel, but only use 1.x versions')
+            ->addOption('2', null, InputOption::VALUE_NONE, 'Force an update to the stable channel, but only use 2.x versions')
+            ->addOption('2.2', null, InputOption::VALUE_NONE, 'Force an update to the stable channel, but only use 2.2.x LTS versions')
+            ->addOption('set-channel-only', null, InputOption::VALUE_NONE, 'Only store the channel as the default one and then exit')
             ->setHelp(
                 <<<EOT
 The <info>self-update</info> command checks getcomposer.org for newer

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -73,30 +73,28 @@ class ShowCommand extends BaseCommand
             ->setName('show')
             ->setAliases(array('info'))
             ->setDescription('Shows information about packages.')
-            ->setDefinition(array(
-                new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.'),
-                new InputArgument('version', InputArgument::OPTIONAL, 'Version or version constraint to inspect'),
-                new InputOption('all', null, InputOption::VALUE_NONE, 'List all packages'),
-                new InputOption('locked', null, InputOption::VALUE_NONE, 'List all locked packages'),
-                new InputOption('installed', 'i', InputOption::VALUE_NONE, 'List installed packages only (enabled by default, only present for BC).'),
-                new InputOption('platform', 'p', InputOption::VALUE_NONE, 'List platform packages only'),
-                new InputOption('available', 'a', InputOption::VALUE_NONE, 'List available packages only'),
-                new InputOption('self', 's', InputOption::VALUE_NONE, 'Show the root package information'),
-                new InputOption('name-only', 'N', InputOption::VALUE_NONE, 'List package names only'),
-                new InputOption('path', 'P', InputOption::VALUE_NONE, 'Show package paths'),
-                new InputOption('tree', 't', InputOption::VALUE_NONE, 'List the dependencies as a tree'),
-                new InputOption('latest', 'l', InputOption::VALUE_NONE, 'Show the latest version'),
-                new InputOption('outdated', 'o', InputOption::VALUE_NONE, 'Show the latest version but only for packages that are outdated'),
-                new InputOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore specified package(s). Use it with the --outdated option if you don\'t want to be informed about new versions of some packages.'),
-                new InputOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show only packages that have minor SemVer-compatible updates. Use with the --outdated option.'),
-                new InputOption('patch-only', null, InputOption::VALUE_NONE, 'Show only packages that have patch SemVer-compatible updates. Use with the --outdated option.'),
-                new InputOption('direct', 'D', InputOption::VALUE_NONE, 'Shows only packages that are directly required by the root package'),
-                new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code when there are outdated packages'),
-                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),
-                new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages). Use with the --outdated option'),
-                new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages). Use with the --outdated option'),
-            ))
+            ->addArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.')
+            ->addArgument('version', InputArgument::OPTIONAL, 'Version or version constraint to inspect')
+            ->addOption('all', null, InputOption::VALUE_NONE, 'List all packages')
+            ->addOption('locked', null, InputOption::VALUE_NONE, 'List all locked packages')
+            ->addOption('installed', 'i', InputOption::VALUE_NONE, 'List installed packages only (enabled by default, only present for BC).')
+            ->addOption('platform', 'p', InputOption::VALUE_NONE, 'List platform packages only')
+            ->addOption('available', 'a', InputOption::VALUE_NONE, 'List available packages only')
+            ->addOption('self', 's', InputOption::VALUE_NONE, 'Show the root package information')
+            ->addOption('name-only', 'N', InputOption::VALUE_NONE, 'List package names only')
+            ->addOption('path', 'P', InputOption::VALUE_NONE, 'Show package paths')
+            ->addOption('tree', 't', InputOption::VALUE_NONE, 'List the dependencies as a tree')
+            ->addOption('latest', 'l', InputOption::VALUE_NONE, 'Show the latest version')
+            ->addOption('outdated', 'o', InputOption::VALUE_NONE, 'Show the latest version but only for packages that are outdated')
+            ->addOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore specified package(s). Use it with the --outdated option if you don\'t want to be informed about new versions of some packages.')
+            ->addOption('minor-only', 'm', InputOption::VALUE_NONE, 'Show only packages that have minor SemVer-compatible updates. Use with the --outdated option.')
+            ->addOption('patch-only', null, InputOption::VALUE_NONE, 'Show only packages that have patch SemVer-compatible updates. Use with the --outdated option.')
+            ->addOption('direct', 'D', InputOption::VALUE_NONE, 'Shows only packages that are directly required by the root package')
+            ->addOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code when there are outdated packages')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.')
+            ->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages). Use with the --outdated option')
+            ->addOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages). Use with the --outdated option')
             ->setHelp(
                 <<<EOT
 The show command displays detailed information about a package, or

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -45,9 +45,7 @@ class StatusCommand extends BaseCommand
         $this
             ->setName('status')
             ->setDescription('Shows a list of locally modified packages.')
-            ->setDefinition(array(
-                new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Show modified files for each directory that contains changes.'),
-            ))
+            ->addOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Show modified files for each directory that contains changes.')
             ->setHelp(
                 <<<EOT
 The status command displays a list of dependencies that have

--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -31,14 +31,12 @@ class SuggestsCommand extends BaseCommand
         $this
             ->setName('suggests')
             ->setDescription('Shows package suggestions.')
-            ->setDefinition(array(
-                new InputOption('by-package', null, InputOption::VALUE_NONE, 'Groups output by suggesting package (default)'),
-                new InputOption('by-suggestion', null, InputOption::VALUE_NONE, 'Groups output by suggested package'),
-                new InputOption('all', 'a', InputOption::VALUE_NONE, 'Show suggestions from all dependencies, including transitive ones'),
-                new InputOption('list', null, InputOption::VALUE_NONE, 'Show only list of suggested package names'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Exclude suggestions from require-dev packages'),
-                new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that you want to list suggestions from.'),
-            ))
+            ->addOption('by-package', null, InputOption::VALUE_NONE, 'Groups output by suggesting package (default)')
+            ->addOption('by-suggestion', null, InputOption::VALUE_NONE, 'Groups output by suggested package')
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Show suggestions from all dependencies, including transitive ones')
+            ->addOption('list', null, InputOption::VALUE_NONE, 'Show only list of suggested package names')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Exclude suggestions from require-dev packages')
+            ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that you want to list suggestions from.')
             ->setHelp(
                 <<<EOT
 

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -46,34 +46,32 @@ class UpdateCommand extends BaseCommand
             ->setName('update')
             ->setAliases(array('u', 'upgrade'))
             ->setDescription('Updates your dependencies to the latest version according to composer.json, and updates the composer.lock file.')
-            ->setDefinition(array(
-                new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that should be updated, if not provided all packages are.'),
-                new InputOption('with', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Temporary version constraint to add, e.g. foo/bar:1.0.0 or foo/bar=1.0.0'),
-                new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),
-                new InputOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).'),
-                new InputOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).'),
-                new InputOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything (implicitly enables --verbose).'),
-                new InputOption('dev', null, InputOption::VALUE_NONE, 'DEPRECATED: Enables installation of require-dev packages (enabled by default, only present for BC).'),
-                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables installation of require-dev packages.'),
-                new InputOption('lock', null, InputOption::VALUE_NONE, 'Overwrites the lock file hash to suppress warning about the lock file being out of date without updating package versions. Package metadata like mirrors and URLs are updated if they changed.'),
-                new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
-                new InputOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation'),
-                new InputOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.'),
-                new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
-                new InputOption('with-dependencies', 'w', InputOption::VALUE_NONE, 'Update also dependencies of packages in the argument list, except those which are root requirements.'),
-                new InputOption('with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Update also dependencies of packages in the argument list, including those which are root requirements.'),
-                new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
-                new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump.'),
-                new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
-                new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
-                new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
-                new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
-                new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
-                new InputOption('prefer-stable', null, InputOption::VALUE_NONE, 'Prefer stable versions of dependencies.'),
-                new InputOption('prefer-lowest', null, InputOption::VALUE_NONE, 'Prefer lowest versions of dependencies.'),
-                new InputOption('interactive', 'i', InputOption::VALUE_NONE, 'Interactive interface with autocompletion to select the packages to update.'),
-                new InputOption('root-reqs', null, InputOption::VALUE_NONE, 'Restricts the update to your first degree dependencies.'),
-            ))
+            ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that should be updated, if not provided all packages are.')
+            ->addOption('with', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Temporary version constraint to add, e.g. foo/bar:1.0.0 or foo/bar=1.0.0')
+            ->addOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.')
+            ->addOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).')
+            ->addOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything (implicitly enables --verbose).')
+            ->addOption('dev', null, InputOption::VALUE_NONE, 'DEPRECATED: Enables installation of require-dev packages (enabled by default, only present for BC).')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Disables installation of require-dev packages.')
+            ->addOption('lock', null, InputOption::VALUE_NONE, 'Overwrites the lock file hash to suppress warning about the lock file being out of date without updating package versions. Package metadata like mirrors and URLs are updated if they changed.')
+            ->addOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.')
+            ->addOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation')
+            ->addOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.')
+            ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.')
+            ->addOption('with-dependencies', 'w', InputOption::VALUE_NONE, 'Update also dependencies of packages in the argument list, except those which are root requirements.')
+            ->addOption('with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Update also dependencies of packages in the argument list, including those which are root requirements.')
+            ->addOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.')
+            ->addOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump.')
+            ->addOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.')
+            ->addOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.')
+            ->addOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader')
+            ->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).')
+            ->addOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).')
+            ->addOption('prefer-stable', null, InputOption::VALUE_NONE, 'Prefer stable versions of dependencies.')
+            ->addOption('prefer-lowest', null, InputOption::VALUE_NONE, 'Prefer lowest versions of dependencies.')
+            ->addOption('interactive', 'i', InputOption::VALUE_NONE, 'Interactive interface with autocompletion to select the packages to update.')
+            ->addOption('root-reqs', null, InputOption::VALUE_NONE, 'Restricts the update to your first degree dependencies.')
             ->setHelp(
                 <<<EOT
 The <info>update</info> command reads the composer.json file from the

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -43,16 +43,14 @@ class ValidateCommand extends BaseCommand
         $this
             ->setName('validate')
             ->setDescription('Validates a composer.json and composer.lock.')
-            ->setDefinition(array(
-                new InputOption('no-check-all', null, InputOption::VALUE_NONE, 'Do not validate requires for overly strict/loose constraints'),
-                new InputOption('check-lock', null, InputOption::VALUE_NONE, 'Check if lock file is up to date (even when config.lock is false)'),
-                new InputOption('no-check-lock', null, InputOption::VALUE_NONE, 'Do not check if lock file is up to date'),
-                new InputOption('no-check-publish', null, InputOption::VALUE_NONE, 'Do not check for publish errors'),
-                new InputOption('no-check-version', null, InputOption::VALUE_NONE, 'Do not report a warning if the version field is present'),
-                new InputOption('with-dependencies', 'A', InputOption::VALUE_NONE, 'Also validate the composer.json of all installed dependencies'),
-                new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code for warnings as well as errors'),
-                new InputArgument('file', InputArgument::OPTIONAL, 'path to composer.json file'),
-            ))
+            ->addOption('no-check-all', null, InputOption::VALUE_NONE, 'Do not validate requires for overly strict/loose constraints')
+            ->addOption('check-lock', null, InputOption::VALUE_NONE, 'Check if lock file is up to date (even when config.lock is false)')
+            ->addOption('no-check-lock', null, InputOption::VALUE_NONE, 'Do not check if lock file is up to date')
+            ->addOption('no-check-publish', null, InputOption::VALUE_NONE, 'Do not check for publish errors')
+            ->addOption('no-check-version', null, InputOption::VALUE_NONE, 'Do not report a warning if the version field is present')
+            ->addOption('with-dependencies', 'A', InputOption::VALUE_NONE, 'Also validate the composer.json of all installed dependencies')
+            ->addOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code for warnings as well as errors')
+            ->addArgument('file', InputArgument::OPTIONAL, 'path to composer.json file')
             ->setHelp(
                 <<<EOT
 The validate command validates a given composer.json and composer.lock


### PR DESCRIPTION
Working on adding bash completion to commands #10320, I found the implementation very verbose. To make things easier, I added to Symfony 6.1 a feature to define suggested values to argument and option definition https://github.com/symfony/symfony/pull/44948.

This preliminary PR uses the functions `Command::addArgument` and `Command::addArgument`; so that I can backport the additional argument to define suggested values for each argument or option.

This change does not affect performances.
