### PR TITLE
Fix processing null config value in DiagnoseCommand

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -76,13 +76,12 @@ class Config
         'use-github-api' => true,
         'lock' => true,
         'platform-check' => 'php-only',
-        // valid keys without defaults (auth config stuff):
-        // bitbucket-oauth
-        // github-oauth
-        // gitlab-oauth
-        // gitlab-token
-        // http-basic
-        // bearer
+        'bitbucket-oauth' => array(),
+        'github-oauth' => array(),
+        'gitlab-oauth' => array(),
+        'gitlab-token' => array(),
+        'http-basic' => array(),
+        'bearer' => array(),
     );
 
     /** @var array<string, mixed> */

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -114,12 +114,12 @@ abstract class BaseIO implements IOInterface
      */
     public function loadConfiguration(Config $config)
     {
-        $bitbucketOauth = $config->get('bitbucket-oauth') ?: array();
-        $githubOauth = $config->get('github-oauth') ?: array();
-        $gitlabOauth = $config->get('gitlab-oauth') ?: array();
-        $gitlabToken = $config->get('gitlab-token') ?: array();
-        $httpBasic = $config->get('http-basic') ?: array();
-        $bearerToken = $config->get('bearer') ?: array();
+        $bitbucketOauth = $config->get('bitbucket-oauth');
+        $githubOauth = $config->get('github-oauth');
+        $gitlabOauth = $config->get('gitlab-oauth');
+        $gitlabToken = $config->get('gitlab-token');
+        $httpBasic = $config->get('http-basic');
+        $bearerToken = $config->get('bearer');
 
         // reload oauth tokens from config if available
 

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -390,4 +390,22 @@ class ConfigTest extends TestCase
 
         $this->assertEquals('COMPOSER_HTACCESS_PROTECT', $result);
     }
+
+    public function testGetDefaultsToAnEmptyArray(): void
+    {
+        $config = new Config;
+        $keys = [
+            'bitbucket-oauth',
+            'github-oauth',
+            'gitlab-oauth',
+            'gitlab-token',
+            'http-basic',
+            'bearer',
+        ];
+        foreach ($keys as $key) {
+            $value = $config->get($key);
+            $this->assertIsArray($value);
+            $this->assertCount(0, $value);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #10814.

2.2 isn't affected, the issue was introduced in https://github.com/composer/composer/commit/bd6403a6bef36fdbefdb287dc7e26286d5e06e5e#diff-608f3426a5aefbff3d9da84c38d75164db806317f92e4a987531915847852380

IMO, these options should default to an empty array.
A possible solution could be to introduce a future BC, as it's done with `allow-plugins`.
