### PR TITLE
Ordered interfaces

### DIFF
--- a/src/Composer/DependencyResolver/Decisions.php
+++ b/src/Composer/DependencyResolver/Decisions.php
@@ -18,7 +18,7 @@ namespace Composer\DependencyResolver;
  * @author Nils Adermann <naderman@naderman.de>
  * @implements \Iterator<array{0: int, 1: Rule}>
  */
-class Decisions implements \Iterator, \Countable
+class Decisions implements \Countable, \Iterator
 {
     public const DECISION_LITERAL = 0;
     public const DECISION_REASON = 1;

--- a/src/Composer/DependencyResolver/RuleSet.php
+++ b/src/Composer/DependencyResolver/RuleSet.php
@@ -18,7 +18,7 @@ use Composer\Repository\RepositorySet;
  * @author Nils Adermann <naderman@naderman.de>
  * @implements \IteratorAggregate<Rule>
  */
-class RuleSet implements \IteratorAggregate, \Countable
+class RuleSet implements \Countable, \IteratorAggregate
 {
     // highest priority => lowest number
     public const TYPE_PACKAGE = 0;

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -42,7 +42,7 @@ use React\Promise\PromiseInterface;
  * @author François Pluchino <francois.pluchino@opendisplay.com>
  * @author Nils Adermann <naderman@naderman.de>
  */
-class FileDownloader implements DownloaderInterface, ChangeReportInterface
+class FileDownloader implements ChangeReportInterface, DownloaderInterface
 {
     /** @var IOInterface */
     protected $io;

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -28,7 +28,7 @@ use Composer\DependencyResolver\Operation\UninstallOperation;
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterface, VcsCapableDownloaderInterface
+abstract class VcsDownloader implements ChangeReportInterface, DownloaderInterface, VcsCapableDownloaderInterface
 {
     /** @var IOInterface */
     protected $io;

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -30,7 +30,7 @@ use Composer\Downloader\DownloadManager;
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
+class LibraryInstaller implements BinaryPresenceInterface, InstallerInterface
 {
     /** @var PartialComposer */
     protected $composer;


### PR DESCRIPTION
Orders the interfaces in an implements or interface extends clause.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
