### PR TITLE
Fix JSON schema regex pattern

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -6,7 +6,7 @@
         "name": {
             "type": "string",
             "description": "Package name, including 'vendor-name/' prefix.",
-            "pattern": "^[a-z0-9]([_.-]?[a-z0-9]++)*+/[a-z0-9](([_.]|-{1,2})?[a-z0-9]++)*+$"
+            "pattern": "^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$"
         },
         "description": {
             "type": "string",

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -25,9 +25,9 @@ class ComposerSchemaTest extends TestCase
         $expectedError = array(
             array(
                 'property' => 'name',
-                'message' => 'Does not match the regex pattern ^[a-z0-9]([_.-]?[a-z0-9]++)*+/[a-z0-9](([_.]|-{1,2})?[a-z0-9]++)*+$',
+                'message' => 'Does not match the regex pattern ^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$',
                 'constraint' => 'pattern',
-                'pattern' => '^[a-z0-9]([_.-]?[a-z0-9]++)*+/[a-z0-9](([_.]|-{1,2})?[a-z0-9]++)*+$',
+                'pattern' => '^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$',
             ),
         );
 


### PR DESCRIPTION
This PR is an attempt to fix #10805 by removing all possessive quantifiers from the regex pattern.

https://jsfiddle.net/wj345vsa/

I'm sending this to 2.2 since it's the oldest branch the issue applies to.
