### PR TITLE
GitLab: handle infinite loop during composer install

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -137,6 +137,7 @@ class AuthHelper
             $message = "\n".'Could not fetch '.$url.', enter your ' . $origin . ' credentials ' .($statusCode === 401 ? 'to access private repos' : 'to go over the API rate limit');
             $gitLabUtil = new GitLab($this->io, $this->config, null);
 
+            $auth = null;
             if ($this->io->hasAuthentication($origin)) {
                 $auth = $this->io->getAuthentication($origin);
                 if (in_array($auth['password'], array('gitlab-ci-token', 'private-token', 'oauth2'), true)) {
@@ -148,6 +149,12 @@ class AuthHelper
                 && (!$this->io->isInteractive() || !$gitLabUtil->authorizeOAuthInteractively(parse_url($url, PHP_URL_SCHEME), $origin, $message))
             ) {
                 throw new TransportException('Could not authenticate against '.$origin, 401);
+            }
+
+            if ($auth !== null && $this->io->hasAuthentication($origin)) {
+                if ($auth === $this->io->getAuthentication($origin)) {
+                    throw new TransportException("Invalid credentials for '" . $url . "', aborting.", $statusCode);
+                }
             }
         } elseif ($origin === 'bitbucket.org' || $origin === 'api.bitbucket.org') {
             $askForOAuthToken = true;

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -92,7 +92,14 @@ class GitLab
         if (isset($token)) {
             $username = is_array($token) && array_key_exists("username", $token) ? $token["username"] : $token;
             $password = is_array($token) && array_key_exists("token", $token) ? $token["token"] : 'private-token';
-            $this->io->setAuthentication($originUrl, $username, $password);
+
+            // Composer expects the GitLab token to be stored as username and 'private-token' or 'gitlab-ci-token' to be stored as password
+            // Detect cases where this is reversed and resolve automatically resolve it
+            if (in_array($username, array('private-token', 'gitlab-ci-token',  'oauth2'), true)) {
+                $this->io->setAuthentication($originUrl, $password, $username);
+            } else {
+                $this->io->setAuthentication($originUrl, $username, $password);
+            }
 
             return true;
         }

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -474,6 +474,9 @@ class AuthHelperTest extends TestCase
         $this->authHelper->storeAuth($origin, $storeAuth);
     }
 
+    /**
+     * @return void
+     */
     public function testStoreAuthWithPromptInvalidAnswer()
     {
         $this->setExpectedException('RuntimeException');
@@ -514,6 +517,9 @@ class AuthHelperTest extends TestCase
         $this->authHelper->storeAuth($origin, $storeAuth);
     }
 
+    /**
+     * @return void
+     */
     public function testPromptAuthIfNeededGitLabNoAuthChange()
     {
         $this->setExpectedException('Composer\Downloader\TransportException');

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\Util;
 
+use Composer\Downloader\TransportException;
 use Composer\IO\IOInterface;
 use Composer\Test\TestCase;
 use Composer\Util\AuthHelper;
@@ -511,6 +512,41 @@ class AuthHelperTest extends TestCase
             });
 
         $this->authHelper->storeAuth($origin, $storeAuth);
