### PR TITLE
Final public method for abstract class

### DIFF
--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -56,7 +56,7 @@ abstract class BaseCommand extends Command
     /**
      * Gets the application instance for this command.
      */
-    public function getApplication(): Application
+    final public function getApplication(): Application
     {
         $application = parent::getApplication();
         if (!$application instanceof Application) {
@@ -74,7 +74,7 @@ abstract class BaseCommand extends Command
      * @return Composer|null
      * @deprecated since Composer 2.3.0 use requireComposer or tryComposer depending on whether you have $required set to true or false
      */
-    public function getComposer(bool $required = true, ?bool $disablePlugins = null, ?bool $disableScripts = null)
+    final public function getComposer(bool $required = true, ?bool $disablePlugins = null, ?bool $disableScripts = null)
     {
         if ($required) {
             return $this->requireComposer($disablePlugins, $disableScripts);
@@ -92,7 +92,7 @@ abstract class BaseCommand extends Command
      * @param bool|null $disableScripts If null, reads --no-scripts as default
      * @throws \RuntimeException
      */
-    public function requireComposer(bool $disablePlugins = null, bool $disableScripts = null): Composer
+    final public function requireComposer(bool $disablePlugins = null, bool $disableScripts = null): Composer
     {
         if (null === $this->composer) {
             $application = parent::getApplication();
@@ -118,7 +118,7 @@ abstract class BaseCommand extends Command
      * @param bool|null $disablePlugins If null, reads --no-plugins as default
      * @param bool|null $disableScripts If null, reads --no-scripts as default
      */
-    public function tryComposer(bool $disablePlugins = null, bool $disableScripts = null): ?Composer
+    final public function tryComposer(bool $disablePlugins = null, bool $disableScripts = null): ?Composer
     {
         if (null === $this->composer) {
             $application = parent::getApplication();
@@ -133,7 +133,7 @@ abstract class BaseCommand extends Command
     /**
      * @return void
      */
-    public function setComposer(Composer $composer)
+    final public function setComposer(Composer $composer)
     {
         $this->composer = $composer;
     }
@@ -143,7 +143,7 @@ abstract class BaseCommand extends Command
      *
      * @return void
      */
-    public function resetComposer()
+    final public function resetComposer()
     {
         $this->composer = null;
         $this->getApplication()->resetComposer();
@@ -156,7 +156,7 @@ abstract class BaseCommand extends Command
      *
      * @return bool
      */
-    public function isProxyCommand()
+    final public function isProxyCommand()
     {
         return false;
     }
@@ -164,7 +164,7 @@ abstract class BaseCommand extends Command
     /**
      * @return IOInterface
      */
-    public function getIO()
+    final public function getIO()
     {
         if (null === $this->io) {
             $application = parent::getApplication();
@@ -181,7 +181,7 @@ abstract class BaseCommand extends Command
     /**
      * @return void
      */
-    public function setIO(IOInterface $io)
+    final public function setIO(IOInterface $io)
     {
         $this->io = $io;
     }
@@ -193,7 +193,7 @@ abstract class BaseCommand extends Command
      *
      * TODO drop when PHP 8.1 / symfony 6.1+ can be required
      */
-    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    final public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
     {
         $definition = $this->getDefinition();
         $name = (string) $input->getCompletionName();

--- a/src/Composer/DependencyResolver/Operation/SolverOperation.php
+++ b/src/Composer/DependencyResolver/Operation/SolverOperation.php
@@ -29,7 +29,7 @@ abstract class SolverOperation implements OperationInterface
      *
      * @return string
      */
-    public function getOperationType(): string
+    final public function getOperationType(): string
     {
         return static::TYPE;
     }

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -89,7 +89,7 @@ abstract class Rule
     /**
      * @return int
      */
-    public function getReason(): int
+    final public function getReason(): int
     {
         return ($this->bitfield & (255 << self::BITFIELD_REASON)) >> self::BITFIELD_REASON;
     }
@@ -97,7 +97,7 @@ abstract class Rule
     /**
      * @phpstan-return ReasonData
      */
-    public function getReasonData()
+    final public function getReasonData()
     {
         return $this->reasonData;
     }
@@ -105,7 +105,7 @@ abstract class Rule
     /**
      * @return string|null
      */
-    public function getRequiredPackage(): ?string
+    final public function getRequiredPackage(): ?string
     {
         $reason = $this->getReason();
 
@@ -128,7 +128,7 @@ abstract class Rule
      * @param RuleSet::TYPE_* $type
      * @return void
      */
-    public function setType($type): void
+    final public function setType($type): void
     {
         $this->bitfield = ($this->bitfield & ~(255 << self::BITFIELD_TYPE)) | ((255 & $type) << self::BITFIELD_TYPE);
     }
@@ -136,7 +136,7 @@ abstract class Rule
     /**
      * @return int
      */
-    public function getType(): int
+    final public function getType(): int
     {
         return ($this->bitfield & (255 << self::BITFIELD_TYPE)) >> self::BITFIELD_TYPE;
     }
@@ -144,7 +144,7 @@ abstract class Rule
     /**
      * @return void
      */
-    public function disable(): void
+    final public function disable(): void
     {
         $this->bitfield = ($this->bitfield & ~(255 << self::BITFIELD_DISABLED)) | (1 << self::BITFIELD_DISABLED);
     }
@@ -152,7 +152,7 @@ abstract class Rule
     /**
      * @return void
      */
-    public function enable(): void
+    final public function enable(): void
     {
         $this->bitfield &= ~(255 << self::BITFIELD_DISABLED);
     }
@@ -160,7 +160,7 @@ abstract class Rule
     /**
      * @return bool
      */
-    public function isDisabled(): bool
+    final public function isDisabled(): bool
     {
         return (bool) (($this->bitfield & (255 << self::BITFIELD_DISABLED)) >> self::BITFIELD_DISABLED);
     }
@@ -168,7 +168,7 @@ abstract class Rule
     /**
      * @return bool
      */
-    public function isEnabled(): bool
+    final public function isEnabled(): bool
     {
         return !(($this->bitfield & (255 << self::BITFIELD_DISABLED)) >> self::BITFIELD_DISABLED);
     }
@@ -181,7 +181,7 @@ abstract class Rule
     /**
      * @return bool
      */
-    public function isCausedByLock(RepositorySet $repositorySet, Request $request, Pool $pool): bool
+    final public function isCausedByLock(RepositorySet $repositorySet, Request $request, Pool $pool): bool
     {
         if ($this->getReason() === self::RULE_PACKAGE_REQUIRES) {
             if (PlatformRepository::isPlatformPackage($this->reasonData->getTarget())) {
@@ -232,7 +232,7 @@ abstract class Rule
      * @internal
      * @return BasePackage
      */
-    public function getSourcePackage(Pool $pool): BasePackage
+    final public function getSourcePackage(Pool $pool): BasePackage
     {
         $literals = $this->getLiterals();
 
@@ -267,7 +267,7 @@ abstract class Rule
      * @param array<Rule[]> $learnedPool
      * @return string
      */
-    public function getPrettyString(RepositorySet $repositorySet, Request $request, Pool $pool, bool $isVerbose, array $installedMap = array(), array $learnedPool = array()): string
+    final public function getPrettyString(RepositorySet $repositorySet, Request $request, Pool $pool, bool $isVerbose, array $installedMap = array(), array $learnedPool = array()): string
     {
         $literals = $this->getLiterals();
 

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -35,7 +35,7 @@ abstract class ArchiveDownloader extends FileDownloader
     /**
      * @return PromiseInterface
      */
-    public function prepare(string $type, PackageInterface $package, string $path, PackageInterface $prevPackage = null): PromiseInterface
+    final public function prepare(string $type, PackageInterface $package, string $path, PackageInterface $prevPackage = null): PromiseInterface
     {
         unset($this->cleanupExecuted[$package->getName()]);
 
@@ -45,7 +45,7 @@ abstract class ArchiveDownloader extends FileDownloader
     /**
      * @return PromiseInterface
      */
-    public function cleanup(string $type, PackageInterface $package, string $path, PackageInterface $prevPackage = null): PromiseInterface
+    final public function cleanup(string $type, PackageInterface $package, string $path, PackageInterface $prevPackage = null): PromiseInterface
     {
         $this->cleanupExecuted[$package->getName()] = true;
 
@@ -62,7 +62,7 @@ abstract class ArchiveDownloader extends FileDownloader
      * @throws \RuntimeException
      * @throws \UnexpectedValueException
      */
-    public function install(PackageInterface $package, string $path, bool $output = true): PromiseInterface
+    final public function install(PackageInterface $package, string $path, bool $output = true): PromiseInterface
     {
         if ($output) {
             $this->io->writeError("  - " . InstallOperation::format($package) . $this->getInstallOperationAppendix($package, $path));

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -52,7 +52,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     /**
      * @inheritDoc
      */
-    public function getInstallationSource(): string
+    final public function getInstallationSource(): string
     {
         return 'source';
     }
@@ -60,7 +60,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     /**
      * @inheritDoc
      */
-    public function download(PackageInterface $package, string $path, PackageInterface $prevPackage = null): PromiseInterface
+    final public function download(PackageInterface $package, string $path, PackageInterface $prevPackage = null): PromiseInterface
     {
         if (!$package->getSourceReference()) {
             throw new \InvalidArgumentException('Package '.$package->getPrettyName().' is missing reference information');
@@ -93,7 +93,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     /**
      * @inheritDoc
      */
-    public function prepare(string $type, PackageInterface $package, string $path, PackageInterface $prevPackage = null): PromiseInterface
+    final public function prepare(string $type, PackageInterface $package, string $path, PackageInterface $prevPackage = null): PromiseInterface
     {
         if ($type === 'update') {
             $this->cleanChanges($prevPackage, $path, true);
@@ -110,7 +110,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     /**
      * @inheritDoc
      */
-    public function cleanup(string $type, PackageInterface $package, string $path, PackageInterface $prevPackage = null): PromiseInterface
+    final public function cleanup(string $type, PackageInterface $package, string $path, PackageInterface $prevPackage = null): PromiseInterface
     {
         if ($type === 'update' && isset($this->hasCleanedChanges[$prevPackage->getUniqueName()])) {
             $this->reapplyChanges($path);
@@ -123,7 +123,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     /**
      * @inheritDoc
      */
-    public function install(PackageInterface $package, string $path): PromiseInterface
+    final public function install(PackageInterface $package, string $path): PromiseInterface
     {
         if (!$package->getSourceReference()) {
             throw new \InvalidArgumentException('Package '.$package->getPrettyName().' is missing reference information');
@@ -158,7 +158,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     /**
      * @inheritDoc
      */
-    public function update(PackageInterface $initial, PackageInterface $target, string $path): PromiseInterface
+    final public function update(PackageInterface $initial, PackageInterface $target, string $path): PromiseInterface
     {
         if (!$target->getSourceReference()) {
             throw new \InvalidArgumentException('Package '.$target->getPrettyName().' is missing reference information');
@@ -222,7 +222,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     /**
      * @inheritDoc
      */
-    public function remove(PackageInterface $package, string $path): PromiseInterface
+    final public function remove(PackageInterface $package, string $path): PromiseInterface
     {
         $this->io->writeError("  - " . UninstallOperation::format($package));
 
@@ -238,7 +238,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     /**
      * @inheritDoc
      */
-    public function getVcsReference(PackageInterface $package, string $path): ?string
+    final public function getVcsReference(PackageInterface $package, string $path): ?string
     {
         $parser = new VersionParser;
         $guesser = new VersionGuesser($this->config, $this->process, $parser);

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -25,7 +25,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function getAuthentications()
+    final public function getAuthentications()
     {
         return $this->authentications;
     }
@@ -33,7 +33,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @return void
      */
-    public function resetAuthentications()
+    final public function resetAuthentications()
     {
         $this->authentications = array();
     }
@@ -41,7 +41,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function hasAuthentication($repositoryName)
+    final public function hasAuthentication($repositoryName)
     {
         return isset($this->authentications[$repositoryName]);
     }
@@ -49,7 +49,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function getAuthentication($repositoryName)
+    final public function getAuthentication($repositoryName)
     {
         if (isset($this->authentications[$repositoryName])) {
             return $this->authentications[$repositoryName];
@@ -61,7 +61,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function setAuthentication($repositoryName, $username, $password = null)
+    final public function setAuthentication($repositoryName, $username, $password = null)
     {
         $this->authentications[$repositoryName] = array('username' => $username, 'password' => $password);
     }
@@ -69,7 +69,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function writeRaw($messages, bool $newline = true, int $verbosity = self::NORMAL)
+    final public function writeRaw($messages, bool $newline = true, int $verbosity = self::NORMAL)
     {
         $this->write($messages, $newline, $verbosity);
     }
@@ -77,7 +77,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function writeErrorRaw($messages, bool $newline = true, int $verbosity = self::NORMAL)
+    final public function writeErrorRaw($messages, bool $newline = true, int $verbosity = self::NORMAL)
     {
         $this->writeError($messages, $newline, $verbosity);
     }
@@ -112,7 +112,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function loadConfiguration(Config $config)
+    final public function loadConfiguration(Config $config)
     {
         $bitbucketOauth = $config->get('bitbucket-oauth');
         $githubOauth = $config->get('github-oauth');
@@ -159,47 +159,47 @@ abstract class BaseIO implements IOInterface
         ProcessExecutor::setTimeout($config->get('process-timeout'));
     }
 
-    public function emergency($message, array $context = array()): void
+    final public function emergency($message, array $context = array()): void
     {
         $this->log(LogLevel::EMERGENCY, $message, $context);
     }
 
-    public function alert($message, array $context = array()): void
+    final public function alert($message, array $context = array()): void
     {
         $this->log(LogLevel::ALERT, $message, $context);
     }
 
-    public function critical($message, array $context = array()): void
+    final public function critical($message, array $context = array()): void
     {
         $this->log(LogLevel::CRITICAL, $message, $context);
     }
 
-    public function error($message, array $context = array()): void
+    final public function error($message, array $context = array()): void
     {
         $this->log(LogLevel::ERROR, $message, $context);
     }
 
-    public function warning($message, array $context = array()): void
+    final public function warning($message, array $context = array()): void
     {
         $this->log(LogLevel::WARNING, $message, $context);
     }
 
-    public function notice($message, array $context = array()): void
+    final public function notice($message, array $context = array()): void
     {
         $this->log(LogLevel::NOTICE, $message, $context);
     }
 
-    public function info($message, array $context = array()): void
+    final public function info($message, array $context = array()): void
     {
         $this->log(LogLevel::INFO, $message, $context);
     }
 
-    public function debug($message, array $context = array()): void
+    final public function debug($message, array $context = array()): void
     {
         $this->log(LogLevel::DEBUG, $message, $context);
     }
 
-    public function log($level, $message, array $context = array()): void
+    final public function log($level, $message, array $context = array()): void
     {
         $message = (string) $message;
 

--- a/src/Composer/Package/Archiver/BaseExcludeFilter.php
+++ b/src/Composer/Package/Archiver/BaseExcludeFilter.php
@@ -49,7 +49,7 @@ abstract class BaseExcludeFilter
      *
      * @return bool Whether the file should be excluded
      */
-    public function filter(string $relativePath, bool $exclude): bool
+    final public function filter(string $relativePath, bool $exclude): bool
     {
         foreach ($this->excludePatterns as $patternData) {
             list($pattern, $negate, $stripLeadingSlash) = $patternData;

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -77,7 +77,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @inheritDoc
      */
-    public function getName(): string
+    final public function getName(): string
     {
         return $this->name;
     }
@@ -85,7 +85,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @inheritDoc
      */
-    public function getPrettyName(): string
+    final public function getPrettyName(): string
     {
         return $this->prettyName;
     }
@@ -93,7 +93,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @inheritDoc
      */
-    public function getNames($provides = true): array
+    final public function getNames($provides = true): array
     {
         $names = array(
             $this->getName() => true,
@@ -115,7 +115,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @inheritDoc
      */
-    public function setId(int $id): void
+    final public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -123,7 +123,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @inheritDoc
      */
-    public function getId(): int
+    final public function getId(): int
     {
         return $this->id;
     }
@@ -131,7 +131,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @inheritDoc
      */
-    public function setRepository(RepositoryInterface $repository): void
+    final public function setRepository(RepositoryInterface $repository): void
     {
         if ($this->repository && $repository !== $this->repository) {
             throw new \LogicException('A package can only be added to one repository');
@@ -142,7 +142,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @inheritDoc
      */
-    public function getRepository(): ?RepositoryInterface
+    final public function getRepository(): ?RepositoryInterface
     {
         return $this->repository;
     }
@@ -152,7 +152,7 @@ abstract class BasePackage implements PackageInterface
      *
      * @return bool
      */
-    public function isPlatform(): bool
+    final public function isPlatform(): bool
     {
         return $this->getRepository() instanceof PlatformRepository;
     }
@@ -162,7 +162,7 @@ abstract class BasePackage implements PackageInterface
      *
      * @return string
      */
-    public function getUniqueName(): string
+    final public function getUniqueName(): string
     {
         return $this->getName().'-'.$this->getVersion();
     }
@@ -170,7 +170,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @return bool
      */
-    public function equals(PackageInterface $package): bool
+    final public function equals(PackageInterface $package): bool
     {
         $self = $this;
         if ($this instanceof AliasPackage) {
@@ -193,7 +193,7 @@ abstract class BasePackage implements PackageInterface
         return $this->getUniqueName();
     }
 
-    public function getPrettyString(): string
+    final public function getPrettyString(): string
     {
         return $this->getPrettyName().' '.$this->getPrettyVersion();
     }
@@ -201,7 +201,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @inheritDoc
      */
-    public function getFullPrettyVersion(bool $truncate = true, int $displayMode = PackageInterface::DISPLAY_SOURCE_REF_IF_DEV): string
+    final public function getFullPrettyVersion(bool $truncate = true, int $displayMode = PackageInterface::DISPLAY_SOURCE_REF_IF_DEV): string
     {
         if ($displayMode === PackageInterface::DISPLAY_SOURCE_REF_IF_DEV &&
             (!$this->isDev() || !\in_array($this->getSourceType(), array('hg', 'git')))
@@ -238,7 +238,7 @@ abstract class BasePackage implements PackageInterface
      *
      * @phpstan-return self::STABILITY_*
      */
-    public function getStabilityPriority(): int
+    final public function getStabilityPriority(): int
     {
         return self::$stabilities[$this->getStability()];
     }
@@ -256,7 +256,7 @@ abstract class BasePackage implements PackageInterface
      * @param  non-empty-string $wrap         Wrap the cleaned string by the given string
      * @return non-empty-string
      */
-    public static function packageNameToRegexp(string $allowPattern, string $wrap = '{^%s$}i'): string
+    final public static function packageNameToRegexp(string $allowPattern, string $wrap = '{^%s$}i'): string
     {
         $cleanedAllowPattern = str_replace('\\*', '.*', preg_quote($allowPattern));
 
@@ -270,7 +270,7 @@ abstract class BasePackage implements PackageInterface
      * @param non-empty-string $wrap
      * @return non-empty-string
      */
-    public static function packageNamesToRegexp(array $packageNames, string $wrap = '{^(?:%s)$}iD'): string
+    final public static function packageNamesToRegexp(array $packageNames, string $wrap = '{^(?:%s)$}iD'): string
     {
         $packageNames = array_map(
             function ($packageName): string {

--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -87,7 +87,7 @@ abstract class VcsDriver implements VcsDriverInterface
     /**
      * @inheritDoc
      */
-    public function getComposerInformation(string $identifier): ?array
+    final public function getComposerInformation(string $identifier): ?array
     {
         if (!isset($this->infoCache[$identifier])) {
             if ($this->shouldCache($identifier) && $res = $this->cache->read($identifier)) {
@@ -135,7 +135,7 @@ abstract class VcsDriver implements VcsDriverInterface
     /**
      * @inheritDoc
      */
-    public function hasComposerFile(string $identifier): bool
+    final public function hasComposerFile(string $identifier): bool
     {
         try {
             return null !== $this->getComposerInformation($identifier);
@@ -179,7 +179,7 @@ abstract class VcsDriver implements VcsDriverInterface
     /**
      * @inheritDoc
      */
-    public function cleanup(): void
+    final public function cleanup(): void
     {
         return;
     }


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
