### PR TITLE
`composer bump` - Fix typo in the warning message

### DIFF
--- a/src/Composer/Command/BumpCommand.php
+++ b/src/Composer/Command/BumpCommand.php
@@ -126,7 +126,7 @@ EOT
             $contents = $composerJson->read();
             if (!isset($contents['type'])) {
                 $io->writeError('<warning>If your package is not a library, you can explicitly specify the "type" by using "composer config type project".</warning>');
-                $io->writeError('<warning>Alternatively you can use --dev to only bump dependencies within "require-dev".</warning>');
+                $io->writeError('<warning>Alternatively you can use --dev-only to only bump dependencies within "require-dev".</warning>');
             }
             unset($contents);
         }


### PR DESCRIPTION
Change warning text 'Alternatively you can use --dev-only to only bump dependencies within "require-dev"' that said `--dev` instead of `--dev-only`.

