### PR TITLE
Fix TypeError in ConfigCommand

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -214,7 +214,7 @@ EOT
     {
         // Open file in editor
         if (true === $input->getOption('editor')) {
-            $editor = escapeshellcmd(Platform::getEnv('EDITOR') ?: '');
+            $editor = Platform::getEnv('EDITOR');
             if (!$editor) {
                 if (Platform::isWindows()) {
                     $editor = 'notepad';
@@ -226,6 +226,8 @@ EOT
                         }
                     }
                 }
+            } else {
+                $editor = escapeshellcmd($editor);
             }
 
             $file = $input->getOption('auth') ? $this->authConfigFile->getPath() : $this->configFile->getPath();

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -214,7 +214,7 @@ EOT
     {
         // Open file in editor
         if (true === $input->getOption('editor')) {
-            $editor = escapeshellcmd(Platform::getEnv('EDITOR'));
+            $editor = escapeshellcmd(Platform::getEnv('EDITOR') ?: '');
             if (!$editor) {
                 if (Platform::isWindows()) {
                     $editor = 'notepad';


### PR DESCRIPTION
```
$ composer config --global --editor

In ConfigCommand.php line 217:
                                                                               
  [TypeError]                                                                  
  escapeshellcmd(): Argument #1 ($command) must be of type string, bool given  
...
Exception trace:
  at phar://C:/ProgramData/ComposerSetup/bin/composer.phar/src/Composer/Command/ConfigCommand.php:217
 escapeshellcmd() at phar://C:/ProgramData/ComposerSetup/bin/composer.phar/src/Composer/Command/ConfigCommand.php:217
 Composer\Command\ConfigCommand->execute() at phar://C:/ProgramData/ComposerSetup/bin/composer.phar/vendor/symfony/console/Command/Command.php:298
 Symfony\Component\Console\Command\Command->run() at phar://C:/ProgramData/ComposerSetup/bin/composer.phar/vendor/symfony/console/Application.php:1015
 Symfony\Component\Console\Application->doRunCommand() at phar://C:/ProgramData/ComposerSetup/bin/composer.phar/vendor/symfony/console/Application.php:299
 Symfony\Component\Console\Application->doRun() at phar://C:/ProgramData/ComposerSetup/bin/composer.phar/src/Composer/Console/Application.php:334
 Composer\Console\Application->doRun() at phar://C:/ProgramData/ComposerSetup/bin/composer.phar/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at phar://C:/ProgramData/ComposerSetup/bin/composer.phar/src/Composer/Console/Application.php:130
 Composer\Console\Application->run() at phar://C:/ProgramData/ComposerSetup/bin/composer.phar/bin/composer:88
 require() at C:\ProgramData\ComposerSetup\bin\composer.phar:29
```

closes https://github.com/composer/composer/issues/10752