### PR TITLE
Remove dead code in poolbuilder

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -234,30 +234,6 @@ class PoolBuilder
             $this->loadPackagesMarkedForLoading($request, $repositories);
         }
 
-        foreach ($this->packages as $i => $package) {
-            // we check all alias related packages at once, so no need to check individual aliases
-            // isset also checks non-null value
-            if (!$package instanceof AliasPackage) {
-                $constraint = new Constraint('==', $package->getVersion());
-                $aliasedPackages = array($i => $package);
-                if (isset($this->aliasMap[spl_object_hash($package)])) {
-                    $aliasedPackages += $this->aliasMap[spl_object_hash($package)];
-                }
-
-                $found = false;
-                foreach ($aliasedPackages as $packageOrAlias) {
-                    if (CompilingMatcher::match($constraint, Constraint::OP_EQ, $packageOrAlias->getVersion())) {
-                        $found = true;
-                    }
-                }
-                if (!$found) {
-                    foreach ($aliasedPackages as $index => $packageOrAlias) {
-                        unset($this->packages[$index]);
-                    }
-                }
-            }
-        }
-
         if ($this->eventDispatcher) {
             $prePoolCreateEvent = new PrePoolCreateEvent(
                 PluginEvents::PRE_POOL_CREATE,


### PR DESCRIPTION
In https://github.com/composer/composer/pull/8850 and specifically https://github.com/composer/composer/commit/912aecb6661b068cf187fb6fd0359798838d86ad#diff-d6d8d75ac1397a615f08c7a046ddbb11ad1ae869623f120be02ccd3c8e49b583L202 I think this whole loop was made useless.

The way it looks, it puts $package inside $aliasedPackages, then creates a constraint with the package's version, and then checks if that constraint matches the version, so $found will always end up being true as $package's version is always equal to itself, and aliases are never unset/removed.

cc @Toflar 