### PR TITLE
Add audit command to check for security issues

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -103,6 +103,8 @@ resolution.
 * **--no-autoloader:** Skips autoloader generation.
 * **--no-progress:** Removes the progress display that can mess with some
   terminals or scripts which don't handle backspace characters.
+* **--no-audit:** Does not run the audit step after installation is complete.
+* **--audit-format:** Audit output format. Must be "table" (default) or "plain".
 * **--optimize-autoloader (-o):** Convert PSR-0/4 autoloading to classmap to get a faster
   autoloader. This is recommended especially for production, but can take
   a bit of time to run so it is currently not done by default.
@@ -182,6 +184,8 @@ and this feature is only available for your root package dependencies.
 * **--dev:** Install packages listed in `require-dev` (this is the default behavior).
 * **--no-dev:** Skip installing packages listed in `require-dev`. The autoloader generation skips the `autoload-dev` rules.
 * **--no-install:** Does not run the install step after updating the composer.lock file.
+* **--no-audit:** Does not run the audit steps after updating the composer.lock file.
+* **--audit-format:** Audit output format. Must be "table" (default) or "plain".
 * **--lock:** Only updates the lock file hash to suppress warning about the
   lock file being out of date.
 * **--with:** Temporary version constraint to add, e.g. foo/bar:1.0.0 or foo/bar=1.0.0
@@ -253,6 +257,8 @@ If you do not specify a package, Composer will prompt you to search for a packag
   terminals or scripts which don't handle backspace characters.
 * **--no-update:** Disables the automatic update of the dependencies (implies --no-install).
 * **--no-install:** Does not run the install step after updating the composer.lock file.
+* **--no-audit:** Does not run the audit steps after updating the composer.lock file.
+* **--audit-format:** Audit output format. Must be "table" (default) or "plain".
 * **--update-no-dev:** Run the dependency update with the `--no-dev` option.
 * **--update-with-dependencies (-w):** Also update dependencies of the newly required packages, except those that are root requirements.
 * **--update-with-all-dependencies (-W):** Also update dependencies of the newly required packages, including those that are root requirements.
@@ -850,6 +856,8 @@ By default the command checks for the packages on packagist.org.
   mode.
 * **--remove-vcs:** Force-remove the VCS metadata without prompting.
 * **--no-install:** Disables installation of the vendors.
+* **--no-audit:** Does not run the audit steps after installation is complete.
+* **--audit-format:** Audit output format. Must be "table" (default) or "plain".
 * **--ignore-platform-reqs:** ignore all platform requirements (`php`, `hhvm`,
   `lib-*` and `ext-*`) and force the installation even if the local machine does
   not fulfill these.
@@ -954,6 +962,22 @@ php composer.phar archive vendor/package 2.0.21 --format=zip
   or zip (default: "tar").
 * **--dir:** Write the archive to this directory (default: ".")
 * **--file:** Write the archive with the given file name.
+
+## audit
+
+This command is used to audit the packages in your composer.lock
+for possible security issues. Currently this only checks for and
+lists security vulnerability advisories according to the
+[packagist api](https://packagist.org/apidoc#list-security-advisories).
+
+```sh
+php composer.phar audit
+```
+
+### Options
+
+* **--no-dev:** Disables auditing of require-dev packages.
+* **--format (-f):** Audit output format. Must be "table" (default) or "plain".
 
 ## help
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -967,7 +967,7 @@ php composer.phar archive vendor/package 2.0.21 --format=zip
 
 ## audit
 
-This command is used to audit the packages in your composer.lock
+This command is used to audit the packages you have installed
 for possible security issues. Currently this only checks for and
 lists security vulnerability advisories according to the
 [Packagist.org api](https://packagist.org/apidoc#list-security-advisories).
@@ -980,6 +980,7 @@ php composer.phar audit
 
 * **--no-dev:** Disables auditing of require-dev packages.
 * **--format (-f):** Audit output format. Must be "table" (default), "plain", or "summary".
+* **--locked:** Audit packages from the lock file, regardless of what is currently in vendor dir.
 
 ## help
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -301,6 +301,8 @@ uninstalled.
   terminals or scripts which don't handle backspace characters.
 * **--no-update:** Disables the automatic update of the dependencies (implies --no-install).
 * **--no-install:** Does not run the install step after updating the composer.lock file.
+* **--no-audit:** Does not run the audit steps after installation is complete.
+* **--audit-format:** Audit output format. Must be "table" (default) or "plain".
 * **--update-no-dev:** Run the dependency update with the --no-dev option.
 * **--update-with-dependencies (-w):** Also update dependencies of the removed packages.
   (Deprecated, is now default behavior)

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -104,7 +104,7 @@ resolution.
 * **--no-progress:** Removes the progress display that can mess with some
   terminals or scripts which don't handle backspace characters.
 * **--no-audit:** Does not run the audit step after installation is complete.
-* **--audit-format:** Audit output format. Must be "table" (default) or "plain".
+* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default).
 * **--optimize-autoloader (-o):** Convert PSR-0/4 autoloading to classmap to get a faster
   autoloader. This is recommended especially for production, but can take
   a bit of time to run so it is currently not done by default.
@@ -185,7 +185,7 @@ and this feature is only available for your root package dependencies.
 * **--no-dev:** Skip installing packages listed in `require-dev`. The autoloader generation skips the `autoload-dev` rules.
 * **--no-install:** Does not run the install step after updating the composer.lock file.
 * **--no-audit:** Does not run the audit steps after updating the composer.lock file.
-* **--audit-format:** Audit output format. Must be "table" (default) or "plain".
+* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default)..
 * **--lock:** Only updates the lock file hash to suppress warning about the
   lock file being out of date.
 * **--with:** Temporary version constraint to add, e.g. foo/bar:1.0.0 or foo/bar=1.0.0
@@ -258,7 +258,7 @@ If you do not specify a package, Composer will prompt you to search for a packag
 * **--no-update:** Disables the automatic update of the dependencies (implies --no-install).
 * **--no-install:** Does not run the install step after updating the composer.lock file.
 * **--no-audit:** Does not run the audit steps after updating the composer.lock file.
-* **--audit-format:** Audit output format. Must be "table" (default) or "plain".
+* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default)..
 * **--update-no-dev:** Run the dependency update with the `--no-dev` option.
 * **--update-with-dependencies (-w):** Also update dependencies of the newly required packages, except those that are root requirements.
 * **--update-with-all-dependencies (-W):** Also update dependencies of the newly required packages, including those that are root requirements.
@@ -302,7 +302,7 @@ uninstalled.
 * **--no-update:** Disables the automatic update of the dependencies (implies --no-install).
 * **--no-install:** Does not run the install step after updating the composer.lock file.
 * **--no-audit:** Does not run the audit steps after installation is complete.
-* **--audit-format:** Audit output format. Must be "table" (default) or "plain".
+* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default)..
 * **--update-no-dev:** Run the dependency update with the --no-dev option.
 * **--update-with-dependencies (-w):** Also update dependencies of the removed packages.
   (Deprecated, is now default behavior)
@@ -859,7 +859,7 @@ By default the command checks for the packages on packagist.org.
 * **--remove-vcs:** Force-remove the VCS metadata without prompting.
 * **--no-install:** Disables installation of the vendors.
 * **--no-audit:** Does not run the audit steps after installation is complete.
-* **--audit-format:** Audit output format. Must be "table" (default) or "plain".
+* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default)..
 * **--ignore-platform-reqs:** ignore all platform requirements (`php`, `hhvm`,
   `lib-*` and `ext-*`) and force the installation even if the local machine does
   not fulfill these.
@@ -979,7 +979,7 @@ php composer.phar audit
 ### Options
 
 * **--no-dev:** Disables auditing of require-dev packages.
-* **--format (-f):** Audit output format. Must be "table" (default) or "plain".
+* **--format (-f):** Audit output format. Must be "table" (default), "plain", or "summary".
 
 ## help
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -185,7 +185,7 @@ and this feature is only available for your root package dependencies.
 * **--no-dev:** Skip installing packages listed in `require-dev`. The autoloader generation skips the `autoload-dev` rules.
 * **--no-install:** Does not run the install step after updating the composer.lock file.
 * **--no-audit:** Does not run the audit steps after updating the composer.lock file.
-* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default)..
+* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default).
 * **--lock:** Only updates the lock file hash to suppress warning about the
   lock file being out of date.
 * **--with:** Temporary version constraint to add, e.g. foo/bar:1.0.0 or foo/bar=1.0.0
@@ -258,7 +258,7 @@ If you do not specify a package, Composer will prompt you to search for a packag
 * **--no-update:** Disables the automatic update of the dependencies (implies --no-install).
 * **--no-install:** Does not run the install step after updating the composer.lock file.
 * **--no-audit:** Does not run the audit steps after updating the composer.lock file.
-* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default)..
+* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default).
 * **--update-no-dev:** Run the dependency update with the `--no-dev` option.
 * **--update-with-dependencies (-w):** Also update dependencies of the newly required packages, except those that are root requirements.
 * **--update-with-all-dependencies (-W):** Also update dependencies of the newly required packages, including those that are root requirements.
@@ -302,7 +302,7 @@ uninstalled.
 * **--no-update:** Disables the automatic update of the dependencies (implies --no-install).
 * **--no-install:** Does not run the install step after updating the composer.lock file.
 * **--no-audit:** Does not run the audit steps after installation is complete.
-* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default)..
+* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default).
 * **--update-no-dev:** Run the dependency update with the --no-dev option.
 * **--update-with-dependencies (-w):** Also update dependencies of the removed packages.
   (Deprecated, is now default behavior)
@@ -859,7 +859,7 @@ By default the command checks for the packages on packagist.org.
 * **--remove-vcs:** Force-remove the VCS metadata without prompting.
 * **--no-install:** Disables installation of the vendors.
 * **--no-audit:** Does not run the audit steps after installation is complete.
-* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default)..
+* **--audit-format:** Audit output format. Must be "table", "plain", or "summary" (default).
 * **--ignore-platform-reqs:** ignore all platform requirements (`php`, `hhvm`,
   `lib-*` and `ext-*`) and force the installation even if the local machine does
   not fulfill these.

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -970,7 +970,7 @@ php composer.phar archive vendor/package 2.0.21 --format=zip
 This command is used to audit the packages in your composer.lock
 for possible security issues. Currently this only checks for and
 lists security vulnerability advisories according to the
