### PR TITLE
Fix TypeError when a JSON file can not be read

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -4366,11 +4366,6 @@ parameters:
 			path: ../src/Composer/Json/JsonFile.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of static method Composer\\\\Json\\\\JsonFile\\:\\:parseJson\\(\\) expects string\\|null, string\\|false\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/Json/JsonFile.php
-
-		-
 			message: "#^Parameter \\#1 \\$json of static method Composer\\\\Json\\\\JsonFile\\:\\:validateSyntax\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: ../src/Composer/Json/JsonFile.php

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -110,6 +110,10 @@ class JsonFile
             throw new \RuntimeException('Could not read '.$this->path."\n\n".$e->getMessage());
         }
 
+        if ($json === false) {
+            throw new \RuntimeException('Could not read '.$this->path);
+        }
+
         return static::parseJson($json, $this->path);
     }
 


### PR DESCRIPTION
Hi,

I got the following error with Composer 2.3.5 but it affects also the 2.2 branch.

It happened after running `composer install`, but unfortunately I didn't manage to reproduce the problem afterwards.

```
Fatal error: Uncaught TypeError: Composer\Json\JsonFile::parseJson(): Argument #1 ($json) must be of type ?string, bool given, called in phar:///usr/local/bin/composer/src/Composer/Json/JsonFile.php on line 117 and defined in phar:///usr/local/bin/composer/src/Composer/Json/JsonFile.php:311
Stack trace:
#0 phar:///usr/local/bin/composer/src/Composer/Json/JsonFile.php(117): Composer\Json\JsonFile::parseJson(false, '/var/www/vendor...')
#1 phar:///usr/local/bin/composer/src/Composer/Repository/FilesystemRepository.php(82): Composer\Json\JsonFile->read()
#2 phar:///usr/local/bin/composer/src/Composer/Repository/ArrayRepository.php(311): Composer\Repository\FilesystemRepository->initialize()
#3 phar:///usr/local/bin/composer/src/Composer/Factory.php(590): Composer\Repository\ArrayRepository->getPackages()
#4 phar:///usr/local/bin/composer/src/Composer/Factory.php(435): Composer\Factory->purgePackages(Object(Composer\Repository\InstalledFilesystemRepository), Object(Composer\Installer\InstallationManager))
#5 phar:///usr/local/bin/composer/src/Composer/Factory.php(614): Composer\Factory->createComposer(Object(Composer\IO\ConsoleIO), Array, true, '/var/www', true, false)
#6 phar:///usr/local/bin/composer/src/Composer/Console/Application.php(469): Composer\Factory::create(Object(Composer\IO\ConsoleIO), NULL, true, false)
#7 phar:///usr/local/bin/composer/src/Composer/Console/Application.php(411): Composer\Console\Application->getComposer(false, true)
#8 phar:///usr/local/bin/composer/src/Composer/Console/Application.php(352): Composer\Console\Application->hintCommonErrors(Object(ErrorException), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 phar:///usr/local/bin/composer/vendor/symfony/console/Application.php(171): Composer\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 phar:///usr/local/bin/composer/src/Composer/Console/Application.php(130): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 phar:///usr/local/bin/composer/bin/composer(88): Composer\Console\Application->run()
#12 /usr/local/bin/composer(29): require('phar:///usr/loc...')
#13 {main}
  thrown in phar:///usr/local/bin/composer/src/Composer/Json/JsonFile.php on line 311
```

PHP version: 8.0.17