### PR TITLE
Allow use of --locked with depends and prohibits

### DIFF
--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -70,6 +70,7 @@ abstract class BaseDependencyCommand extends BaseCommand
             }
 
             $repos[] = $locker->getLockedRepository(true);
+            $repos[] = new PlatformRepository([], $locker->getPlatformOverrides());
         } else {
             $localRepo = $composer->getRepositoryManager()->getLocalRepository();
             $rootPkg = $composer->getPackage();

--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -70,12 +70,12 @@ abstract class BaseDependencyCommand extends BaseCommand
             }
 
             $repos[] = $locker->getLockedRepository(true);
+        } else {
+            $repos[] = $localRepo = $composer->getRepositoryManager()->getLocalRepository();
+
+            $platformOverrides = $composer->getConfig()->get('platform') ?: array();
+            $repos[] = new PlatformRepository([], $platformOverrides);
         }
-
-        $repos[] = $localRepo = $composer->getRepositoryManager()->getLocalRepository();
-
-        $platformOverrides = $composer->getConfig()->get('platform') ?: array();
-        $repos[] = new PlatformRepository([], $platformOverrides);
 
         $installedRepo = new InstalledRepository($repos);
 

--- a/src/Composer/Command/DependsCommand.php
+++ b/src/Composer/Command/DependsCommand.php
@@ -39,6 +39,7 @@ class DependsCommand extends BaseDependencyCommand
                 new InputArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect', null, $this->suggestInstalledPackage(true)),
                 new InputOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package'),
                 new InputOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree'),
+                new InputOption('locked', null, InputOption::VALUE_NONE, 'Read dependency information from composer.lock'),
             ))
             ->setHelp(
                 <<<EOT

--- a/src/Composer/Command/ProhibitsCommand.php
+++ b/src/Composer/Command/ProhibitsCommand.php
@@ -40,6 +40,7 @@ class ProhibitsCommand extends BaseDependencyCommand
                 new InputArgument(self::ARGUMENT_CONSTRAINT, InputArgument::REQUIRED, 'Version constraint, which version you expected to be installed'),
                 new InputOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package'),
                 new InputOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree'),
+                new InputOption('locked', null, InputOption::VALUE_NONE, 'Read dependency information from composer.lock'),
             ))
             ->setHelp(
                 <<<EOT


### PR DESCRIPTION
Fixes #10790 by adding an error message that tells users how to recover / get the information they wanted.
Fixes #10717 by adding the ability to use `--locked` on `composer depends` and `composer prohibits` commands (to read the dependency information from `composer.lock`).