### PR TITLE
Fix exported path with space in binary installer proxy

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -437,7 +437,7 @@ if [ -d /proc/cygdrive ]; then
     esac
 fi
 
-export COMPOSER_RUNTIME_BIN_DIR=\$(cd "\${self%[/\\\\]*}" > /dev/null; pwd)
+export COMPOSER_RUNTIME_BIN_DIR="\$(cd "\${self%[/\\\\]*}" > /dev/null; pwd)"
 
 # If bash is sourcing this file, we have to source the target as well
 bashSource="\$BASH_SOURCE"


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
I noticed an issue with a composer vendor binary. If the current working directory path contains a space, upon running a composer vendor binary the following error is thrown:
`./vendor/bin/sail: 26: export: PART_OF_PATH/vendor/bin: bad variable name`
PART_OF_PATH would be `website` if working directory path was `/home/user/my website` for example

Identified issue and tested fix on Ubuntu 20.04. The package/binary I was using: https://github.com/laravel/sail

This PR just quotes the export value in the shell script to allow for paths with spaces.
