### PR TITLE
#10738 - Allow config unset for unrecognized keys

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -634,11 +634,6 @@ EOT
         if ($input->getOption('global') && (isset($uniqueProps[$settingKey]) || isset($multiProps[$settingKey]) || strpos($settingKey, 'extra.') === 0)) {
             throw new \InvalidArgumentException('The ' . $settingKey . ' property can not be set in the global config.json file. Use `composer global config` to apply changes to the global composer.json');
         }
-        if ($input->getOption('unset')) {
-            $this->configSource->removeProperty($settingKey);
-
-            return 0;
-        }
         if (isset($uniqueProps[$settingKey])) {
             $this->handleSingleValue($settingKey, $uniqueProps[$settingKey], $values, 'addProperty');
 
@@ -797,6 +792,12 @@ EOT
             }
 
             $this->configSource->addProperty($settingKey, count($values) > 1 ? $values : $values[0]);
+
+            return 0;
+        }
+
+        if ($input->getOption('unset')) {
+            $this->configSource->removeProperty($settingKey);
 
             return 0;
         }

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -634,7 +634,7 @@ EOT
         if ($input->getOption('global') && (isset($uniqueProps[$settingKey]) || isset($multiProps[$settingKey]) || strpos($settingKey, 'extra.') === 0)) {
             throw new \InvalidArgumentException('The ' . $settingKey . ' property can not be set in the global config.json file. Use `composer global config` to apply changes to the global composer.json');
         }
-        if ($input->getOption('unset') && (isset($uniqueProps[$settingKey]) || isset($multiProps[$settingKey]))) {
+        if ($input->getOption('unset')) {
             $this->configSource->removeProperty($settingKey);
 
             return 0;


### PR DESCRIPTION
Fix #10738 

Allows unsetting any config key and not only the ones from the recognised schema.

Because key removal is done without matching the key in the recognized composer.json schema, leaving the key removal before other checks would have stopped the execution there without reaching the specific config add (eg. `composer config repo [--unset]` which was right after the removal)