+    }
+
+    public function testPromptAuthIfNeededGitLabNoAuthChange()
+    {
+        $this->setExpectedException('Composer\Downloader\TransportException');
+
+        $origin = 'gitlab.com';
+
+        $this->io
+            ->method('hasAuthentication')
+            ->with($origin)
+            ->willReturn(true);
+
+        $this->io
+            ->method('getAuthentication')
+            ->with($origin)
+            ->willReturn(array(
+                'username' => 'gitlab-user',
+                'password' => 'gitlab-password',
+            ));
+
+        $this->io
+            ->expects($this->once())
+            ->method('setAuthentication')
+            ->with('gitlab.com', 'gitlab-user', 'gitlab-password');
+
+        $this->config
+            ->method('get')
+            ->willReturnMap(array(
+                array('github-domains', 0, array()),
+                array('gitlab-domains', 0, array('gitlab.com')),
+                array('gitlab-token', 0, array('gitlab.com' => array('username' => 'gitlab-user', 'token' => 'gitlab-password'))),
+            ));
+
+        $this->authHelper->promptAuthIfNeeded('https://gitlab.com/acme/archive.zip', $origin, 404, 'GitLab requires authentication and it was not provided');
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/composer/composer/issues/10353

To reproduce: have a Composer project using GitLab with a composer.lock file.

Have invalid authentication configured like
```
composer config http-basic.gitlab.example.com random string
```

Then run
```
composer install
```

Current output
```
composer install -vvv                                                                                                                                      ◼
Running 2.3.5 (2022-04-13 16:43:00) with PHP 8.0.17 on Darwin / 21.4.0
[...]
Dependency resolution completed in 0.000 seconds
Package operations: 1 install, 0 updates, 0 removals
Installs: one-more/test:dev-main 8cb508d
  - Downloading one-more/test (dev-main 8cb508d)
Using HTTP basic authentication with username "random"
Downloading https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
[404] https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
Executing command (CWD): git config gitlab.accesstoken
Executing command (CWD): git config gitlab.deploytoken.user
Downloading https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
[404] https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
Executing command (CWD): git config gitlab.accesstoken
Executing command (CWD): git config gitlab.deploytoken.user
Downloading https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
[...]
```

With patch aborts install from dist and falls back to install from source
```
composer install -vvv
Running 2.3.999-dev+source (@release_date@) with PHP 8.0.17 on Darwin / 21.4.0
[...]
Dependency resolution completed in 0.000 seconds
Package operations: 1 install, 0 updates, 0 removals
Installs: one-more/test:dev-main 8cb508d
  - Downloading one-more/test (dev-main 8cb508d)
Using HTTP basic authentication with username "gitlab-ci-token"
Downloading https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
[404] https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
Executing command (CWD): git config gitlab.accesstoken
Executing command (CWD): git config gitlab.deploytoken.user
Using GitLab private token authentication
Downloading https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
[401] https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
    Failed to download one-more/test from dist: Invalid credentials for 'https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15', aborting.
    Now trying to download from source
Executing command (CWD): git --version
  - Syncing one-more/test (dev-main 8cb508d) into cache
    Cloning to cache at '/Users/glaubinix/Library/Caches/composer/vcs/git-gitlab.com-another-test-group2-one-more.git/'
Executing command (/Users/glaubinix/Library/Caches/composer/vcs/git-gitlab.com-another-test-group2-one-more.git/): git rev-parse --git-dir
Executing command (/Users/glaubinix/Library/Caches/composer/vcs/git-gitlab.com-another-test-group2-one-more.git/): git rev-parse --quiet --verify '8cb508d115604334d813f50325c97a6893717a15^{commit}'
  - Installing one-more/test (dev-main 8cb508d): Cloning 8cb508d115604334d813f50325c97a6893717a15 from cache
Executing command (CWD): git clone --no-checkout '/Users/glaubinix/Library/Caches/composer/vcs/git-gitlab.com-another-test-group2-one-more.git/' '/Users/glaubinix/Projects/packagist/composer/stephan/vendor/one-more/test' --dissociate --reference '/Users/glaubinix/Library/Caches/composer/vcs/git-gitlab.com-another-test-group2-one-more.git/' && cd '/Users/glaubinix/Projects/packagist/composer/stephan/vendor/one-more/test' && git remote set-url origin -- 'git@gitlab.com:another-test-group2/one-more.git' && git remote add composer -- 'git@gitlab.com:another-test-group2/one-more.git'
Executing command (/Users/glaubinix/Projects/packagist/composer/stephan/vendor/one-more/test): git branch -r
Executing command (/Users/glaubinix/Projects/packagist/composer/stephan/vendor/one-more/test): (git checkout 'main' -- || git checkout -B 'main' 'composer/main' --) && git reset --hard '8cb508d115604334d813f50325c97a6893717a15' --
  - Marking one-more/test (9999999-dev 8cb508d) as installed, alias of one-more/test (dev-main 8cb508d)
Generating autoload files
```

With authentication set up as mentioned in issue
```
composer config gitlab-token.gitlab.com gitlab-ci-token $CI_JOB_TOKEN
Running 2.3.999-dev+source (@release_date@) with PHP 8.0.17 on Darwin / 21.4.0
[...]
Dependency resolution completed in 0.000 seconds
Package operations: 1 install, 0 updates, 0 removals
Installs: one-more/test:dev-main 8cb508d
  - Downloading one-more/test (dev-main 8cb508d)
Using HTTP basic authentication with username "gitlab-ci-token"
Downloading https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
[404] https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
Executing command (CWD): git config gitlab.accesstoken
Executing command (CWD): git config gitlab.deploytoken.user
Using GitLab private token authentication
Downloading https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
[200] https://gitlab.com/api/v4/projects/another-test-group2%2Fone-more/repository/archive.zip?sha=8cb508d115604334d813f50325c97a6893717a15
Writing /Users/glaubinix/Library/Caches/composer/files/one-more/test/e710094baa1434f5e4c6c8e69e488208b65b4b70.zip into cache from /Users/glaubinix/Projects/packagist/composer/stephan/vendor/composer/tmp-50b3ff79c2676cc4bf41ca38dc233cd6.zip
  - Installing one-more/test (dev-main 8cb508d): Extracting archive
Executing async command (CWD): '/usr/bin/unzip' -qq '/Users/glaubinix/Projects/packagist/composer/stephan/vendor/composer/tmp-50b3ff79c2676cc4bf41ca38dc233cd6.zip' -d '/Users/glaubinix/Projects/packagist/composer/stephan/vendor/composer/a3062611'
  - Marking one-more/test (9999999-dev 8cb508d) as installed, alias of one-more/test (dev-main 8cb508d)
Executing async command (CWD): rm -rf '/Users/glaubinix/Projects/packagist/composer/stephan/vendor/composer/a3062611'
Generating autoload files
```