### PR TITLE
Specify optional array keys in `ConfigReturnTypeExtension`

### DIFF
--- a/src/Composer/PHPStan/ConfigReturnTypeExtension.php
+++ b/src/Composer/PHPStan/ConfigReturnTypeExtension.php
@@ -123,19 +123,23 @@ final class ConfigReturnTypeExtension implements DynamicMethodReturnTypeExtensio
                         if (isset($def['properties'])) {
                             $keyNames = [];
                             $valTypes = [];
+                            $optionalKeys = [];
+                            $propIndex = 0;
                             foreach ($def['properties'] as $propName => $propdef) {
                                 $keyNames[] = new ConstantStringType($propName);
                                 $valType = $this->parseType($propdef, $path.'.'.$propName);
                                 if (!isset($def['required']) || !in_array($propName, $def['required'], true)) {
                                     $valType = TypeCombinator::addNull($valType);
+                                    $optionalKeys[] = $propIndex;
                                 }
                                 $valTypes[] = $valType;
+                                $propIndex++;
                             }
 
                             if ($addlPropType !== null) {
                                 $types[] = new ArrayType(TypeCombinator::union(new StringType(), ...$keyNames), TypeCombinator::union($addlPropType, ...$valTypes));
                             } else {
-                                $types[] = new ConstantArrayType($keyNames, $valTypes);
+                                $types[] = new ConstantArrayType($keyNames, $valTypes, [0], $optionalKeys);
                             }
                         } else {
                             $types[] = new ArrayType(new StringType(), $addlPropType ?? new MixedType());


### PR DESCRIPTION
Refs: https://github.com/composer/composer/pull/10635#discussion_r887745061

The value types of the optional props are already unioned with a NullType though. Just wanted to mention this again because I'm not a 100% sure about the schema.

Looks like constant arrays are currently only created for 3 paths and only one of them has 2 optional keys.
- `gitlab-token.additionalProperties`
- `http-basic.additionalProperties`
- `bitbucket-oauth.additionalProperties`: `access-token` and `access-token-expiration` are optional