### PR TITLE
CurlDownloader: Always cast Content-Type header value to string when passing to strtolower()

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -604,7 +604,7 @@ class CurlDownloader
         }
 
         $details = '';
-        if (in_array(strtolower($response->getHeader('content-type')), array('application/json', 'application/json; charset=utf-8'), true)) {
+        if (in_array(strtolower((string) $response->getHeader('content-type')), array('application/json', 'application/json; charset=utf-8'), true)) {
             $details = ':'.PHP_EOL.substr($response->getBody(), 0, 200).(strlen($response->getBody()) > 200 ? '...' : '');
         }
 


### PR DESCRIPTION
GitHub does not always set the `Content-Type` header on `500 Internal Server Error` responses.

```
2022-05-11T11:42:37+00:00 app.CRITICAL Uncaught Console Exception: strtolower(): Argument #1 ($string) must be of type string, null given
{
    "exception": {
        "class": "TypeError",
        "message": "strtolower(): Argument #1 ($string) must be of type string, null given",
        "code": 0,
        "file": "\/vendor\/composer\/composer\/src\/Composer\/Util\/Http\/CurlDownloader.php:609",
        "trace": [
            "\/vendor\/composer\/composer\/src\/Composer\/Util\/Http\/CurlDownloader.php:609",
            "\/vendor\/composer\/composer\/src\/Composer\/Util\/Http\/CurlDownloader.php:434",
            "\/vendor\/composer\/composer\/src\/Composer\/Util\/HttpDownloader.php:378",
            "\/vendor\/composer\/composer\/src\/Composer\/Util\/HttpDownloader.php:347",
            "\/vendor\/composer\/composer\/src\/Composer\/Util\/HttpDownloader.php:109",
            ...
            "\/vendor\/composer\/composer\/src\/Composer\/Repository\/Vcs\/VcsDriver.php:176",
            "\/vendor\/composer\/composer\/src\/Composer\/Repository\/Vcs\/GitHubDriver.php:436",
            "\/vendor\/composer\/composer\/src\/Composer\/Repository\/Vcs\/GitHubDriver.php:297",
            ...
            "\/vendor\/symfony\/console\/Command\/Command.php:298",
            "\/vendor\/symfony\/console\/Application.php:1033",
            "\/vendor\/symfony\/framework-bundle\/Console\/Application.php:96",
            "\/vendor\/symfony\/console\/Application.php:299",
            "\/vendor\/symfony\/framework-bundle\/Console\/Application.php:82",
            "\/vendor\/symfony\/console\/Application.php:171",
            "\/app\/console:32"
        ]
    }
}
```