### PR TITLE
Ignoring passed arguments for @putenv

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -272,11 +272,11 @@ class EventDispatcher
                         }
                     }
 
-                    if (strpos($exec, '@putenv ') === 0) {
-                        if (false === strpos($exec, '=')) {
-                            Platform::clearEnv(substr($exec, 8));
+                    if (strpos($callable, '@putenv ') === 0) {
+                        if (false === strpos($callable, '=')) {
+                            Platform::clearEnv(substr($callable, 8));
                         } else {
-                            list($var, $value) = explode('=', substr($exec, 8), 2);
+                            list($var, $value) = explode('=', substr($callable, 8), 2);
                             Platform::putEnv($var, $value);
                         }
 


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->

When running a composer script with arguments, the arguments are currently passed to each executable.
This causes problems when using `@putenv` feature.

For example like this

```
"test:integration-fast": [
    "@putenv POPULATE_DB=0",
    "@test:integration"
],
```

then calling `composer test:integration-fast tests/integration/Database/DatabaseTest.php`

sets ENV `POPULATE_DB=0 'tests/integration/Database/DatabaseTest.php'` instead of `0`.

This change ignores the arguments when using `@putenv`.

OFC, this is a minor BC break so please consider if it's acceptable.

Thanks.