-[packagist api](https://packagist.org/apidoc#list-security-advisories).
+[Packagist.org api](https://packagist.org/apidoc#list-security-advisories).
 
 ```sh
 php composer.phar audit

--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -4579,6 +4579,21 @@ parameters:
 			path: ../src/Composer/SelfUpdate/Versions.php
 
 		-
+			message: "#^Method Composer\\\\Command\\\\AuditCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Composer/Command/AuditCommand.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 2
+			path: src/Composer/Util/Auditor.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: src/Composer/Util/Auditor.php
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: ../src/Composer/Util/AuthHelper.php

--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -4579,16 +4579,6 @@ parameters:
 			path: ../src/Composer/SelfUpdate/Versions.php
 
 		-
-			message: "#^Method Composer\\\\Command\\\\AuditCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Composer/Command/AuditCommand.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
-			path: src/Composer/Util/Auditor.php
-
-		-
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: src/Composer/Util/Auditor.php

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -18,7 +18,7 @@ class AuditCommand extends BaseCommand
             ->setDescription('Checks for security vulnerability advisories for packages in your composer.lock.')
             ->setDefinition(array(
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables auditing of require-dev packages.'),
-                new InputOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
+                new InputOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format. Must be "table", "plain", or "summary".', Auditor::FORMAT_TABLE),
             ))
             ->setHelp(
                 <<<EOT

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Composer\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Composer\Factory;
+use Composer\Util\Auditor;
+use Composer\Util\Filesystem;
+use Symfony\Component\Console\Input\InputOption;
+
+class AuditCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('audit')
+            ->setDescription('Checks for security vulnerability advisories for packages in your composer.lock.')
+            ->setDefinition(array(
+                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables auditing of require-dev packages.'),
+                new InputOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
+            ))
+            ->setHelp(
+                <<<EOT
+The <info>audit</info> command checks for security vulnerability advisories for packages in your composer.lock.
+
+If you do not want to include dev dependencies in the audit you can omit them with --no-dev
+
+Read more at https://getcomposer.org/doc/03-cli.md#audit
+EOT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $lockFile = Factory::getLockFile(Factory::getComposerFile());
+        if (!Filesystem::isReadable($lockFile)) {
+            $this->getIO()->writeError('<error>' . $lockFile . ' is not readable.</error>');
+            return 1;
+        }
+
+        $composer = $this->requireComposer($input->getOption('no-plugins'), $input->getOption('no-scripts'));
+        $locker = $composer->getLocker();
+        $packages = $locker->getLockedRepository(!$input->getOption('no-dev'))->getPackages();
+        $httpDownloader = Factory::createHttpDownloader($this->getIO(), $composer->getConfig());
+
+        if (count($packages) === 0) {
+            $this->io->writeError('No packages - skipping audit.');
+            return 0;
+        }
+
+        $auditor = new Auditor($httpDownloader, $input->getOption('format'));
+        return $auditor->audit($this->getIO(), $packages, false);
+    }
+}

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -43,7 +43,7 @@ EOT
         $httpDownloader = $composer->getLoop()->getHttpDownloader();
 
         if (count($packages) === 0) {
-            $this->io->writeError('No packages - skipping audit.');
+            $this->getIO()->writeError('No packages - skipping audit.');
             return 0;
         }
 

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -37,7 +37,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $composer = $this->requireComposer($input->getOption('no-plugins'), $input->getOption('no-scripts'));
+        $composer = $this->requireComposer();
         $packages = $this->getPackages($composer, $input);
         $httpDownloader = $composer->getLoop()->getHttpDownloader();
 

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -43,7 +43,7 @@ EOT
         $composer = $this->requireComposer($input->getOption('no-plugins'), $input->getOption('no-scripts'));
         $locker = $composer->getLocker();
         $packages = $locker->getLockedRepository(!$input->getOption('no-dev'))->getPackages();
-        $httpDownloader = Factory::createHttpDownloader($this->getIO(), $composer->getConfig());
+        $httpDownloader = $composer->getLoop()->getHttpDownloader();
 
         if (count($packages) === 0) {
             $this->io->writeError('No packages - skipping audit.');

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -20,7 +20,7 @@ class AuditCommand extends BaseCommand
             ->setDescription('Checks for security vulnerability advisories for installed packages.')
             ->setDefinition(array(
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables auditing of require-dev packages.'),
-                new InputOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format. Must be "table", "plain", or "summary".', Auditor::FORMAT_TABLE),
+                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format. Must be "table", "plain", or "summary".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
                 new InputOption('locked', null, InputOption::VALUE_NONE, 'Audit based on the lock file instead of the installed packages.'),
             ))
             ->setHelp(

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -4,12 +4,10 @@ namespace Composer\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Composer\Factory;
 use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepository;
 use Composer\Repository\RepositoryInterface;
 use Composer\Util\Auditor;
-use Composer\Util\Filesystem;
 use Symfony\Component\Console\Input\InputOption;
 
 class AuditCommand extends BaseCommand

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class AuditCommand extends BaseCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('audit')

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -53,7 +53,7 @@ EOT
 
     /**
      * @param InputInterface $input
-     * @return BasePackage[]
+     * @return PackageInterface[]
      */
     private function getPackages(InputInterface $input): array
     {

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -45,8 +45,8 @@ EOT
             return 0;
         }
 
-        $auditor = new Auditor($httpDownloader, $input->getOption('format'));
-        return $auditor->audit($this->getIO(), $packages, false);
+        $auditor = new Auditor($httpDownloader);
+        return $auditor->audit($this->getIO(), $packages, $input->getOption('format'), false);
     }
 
     /**

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -2,6 +2,7 @@
 
 namespace Composer\Command;
 
+use Composer\Composer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Composer\Package\PackageInterface;
@@ -37,7 +38,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $composer = $this->requireComposer($input->getOption('no-plugins'), $input->getOption('no-scripts'));
-        $packages = $this->getPackages($input);
+        $packages = $this->getPackages($composer, $input);
         $httpDownloader = $composer->getLoop()->getHttpDownloader();
 
         if (count($packages) === 0) {
@@ -53,9 +54,8 @@ EOT
      * @param InputInterface $input
      * @return PackageInterface[]
      */
-    private function getPackages(InputInterface $input): array
+    private function getPackages(Composer $composer, InputInterface $input): array
     {
-        $composer = $this->requireComposer($input->getOption('no-plugins'), $input->getOption('no-scripts'));
         if ($input->getOption('locked')) {
             if (!$composer->getLocker()->isLocked()) {
                 throw new \UnexpectedValueException('Valid composer.json and composer.lock files is required to run this command with --locked');

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -58,7 +58,7 @@ EOT
     {
         if ($input->getOption('locked')) {
             if (!$composer->getLocker()->isLocked()) {
-                throw new \UnexpectedValueException('Valid composer.json and composer.lock files is required to run this command with --locked');
+                throw new \UnexpectedValueException('Valid composer.json and composer.lock files are required to run this command with --locked');
             }
             $locker = $composer->getLocker();
             return $locker->getLockedRepository(!$input->getOption('no-dev'))->getPackages();

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -90,7 +90,7 @@ class CreateProjectCommand extends BaseCommand
                 new InputOption('remove-vcs', null, InputOption::VALUE_NONE, 'Whether to force deletion of the vcs folder without prompting.'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Whether to skip installation of the package dependencies.'),
                 new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Whether to skip auditing of the installed package dependencies.'),
-                new InputOption('audit-format', null, InputOption::VALUE_OPTIONAL, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
+                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
                 new InputOption('ask', null, InputOption::VALUE_NONE, 'Whether to ask for project directory.'),

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -44,6 +44,7 @@ use Composer\Util\Filesystem;
 use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Composer\Package\Version\VersionParser;
+use Composer\Util\Auditor;
 
 /**
  * Install a package as new project into new directory.
@@ -88,6 +89,8 @@ class CreateProjectCommand extends BaseCommand
                 new InputOption('keep-vcs', null, InputOption::VALUE_NONE, 'Whether to prevent deleting the vcs folder.'),
                 new InputOption('remove-vcs', null, InputOption::VALUE_NONE, 'Whether to force deletion of the vcs folder without prompting.'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Whether to skip installation of the package dependencies.'),
+                new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Whether to skip auditing of the installed package dependencies.'),
+                new InputOption('audit-format', null, InputOption::VALUE_OPTIONAL, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
                 new InputOption('ask', null, InputOption::VALUE_NONE, 'Whether to ask for project directory.'),
@@ -257,7 +260,9 @@ EOT
                 ->setSuggestedPackagesReporter($this->suggestedPackagesReporter)
                 ->setOptimizeAutoloader($config->get('optimize-autoloader'))
                 ->setClassMapAuthoritative($config->get('classmap-authoritative'))
-                ->setApcuAutoloader($config->get('apcu-autoloader'));
+                ->setApcuAutoloader($config->get('apcu-autoloader'))
+                ->setAudit(!$input->getOption('no-audit'))
+                ->setAuditFormat($input->getOption('audit-format'));
 
             if (!$composer->getLocker()->isLocked()) {
                 $installer->setUpdate(true);

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -90,7 +90,7 @@ class CreateProjectCommand extends BaseCommand
                 new InputOption('remove-vcs', null, InputOption::VALUE_NONE, 'Whether to force deletion of the vcs folder without prompting.'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Whether to skip installation of the package dependencies.'),
                 new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Whether to skip auditing of the installed package dependencies.'),
-                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
+                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table", "plain", or "summary".', Auditor::FORMAT_SUMMARY, Auditor::FORMATS),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
                 new InputOption('ask', null, InputOption::VALUE_NONE, 'Whether to ask for project directory.'),

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -51,7 +51,7 @@ class InstallCommand extends BaseCommand
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Do not use, only defined here to catch misuse of the install command.'),
                 new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after installation is complete.'),
-                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
+                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table", "plain", or "summary".', Auditor::FORMAT_SUMMARY, Auditor::FORMATS),
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -15,6 +15,7 @@ namespace Composer\Command;
 use Composer\Installer;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
+use Composer\Util\Auditor;
 use Composer\Util\HttpDownloader;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -49,6 +50,8 @@ class InstallCommand extends BaseCommand
                 new InputOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Do not use, only defined here to catch misuse of the install command.'),
+                new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after installation is complete.'),
+                new InputOption('audit-format', null, InputOption::VALUE_OPTIONAL, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
@@ -128,6 +131,8 @@ EOT
             ->setClassMapAuthoritative($authoritative)
             ->setApcuAutoloader($apcu, $apcuPrefix)
             ->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input))
+            ->setAudit(!$input->getOption('no-audit'))
+            ->setAuditFormat($input->getOption('audit-format'))
         ;
 
         if ($input->getOption('no-plugins')) {

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -51,7 +51,7 @@ class InstallCommand extends BaseCommand
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Do not use, only defined here to catch misuse of the install command.'),
                 new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after installation is complete.'),
-                new InputOption('audit-format', null, InputOption::VALUE_OPTIONAL, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
+                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -280,6 +280,7 @@ EOT
             ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
             ->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input))
             ->setDryRun($dryRun)
+            ->setAudit(false)
         ;
 
         // if no lock is present, we do not do a partial update as

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -49,7 +49,7 @@ class RemoveCommand extends BaseCommand
                 new InputOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies (implies --no-install).'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
                 new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after updating the composer.lock file.'),
-                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
+                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table", "plain", or "summary".', Auditor::FORMAT_SUMMARY, Auditor::FORMATS),
                 new InputOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.'),
                 new InputOption('update-with-dependencies', 'w', InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated with explicit dependencies. (Deprecrated, is now default behavior)'),
                 new InputOption('update-with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.'),

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -25,6 +25,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 use Composer\Package\BasePackage;
+use Composer\Util\Auditor;
 
 /**
  * @author Pierre du Plessis <pdples@gmail.com>
@@ -47,6 +48,8 @@ class RemoveCommand extends BaseCommand
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
                 new InputOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies (implies --no-install).'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
+                new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after updating the composer.lock file.'),
+                new InputOption('audit-format', null, InputOption::VALUE_OPTIONAL, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
                 new InputOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.'),
                 new InputOption('update-with-dependencies', 'w', InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated with explicit dependencies. (Deprecrated, is now default behavior)'),
                 new InputOption('update-with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.'),
@@ -280,7 +283,8 @@ EOT
             ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
             ->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input))
             ->setDryRun($dryRun)
-            ->setAudit(false)
+            ->setAudit(!$input->getOption('no-audit'))
+            ->setAuditFormat($input->getOption('audit-format'))
         ;
 
         // if no lock is present, we do not do a partial update as

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -49,7 +49,7 @@ class RemoveCommand extends BaseCommand
                 new InputOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies (implies --no-install).'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
                 new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after updating the composer.lock file.'),
-                new InputOption('audit-format', null, InputOption::VALUE_OPTIONAL, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
+                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
                 new InputOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.'),
                 new InputOption('update-with-dependencies', 'w', InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated with explicit dependencies. (Deprecrated, is now default behavior)'),
                 new InputOption('update-with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.'),

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -80,7 +80,7 @@ class RequireCommand extends BaseCommand
                 new InputOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies (implies --no-install).'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
                 new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after updating the composer.lock file.'),
-                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
+                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table", "plain", or "summary".', Auditor::FORMAT_SUMMARY, Auditor::FORMATS),
                 new InputOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.'),
                 new InputOption('update-with-dependencies', 'w', InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated, except those that are root requirements.'),
                 new InputOption('update-with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.'),

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -80,7 +80,7 @@ class RequireCommand extends BaseCommand
                 new InputOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies (implies --no-install).'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
                 new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after updating the composer.lock file.'),
-                new InputOption('audit-format', null, InputOption::VALUE_OPTIONAL, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
+                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
                 new InputOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.'),
                 new InputOption('update-with-dependencies', 'w', InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated, except those that are root requirements.'),
                 new InputOption('update-with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.'),

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -31,6 +31,7 @@ use Composer\Plugin\PluginEvents;
 use Composer\Repository\CompositeRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\IO\IOInterface;
+use Composer\Util\Auditor;
 use Composer\Util\Silencer;
 
 /**
@@ -78,6 +79,8 @@ class RequireCommand extends BaseCommand
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
                 new InputOption('no-update', null, InputOption::VALUE_NONE, 'Disables the automatic update of the dependencies (implies --no-install).'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
+                new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after updating the composer.lock file.'),
+                new InputOption('audit-format', null, InputOption::VALUE_OPTIONAL, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
                 new InputOption('update-no-dev', null, InputOption::VALUE_NONE, 'Run the dependency update with the --no-dev option.'),
                 new InputOption('update-with-dependencies', 'w', InputOption::VALUE_NONE, 'Allows inherited dependencies to be updated, except those that are root requirements.'),
                 new InputOption('update-with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.'),
@@ -414,6 +417,8 @@ EOT
             ->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input))
             ->setPreferStable($input->getOption('prefer-stable'))
             ->setPreferLowest($input->getOption('prefer-lowest'))
+            ->setAudit(!$input->getOption('no-audit'))
+            ->setAuditFormat($input->getOption('audit-format'))
         ;
 
         // if no lock is present, or the file is brand new, we do not do a

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -25,6 +25,7 @@ use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Util\HttpDownloader;
 use Composer\Semver\Constraint\MultiConstraint;
 use Composer\Package\Link;
+use Composer\Util\Auditor;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -58,6 +59,8 @@ class UpdateCommand extends BaseCommand
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables installation of require-dev packages.'),
                 new InputOption('lock', null, InputOption::VALUE_NONE, 'Overwrites the lock file hash to suppress warning about the lock file being out of date without updating package versions. Package metadata like mirrors and URLs are updated if they changed.'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
+                new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after updating the composer.lock file.'),
+                new InputOption('audit-format', null, InputOption::VALUE_OPTIONAL, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
                 new InputOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation'),
                 new InputOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
@@ -227,6 +230,8 @@ EOT
             ->setPreferStable($input->getOption('prefer-stable'))
             ->setPreferLowest($input->getOption('prefer-lowest'))
             ->setTemporaryConstraints($temporaryConstraints)
+            ->setAudit(!$input->getOption('no-audit'))
+            ->setAuditFormat($input->getOption('audit-format'))
         ;
 
         if ($input->getOption('no-plugins')) {

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -60,7 +60,7 @@ class UpdateCommand extends BaseCommand
                 new InputOption('lock', null, InputOption::VALUE_NONE, 'Overwrites the lock file hash to suppress warning about the lock file being out of date without updating package versions. Package metadata like mirrors and URLs are updated if they changed.'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
                 new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after updating the composer.lock file.'),
-                new InputOption('audit-format', null, InputOption::VALUE_OPTIONAL, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE),
+                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
                 new InputOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation'),
                 new InputOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -60,7 +60,7 @@ class UpdateCommand extends BaseCommand
                 new InputOption('lock', null, InputOption::VALUE_NONE, 'Overwrites the lock file hash to suppress warning about the lock file being out of date without updating package versions. Package metadata like mirrors and URLs are updated if they changed.'),
                 new InputOption('no-install', null, InputOption::VALUE_NONE, 'Skip the install step after updating the composer.lock file.'),
                 new InputOption('no-audit', null, InputOption::VALUE_NONE, 'Skip the audit step after updating the composer.lock file.'),
-                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table" or "plain".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
+                new InputOption('audit-format', null, InputOption::VALUE_REQUIRED, 'Audit output format. Must be "table", "plain", or "summary".', Auditor::FORMAT_SUMMARY, Auditor::FORMATS),
                 new InputOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation'),
                 new InputOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -529,6 +529,7 @@ class Application extends BaseApplication
             new Command\UpdateCommand(),
             new Command\SearchCommand(),
             new Command\ValidateCommand(),
+            new Command\AuditCommand(),
             new Command\ShowCommand(),
             new Command\SuggestsCommand(),
             new Command\RequireCommand(),

--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -15,6 +15,7 @@ namespace Composer\IO;
 use Composer\Question\StrictConfirmationQuestion;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -340,6 +341,14 @@ class ConsoleIO extends BaseIO
         }
 
         return $results;
+    }
+
+    /**
+     * @return Table
+     */
+    public function getTable(): Table
+    {
+        return new Table($this->output);
     }
 
     /**

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -394,7 +394,7 @@ class Installer
                     $auditor = new Auditor(Factory::createHttpDownloader($this->io, $this->config));
                     $auditor->audit($this->io, $packages, $this->auditFormat);
                 } catch (TransportException $e) {
-                    $this->io->error('Error occurred while auditing locked packages.');
+                    $this->io->error('Failed to audit installed packages.');
                     if ($this->io->isVerbose()) {
                         $this->io->error($e->getMessage());
                     }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -388,7 +388,7 @@ class Installer
         }
 
         if ($this->audit) {
-            $packages = $this->locker->getLockedRepository($this->devMode)->getPackages();
+            $packages = $localRepo->getCanonicalPackages();
             if (count($packages) > 0) {
                 try {
                     $auditor = new Auditor(Factory::createHttpDownloader($this->io, $this->config), $this->auditFormat);

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1071,10 +1071,13 @@ class Installer
 
     /**
      * @param array<string, ConstraintInterface> $constraints
+     * @return Installer
      */
-    public function setTemporaryConstraints(array $constraints): void
+    public function setTemporaryConstraints(array $constraints): self
     {
         $this->temporaryConstraints = $constraints;
+
+        return $this;
     }
 
     /**

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -391,8 +391,8 @@ class Installer
             $packages = $localRepo->getCanonicalPackages();
             if (count($packages) > 0) {
                 try {
-                    $auditor = new Auditor(Factory::createHttpDownloader($this->io, $this->config), $this->auditFormat);
-                    $auditor->audit($this->io, $packages);
+                    $auditor = new Auditor(Factory::createHttpDownloader($this->io, $this->config));
+                    $auditor->audit($this->io, $packages, $this->auditFormat);
                 } catch (TransportException $e) {
                     $this->io->error('Error occurred while auditing locked packages.');
                     if ($this->io->isVerbose()) {

--- a/src/Composer/Util/Auditor.php
+++ b/src/Composer/Util/Auditor.php
@@ -24,13 +24,15 @@ class Auditor
         self::FORMAT_SUMMARY,
     ];
 
+    /** @var HttpDownloader */
     private $httpDownloader;
 
+    /** @var self::FORMAT_* */
     private $format;
 
     /**
      * @param HttpDownloader $httpDownloader
-     * @param string $format The format that will be used to output audit results.
+     * @param self::FORMAT_* $format The format that will be used to output audit results.
      */
     public function __construct(HttpDownloader $httpDownloader, string $format = self::FORMAT_TABLE)
     {
@@ -41,7 +43,7 @@ class Auditor
     /**
      * Get the format that will be used to output audit results.
      *
-     * @return string
+     * @return self::FORMAT_*
      */
     public function getFormat(): string
     {
@@ -51,7 +53,7 @@ class Auditor
     /**
      * Set the format that will be used to output audit results.
      *
-     * @param string $format
+     * @param self::FORMAT_* $format
      * @return self
      */
     public function setFormat(string $format): self

--- a/src/Composer/Util/Auditor.php
+++ b/src/Composer/Util/Auditor.php
@@ -136,7 +136,7 @@ class Auditor
             'http' => [
                 'method' => 'POST',
                 'header' => ['Content-type: application/x-www-form-urlencoded'],
-                'timeout' => 3,
+                'timeout' => 10,
             ],
         ];
         if (count($packages) > 0) {

--- a/src/Composer/Util/Auditor.php
+++ b/src/Composer/Util/Auditor.php
@@ -16,9 +16,12 @@ class Auditor
 
     public const FORMAT_PLAIN = 'plain';
 
+    public const FORMAT_SUMMARY = 'summary';
+
     public const FORMATS = [
         self::FORMAT_TABLE,
         self::FORMAT_PLAIN,
+        self::FORMAT_SUMMARY,
     ];
 
     private $httpDownloader;
@@ -53,7 +56,7 @@ class Auditor
      */
     public function setFormat(string $format): self
     {
-        if (!in_array($format, [self::FORMAT_TABLE, self::FORMAT_PLAIN])) {
+        if (!in_array($format, self::FORMATS, true)) {
             throw new InvalidArgumentException('Invalid format.');
         }
         $this->format = $format;
@@ -184,13 +187,19 @@ class Auditor
      */
     private function outputAdvisories(IOInterface $io, array $advisories): void
     {
-        if ($this->format === self::FORMAT_TABLE) {
-            if (!($io instanceof ConsoleIO)) {
-                throw new InvalidArgumentException('Cannot use table format with ' . get_class($io));
-            }
-            $this->outputAvisoriesTable($io, $advisories);
-        } else {
-            $this->outputAdvisoriesPlain($io, $advisories);
+        switch ($this->format) {
+            case self::FORMAT_TABLE:
+                if (!($io instanceof ConsoleIO)) {
+                    throw new InvalidArgumentException('Cannot use table format with ' . get_class($io));
+                }
+                $this->outputAvisoriesTable($io, $advisories);
+                return;
+            case self::FORMAT_PLAIN:
+                $this->outputAdvisoriesPlain($io, $advisories);
+                return;
+            case self::FORMAT_SUMMARY:
+                // We've already output the number of advisories in audit()
+                $io->writeError('Run composer audit for a full list of advisories.');
         }
     }
 

--- a/src/Composer/Util/Auditor.php
+++ b/src/Composer/Util/Auditor.php
@@ -16,6 +16,11 @@ class Auditor
 
     public const FORMAT_PLAIN = 'plain';
 
+    public const FORMATS = [
+        self::FORMAT_TABLE,
+        self::FORMAT_PLAIN,
+    ];
+
     private $httpDownloader;
 
     private $format;

--- a/src/Composer/Util/Auditor.php
+++ b/src/Composer/Util/Auditor.php
@@ -118,7 +118,7 @@ class Auditor
         $response = $this->httpDownloader->get($url, $this->createPostOptions($packages));
         $advisories = $response->decodeJson()['advisories'];
 
-        if (count($packages) > 0 && $filterByVersion) {
+        if (count($advisories) > 0 && $filterByVersion) {
             return $this->filterAdvisories($advisories, $packages);
         }
 

--- a/src/Composer/Util/Auditor.php
+++ b/src/Composer/Util/Auditor.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Composer\Util;
+
+use Composer\IO\ConsoleIO;
+use Composer\IO\IOInterface;
+use Composer\Package\BasePackage;
+use Composer\Semver\Semver;
+use InvalidArgumentException;
+
+class Auditor
+{
+    public const API_URL = 'https://packagist.org/api/security-advisories/';
+
+    public const FORMAT_TABLE = 'table';
+
+    public const FORMAT_PLAIN = 'plain';
+
+    private $httpDownloader;
+
+    private $format;
+
+    /**
+     * @param HttpDownloader $httpDownloader
+     * @param string $format The format that will be used to output audit results.
+     */
+    public function __construct(HttpDownloader $httpDownloader, string $format = self::FORMAT_TABLE)
+    {
+        $this->httpDownloader = $httpDownloader;
+        $this->setFormat($format);
+    }
+
+    /**
+     * Get the format that will be used to output audit results.
+     *
+     * @return string
+     */
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
+    /**
+     * Set the format that will be used to output audit results.
+     *
+     * @param string $format
+     * @return self
+     */
+    public function setFormat(string $format): self
+    {
+        if (!in_array($format, [self::FORMAT_TABLE, self::FORMAT_PLAIN])) {
+            throw new InvalidArgumentException('Invalid format.');
+        }
+        $this->format = $format;
+        return $this;
+    }
+
+    /**
+     * @param IOInterface $io
+     * @param BasePackage[] $packages
+     * @param bool $warningOnly If true, outputs a warning. If false, outputs an error.
+     * @return int
+     * @throws InvalidArgumentException If no packages are passed in
+     */
+    public function audit(IOInterface $io, array $packages, bool $warningOnly = true): int
+    {
+        $advisories = $this->getAdvisories($packages);
+        $format = $warningOnly ? 'warning' : 'error';
+        if (count($advisories) > 0) {
+            $numAdvisories = $this->countAdvisories($advisories);
+            $plurality = $numAdvisories === 1 ? 'y' : 'ies';
+            $io->writeError("<$format>Found $numAdvisories security vulnerability advisor$plurality:</$format>");
+            $this->outputAdvisories($io, $advisories);
+            return 1;
+        }
+        $io->writeError('<info>No security vulnerability advisories found</info>');
+        return 0;
+    }
+
+    /**
+     * Get advisories from packagist.org
+     *
+     * @param BasePackage[] $packages
+     * @param ?int $updatedSince Timestamp
+     * @param bool $filterByVersion Filter by the package versions if true
+     * @return string[][][]
+     * @throws InvalidArgumentException If no packages and no updatedSince timestamp are passed in
+     */
+    public function getAdvisories(array $packages = [], int $updatedSince = null, bool $filterByVersion = true): array
+    {
+        if (count($packages) === 0 && $updatedSince === null) {
+            throw new InvalidArgumentException(
+                'At least one package or an $updatedSince timestamp must be passed in.'
+            );
+        }
+
+        if (count($packages) === 0 && $filterByVersion) {
+            return [];
+        }
+
+        // Add updatedSince query to URL if passed in
+        $url = self::API_URL;
+        if ($updatedSince !== null) {
+            $url .= "?updatedSince=$updatedSince";
+        }
+
+        // Get advisories from API
+        $response = $this->httpDownloader->get($url, $this->createPostOptions($packages));
+        $advisories = $response->decodeJson()['advisories'];
+
+        if (count($packages) > 0 && $filterByVersion) {
+            return $this->filterAdvisories($advisories, $packages);
+        }
+
+        return $advisories;
+    }
+
+    /**
+     * @param BasePackage[] $packages
+     * @return string[]
+     * @phpstan-return array<string, array<string, array<int, string>|int|string>>
+     */
+    private function createPostOptions(array $packages): array
+    {
+        $options = [
+            'http' => [
+                'method' => 'POST',
+                'header' => ['Content-type: application/x-www-form-urlencoded'],
+                'timeout' => 3,
+            ],
+        ];
+        if (count($packages) > 0) {
+            $content = ['packages' => []];
+            foreach ($packages as $package) {
+                $content['packages'][] = $package->getName();
+            }
+            $options['http']['content'] = http_build_query($content);
+        }
+        return $options;
+    }
+
+    /**
+     * @param string[][][] $advisories
+     * @param BasePackage[] $packages
+     * @return string[][][]
+     */
+    private function filterAdvisories(array $advisories, array $packages): array
+    {
+        $filteredAdvisories = [];
+        foreach ($packages as $package) {
+            if (array_key_exists($package->getName(), $advisories)) {
+                foreach ($advisories[$package->getName()] as $advisory) {
+                    if (Semver::satisfies($package->getVersion(), $advisory['affectedVersions'])) {
+                        $filteredAdvisories[$package->getName()][] = $advisory;
+                    }
+                }
+            }
+        }
+        return $filteredAdvisories;
+    }
+
+    /**
+     * @param string[][][] $advisories
+     * @return integer
+     */
+    private function countAdvisories(array $advisories): int
+    {
+        $count = 0;
+        foreach ($advisories as $packageAdvisories) {
+            $count += count($packageAdvisories);
+        }
+        return $count;
+    }
+
+    /**
+     * @param IOInterface $io
+     * @param string[][][] $advisories
+     * @return void
+     */
+    private function outputAdvisories(IOInterface $io, array $advisories): void
+    {
+        if ($this->format === self::FORMAT_TABLE) {
+            if (!($io instanceof ConsoleIO)) {
+                throw new InvalidArgumentException('Cannot use table format with ' . get_class($io));
+            }
+            $this->outputAvisoriesTable($io, $advisories);
+        } else {
+            $this->outputAdvisoriesPlain($io, $advisories);
+        }
+    }
+
+    /**
+     * @param ConsoleIO $io
+     * @param string[][][] $advisories
+     * @return void
+     */
+    private function outputAvisoriesTable(ConsoleIO $io, array $advisories): void
+    {
+        foreach ($advisories as $package => $packageAdvisories) {
+            foreach ($packageAdvisories as $advisory) {
+                $io->getTable()
+                    ->setHorizontal()
+                    ->setHeaders([
+                        '<fg=red>Package</>',
+                        '<fg=red>CVE</>',
+                        '<fg=red>Title</>',
+                        '<fg=red>URL</>',
+                        '<fg=red>Affected versions</>',
+                        '<fg=red>Reported at</>',
+                    ])
+                    ->addRow([
+                        $package,
+                        $advisory['cve'] ?: 'NO CVE',
+                        $advisory['title'],
+                        $advisory['link'],
+                        $advisory['affectedVersions'],
+                        $advisory['reportedAt'],
+                    ])
+                    ->setColumnWidth(1, 80)
+                    ->setColumnMaxWidth(1, 80)
+                    ->render();
+            }
+        }
+    }
+
+    /**
+     * @param IOInterface $io
+     * @param string[][][] $advisories
+     * @return void
+     */
+    private function outputAdvisoriesPlain(IOInterface $io, array $advisories): void
+    {
+        $error = [];
+        $firstAdvisory = true;
+        foreach ($advisories as $package => $packageAdvisories) {
+            foreach ($packageAdvisories as $advisory) {
+                if (!$firstAdvisory) {
+                    $error[] = '--------';
+                }
+                $cve = $advisory['cve'] ?: 'NO CVE';
+                $error[] = "<fg=red>Package:</> $package";
+                $error[] = "<fg=red>CVE:</> $cve";
+                $error[] = "<fg=red>Title:</> {$advisory['title']}";
+                $error[] = "<fg=red>URL:</> {$advisory['link']}";
+                $error[] = "<fg=red>Affected versions:</> {$advisory['affectedVersions']}";
+                $error[] = "<fg=red>Reported at:</> {$advisory['reportedAt']}";
+                $firstAdvisory = false;
+            }
+        }
+        $io->writeError($error);
+    }
+}

--- a/src/Composer/Util/Auditor.php
+++ b/src/Composer/Util/Auditor.php
@@ -8,9 +8,12 @@ use Composer\Package\PackageInterface;
 use Composer\Semver\Semver;
 use InvalidArgumentException;
 
+/**
+ * @internal
+ */
 class Auditor
 {
-    public const API_URL = 'https://packagist.org/api/security-advisories/';
+    private const API_URL = 'https://packagist.org/api/security-advisories/';
 
     public const FORMAT_TABLE = 'table';
 

--- a/src/Composer/Util/Auditor.php
+++ b/src/Composer/Util/Auditor.php
@@ -206,12 +206,12 @@ class Auditor
                 $io->getTable()
                     ->setHorizontal()
                     ->setHeaders([
-                        '<fg=red>Package</>',
-                        '<fg=red>CVE</>',
-                        '<fg=red>Title</>',
-                        '<fg=red>URL</>',
-                        '<fg=red>Affected versions</>',
-                        '<fg=red>Reported at</>',
+                        'Package',
+                        'CVE',
+                        'Title',
+                        'URL',
+                        'Affected versions',
+                        'Reported at',
                     ])
                     ->addRow([
                         $package,
@@ -243,12 +243,12 @@ class Auditor
                     $error[] = '--------';
                 }
                 $cve = $advisory['cve'] ?: 'NO CVE';
-                $error[] = "<fg=red>Package:</> $package";
-                $error[] = "<fg=red>CVE:</> $cve";
-                $error[] = "<fg=red>Title:</> {$advisory['title']}";
-                $error[] = "<fg=red>URL:</> {$advisory['link']}";
-                $error[] = "<fg=red>Affected versions:</> {$advisory['affectedVersions']}";
-                $error[] = "<fg=red>Reported at:</> {$advisory['reportedAt']}";
+                $error[] = "Package: $package";
+                $error[] = "CVE: $cve";
+                $error[] = "Title: {$advisory['title']}";
+                $error[] = "URL: {$advisory['link']}";
+                $error[] = "Affected versions: {$advisory['affectedVersions']}";
+                $error[] = "Reported at: {$advisory['reportedAt']}";
                 $firstAdvisory = false;
             }
         }

--- a/src/Composer/Util/Auditor.php
+++ b/src/Composer/Util/Auditor.php
@@ -4,7 +4,7 @@ namespace Composer\Util;
 
 use Composer\IO\ConsoleIO;
 use Composer\IO\IOInterface;
-use Composer\Package\BasePackage;
+use Composer\Package\PackageInterface;
 use Composer\Semver\Semver;
 use InvalidArgumentException;
 
@@ -67,7 +67,7 @@ class Auditor
 
     /**
      * @param IOInterface $io
-     * @param BasePackage[] $packages
+     * @param PackageInterface[] $packages
      * @param bool $warningOnly If true, outputs a warning. If false, outputs an error.
      * @return int
      * @throws InvalidArgumentException If no packages are passed in
@@ -90,7 +90,7 @@ class Auditor
     /**
      * Get advisories from packagist.org
      *
-     * @param BasePackage[] $packages
+     * @param PackageInterface[] $packages
      * @param ?int $updatedSince Timestamp
      * @param bool $filterByVersion Filter by the package versions if true
      * @return string[][][]
@@ -126,7 +126,7 @@ class Auditor
     }
 
     /**
-     * @param BasePackage[] $packages
+     * @param PackageInterface[] $packages
      * @return string[]
      * @phpstan-return array<string, array<string, array<int, string>|int|string>>
      */
@@ -151,7 +151,7 @@ class Auditor
 
     /**
      * @param string[][][] $advisories
-     * @param BasePackage[] $packages
+     * @param PackageInterface[] $packages
      * @return string[][][]
      */
     private function filterAdvisories(array $advisories, array $packages): array

--- a/tests/Composer/Test/Command/UpdateCommandTest.php
+++ b/tests/Composer/Test/Command/UpdateCommandTest.php
@@ -26,7 +26,7 @@ class UpdateCommandTest extends TestCase
         $this->initTempComposer($composerJson);
 
         $appTester = $this->getApplicationTester();
-        $appTester->run(array_merge(['command' => 'update', '--dry-run' => true], $command));
+        $appTester->run(array_merge(['command' => 'update', '--dry-run' => true, '--no-audit' => true], $command));
 
         $this->assertSame(trim($expected), trim($appTester->getDisplay()));
     }

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -136,6 +136,7 @@ class InstallerTest extends TestCase
         $autoloadGenerator = $this->getMockBuilder('Composer\Autoload\AutoloadGenerator')->disableOriginalConstructor()->getMock();
 
         $installer = new Installer($io, $config, clone $rootPackage, $downloadManager, $repositoryManager, $locker, $installationManager, $eventDispatcher, $autoloadGenerator);
+        $installer->setAudit(false);
         $result = $installer->run();
 
         $output = str_replace("\r", '', $io->getOutput());
@@ -395,7 +396,8 @@ class InstallerTest extends TestCase
             $installer
                 ->setDevMode(!$input->getOption('no-dev'))
                 ->setDryRun($input->getOption('dry-run'))
-                ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
+                ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs))
+                ->setAudit(false);
 
             return $installer->run();
         });
@@ -440,7 +442,8 @@ class InstallerTest extends TestCase
                 ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
                 ->setPreferStable($input->getOption('prefer-stable'))
                 ->setPreferLowest($input->getOption('prefer-lowest'))
-                ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
+                ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs))
+                ->setAudit(false);
 
             return $installer->run();
         });

--- a/tests/Composer/Test/Util/AuditorTest.php
+++ b/tests/Composer/Test/Util/AuditorTest.php
@@ -204,9 +204,9 @@ class AuditorTest extends TestCase
             ->getMock();
 
         $callback = function(string $url, array $options) {
-            parse_str(parse_url($url, PHP_URL_QUERY), $query);
+            parse_str(parse_url($url, PHP_URL_QUERY) ?? '', $query);
             $updatedSince = null;
-            if (!empty($query)) {
+            if (isset($query['updatedSince'])) {
                 $updatedSince = $query['updatedSince'];
             }
 

--- a/tests/Composer/Test/Util/AuditorTest.php
+++ b/tests/Composer/Test/Util/AuditorTest.php
@@ -74,8 +74,8 @@ class AuditorTest extends TestCase
         if (count($data['packages']) === 0) {
             $this->expectException(InvalidArgumentException::class);
         }
-        $auditor = new Auditor($this->getHttpDownloader(), Auditor::FORMAT_PLAIN);
-        $result = $auditor->audit($this->io, $data['packages'], $data['warningOnly']);
+        $auditor = new Auditor($this->getHttpDownloader());
+        $result = $auditor->audit($this->io, $data['packages'], Auditor::FORMAT_PLAIN, $data['warningOnly']);
         $this->assertSame($expected, $result, $message);
     }
 

--- a/tests/Composer/Test/Util/AuditorTest.php
+++ b/tests/Composer/Test/Util/AuditorTest.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace Composer\Test\Util;
+
+use Composer\IO\IOInterface;
+use Composer\Package\Package;
+use Composer\Test\TestCase;
+use Composer\Util\Auditor;
+use Composer\Util\Http\Response;
+use Composer\Util\HttpDownloader;
+use InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AuditorTest extends TestCase
+{
+    /** @var IOInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $io;
+
+    protected function setUp(): void
+    {
+        $this->io = $this
+            ->getMockBuilder(IOInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function auditProvider()
+    {
+        return [
+            // Test no advisories returns 0
+            [
+                'data' => [
+                    'packages' => [
+                        new Package('vendor1/package2', '9.0.0', '9.0.0'),
+                        new Package('vendor1/package1', '9.0.0', '9.0.0'),
+                        new Package('vendor3/package1', '9.0.0', '9.0.0'),
+                    ],
+                    'warningOnly' => true,
+                ],
+                'expected' => 0,
+                'message' => 'Test no advisories returns 0',
+            ],
+            // Test with advisories returns 1
+            [
+                'data' => [
+                    'packages' => [
+                        new Package('vendor1/package2', '9.0.0', '9.0.0'),
+                        new Package('vendor1/package1', '8.2.1', '8.2.1'),
+                        new Package('vendor3/package1', '9.0.0', '9.0.0'),
+                    ],
+                    'warningOnly' => true,
+                ],
+                'expected' => 1,
+                'message' => 'Test with advisories returns 1',
+            ],
+            // Test no packages throws InvalidArgumentException
+            [
+                'data' => [
+                    'packages' => [],
+                    'warningOnly' => true,
+                ],
+                'expected' => 1,
+                'message' => 'Test no packages throws InvalidArgumentException',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider auditProvider
+     * @phpstan-param array<string, mixed> $data
+     */
+    public function testAudit(array $data, int $expected, string $message): void
+    {
+        if (count($data['packages']) === 0) {
+            $this->expectException(InvalidArgumentException::class);
+        }
+        $auditor = new Auditor($this->getHttpDownloader(), Auditor::FORMAT_PLAIN);
+        $result = $auditor->audit($this->io, $data['packages'], $data['warningOnly']);
+        $this->assertSame($expected, $result, $message);
+    }
+
+    public function advisoriesProvider()
+    {
+        $advisories = static::getMockAdvisories(null);
+        return [
+            [
+                'data' => [
+                    'packages' => [
+                        new Package('vendor1/package1', '8.2.1', '8.2.1'),
+                        new Package('vendor1/package2', '3.1.0', '3.1.0'),
+                        // Check a package with no advisories at all doesn't cause any issues
+                        new Package('vendor5/package2', '5.0.0', '5.0.0'),
+                    ],
+                    'updatedSince' => null,
+                    'filterByVersion' => false
+                ],
+                'expected' => [
+                    'vendor1/package1' => $advisories['vendor1/package1'],
+                    'vendor1/package2' => $advisories['vendor1/package2'],
+                ],
+                'message' => 'Check not filtering by version',
+            ],
+            [
+                'data' => [
+                    'packages' => [
+                        new Package('vendor1/package1', '8.2.1', '8.2.1'),
+                        new Package('vendor1/package2', '3.1.0', '3.1.0'),
+                        // Check a package with no advisories at all doesn't cause any issues
+                        new Package('vendor5/package2', '5.0.0', '5.0.0'),
+                    ],
+                    'updatedSince' => null,
+                    'filterByVersion' => true
+                ],
+                'expected' => [
+                    'vendor1/package1' => [
+                        $advisories['vendor1/package1'][1],
+                        $advisories['vendor1/package1'][2],
+                    ],
+                    'vendor1/package2' => [
+                        $advisories['vendor1/package2'][0],
+                    ],
+                ],
+                'message' => 'Check filter by version',
+            ],
+            [
+                'data' => [
+                    'packages' => [
+                        new Package('vendor1/package1', '8.2.1', '8.2.1'),
+                        new Package('vendor1/package2', '5.0.0', '5.0.0'),
+                        new Package('vendor2/package1', '3.0.0', '3.0.0'),
+                    ],
+                    'updatedSince' => 1335939007,
+                    'filterByVersion' => false
+                ],
+                'expected' => [
+                    'vendor1/package1' => [
+                        $advisories['vendor1/package1'][0],
+                        $advisories['vendor1/package1'][1],
+                    ],
+                    'vendor1/package2' => [
+                        $advisories['vendor1/package2'][0],
+                    ],
+                    'vendor2/package1' => [
+                        $advisories['vendor2/package1'][0],
+                    ],
+                ],
+                'message' => 'Check updatedSince is passed through to the API',
+            ],
+            [
+                'data' => [
+                    'packages' => [],
+                    'updatedSince' => 1335939007,
+                    'filterByVersion' => true
+                ],
+                'expected' => [],
+                'message' => 'No packages and filterByVersion === true should return 0 results',
+            ],
+            [
+                'data' => [
+                    'packages' => [],
+                    'updatedSince' => 0,
+                    'filterByVersion' => false
+                ],
+                // All advisories expected with no packages and updatedSince === 0
+                'expected' => $advisories,
+                'message' => 'No packages and updatedSince === 0 should NOT throw LogicException',
+            ],
+            [
+                'data' => [
+                    'packages' => [],
+                    'updatedSince' => null,
+                    'filterByVersion' => false
+                ],
+                'expected' => [],
+                'message' => 'No packages and updatedSince === null should throw LogicException',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider advisoriesProvider
+     * @phpstan-param array<string, mixed> $data
+     * @phpstan-param string[][][] $expected
+     */
+    public function testGetAdvisories(array $data, array $expected, string $message): void
+    {
+        if (count($data['packages']) === 0 && $data['updatedSince'] === null) {
+            $this->expectException(InvalidArgumentException::class);
+        }
+        $auditor = new Auditor($this->getHttpDownloader(), Auditor::FORMAT_PLAIN);
+        $result = $auditor->getAdvisories($data['packages'], $data['updatedSince'], $data['filterByVersion']);
+        $this->assertSame($expected, $result, $message);
+    }
+
+    /**
+     * @return HttpDownloader&MockObject
+     */
+    private function getHttpDownloader(): MockObject
+    {
+        $httpDownloader = $this
+            ->getMockBuilder(HttpDownloader::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $callback = function(string $url, array $options) {
+            parse_str(parse_url($url, PHP_URL_QUERY), $query);
+            $updatedSince = null;
+            if (!empty($query)) {
+                $updatedSince = $query['updatedSince'];
+            }
+
+            $advisories = AuditorTest::getMockAdvisories($updatedSince);
+
+            // If the mock API request is for specific packages, only include advisories for those packages
+            if (isset($options['http']['content'])) {
+                parse_str($options['http']['content'], $body);
+                $packages = $body['packages'];
+                foreach ($advisories as $package => $data) {
+                    if (!in_array($package, $packages)) {
+                        unset($advisories[$package]);
+                    }
+                }
+            }
+
+            return new Response(['url' => Auditor::API_URL], 200, [], json_encode(['advisories' => $advisories]));
+        };
+
+        $httpDownloader
+            ->method('get')
+            ->willReturnCallback($callback);
+
+        return $httpDownloader;
+    }
+
+    public static function getMockAdvisories(?int $updatedSince)
+    {
+        $advisories = [
+            'vendor1/package1' => [
+                [
+                    'advisoryId' => 'ID1',
+                    'packageName' => 'vendor1/package1',
+                    'title' => 'advisory1',
+                    'link' => 'https://advisory.example.com/advisory1',
+                    'cve' => 'CVE1',
+                    'affectedVersions' => '>=3,<3.4.3|>=1,<2.5.6',
+                    'sources' => [
+                        [
+                            'name' => 'source1',
+                            'remoteId' => 'RemoteID1',
+                        ],
+                    ],
+                    'reportedAt' => '2022-05-25 13:21:00',
+                    'composerRepository' => 'https://packagist.org',
+                ],
+                [
+                    'advisoryId' => 'ID4',
+                    'packageName' => 'vendor1/package1',
+                    'title' => 'advisory4',
+                    'link' => 'https://advisory.example.com/advisory4',
+                    'cve' => 'CVE3',
+                    'affectedVersions' => '>=8,<8.2.2|>=1,<2.5.6',
+                    'sources' => [
+                        [
+                            'name' => 'source2',
+                            'remoteId' => 'RemoteID2',
+                        ],
+                    ],
+                    'reportedAt' => '2022-05-25 13:21:00',
+                    'composerRepository' => 'https://packagist.org',
+                ],
+            ],
+            'vendor1/package2' => [
+                [
+                    'advisoryId' => 'ID2',
+                    'packageName' => 'vendor1/package2',
+                    'title' => 'advisory2',
+                    'link' => 'https://advisory.example.com/advisory2',
+                    'cve' => '',
+                    'affectedVersions' => '>=3,<3.4.3|>=1,<2.5.6',
+                    'sources' => [
+                        [
+                            'name' => 'source1',
+                            'remoteId' => 'RemoteID2',
+                        ],
+                    ],
+                    'reportedAt' => '2022-05-25 13:21:00',
+                    'composerRepository' => 'https://packagist.org',
+                ],
+            ],
+            'vendorx/packagex' => [
+                [
+                    'advisoryId' => 'IDx',
+                    'packageName' => 'vendorx/packagex',
+                    'title' => 'advisory7',
+                    'link' => 'https://advisory.example.com/advisory7',
+                    'cve' => 'CVE5',
+                    'affectedVersions' => '>=3,<3.4.3|>=1,<2.5.6',
+                    'sources' => [
+                        [
+                            'name' => 'source2',
+                            'remoteId' => 'RemoteID4',
+                        ],
+                    ],
+                    'reportedAt' => '2015-05-25 13:21:00',
+                    'composerRepository' => 'https://packagist.org',
+                ],
+            ],
+            'vendor2/package1' => [
+                [
+                    'advisoryId' => 'ID3',
+                    'packageName' => 'vendor2/package1',
+                    'title' => 'advisory3',
+                    'link' => 'https://advisory.example.com/advisory3',
+                    'cve' => 'CVE2',
+                    'affectedVersions' => '>=3,<3.4.3|>=1,<2.5.6',
+                    'sources' => [
+                        [
+                            'name' => 'source2',
+                            'remoteId' => 'RemoteID1',
+                        ],
+                    ],
+                    'reportedAt' => '2022-05-25 13:21:00',
+                    'composerRepository' => 'https://packagist.org',
+                ],
+            ],
+        ];
+
+        // Intentionally allow updatedSince === 0 to include these advisories
+        if (!$updatedSince) {
+            $advisories['vendor1/package1'][] = [
+                'advisoryId' => 'ID5',
+                'packageName' => 'vendor1/package1',
+                'title' => 'advisory5',
+                'link' => 'https://advisory.example.com/advisory5',
+                'cve' => '',
+                'affectedVersions' => '>=8,<8.2.2|>=1,<2.5.6',
+                'sources' => [
+                    [
+                        'name' => 'source1',
+                        'remoteId' => 'RemoteID3',
+                    ],
+                ],
+                'reportedAt' => '',
+                'composerRepository' => 'https://packagist.org',
+            ];
+            $advisories['vendor2/package1'][] = [
+                'advisoryId' => 'ID6',
+                'packageName' => 'vendor2/package1',
+                'title' => 'advisory6',
+                'link' => 'https://advisory.example.com/advisory6',
+                'cve' => 'CVE4',
+                'affectedVersions' => '>=3,<3.4.3|>=1,<2.5.6',
+                'sources' => [
+                    [
+                        'name' => 'source2',
+                        'remoteId' => 'RemoteID3',
+                    ],
+                ],
+                'reportedAt' => '2015-05-25 13:21:00',
+                'composerRepository' => 'https://packagist.org',
+            ];
+            $advisories['vendory/packagey'][] = [
+                'advisoryId' => 'IDy',
+                'packageName' => 'vendory/packagey',
+                'title' => 'advisory7',
+                'link' => 'https://advisory.example.com/advisory7',
+                'cve' => 'CVE5',
+                'affectedVersions' => '>=3,<3.4.3|>=1,<2.5.6',
+                'sources' => [
+                    [
+                        'name' => 'source2',
+                        'remoteId' => 'RemoteID4',
+                    ],
+                ],
+                'reportedAt' => '2015-05-25 13:21:00',
+                'composerRepository' => 'https://packagist.org',
+            ];
+            $advisories['vendor3/package1'][] = [
+                'advisoryId' => 'ID7',
+                'packageName' => 'vendor3/package1',
+                'title' => 'advisory7',
+                'link' => 'https://advisory.example.com/advisory7',
+                'cve' => 'CVE5',
+                'affectedVersions' => '>=3,<3.4.3|>=1,<2.5.6',
+                'sources' => [
+                    [
+                        'name' => 'source2',
+                        'remoteId' => 'RemoteID4',
+                    ],
+                ],
+                'reportedAt' => '2015-05-25 13:21:00',
+                'composerRepository' => 'https://packagist.org',
+            ];
+        }
+
+        return $advisories;
+    }
+}

--- a/tests/Composer/Test/Util/AuditorTest.php
+++ b/tests/Composer/Test/Util/AuditorTest.php
@@ -223,7 +223,7 @@ class AuditorTest extends TestCase
                 }
             }
 
-            return new Response(['url' => Auditor::API_URL], 200, [], json_encode(['advisories' => $advisories]));
+            return new Response(['url' => 'https://packagist.org/api/security-advisories/'], 200, [], json_encode(['advisories' => $advisories]));
         };
 
         $httpDownloader


### PR DESCRIPTION
Closes #10329

## Description
Adds an audit command which checks for security vulnerability advisories for installed packages using [the API on packagist.org](https://packagist.org/apidoc#list-security-advisories).

Also adds optional auditing (on by default) to the following commands:
- `create-project`
- `update`
- `install`
- `require`
- `remove`

### Table output (default)
![audit-output-table](https://user-images.githubusercontent.com/36352093/171149069-32cf27c1-3695-4b5a-a42d-8f1964f2b41b.png)

### Plain output
![audit-output-plain](https://user-images.githubusercontent.com/36352093/171149111-5a209074-8bb7-453f-bc28-3f2ce0f77fa1.png)

## Things the audit command does not do:
- Confirm the packages in `vendor` dir match what `composer.lock` says they should be
- If composer.lock is missing, check for advisories based on the constraints in the `composer.json` file

## Out of scope, but would be a good future enhancement
- A new `--no-insecure` (or `--allow-insecure`) flag could be added to `update` and `require`. This could use `Auditor` to take versions with advisories out of the version candidate pool, so that you can't accidentally update to or require an insecure version of a package.
- new config in composer.json where you can declare specific advisories which should be ignored by the audit (e.g. the advisory doesn't apply for your project and you don't want audit to keep failing because of it). Would likely need to include the advisory ID in audit output for this to be feasible.

## Things I'm unsure about
- I don't know how to resolve the PHPStan failures - some seem overly strict so I'm hesitant to just blindly follow them.
- Is there a clean way to test the different formats are working as expected in a unit test?