### PR TITLE
allow chained proxy-binary php-inclusion - solution (b)

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -379,6 +379,10 @@ if (PHP_VERSION_ID < 80000) {
         }
     }
 
+    if (function_exists('stream_get_wrappers') && in_array('phpvfscomposer', stream_get_wrappers()) && function_exists('stream_wrapper_unregister')) {
+        stream_wrapper_unregister('phpvfscomposer');
+    }
+
     if (function_exists('stream_wrapper_register') && stream_wrapper_register('phpvfscomposer', 'Composer\BinProxyWrapper')) {
         include("phpvfscomposer://" . $binPathExported);
         exit(0);


### PR DESCRIPTION
This PR allow chained proxy-binary php-inclusion by unregistering any earlier registered `phpvfscomposer` stream-wrapper before registering the current `phpvfscomposer` stream-wrapper. For details, please see #10820 …