### PR TITLE
Removed blank line in missing extensions hint when having no php.ini loaded file

### DIFF
--- a/src/Composer/DependencyResolver/SolverProblemsException.php
+++ b/src/Composer/DependencyResolver/SolverProblemsException.php
@@ -113,11 +113,11 @@ class SolverProblemsException extends \RuntimeException
     {
         $paths = IniHelper::getAll();
 
-        if (count($paths) === 1 && empty($paths[0])) {
-            return '';
-        }
+        if ('' === $paths[0]) {
+            if (count($paths) === 1) {
+                return '';
+            }
 
-        if (count($paths) > 1 && $paths[0] === '') {
             array_shift($paths);
         }
 

--- a/src/Composer/DependencyResolver/SolverProblemsException.php
+++ b/src/Composer/DependencyResolver/SolverProblemsException.php
@@ -117,7 +117,7 @@ class SolverProblemsException extends \RuntimeException
             return '';
         }
 
-        if (count($paths) > 1 && empty($paths[0])) {
+        if (count($paths) > 1 && $paths[0] === '') {
             array_shift($paths);
         }
 

--- a/src/Composer/DependencyResolver/SolverProblemsException.php
+++ b/src/Composer/DependencyResolver/SolverProblemsException.php
@@ -117,6 +117,10 @@ class SolverProblemsException extends \RuntimeException
             return '';
         }
 
+        if (count($paths) > 1 && empty($paths[0])) {
+            array_shift($paths);
+        }
+
         $ignoreExtensionsArguments = implode(" ", array_map(function ($extension) {
             return "--ignore-platform-req=$extension";
         }, $missingExtensions));


### PR DESCRIPTION
I'm using a custom php docker image and all my .ini files are located in the conf.d directory.

This means that `php_ini_loaded_file()` returns `false`, the result is then casted to an empty string.
ini files from the conf.d directory are retrieved from `php_ini_scanned_files()`.

The problem is that `SolverProblemsException::createExtensionHint()` uses these results to display the list of all php ini files, leaving a blank line in place of the missing loaded file :
```
To enable extensions, verify that they are enabled in your .ini files:
    -
    - /usr/local/etc/php/conf.d/docker-php-ext-intl.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-pdo_pgsql.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-zip.ini
```

This leads to tests failing when comparing the output to the expected one (`InstallerTest::testIntegrationWithPoolOptimizer()` and `InstallerTest::testIntegrationWithRawPool()`)

The solution is to remove the empty string from the array before building the output in `createExtensionHint()` (the case of no ini file at all is already handled).
This fixes tests for people with this kind of php configuration and also removes the blank line for composer users.
