### PR TITLE
WIP: Added documentation about HTTP Bearer Auth

### DIFF
--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -18,7 +18,7 @@ for credentials and save them (or a token if Composer is able to retrieve one).
 |---|---|
 |[http-basic](#http-basic)|yes|
 |[Inline http-basic](#inline-http-basic)|no|
-|[HTTP Bearer](#http-bearer)|no?|
+|[HTTP Bearer](#http-bearer)|no|
 |[Custom header](#custom-token-authentication)|no|
 |[gitlab-oauth](#gitlab-oauth)|yes|
 |[gitlab-token](#gitlab-token)|yes|

--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -104,7 +104,7 @@ section or directly in the repository definition.
 
 > **Note:** Using the command line environment variable method also has security implications.
 > These credentials will most likely be stored in memory,
-> and on be persisted to a file like `~/.bash_history`(linux) or `ConsoleHost_history.txt`
+> and may be persisted to a file like `~/.bash_history` (linux) or `ConsoleHost_history.txt`
 > (PowerShell on Windows) when closing a session.
 
 The final option to supply Composer with credentials is to use the `COMPOSER_AUTH` environment variable.
@@ -118,8 +118,13 @@ Read more about the usage of this environment variable [here](../03-cli.md#compo
 ### Command line http-basic
 
 ```sh
-php composer.phar config [--global] http-basic.example.org username password
+php composer.phar config [--global] http-basic.repo.example.org username password
 ```
+
+In the above command, the config key `http-basic.example.org` consists of two parts:
+
+- `http-basic` is the authentication method.
+- `repo.example.org` is the repository host name, you should replace it with the host name of your repository. 
 
 ### Manual http-basic
 
@@ -172,7 +177,22 @@ php composer.phar config [--global] --editor
 
 ## HTTP Bearer
 
-TODO
+### Command line HTTP Bearer authentication
+
+```sh
+php composer.phar config [--global] bearer.repo.example.org token
+```
+
+In the above command, the config key `bearer.repo.example.org` consists of two parts:
+
+- `bearer` is the authentication method.
+- `repo.example.org` is the repository host name, you should replace it with the host name of your repository. 
+
+### Manual HTTP Bearer authentication
+
+```sh
+php composer.phar config [--global] --editor --auth
+```
 
 ```json
 {
@@ -217,8 +237,13 @@ php composer.phar config [--global] --editor
 ### Command line gitlab-oauth
 
 ```sh
-php composer.phar config [--global] gitlab-oauth.example.org token
+php composer.phar config [--global] gitlab-oauth.gitlab.example.org token
 ```
+
+In the above command, the config key `gitlab-oauth.gitlab.example.org` consists of two parts:
+
+- `gitlab-oauth` is the authentication method.
+- `gitlab.example.org` is the host name of your GitLab instance, you should replace it with the host name of your GitLab instance or use `gitlab.com` if you don't have a self-hosted GitLab instance.
 
 ### Manual gitlab-oauth
 
@@ -247,8 +272,13 @@ When creating a gitlab token manually, make sure it has either the `read_api` or
 ### Command line gitlab-token
 
 ```sh
-php composer.phar config [--global] gitlab-token.example.org token
+php composer.phar config [--global] gitlab-token.gitlab.example.org token
 ```
+
+In the above command, the config key `gitlab-token.gitlab.example.org` consists of two parts:
+
+- `gitlab-token` is the authentication method.
+- `gitlab.example.org` is the host name of your GitLab instance, you should replace it with the host name of your GitLab instance or use `gitlab.com` if you don't have a self-hosted GitLab instance.
 
 ### Manual gitlab-token
 
@@ -280,6 +310,11 @@ Read more about [Personal Access Tokens](https://docs.github.com/en/authenticati
 php composer.phar config [--global] github-oauth.github.com token
 ```
 
+In the above command, the config key `github-oauth.github.com` consists of two parts:
+
+- `github-oauth` is the authentication method.
+- `github.com` is the host name for which this token applies. For GitHub you most likely do not need to change this.
+
 ### Manual github-oauth
 
 ```sh
@@ -303,6 +338,11 @@ The BitBucket driver uses OAuth to access your private repositories via the BitB
 ```sh
 php composer.phar config [--global] bitbucket-oauth.bitbucket.org consumer-key consumer-secret
 ```
+
+In the above command, the config key `bitbucket-oauth.bitbucket.org` consists of two parts:
+
+- `bitbucket-oauth` is the authentication method.
+- `bitbucket.org` is the host name for which this token applies. Unless you have a private instance you don't need to change this.
 
 ### Manual bitbucket-oauth
 

--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -18,6 +18,7 @@ for credentials and save them (or a token if Composer is able to retrieve one).
 |---|---|
 |[http-basic](#http-basic)|yes|
 |[Inline http-basic](#inline-http-basic)|no|
+|[HTTP Bearer](#http-bearer)|no?|
 |[Custom header](#custom-token-authentication)|no|
 |[gitlab-oauth](#gitlab-oauth)|yes|
 |[gitlab-token](#gitlab-token)|yes|
@@ -50,6 +51,7 @@ Composer home directory.
 For all authentication methods it is possible to edit them using the command line;
  - [http-basic](#command-line-http-basic)
  - [Inline http-basic](#command-line-inline-http-basic)
+ - [HTTP Bearer](#http-bearer)
  - [gitlab-oauth](#command-line-gitlab-oauth)
  - [gitlab-token](#command-line-gitlab-token)
  - [github-oauth](#command-line-github-oauth)
@@ -69,6 +71,7 @@ php composer.phar config --global --editor [--auth]
 For specific authentication implementations, see their sections;
  - [http-basic](#manual-http-basic)
  - [Inline http-basic](#manual-inline-http-basic)
+ - [HTTP Bearer](#http-bearer)
  - [custom header](#manual-custom-token-authentication)
  - [gitlab-oauth](#manual-gitlab-oauth)
  - [gitlab-token](#manual-gitlab-token)
@@ -166,6 +169,19 @@ php composer.phar config [--global] --editor
     ]
 }
 ```
+
+## HTTP Bearer
+
+TODO
+
+```json
+{
+    "bearer": {
+        "example.org": "TOKEN"
+    }
+}
+```
+
 
 ## Custom token authentication
 

--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -121,7 +121,7 @@ Read more about the usage of this environment variable [here](../03-cli.md#compo
 php composer.phar config [--global] http-basic.repo.example.org username password
 ```
 
-In the above command, the config key `http-basic.example.org` consists of two parts:
+In the above command, the config key `http-basic.repo.example.org` consists of two parts:
 
 - `http-basic` is the authentication method.
 - `repo.example.org` is the repository host name, you should replace it with the host name of your repository. 


### PR DESCRIPTION
Bearer Auth has been added here:

- https://github.com/composer/composer/commit/548505f103d4e55a4044bedcd17bd93eba2fe68b
- https://github.com/composer/composer/commit/f964b8301837a49ee1a4cf77dbfb38d0c2c2a340
- #8671
- #8642

but it was not documented in this file.

Committing a draft here, will polish it up later.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
