### PR TITLE
Escape forward slash in `properties.name`

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -6,7 +6,7 @@
         "name": {
             "type": "string",
             "description": "Package name, including 'vendor-name/' prefix.",
-            "pattern": "^[a-z0-9]([_.-]?[a-z0-9]++)*+/[a-z0-9](([_.]|-{1,2})?[a-z0-9]++)*+$"
+            "pattern": "^[a-z0-9]([_.-]?[a-z0-9]++)*+\/[a-z0-9](([_.]|-{1,2})?[a-z0-9]++)*+$"
         },
         "description": {
             "type": "string",


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
