### PR TITLE
docs: Fix inconsist semver operator suggestion

### DIFF
--- a/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md
+++ b/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md
@@ -12,7 +12,7 @@ The only good alternative is to define an upper bound on your constraints,
 which you can increase in a new release after testing that your package is
 compatible with the new major version of your dependency.
 
-For example instead of using `>=3.4` you should use `~3.4` which allows all
+For example instead of using `>=3.4` you should use `^3.4` which allows all
 versions up to `3.999` but does not include `4.0` and above. The `^` operator
 works very well with libraries following [semantic versioning](https://semver.org).
 


### PR DESCRIPTION
Using caret over tilde is better since it behaves the same as in npm: https://jubianchi.github.io/semver-check/#/constraint/~3.0
But when this change was introduced in https://github.com/composer/composer/pull/5396, it was not complete.
