### PR TITLE
Fix cmd splitting paths on commas

### DIFF
--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -490,7 +490,8 @@ class ProcessExecutor
         // New lines break cmd.exe command parsing
         $argument = strtr($argument, "\n", ' ');
 
-        $quote = strpbrk($argument, " \t") !== false;
+        // In addition to whitespace, commas need quoting to preserve paths
+        $quote = strpbrk($argument, " \t,") !== false;
         $argument = Preg::replace('/(\\\\*)"/', '$1$1\\"', $argument, -1, $dquotes);
         $meta = $dquotes || Preg::isMatch('/%[^%]+%|![^!]+!/', $argument);
 

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -178,6 +178,9 @@ class ProcessExecutorTest extends TestCase
             // no whitespace must not be quoted
             'no-ws' => array('abc', 'abc', "'abc'"),
 
+            // commas must be quoted
+            'comma' => array('a,bc', '"a,bc"', "'a,bc'"),
+
             // double-quotes must be backslash-escaped
             'dq' => array('a"bc', 'a\^"bc', "'a\"bc'"),
 


### PR DESCRIPTION
Cmd apparently splits paths on commas, which can have bad consequences when calling destructive commands like `rmdir`.

Simply fixed by double-quoting the param (as with white-space).

See https://github.com/composer/composer/issues/10745#issuecomment-1118604588

