### PR TITLE
Array syntax

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -190,9 +190,9 @@ class AutoloadGenerator
                 Platform::putEnv('COMPOSER_DEV_MODE', $this->devMode ? '1' : '0');
             }
 
-            $this->eventDispatcher->dispatchScript(ScriptEvents::PRE_AUTOLOAD_DUMP, $this->devMode, array(), array(
+            $this->eventDispatcher->dispatchScript(ScriptEvents::PRE_AUTOLOAD_DUMP, $this->devMode, [], [
                 'optimize' => $scanPsrPackages,
-            ));
+            ]);
         }
 
         $filesystem = new Filesystem();
@@ -251,7 +251,7 @@ EOF;
 
         // Process the 'psr-0' base directories.
         foreach ($autoloads['psr-0'] as $namespace => $paths) {
-            $exportedPaths = array();
+            $exportedPaths = [];
             foreach ($paths as $path) {
                 $exportedPaths[] = $this->getPathCode($filesystem, $basePath, $vendorPath, $path);
             }
@@ -263,7 +263,7 @@ EOF;
 
         // Process the 'psr-4' base directories.
         foreach ($autoloads['psr-4'] as $namespace => $paths) {
-            $exportedPaths = array();
+            $exportedPaths = [];
             foreach ($paths as $path) {
                 $exportedPaths[] = $this->getPathCode($filesystem, $basePath, $vendorPath, $path);
             }
@@ -323,20 +323,20 @@ EOF;
             $excluded = $autoloads['exclude-from-classmap'];
         }
 
-        $classMap = array();
-        $ambiguousClasses = array();
-        $scannedFiles = array();
+        $classMap = [];
+        $ambiguousClasses = [];
+        $scannedFiles = [];
         foreach ($autoloads['classmap'] as $dir) {
             $classMap = $this->addClassMapCode($filesystem, $basePath, $vendorPath, $dir, $excluded, null, null, $classMap, $ambiguousClasses, $scannedFiles);
         }
 
         if ($scanPsrPackages) {
-            $namespacesToScan = array();
+            $namespacesToScan = [];
 
             // Scan the PSR-0/4 directories for class files, and add them to the class map
-            foreach (array('psr-4', 'psr-0') as $psrType) {
+            foreach (['psr-4', 'psr-0'] as $psrType) {
                 foreach ($autoloads[$psrType] as $namespace => $paths) {
-                    $namespacesToScan[$namespace][] = array('paths' => $paths, 'type' => $psrType);
+                    $namespacesToScan[$namespace][] = ['paths' => $paths, 'type' => $psrType];
                 }
             }
 
@@ -357,7 +357,7 @@ EOF;
         }
 
         foreach ($ambiguousClasses as $className => $ambiguousPaths) {
-            $cleanPath = str_replace(array('$vendorDir . \'', '$baseDir . \'', "',\n"), array($vendorPath, $basePath, ''), $classMap[$className]);
+            $cleanPath = str_replace(['$vendorDir . \'', '$baseDir . \'', "',\n"], [$vendorPath, $basePath, ''], $classMap[$className]);
 
             $this->io->writeError(
                 '<warning>Warning: Ambiguous class resolution, "'.$className.'"'.
@@ -428,9 +428,9 @@ EOF;
         $filesystem->safeCopy(__DIR__.'/../../../LICENSE', $targetDir.'/LICENSE');
 
         if ($this->runScripts) {
-            $this->eventDispatcher->dispatchScript(ScriptEvents::POST_AUTOLOAD_DUMP, $this->devMode, array(), array(
+            $this->eventDispatcher->dispatchScript(ScriptEvents::POST_AUTOLOAD_DUMP, $this->devMode, [], [
                 'optimize' => $scanPsrPackages,
-            ));
+            ]);
         }
 
         return count($classMap);
@@ -504,7 +504,7 @@ EOF;
     public function buildPackageMap(InstallationManager $installationManager, PackageInterface $rootPackage, array $packages)
     {
         // build package => install path map
-        $packageMap = array(array($rootPackage, ''));
+        $packageMap = [[$rootPackage, '']];
 
         foreach ($packages as $package) {
             if ($package instanceof AliasPackage) {
@@ -512,10 +512,10 @@ EOF;
             }
             $this->validatePackage($package);
 
-            $packageMap[] = array(
+            $packageMap[] = [
                 $package,
                 $installationManager->getInstallPath($package),
-            );
+            ];
         }
 
         return $packageMap;
@@ -580,13 +580,13 @@ EOF;
         krsort($psr0);
         krsort($psr4);
 
-        return array(
+        return [
             'psr-0' => $psr0,
             'psr-4' => $psr4,
             'classmap' => $classmap,
             'files' => $files,
             'exclude-from-classmap' => $exclude,
-        );
+        ];
     }
 
     /**
@@ -618,7 +618,7 @@ EOF;
                 $excluded = $autoloads['exclude-from-classmap'];
             }
 
-            $scannedFiles = array();
+            $scannedFiles = [];
             foreach ($autoloads['classmap'] as $dir) {
                 try {
                     $loader->addClassMap($this->generateClassMap($dir, $excluded, null, null, false, $scannedFiles));
@@ -641,7 +641,7 @@ EOF;
      */
     protected function getIncludePathsFile(array $packageMap, Filesystem $filesystem, string $basePath, string $vendorPath, string $vendorPathCode, string $appBaseDirCode)
     {
-        $includePaths = array();
+        $includePaths = [];
 
         foreach ($packageMap as $item) {
             list($package, $installPath) = $item;
@@ -754,8 +754,8 @@ EOF;
     protected function getPlatformCheck(array $packageMap, $checkPlatform, array $devPackageNames)
     {
         $lowestPhpVersion = Bound::zero();
-        $requiredExtensions = array();
-        $extensionProviders = array();
+        $requiredExtensions = [];
+        $extensionProviders = [];
 
         foreach ($packageMap as $item) {
             $package = $item[0];
@@ -1148,9 +1148,9 @@ HEADER;
         $prefix = "\0Composer\Autoload\ClassLoader\0";
         $prefixLen = strlen($prefix);
         if (file_exists($targetDir . '/autoload_files.php')) {
-            $maps = array('files' => require $targetDir . '/autoload_files.php');
+            $maps = ['files' => require $targetDir . '/autoload_files.php'];
         } else {
-            $maps = array();
+            $maps = [];
         }
 
         foreach ((array) $loader as $prop => $value) {
@@ -1162,12 +1162,12 @@ HEADER;
         foreach ($maps as $prop => $value) {
             $value = strtr(
                 var_export($value, true),
-                array(
+                [
                     $absoluteVendorPathCode => $vendorPathCode,
                     $absoluteVendorPharPathCode => $vendorPharPathCode,
                     $absoluteAppBaseDirCode => $appBaseDirCode,
                     $absoluteAppBaseDirPharCode => $appBaseDirPharCode,
-                )
+                ]
             );
             $value = ltrim(Preg::replace('/^ */m', '    $0$0', $value));
 
@@ -1196,7 +1196,7 @@ INITIALIZER;
      */
     protected function parseAutoloadsType(array $packageMap, string $type, RootPackageInterface $rootPackage)
     {
-        $autoloads = array();
+        $autoloads = [];
 
         foreach ($packageMap as $item) {
             list($package, $installPath) = $item;
@@ -1219,7 +1219,7 @@ INITIALIZER;
                     if (($type === 'files' || $type === 'classmap' || $type === 'exclude-from-classmap') && $package->getTargetDir() && !Filesystem::isReadable($installPath.'/'.$path)) {
                         // remove target-dir from file paths of the root package
                         if ($package === $rootPackage) {
-                            $targetDir = str_replace('\\<dirsep\\>', '[\\\\/]', preg_quote(str_replace(array('/', '\\'), '<dirsep>', $package->getTargetDir())));
+                            $targetDir = str_replace('\\<dirsep\\>', '[\\\\/]', preg_quote(str_replace(['/', '\\'], '<dirsep>', $package->getTargetDir())));
                             $path = ltrim(Preg::replace('{^'.$targetDir.'}', '', ltrim($path, '\\/')), '\\/');
                         } else {
                             // add target-dir from file paths that don't have it
@@ -1232,7 +1232,7 @@ INITIALIZER;
                         $path = Preg::replace('{/+}', '/', preg_quote(trim(strtr($path, '\\', '/'), '/')));
 
                         // add support for wildcards * and **
-                        $path = strtr($path, array('\\*\\*' => '.+?', '\\*' => '[^/]+?'));
+                        $path = strtr($path, ['\\*\\*' => '.+?', '\\*' => '[^/]+?']);
 
                         // add support for up-level relative paths
                         $updir = null;
@@ -1299,9 +1299,9 @@ INITIALIZER;
      */
     protected function filterPackageMap(array $packageMap, RootPackageInterface $rootPackage)
     {
-        $packages = array();
-        $include = array();
-        $replacedBy = array();
+        $packages = [];
+        $include = [];
+        $replacedBy = [];
 
         foreach ($packageMap as $item) {
             $package = $item[0];
@@ -1353,8 +1353,8 @@ INITIALIZER;
      */
     protected function sortPackageMap(array $packageMap)
     {
-        $packages = array();
-        $paths = array();
+        $packages = [];
+        $paths = [];
 
         foreach ($packageMap as $item) {
             list($package, $path) = $item;
@@ -1365,11 +1365,11 @@ INITIALIZER;
 
         $sortedPackages = PackageSorter::sortPackages($packages);
 
-        $sortedPackageMap = array();
+        $sortedPackageMap = [];
 
         foreach ($sortedPackages as $package) {
             $name = $package->getName();
-            $sortedPackageMap[] = array($packages[$name], $paths[$name]);
+            $sortedPackageMap[] = [$packages[$name], $paths[$name]];
         }
 
         return $sortedPackageMap;

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -50,29 +50,29 @@ class ClassLoader
      * @var array[]
      * @psalm-var array<string, array<string, int>>
      */
-    private $prefixLengthsPsr4 = array();
+    private $prefixLengthsPsr4 = [];
     /**
      * @var array[]
      * @psalm-var array<string, array<int, string>>
      */
-    private $prefixDirsPsr4 = array();
+    private $prefixDirsPsr4 = [];
     /**
      * @var array[]
      * @psalm-var array<string, string>
      */
-    private $fallbackDirsPsr4 = array();
+    private $fallbackDirsPsr4 = [];
 
     // PSR-0
     /**
      * @var array[]
      * @psalm-var array<string, array<string, string[]>>
      */
-    private $prefixesPsr0 = array();
+    private $prefixesPsr0 = [];
     /**
      * @var array[]
      * @psalm-var array<string, string>
      */
-    private $fallbackDirsPsr0 = array();
+    private $fallbackDirsPsr0 = [];
 
     /** @var bool */
     private $useIncludePath = false;
@@ -81,7 +81,7 @@ class ClassLoader
      * @var string[]
      * @psalm-var array<string, string>
      */
-    private $classMap = array();
+    private $classMap = [];
 
     /** @var bool */
     private $classMapAuthoritative = false;
@@ -90,7 +90,7 @@ class ClassLoader
      * @var bool[]
      * @psalm-var array<string, bool>
      */
-    private $missingClasses = array();
+    private $missingClasses = [];
 
     /** @var ?string */
     private $apcuPrefix;
@@ -98,7 +98,7 @@ class ClassLoader
     /**
      * @var self[]
      */
-    private static $registeredLoaders = array();
+    private static $registeredLoaders = [];
 
     /**
      * @param ?string $vendorDir
@@ -117,7 +117,7 @@ class ClassLoader
             return call_user_func_array('array_merge', array_values($this->prefixesPsr0));
         }
 
-        return array();
+        return [];
     }
 
     /**
@@ -388,14 +388,14 @@ class ClassLoader
      */
     public function register($prepend = false)
     {
-        spl_autoload_register(array($this, 'loadClass'), true, $prepend);
+        spl_autoload_register([$this, 'loadClass'], true, $prepend);
 
         if (null === $this->vendorDir) {
             return;
         }
 
         if ($prepend) {
-            self::$registeredLoaders = array($this->vendorDir => $this) + self::$registeredLoaders;
+            self::$registeredLoaders = [$this->vendorDir => $this] + self::$registeredLoaders;
         } else {
             unset(self::$registeredLoaders[$this->vendorDir]);
             self::$registeredLoaders[$this->vendorDir] = $this;
@@ -409,7 +409,7 @@ class ClassLoader
      */
     public function unregister()
     {
-        spl_autoload_unregister(array($this, 'loadClass'));
+        spl_autoload_unregister([$this, 'loadClass']);
 
         if (null !== $this->vendorDir) {
             unset(self::$registeredLoaders[$this->vendorDir]);

--- a/src/Composer/Autoload/ClassMapGenerator.php
+++ b/src/Composer/Autoload/ClassMapGenerator.php
@@ -41,7 +41,7 @@ class ClassMapGenerator
      */
     public static function dump(iterable $dirs, string $file): void
     {
-        $maps = array();
+        $maps = [];
 
         foreach ($dirs as $dir) {
             $maps = array_merge($maps, static::createMap($dir));
@@ -62,12 +62,12 @@ class ClassMapGenerator
      * @return array<class-string, string> A class map array
      * @throws \RuntimeException When the path is neither an existing file nor directory
      */
-    public static function createMap($path, string $excluded = null, IOInterface $io = null, ?string $namespace = null, ?string $autoloadType = null, array &$scannedFiles = array()): array
+    public static function createMap($path, string $excluded = null, IOInterface $io = null, ?string $namespace = null, ?string $autoloadType = null, array &$scannedFiles = []): array
     {
         $basePath = $path;
         if (is_string($path)) {
             if (is_file($path)) {
-                $path = array(new \SplFileInfo($path));
+                $path = [new \SplFileInfo($path)];
             } elseif (is_dir($path) || strpos($path, '*') !== false) {
                 $path = Finder::create()->files()->followLinks()->name('/\.(php|inc|hh)$/')->in($path);
             } else {
@@ -80,13 +80,13 @@ class ClassMapGenerator
             throw new \RuntimeException('Path must be a string when specifying an autoload type');
         }
 
-        $map = array();
+        $map = [];
         $filesystem = new Filesystem();
         $cwd = realpath(Platform::getCwd());
 
         foreach ($path as $file) {
             $filePath = $file->getPathname();
-            if (!in_array(pathinfo($filePath, PATHINFO_EXTENSION), array('php', 'inc', 'hh'))) {
+            if (!in_array(pathinfo($filePath, PATHINFO_EXTENSION), ['php', 'inc', 'hh'])) {
                 continue;
             }
 
@@ -160,8 +160,8 @@ class ClassMapGenerator
      */
     private static function filterByNamespace(array $classes, string $filePath, string $baseNamespace, string $namespaceType, string $basePath, ?IOInterface $io): array
     {
-        $validClasses = array();
-        $rejectedClasses = array();
+        $validClasses = [];
+        $rejectedClasses = [];
 
         $realSubPath = substr($filePath, strlen($basePath) + 1);
         $dotPosition = strrpos($realSubPath, '.');
@@ -203,7 +203,7 @@ class ClassMapGenerator
                 }
             }
 
-            return array();
+            return [];
         }
 
         return $validClasses;
@@ -230,7 +230,7 @@ class ClassMapGenerator
                 $message = 'File at "%s" is not readable, check its permissions';
             } elseif ('' === trim((string) file_get_contents($path))) {
                 // The input file was really empty and thus contains no classes
-                return array();
+                return [];
             } else {
                 $message = 'File at "%s" could not be parsed as PHP, it may be binary or corrupted';
             }
@@ -244,7 +244,7 @@ class ClassMapGenerator
         // return early if there is no chance of matching anything in this file
         Preg::matchAll('{\b(?:class|interface|trait'.$extraTypes.')\s}i', $contents, $matches);
         if (!$matches) {
-            return array();
+            return [];
         }
 
         $p = new PhpFileCleaner($contents, count($matches[0]));
@@ -258,12 +258,12 @@ class ClassMapGenerator
             )
         }ix', $contents, $matches);
 
-        $classes = array();
+        $classes = [];
         $namespace = '';
 
         for ($i = 0, $len = count($matches['type']); $i < $len; $i++) {
             if (!empty($matches['ns'][$i])) {
-                $namespace = str_replace(array(' ', "\t", "\r", "\n"), '', (string) $matches['nsname'][$i]) . '\\';
+                $namespace = str_replace([' ', "\t", "\r", "\n"], '', (string) $matches['nsname'][$i]) . '\\';
             } else {
                 $name = $matches['name'][$i];
                 // skip anon classes extending/implementing
@@ -272,7 +272,7 @@ class ClassMapGenerator
                 }
                 if ($name[0] === ':') {
                     // This is an XHP class, https://github.com/facebook/xhp
-                    $name = 'xhp'.substr(str_replace(array('-', ':'), array('_', '__'), $name), 1);
+                    $name = 'xhp'.substr(str_replace(['-', ':'], ['_', '__'], $name), 1);
                 } elseif (strtolower($matches['type'][$i]) === 'enum') {
                     // something like:
                     //   enum Foo: int { HERP = '123'; }

--- a/src/Composer/Autoload/PhpFileCleaner.php
+++ b/src/Composer/Autoload/PhpFileCleaner.php
@@ -54,11 +54,11 @@ class PhpFileCleaner
     public static function setTypeConfig(array $types): void
     {
         foreach ($types as $type) {
-            self::$typeConfig[$type[0]] = array(
+            self::$typeConfig[$type[0]] = [
                 'name' => $type,
                 'length' => \strlen($type),
                 'pattern' => '{.\b(?<![\$:>])'.$type.'\s++[a-zA-Z_\x7f-\xff:][a-zA-Z0-9_\x7f-\xff:\-]*+}Ais',
-            );
+            ];
         }
 
         self::$restPattern = '{[^?"\'</'.implode('', array_keys(self::$typeConfig)).']+}A';

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -51,7 +51,7 @@ class ArchiveCommand extends BaseCommand
         $this
             ->setName('archive')
             ->setDescription('Creates an archive of this composer package.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('package', InputArgument::OPTIONAL, 'The package to archive instead of the current project', null, $this->suggestAvailablePackage()),
                 new InputArgument('version', InputArgument::OPTIONAL, 'A version constraint to find the package to archive'),
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the resulting archive: tar, tar.gz, tar.bz2 or zip (default tar)', null, self::FORMATS),
@@ -59,7 +59,7 @@ class ArchiveCommand extends BaseCommand
                 new InputOption('file', null, InputOption::VALUE_REQUIRED, 'Write the archive with the given file name.'
                     .' Note that the format will be appended.'),
                 new InputOption('ignore-filters', null, InputOption::VALUE_NONE, 'Ignore filters when saving package'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>archive</info> command creates an archive of the specified format
@@ -161,7 +161,7 @@ EOT
 
         if ($composer = $this->tryComposer()) {
             $localRepo = $composer->getRepositoryManager()->getLocalRepository();
-            $repo = new CompositeRepository(array_merge(array($localRepo), $composer->getRepositoryManager()->getRepositories()));
+            $repo = new CompositeRepository(array_merge([$localRepo], $composer->getRepositoryManager()->getRepositories()));
         } else {
             $defaultRepos = RepositoryFactory::defaultReposWithDefaultManager($io);
             $io->writeError('No composer.json found in the current directory, searching packages from ' . implode(', ', array_keys($defaultRepos)));

--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -238,7 +238,7 @@ abstract class BaseCommand extends Command
             $composer->getEventDispatcher()->dispatch($preCommandRunEvent->getName(), $preCommandRunEvent);
         }
 
-        if (true === $input->hasParameterOption(array('--no-ansi')) && $input->hasOption('no-progress')) {
+        if (true === $input->hasParameterOption(['--no-ansi']) && $input->hasOption('no-progress')) {
             $input->setOption('no-progress', true);
         }
 
@@ -325,7 +325,7 @@ abstract class BaseCommand extends Command
             $preferDist = $input->getOption('prefer-dist');
         }
 
-        return array($preferSource, $preferDist);
+        return [$preferSource, $preferDist];
     }
 
     protected function getPlatformRequirementFilter(InputInterface $input): PlatformRequirementFilterInterface
@@ -353,7 +353,7 @@ abstract class BaseCommand extends Command
      */
     protected function formatRequirements(array $requirements)
     {
-        $requires = array();
+        $requires = [];
         $requirements = $this->normalizeRequirements($requirements);
         foreach ($requirements as $requirement) {
             if (!isset($requirement['version'])) {

--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -58,12 +58,12 @@ abstract class BaseDependencyCommand extends BaseCommand
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, $this->getName(), $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
 
-        $platformOverrides = $composer->getConfig()->get('platform') ?: array();
-        $installedRepo = new InstalledRepository(array(
+        $platformOverrides = $composer->getConfig()->get('platform') ?: [];
+        $installedRepo = new InstalledRepository([
             new RootPackageRepository($composer->getPackage()),
             $composer->getRepositoryManager()->getLocalRepository(),
-            new PlatformRepository(array(), $platformOverrides),
-        ));
+            new PlatformRepository([], $platformOverrides),
+        ]);
 
         // Parse package name and constraint
         list($needle, $textConstraint) = array_pad(
@@ -83,12 +83,12 @@ abstract class BaseDependencyCommand extends BaseCommand
         if (!$installedRepo->findPackage($needle, $textConstraint)) {
             $defaultRepos = new CompositeRepository(RepositoryFactory::defaultRepos($this->getIO(), $composer->getConfig(), $composer->getRepositoryManager()));
             if ($match = $defaultRepos->findPackage($needle, $textConstraint)) {
-                $installedRepo->addRepository(new InstalledArrayRepository(array(clone $match)));
+                $installedRepo->addRepository(new InstalledArrayRepository([clone $match]));
             }
         }
 
         // Include replaced packages for inverted lookups as they are then the actual starting point to consider
-        $needles = array($needle);
+        $needles = [$needle];
         if ($inverted) {
             foreach ($packages as $package) {
                 $needles = array_merge($needles, array_map(function (Link $link): string {
@@ -139,11 +139,11 @@ abstract class BaseDependencyCommand extends BaseCommand
      */
     protected function printTable(OutputInterface $output, $results): void
     {
-        $table = array();
-        $doubles = array();
+        $table = [];
+        $doubles = [];
         do {
-            $queue = array();
-            $rows = array();
+            $queue = [];
+            $rows = [];
             foreach ($results as $result) {
                 /**
                  * @var PackageInterface $package
@@ -156,7 +156,7 @@ abstract class BaseDependencyCommand extends BaseCommand
                 }
                 $doubles[$unique] = true;
                 $version = $package->getPrettyVersion() === RootPackage::DEFAULT_PRETTY_VERSION ? '-' : $package->getPrettyVersion();
-                $rows[] = array($package->getPrettyName(), $version, $link->getDescription(), sprintf('%s (%s)', $link->getTarget(), $link->getPrettyConstraint()));
+                $rows[] = [$package->getPrettyName(), $version, $link->getDescription(), sprintf('%s (%s)', $link->getTarget(), $link->getPrettyConstraint())];
                 if ($children) {
                     $queue = array_merge($queue, $children);
                 }
@@ -175,13 +175,13 @@ abstract class BaseDependencyCommand extends BaseCommand
      */
     protected function initStyles(OutputInterface $output): void
     {
-        $this->colors = array(
+        $this->colors = [
             'green',
             'yellow',
             'cyan',
             'magenta',
             'blue',
-        );
+        ];
 
         foreach ($this->colors as $color) {
             $style = new OutputFormatterStyle($color);
@@ -228,7 +228,7 @@ abstract class BaseDependencyCommand extends BaseCommand
     {
         $io = $this->getIO();
         if (!$io->isDecorated()) {
-            $line = str_replace(array('└', '├', '──', '│'), array('`-', '|-', '-', '|'), $line);
+            $line = str_replace(['└', '├', '──', '│'], ['`-', '|-', '-', '|'], $line);
         }
 
         $io->write($line);

--- a/src/Composer/Command/BumpCommand.php
+++ b/src/Composer/Command/BumpCommand.php
@@ -52,11 +52,11 @@ final class BumpCommand extends BaseCommand
         $this
             ->setName('bump')
             ->setDescription('Increases the lower limit of your composer.json requirements to the currently installed versions.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Optional package name(s) to restrict which packages are bumped.', null, $this->suggestRootRequirement()),
                 new InputOption('dev-only', 'D', InputOption::VALUE_NONE, 'Only bump requirements in "require-dev".'),
                 new InputOption('no-dev-only', 'R', InputOption::VALUE_NONE, 'Only bump requirements in "require".'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>bump</info> command increases the lower limit of your composer.json requirements

--- a/src/Composer/Command/CheckPlatformReqsCommand.php
+++ b/src/Composer/Command/CheckPlatformReqsCommand.php
@@ -30,10 +30,10 @@ class CheckPlatformReqsCommand extends BaseCommand
     {
         $this->setName('check-platform-reqs')
             ->setDescription('Check that platform requirements are satisfied.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables checking of require-dev packages requirements.'),
                 new InputOption('lock', null, InputOption::VALUE_NONE, 'Checks requirements only from the lock file, not from installed packages.'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 Checks that your PHP and extensions versions match the platform requirements of the installed packages.
@@ -50,8 +50,8 @@ EOT
     {
         $composer = $this->requireComposer();
 
-        $requires = array();
-        $removePackages = array();
+        $requires = [];
+        $removePackages = [];
         if ($input->getOption('lock')) {
             $this->getIO()->writeError('<info>Checking '.($input->getOption('no-dev') ? 'non-dev ' : '').'platform requirements using the lock file</info>');
             $installedRepo = $composer->getLocker()->getLockedRepository(!$input->getOption('no-dev'));
@@ -74,10 +74,10 @@ EOT
         }
 
         foreach ($requires as $require => $link) {
-            $requires[$require] = array($link);
+            $requires[$require] = [$link];
         }
 
-        $installedRepo = new InstalledRepository(array($installedRepo, new RootPackageRepository($composer->getPackage())));
+        $installedRepo = new InstalledRepository([$installedRepo, new RootPackageRepository($composer->getPackage())]);
         foreach ($installedRepo->getPackages() as $package) {
             if (in_array($package->getName(), $removePackages, true)) {
                 continue;
@@ -89,9 +89,9 @@ EOT
 
         ksort($requires);
 
-        $installedRepo->addRepository(new PlatformRepository(array(), array()));
+        $installedRepo->addRepository(new PlatformRepository([], []));
 
-        $results = array();
+        $results = [];
         $exitCode = 0;
 
         /**
@@ -101,7 +101,7 @@ EOT
             if (PlatformRepository::isPlatformPackage($require)) {
                 $candidates = $installedRepo->findPackagesWithReplacersAndProviders($require);
                 if ($candidates) {
-                    $reqResults = array();
+                    $reqResults = [];
                     foreach ($candidates as $candidate) {
                         $candidateConstraint = null;
                         if ($candidate->getName() === $require) {
@@ -123,24 +123,24 @@ EOT
 
                         foreach ($links as $link) {
                             if (!$link->getConstraint()->matches($candidateConstraint)) {
-                                $reqResults[] = array(
+                                $reqResults[] = [
                                     $candidate->getName() === $require ? $candidate->getPrettyName() : $require,
                                     $candidateConstraint->getPrettyString(),
                                     $link,
                                     '<error>failed</error>'.($candidate->getName() === $require ? '' : ' <comment>provided by '.$candidate->getPrettyName().'</comment>'),
-                                );
+                                ];
 
                                 // skip to next candidate
                                 continue 2;
                             }
                         }
 
-                        $results[] = array(
+                        $results[] = [
                             $candidate->getName() === $require ? $candidate->getPrettyName() : $require,
                             $candidateConstraint->getPrettyString(),
                             null,
                             '<info>success</info>'.($candidate->getName() === $require ? '' : ' <comment>provided by '.$candidate->getPrettyName().'</comment>'),
-                        );
+                        ];
 
                         // candidate matched, skip to next requirement
                         continue 2;
@@ -153,12 +153,12 @@ EOT
                     continue;
                 }
 
-                $results[] = array(
+                $results[] = [
                     $require,
                     'n/a',
                     $links[0],
                     '<error>missing</error>',
-                );
+                ];
 
                 $exitCode = max($exitCode, 2);
             }
@@ -176,18 +176,18 @@ EOT
      */
     protected function printTable(OutputInterface $output, array $results): void
     {
-        $rows = array();
+        $rows = [];
         foreach ($results as $result) {
             /**
              * @var Link|null $link
              */
             list($platformPackage, $version, $link, $status) = $result;
-            $rows[] = array(
+            $rows[] = [
                 $platformPackage,
                 $version,
                 $link ? sprintf('%s %s %s (%s)', $link->getSource(), $link->getDescription(), $link->getTarget(), $link->getPrettyConstraint()) : '',
                 $status,
-            );
+            ];
         }
 
         $this->renderTable($rows, $output);

--- a/src/Composer/Command/ClearCacheCommand.php
+++ b/src/Composer/Command/ClearCacheCommand.php
@@ -30,11 +30,11 @@ class ClearCacheCommand extends BaseCommand
     {
         $this
             ->setName('clear-cache')
-            ->setAliases(array('clearcache', 'cc'))
+            ->setAliases(['clearcache', 'cc'])
             ->setDescription('Clears composer\'s internal package cache.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('gc', null, InputOption::VALUE_NONE, 'Only run garbage collection, not a full cache clear'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>clear-cache</info> deletes all cached packages from composer's
@@ -51,12 +51,12 @@ EOT
         $config = Factory::createConfig();
         $io = $this->getIO();
 
-        $cachePaths = array(
+        $cachePaths = [
             'cache-vcs-dir' => $config->get('cache-vcs-dir'),
             'cache-repo-dir' => $config->get('cache-repo-dir'),
             'cache-files-dir' => $config->get('cache-files-dir'),
             'cache-dir' => $config->get('cache-dir'),
-        );
+        ];
 
         foreach ($cachePaths as $key => $cachePath) {
             // only individual dirs get garbage collected

--- a/src/Composer/Command/CompletionTrait.php
+++ b/src/Composer/Command/CompletionTrait.php
@@ -76,9 +76,9 @@ trait CompletionTrait
             $platformHint = [];
             if ($includePlatformPackages) {
                 if ($locker->isLocked()) {
-                    $platformRepo = new PlatformRepository(array(), $locker->getPlatformOverrides());
+                    $platformRepo = new PlatformRepository([], $locker->getPlatformOverrides());
                 } else {
-                    $platformRepo = new PlatformRepository(array(), $composer->getConfig()->get('platform'));
+                    $platformRepo = new PlatformRepository([], $composer->getConfig()->get('platform'));
                 }
                 if ($input->getCompletionValue() === '') {
                     // to reduce noise, when no text is yet entered we list only two entries for ext- and lib- prefixes

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -67,7 +67,7 @@ class ConfigCommand extends BaseCommand
         $this
             ->setName('config')
             ->setDescription('Sets config options.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('global', 'g', InputOption::VALUE_NONE, 'Apply command to the global config file'),
                 new InputOption('editor', 'e', InputOption::VALUE_NONE, 'Open editor'),
                 new InputOption('auth', 'a', InputOption::VALUE_NONE, 'Affect auth config file (only used for --editor)'),
@@ -81,7 +81,7 @@ class ConfigCommand extends BaseCommand
                 new InputOption('source', null, InputOption::VALUE_NONE, 'Display where the config value is loaded from'),
                 new InputArgument('setting-key', null, 'Setting key'),
                 new InputArgument('setting-value', InputArgument::IS_ARRAY, 'Setting value'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 This command allows you to edit composer config settings and repositories
@@ -193,12 +193,12 @@ EOT
         // Initialize the global file if it's not there, ignoring any warnings or notices
         if ($input->getOption('global') && !$this->configFile->exists()) {
             touch($this->configFile->getPath());
-            $this->configFile->write(array('config' => new \ArrayObject));
+            $this->configFile->write(['config' => new \ArrayObject]);
             Silencer::call('chmod', $this->configFile->getPath(), 0600);
         }
         if ($input->getOption('global') && !$this->authConfigFile->exists()) {
             touch($this->authConfigFile->getPath());
-            $this->authConfigFile->write(array('bitbucket-oauth' => new \ArrayObject, 'github-oauth' => new \ArrayObject, 'gitlab-oauth' => new \ArrayObject, 'gitlab-token' => new \ArrayObject, 'http-basic' => new \ArrayObject, 'bearer' => new \ArrayObject));
+            $this->authConfigFile->write(['bitbucket-oauth' => new \ArrayObject, 'github-oauth' => new \ArrayObject, 'gitlab-oauth' => new \ArrayObject, 'gitlab-token' => new \ArrayObject, 'http-basic' => new \ArrayObject, 'bearer' => new \ArrayObject]);
             Silencer::call('chmod', $this->authConfigFile->getPath(), 0600);
         }
 
@@ -219,7 +219,7 @@ EOT
                 if (Platform::isWindows()) {
                     $editor = 'notepad';
                 } else {
-                    foreach (array('editor', 'vim', 'vi', 'nano', 'pico', 'ed') as $candidate) {
+                    foreach (['editor', 'vim', 'vi', 'nano', 'pico', 'ed'] as $candidate) {
                         if (exec('which '.$candidate)) {
                             $editor = $candidate;
                             break;
@@ -238,7 +238,7 @@ EOT
 
         if (false === $input->getOption('global')) {
             $this->config->merge($this->configFile->read(), $this->configFile->getPath());
-            $this->config->merge(array('config' => $this->authConfigFile->exists() ? $this->authConfigFile->read() : array()), $this->authConfigFile->getPath());
+            $this->config->merge(['config' => $this->authConfigFile->exists() ? $this->authConfigFile->read() : []], $this->authConfigFile->getPath());
         }
 
         // List the configuration of the file settings
@@ -254,18 +254,18 @@ EOT
         }
 
         // If the user enters in a config variable, parse it and save to file
-        if (array() !== $input->getArgument('setting-value') && $input->getOption('unset')) {
+        if ([] !== $input->getArgument('setting-value') && $input->getOption('unset')) {
             throw new \RuntimeException('You can not combine a setting value with --unset');
         }
 
         // show the value if no value is provided
-        if (array() === $input->getArgument('setting-value') && !$input->getOption('unset')) {
-            $properties = array('name', 'type', 'description', 'homepage', 'version', 'minimum-stability', 'prefer-stable', 'keywords', 'license', 'extra');
+        if ([] === $input->getArgument('setting-value') && !$input->getOption('unset')) {
+            $properties = ['name', 'type', 'description', 'homepage', 'version', 'minimum-stability', 'prefer-stable', 'keywords', 'license', 'extra'];
             $rawData = $this->configFile->read();
             $data = $this->config->all();
             if (Preg::isMatch('/^repos?(?:itories)?(?:\.(.+))?/', $settingKey, $matches)) {
                 if (!isset($matches[1]) || $matches[1] === '') {
-                    $value = $data['repositories'] ?? array();
+                    $value = $data['repositories'] ?? [];
                 } else {
                     if (!isset($data['repositories'][$matches[1]])) {
                         throw new \InvalidArgumentException('There is no '.$matches[1].' repository defined');
@@ -321,36 +321,36 @@ EOT
         $values = $input->getArgument('setting-value'); // what the user is trying to add/change
 
         $booleanValidator = function ($val): bool {
-            return in_array($val, array('true', 'false', '1', '0'), true);
+            return in_array($val, ['true', 'false', '1', '0'], true);
         };
         $booleanNormalizer = function ($val): bool {
             return $val !== 'false' && (bool) $val;
         };
 
         // handle config values
-        $uniqueConfigValues = array(
-            'process-timeout' => array('is_numeric', 'intval'),
-            'use-include-path' => array($booleanValidator, $booleanNormalizer),
-            'use-github-api' => array($booleanValidator, $booleanNormalizer),
-            'preferred-install' => array(
+        $uniqueConfigValues = [
+            'process-timeout' => ['is_numeric', 'intval'],
+            'use-include-path' => [$booleanValidator, $booleanNormalizer],
+            'use-github-api' => [$booleanValidator, $booleanNormalizer],
+            'preferred-install' => [
                 function ($val): bool {
-                    return in_array($val, array('auto', 'source', 'dist'), true);
+                    return in_array($val, ['auto', 'source', 'dist'], true);
                 },
                 function ($val) {
                     return $val;
                 },
-            ),
-            'gitlab-protocol' => array(
+            ],
+            'gitlab-protocol' => [
                 function ($val): bool {
-                    return in_array($val, array('git', 'http', 'https'), true);
+                    return in_array($val, ['git', 'http', 'https'], true);
                 },
                 function ($val) {
                     return $val;
                 },
-            ),
-            'store-auths' => array(
+            ],
+            'store-auths' => [
                 function ($val): bool {
-                    return in_array($val, array('true', 'false', 'prompt'), true);
+                    return in_array($val, ['true', 'false', 'prompt'], true);
                 },
                 function ($val) {
                     if ('prompt' === $val) {
@@ -359,56 +359,56 @@ EOT
 
                     return $val !== 'false' && (bool) $val;
                 },
-            ),
-            'notify-on-install' => array($booleanValidator, $booleanNormalizer),
-            'vendor-dir' => array('is_string', function ($val) {
+            ],
+            'notify-on-install' => [$booleanValidator, $booleanNormalizer],
+            'vendor-dir' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'bin-dir' => array('is_string', function ($val) {
+            }],
+            'bin-dir' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'archive-dir' => array('is_string', function ($val) {
+            }],
+            'archive-dir' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'archive-format' => array('is_string', function ($val) {
+            }],
+            'archive-format' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'data-dir' => array('is_string', function ($val) {
+            }],
+            'data-dir' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'cache-dir' => array('is_string', function ($val) {
+            }],
+            'cache-dir' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'cache-files-dir' => array('is_string', function ($val) {
+            }],
+            'cache-files-dir' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'cache-repo-dir' => array('is_string', function ($val) {
+            }],
+            'cache-repo-dir' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'cache-vcs-dir' => array('is_string', function ($val) {
+            }],
+            'cache-vcs-dir' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'cache-ttl' => array('is_numeric', 'intval'),
-            'cache-files-ttl' => array('is_numeric', 'intval'),
-            'cache-files-maxsize' => array(
+            }],
+            'cache-ttl' => ['is_numeric', 'intval'],
+            'cache-files-ttl' => ['is_numeric', 'intval'],
+            'cache-files-maxsize' => [
                 function ($val): bool {
                     return Preg::isMatch('/^\s*([0-9.]+)\s*(?:([kmg])(?:i?b)?)?\s*$/i', $val);
                 },
                 function ($val) {
                     return $val;
                 },
-            ),
-            'bin-compat' => array(
+            ],
+            'bin-compat' => [
                 function ($val): bool {
-                    return in_array($val, array('auto', 'full', 'symlink'));
+                    return in_array($val, ['auto', 'full', 'symlink']);
                 },
                 function ($val) {
                     return $val;
                 },
-            ),
-            'discard-changes' => array(
+            ],
+            'discard-changes' => [
                 function ($val): bool {
-                    return in_array($val, array('stash', 'true', 'false', '1', '0'), true);
+                    return in_array($val, ['stash', 'true', 'false', '1', '0'], true);
                 },
                 function ($val) {
                     if ('stash' === $val) {
@@ -417,40 +417,40 @@ EOT
 
                     return $val !== 'false' && (bool) $val;
                 },
-            ),
-            'autoloader-suffix' => array('is_string', function ($val) {
+            ],
+            'autoloader-suffix' => ['is_string', function ($val) {
                 return $val === 'null' ? null : $val;
-            }),
-            'sort-packages' => array($booleanValidator, $booleanNormalizer),
-            'optimize-autoloader' => array($booleanValidator, $booleanNormalizer),
-            'classmap-authoritative' => array($booleanValidator, $booleanNormalizer),
-            'apcu-autoloader' => array($booleanValidator, $booleanNormalizer),
-            'prepend-autoloader' => array($booleanValidator, $booleanNormalizer),
-            'disable-tls' => array($booleanValidator, $booleanNormalizer),
-            'secure-http' => array($booleanValidator, $booleanNormalizer),
-            'cafile' => array(
+            }],
+            'sort-packages' => [$booleanValidator, $booleanNormalizer],
+            'optimize-autoloader' => [$booleanValidator, $booleanNormalizer],
+            'classmap-authoritative' => [$booleanValidator, $booleanNormalizer],
+            'apcu-autoloader' => [$booleanValidator, $booleanNormalizer],
+            'prepend-autoloader' => [$booleanValidator, $booleanNormalizer],
+            'disable-tls' => [$booleanValidator, $booleanNormalizer],
+            'secure-http' => [$booleanValidator, $booleanNormalizer],
+            'cafile' => [
                 function ($val): bool {
                     return file_exists($val) && Filesystem::isReadable($val);
                 },
                 function ($val) {
                     return $val === 'null' ? null : $val;
                 },
-            ),
-            'capath' => array(
+            ],
+            'capath' => [
                 function ($val): bool {
                     return is_dir($val) && Filesystem::isReadable($val);
                 },
                 function ($val) {
                     return $val === 'null' ? null : $val;
                 },
-            ),
-            'github-expose-hostname' => array($booleanValidator, $booleanNormalizer),
-            'htaccess-protect' => array($booleanValidator, $booleanNormalizer),
-            'lock' => array($booleanValidator, $booleanNormalizer),
-            'allow-plugins' => array($booleanValidator, $booleanNormalizer),
-            'platform-check' => array(
+            ],
+            'github-expose-hostname' => [$booleanValidator, $booleanNormalizer],
+            'htaccess-protect' => [$booleanValidator, $booleanNormalizer],
+            'lock' => [$booleanValidator, $booleanNormalizer],
+            'allow-plugins' => [$booleanValidator, $booleanNormalizer],
+            'platform-check' => [
                 function ($val): bool {
-                    return in_array($val, array('php-only', 'true', 'false', '1', '0'), true);
+                    return in_array($val, ['php-only', 'true', 'false', '1', '0'], true);
                 },
                 function ($val) {
                     if ('php-only' === $val) {
@@ -459,10 +459,10 @@ EOT
 
                     return $val !== 'false' && (bool) $val;
                 },
-            ),
-            'use-parent-dir' => array(
+            ],
+            'use-parent-dir' => [
                 function ($val): bool {
-                    return in_array($val, array('true', 'false', 'prompt'), true);
+                    return in_array($val, ['true', 'false', 'prompt'], true);
                 },
                 function ($val) {
                     if ('prompt' === $val) {
@@ -471,17 +471,17 @@ EOT
 
                     return $val !== 'false' && (bool) $val;
                 },
-            ),
-        );
-        $multiConfigValues = array(
-            'github-protocols' => array(
+            ],
+        ];
+        $multiConfigValues = [
+            'github-protocols' => [
                 function ($vals) {
                     if (!is_array($vals)) {
                         return 'array expected';
                     }
 
                     foreach ($vals as $val) {
-                        if (!in_array($val, array('git', 'https', 'ssh'))) {
+                        if (!in_array($val, ['git', 'https', 'ssh'])) {
                             return 'valid protocols include: git, https, ssh';
                         }
                     }
@@ -491,8 +491,8 @@ EOT
                 function ($vals) {
                     return $vals;
                 },
-            ),
-            'github-domains' => array(
+            ],
+            'github-domains' => [
                 function ($vals) {
                     if (!is_array($vals)) {
                         return 'array expected';
@@ -503,8 +503,8 @@ EOT
                 function ($vals) {
                     return $vals;
                 },
-            ),
-            'gitlab-domains' => array(
+            ],
+            'gitlab-domains' => [
                 function ($vals) {
                     if (!is_array($vals)) {
                         return 'array expected';
@@ -515,8 +515,8 @@ EOT
                 function ($vals) {
                     return $vals;
                 },
-            ),
-        );
+            ],
+        ];
 
         if ($input->getOption('unset') && (isset($uniqueConfigValues[$settingKey]) || isset($multiConfigValues[$settingKey]))) {
             if ($settingKey === 'disable-tls' && $this->config->get('disable-tls')) {
@@ -578,34 +578,34 @@ EOT
         }
 
         // handle properties
-        $uniqueProps = array(
-            'name' => array('is_string', function ($val) {
+        $uniqueProps = [
+            'name' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'type' => array('is_string', function ($val) {
+            }],
+            'type' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'description' => array('is_string', function ($val) {
+            }],
+            'description' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'homepage' => array('is_string', function ($val) {
+            }],
+            'homepage' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'version' => array('is_string', function ($val) {
+            }],
+            'version' => ['is_string', function ($val) {
                 return $val;
-            }),
-            'minimum-stability' => array(
+            }],
+            'minimum-stability' => [
                 function ($val): bool {
                     return isset(BasePackage::$stabilities[VersionParser::normalizeStability($val)]);
                 },
                 function ($val): string {
                     return VersionParser::normalizeStability($val);
                 },
-            ),
-            'prefer-stable' => array($booleanValidator, $booleanNormalizer),
-        );
-        $multiProps = array(
-            'keywords' => array(
+            ],
+            'prefer-stable' => [$booleanValidator, $booleanNormalizer],
+        ];
+        $multiProps = [
+            'keywords' => [
                 function ($vals) {
                     if (!is_array($vals)) {
                         return 'array expected';
@@ -616,8 +616,8 @@ EOT
                 function ($vals) {
                     return $vals;
                 },
-            ),
-            'license' => array(
+            ],
+            'license' => [
                 function ($vals) {
                     if (!is_array($vals)) {
                         return 'array expected';
@@ -628,8 +628,8 @@ EOT
                 function ($vals) {
                     return $vals;
                 },
-            ),
-        );
+            ],
+        ];
 
         if ($input->getOption('global') && (isset($uniqueProps[$settingKey]) || isset($multiProps[$settingKey]) || strpos($settingKey, 'extra.') === 0)) {
             throw new \InvalidArgumentException('The ' . $settingKey . ' property can not be set in the global config.json file. Use `composer global config` to apply changes to the global composer.json');
@@ -659,10 +659,10 @@ EOT
             }
 
             if (2 === count($values)) {
-                $this->configSource->addRepository($matches[1], array(
+                $this->configSource->addRepository($matches[1], [
                     'type' => $values[0],
                     'url' => $values[1],
-                ), $input->getOption('append'));
+                ], $input->getOption('append'));
 
                 return 0;
             }
@@ -727,7 +727,7 @@ EOT
         }
 
         // handle unsetting extra/suggest
-        if (in_array($settingKey, array('suggest', 'extra'), true) && $input->getOption('unset')) {
+        if (in_array($settingKey, ['suggest', 'extra'], true) && $input->getOption('unset')) {
             $this->configSource->removeProperty($settingKey);
 
             return 0;
@@ -767,11 +767,11 @@ EOT
                     throw new \RuntimeException('Expected two arguments (consumer-key, consumer-secret), got '.count($values));
                 }
                 $this->configSource->removeConfigSetting($matches[1].'.'.$matches[2]);
-                $this->authConfigSource->addConfigSetting($matches[1].'.'.$matches[2], array('consumer-key' => $values[0], 'consumer-secret' => $values[1]));
+                $this->authConfigSource->addConfigSetting($matches[1].'.'.$matches[2], ['consumer-key' => $values[0], 'consumer-secret' => $values[1]]);
             } elseif ($matches[1] === 'gitlab-token' && 2 === count($values)) {
                 $this->configSource->removeConfigSetting($matches[1].'.'.$matches[2]);
-                $this->authConfigSource->addConfigSetting($matches[1].'.'.$matches[2], array('username' => $values[0], 'token' => $values[1]));
-            } elseif (in_array($matches[1], array('github-oauth', 'gitlab-oauth', 'gitlab-token', 'bearer'), true)) {
+                $this->authConfigSource->addConfigSetting($matches[1].'.'.$matches[2], ['username' => $values[0], 'token' => $values[1]]);
+            } elseif (in_array($matches[1], ['github-oauth', 'gitlab-oauth', 'gitlab-token', 'bearer'], true)) {
                 if (1 !== count($values)) {
                     throw new \RuntimeException('Too many arguments, expected only one token');
                 }
@@ -782,7 +782,7 @@ EOT
                     throw new \RuntimeException('Expected two arguments (username, password), got '.count($values));
                 }
                 $this->configSource->removeConfigSetting($matches[1].'.'.$matches[2]);
-                $this->authConfigSource->addConfigSetting($matches[1].'.'.$matches[2], array('username' => $values[0], 'password' => $values[1]));
+                $this->authConfigSource->addConfigSetting($matches[1].'.'.$matches[2], ['username' => $values[0], 'password' => $values[1]]);
             }
 
             return 0;
@@ -843,7 +843,7 @@ EOT
             }
         }
 
-        call_user_func(array($this->configSource, $method), $key, $normalizedValue);
+        call_user_func([$this->configSource, $method], $key, $normalizedValue);
     }
 
     /**
@@ -864,7 +864,7 @@ EOT
             ));
         }
 
-        call_user_func(array($this->configSource, $method), $key, $normalizer($values));
+        call_user_func([$this->configSource, $method], $key, $normalizer($values));
     }
 
     /**
@@ -882,7 +882,7 @@ EOT
         $origK = $k;
         $io = $this->getIO();
         foreach ($contents as $key => $value) {
-            if ($k === null && !in_array($key, array('config', 'repositories'))) {
+            if ($k === null && !in_array($key, ['config', 'repositories'])) {
                 continue;
             }
 

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -70,7 +70,7 @@ class CreateProjectCommand extends BaseCommand
         $this
             ->setName('create-project')
             ->setDescription('Creates new project from a package into given directory.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package name to be installed', null, $this->suggestAvailablePackage()),
                 new InputArgument('directory', InputArgument::OPTIONAL, 'Directory where the files should be created'),
                 new InputArgument('version', InputArgument::OPTIONAL, 'Version, will default to latest'),
@@ -93,7 +93,7 @@ class CreateProjectCommand extends BaseCommand
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
                 new InputOption('ask', null, InputOption::VALUE_NONE, 'Whether to ask for project directory.'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>create-project</info> command creates a new project from a given
@@ -225,8 +225,8 @@ EOT
                 $configSource = new JsonConfigSource(new JsonFile('composer.json'));
 
                 if (
-                    (isset($repoConfig['packagist']) && $repoConfig === array('packagist' => false))
-                    || (isset($repoConfig['packagist.org']) && $repoConfig === array('packagist.org' => false))
+                    (isset($repoConfig['packagist']) && $repoConfig === ['packagist' => false])
+                    || (isset($repoConfig['packagist.org']) && $repoConfig === ['packagist.org' => false])
                 ) {
                     $configSource->addRepository('packagist.org', false);
                 } else {
@@ -287,7 +287,7 @@ EOT
         ) {
             $finder = new Finder();
             $finder->depth(0)->directories()->in(Platform::getCwd())->ignoreVCS(false)->ignoreDotFiles(false);
-            foreach (array('.svn', '_svn', 'CVS', '_darcs', '.arch-params', '.monotone', '.bzr', '.git', '.hg', '.fslckout', '_FOSSIL_') as $vcsName) {
+            foreach (['.svn', '_svn', 'CVS', '_darcs', '.arch-params', '.monotone', '.bzr', '.git', '.hg', '.fslckout', '_FOSSIL_'] as $vcsName) {
                 $finder->name($vcsName);
             }
 
@@ -355,11 +355,11 @@ EOT
     protected function installRootPackage(IOInterface $io, Config $config, string $packageName, PlatformRequirementFilterInterface $platformRequirementFilter, ?string $directory = null, ?string $packageVersion = null, ?string $stability = 'stable', bool $preferSource = false, bool $preferDist = false, bool $installDevPackages = false, array $repositories = null, bool $disablePlugins = false, bool $disableScripts = false, bool $noProgress = false, bool $secureHttp = true): bool
     {
         if (!$secureHttp) {
-            $config->merge(array('config' => array('secure-http' => false)), Config::SOURCE_COMMAND);
+            $config->merge(['config' => ['secure-http' => false]], Config::SOURCE_COMMAND);
         }
 
         $parser = new VersionParser();
-        $requirements = $parser->parseNameVersionPairs(array($packageName));
+        $requirements = $parser->parseNameVersionPairs([$packageName]);
         $name = strtolower($requirements[0]['name']);
         if (!$packageVersion && isset($requirements[0]['version'])) {
             $packageVersion = $requirements[0]['version'];
@@ -415,8 +415,8 @@ EOT
             foreach ($repositories as $repo) {
                 $repoConfig = RepositoryFactory::configFromString($io, $config, $repo, true);
                 if (
-                    (isset($repoConfig['packagist']) && $repoConfig === array('packagist' => false))
-                    || (isset($repoConfig['packagist.org']) && $repoConfig === array('packagist.org' => false))
+                    (isset($repoConfig['packagist']) && $repoConfig === ['packagist' => false])
+                    || (isset($repoConfig['packagist.org']) && $repoConfig === ['packagist.org' => false])
                 ) {
                     continue;
                 }
@@ -425,7 +425,7 @@ EOT
         }
 
         $platformOverrides = $config->get('platform');
-        $platformRepo = new PlatformRepository(array(), $platformOverrides);
+        $platformRepo = new PlatformRepository([], $platformOverrides);
 
         // find the latest version if there are multiple
         $versionSelector = new VersionSelector($repositorySet, $platformRepo);
@@ -487,7 +487,7 @@ EOT
         $im = $composer->getInstallationManager();
         $im->setOutputProgress(!$noProgress);
         $im->addInstaller($projectInstaller);
-        $im->execute(new InstalledArrayRepository(), array(new InstallOperation($package)));
+        $im->execute(new InstalledArrayRepository(), [new InstallOperation($package)]);
         $im->notifyInstalls($io);
 
         // collect suggestions

--- a/src/Composer/Command/DependsCommand.php
+++ b/src/Composer/Command/DependsCommand.php
@@ -33,13 +33,13 @@ class DependsCommand extends BaseDependencyCommand
     {
         $this
             ->setName('depends')
-            ->setAliases(array('why'))
+            ->setAliases(['why'])
             ->setDescription('Shows which packages cause the given package to be installed.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect', null, $this->suggestInstalledPackage(true)),
                 new InputOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package'),
                 new InputOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 Displays detailed information about where a package is referenced.

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -91,7 +91,7 @@ EOT
             $config = Factory::createConfig();
         }
 
-        $config->merge(array('config' => array('secure-http' => false)), Config::SOURCE_COMMAND);
+        $config->merge(['config' => ['secure-http' => false]], Config::SOURCE_COMMAND);
         $config->prohibitUrlByConfig('http://repo.packagist.org', new NullIO);
 
         $this->httpDownloader = Factory::createHttpDownloader($io, $config);
@@ -161,8 +161,8 @@ EOT
 
         $io->write(sprintf('Composer version: <comment>%s</comment>', Composer::getVersion()));
 
-        $platformOverrides = $config->get('platform') ?: array();
-        $platformRepo = new PlatformRepository(array(), $platformOverrides);
+        $platformOverrides = $config->get('platform') ?: [];
+        $platformRepo = new PlatformRepository([], $platformOverrides);
         $phpPkg = $platformRepo->findPackage('php', '*');
         $phpVersion = $phpPkg->getPrettyVersion();
         if ($phpPkg instanceof CompletePackageInterface && false !== strpos($phpPkg->getDescription(), 'overridden')) {
@@ -181,7 +181,7 @@ EOT
         $finder = new ExecutableFinder;
         $hasSystemUnzip = (bool) $finder->find('unzip');
         $bin7zip = '';
-        if ($hasSystem7zip = (bool) $finder->find('7z', null, array('C:\Program Files\7-Zip'))) {
+        if ($hasSystem7zip = (bool) $finder->find('7z', null, ['C:\Program Files\7-Zip'])) {
             $bin7zip = '7z';
         }
         if (!Platform::isWindows() && !$hasSystem7zip && $hasSystem7zip = (bool) $finder->find('7zz')) {
@@ -207,10 +207,10 @@ EOT
         list($errors, , $warnings) = $validator->validate(Factory::getComposerFile());
 
         if ($errors || $warnings) {
-            $messages = array(
+            $messages = [
                 'error' => $errors,
                 'warning' => $warnings,
-            );
+            ];
 
             $output = '';
             foreach ($messages as $style => $msgs) {
@@ -254,7 +254,7 @@ EOT
             return $result;
         }
 
-        $result = array();
+        $result = [];
         if ($proto === 'https' && $config->get('disable-tls') === true) {
             $tlsWarning = '<warning>Composer is configured to disable SSL/TLS protection. This will leave remote HTTPS requests vulnerable to Man-In-The-Middle attacks.</warning>';
         }
@@ -328,9 +328,9 @@ EOT
         try {
             $url = $domain === 'github.com' ? 'https://api.'.$domain.'/' : 'https://'.$domain.'/api/v3/';
 
-            $this->httpDownloader->get($url, array(
+            $this->httpDownloader->get($url, [
                 'retry-auth-failure' => false,
-            ));
+            ]);
 
             return true;
         } catch (\Exception $e) {
@@ -360,7 +360,7 @@ EOT
         }
 
         $url = $domain === 'github.com' ? 'https://api.'.$domain.'/rate_limit' : 'https://'.$domain.'/api/rate_limit';
-        $data = $this->httpDownloader->get($url, array('retry-auth-failure' => false))->decodeJson();
+        $data = $this->httpDownloader->get($url, ['retry-auth-failure' => false])->decodeJson();
 
         return $data['resources']['core'];
     }
@@ -386,7 +386,7 @@ EOT
     private function checkPubKeys(Config $config)
     {
         $home = $config->get('home');
-        $errors = array();
+        $errors = [];
         $io = $this->getIO();
 
         if (file_exists($home.'/keys.tags.pub') && file_exists($home.'/keys.dev.pub')) {
@@ -481,7 +481,7 @@ EOT
             $hadError = true;
         } else {
             if (!is_array($result)) {
-                $result = array($result);
+                $result = [$result];
             }
             foreach ($result as $message) {
                 if (false !== strpos($message, '<error>')) {
@@ -518,8 +518,8 @@ EOT
         };
 
         // code below taken from getcomposer.org/installer, any changes should be made there and replicated here
-        $errors = array();
-        $warnings = array();
+        $errors = [];
+        $warnings = [];
         $displayIniMessage = false;
 
         $iniMessage = PHP_EOL.PHP_EOL.IniHelper::getMessage();

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -30,9 +30,9 @@ class DumpAutoloadCommand extends BaseCommand
     {
         $this
             ->setName('dump-autoload')
-            ->setAliases(array('dumpautoload'))
+            ->setAliases(['dumpautoload'])
             ->setDescription('Dumps the autoloader.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('optimize', 'o', InputOption::VALUE_NONE, 'Optimizes PSR0 and PSR4 packages to be loaded with classmaps too, good for production.'),
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.'),
                 new InputOption('apcu', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
@@ -41,7 +41,7 @@ class DumpAutoloadCommand extends BaseCommand
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables autoload-dev rules. Composer will by default infer this automatically according to the last install or update --no-dev state.'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 <info>php composer.phar dump-autoload</info>

--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -30,7 +30,7 @@ class ExecCommand extends BaseCommand
         $this
             ->setName('exec')
             ->setDescription('Executes a vendored binary/script.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('list', 'l', InputOption::VALUE_NONE),
                 new InputArgument('binary', InputArgument::OPTIONAL, 'The binary to run, e.g. phpunit', null, function () {
                     return $this->getBinaries(false);
@@ -40,7 +40,7 @@ class ExecCommand extends BaseCommand
                     InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
                     'Arguments to pass to the binary. Use <info>--</info> to separate from composer arguments'
                 ),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 Executes a vendored binary/script.

--- a/src/Composer/Command/FundCommand.php
+++ b/src/Composer/Command/FundCommand.php
@@ -37,9 +37,9 @@ class FundCommand extends BaseCommand
     {
         $this->setName('fund')
             ->setDescription('Discover how to help fund the maintenance of your dependencies.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text', ['text', 'json']),
-            ))
+            ])
         ;
     }
 
@@ -49,9 +49,9 @@ class FundCommand extends BaseCommand
 
         $repo = $composer->getRepositoryManager()->getLocalRepository();
         $remoteRepos = new CompositeRepository($composer->getRepositoryManager()->getRepositories());
-        $fundings = array();
+        $fundings = [];
 
-        $packagesToLoad = array();
+        $packagesToLoad = [];
         foreach ($repo->getPackages() as $package) {
             if ($package instanceof AliasPackage) {
                 continue;
@@ -60,7 +60,7 @@ class FundCommand extends BaseCommand
         }
 
         // load all packages dev versions in parallel
-        $result = $remoteRepos->loadPackages($packagesToLoad, array('dev' => BasePackage::STABILITY_DEV), array());
+        $result = $remoteRepos->loadPackages($packagesToLoad, ['dev' => BasePackage::STABILITY_DEV], []);
 
         // collect funding data from default branches
         foreach ($result['packages'] as $package) {
@@ -92,7 +92,7 @@ class FundCommand extends BaseCommand
         $io = $this->getIO();
 
         $format = $input->getOption('format');
-        if (!in_array($format, array('text', 'json'))) {
+        if (!in_array($format, ['text', 'json'])) {
             $io->writeError(sprintf('Unsupported format "%s". See help for supported formats.', $format));
 
             return 1;

--- a/src/Composer/Command/GlobalCommand.php
+++ b/src/Composer/Command/GlobalCommand.php
@@ -59,10 +59,10 @@ class GlobalCommand extends BaseCommand
         $this
             ->setName('global')
             ->setDescription('Allows running commands in the global composer dir ($COMPOSER_HOME).')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('command-name', InputArgument::REQUIRED, ''),
                 new InputArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, ''),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 Use this command as a wrapper to run other Composer commands
@@ -98,7 +98,7 @@ EOT
 
         // extract real command name
         $tokens = Preg::split('{\s+}', $input->__toString());
-        $args = array();
+        $args = [];
         foreach ($tokens as $token) {
             if ($token && $token[0] !== '-') {
                 $args[] = $token;

--- a/src/Composer/Command/HomeCommand.php
+++ b/src/Composer/Command/HomeCommand.php
@@ -39,13 +39,13 @@ class HomeCommand extends BaseCommand
     {
         $this
             ->setName('browse')
-            ->setAliases(array('home'))
+            ->setAliases(['home'])
             ->setDescription('Opens the package\'s repository URL or homepage in your browser.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('packages', InputArgument::IS_ARRAY, 'Package(s) to browse to.', null, $this->suggestInstalledPackage()),
                 new InputOption('homepage', 'H', InputOption::VALUE_NONE, 'Open the homepage instead of the repository URL.'),
                 new InputOption('show', 's', InputOption::VALUE_NONE, 'Only show the homepage or repository URL.'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The home command opens or shows a package's repository URL or
@@ -68,7 +68,7 @@ EOT
         $packages = $input->getArgument('packages');
         if (count($packages) === 0) {
             $io->writeError('No package specified, opening homepage for the root package');
-            $packages = array($this->requireComposer()->getPackage()->getName());
+            $packages = [$this->requireComposer()->getPackage()->getName()];
         }
 
         foreach ($packages as $packageName) {
@@ -166,8 +166,8 @@ EOT
 
         if ($composer) {
             return array_merge(
-                array(new RootPackageRepository($composer->getPackage())), // root package
-                array($composer->getRepositoryManager()->getLocalRepository()), // installed packages
+                [new RootPackageRepository($composer->getPackage())], // root package
+                [$composer->getRepositoryManager()->getLocalRepository()], // installed packages
                 $composer->getRepositoryManager()->getRepositories() // remotes
             );
         }

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -53,7 +53,7 @@ class InitCommand extends BaseCommand
         $this
             ->setName('init')
             ->setDescription('Creates a basic composer.json file in current directory.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('name', null, InputOption::VALUE_REQUIRED, 'Name of the package'),
                 new InputOption('description', null, InputOption::VALUE_REQUIRED, 'Description of package'),
                 new InputOption('author', null, InputOption::VALUE_REQUIRED, 'Author name of package'),
@@ -65,7 +65,7 @@ class InitCommand extends BaseCommand
                 new InputOption('license', 'l', InputOption::VALUE_REQUIRED, 'License of package'),
                 new InputOption('repository', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add custom repositories, either by URL or using JSON arrays'),
                 new InputOption('autoload', 'a', InputOption::VALUE_REQUIRED, 'Add PSR-4 autoload mapping. Maps your package\'s namespace to the provided directory. (Expects a relative path, e.g. src/)'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>init</info> command creates a basic composer.json file
@@ -86,7 +86,7 @@ EOT
     {
         $io = $this->getIO();
 
-        $allowlist = array('name', 'description', 'author', 'type', 'homepage', 'require', 'require-dev', 'stability', 'license', 'autoload');
+        $allowlist = ['name', 'description', 'author', 'type', 'homepage', 'require', 'require-dev', 'stability', 'license', 'autoload'];
         $options = array_filter(array_intersect_key($input->getOptions(), array_flip($allowlist)));
 
         if (isset($options['name']) && !Preg::isMatch('{^[a-z0-9_.-]+/[a-z0-9_.-]+$}D', $options['name'])) {
@@ -114,13 +114,13 @@ EOT
         }
 
         $options['require'] = isset($options['require']) ? $this->formatRequirements($options['require']) : new \stdClass;
-        if (array() === $options['require']) {
+        if ([] === $options['require']) {
             $options['require'] = new \stdClass;
         }
 
         if (isset($options['require-dev'])) {
             $options['require-dev'] = $this->formatRequirements($options['require-dev']);
-            if (array() === $options['require-dev']) {
+            if ([] === $options['require-dev']) {
                 $options['require-dev'] = new \stdClass;
             }
         }
@@ -130,18 +130,18 @@ EOT
         if (isset($options['autoload'])) {
             $autoloadPath = $options['autoload'];
             $namespace = $this->namespaceFromPackageName((string) $input->getOption('name'));
-            $options['autoload'] = (object) array(
-                'psr-4' => array(
+            $options['autoload'] = (object) [
+                'psr-4' => [
                     $namespace . '\\' => $autoloadPath,
-                ),
-            );
+                ],
+            ];
         }
 
         $file = new JsonFile(Factory::getComposerFile());
         $json = JsonFile::encode($options);
 
         if ($input->isInteractive()) {
-            $io->writeError(array('', $json, ''));
+            $io->writeError(['', $json, '']);
             if (!$io->askConfirmation('Do you confirm generation [<comment>yes</comment>]? ')) {
                 $io->writeError('<error>Command aborted</error>');
 
@@ -229,13 +229,13 @@ EOT
             $io->loadConfiguration($config);
             $repoManager = RepositoryFactory::manager($io, $config);
 
-            $repos = array(new PlatformRepository);
+            $repos = [new PlatformRepository];
             $createDefaultPackagistRepo = true;
             foreach ($repositories as $repo) {
                 $repoConfig = RepositoryFactory::configFromString($io, $config, $repo, true);
                 if (
-                    (isset($repoConfig['packagist']) && $repoConfig === array('packagist' => false))
-                    || (isset($repoConfig['packagist.org']) && $repoConfig === array('packagist.org' => false))
+                    (isset($repoConfig['packagist']) && $repoConfig === ['packagist' => false])
+                    || (isset($repoConfig['packagist.org']) && $repoConfig === ['packagist.org' => false])
                 ) {
                     $createDefaultPackagistRepo = false;
                     continue;
@@ -244,28 +244,28 @@ EOT
             }
 
             if ($createDefaultPackagistRepo) {
-                $repos[] = RepositoryFactory::createRepo($io, $config, array(
+                $repos[] = RepositoryFactory::createRepo($io, $config, [
                     'type' => 'composer',
                     'url' => 'https://repo.packagist.org',
-                ), $repoManager);
+                ], $repoManager);
             }
 
             $this->repos = new CompositeRepository($repos);
             unset($repos, $config, $repositories);
         }
 
-        $io->writeError(array(
+        $io->writeError([
             '',
             $formatter->formatBlock('Welcome to the Composer config generator', 'bg=blue;fg=white', true),
             '',
-        ));
+        ]);
 
         // namespace
-        $io->writeError(array(
+        $io->writeError([
             '',
             'This command will guide you through creating your composer.json config.',
             '',
-        ));
+        ]);
 
         $cwd = realpath(".");
 
@@ -397,7 +397,7 @@ EOT
         );
         $input->setOption('license', $license);
 
-        $io->writeError(array('', 'Define your dependencies.', ''));
+        $io->writeError(['', 'Define your dependencies.', '']);
 
         // prepare to resolve dependencies
         $repos = $this->getRepos();
@@ -414,7 +414,7 @@ EOT
 
         $question = 'Would you like to define your dependencies (require) interactively [<comment>yes</comment>]? ';
         $require = $input->getOption('require');
-        $requirements = array();
+        $requirements = [];
         if (count($require) > 0 || $io->askConfirmation($question)) {
             $requirements = $this->determineRequirements($input, $output, $require, $platformRepo, $preferredStability);
         }
@@ -422,7 +422,7 @@ EOT
 
         $question = 'Would you like to define your dev dependencies (require-dev) interactively [<comment>yes</comment>]? ';
         $requireDev = $input->getOption('require-dev');
-        $devRequirements = array();
+        $devRequirements = [];
         if (count($requireDev) > 0 || $io->askConfirmation($question)) {
             $devRequirements = $this->determineRequirements($input, $output, $requireDev, $platformRepo, $preferredStability);
         }
@@ -471,10 +471,10 @@ EOT
                 throw new \InvalidArgumentException('Invalid email "'.$match['email'].'"');
             }
 
-            return array(
+            return [
                 'name' => trim($match['name']),
                 'email' => $hasEmail ? $match['email'] : null,
-            );
+            ];
         }
 
         throw new \InvalidArgumentException(
@@ -495,7 +495,7 @@ EOT
             unset($author['email']);
         }
 
-        return array($author);
+        return [$author];
     }
 
     /**
@@ -538,11 +538,11 @@ EOT
         $finder = new ExecutableFinder();
         $gitBin = $finder->find('git');
 
-        $cmd = new Process(array($gitBin, 'config', '-l'));
+        $cmd = new Process([$gitBin, 'config', '-l']);
         $cmd->run();
 
         if ($cmd->isSuccessful()) {
-            $this->gitConfig = array();
+            $this->gitConfig = [];
             Preg::matchAll('{^([^=]+)=(.*)$}m', $cmd->getOutput(), $matches);
             foreach ($matches[1] as $key => $match) {
                 $this->gitConfig[$match] = $matches[2][$key];
@@ -551,7 +551,7 @@ EOT
             return $this->gitConfig;
         }
 
-        return $this->gitConfig = array();
+        return $this->gitConfig = [];
     }
 
     /**
@@ -631,7 +631,7 @@ EOT
         try {
             $updateCommand = $this->getApplication()->find('update');
             $this->getApplication()->resetComposer();
-            $updateCommand->run(new ArrayInput(array()), $output);
+            $updateCommand->run(new ArrayInput([]), $output);
         } catch (\Exception $e) {
             $this->getIO()->writeError('Could not update dependencies. Run `composer update` to see more information.');
         }
@@ -645,7 +645,7 @@ EOT
         try {
             $command = $this->getApplication()->find('dump-autoload');
             $this->getApplication()->resetComposer();
-            $command->run(new ArrayInput(array()), $output);
+            $command->run(new ArrayInput([]), $output);
         } catch (\Exception $e) {
             $this->getIO()->writeError('Could not run dump-autoload.');
         }
@@ -658,7 +658,7 @@ EOT
     private function hasDependencies(array $options): bool
     {
         $requires = (array) $options['require'];
-        $devRequires = isset($options['require-dev']) ? (array) $options['require-dev'] : array();
+        $devRequires = isset($options['require-dev']) ? (array) $options['require-dev'] : [];
 
         return !empty($requires) || !empty($devRequires);
     }

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -38,9 +38,9 @@ class InstallCommand extends BaseCommand
     {
         $this
             ->setName('install')
-            ->setAliases(array('i'))
+            ->setAliases(['i'])
             ->setDescription('Installs the project dependencies from the composer.lock file if present, or falls back on the composer.json.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),
                 new InputOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).'),
                 new InputOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).', null, $this->suggestPreferInstall()),
@@ -59,7 +59,7 @@ class InstallCommand extends BaseCommand
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Should not be provided, use composer require instead to add a given package to composer.json.'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>install</info> command reads the composer.lock file from

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -39,10 +39,10 @@ class LicensesCommand extends BaseCommand
         $this
             ->setName('licenses')
             ->setDescription('Shows information about licenses of dependencies.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text, json or summary', 'text', ['text', 'json', 'summary']),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The license command displays detailed information about the licenses of
@@ -67,7 +67,7 @@ EOT
         if ($input->getOption('no-dev')) {
             $packages = $this->filterRequiredPackages($repo, $root);
         } else {
-            $packages = $this->appendPackages($repo->getPackages(), array());
+            $packages = $this->appendPackages($repo->getPackages(), []);
         }
 
         ksort($packages);
@@ -83,7 +83,7 @@ EOT
 
                 $table = new Table($output);
                 $table->setStyle('compact');
-                $table->setHeaders(array('Name', 'Version', 'Licenses'));
+                $table->setHeaders(['Name', 'Version', 'Licenses']);
                 foreach ($packages as $package) {
                     $link = PackageInfo::getViewSourceOrHomepageUrl($package);
                     if ($link !== null) {
@@ -92,36 +92,36 @@ EOT
                         $name = $package->getPrettyName();
                     }
 
-                    $table->addRow(array(
+                    $table->addRow([
                         $name,
                         $package->getFullPrettyVersion(),
-                        implode(', ', $package instanceof CompletePackageInterface ? $package->getLicense() : array()) ?: 'none',
-                    ));
+                        implode(', ', $package instanceof CompletePackageInterface ? $package->getLicense() : []) ?: 'none',
+                    ]);
                 }
                 $table->render();
                 break;
 
             case 'json':
-                $dependencies = array();
+                $dependencies = [];
                 foreach ($packages as $package) {
-                    $dependencies[$package->getPrettyName()] = array(
+                    $dependencies[$package->getPrettyName()] = [
                         'version' => $package->getFullPrettyVersion(),
-                        'license' => $package instanceof CompletePackageInterface ? $package->getLicense() : array(),
-                    );
+                        'license' => $package instanceof CompletePackageInterface ? $package->getLicense() : [],
+                    ];
                 }
 
-                $io->write(JsonFile::encode(array(
+                $io->write(JsonFile::encode([
                     'name' => $root->getPrettyName(),
                     'version' => $root->getFullPrettyVersion(),
                     'license' => $root->getLicense(),
                     'dependencies' => $dependencies,
-                )));
+                ]));
                 break;
 
             case 'summary':
-                $usedLicenses = array();
+                $usedLicenses = [];
                 foreach ($packages as $package) {
-                    $licenses = $package instanceof CompletePackageInterface ? $package->getLicense() : array();
+                    $licenses = $package instanceof CompletePackageInterface ? $package->getLicense() : [];
                     if (count($licenses) === 0) {
                         $licenses[] = 'none';
                     }
@@ -136,14 +136,14 @@ EOT
                 // Sort licenses so that the most used license will appear first
                 arsort($usedLicenses, SORT_NUMERIC);
 
-                $rows = array();
+                $rows = [];
                 foreach ($usedLicenses as $usedLicense => $numberOfDependencies) {
-                    $rows[] = array($usedLicense, $numberOfDependencies);
+                    $rows[] = [$usedLicense, $numberOfDependencies];
                 }
 
                 $symfonyIo = new SymfonyStyle($input, $output);
                 $symfonyIo->table(
-                    array('License', 'Number of dependencies'),
+                    ['License', 'Number of dependencies'],
                     $rows
                 );
                 break;
@@ -160,7 +160,7 @@ EOT
      * @param  array<string, PackageInterface> $bucket
      * @return array<string, PackageInterface>
      */
-    private function filterRequiredPackages(RepositoryInterface $repo, PackageInterface $package, array $bucket = array()): array
+    private function filterRequiredPackages(RepositoryInterface $repo, PackageInterface $package, array $bucket = []): array
     {
         $requires = array_keys($package->getRequires());
 

--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -33,7 +33,7 @@ class OutdatedCommand extends BaseCommand
         $this
             ->setName('outdated')
             ->setDescription('Shows a list of installed packages that have updates available, including their latest version.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.', null, $this->suggestInstalledPackage()),
                 new InputOption('outdated', 'o', InputOption::VALUE_NONE, 'Show only packages that are outdated (this is the default, but present here for compat with `show`'),
                 new InputOption('all', 'a', InputOption::VALUE_NONE, 'Show all installed packages with their latest versions'),
@@ -48,7 +48,7 @@ class OutdatedCommand extends BaseCommand
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages). Use with the --outdated option'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages). Use with the --outdated option'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The outdated command is just a proxy for `composer show -l`
@@ -69,10 +69,10 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $args = array(
+        $args = [
             'command' => 'show',
             '--latest' => true,
-        );
+        ];
         if (!$input->getOption('all')) {
             $args['--outdated'] = true;
         }

--- a/src/Composer/Command/PackageDiscoveryTrait.php
+++ b/src/Composer/Command/PackageDiscoveryTrait.php
@@ -46,7 +46,7 @@ trait PackageDiscoveryTrait
     {
         if (null === $this->repos) {
             $this->repos = new CompositeRepository(array_merge(
-                array(new PlatformRepository),
+                [new PlatformRepository],
                 RepositoryFactory::defaultReposWithDefaultManager($this->getIO())
             ));
         }
@@ -89,11 +89,11 @@ trait PackageDiscoveryTrait
      * @return array<string>
      * @throws \Exception
      */
-    final protected function determineRequirements(InputInterface $input, OutputInterface $output, array $requires = array(), ?PlatformRepository $platformRepo = null, string $preferredStability = 'stable', bool $checkProvidedVersions = true, bool $fixed = false): array
+    final protected function determineRequirements(InputInterface $input, OutputInterface $output, array $requires = [], ?PlatformRepository $platformRepo = null, string $preferredStability = 'stable', bool $checkProvidedVersions = true, bool $fixed = false): array
     {
         if (count($requires) > 0) {
             $requires = $this->normalizeRequirements($requires);
-            $result = array();
+            $result = [];
             $io = $this->getIO();
 
             foreach ($requires as $requirement) {
@@ -126,7 +126,7 @@ trait PackageDiscoveryTrait
         if (null !== $composer) {
             $installedRepo = $composer->getRepositoryManager()->getLocalRepository();
         }
-        $existingPackages = array();
+        $existingPackages = [];
         if (null !== $installedRepo) {
             foreach ($installedRepo->getPackages() as $package) {
                 $existingPackages[] = $package->getName();
@@ -159,10 +159,10 @@ trait PackageDiscoveryTrait
                 if (!$exactMatch) {
                     $providers = $this->getRepos()->getProviders($package);
                     if (count($providers) > 0) {
-                        array_unshift($matches, array('name' => $package, 'description' => ''));
+                        array_unshift($matches, ['name' => $package, 'description' => '']);
                     }
 
-                    $choices = array();
+                    $choices = [];
                     foreach ($matches as $position => $foundPackage) {
                         $abandoned = '';
                         if (isset($foundPackage['abandoned'])) {
@@ -177,11 +177,11 @@ trait PackageDiscoveryTrait
                         $choices[] = sprintf(' <info>%5s</info> %s %s', "[$position]", $foundPackage['name'], $abandoned);
                     }
 
-                    $io->writeError(array(
+                    $io->writeError([
                         '',
                         sprintf('Found <info>%s</info> packages matching <info>%s</info>', count($matches), $package),
                         '',
-                    ));
+                    ]);
 
                     $io->writeError($choices);
                     $io->writeError('');
@@ -288,7 +288,7 @@ trait PackageDiscoveryTrait
             // platform packages can not be found in the pool in versions other than the local platform's has
             // so if platform reqs are ignored we just take the user's word for it
             if ($platformRequirementFilter->isIgnored($name)) {
-                return array($name, '*');
+                return [$name, '*'];
             }
 
             // Check if it is a virtual package provided by others
@@ -304,7 +304,7 @@ trait PackageDiscoveryTrait
                     }, 3, '*');
                 }
 
-                return array($name, $constraint);
+                return [$name, $constraint];
             }
 
             // Check whether the package requirements were the problem
@@ -367,10 +367,10 @@ trait PackageDiscoveryTrait
             ));
         }
 
-        return array(
+        return [
             $package->getPrettyName(),
             $fixed ? $package->getPrettyVersion() : $versionSelector->findRecommendedRequireVersion($package),
-        );
+        ];
     }
 
     /**
@@ -389,9 +389,9 @@ trait PackageDiscoveryTrait
             }
 
             // ignore search errors
-            return array();
+            return [];
         }
-        $similarPackages = array();
+        $similarPackages = [];
 
         $installedRepo = $this->requireComposer()->getRepositoryManager()->getLocalRepository();
 
@@ -409,7 +409,7 @@ trait PackageDiscoveryTrait
 
     private function getPlatformExceptionDetails(PackageInterface $candidate, ?PlatformRepository $platformRepo = null): string
     {
-        $details = array();
+        $details = [];
         if (null === $platformRepo) {
             return '';
         }

--- a/src/Composer/Command/ProhibitsCommand.php
+++ b/src/Composer/Command/ProhibitsCommand.php
@@ -33,14 +33,14 @@ class ProhibitsCommand extends BaseDependencyCommand
     {
         $this
             ->setName('prohibits')
-            ->setAliases(array('why-not'))
+            ->setAliases(['why-not'])
             ->setDescription('Shows which packages prevent the given package from being installed.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument(self::ARGUMENT_PACKAGE, InputArgument::REQUIRED, 'Package to inspect', null, $this->suggestAvailablePackage()),
                 new InputArgument(self::ARGUMENT_CONSTRAINT, InputArgument::REQUIRED, 'Version constraint, which version you expected to be installed'),
                 new InputOption(self::OPTION_RECURSIVE, 'r', InputOption::VALUE_NONE, 'Recursively resolves up to the root package'),
                 new InputOption(self::OPTION_TREE, 't', InputOption::VALUE_NONE, 'Prints the results as a nested tree'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 Displays detailed information about why a package cannot be installed.

--- a/src/Composer/Command/ReinstallCommand.php
+++ b/src/Composer/Command/ReinstallCommand.php
@@ -42,7 +42,7 @@ class ReinstallCommand extends BaseCommand
         $this
             ->setName('reinstall')
             ->setDescription('Uninstalls and reinstalls the given package names')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),
                 new InputOption('prefer-dist', null, InputOption::VALUE_NONE, 'Forces installation from package dist (default behavior).'),
                 new InputOption('prefer-install', null, InputOption::VALUE_REQUIRED, 'Forces installation from package dist|source|auto (auto chooses source for dev versions, dist for the rest).', null, $this->suggestPreferInstall()),
@@ -55,7 +55,7 @@ class ReinstallCommand extends BaseCommand
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'List of package names to reinstall, can include a wildcard (*) to match any substring.', null, $this->suggestInstalledPackage()),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>reinstall</info> command looks up installed packages by name,
@@ -78,8 +78,8 @@ EOT
         $composer = $this->requireComposer();
 
         $localRepo = $composer->getRepositoryManager()->getLocalRepository();
-        $packagesToReinstall = array();
-        $packageNamesToReinstall = array();
+        $packagesToReinstall = [];
+        $packageNamesToReinstall = [];
         foreach ($input->getArgument('packages') as $pattern) {
             $patternRegexp = BasePackage::packageNameToRegexp($pattern);
             $matched = false;
@@ -102,7 +102,7 @@ EOT
             return 1;
         }
 
-        $uninstallOperations = array();
+        $uninstallOperations = [];
         foreach ($packagesToReinstall as $package) {
             $uninstallOperations[] = new UninstallOperation($package);
         }
@@ -119,7 +119,7 @@ EOT
         $installOperations = $transaction->getOperations();
 
         // reverse-sort the uninstalls based on the install order
-        $installOrder = array();
+        $installOrder = [];
         foreach ($installOperations as $index => $op) {
             if ($op instanceof InstallOperation && !$op->getPackage() instanceof AliasPackage) {
                 $installOrder[$op->getPackage()->getName()] = $index;

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -42,7 +42,7 @@ class RemoveCommand extends BaseCommand
         $this
             ->setName('remove')
             ->setDescription('Removes a package from the require or require-dev.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Packages that should be removed.', null, $this->suggestInstalledPackage(true)),
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Removes a package from the require-dev section.'),
                 new InputOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything (implicitly enables --verbose).'),
@@ -61,7 +61,7 @@ class RemoveCommand extends BaseCommand
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
                 new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
                 new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>remove</info> command removes a package from the current
@@ -89,7 +89,7 @@ EOT
 
             $lockedPackages = $locker->getLockedRepository()->getPackages();
 
-            $required = array();
+            $required = [];
             foreach (array_merge($composer->getPackage()->getRequires(), $composer->getPackage()->getDevRequires()) as $link) {
                 $required[$link->getTarget()] = true;
             }
@@ -110,7 +110,7 @@ EOT
                 }
             } while ($found);
 
-            $unused = array();
+            $unused = [];
             foreach ($lockedPackages as $package) {
                 $unused[] = $package->getName();
             }
@@ -151,7 +151,7 @@ EOT
         }
 
         // make sure name checks are done case insensitively
-        foreach (array('require', 'require-dev') as $linkType) {
+        foreach (['require', 'require-dev'] as $linkType) {
             if (isset($composer[$linkType])) {
                 foreach ($composer[$linkType] as $name => $version) {
                     $composer[$linkType][strtolower($name)] = $name;
@@ -160,7 +160,7 @@ EOT
         }
 
         $dryRun = $input->getOption('dry-run');
-        $toRemove = array();
+        $toRemove = [];
         foreach ($packages as $package) {
             if (isset($composer[$type][$package])) {
                 if ($dryRun) {
@@ -221,10 +221,10 @@ EOT
 
         if ($dryRun) {
             $rootPackage = $composer->getPackage();
-            $links = array(
+            $links = [
                 'require' => $rootPackage->getRequires(),
                 'require-dev' => $rootPackage->getDevRequires(),
-            );
+            ];
             foreach ($toRemove as $type => $names) {
                 foreach ($names as $name) {
                     unset($links[$type][$name]);

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -67,7 +67,7 @@ class RequireCommand extends BaseCommand
         $this
             ->setName('require')
             ->setDescription('Adds required packages to your composer.json and installs them.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Optional package name can also include a version constraint, e.g. foo/bar or foo/bar:1.0.0 or foo/bar=1.0.0 or "foo/bar 1.0.0"', null, $this->suggestAvailablePackageInclPlatform()),
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Add requirement to require-dev.'),
                 new InputOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything (implicitly enables --verbose).'),
@@ -93,7 +93,7 @@ class RequireCommand extends BaseCommand
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
                 new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
                 new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The require command adds required packages to your composer.json and installs them.
@@ -184,7 +184,7 @@ EOT
         $platformOverrides = $composer->getConfig()->get('platform');
         // initialize $this->repos as it is used by the PackageDiscoveryTrait
         $this->repos = new CompositeRepository(array_merge(
-            array($platformRepo = new PlatformRepository(array(), $platformOverrides)),
+            [$platformRepo = new PlatformRepository([], $platformOverrides)],
             $repos
         ));
 
@@ -250,7 +250,7 @@ EOT
                         return 0;
                     }
 
-                    list($requireKey, $removeKey) = array($removeKey, $requireKey);
+                    list($requireKey, $removeKey) = [$removeKey, $requireKey];
                 }
             }
         }
@@ -303,7 +303,7 @@ EOT
     private function getInconsistentRequireKeys(array $newRequirements, string $requireKey): array
     {
         $requireKeys = $this->getPackagesByRequireKey();
-        $inconsistentRequirements = array();
+        $inconsistentRequirements = [];
         foreach ($requireKeys as $package => $packageRequireKey) {
             if (!isset($newRequirements[$package])) {
                 continue;
@@ -322,8 +322,8 @@ EOT
     private function getPackagesByRequireKey(): array
     {
         $composerDefinition = $this->json->read();
-        $require = array();
-        $requireDev = array();
+        $require = [];
+        $requireDev = [];
 
         if (isset($composerDefinition['require'])) {
             $require = $composerDefinition['require'];
@@ -359,10 +359,10 @@ EOT
 
         if ($input->getOption('dry-run')) {
             $rootPackage = $composer->getPackage();
-            $links = array(
+            $links = [
                 'require' => $rootPackage->getRequires(),
                 'require-dev' => $rootPackage->getDevRequires(),
-            );
+            ];
             $loader = new ArrayLoader();
             $newLinks = $loader->parseLinks($rootPackage->getName(), $rootPackage->getPrettyVersion(), BasePackage::$supportedLinkTypes[$requireKey]['method'], $requirements);
             $links[$requireKey] = array_merge($links[$requireKey], $newLinks);

--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -29,7 +29,7 @@ class RunScriptCommand extends BaseCommand
     /**
      * @var string[] Array with command events
      */
-    protected $scriptEvents = array(
+    protected $scriptEvents = [
         ScriptEvents::PRE_INSTALL_CMD,
         ScriptEvents::POST_INSTALL_CMD,
         ScriptEvents::PRE_UPDATE_CMD,
@@ -42,7 +42,7 @@ class RunScriptCommand extends BaseCommand
         ScriptEvents::POST_ARCHIVE_CMD,
         ScriptEvents::PRE_AUTOLOAD_DUMP,
         ScriptEvents::POST_AUTOLOAD_DUMP,
-    );
+    ];
 
     /**
      * @return void
@@ -51,9 +51,9 @@ class RunScriptCommand extends BaseCommand
     {
         $this
             ->setName('run-script')
-            ->setAliases(array('run'))
+            ->setAliases(['run'])
             ->setDescription('Runs the scripts defined in composer.json.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('script', InputArgument::OPTIONAL, 'Script name to run.', null, function () {
                     return array_keys($this->requireComposer()->getPackage()->getScripts());
                 }),
@@ -62,7 +62,7 @@ class RunScriptCommand extends BaseCommand
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Sets the dev mode.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables the dev mode.'),
                 new InputOption('list', 'l', InputOption::VALUE_NONE, 'List scripts.'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>run-script</info> command runs scripts defined in composer.json:
@@ -128,7 +128,7 @@ EOT
 
         $io = $this->getIO();
         $io->writeError('<info>scripts:</info>');
-        $table = array();
+        $table = [];
         foreach ($scripts as $name => $script) {
             $description = '';
             try {
@@ -139,7 +139,7 @@ EOT
             } catch (\Symfony\Component\Console\Exception\CommandNotFoundException $e) {
                 // ignore scripts that have no command associated, like native Composer script listeners
             }
-            $table[] = array('  '.$name, $description);
+            $table[] = ['  '.$name, $description];
         }
 
         $this->renderTable($table, $output);

--- a/src/Composer/Command/ScriptAliasCommand.php
+++ b/src/Composer/Command/ScriptAliasCommand.php
@@ -43,11 +43,11 @@ class ScriptAliasCommand extends BaseCommand
         $this
             ->setName($this->script)
             ->setDescription($this->description)
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Sets the dev mode.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables the dev mode.'),
                 new InputArgument('args', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, ''),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>run-script</info> command runs scripts defined in composer.json:

--- a/src/Composer/Command/SearchCommand.php
+++ b/src/Composer/Command/SearchCommand.php
@@ -38,13 +38,13 @@ class SearchCommand extends BaseCommand
         $this
             ->setName('search')
             ->setDescription('Searches for packages.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('only-name', 'N', InputOption::VALUE_NONE, 'Search only in package names'),
                 new InputOption('only-vendor', 'O', InputOption::VALUE_NONE, 'Search only for vendor / organization names, returns only "vendor" as result'),
                 new InputOption('type', 't', InputOption::VALUE_REQUIRED, 'Search for a specific package type'),
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text', ['json', 'text']),
                 new InputArgument('tokens', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'tokens to search for'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The search command searches for packages by its name
@@ -63,18 +63,18 @@ EOT
         $io = $this->getIO();
 
         $format = $input->getOption('format');
-        if (!in_array($format, array('text', 'json'))) {
+        if (!in_array($format, ['text', 'json'])) {
             $io->writeError(sprintf('Unsupported format "%s". See help for supported formats.', $format));
 
             return 1;
         }
 
         if (!($composer = $this->tryComposer())) {
-            $composer = Factory::create($this->getIO(), array(), $input->hasParameterOption('--no-plugins'));
+            $composer = Factory::create($this->getIO(), [], $input->hasParameterOption('--no-plugins'));
         }
         $localRepo = $composer->getRepositoryManager()->getLocalRepository();
-        $installedRepo = new CompositeRepository(array($localRepo, $platformRepo));
-        $repos = new CompositeRepository(array_merge(array($installedRepo), $composer->getRepositoryManager()->getRepositories()));
+        $installedRepo = new CompositeRepository([$localRepo, $platformRepo]);
+        $repos = new CompositeRepository(array_merge([$installedRepo], $composer->getRepositoryManager()->getRepositories()));
 
         $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'search', $input, $output);
         $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -46,9 +46,9 @@ class SelfUpdateCommand extends BaseCommand
     {
         $this
             ->setName('self-update')
-            ->setAliases(array('selfupdate'))
+            ->setAliases(['selfupdate'])
             ->setDescription('Updates composer.phar to the latest version.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('rollback', 'r', InputOption::VALUE_NONE, 'Revert to an older installation of composer'),
                 new InputOption('clean-backups', null, InputOption::VALUE_NONE, 'Delete old backups during an update. This makes the current version of composer the only backup available after the update'),
                 new InputArgument('version', InputArgument::OPTIONAL, 'The version to update to'),
@@ -61,7 +61,7 @@ class SelfUpdateCommand extends BaseCommand
                 new InputOption('2', null, InputOption::VALUE_NONE, 'Force an update to the stable channel, but only use 2.x versions'),
                 new InputOption('2.2', null, InputOption::VALUE_NONE, 'Force an update to the stable channel, but only use 2.2.x LTS versions'),
                 new InputOption('set-channel-only', null, InputOption::VALUE_NONE, 'Only store the channel as the default one and then exit'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>self-update</info> command checks getcomposer.org for newer

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -45,9 +45,9 @@ class StatusCommand extends BaseCommand
         $this
             ->setName('status')
             ->setDescription('Shows a list of locally modified packages.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Show modified files for each directory that contains changes.'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The status command displays a list of dependencies that have
@@ -90,10 +90,10 @@ EOT
         $dm = $composer->getDownloadManager();
         $im = $composer->getInstallationManager();
 
-        $errors = array();
+        $errors = [];
         $io = $this->getIO();
-        $unpushedChanges = array();
-        $vcsVersionChanges = array();
+        $unpushedChanges = [];
+        $vcsVersionChanges = [];
 
         $parser = new VersionParser;
         $guesser = new VersionGuesser($composer->getConfig(), $composer->getLoop()->getProcessExecutor() ?? new ProcessExecutor($io), $parser);
@@ -130,16 +130,16 @@ EOT
                     $currentVersion = $guesser->guessVersion($dumper->dump($package), $targetDir);
 
                     if ($previousRef && $currentVersion && $currentVersion['commit'] !== $previousRef) {
-                        $vcsVersionChanges[$targetDir] = array(
-                            'previous' => array(
+                        $vcsVersionChanges[$targetDir] = [
+                            'previous' => [
                                 'version' => $package->getPrettyVersion(),
                                 'ref' => $previousRef,
-                            ),
-                            'current' => array(
+                            ],
+                            'current' => [
                                 'version' => $currentVersion['pretty_version'],
                                 'ref' => $currentVersion['commit'],
-                            ),
-                        );
+                            ],
+                        ];
                     }
                 }
             }

--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -33,14 +33,14 @@ class SuggestsCommand extends BaseCommand
         $this
             ->setName('suggests')
             ->setDescription('Shows package suggestions.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('by-package', null, InputOption::VALUE_NONE, 'Groups output by suggesting package (default)'),
                 new InputOption('by-suggestion', null, InputOption::VALUE_NONE, 'Groups output by suggested package'),
                 new InputOption('all', 'a', InputOption::VALUE_NONE, 'Show suggestions from all dependencies, including transitive ones'),
                 new InputOption('list', null, InputOption::VALUE_NONE, 'Show only list of suggested package names'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Exclude suggestions from require-dev packages'),
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that you want to list suggestions from.', null, $this->suggestInstalledPackage()),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 
@@ -56,16 +56,16 @@ EOT
     {
         $composer = $this->requireComposer();
 
-        $installedRepos = array(
+        $installedRepos = [
             new RootPackageRepository(clone $composer->getPackage()),
-        );
+        ];
 
         $locker = $composer->getLocker();
         if ($locker->isLocked()) {
-            $installedRepos[] = new PlatformRepository(array(), $locker->getPlatformOverrides());
+            $installedRepos[] = new PlatformRepository([], $locker->getPlatformOverrides());
             $installedRepos[] = $locker->getLockedRepository(!$input->getOption('no-dev'));
         } else {
-            $installedRepos[] = new PlatformRepository(array(), $composer->getConfig()->get('platform'));
+            $installedRepos[] = new PlatformRepository([], $composer->getConfig()->get('platform'));
             $installedRepos[] = $composer->getRepositoryManager()->getLocalRepository();
         }
 

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -47,9 +47,9 @@ class UpdateCommand extends BaseCommand
     {
         $this
             ->setName('update')
-            ->setAliases(array('u', 'upgrade'))
+            ->setAliases(['u', 'upgrade'])
             ->setDescription('Updates your dependencies to the latest version according to composer.json, and updates the composer.lock file.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that should be updated, if not provided all packages are.', null, $this->suggestInstalledPackage()),
                 new InputOption('with', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Temporary version constraint to add, e.g. foo/bar:1.0.0 or foo/bar=1.0.0'),
                 new InputOption('prefer-source', null, InputOption::VALUE_NONE, 'Forces installation from package sources when possible, including VCS information.'),
@@ -76,7 +76,7 @@ class UpdateCommand extends BaseCommand
                 new InputOption('prefer-lowest', null, InputOption::VALUE_NONE, 'Prefer lowest versions of dependencies.'),
                 new InputOption('interactive', 'i', InputOption::VALUE_NONE, 'Interactive interface with autocompletion to select the packages to update.'),
                 new InputOption('root-reqs', null, InputOption::VALUE_NONE, 'Restricts the update to your first degree dependencies.'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The <info>update</info> command reads the composer.json file from the
@@ -177,7 +177,7 @@ EOT
         // the arguments lock/nothing/mirrors are not package names but trigger a mirror update instead
         // they are further mutually exclusive with listing actual package names
         $filteredPackages = array_filter($packages, function ($package): bool {
-            return !in_array($package, array('lock', 'nothing', 'mirrors'), true);
+            return !in_array($package, ['lock', 'nothing', 'mirrors'], true);
         });
         $updateMirrors = $input->getOption('lock') || count($filteredPackages) != count($packages);
         $packages = $filteredPackages;
@@ -252,7 +252,7 @@ EOT
             $composer->getPackage()->getRequires(),
             $composer->getPackage()->getDevRequires()
         );
-        $autocompleterValues = array();
+        $autocompleterValues = [];
         foreach ($requires as $require) {
             $target = $require->getTarget();
             $autocompleterValues[strtolower($target)] = $target;
@@ -289,9 +289,9 @@ EOT
         }
 
         $table = new Table($output);
-        $table->setHeaders(array('Selected packages'));
+        $table->setHeaders(['Selected packages']);
         foreach ($packages as $package) {
-            $table->addRow(array($package));
+            $table->addRow([$package]);
         }
         $table->render();
 

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -43,7 +43,7 @@ class ValidateCommand extends BaseCommand
         $this
             ->setName('validate')
             ->setDescription('Validates a composer.json and composer.lock.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('no-check-all', null, InputOption::VALUE_NONE, 'Do not validate requires for overly strict/loose constraints'),
                 new InputOption('check-lock', null, InputOption::VALUE_NONE, 'Check if lock file is up to date (even when config.lock is false)'),
                 new InputOption('no-check-lock', null, InputOption::VALUE_NONE, 'Do not check if lock file is up to date'),
@@ -52,7 +52,7 @@ class ValidateCommand extends BaseCommand
                 new InputOption('with-dependencies', 'A', InputOption::VALUE_NONE, 'Also validate the composer.json of all installed dependencies'),
                 new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code for warnings as well as errors'),
                 new InputArgument('file', InputArgument::OPTIONAL, 'path to composer.json file'),
-            ))
+            ])
             ->setHelp(
                 <<<EOT
 The validate command validates a given composer.json and composer.lock
@@ -91,7 +91,7 @@ EOT
         $isStrict = $input->getOption('strict');
         list($errors, $publishErrors, $warnings) = $validator->validate($file, $checkAll, $checkVersion);
 
-        $lockErrors = array();
+        $lockErrors = [];
         $composer = Factory::create($io, $file, $input->hasParameterOption('--no-plugins'));
         // config.lock = false ~= implicit --no-check-lock; --check-lock overrides
         $checkLock = ($checkLock && $composer->getConfig()->get('lock')) || $input->getOption('check-lock');
@@ -102,14 +102,14 @@ EOT
 
         if ($locker->isLocked()) {
             $missingRequirements = false;
-            $sets = array(
-                array('repo' => $locker->getLockedRepository(false), 'method' => 'getRequires', 'description' => 'Required'),
-                array('repo' => $locker->getLockedRepository(true), 'method' => 'getDevRequires', 'description' => 'Required (in require-dev)'),
-            );
+            $sets = [
+                ['repo' => $locker->getLockedRepository(false), 'method' => 'getRequires', 'description' => 'Required'],
+                ['repo' => $locker->getLockedRepository(true), 'method' => 'getDevRequires', 'description' => 'Required (in require-dev)'],
+            ];
             foreach ($sets as $set) {
-                $installedRepo = new InstalledRepository(array($set['repo']));
+                $installedRepo = new InstalledRepository([$set['repo']]);
 
-                foreach (call_user_func(array($composer->getPackage(), $set['method'])) as $link) {
+                foreach (call_user_func([$composer->getPackage(), $set['method']]) as $link) {
                     if (PlatformRepository::isPlatformPackage($link->getTarget())) {
                         continue;
                     }
@@ -172,7 +172,7 @@ EOT
      *
      * @return void
      */
-    private function outputResult(IOInterface $io, string $name, array &$errors, array &$warnings, bool $checkPublish = false, array $publishErrors = array(), bool $checkLock = false, array $lockErrors = array(), bool $printSchemaUrl = false): void
+    private function outputResult(IOInterface $io, string $name, array &$errors, array &$warnings, bool $checkPublish = false, array $publishErrors = [], bool $checkLock = false, array $lockErrors = [], bool $printSchemaUrl = false): void
     {
         $doPrintSchemaUrl = false;
 
@@ -209,7 +209,7 @@ EOT
         }
 
         // Avoid setting the exit code to 1 in case --strict and --no-check-publish/--no-check-lock are combined
-        $extraWarnings = array();
+        $extraWarnings = [];
 
         // If checking publish errors, display them as errors, otherwise just show them as warnings
         if ($publishErrors) {
@@ -237,10 +237,10 @@ EOT
             }
         }
 
-        $messages = array(
+        $messages = [
             'error' => $errors,
             'warning' => array_merge($warnings, $extraWarnings),
-        );
+        ];
 
         foreach ($messages as $style => $msgs) {
             foreach ($msgs as $msg) {

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -50,13 +50,13 @@ class Compiler
             unlink($pharFile);
         }
 
-        $process = new Process(array('git', 'log', '--pretty=%H', '-n1', 'HEAD'), __DIR__);
+        $process = new Process(['git', 'log', '--pretty=%H', '-n1', 'HEAD'], __DIR__);
         if ($process->run() != 0) {
             throw new \RuntimeException('Can\'t run git log. You must ensure to run compile from composer git repository clone and that git binary is available.');
         }
         $this->version = trim($process->getOutput());
 
-        $process = new Process(array('git', 'log', '-n1', '--pretty=%ci', 'HEAD'), __DIR__);
+        $process = new Process(['git', 'log', '-n1', '--pretty=%ci', 'HEAD'], __DIR__);
         if ($process->run() != 0) {
             throw new \RuntimeException('Can\'t run git log. You must ensure to run compile from composer git repository clone and that git binary is available.');
         }
@@ -64,7 +64,7 @@ class Compiler
         $this->versionDate = new \DateTime(trim($process->getOutput()));
         $this->versionDate->setTimezone(new \DateTimeZone('UTC'));
 
-        $process = new Process(array('git', 'describe', '--tags', '--exact-match', 'HEAD'), __DIR__);
+        $process = new Process(['git', 'describe', '--tags', '--exact-match', 'HEAD'], __DIR__);
         if ($process->run() == 0) {
             $this->version = trim($process->getOutput());
         } else {
@@ -132,19 +132,19 @@ class Compiler
         ;
 
         $extraFiles = [];
-        foreach (array(
+        foreach ([
             __DIR__ . '/../../vendor/composer/spdx-licenses/res/spdx-exceptions.json',
             __DIR__ . '/../../vendor/composer/spdx-licenses/res/spdx-licenses.json',
             CaBundle::getBundledCaBundlePath(),
             __DIR__ . '/../../vendor/symfony/console/Resources/bin/hiddeninput.exe',
             __DIR__ . '/../../vendor/symfony/console/Resources/completion.bash',
-        ) as $file) {
+        ] as $file) {
             $extraFiles[$file] = realpath($file);
             if (!file_exists($file)) {
                 throw new \RuntimeException('Extra file listed is missing from the filesystem: '.$file);
             }
         }
-        $unexpectedFiles = array();
+        $unexpectedFiles = [];
 
         foreach ($finder as $file) {
             if (false !== ($index = array_search($file->getRealPath(), $extraFiles, true))) {
@@ -230,11 +230,11 @@ class Compiler
         if ($path === 'src/Composer/Composer.php') {
             $content = strtr(
                 $content,
-                array(
+                [
                     '@package_version@' => $this->version,
                     '@package_branch_alias_version@' => $this->branchAliasVersion,
                     '@release_date@' => $this->versionDate->format('Y-m-d H:i:s'),
-                )
+                ]
             );
             $content = Preg::replace('{SOURCE_VERSION = \'[^\']+\';}', 'SOURCE_VERSION = \'\';', $content);
         }
@@ -268,7 +268,7 @@ class Compiler
         foreach (token_get_all($source) as $token) {
             if (is_string($token)) {
                 $output .= $token;
-            } elseif (in_array($token[0], array(T_COMMENT, T_DOC_COMMENT))) {
+            } elseif (in_array($token[0], [T_COMMENT, T_DOC_COMMENT])) {
                 $output .= str_repeat("\n", substr_count($token[1], "\n"));
             } elseif (T_WHITESPACE === $token[0]) {
                 // reduce wide spaces

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -31,14 +31,14 @@ class Config
     public const RELATIVE_PATHS = 1;
 
     /** @var array<string, mixed> */
-    public static $defaultConfig = array(
+    public static $defaultConfig = [
         'process-timeout' => 300,
         'use-include-path' => false,
         'allow-plugins' => null, // null for BC for now, will become array() after July 2022
         'use-parent-dir' => 'prompt',
         'preferred-install' => 'dist',
         'notify-on-install' => true,
-        'github-protocols' => array('https', 'ssh', 'git'),
+        'github-protocols' => ['https', 'ssh', 'git'],
         'gitlab-protocol' => null,
         'vendor-dir' => 'vendor',
         'bin-dir' => '{$vendor-dir}/bin',
@@ -59,38 +59,38 @@ class Config
         'classmap-authoritative' => false,
         'apcu-autoloader' => false,
         'prepend-autoloader' => true,
-        'github-domains' => array('github.com'),
+        'github-domains' => ['github.com'],
         'bitbucket-expose-hostname' => true,
         'disable-tls' => false,
         'secure-http' => true,
-        'secure-svn-domains' => array(),
+        'secure-svn-domains' => [],
         'cafile' => null,
         'capath' => null,
         'github-expose-hostname' => true,
-        'gitlab-domains' => array('gitlab.com'),
+        'gitlab-domains' => ['gitlab.com'],
         'store-auths' => 'prompt',
-        'platform' => array(),
+        'platform' => [],
         'archive-format' => 'tar',
         'archive-dir' => '.',
         'htaccess-protect' => true,
         'use-github-api' => true,
         'lock' => true,
         'platform-check' => 'php-only',
-        'bitbucket-oauth' => array(),
-        'github-oauth' => array(),
-        'gitlab-oauth' => array(),
-        'gitlab-token' => array(),
-        'http-basic' => array(),
-        'bearer' => array(),
-    );
+        'bitbucket-oauth' => [],
+        'github-oauth' => [],
+        'gitlab-oauth' => [],
+        'gitlab-token' => [],
+        'http-basic' => [],
+        'bearer' => [],
+    ];
 
     /** @var array<string, mixed> */
-    public static $defaultRepositories = array(
-        'packagist.org' => array(
+    public static $defaultRepositories = [
+        'packagist.org' => [
             'type' => 'composer',
             'url' => 'https://repo.packagist.org',
-        ),
-    );
+        ],
+    ];
 
     /** @var array<string, mixed> */
     private $config;
@@ -105,11 +105,11 @@ class Config
     /** @var bool */
     private $useEnvironment;
     /** @var array<string, true> */
-    private $warnedHosts = array();
+    private $warnedHosts = [];
     /** @var array<string, true> */
-    private $sslVerifyWarnedHosts = array();
+    private $sslVerifyWarnedHosts = [];
     /** @var array<string, string> */
-    private $sourceOfConfigValue = array();
+    private $sourceOfConfigValue = [];
 
     /**
      * @param bool    $useEnvironment Use COMPOSER_ environment variables to replace config settings
@@ -122,7 +122,7 @@ class Config
 
         // TODO after July 2022 remove this and update the default value above in self::$defaultConfig + remove note from 06-config.md
         if (strtotime('2022-07-01') < time()) {
-            $this->config['allow-plugins'] = array();
+            $this->config['allow-plugins'] = [];
         }
 
         $this->repositories = static::$defaultRepositories;
@@ -183,24 +183,24 @@ class Config
         // override defaults with given config
         if (!empty($config['config']) && is_array($config['config'])) {
             foreach ($config['config'] as $key => $val) {
-                if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic', 'bearer'), true) && isset($this->config[$key])) {
+                if (in_array($key, ['bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic', 'bearer'], true) && isset($this->config[$key])) {
                     $this->config[$key] = array_merge($this->config[$key], $val);
                     $this->setSourceOfConfigValue($val, $key, $source);
-                } elseif (in_array($key, array('allow-plugins'), true) && isset($this->config[$key]) && is_array($this->config[$key])) {
+                } elseif (in_array($key, ['allow-plugins'], true) && isset($this->config[$key]) && is_array($this->config[$key])) {
                     // merging $val first to get the local config on top of the global one, then appending the global config,
                     // then merging local one again to make sure the values from local win over global ones for keys present in both
                     $this->config[$key] = array_merge($val, $this->config[$key], $val);
                     $this->setSourceOfConfigValue($val, $key, $source);
-                } elseif (in_array($key, array('gitlab-domains', 'github-domains'), true) && isset($this->config[$key])) {
+                } elseif (in_array($key, ['gitlab-domains', 'github-domains'], true) && isset($this->config[$key])) {
                     $this->config[$key] = array_unique(array_merge($this->config[$key], $val));
                     $this->setSourceOfConfigValue($val, $key, $source);
                 } elseif ('preferred-install' === $key && isset($this->config[$key])) {
                     if (is_array($val) || is_array($this->config[$key])) {
                         if (is_string($val)) {
-                            $val = array('*' => $val);
+                            $val = ['*' => $val];
                         }
                         if (is_string($this->config[$key])) {
-                            $this->config[$key] = array('*' => $this->config[$key]);
+                            $this->config[$key] = ['*' => $this->config[$key]];
                             $this->sourceOfConfigValue[$key . '*'] = $source;
                         }
                         $this->config[$key] = array_merge($this->config[$key], $val);
@@ -384,7 +384,7 @@ class Config
             case 'bin-compat':
                 $value = $this->getComposerEnv('COMPOSER_BIN_COMPAT') ?: $this->config[$key];
 
-                if (!in_array($value, array('auto', 'full', 'proxy', 'symlink'))) {
+                if (!in_array($value, ['auto', 'full', 'proxy', 'symlink'])) {
                     throw new \RuntimeException(
                         "Invalid value for 'bin-compat': {$value}. Expected auto, full or proxy"
                     );
@@ -398,7 +398,7 @@ class Config
 
             case 'discard-changes':
                 if ($env = $this->getComposerEnv('COMPOSER_DISCARD_CHANGES')) {
-                    if (!in_array($env, array('stash', 'true', 'false', '1', '0'), true)) {
+                    if (!in_array($env, ['stash', 'true', 'false', '1', '0'], true)) {
                         throw new \RuntimeException(
                             "Invalid value for COMPOSER_DISCARD_CHANGES: {$env}. Expected 1, 0, true, false or stash"
                         );
@@ -411,7 +411,7 @@ class Config
                     return $env !== 'false' && (bool) $env;
                 }
 
-                if (!in_array($this->config[$key], array(true, false, 'stash'), true)) {
+                if (!in_array($this->config[$key], [true, false, 'stash'], true)) {
                     throw new \RuntimeException(
                         "Invalid value for 'discard-changes': {$this->config[$key]}. Expected true, false or stash"
                     );
@@ -453,9 +453,9 @@ class Config
      */
     public function all(int $flags = 0): array
     {
-        $all = array(
+        $all = [
             'repositories' => $this->getRepositories(),
-        );
+        ];
         foreach (array_keys($this->config) as $key) {
             $all['config'][$key] = $this->get($key, $flags);
         }
@@ -497,10 +497,10 @@ class Config
      */
     public function raw(): array
     {
-        return array(
+        return [
             'repositories' => $this->getRepositories(),
             'config' => $this->config,
-        );
+        ];
     }
 
     /**
@@ -601,7 +601,7 @@ class Config
         // Extract scheme and throw exception on known insecure protocols
         $scheme = parse_url($url, PHP_URL_SCHEME);
         $hostname = parse_url($url, PHP_URL_HOST);
-        if (in_array($scheme, array('http', 'git', 'ftp', 'svn'))) {
+        if (in_array($scheme, ['http', 'git', 'ftp', 'svn'])) {
             if ($this->get('secure-http')) {
                 if ($scheme === 'svn') {
                     if (in_array($hostname, $this->get('secure-svn-domains'), true)) {

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -70,7 +70,7 @@ class JsonConfigSource implements ConfigSourceInterface
                     if ($index === $repo) {
                         continue;
                     }
-                    if (is_numeric($index) && ($val === array('packagist' => false) || $val === array('packagist.org' => false))) {
+                    if (is_numeric($index) && ($val === ['packagist' => false] || $val === ['packagist.org' => false])) {
                         unset($config['repositories'][$index]);
                         $config['repositories']['packagist.org'] = false;
                         break;
@@ -81,7 +81,7 @@ class JsonConfigSource implements ConfigSourceInterface
             if ($append) {
                 $config['repositories'][$repo] = $repoConfig;
             } else {
-                $config['repositories'] = array($repo => $repoConfig) + $config['repositories'];
+                $config['repositories'] = [$repo => $repoConfig] + $config['repositories'];
             }
         }, $name, $config, $append);
     }
@@ -148,7 +148,7 @@ class JsonConfigSource implements ConfigSourceInterface
                 $arr = &$config[reset($bits)];
                 foreach ($bits as $bit) {
                     if (!isset($arr[$bit])) {
-                        $arr[$bit] = array();
+                        $arr[$bit] = [];
                     }
                     $arr = &$arr[$bit];
                 }
@@ -240,15 +240,15 @@ class JsonConfigSource implements ConfigSourceInterface
         if ($this->authConfig && $method === 'addConfigSetting') {
             $method = 'addSubNode';
             list($mainNode, $name) = explode('.', $args[0], 2);
-            $args = array($mainNode, $name, $args[1]);
+            $args = [$mainNode, $name, $args[1]];
         } elseif ($this->authConfig && $method === 'removeConfigSetting') {
             $method = 'removeSubNode';
             list($mainNode, $name) = explode('.', $args[0], 2);
-            $args = array($mainNode, $name);
+            $args = [$mainNode, $name];
         }
 
         // try to update cleanly
-        if (call_user_func_array(array($manipulator, $method), $args)) {
+        if (call_user_func_array([$manipulator, $method], $args)) {
             file_put_contents($this->file->getPath(), $manipulator->getContents());
         } else {
             // on failed clean update, call the fallback and rewrite the whole file
@@ -256,21 +256,21 @@ class JsonConfigSource implements ConfigSourceInterface
             $this->arrayUnshiftRef($args, $config);
             call_user_func_array($fallback, $args);
             // avoid ending up with arrays for keys that should be objects
-            foreach (array('require', 'require-dev', 'conflict', 'provide', 'replace', 'suggest', 'config', 'autoload', 'autoload-dev', 'scripts', 'scripts-descriptions', 'support') as $prop) {
-                if (isset($config[$prop]) && $config[$prop] === array()) {
+            foreach (['require', 'require-dev', 'conflict', 'provide', 'replace', 'suggest', 'config', 'autoload', 'autoload-dev', 'scripts', 'scripts-descriptions', 'support'] as $prop) {
+                if (isset($config[$prop]) && $config[$prop] === []) {
                     $config[$prop] = new \stdClass;
                 }
             }
-            foreach (array('psr-0', 'psr-4') as $prop) {
-                if (isset($config['autoload'][$prop]) && $config['autoload'][$prop] === array()) {
+            foreach (['psr-0', 'psr-4'] as $prop) {
+                if (isset($config['autoload'][$prop]) && $config['autoload'][$prop] === []) {
                     $config['autoload'][$prop] = new \stdClass;
                 }
-                if (isset($config['autoload-dev'][$prop]) && $config['autoload-dev'][$prop] === array()) {
+                if (isset($config['autoload-dev'][$prop]) && $config['autoload-dev'][$prop] === []) {
                     $config['autoload-dev'][$prop] = new \stdClass;
                 }
             }
-            foreach (array('platform', 'http-basic', 'bearer', 'gitlab-token', 'gitlab-oauth', 'github-oauth', 'preferred-install') as $prop) {
-                if (isset($config['config'][$prop]) && $config['config'][$prop] === array()) {
+            foreach (['platform', 'http-basic', 'bearer', 'gitlab-token', 'gitlab-oauth', 'github-oauth', 'preferred-install'] as $prop) {
+                if (isset($config['config'][$prop]) && $config['config'][$prop] === []) {
                     $config['config'][$prop] = new \stdClass;
                 }
             }

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -140,9 +140,9 @@ class Application extends BaseApplication
             $input->setInteractive(false);
         }
 
-        $io = $this->io = new ConsoleIO($input, $output, new HelperSet(array(
+        $io = $this->io = new ConsoleIO($input, $output, new HelperSet([
             new QuestionHelper(),
-        )));
+        ]));
 
         // Register error handler again to pass it the IO instance
         ErrorHandler::register($io);
@@ -175,7 +175,7 @@ class Application extends BaseApplication
         }
 
         // prompt user for dir change if no composer.json is present in current dir
-        if ($io->isInteractive() && null === $newWorkDir && !in_array($commandName, array('', 'list', 'init', 'about', 'help', 'diagnose', 'self-update', 'global', 'create-project', 'outdated'), true) && !file_exists(Factory::getComposerFile()) && ($useParentDirIfNoJsonAvailable = $this->getUseParentDirConfigValue()) !== false) {
+        if ($io->isInteractive() && null === $newWorkDir && !in_array($commandName, ['', 'list', 'init', 'about', 'help', 'diagnose', 'self-update', 'global', 'create-project', 'outdated'], true) && !file_exists(Factory::getComposerFile()) && ($useParentDirIfNoJsonAvailable = $this->getUseParentDirConfigValue()) !== false) {
             $dir = dirname(Platform::getCwd(true));
             $home = realpath(Platform::getEnv('HOME') ?: Platform::getEnv('USERPROFILE') ?: '/');
 
@@ -199,12 +199,12 @@ class Application extends BaseApplication
 
         // avoid loading plugins/initializing the Composer instance earlier than necessary if no plugin command is needed
         // if showing the version, we never need plugin commands
-        $mayNeedPluginCommand = false === $input->hasParameterOption(array('--version', '-V'))
+        $mayNeedPluginCommand = false === $input->hasParameterOption(['--version', '-V'])
             && (
                 // not a composer command, so try loading plugin ones
                 false === $commandName
                 // list command requires plugin commands to show them
-                || in_array($commandName, array('', 'list', 'help'), true)
+                || in_array($commandName, ['', 'list', 'help'], true)
             );
 
         if ($mayNeedPluginCommand && !$this->disablePluginsByDefault && !$this->hasPluginCommands) {
@@ -388,7 +388,7 @@ class Application extends BaseApplication
     private function getNewWorkingDir(InputInterface $input): ?string
     {
         /** @var string|null $workingDir */
-        $workingDir = $input->getParameterOption(array('--working-dir', '-d'), null, true);
+        $workingDir = $input->getParameterOption(['--working-dir', '-d'], null, true);
         if (null !== $workingDir && !is_dir($workingDir)) {
             throw new \RuntimeException('Invalid working directory specified, '.$workingDir.' does not exist.');
         }
@@ -518,7 +518,7 @@ class Application extends BaseApplication
      */
     protected function getDefaultCommands(): array
     {
-        $commands = array_merge(parent::getDefaultCommands(), array(
+        $commands = array_merge(parent::getDefaultCommands(), [
             new Command\AboutCommand(),
             new Command\ConfigCommand(),
             new Command\DependsCommand(),
@@ -548,7 +548,7 @@ class Application extends BaseApplication
             new Command\FundCommand(),
             new Command\ReinstallCommand(),
             new Command\BumpCommand(),
-        ));
+        ]);
 
         if (strpos(__FILE__, 'phar:') === 0 || '1' === Platform::getEnv('COMPOSER_TESTS_ARE_RUNNING')) {
             $commands[] = new Command\SelfUpdateCommand();
@@ -590,7 +590,7 @@ class Application extends BaseApplication
      */
     private function getPluginCommands(): array
     {
-        $commands = array();
+        $commands = [];
 
         $composer = $this->getComposer(false, false);
         if (null === $composer) {
@@ -599,7 +599,7 @@ class Application extends BaseApplication
 
         if (null !== $composer) {
             $pm = $composer->getPluginManager();
-            foreach ($pm->getPluginCapabilities('Composer\Plugin\Capability\CommandProvider', array('composer' => $composer, 'io' => $this->io)) as $capability) {
+            foreach ($pm->getPluginCapabilities('Composer\Plugin\Capability\CommandProvider', ['composer' => $composer, 'io' => $this->io]) as $capability) {
                 $newCommands = $capability->getCommands();
                 if (!is_array($newCommands)) {
                     throw new \UnexpectedValueException('Plugin capability '.get_class($capability).' failed to return an array from getCommands');

--- a/src/Composer/Console/HtmlOutputFormatter.php
+++ b/src/Composer/Console/HtmlOutputFormatter.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 class HtmlOutputFormatter extends OutputFormatter
 {
     /** @var array<int, string> */
-    private static $availableForegroundColors = array(
+    private static $availableForegroundColors = [
         30 => 'black',
         31 => 'red',
         32 => 'green',
@@ -32,9 +32,9 @@ class HtmlOutputFormatter extends OutputFormatter
         35 => 'magenta',
         36 => 'cyan',
         37 => 'white',
-    );
+    ];
     /** @var array<int, string> */
-    private static $availableBackgroundColors = array(
+    private static $availableBackgroundColors = [
         40 => 'black',
         41 => 'red',
         42 => 'green',
@@ -43,20 +43,20 @@ class HtmlOutputFormatter extends OutputFormatter
         45 => 'magenta',
         46 => 'cyan',
         47 => 'white',
-    );
+    ];
     /** @var array<int, string> */
-    private static $availableOptions = array(
+    private static $availableOptions = [
         1 => 'bold',
         4 => 'underscore',
         //5 => 'blink',
         //7 => 'reverse',
         //8 => 'conceal'
-    );
+    ];
 
     /**
      * @param array<string, OutputFormatterStyle> $styles Array of "name => FormatterStyle" instances
      */
-    public function __construct(array $styles = array())
+    public function __construct(array $styles = [])
     {
         parent::__construct(true, $styles);
     }

--- a/src/Composer/DependencyResolver/Decisions.php
+++ b/src/Composer/DependencyResolver/Decisions.php
@@ -30,12 +30,12 @@ class Decisions implements \Iterator, \Countable
     /**
      * @var array<array{0: int, 1: Rule}>
      */
-    protected $decisionQueue = array();
+    protected $decisionQueue = [];
 
     public function __construct(Pool $pool)
     {
         $this->pool = $pool;
-        $this->decisionMap = array();
+        $this->decisionMap = [];
     }
 
     /**
@@ -46,10 +46,10 @@ class Decisions implements \Iterator, \Countable
     public function decide(int $literal, int $level, Rule $why): void
     {
         $this->addDecision($literal, $level);
-        $this->decisionQueue[] = array(
+        $this->decisionQueue[] = [
             self::DECISION_LITERAL => $literal,
             self::DECISION_REASON => $why,
-        );
+        ];
     }
 
     /**
@@ -258,7 +258,7 @@ class Decisions implements \Iterator, \Countable
 
         $previousDecision = $this->decisionMap[$packageId] ?? null;
         if ($previousDecision != 0) {
-            $literalString = $this->pool->literalToPrettyString($literal, array());
+            $literalString = $this->pool->literalToPrettyString($literal, []);
             $package = $this->pool->literalToPackage($literal);
             throw new SolverBugException(
                 "Trying to decide $literalString on level $level, even though $package was previously decided as ".(int) $previousDecision."."

--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -116,12 +116,12 @@ class DefaultPolicy implements PolicyInterface
      */
     protected function groupLiteralsByName(Pool $pool, array $literals): array
     {
-        $packages = array();
+        $packages = [];
         foreach ($literals as $literal) {
             $packageName = $pool->literalToPackage($literal)->getName();
 
             if (!isset($packages[$packageName])) {
-                $packages[$packageName] = array();
+                $packages[$packageName] = [];
             }
             $packages[$packageName][] = $literal;
         }
@@ -209,7 +209,7 @@ class DefaultPolicy implements PolicyInterface
     protected function pruneToBestVersion(Pool $pool, array $literals): array
     {
         $operator = $this->preferLowest ? '<' : '>';
-        $bestLiterals = array($literals[0]);
+        $bestLiterals = [$literals[0]];
         $bestPackage = $pool->literalToPackage($literals[0]);
         foreach ($literals as $i => $literal) {
             if (0 === $i) {
@@ -220,7 +220,7 @@ class DefaultPolicy implements PolicyInterface
 
             if ($this->versionCompare($package, $bestPackage, $operator)) {
                 $bestPackage = $package;
-                $bestLiterals = array($literal);
+                $bestLiterals = [$literal];
             } elseif ($this->versionCompare($package, $bestPackage, '==')) {
                 $bestLiterals[] = $literal;
             }
@@ -254,7 +254,7 @@ class DefaultPolicy implements PolicyInterface
             return $literals;
         }
 
-        $selected = array();
+        $selected = [];
         foreach ($literals as $literal) {
             $package = $pool->literalToPackage($literal);
 

--- a/src/Composer/DependencyResolver/LockTransaction.php
+++ b/src/Composer/DependencyResolver/LockTransaction.php
@@ -64,7 +64,7 @@ class LockTransaction extends Transaction
      */
     public function setResultPackages(Pool $pool, Decisions $decisions): void
     {
-        $this->resultPackages = array('all' => array(), 'non-dev' => array(), 'dev' => array());
+        $this->resultPackages = ['all' => [], 'non-dev' => [], 'dev' => []];
         foreach ($decisions as $i => $decision) {
             $literal = $decision[Decisions::DECISION_LITERAL];
 
@@ -87,7 +87,7 @@ class LockTransaction extends Transaction
         $packages = $extractionResult->getNewLockPackages(false);
 
         $this->resultPackages['dev'] = $this->resultPackages['non-dev'];
-        $this->resultPackages['non-dev'] = array();
+        $this->resultPackages['non-dev'] = [];
 
         foreach ($packages as $package) {
             foreach ($this->resultPackages['dev'] as $i => $resultPackage) {
@@ -108,7 +108,7 @@ class LockTransaction extends Transaction
      */
     public function getNewLockPackages(bool $devMode, bool $updateMirrors = false): array
     {
-        $packages = array();
+        $packages = [];
         foreach ($this->resultPackages[$devMode ? 'dev' : 'non-dev'] as $package) {
             if (!$package instanceof AliasPackage) {
                 // if we're just updating mirrors we need to reset references to the same as currently "present" packages' references to keep the lock file as-is
@@ -139,7 +139,7 @@ class LockTransaction extends Transaction
      */
     public function getAliases(array $aliases): array
     {
-        $usedAliases = array();
+        $usedAliases = [];
 
         foreach ($this->resultPackages['all'] as $package) {
             if ($package instanceof AliasPackage) {

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -27,19 +27,19 @@ use Composer\Semver\Constraint\Constraint;
 class Pool implements \Countable
 {
     /** @var BasePackage[] */
-    protected $packages = array();
+    protected $packages = [];
     /** @var array<string, BasePackage[]> */
-    protected $packageByName = array();
+    protected $packageByName = [];
     /** @var VersionParser */
     protected $versionParser;
     /** @var array<string, array<string, BasePackage[]>> */
-    protected $providerCache = array();
+    protected $providerCache = [];
     /** @var BasePackage[] */
     protected $unacceptableFixedOrLockedPackages;
     /** @var array<string, array<string, string>> Map of package name => normalized version => pretty version */
-    protected $removedVersions = array();
+    protected $removedVersions = [];
     /** @var array<string, array<string, string>> Map of package object hash => removed normalized versions => removed pretty version */
-    protected $removedVersionsByPackage = array();
+    protected $removedVersionsByPackage = [];
 
     /**
      * @param BasePackage[] $packages
@@ -47,7 +47,7 @@ class Pool implements \Countable
      * @param array<string, array<string, string>> $removedVersions
      * @param array<string, array<string, string>> $removedVersionsByPackage
      */
-    public function __construct(array $packages = array(), array $unacceptableFixedOrLockedPackages = array(), array $removedVersions = array(), array $removedVersionsByPackage = array())
+    public function __construct(array $packages = [], array $unacceptableFixedOrLockedPackages = [], array $removedVersions = [], array $removedVersionsByPackage = [])
     {
         $this->versionParser = new VersionParser;
         $this->setPackages($packages);
@@ -63,10 +63,10 @@ class Pool implements \Countable
     public function getRemovedVersions(string $name, ConstraintInterface $constraint): array
     {
         if (!isset($this->removedVersions[$name])) {
-            return array();
+            return [];
         }
 
-        $result = array();
+        $result = [];
         foreach ($this->removedVersions[$name] as $version => $prettyVersion) {
             if ($constraint->matches(new Constraint('==', $version))) {
                 $result[$version] = $prettyVersion;
@@ -83,7 +83,7 @@ class Pool implements \Countable
     public function getRemovedVersionsByPackage(string $objectHash): array
     {
         if (!isset($this->removedVersionsByPackage[$objectHash])) {
-            return array();
+            return [];
         }
 
         return $this->removedVersionsByPackage[$objectHash];
@@ -162,10 +162,10 @@ class Pool implements \Countable
     private function computeWhatProvides(string $name, ConstraintInterface $constraint = null): array
     {
         if (!isset($this->packageByName[$name])) {
-            return array();
+            return [];
         }
 
-        $matches = array();
+        $matches = [];
 
         foreach ($this->packageByName[$name] as $candidate) {
             if ($this->match($candidate, $name, $constraint)) {

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -78,34 +78,34 @@ class PoolBuilder
      * @var array[]
      * @phpstan-var array<string, AliasPackage[]>
      */
-    private $aliasMap = array();
+    private $aliasMap = [];
     /**
      * @var ConstraintInterface[]
      * @phpstan-var array<string, ConstraintInterface>
      */
-    private $packagesToLoad = array();
+    private $packagesToLoad = [];
     /**
      * @var ConstraintInterface[]
      * @phpstan-var array<string, ConstraintInterface>
      */
-    private $loadedPackages = array();
+    private $loadedPackages = [];
     /**
      * @var array[]
      * @phpstan-var array<int, array<string, array<string, PackageInterface>>>
      */
-    private $loadedPerRepo = array();
+    private $loadedPerRepo = [];
     /**
      * @var BasePackage[]
      */
-    private $packages = array();
+    private $packages = [];
     /**
      * @var BasePackage[]
      */
-    private $unacceptableFixedOrLockedPackages = array();
+    private $unacceptableFixedOrLockedPackages = [];
     /** @var string[] */
-    private $updateAllowList = array();
+    private $updateAllowList = [];
     /** @var array<string, array<PackageInterface>> */
-    private $skippedLoad = array();
+    private $skippedLoad = [];
 
     /**
      * Keeps a list of dependencies which are locked but were auto-unlocked as they are path repositories
@@ -115,7 +115,7 @@ class PoolBuilder
      *
      * @var array<string, true>
      */
-    private $pathRepoUnlocked = array();
+    private $pathRepoUnlocked = [];
 
     /**
      * Keeps a list of dependencies which are root requirements, and as such
@@ -127,12 +127,12 @@ class PoolBuilder
      *
      * @var array<string, true>
      */
-    private $maxExtendedReqs = array();
+    private $maxExtendedReqs = [];
     /**
      * @var array
      * @phpstan-var array<string, bool>
      */
-    private $updateAllowWarned = array();
+    private $updateAllowWarned = [];
 
     /** @var int */
     private $indexCounter = 0;
@@ -248,7 +248,7 @@ class PoolBuilder
                 }
 
                 $constraint = $this->temporaryConstraints[$package->getName()];
-                $packageAndAliases = array($i => $package);
+                $packageAndAliases = [$i => $package];
                 if (isset($this->aliasMap[spl_object_hash($package)])) {
                     $packageAndAliases += $this->aliasMap[spl_object_hash($package)];
                 }
@@ -287,14 +287,14 @@ class PoolBuilder
 
         $pool = new Pool($this->packages, $this->unacceptableFixedOrLockedPackages);
 
-        $this->aliasMap = array();
-        $this->packagesToLoad = array();
-        $this->loadedPackages = array();
-        $this->loadedPerRepo = array();
-        $this->packages = array();
-        $this->unacceptableFixedOrLockedPackages = array();
-        $this->maxExtendedReqs = array();
-        $this->skippedLoad = array();
+        $this->aliasMap = [];
+        $this->packagesToLoad = [];
+        $this->loadedPackages = [];
+        $this->loadedPerRepo = [];
+        $this->packages = [];
+        $this->unacceptableFixedOrLockedPackages = [];
+        $this->maxExtendedReqs = [];
+        $this->skippedLoad = [];
         $this->indexCounter = 0;
 
         $this->io->debug('Built pool.');
@@ -344,7 +344,7 @@ class PoolBuilder
                 }
 
                 // extend the constraint to be loaded
-                $constraint = Intervals::compactConstraint(MultiConstraint::create(array($this->packagesToLoad[$name], $constraint), false));
+                $constraint = Intervals::compactConstraint(MultiConstraint::create([$this->packagesToLoad[$name], $constraint], false));
             }
 
             $this->packagesToLoad[$name] = $constraint;
@@ -361,7 +361,7 @@ class PoolBuilder
         // We have already loaded that package but not in the constraint that's
         // required. We extend the constraint and mark that package as not being loaded
         // yet so we get the required package versions
-        $this->packagesToLoad[$name] = Intervals::compactConstraint(MultiConstraint::create(array($this->loadedPackages[$name], $constraint), false));
+        $this->packagesToLoad[$name] = Intervals::compactConstraint(MultiConstraint::create([$this->loadedPackages[$name], $constraint], false));
         unset($this->loadedPackages[$name]);
     }
 
@@ -376,7 +376,7 @@ class PoolBuilder
         }
 
         $packageBatch = $this->packagesToLoad;
-        $this->packagesToLoad = array();
+        $this->packagesToLoad = [];
 
         foreach ($repositories as $repoIndex => $repository) {
             if (empty($packageBatch)) {
@@ -388,7 +388,7 @@ class PoolBuilder
             if ($repository instanceof PlatformRepository || $repository === $request->getLockedRepository()) {
                 continue;
             }
-            $result = $repository->loadPackages($packageBatch, $this->acceptableStabilities, $this->stabilityFlags, $this->loadedPerRepo[$repoIndex] ?? array());
+            $result = $repository->loadPackages($packageBatch, $this->acceptableStabilities, $this->stabilityFlags, $this->loadedPerRepo[$repoIndex] ?? []);
 
             foreach ($result['namesFound'] as $name) {
                 // avoid loading the same package again from other repositories once it has been found
@@ -525,11 +525,11 @@ class PoolBuilder
     private function getSkippedRootRequires(Request $request, string $name): array
     {
         if (!isset($this->skippedLoad[$name])) {
-            return array();
+            return [];
         }
 
         $rootRequires = $request->getRequires();
-        $matches = array();
+        $matches = [];
 
         if (isset($rootRequires[$name])) {
             return array_map(function (PackageInterface $package) use ($name): string {

--- a/src/Composer/DependencyResolver/PoolOptimizer.php
+++ b/src/Composer/DependencyResolver/PoolOptimizer.php
@@ -36,32 +36,32 @@ class PoolOptimizer
     /**
      * @var array<int, true>
      */
-    private $irremovablePackages = array();
+    private $irremovablePackages = [];
 
     /**
      * @var array<string, array<string, ConstraintInterface>>
      */
-    private $requireConstraintsPerPackage = array();
+    private $requireConstraintsPerPackage = [];
 
     /**
      * @var array<string, array<string, ConstraintInterface>>
      */
-    private $conflictConstraintsPerPackage = array();
+    private $conflictConstraintsPerPackage = [];
 
     /**
      * @var array<int, true>
      */
-    private $packagesToRemove = array();
+    private $packagesToRemove = [];
 
     /**
      * @var array<int, BasePackage[]>
      */
-    private $aliasesPerPackage = array();
+    private $aliasesPerPackage = [];
 
     /**
      * @var array<string, array<string, string>>
      */
-    private $removedVersionsByPackage = array();
+    private $removedVersionsByPackage = [];
 
     public function __construct(PolicyInterface $policy)
     {
@@ -86,12 +86,12 @@ class PoolOptimizer
         // even more gains when ran again. Might change
         // in the future with additional optimizations.
 
-        $this->irremovablePackages = array();
-        $this->requireConstraintsPerPackage = array();
-        $this->conflictConstraintsPerPackage = array();
-        $this->packagesToRemove = array();
-        $this->aliasesPerPackage = array();
-        $this->removedVersionsByPackage = array();
+        $this->irremovablePackages = [];
+        $this->requireConstraintsPerPackage = [];
+        $this->conflictConstraintsPerPackage = [];
+        $this->packagesToRemove = [];
+        $this->aliasesPerPackage = [];
+        $this->removedVersionsByPackage = [];
 
         return $optimizedPool;
     }
@@ -101,7 +101,7 @@ class PoolOptimizer
      */
     private function prepare(Request $request, Pool $pool): void
     {
-        $irremovablePackageConstraintGroups = array();
+        $irremovablePackageConstraintGroups = [];
 
         // Mark fixed or locked packages as irremovable
         foreach ($request->getFixedOrLockedPackages() as $package) {
@@ -131,7 +131,7 @@ class PoolOptimizer
             }
         }
 
-        $irremovablePackageConstraints = array();
+        $irremovablePackageConstraints = [];
         foreach ($irremovablePackageConstraintGroups as $packageName => $constraints) {
             $irremovablePackageConstraints[$packageName] = 1 === \count($constraints) ? $constraints[0] : new MultiConstraint($constraints, false);
         }
@@ -172,8 +172,8 @@ class PoolOptimizer
      */
     private function applyRemovalsToPool(Pool $pool): Pool
     {
-        $packages = array();
-        $removedVersions = array();
+        $packages = [];
+        $removedVersions = [];
         foreach ($pool->getPackages() as $package) {
             if (!isset($this->packagesToRemove[$package->id])) {
                 $packages[] = $package;
@@ -192,8 +192,8 @@ class PoolOptimizer
      */
     private function optimizeByIdenticalDependencies(Request $request, Pool $pool): void
     {
-        $identicalDefinitionsPerPackage = array();
-        $packageIdenticalDefinitionLookup = array();
+        $identicalDefinitionsPerPackage = [];
+        $packageIdenticalDefinitionLookup = [];
 
         foreach ($pool->getPackages() as $package) {
 
@@ -213,7 +213,7 @@ class PoolOptimizer
                 }
 
                 foreach ($this->requireConstraintsPerPackage[$packageName] as $requireConstraint) {
-                    $groupHashParts = array();
+                    $groupHashParts = [];
 
                     if (CompilingMatcher::match($requireConstraint, Constraint::OP_EQ, $package->getVersion())) {
                         $groupHashParts[] = 'require:' . (string) $requireConstraint;
@@ -242,7 +242,7 @@ class PoolOptimizer
 
                     $groupHash = implode('', $groupHashParts);
                     $identicalDefinitionsPerPackage[$packageName][$groupHash][$dependencyHash][] = $package;
-                    $packageIdenticalDefinitionLookup[$package->id][$packageName] = array('groupHash' => $groupHash, 'dependencyHash' => $dependencyHash);
+                    $packageIdenticalDefinitionLookup[$package->id][$packageName] = ['groupHash' => $groupHash, 'dependencyHash' => $dependencyHash];
                 }
             }
         }
@@ -258,7 +258,7 @@ class PoolOptimizer
 
                     // Otherwise we find out which one is the preferred package in this constraint group which is
                     // then not allowed to be removed either
-                    $literals = array();
+                    $literals = [];
 
                     foreach ($packages as $package) {
                         $literals[] = $package->id;
@@ -279,12 +279,12 @@ class PoolOptimizer
     {
         $hash = '';
 
-        $hashRelevantLinks = array(
+        $hashRelevantLinks = [
             'requires' => $package->getRequires(),
             'conflicts' => $package->getConflicts(),
             'replaces' => $package->getReplaces(),
             'provides' => $package->getProvides(),
-        );
+        ];
 
         foreach ($hashRelevantLinks as $key => $links) {
             if (0 === \count($links)) {
@@ -294,7 +294,7 @@ class PoolOptimizer
             // start new hash section
             $hash .= $key . ':';
 
-            $subhash = array();
+            $subhash = [];
 
             foreach ($links as $link) {
                 // To get the best dependency hash matches we should use Intervals::compactConstraint() here.
@@ -397,7 +397,7 @@ class PoolOptimizer
             return;
         }
 
-        $packageIndex = array();
+        $packageIndex = [];
 
         foreach ($pool->getPackages() as $package) {
             $id = $package->id;
@@ -498,6 +498,6 @@ class PoolOptimizer
         }
 
         // Regular constraints and conjunctive MultiConstraints
-        return array($constraint);
+        return [$constraint];
     }
 }

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -43,7 +43,7 @@ class Problem
      * A set of reasons for the problem, each is a rule or a root require and a rule
      * @var array<int, array<int, Rule>>
      */
-    protected $reasons = array();
+    protected $reasons = [];
 
     /** @var int */
     protected $section = 0;
@@ -77,7 +77,7 @@ class Problem
      * @param array<Rule[]> $learnedPool
      * @return string
      */
-    public function getPrettyString(RepositorySet $repositorySet, Request $request, Pool $pool, bool $isVerbose, array $installedMap = array(), array $learnedPool = array()): string
+    public function getPrettyString(RepositorySet $repositorySet, Request $request, Pool $pool, bool $isVerbose, array $installedMap = [], array $learnedPool = []): string
     {
         // TODO doesn't this entirely defeat the purpose of the problem sections? what's the point of sections?
         $reasons = call_user_func_array('array_merge', array_reverse($this->reasons));
@@ -86,7 +86,7 @@ class Problem
             reset($reasons);
             $rule = current($reasons);
 
-            if (!in_array($rule->getReason(), array(Rule::RULE_ROOT_REQUIRE, Rule::RULE_FIXED), true)) {
+            if (!in_array($rule->getReason(), [Rule::RULE_ROOT_REQUIRE, Rule::RULE_FIXED], true)) {
                 throw new \LogicException("Single reason problems must contain a request rule.");
             }
 
@@ -97,7 +97,7 @@ class Problem
             if (isset($constraint)) {
                 $packages = $pool->whatProvides($packageName, $constraint);
             } else {
-                $packages = array();
+                $packages = [];
             }
 
             if (empty($packages)) {
@@ -117,12 +117,12 @@ class Problem
      * @return string
      * @internal
      */
-    public static function formatDeduplicatedRules(array $rules, string $indent, RepositorySet $repositorySet, Request $request, Pool $pool, bool $isVerbose, array $installedMap = array(), array $learnedPool = array()): string
+    public static function formatDeduplicatedRules(array $rules, string $indent, RepositorySet $repositorySet, Request $request, Pool $pool, bool $isVerbose, array $installedMap = [], array $learnedPool = []): string
     {
-        $messages = array();
-        $templates = array();
+        $messages = [];
+        $templates = [];
         $parser = new VersionParser;
-        $deduplicatableRuleTypes = array(Rule::RULE_PACKAGE_REQUIRES, Rule::RULE_PACKAGE_CONFLICT);
+        $deduplicatableRuleTypes = [Rule::RULE_PACKAGE_REQUIRES, Rule::RULE_PACKAGE_CONFLICT];
         foreach ($rules as $rule) {
             $message = $rule->getPrettyString($repositorySet, $request, $pool, $isVerbose, $installedMap, $learnedPool);
             if (in_array($rule->getReason(), $deduplicatableRuleTypes, true) && Preg::isMatch('{^(?P<package>\S+) (?P<version>\S+) (?P<type>requires|conflicts)}', $message, $m)) {
@@ -138,7 +138,7 @@ class Problem
             }
         }
 
-        $result = array();
+        $result = [];
         foreach (array_unique($messages) as $message) {
             if (isset($templates[$message])) {
                 foreach ($templates[$message] as $package => $versions) {
@@ -220,24 +220,24 @@ class Problem
                 $msg = "- Root composer.json requires ".$packageName.self::constraintToText($constraint).' but ';
 
                 if (defined('HHVM_VERSION') || ($packageName === 'hhvm' && count($pool->whatProvides($packageName)) > 0)) {
-                    return array($msg, 'your HHVM version does not satisfy that requirement.');
+                    return [$msg, 'your HHVM version does not satisfy that requirement.'];
                 }
 
                 if ($packageName === 'hhvm') {
-                    return array($msg, 'HHVM was not detected on this machine, make sure it is in your PATH.');
+                    return [$msg, 'HHVM was not detected on this machine, make sure it is in your PATH.'];
                 }
 
                 if (null === $version) {
-                    return array($msg, 'the '.$packageName.' package is disabled by your platform config. Enable it again with "composer config platform.'.$packageName.' --unset".');
+                    return [$msg, 'the '.$packageName.' package is disabled by your platform config. Enable it again with "composer config platform.'.$packageName.' --unset".'];
                 }
 
-                return array($msg, 'your '.$packageName.' version ('. $version .') does not satisfy that requirement.');
+                return [$msg, 'your '.$packageName.' version ('. $version .') does not satisfy that requirement.'];
             }
 
             // handle php extensions
             if (0 === stripos($packageName, 'ext-')) {
                 if (false !== strpos($packageName, ' ')) {
-                    return array('- ', "PHP extension ".$packageName.' should be required as '.str_replace(' ', '-', $packageName).'.');
+                    return ['- ', "PHP extension ".$packageName.' should be required as '.str_replace(' ', '-', $packageName).'.'];
                 }
 
                 $ext = substr($packageName, 4);
@@ -246,16 +246,16 @@ class Problem
                 $version = self::getPlatformPackageVersion($pool, $packageName, phpversion($ext) ?: '0');
                 if (null === $version) {
                     if (extension_loaded($ext)) {
-                        return array(
+                        return [
                             $msg,
                             'the '.$packageName.' package is disabled by your platform config. Enable it again with "composer config platform.'.$packageName.' --unset".',
-                        );
+                        ];
                     }
 
-                    return array($msg, 'it is missing from your system. Install or enable PHP\'s '.$ext.' extension.');
+                    return [$msg, 'it is missing from your system. Install or enable PHP\'s '.$ext.' extension.'];
                 }
 
-                return array($msg, 'it has the wrong version installed ('.$version.').');
+                return [$msg, 'it has the wrong version installed ('.$version.').'];
             }
 
             // handle linked libs
@@ -263,10 +263,10 @@ class Problem
                 if (strtolower($packageName) === 'lib-icu') {
                     $error = extension_loaded('intl') ? 'it has the wrong version installed, try upgrading the intl extension.' : 'it is missing from your system, make sure the intl extension is loaded.';
 
-                    return array("- Root composer.json requires linked library ".$packageName.self::constraintToText($constraint).' but ', $error);
+                    return ["- Root composer.json requires linked library ".$packageName.self::constraintToText($constraint).' but ', $error];
                 }
 
-                return array("- Root composer.json requires linked library ".$packageName.self::constraintToText($constraint).' but ', 'it has the wrong version installed or is missing from your system, make sure to load the extension providing it.');
+                return ["- Root composer.json requires linked library ".$packageName.self::constraintToText($constraint).' but ', 'it has the wrong version installed or is missing from your system, make sure to load the extension providing it.'];
             }
         }
 
@@ -275,7 +275,7 @@ class Problem
             if ($package->getName() === $packageName) {
                 $lockedPackage = $package;
                 if ($pool->isUnacceptableFixedOrLockedPackage($package)) {
-                    return array("- ", $package->getPrettyName().' is fixed to '.$package->getPrettyVersion().' (lock file version) by a partial update but that version is rejected by your minimum-stability. Make sure you list it as an argument for the update command.');
+                    return ["- ", $package->getPrettyName().' is fixed to '.$package->getPrettyVersion().' (lock file version) by a partial update but that version is rejected by your minimum-stability. Make sure you list it as an argument for the update command.'];
                 }
                 break;
             }
@@ -290,7 +290,7 @@ class Problem
                     return $rootReqs[$packageName]->matches(new Constraint('==', $p->getVersion()));
                 });
                 if (0 === count($filtered)) {
-                    return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but '.(self::hasMultipleNames($packages) ? 'these conflict' : 'it conflicts').' with your root composer.json require ('.$rootReqs[$packageName]->getPrettyString().').');
+                    return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but '.(self::hasMultipleNames($packages) ? 'these conflict' : 'it conflicts').' with your root composer.json require ('.$rootReqs[$packageName]->getPrettyString().').'];
                 }
             }
 
@@ -300,7 +300,7 @@ class Problem
                     return $tempReqs[$packageName]->matches(new Constraint('==', $p->getVersion()));
                 });
                 if (0 === count($filtered)) {
-                    return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but '.(self::hasMultipleNames($packages) ? 'these conflict' : 'it conflicts').' with your temporary update constraint ('.$packageName.':'.$tempReqs[$packageName]->getPrettyString().').');
+                    return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but '.(self::hasMultipleNames($packages) ? 'these conflict' : 'it conflicts').' with your temporary update constraint ('.$packageName.':'.$tempReqs[$packageName]->getPrettyString().').'];
                 }
             }
 
@@ -310,7 +310,7 @@ class Problem
                     return $fixedConstraint->matches(new Constraint('==', $p->getVersion()));
                 });
                 if (0 === count($filtered)) {
-                    return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but the package is fixed to '.$lockedPackage->getPrettyVersion().' (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.');
+                    return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but the package is fixed to '.$lockedPackage->getPrettyVersion().' (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.'];
                 }
             }
 
@@ -319,10 +319,10 @@ class Problem
             });
 
             if (!$nonLockedPackages) {
-                return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' in the lock file but not in remote repositories, make sure you avoid updating this package to keep the one from the lock file.');
+                return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' in the lock file but not in remote repositories, make sure you avoid updating this package to keep the one from the lock file.'];
             }
 
-            return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but these were not loaded, likely because '.(self::hasMultipleNames($packages) ? 'they conflict' : 'it conflicts').' with another require.');
+            return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but these were not loaded, likely because '.(self::hasMultipleNames($packages) ? 'they conflict' : 'it conflicts').' with another require.'];
         }
 
         // check if the package is found when bypassing stability checks
@@ -332,7 +332,7 @@ class Problem
                 return self::computeCheckForLowerPrioRepo($pool, $isVerbose, $packageName, $packages, $allReposPackages, 'minimum-stability', $constraint);
             }
 
-            return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but '.(self::hasMultipleNames($packages) ? 'these do' : 'it does').' not match your minimum-stability.');
+            return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but '.(self::hasMultipleNames($packages) ? 'these do' : 'it does').' not match your minimum-stability.'];
         }
 
         // check if the package is found when bypassing the constraint and stability checks
@@ -345,7 +345,7 @@ class Problem
             $suffix = '';
             if ($constraint instanceof Constraint && $constraint->getVersion() === 'dev-master') {
                 foreach ($packages as $candidate) {
-                    if (in_array($candidate->getVersion(), array('dev-default', 'dev-main'), true)) {
+                    if (in_array($candidate->getVersion(), ['dev-default', 'dev-main'], true)) {
                         $suffix = ' Perhaps dev-master was renamed to '.$candidate->getPrettyVersion().'?';
                         break;
                     }
@@ -359,13 +359,13 @@ class Problem
                 $suffix = ' See https://getcomposer.org/dep-on-root for details and assistance.';
             }
 
-            return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but '.(self::hasMultipleNames($packages) ? 'these do' : 'it does').' not match the constraint.' . $suffix);
+            return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but '.(self::hasMultipleNames($packages) ? 'these do' : 'it does').' not match the constraint.' . $suffix];
         }
 
         if (!Preg::isMatch('{^[A-Za-z0-9_./-]+$}', $packageName)) {
             $illegalChars = Preg::replace('{[A-Za-z0-9_./-]+}', '', $packageName);
 
-            return array("- Root composer.json requires $packageName, it ", 'could not be found, it looks like its name is invalid, "'.$illegalChars.'" is not allowed in package names.');
+            return ["- Root composer.json requires $packageName, it ", 'could not be found, it looks like its name is invalid, "'.$illegalChars.'" is not allowed in package names.'];
         }
 
         if ($providers = $repositorySet->getProviders($packageName)) {
@@ -379,10 +379,10 @@ class Problem
                 $providersStr .= '      ... and '.(count($providers) - $maxProviders).' more.'."\n";
             }
 
-            return array("- Root composer.json requires $packageName".self::constraintToText($constraint).", it ", "could not be found in any version, but the following packages provide it:\n".$providersStr."      Consider requiring one of these to satisfy the $packageName requirement.");
+            return ["- Root composer.json requires $packageName".self::constraintToText($constraint).", it ", "could not be found in any version, but the following packages provide it:\n".$providersStr."      Consider requiring one of these to satisfy the $packageName requirement."];
         }
 
-        return array("- Root composer.json requires $packageName, it ", "could not be found in any version, there may be a typo in the package name.");
+        return ["- Root composer.json requires $packageName, it ", "could not be found in any version, there may be a typo in the package name."];
     }
 
     /**
@@ -394,8 +394,8 @@ class Problem
      */
     public static function getPackageList(array $packages, bool $isVerbose, Pool $pool = null, ConstraintInterface $constraint = null, bool $useRemovedVersionGroup = false): string
     {
-        $prepared = array();
-        $hasDefaultBranch = array();
+        $prepared = [];
+        $hasDefaultBranch = [];
         foreach ($packages as $package) {
             $prepared[$package->getName()]['name'] = $package->getPrettyName();
             $prepared[$package->getName()]['versions'][$package->getVersion()] = $package->getPrettyVersion().($package instanceof AliasPackage ? ' (alias of '.$package->getAliasOf()->getPrettyVersion().')' : '');
@@ -414,7 +414,7 @@ class Problem
             }
         }
 
-        $preparedStrings = array();
+        $preparedStrings = [];
         foreach ($prepared as $name => $package) {
             // remove the implicit default branch alias to avoid cruft in the display
             if (isset($package['versions'][VersionParser::DEFAULT_BRANCH_ALIAS], $hasDefaultBranch[$name])) {
@@ -487,8 +487,8 @@ class Problem
             return $versions;
         }
 
-        $filtered = array();
-        $byMajor = array();
+        $filtered = [];
+        $byMajor = [];
         foreach ($versions as $version => $pretty) {
             if (0 === stripos($version, 'dev-')) {
                 $byMajor['dev'][] = $pretty;
@@ -539,7 +539,7 @@ class Problem
      */
     private static function computeCheckForLowerPrioRepo(Pool $pool, bool $isVerbose, string $packageName, array $higherRepoPackages, array $allReposPackages, string $reason, ConstraintInterface $constraint = null): array
     {
-        $nextRepoPackages = array();
+        $nextRepoPackages = [];
         $nextRepo = null;
 
         foreach ($allReposPackages as $package) {
@@ -554,10 +554,10 @@ class Problem
         if ($higherRepoPackages) {
             $topPackage = reset($higherRepoPackages);
             if ($topPackage instanceof RootPackageInterface) {
-                return array(
+                return [
                     "- Root composer.json requires $packageName".self::constraintToText($constraint).', it is ',
                     'satisfiable by '.self::getPackageList($nextRepoPackages, $isVerbose, $pool, $constraint).' from '.$nextRepo->getRepoName().' but '.$topPackage->getPrettyName().' is the root package and cannot be modified. See https://getcomposer.org/dep-on-root for details and assistance.',
-                );
+                ];
             }
         }
 
@@ -573,12 +573,12 @@ class Problem
                 }
             }
 
-            return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ',
+            return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ',
                 'found ' . self::getPackageList($higherRepoPackages, $isVerbose, $pool, $constraint).' but ' . ($singular ? 'it does' : 'these do') . ' not match your '.$reason.' and ' . ($singular ? 'is' : 'are') . ' therefore not installable. '.$suggestion,
-            );
+            ];
         }
 
-        return array("- Root composer.json requires $packageName".self::constraintToText($constraint) . ', it is ', 'satisfiable by '.self::getPackageList($nextRepoPackages, $isVerbose, $pool, $constraint).' from '.$nextRepo->getRepoName().' but '.self::getPackageList($higherRepoPackages, $isVerbose, $pool, $constraint).' from '.reset($higherRepoPackages)->getRepository()->getRepoName().' has higher repository priority. The packages from the higher priority repository do not match your '.$reason.' and are therefore not installable. That repository is canonical so the lower priority repo\'s packages are not installable. See https://getcomposer.org/repoprio for details and assistance.');
+        return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', it is ', 'satisfiable by '.self::getPackageList($nextRepoPackages, $isVerbose, $pool, $constraint).' from '.$nextRepo->getRepoName().' but '.self::getPackageList($higherRepoPackages, $isVerbose, $pool, $constraint).' from '.reset($higherRepoPackages)->getRepository()->getRepoName().' has higher repository priority. The packages from the higher priority repository do not match your '.$reason.' and are therefore not installable. That repository is canonical so the lower priority repo\'s packages are not installable. See https://getcomposer.org/repoprio for details and assistance.'];
     }
 
     /**

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -43,15 +43,15 @@ class Request
     /** @var ?LockArrayRepository */
     protected $lockedRepository;
     /** @var array<string, ConstraintInterface> */
-    protected $requires = array();
+    protected $requires = [];
     /** @var array<string, BasePackage> */
-    protected $fixedPackages = array();
+    protected $fixedPackages = [];
     /** @var array<string, BasePackage> */
-    protected $lockedPackages = array();
+    protected $lockedPackages = [];
     /** @var array<string, BasePackage> */
-    protected $fixedLockedPackages = array();
+    protected $fixedLockedPackages = [];
     /** @var string[] */
-    protected $updateAllowList = array();
+    protected $updateAllowList = [];
     /** @var false|self::UPDATE_* */
     protected $updateAllowTransitiveDependencies = false;
 
@@ -224,7 +224,7 @@ class Request
      */
     public function getPresentMap(bool $packageIds = false): array
     {
-        $presentMap = array();
+        $presentMap = [];
 
         if ($this->lockedRepository) {
             foreach ($this->lockedRepository->getPackages() as $package) {
@@ -244,7 +244,7 @@ class Request
      */
     public function getFixedPackagesMap(): array
     {
-        $fixedPackagesMap = array();
+        $fixedPackagesMap = [];
 
         foreach ($this->fixedPackages as $package) {
             $fixedPackagesMap[$package->getId()] = $package;

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -244,7 +244,7 @@ abstract class Rule
                 if ($reasonData = $this->getReasonData()) {
                     // swap literals if they are not in the right order with package2 being the conflicter
                     if ($reasonData->getSource() === $package1->getName()) {
-                        list($package2, $package1) = array($package1, $package2);
+                        list($package2, $package1) = [$package1, $package2];
                     }
                 }
 
@@ -267,7 +267,7 @@ abstract class Rule
      * @param array<Rule[]> $learnedPool
      * @return string
      */
-    public function getPrettyString(RepositorySet $repositorySet, Request $request, Pool $pool, bool $isVerbose, array $installedMap = array(), array $learnedPool = array()): string
+    public function getPrettyString(RepositorySet $repositorySet, Request $request, Pool $pool, bool $isVerbose, array $installedMap = [], array $learnedPool = []): string
     {
         $literals = $this->getLiterals();
 
@@ -312,7 +312,7 @@ abstract class Rule
 
                     // swap literals if they are not in the right order with package2 being the conflicter
                     if ($reasonData->getSource() === $package1->getName()) {
-                        list($package2, $package1) = array($package1, $package2);
+                        list($package2, $package1) = [$package1, $package2];
                         $conflictTarget = $package1->getPrettyName().' '.$reasonData->getPrettyConstraint();
                     }
 
@@ -349,7 +349,7 @@ abstract class Rule
                 /** @var Link */
                 $reasonData = $this->reasonData;
 
-                $requires = array();
+                $requires = [];
                 foreach ($literals as $literal) {
                     $requires[] = $pool->literalToPackage($literal);
                 }
@@ -368,7 +368,7 @@ abstract class Rule
                 return $text;
 
             case self::RULE_PACKAGE_SAME_NAME:
-                $packageNames = array();
+                $packageNames = [];
                 foreach ($literals as $literal) {
                     $package = $pool->literalToPackage($literal);
                     $packageNames[$package->getName()] = true;
@@ -394,8 +394,8 @@ abstract class Rule
                         $reason .= $replacedName.' and thus cannot coexist with it.';
                     }
 
-                    $installedPackages = array();
-                    $removablePackages = array();
+                    $installedPackages = [];
+                    $removablePackages = [];
                     foreach ($literals as $literal) {
                         if (isset($installedMap[abs($literal)])) {
                             $installedPackages[] = $pool->literalToPackage($literal);
@@ -425,7 +425,7 @@ abstract class Rule
                 if (count($literals) === 1) {
                     $ruleText = $pool->literalToPrettyString($literals[0], $installedMap);
                 } else {
-                    $groups = array();
+                    $groups = [];
                     foreach ($literals as $literal) {
                         $package = $pool->literalToPackage($literal);
                         if (isset($installedMap[$package->id])) {
@@ -436,7 +436,7 @@ abstract class Rule
 
                         $groups[$group][] = $this->deduplicateDefaultBranchAlias($package);
                     }
-                    $ruleTexts = array();
+                    $ruleTexts = [];
                     foreach ($groups as $group => $packages) {
                         $ruleTexts[] = $group . (count($packages) > 1 ? ' one of' : '').' ' . $this->formatPackagesUnique($pool, $packages, $isVerbose);
                     }

--- a/src/Composer/DependencyResolver/Rule2Literals.php
+++ b/src/Composer/DependencyResolver/Rule2Literals.php
@@ -47,7 +47,7 @@ class Rule2Literals extends Rule
     /** @return int[] */
     public function getLiterals(): array
     {
-        return array($this->literal1, $this->literal2);
+        return [$this->literal1, $this->literal2];
     }
 
     /**

--- a/src/Composer/DependencyResolver/RuleSet.php
+++ b/src/Composer/DependencyResolver/RuleSet.php
@@ -30,14 +30,14 @@ class RuleSet implements \IteratorAggregate, \Countable
      *
      * @var array<int, Rule>
      */
-    public $ruleById = array();
+    public $ruleById = [];
 
     /** @var array<0|1|4, string> */
-    protected static $types = array(
+    protected static $types = [
         self::TYPE_PACKAGE => 'PACKAGE',
         self::TYPE_REQUEST => 'REQUEST',
         self::TYPE_LEARNED => 'LEARNED',
-    );
+    ];
 
     /** @var array<self::TYPE_*, Rule[]> */
     protected $rules;
@@ -46,12 +46,12 @@ class RuleSet implements \IteratorAggregate, \Countable
     protected $nextRuleId = 0;
 
     /** @var array<int|string, Rule|Rule[]> */
-    protected $rulesByHash = array();
+    protected $rulesByHash = [];
 
     public function __construct()
     {
         foreach ($this->getTypes() as $type) {
-            $this->rules[$type] = array();
+            $this->rules[$type] = [];
         }
     }
 
@@ -84,7 +84,7 @@ class RuleSet implements \IteratorAggregate, \Countable
         }
 
         if (!isset($this->rules[$type])) {
-            $this->rules[$type] = array();
+            $this->rules[$type] = [];
         }
 
         $this->rules[$type][] = $rule;
@@ -99,7 +99,7 @@ class RuleSet implements \IteratorAggregate, \Countable
             $this->rulesByHash[$hash][] = $rule;
         } else {
             $originalRule = $this->rulesByHash[$hash];
-            $this->rulesByHash[$hash] = array($originalRule, $rule);
+            $this->rulesByHash[$hash] = [$originalRule, $rule];
         }
     }
 
@@ -135,13 +135,13 @@ class RuleSet implements \IteratorAggregate, \Countable
     public function getIteratorFor($types): RuleSetIterator
     {
         if (!\is_array($types)) {
-            $types = array($types);
+            $types = [$types];
         }
 
         $allRules = $this->getRules();
 
         /** @var array<self::TYPE_*, Rule[]> $rules */
-        $rules = array();
+        $rules = [];
 
         foreach ($types as $type) {
             $rules[$type] = $allRules[$type];
@@ -157,7 +157,7 @@ class RuleSet implements \IteratorAggregate, \Countable
     public function getIteratorWithout($types): RuleSetIterator
     {
         if (!\is_array($types)) {
-            $types = array($types);
+            $types = [$types];
         }
 
         $rules = $this->getRules();

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -31,9 +31,9 @@ class RuleSetGenerator
     /** @var RuleSet */
     protected $rules;
     /** @var array<int, BasePackage> */
-    protected $addedMap = array();
+    protected $addedMap = [];
     /** @var array<string, BasePackage[]> */
-    protected $addedPackagesByNames = array();
+    protected $addedPackagesByNames = [];
 
     public function __construct(PolicyInterface $policy, Pool $pool)
     {
@@ -58,7 +58,7 @@ class RuleSetGenerator
      */
     protected function createRequireRule(BasePackage $package, array $providers, $reason, $reasonData = null): ?Rule
     {
-        $literals = array(-$package->id);
+        $literals = [-$package->id];
 
         foreach ($providers as $provider) {
             // self fulfilling rule?
@@ -87,7 +87,7 @@ class RuleSetGenerator
      */
     protected function createInstallOneOfRule(array $packages, $reason, $reasonData): Rule
     {
-        $literals = array();
+        $literals = [];
         foreach ($packages as $package) {
             $literals[] = $package->id;
         }
@@ -129,7 +129,7 @@ class RuleSetGenerator
      */
     protected function createMultiConflictRule(array $packages, $reason, $reasonData): Rule
     {
-        $literals = array();
+        $literals = [];
         foreach ($packages as $package) {
             $literals[] = -$package->id;
         }
@@ -184,10 +184,10 @@ class RuleSetGenerator
                 }
             } else {
                 $workQueue->enqueue($package->getAliasOf());
-                $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRequireRule($package, array($package->getAliasOf()), Rule::RULE_PACKAGE_ALIAS, $package));
+                $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRequireRule($package, [$package->getAliasOf()], Rule::RULE_PACKAGE_ALIAS, $package));
 
                 // aliases must be installed with their main package, so create a rule the other way around as well
-                $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRequireRule($package->getAliasOf(), array($package), Rule::RULE_PACKAGE_INVERSE_ALIAS, $package->getAliasOf()));
+                $this->addRule(RuleSet::TYPE_PACKAGE, $this->createRequireRule($package->getAliasOf(), [$package], Rule::RULE_PACKAGE_INVERSE_ALIAS, $package->getAliasOf()));
 
                 // if alias package has no self.version requires, its requirements do not
                 // need to be added as the aliased package processing will take care of it
@@ -274,9 +274,9 @@ class RuleSetGenerator
 
             $this->addRulesForPackage($package, $platformRequirementFilter);
 
-            $rule = $this->createInstallOneOfRule(array($package), Rule::RULE_FIXED, array(
+            $rule = $this->createInstallOneOfRule([$package], Rule::RULE_FIXED, [
                 'package' => $package,
-            ));
+            ]);
             $this->addRule(RuleSet::TYPE_REQUEST, $rule);
         }
 
@@ -293,10 +293,10 @@ class RuleSetGenerator
                     $this->addRulesForPackage($package, $platformRequirementFilter);
                 }
 
-                $rule = $this->createInstallOneOfRule($packages, Rule::RULE_ROOT_REQUIRE, array(
+                $rule = $this->createInstallOneOfRule($packages, Rule::RULE_ROOT_REQUIRE, [
                     'packageName' => $packageName,
                     'constraint' => $constraint,
-                ));
+                ]);
                 $this->addRule(RuleSet::TYPE_REQUEST, $rule);
             }
         }
@@ -334,7 +334,7 @@ class RuleSetGenerator
         $this->addConflictRules($platformRequirementFilter);
 
         // Remove references to packages
-        $this->addedMap = $this->addedPackagesByNames = array();
+        $this->addedMap = $this->addedPackagesByNames = [];
 
         $rules = $this->rules;
 

--- a/src/Composer/DependencyResolver/RuleWatchGraph.php
+++ b/src/Composer/DependencyResolver/RuleWatchGraph.php
@@ -25,7 +25,7 @@ namespace Composer\DependencyResolver;
 class RuleWatchGraph
 {
     /** @var array<int, RuleWatchChain> */
-    protected $watchChains = array();
+    protected $watchChains = [];
 
     /**
      * Inserts a rule node into the appropriate chains within the graph
@@ -47,7 +47,7 @@ class RuleWatchGraph
         }
 
         if (!$node->getRule() instanceof MultiConflictRule) {
-            foreach (array($node->watch1, $node->watch2) as $literal) {
+            foreach ([$node->watch1, $node->watch2] as $literal) {
                 if (!isset($this->watchChains[$literal])) {
                     $this->watchChains[$literal] = new RuleWatchChain;
                 }

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -44,13 +44,13 @@ class Solver
     /** @var int */
     protected $propagateIndex;
     /** @var mixed[] */
-    protected $branches = array();
+    protected $branches = [];
     /** @var Problem[] */
-    protected $problems = array();
+    protected $problems = [];
     /** @var array<Rule[]> */
-    protected $learnedPool = array();
+    protected $learnedPool = [];
     /** @var array<string, int> */
-    protected $learnedWhy = array();
+    protected $learnedWhy = [];
 
     /** @var bool */
     public $testFlagLearnedPositiveLiteral = false;
@@ -161,7 +161,7 @@ class Solver
      */
     protected function setupFixedMap(Request $request): void
     {
-        $this->fixedMap = array();
+        $this->fixedMap = [];
         foreach ($request->getFixedPackages() as $package) {
             $this->fixedMap[$package->id] = $package;
         }
@@ -181,7 +181,7 @@ class Solver
 
             if (!$this->pool->whatProvides($packageName, $constraint)) {
                 $problem = new Problem();
-                $problem->addRule(new GenericRule(array(), Rule::RULE_ROOT_REQUIRE, array('packageName' => $packageName, 'constraint' => $constraint)));
+                $problem->addRule(new GenericRule([], Rule::RULE_ROOT_REQUIRE, ['packageName' => $packageName, 'constraint' => $constraint]));
                 $this->problems[] = $problem;
             }
         }
@@ -360,7 +360,7 @@ class Solver
 
         // if there are multiple candidates, then branch
         if (\count($literals)) {
-            $this->branches[] = array($literals, $level);
+            $this->branches[] = [$literals, $level];
         }
 
         return $this->setPropagateLearn($level, $selectedLiteral, $rule);
@@ -376,12 +376,12 @@ class Solver
         $ruleLevel = 1;
         $num = 0;
         $l1num = 0;
-        $seen = array();
-        $learnedLiterals = array(null);
+        $seen = [];
+        $learnedLiterals = [null];
 
         $decisionId = \count($this->decisions);
 
-        $this->learnedPool[] = array();
+        $this->learnedPool[] = [];
 
         while (true) {
             $this->learnedPool[\count($this->learnedPool) - 1][] = $rule;
@@ -511,7 +511,7 @@ class Solver
 
         $newRule = new GenericRule($learnedLiterals, Rule::RULE_LEARNED, $why);
 
-        return array($learnedLiterals[0], $ruleLevel, $newRule, $why);
+        return [$learnedLiterals[0], $ruleLevel, $newRule, $why];
     }
 
     /**
@@ -553,13 +553,13 @@ class Solver
         $problem = new Problem();
         $problem->addRule($conflictRule);
 
-        $ruleSeen = array();
+        $ruleSeen = [];
 
         $this->analyzeUnsolvableRule($problem, $conflictRule, $ruleSeen);
 
         $this->problems[] = $problem;
 
-        $seen = array();
+        $seen = [];
         $literals = $conflictRule->getLiterals();
 
         foreach ($literals as $literal) {
@@ -665,7 +665,7 @@ class Solver
                 $iterator = $this->rules->getIteratorFor(RuleSet::TYPE_REQUEST);
                 foreach ($iterator as $rule) {
                     if ($rule->isEnabled()) {
-                        $decisionQueue = array();
+                        $decisionQueue = [];
                         $noneSatisfied = true;
 
                         foreach ($rule->getLiterals() as $literal) {
@@ -680,7 +680,7 @@ class Solver
 
                         if ($noneSatisfied && \count($decisionQueue)) {
                             // if any of the options in the decision queue are fixed, only use those
-                            $prunedQueue = array();
+                            $prunedQueue = [];
                             foreach ($decisionQueue as $literal) {
                                 if (isset($this->fixedMap[abs($literal)])) {
                                     $prunedQueue[] = $literal;
@@ -741,7 +741,7 @@ class Solver
                     continue;
                 }
 
-                $decisionQueue = array();
+                $decisionQueue = [];
 
                 // make sure that
                 // * all negative literals are installed

--- a/src/Composer/DependencyResolver/SolverProblemsException.php
+++ b/src/Composer/DependencyResolver/SolverProblemsException.php
@@ -49,10 +49,10 @@ class SolverProblemsException extends \RuntimeException
     public function getPrettyString(RepositorySet $repositorySet, Request $request, Pool $pool, bool $isVerbose, bool $isDevExtraction = false): string
     {
         $installedMap = $request->getPresentMap(true);
-        $missingExtensions = array();
+        $missingExtensions = [];
         $isCausedByLock = false;
 
-        $problems = array();
+        $problems = [];
         foreach ($this->problems as $problem) {
             $problems[] = $problem->getPrettyString($repositorySet, $request, $pool, $isVerbose, $installedMap, $this->learnedPool)."\n";
 
@@ -67,7 +67,7 @@ class SolverProblemsException extends \RuntimeException
             $text .= "  Problem ".($i++).$problem;
         }
 
-        $hints = array();
+        $hints = [];
         if (!$isDevExtraction && (strpos($text, 'could not be found') || strpos($text, 'no matching package found'))) {
             $hints[] = "Potential causes:\n - A typo in the package name\n - The package is not available in a stable-enough version according to your minimum-stability setting\n   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.\n - It's a private package and you forgot to add a custom repository to find it\n\nRead <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.";
         }
@@ -135,7 +135,7 @@ class SolverProblemsException extends \RuntimeException
      */
     private function getExtensionProblems(array $reasonSets): array
     {
-        $missingExtensions = array();
+        $missingExtensions = [];
         foreach ($reasonSets as $reasonSet) {
             foreach ($reasonSet as $rule) {
                 $required = $rule->getRequiredPackage();

--- a/src/Composer/DependencyResolver/Transaction.php
+++ b/src/Composer/DependencyResolver/Transaction.php
@@ -44,7 +44,7 @@ class Transaction
     /**
      * @var array<string, PackageInterface[]>
      */
-    protected $resultPackagesByName = array();
+    protected $resultPackagesByName = [];
 
     /**
      * @param PackageInterface[] $presentPackages
@@ -84,7 +84,7 @@ class Transaction
             return strcmp($b->getName(), $a->getName());
         };
 
-        $this->resultPackageMap = array();
+        $this->resultPackageMap = [];
         foreach ($resultPackages as $package) {
             $this->resultPackageMap[spl_object_hash($package)] = $package;
             foreach ($package->getNames() as $name) {
@@ -103,12 +103,12 @@ class Transaction
      */
     protected function calculateOperations(): array
     {
-        $operations = array();
+        $operations = [];
 
-        $presentPackageMap = array();
-        $removeMap = array();
-        $presentAliasMap = array();
-        $removeAliasMap = array();
+        $presentPackageMap = [];
+        $removeMap = [];
+        $presentAliasMap = [];
+        $removeAliasMap = [];
         foreach ($this->presentPackages as $package) {
             if ($package instanceof AliasPackage) {
                 $presentAliasMap[$package->getName().'::'.$package->getVersion()] = $package;
@@ -121,8 +121,8 @@ class Transaction
 
         $stack = $this->getRootPackages();
 
-        $visited = array();
-        $processed = array();
+        $visited = [];
+        $processed = [];
 
         while (!empty($stack)) {
             $package = array_pop($stack);
@@ -247,7 +247,7 @@ class Transaction
     protected function getProvidersInResult(Link $link): array
     {
         if (!isset($this->resultPackagesByName[$link->getTarget()])) {
-            return array();
+            return [];
         }
 
         return $this->resultPackagesByName[$link->getTarget()];
@@ -268,12 +268,12 @@ class Transaction
      */
     private function movePluginsToFront(array $operations): array
     {
-        $dlModifyingPluginsNoDeps = array();
-        $dlModifyingPluginsWithDeps = array();
-        $dlModifyingPluginRequires = array();
-        $pluginsNoDeps = array();
-        $pluginsWithDeps = array();
-        $pluginRequires = array();
+        $dlModifyingPluginsNoDeps = [];
+        $dlModifyingPluginsWithDeps = [];
+        $dlModifyingPluginRequires = [];
+        $pluginsNoDeps = [];
+        $pluginsWithDeps = [];
+        $pluginRequires = [];
 
         foreach (array_reverse($operations, true) as $idx => $op) {
             if ($op instanceof Operation\InstallOperation) {
@@ -345,7 +345,7 @@ class Transaction
      */
     private function moveUninstallsToFront(array $operations): array
     {
-        $uninstOps = array();
+        $uninstOps = [];
         foreach ($operations as $idx => $op) {
             if ($op instanceof Operation\UninstallOperation || $op instanceof Operation\MarkAliasUninstalledOperation) {
                 $uninstOps[] = $op;

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -30,7 +30,7 @@ abstract class ArchiveDownloader extends FileDownloader
     /**
      * @var array<string, true>
      */
-    protected $cleanupExecuted = array();
+    protected $cleanupExecuted = [];
 
     /**
      * @return PromiseInterface

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -33,11 +33,11 @@ class DownloadManager
     /** @var bool */
     private $preferSource;
     /** @var array<string, string> */
-    private $packagePreferences = array();
+    private $packagePreferences = [];
     /** @var Filesystem */
     private $filesystem;
     /** @var array<string, DownloaderInterface> */
-    private $downloaders = array();
+    private $downloaders = [];
 
     /**
      * Initializes download manager.
@@ -406,7 +406,7 @@ class DownloadManager
         $distType = $package->getDistType();
 
         // add source before dist by default
-        $sources = array();
+        $sources = [];
         if ($sourceType) {
             $sources[] = 'source';
         }

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -63,14 +63,14 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
      * @private
      * @internal
      */
-    public static $downloadMetadata = array();
+    public static $downloadMetadata = [];
 
     /**
      * @var array<string, string> Map of package name to cache key
      */
-    private $lastCacheWrites = array();
+    private $lastCacheWrites = [];
     /** @var array<string, string[]> Map of package name to list of paths */
-    private $additionalCleanupPaths = array();
+    private $additionalCleanupPaths = [];
 
     /**
      * Constructor.
@@ -126,10 +126,10 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
         $retries = 3;
         $distUrls = $package->getDistUrls();
         /** @var array<array{base: string, processed: string, cacheKey: string}> $urls */
-        $urls = array();
+        $urls = [];
         foreach ($distUrls as $index => $url) {
             $processedUrl = $this->processUrl($package, $url);
-            $urls[$index] = array(
+            $urls[$index] = [
                 'base' => $url,
                 'processed' => $processedUrl,
                 // we use the complete download url here to avoid conflicting entries
@@ -137,7 +137,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
                 // in a third party repo to pre-populate the cache for the same package in
                 // packagist for example.
                 'cacheKey' => $cacheKeyGenerator($package, $processedUrl),
-            );
+            ];
         }
 
         $fileName = $this->getFileName($package, $path);
@@ -252,7 +252,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
 
             if ($e instanceof TransportException) {
                 // if we got an http response with a proper code, then requesting again will probably not help, abort
-                if ((0 !== $e->getCode() && !in_array($e->getCode(), array(500, 502, 503, 504))) || !$retries) {
+                if ((0 !== $e->getCode() && !in_array($e->getCode(), [500, 502, 503, 504])) || !$retries) {
                     $retries = 0;
                 }
             }
@@ -260,7 +260,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             // special error code returned when network is being artificially disabled
             if ($e instanceof TransportException && $e->getStatusCode() === 499) {
                 $retries = 0;
-                $urls = array();
+                $urls = [];
             }
 
             if ($retries) {
@@ -309,11 +309,11 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             $this->filesystem->unlink($fileName);
         }
 
-        $dirsToCleanUp = array(
+        $dirsToCleanUp = [
             $this->config->get('vendor-dir').'/composer/',
             $this->config->get('vendor-dir'),
             $path,
-        );
+        ];
 
         if (isset($this->additionalCleanupPaths[$package->getName()])) {
             foreach ($this->additionalCleanupPaths[$package->getName()] as $path) {

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -33,12 +33,12 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
      * @var bool[]
      * @phpstan-var array<string, bool>
      */
-    private $hasStashedChanges = array();
+    private $hasStashedChanges = [];
     /**
      * @var bool[]
      * @phpstan-var array<string, bool>
      */
-    private $hasDiscardedChanges = array();
+    private $hasDiscardedChanges = [];
     /**
      * @var GitUtil
      */
@@ -47,7 +47,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
      * @var array
      * @phpstan-var array<int, array<string, bool>>
      */
-    private $cachedPackages = array();
+    private $cachedPackages = [];
 
     public function __construct(IOInterface $io, Config $config, ProcessExecutor $process = null, Filesystem $fs = null)
     {
@@ -116,13 +116,13 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
 
         $commandCallable = function (string $url) use ($path, $command, $cachePath): string {
             return str_replace(
-                array('%url%', '%path%', '%cachePath%', '%sanitizedUrl%'),
-                array(
+                ['%url%', '%path%', '%cachePath%', '%sanitizedUrl%'],
+                [
                     ProcessExecutor::escape($url),
                     ProcessExecutor::escape($path),
                     ProcessExecutor::escape($cachePath),
                     ProcessExecutor::escape(Preg::replace('{://([^@]+?):(.+?)@}', '://', $url)),
-                ),
+                ],
                 $command
             );
         };
@@ -174,13 +174,13 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
 
         $commandCallable = function ($url) use ($ref, $command, $cachePath): string {
             return str_replace(
-                array('%url%', '%ref%', '%cachePath%', '%sanitizedUrl%'),
-                array(
+                ['%url%', '%ref%', '%cachePath%', '%sanitizedUrl%'],
+                [
                     ProcessExecutor::escape($url),
                     ProcessExecutor::escape($ref.'^{commit}'),
                     ProcessExecutor::escape($cachePath),
                     ProcessExecutor::escape(Preg::replace('{://([^@]+?):(.+?)@}', '://', $url)),
-                ),
+                ],
                 $command
             );
         };
@@ -266,7 +266,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
 
         // do two passes, as if we find anything we want to fetch and then re-try
         for ($i = 0; $i <= 1; $i++) {
-            $remoteBranches = array();
+            $remoteBranches = [];
 
             // try to find matching branch names in remote repos
             foreach ($candidateBranches as $candidate) {
@@ -397,12 +397,12 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
                 case '?':
                 default:
                     help :
-                    $this->io->writeError(array(
+                    $this->io->writeError([
                         '    y - discard changes and apply the '.($update ? 'update' : 'uninstall'),
                         '    n - abort the '.($update ? 'update' : 'uninstall').' and let you manually clean things up',
                         '    v - view modified files',
                         '    d - view local modifications (diff)',
-                    ));
+                    ]);
                     if ($update) {
                         $this->io->writeError('    s - stash changes and try to reapply them after the update');
                     }
@@ -612,7 +612,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
     {
         if (Platform::isWindows() && strlen($path) > 0) {
             $basePath = $path;
-            $removed = array();
+            $removed = [];
 
             while (!is_dir($basePath) && $basePath !== '\\') {
                 array_unshift($removed, basename($basePath));

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -90,7 +90,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
         }
 
         // Get the transport options with default values
-        $transportOptions = $package->getTransportOptions() + array('relative' => true);
+        $transportOptions = $package->getTransportOptions() + ['relative' => true];
 
         list($currentStrategy, $allowedStrategies) = $this->computeAllowedStrategies($transportOptions);
 
@@ -147,7 +147,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             if ($output) {
                 $this->io->writeError(sprintf('%sMirroring from %s', $isFallback ? '    ' : '', $url), false);
             }
-            $iterator = new ArchivableFilesFinder($realUrl, array());
+            $iterator = new ArchivableFilesFinder($realUrl, []);
             $symfonyFilesystem->mirror($realUrl, $path, $iterator);
         }
 
@@ -254,7 +254,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
     {
         // When symlink transport option is null, both symlink and mirror are allowed
         $currentStrategy = self::STRATEGY_SYMLINK;
-        $allowedStrategies = array(self::STRATEGY_SYMLINK, self::STRATEGY_MIRROR);
+        $allowedStrategies = [self::STRATEGY_SYMLINK, self::STRATEGY_MIRROR];
 
         $mirrorPathRepos = Platform::getEnv('COMPOSER_MIRROR_PATH_REPOS');
         if ($mirrorPathRepos) {
@@ -265,10 +265,10 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
 
         if (true === $symlinkOption) {
             $currentStrategy = self::STRATEGY_SYMLINK;
-            $allowedStrategies = array(self::STRATEGY_SYMLINK);
+            $allowedStrategies = [self::STRATEGY_SYMLINK];
         } elseif (false === $symlinkOption) {
             $currentStrategy = self::STRATEGY_MIRROR;
-            $allowedStrategies = array(self::STRATEGY_MIRROR);
+            $allowedStrategies = [self::STRATEGY_MIRROR];
         }
 
         // Check we can use junctions safely if we are on Windows
@@ -277,7 +277,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
                 throw new \RuntimeException('You are on an old Windows / old PHP combo which does not allow Composer to use junctions/symlinks and this path repository has symlink:true in its options so copying is not allowed');
             }
             $currentStrategy = self::STRATEGY_MIRROR;
-            $allowedStrategies = array(self::STRATEGY_MIRROR);
+            $allowedStrategies = [self::STRATEGY_MIRROR];
         }
 
         // Check we can use symlink() otherwise
@@ -286,10 +286,10 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
                 throw new \RuntimeException('Your PHP has the symlink() function disabled which does not allow Composer to use symlinks and this path repository has symlink:true in its options so copying is not allowed');
             }
             $currentStrategy = self::STRATEGY_MIRROR;
-            $allowedStrategies = array(self::STRATEGY_MIRROR);
+            $allowedStrategies = [self::STRATEGY_MIRROR];
         }
 
-        return array($currentStrategy, $allowedStrategies);
+        return [$currentStrategy, $allowedStrategies];
     }
 
     /**

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -175,12 +175,12 @@ class SvnDownloader extends VcsDownloader
 
                 case '?':
                 default:
-                    $this->io->writeError(array(
+                    $this->io->writeError([
                         '    y - discard changes and apply the '.($update ? 'update' : 'uninstall'),
                         '    n - abort the '.($update ? 'update' : 'uninstall').' and let you manually clean things up',
                         '    v - view modified files',
                         '    ? - print help',
-                    ));
+                    ]);
                     break;
             }
         }

--- a/src/Composer/Downloader/TransportException.php
+++ b/src/Composer/Downloader/TransportException.php
@@ -24,7 +24,7 @@ class TransportException extends \RuntimeException
     /** @var ?int */
     protected $statusCode;
     /** @var array<mixed> */
-    protected $responseInfo = array();
+    protected $responseInfo = [];
 
     /**
      * @param array<string> $headers

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -39,7 +39,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     /** @var Filesystem */
     protected $filesystem;
     /** @var array<string, true> */
-    protected $hasCleanedChanges = array();
+    protected $hasCleanedChanges = [];
 
     public function __construct(IOInterface $io, Config $config, ProcessExecutor $process = null, Filesystem $fs = null)
     {

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -43,25 +43,25 @@ class ZipDownloader extends ArchiveDownloader
     public function download(PackageInterface $package, string $path, PackageInterface $prevPackage = null, bool $output = true): PromiseInterface
     {
         if (null === self::$unzipCommands) {
-            self::$unzipCommands = array();
+            self::$unzipCommands = [];
             $finder = new ExecutableFinder;
-            if (Platform::isWindows() && ($cmd = $finder->find('7z', null, array('C:\Program Files\7-Zip')))) {
-                self::$unzipCommands[] = array('7z', ProcessExecutor::escape($cmd).' x -bb0 -y %s -o%s');
+            if (Platform::isWindows() && ($cmd = $finder->find('7z', null, ['C:\Program Files\7-Zip']))) {
+                self::$unzipCommands[] = ['7z', ProcessExecutor::escape($cmd).' x -bb0 -y %s -o%s'];
             }
             if ($cmd = $finder->find('unzip')) {
-                self::$unzipCommands[] = array('unzip', ProcessExecutor::escape($cmd).' -qq %s -d %s');
+                self::$unzipCommands[] = ['unzip', ProcessExecutor::escape($cmd).' -qq %s -d %s'];
             }
             if (!Platform::isWindows() && ($cmd = $finder->find('7z'))) { // 7z linux/macOS support is only used if unzip is not present
-                self::$unzipCommands[] = array('7z', ProcessExecutor::escape($cmd).' x -bb0 -y %s -o%s');
+                self::$unzipCommands[] = ['7z', ProcessExecutor::escape($cmd).' x -bb0 -y %s -o%s'];
             }
             if (!Platform::isWindows() && ($cmd = $finder->find('7zz'))) { // 7zz linux/macOS support is only used if unzip is not present
-                self::$unzipCommands[] = array('7zz', ProcessExecutor::escape($cmd).' x -bb0 -y %s -o%s');
+                self::$unzipCommands[] = ['7zz', ProcessExecutor::escape($cmd).' x -bb0 -y %s -o%s'];
             }
         }
 
         $procOpenMissing = false;
         if (!function_exists('proc_open')) {
-            self::$unzipCommands = array();
+            self::$unzipCommands = [];
             $procOpenMissing = true;
         }
 
@@ -129,7 +129,7 @@ class ZipDownloader extends ArchiveDownloader
         }
 
         $executable = $commandSpec[0];
-        if (!$warned7ZipLinux && !Platform::isWindows() && in_array($executable, array('7z', '7zz'), true)) {
+        if (!$warned7ZipLinux && !Platform::isWindows() && in_array($executable, ['7z', '7zz'], true)) {
             $warned7ZipLinux = true;
             if (0 === $this->process->execute($executable, $output)) {
                 if (Preg::isMatch('{^\s*7-Zip(?: \[64\])? ([0-9.]+)}', $output, $match) && version_compare($match[1], '21.01', '<')) {

--- a/src/Composer/EventDispatcher/Event.php
+++ b/src/Composer/EventDispatcher/Event.php
@@ -46,7 +46,7 @@ class Event
      * @param string[] $args  Arguments passed by the user
      * @param mixed[]  $flags Optional flags to pass data not as argument
      */
-    public function __construct(string $name, array $args = array(), array $flags = array())
+    public function __construct(string $name, array $args = [], array $flags = [])
     {
         $this->name = $name;
         $this->args = $args;

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -54,7 +54,7 @@ class EventDispatcher
     /** @var ProcessExecutor */
     protected $process;
     /** @var array<string, array<int, array<callable|string>>> */
-    protected $listeners = array();
+    protected $listeners = [];
     /** @var bool */
     protected $runScripts = true;
     /** @var list<string> */
@@ -72,7 +72,7 @@ class EventDispatcher
         $this->composer = $composer;
         $this->io = $io;
         $this->process = $process ?? new ProcessExecutor($io);
-        $this->eventStack = array();
+        $this->eventStack = [];
     }
 
     /**
@@ -118,7 +118,7 @@ class EventDispatcher
      * @return int                                  return code of the executed script if any, for php scripts a false return
      *                                              value is changed to 1, anything else to 0
      */
-    public function dispatchScript(string $eventName, bool $devMode = false, array $additionalArgs = array(), array $flags = array()): int
+    public function dispatchScript(string $eventName, bool $devMode = false, array $additionalArgs = [], array $flags = []): int
     {
         assert($this->composer instanceof Composer, new \LogicException('This should only be reached with a fully loaded Composer'));
 
@@ -252,7 +252,7 @@ class EventDispatcher
                         throw $e;
                     }
                 } else {
-                    $args = implode(' ', array_map(array('Composer\Util\ProcessExecutor', 'escape'), $event->getArguments()));
+                    $args = implode(' ', array_map(['Composer\Util\ProcessExecutor', 'escape'], $event->getArguments()));
                     $exec = $callable . ($args === '' ? '' : ' '.$args);
                     if ($this->io->isVerbose()) {
                         $this->io->writeError(sprintf('> %s: %s', $event->getName(), $exec));
@@ -436,12 +436,12 @@ class EventDispatcher
     {
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
             if (is_string($params)) {
-                $this->addListener($eventName, array($subscriber, $params));
+                $this->addListener($eventName, [$subscriber, $params]);
             } elseif (is_string($params[0])) {
-                $this->addListener($eventName, array($subscriber, $params[0]), $params[1] ?? 0);
+                $this->addListener($eventName, [$subscriber, $params[0]], $params[1] ?? 0);
             } else {
                 foreach ($params as $listener) {
-                    $this->addListener($eventName, array($subscriber, $listener[0]), $listener[1] ?? 0);
+                    $this->addListener($eventName, [$subscriber, $listener[0]], $listener[1] ?? 0);
                 }
             }
         }
@@ -455,10 +455,10 @@ class EventDispatcher
      */
     protected function getListeners(Event $event): array
     {
-        $scriptListeners = $this->runScripts ? $this->getScriptListeners($event) : array();
+        $scriptListeners = $this->runScripts ? $this->getScriptListeners($event) : [];
 
         if (!isset($this->listeners[$event->getName()][0])) {
-            $this->listeners[$event->getName()][0] = array();
+            $this->listeners[$event->getName()][0] = [];
         }
         krsort($this->listeners[$event->getName()]);
 
@@ -493,7 +493,7 @@ class EventDispatcher
         $scripts = $package->getScripts();
 
         if (empty($scripts[$event->getName()])) {
-            return array();
+            return [];
         }
 
         assert($this->composer instanceof Composer, new \LogicException('This should only be reached with a fully loaded Composer'));

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -72,7 +72,7 @@ class Factory
         }
 
         $userDir = self::getUserDir();
-        $dirs = array();
+        $dirs = [];
 
         if (self::useXdg()) {
             // XDG Base Directory Specifications
@@ -171,13 +171,13 @@ class Factory
 
         // determine and add main dirs to the config
         $home = self::getHomeDir();
-        $config->merge(array(
-            'config' => array(
+        $config->merge([
+            'config' => [
                 'home' => $home,
                 'cache-dir' => self::getCacheDir($home),
                 'data-dir' => self::getDataDir($home),
-            )
-        ), Config::SOURCE_DEFAULT);
+            ]
+        ], Config::SOURCE_DEFAULT);
 
         // load global config
         $file = new JsonFile($config->get('home').'/config.json');
@@ -195,7 +195,7 @@ class Factory
             // Protect directory against web access. Since HOME could be
             // the www-data's user home and be web-accessible it is a
             // potential security risk
-            $dirs = array($config->get('home'), $config->get('cache-dir'), $config->get('data-dir'));
+            $dirs = [$config->get('home'), $config->get('cache-dir'), $config->get('data-dir')];
             foreach ($dirs as $dir) {
                 if (!file_exists($dir . '/.htaccess')) {
                     if (!is_dir($dir)) {
@@ -213,7 +213,7 @@ class Factory
                 $io->writeError('Loading config file ' . $file->getPath(), true, IOInterface::DEBUG);
             }
             self::validateJsonSchema($io, $file, JsonFile::AUTH_SCHEMA);
-            $config->merge(array('config' => $file->read()), $file->getPath());
+            $config->merge(['config' => $file->read()], $file->getPath());
         }
         $config->setAuthConfigSource(new JsonConfigSource($file, true));
 
@@ -231,7 +231,7 @@ class Factory
                 self::validateJsonSchema($io, $authData, JsonFile::AUTH_SCHEMA, 'COMPOSER_AUTH');
                 $authData = json_decode($composerAuthEnv, true);
                 if (null !== $authData) {
-                    $config->merge(array('config' => $authData), 'COMPOSER_AUTH');
+                    $config->merge(['config' => $authData], 'COMPOSER_AUTH');
                 }
             }
         }
@@ -256,10 +256,10 @@ class Factory
      */
     public static function createAdditionalStyles(): array
     {
-        return array(
+        return [
             'highlight' => new OutputFormatterStyle('red'),
             'warning' => new OutputFormatterStyle('black', 'yellow'),
-        );
+        ];
     }
 
     public static function createOutput(): ConsoleOutput
@@ -334,7 +334,7 @@ class Factory
             if ($localAuthFile->exists()) {
                 $io->writeError('Loading config file ' . $localAuthFile->getPath(), true, IOInterface::DEBUG);
                 self::validateJsonSchema($io, $localAuthFile, JsonFile::AUTH_SCHEMA);
-                $config->merge(array('config' => $localAuthFile->read()), $localAuthFile->getPath());
+                $config->merge(['config' => $localAuthFile->read()], $localAuthFile->getPath());
                 $config->setAuthConfigSource(new JsonConfigSource($localAuthFile, true));
             }
         }
@@ -628,7 +628,7 @@ class Factory
      * @param  mixed[]        $options Array of options passed directly to HttpDownloader constructor
      * @return HttpDownloader
      */
-    public static function createHttpDownloader(IOInterface $io, Config $config, array $options = array()): HttpDownloader
+    public static function createHttpDownloader(IOInterface $io, Config $config, array $options = []): HttpDownloader
     {
         static $warned = false;
         $disableTls = false;
@@ -646,7 +646,7 @@ class Factory
             throw new Exception\NoSslException('The openssl extension is required for SSL/TLS protection but is not available. '
                 . 'If you can not enable the openssl extension, you can disable this error, at your own risk, by setting the \'disable-tls\' option to true.');
         }
-        $httpDownloaderOptions = array();
+        $httpDownloaderOptions = [];
         if ($disableTls === false) {
             if ('' !== $config->get('cafile')) {
                 $httpDownloaderOptions['ssl']['cafile'] = $config->get('cafile');

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
@@ -39,7 +39,7 @@ final class IgnoreListPlatformRequirementFilter implements PlatformRequirementFi
      */
     public function __construct(array $reqList)
     {
-        $ignoreAll = $ignoreUpperBound = array();
+        $ignoreAll = $ignoreUpperBound = [];
         foreach ($reqList as $req) {
             if (substr($req, -1) === '+') {
                 $ignoreUpperBound[] = substr($req, 0, -1);
@@ -85,7 +85,7 @@ final class IgnoreListPlatformRequirementFilter implements PlatformRequirementFi
         $intervals = Intervals::get($constraint);
         $last = end($intervals['numeric']);
         if ($last !== false && (string) $last->getEnd() !== (string) Interval::untilPositiveInfinity()) {
-            $constraint = new MultiConstraint(array($constraint, new Constraint('>=', $last->getEnd()->getVersion())), false);
+            $constraint = new MultiConstraint([$constraint, new Constraint('>=', $last->getEnd()->getVersion())], false);
         }
 
         return $constraint;

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -20,7 +20,7 @@ use Psr\Log\LogLevel;
 abstract class BaseIO implements IOInterface
 {
     /** @var array<string, array{username: string|null, password: string|null}> */
-    protected $authentications = array();
+    protected $authentications = [];
 
     /**
      * @inheritDoc
@@ -35,7 +35,7 @@ abstract class BaseIO implements IOInterface
      */
     public function resetAuthentications()
     {
-        $this->authentications = array();
+        $this->authentications = [];
     }
 
     /**
@@ -55,7 +55,7 @@ abstract class BaseIO implements IOInterface
             return $this->authentications[$repositoryName];
         }
 
-        return array('username' => null, 'password' => null);
+        return ['username' => null, 'password' => null];
     }
 
     /**
@@ -63,7 +63,7 @@ abstract class BaseIO implements IOInterface
      */
     public function setAuthentication($repositoryName, $username, $password = null)
     {
-        $this->authentications[$repositoryName] = array('username' => $username, 'password' => $password);
+        $this->authentications[$repositoryName] = ['username' => $username, 'password' => $password];
     }
 
     /**
@@ -159,51 +159,51 @@ abstract class BaseIO implements IOInterface
         ProcessExecutor::setTimeout($config->get('process-timeout'));
     }
 
-    public function emergency($message, array $context = array()): void
+    public function emergency($message, array $context = []): void
     {
         $this->log(LogLevel::EMERGENCY, $message, $context);
     }
 
-    public function alert($message, array $context = array()): void
+    public function alert($message, array $context = []): void
     {
         $this->log(LogLevel::ALERT, $message, $context);
     }
 
-    public function critical($message, array $context = array()): void
+    public function critical($message, array $context = []): void
     {
         $this->log(LogLevel::CRITICAL, $message, $context);
     }
 
-    public function error($message, array $context = array()): void
+    public function error($message, array $context = []): void
     {
         $this->log(LogLevel::ERROR, $message, $context);
     }
 
-    public function warning($message, array $context = array()): void
+    public function warning($message, array $context = []): void
     {
         $this->log(LogLevel::WARNING, $message, $context);
     }
 
-    public function notice($message, array $context = array()): void
+    public function notice($message, array $context = []): void
     {
         $this->log(LogLevel::NOTICE, $message, $context);
     }
 
-    public function info($message, array $context = array()): void
+    public function info($message, array $context = []): void
     {
         $this->log(LogLevel::INFO, $message, $context);
     }
 
-    public function debug($message, array $context = array()): void
+    public function debug($message, array $context = []): void
     {
         $this->log(LogLevel::DEBUG, $message, $context);
     }
 
-    public function log($level, $message, array $context = array()): void
+    public function log($level, $message, array $context = []): void
     {
         $message = (string) $message;
 
-        if (in_array($level, array(LogLevel::EMERGENCY, LogLevel::ALERT, LogLevel::CRITICAL, LogLevel::ERROR))) {
+        if (in_array($level, [LogLevel::EMERGENCY, LogLevel::ALERT, LogLevel::CRITICAL, LogLevel::ERROR])) {
             $this->writeError('<error>'.$message.'</error>');
         } elseif ($level === LogLevel::WARNING) {
             $this->writeError('<warning>'.$message.'</warning>');

--- a/src/Composer/IO/BufferIO.php
+++ b/src/Composer/IO/BufferIO.php
@@ -42,9 +42,9 @@ class BufferIO extends ConsoleIO
 
         $output = new StreamOutput(fopen('php://memory', 'rw'), $verbosity, $formatter ? $formatter->isDecorated() : false, $formatter);
 
-        parent::__construct($input, $output, new HelperSet(array(
+        parent::__construct($input, $output, new HelperSet([
             new QuestionHelper(),
-        )));
+        ]));
     }
 
     /**

--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -57,13 +57,13 @@ class ConsoleIO extends BaseIO
         $this->input = $input;
         $this->output = $output;
         $this->helperSet = $helperSet;
-        $this->verbosityMap = array(
+        $this->verbosityMap = [
             self::QUIET => OutputInterface::VERBOSITY_QUIET,
             self::NORMAL => OutputInterface::VERBOSITY_NORMAL,
             self::VERBOSE => OutputInterface::VERBOSITY_VERBOSE,
             self::VERY_VERBOSE => OutputInterface::VERBOSITY_VERY_VERBOSE,
             self::DEBUG => OutputInterface::VERBOSITY_DEBUG,
-        );
+        ];
     }
 
     /**
@@ -332,7 +332,7 @@ class ConsoleIO extends BaseIO
             return (string) array_search($result, $choices, true);
         }
 
-        $results = array();
+        $results = [];
         foreach ($choices as $index => $choice) {
             if (in_array($choice, $result, true)) {
                 $results[] = (string) $index;

--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -41,7 +41,7 @@ class InstalledVersions
      * @var array[]
      * @psalm-var array<string, array{root: array{name: string, pretty_version: string, version: string, reference: string|null, type: string, install_path: string, aliases: string[], dev: bool}, versions: array<string, array{pretty_version?: string, version?: string, reference?: string|null, type?: string, install_path?: string, aliases?: string[], dev_requirement: bool, replaced?: string[], provided?: string[]}>}>
      */
-    private static $installedByVendor = array();
+    private static $installedByVendor = [];
 
     /**
      * Returns a list of all package names which are present, either by being installed, replaced or provided
@@ -51,7 +51,7 @@ class InstalledVersions
      */
     public static function getInstalledPackages()
     {
-        $packages = array();
+        $packages = [];
         foreach (self::getInstalled() as $installed) {
             $packages[] = array_keys($installed['versions']);
         }
@@ -72,7 +72,7 @@ class InstalledVersions
      */
     public static function getInstalledPackagesByType($type)
     {
-        $packagesByType = array();
+        $packagesByType = [];
 
         foreach (self::getInstalled() as $installed) {
             foreach ($installed['versions'] as $name => $package) {
@@ -141,7 +141,7 @@ class InstalledVersions
                 continue;
             }
 
-            $ranges = array();
+            $ranges = [];
             if (isset($installed['versions'][$packageName]['pretty_version'])) {
                 $ranges[] = $installed['versions'][$packageName]['pretty_version'];
             }
@@ -269,7 +269,7 @@ class InstalledVersions
             if (substr(__DIR__, -8, 1) !== 'C') {
                 self::$installed = include __DIR__ . '/installed.php';
             } else {
-                self::$installed = array();
+                self::$installed = [];
             }
         }
 
@@ -308,7 +308,7 @@ class InstalledVersions
     public static function reload($data)
     {
         self::$installed = $data;
-        self::$installedByVendor = array();
+        self::$installedByVendor = [];
     }
 
     /**
@@ -321,7 +321,7 @@ class InstalledVersions
             self::$canGetVendors = method_exists('Composer\Autoload\ClassLoader', 'getRegisteredLoaders');
         }
 
-        $installed = array();
+        $installed = [];
 
         if (self::$canGetVendors) {
             foreach (ClassLoader::getRegisteredLoaders() as $vendorDir => $loader) {
@@ -342,7 +342,7 @@ class InstalledVersions
             if (substr(__DIR__, -8, 1) !== 'C') {
                 self::$installed = require __DIR__ . '/installed.php';
             } else {
-                self::$installed = array();
+                self::$installed = [];
             }
         }
         $installed[] = self::$installed;

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -299,11 +299,11 @@ class Installer
         }
 
         if ($this->update) {
-            $installedRepo = new InstalledRepository(array(
+            $installedRepo = new InstalledRepository([
                 $this->locker->getLockedRepository($this->devMode),
                 $this->createPlatformRepo(false),
                 new RootPackageRepository(clone $this->package),
-            ));
+            ]);
             if ($isFreshInstall) {
                 $this->suggestedPackagesReporter->addSuggestionsFromPackage($this->package);
             }
@@ -359,7 +359,7 @@ class Installer
             }
         }
         if ($fundingCount > 0) {
-            $this->io->writeError(array(
+            $this->io->writeError([
                 sprintf(
                     "<info>%d package%s you are using %s looking for funding.</info>",
                     $fundingCount,
@@ -367,7 +367,7 @@ class Installer
                     1 === $fundingCount ? 'is' : 'are'
                 ),
                 '<info>Use the `composer fund` command to find out more!</info>',
-            ));
+            ]);
         }
 
         if ($this->runScripts) {
@@ -486,9 +486,9 @@ class Installer
         $platformReqs = $this->extractPlatformRequirements($this->package->getRequires());
         $platformDevReqs = $this->extractPlatformRequirements($this->package->getDevRequires());
 
-        $installsUpdates = $uninstalls = array();
+        $installsUpdates = $uninstalls = [];
         if ($lockTransaction->getOperations()) {
-            $installNames = $updateNames = $uninstallNames = array();
+            $installNames = $updateNames = $uninstallNames = [];
             foreach ($lockTransaction->getOperations() as $operation) {
                 if ($operation instanceof InstallOperation) {
                     $installsUpdates[] = $operation;
@@ -572,7 +572,7 @@ class Installer
             $this->package->getStabilityFlags(),
             $this->preferStable || $this->package->getPreferStable(),
             $this->preferLowest,
-            $this->config->get('platform') ?: array(),
+            $this->config->get('platform') ?: [],
             $this->writeLock && $this->executeOperations
         );
         if ($updatedLock && $this->writeLock && $this->executeOperations) {
@@ -614,7 +614,7 @@ class Installer
             return 0;
         }
 
-        $resultRepo = new ArrayRepository(array());
+        $resultRepo = new ArrayRepository([]);
         $loader = new ArrayLoader(null, true);
         $dumper = new ArrayDumper();
         foreach ($lockTransaction->getNewLockPackages(false) as $pkg) {
@@ -676,7 +676,7 @@ class Installer
             // creating repository set
             $policy = $this->createPolicy(false);
             // use aliases from lock file only, so empty root aliases here
-            $repositorySet = $this->createRepositorySet(false, $platformRepo, array(), $lockedRepository);
+            $repositorySet = $this->createRepositorySet(false, $platformRepo, [], $lockedRepository);
             $repositorySet->addRepository($lockedRepository);
 
             // creating requirements request
@@ -731,7 +731,7 @@ class Installer
         }
 
         if ($localRepoTransaction->getOperations()) {
-            $installs = $updates = $uninstalls = array();
+            $installs = $updates = $uninstalls = [];
             foreach ($localRepoTransaction->getOperations() as $operation) {
                 if ($operation instanceof InstallOperation) {
                     $installs[] = $operation->getPackage()->getPrettyName().':'.$operation->getPackage()->getFullPrettyVersion();
@@ -785,12 +785,12 @@ class Installer
     protected function createPlatformRepo(bool $forUpdate): PlatformRepository
     {
         if ($forUpdate) {
-            $platformOverrides = $this->config->get('platform') ?: array();
+            $platformOverrides = $this->config->get('platform') ?: [];
         } else {
             $platformOverrides = $this->locker->getPlatformOverrides();
         }
 
-        return new PlatformRepository(array(), $platformOverrides);
+        return new PlatformRepository([], $platformOverrides);
     }
 
     /**
@@ -802,7 +802,7 @@ class Installer
      *
      * @phpstan-param list<array{package: string, version: string, alias: string, alias_normalized: string}> $rootAliases
      */
-    private function createRepositorySet(bool $forUpdate, PlatformRepository $platformRepo, array $rootAliases = array(), ?RepositoryInterface $lockedRepository = null): RepositorySet
+    private function createRepositorySet(bool $forUpdate, PlatformRepository $platformRepo, array $rootAliases = [], ?RepositoryInterface $lockedRepository = null): RepositorySet
     {
         if ($forUpdate) {
             $minimumStability = $this->package->getMinimumStability();
@@ -813,7 +813,7 @@ class Installer
             $minimumStability = $this->locker->getMinimumStability();
             $stabilityFlags = $this->locker->getStabilityFlags();
 
-            $requires = array();
+            $requires = [];
             foreach ($lockedRepository->getPackages() as $package) {
                 $constraint = new Constraint('=', $package->getVersion());
                 $constraint->setPrettyString($package->getPrettyVersion());
@@ -821,7 +821,7 @@ class Installer
             }
         }
 
-        $rootRequires = array();
+        $rootRequires = [];
         foreach ($requires as $req => $constraint) {
             if ($constraint instanceof Link) {
                 $constraint = $constraint->getConstraint();
@@ -836,8 +836,8 @@ class Installer
         }
 
         $this->fixedRootPackage = clone $this->package;
-        $this->fixedRootPackage->setRequires(array());
-        $this->fixedRootPackage->setDevRequires(array());
+        $this->fixedRootPackage->setRequires([]);
+        $this->fixedRootPackage->setDevRequires([]);
 
         $stabilityFlags[$this->package->getName()] = BasePackage::$stabilities[VersionParser::parseStability($this->package->getVersion())];
 
@@ -851,7 +851,7 @@ class Installer
             if ($additionalFixedRepositories instanceof CompositeRepository) {
                 $additionalFixedRepositories = $additionalFixedRepositories->getRepositories();
             } else {
-                $additionalFixedRepositories = array($additionalFixedRepositories);
+                $additionalFixedRepositories = [$additionalFixedRepositories];
             }
             foreach ($additionalFixedRepositories as $additionalFixedRepository) {
                 if ($additionalFixedRepository instanceof InstalledRepository || $additionalFixedRepository instanceof InstalledRepositoryInterface) {
@@ -936,7 +936,7 @@ class Installer
     {
         // if we're updating mirrors we want to keep exactly the same versions installed which are in the lock file, but we want current remote metadata
         if ($this->updateMirrors) {
-            $excludedPackages = array();
+            $excludedPackages = [];
             if (!$includeDevRequires) {
                 $excludedPackages = array_flip($this->locker->getDevPackageNames());
             }
@@ -984,7 +984,7 @@ class Installer
      */
     private function extractPlatformRequirements(array $links): array
     {
-        $platformReqs = array();
+        $platformReqs = [];
         foreach ($links as $link) {
             if (PlatformRepository::isPlatformPackage($link->getTarget())) {
                 $platformReqs[$link->getTarget()] = $link->getPrettyConstraint();
@@ -1003,7 +1003,7 @@ class Installer
      */
     private function mockLocalRepositories(RepositoryManager $rm): void
     {
-        $packages = array();
+        $packages = [];
         foreach ($rm->getLocalRepository()->getPackages() as $package) {
             $packages[(string) $package] = clone $package;
         }
@@ -1353,7 +1353,7 @@ class Installer
      */
     public function setUpdateAllowTransitiveDependencies(int $updateAllowTransitiveDependencies): self
     {
-        if (!in_array($updateAllowTransitiveDependencies, array(Request::UPDATE_ONLY_LISTED, Request::UPDATE_LISTED_WITH_TRANSITIVE_DEPS_NO_ROOT_REQUIRE, Request::UPDATE_LISTED_WITH_TRANSITIVE_DEPS), true)) {
+        if (!in_array($updateAllowTransitiveDependencies, [Request::UPDATE_ONLY_LISTED, Request::UPDATE_LISTED_WITH_TRANSITIVE_DEPS_NO_ROOT_REQUIRE, Request::UPDATE_LISTED_WITH_TRANSITIVE_DEPS], true)) {
             throw new \RuntimeException("Invalid value for updateAllowTransitiveDependencies supplied");
         }
 

--- a/src/Composer/Installer/SuggestedPackagesReporter.php
+++ b/src/Composer/Installer/SuggestedPackagesReporter.php
@@ -32,7 +32,7 @@ class SuggestedPackagesReporter
     /**
      * @var array<array{source: string, target: string, reason: string}>
      */
-    protected $suggestedPackages = array();
+    protected $suggestedPackages = [];
 
     /**
      * @var IOInterface
@@ -65,11 +65,11 @@ class SuggestedPackagesReporter
      */
     public function addPackage(string $source, string $target, string $reason): SuggestedPackagesReporter
     {
-        $this->suggestedPackages[] = array(
+        $this->suggestedPackages[] = [
             'source' => $source,
             'target' => $target,
             'reason' => $reason,
-        );
+        ];
 
         return $this;
     }
@@ -108,8 +108,8 @@ class SuggestedPackagesReporter
     {
         $suggestedPackages = $this->getFilteredSuggestions($installedRepo, $onlyDependentsOf);
 
-        $suggesters = array();
-        $suggested = array();
+        $suggesters = [];
+        $suggested = [];
         foreach ($suggestedPackages as $suggestion) {
             $suggesters[$suggestion['source']][$suggestion['target']] = $suggestion['reason'];
             $suggested[$suggestion['target']][$suggestion['source']] = $suggestion['reason'];
@@ -186,7 +186,7 @@ class SuggestedPackagesReporter
     private function getFilteredSuggestions(InstalledRepository $installedRepo = null, PackageInterface $onlyDependentsOf = null): array
     {
         $suggestedPackages = $this->getPackages();
-        $installedNames = array();
+        $installedNames = [];
         if (null !== $installedRepo && !empty($suggestedPackages)) {
             foreach ($installedRepo->getPackages() as $package) {
                 $installedNames = array_merge(
@@ -196,7 +196,7 @@ class SuggestedPackagesReporter
             }
         }
 
-        $sourceFilter = array();
+        $sourceFilter = [];
         if ($onlyDependentsOf) {
             $sourceFilter = array_map(function ($link): string {
                 return $link->getTarget();
@@ -204,7 +204,7 @@ class SuggestedPackagesReporter
             $sourceFilter[] = $onlyDependentsOf->getName();
         }
 
-        $suggestions = array();
+        $suggestions = [];
         foreach ($suggestedPackages as $suggestion) {
             if (in_array($suggestion['target'], $installedNames) || ($sourceFilter && !in_array($suggestion['source'], $sourceFilter))) {
                 continue;

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -231,23 +231,23 @@ class JsonFile
             $schemaFile = 'file://' . $schemaFile;
         }
 
-        $schemaData = (object) array('$ref' => $schemaFile);
+        $schemaData = (object) ['$ref' => $schemaFile];
 
         if ($schema === self::LAX_SCHEMA) {
             $schemaData->additionalProperties = true;
-            $schemaData->required = array();
+            $schemaData->required = [];
         } elseif ($schema === self::STRICT_SCHEMA && $isComposerSchemaFile) {
             $schemaData->additionalProperties = false;
-            $schemaData->required = array('name', 'description');
+            $schemaData->required = ['name', 'description'];
         } elseif ($schema === self::AUTH_SCHEMA && $isComposerSchemaFile) {
-            $schemaData = (object) array('$ref' => $schemaFile.'#/properties/config', '$schema'=> "https://json-schema.org/draft-04/schema#");
+            $schemaData = (object) ['$ref' => $schemaFile.'#/properties/config', '$schema'=> "https://json-schema.org/draft-04/schema#"];
         }
 
         $validator = new Validator();
         $validator->check($data, $schemaData);
 
         if (!$validator->isValid()) {
-            $errors = array();
+            $errors = [];
             foreach ((array) $validator->getErrors() as $error) {
                 $errors[] = ($error['property'] ? $error['property'].' : ' : '').$error['message'];
             }

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -76,7 +76,7 @@ class JsonManipulator
 
         // no link of that type yet
         if (!isset($decoded[$type])) {
-            return $this->addMainKey($type, array($package => $constraint));
+            return $this->addMainKey($type, [$package => $constraint]);
         }
 
         $regex = '{'.self::$DEFINES.'^(?P<start>\s*\{\s*(?:(?&string)\s*:\s*(?&json)\s*,\s*)*?)'.
@@ -133,25 +133,25 @@ class JsonManipulator
      * @param array<string> $packages
      * @return void
      */
-    private function sortPackages(array &$packages = array()): void
+    private function sortPackages(array &$packages = []): void
     {
         $prefix = function ($requirement): string {
             if (PlatformRepository::isPlatformPackage($requirement)) {
                 return Preg::replace(
-                    array(
+                    [
                         '/^php/',
                         '/^hhvm/',
                         '/^ext/',
                         '/^lib/',
                         '/^\D/',
-                    ),
-                    array(
+                    ],
+                    [
                         '0-$0',
                         '1-$0',
                         '2-$0',
                         '3-$0',
                         '4-$0',
-                    ),
+                    ],
                     $requirement
                 );
             }
@@ -258,16 +258,16 @@ class JsonManipulator
         $decoded = JsonFile::parseJson($this->contents);
 
         $subName = null;
-        if (in_array($mainNode, array('config', 'extra', 'scripts')) && false !== strpos($name, '.')) {
+        if (in_array($mainNode, ['config', 'extra', 'scripts']) && false !== strpos($name, '.')) {
             list($name, $subName) = explode('.', $name, 2);
         }
 
         // no main node yet
         if (!isset($decoded[$mainNode])) {
             if ($subName !== null) {
-                $this->addMainKey($mainNode, array($name => array($subName => $value)));
+                $this->addMainKey($mainNode, [$name => [$subName => $value]]);
             } else {
-                $this->addMainKey($mainNode, array($name => $value));
+                $this->addMainKey($mainNode, [$name => $value]);
             }
 
             return true;
@@ -301,7 +301,7 @@ class JsonManipulator
                 if ($subName !== null) {
                     $curVal = json_decode($matches['content'], true);
                     if (!is_array($curVal)) {
-                        $curVal = array();
+                        $curVal = [];
                     }
                     $curVal[$subName] = $value;
                     $value = $curVal;
@@ -319,7 +319,7 @@ class JsonManipulator
 
             if (!empty($match['content'])) {
                 if ($subName !== null) {
-                    $value = array($subName => $value);
+                    $value = [$subName => $value];
                 }
 
                 // child missing but non empty children
@@ -343,7 +343,7 @@ class JsonManipulator
                 }
             } else {
                 if ($subName !== null) {
-                    $value = array($subName => $value);
+                    $value = [$subName => $value];
                 }
 
                 // children present but empty
@@ -394,7 +394,7 @@ class JsonManipulator
         }
 
         $subName = null;
-        if (in_array($mainNode, array('config', 'extra', 'scripts')) && false !== strpos($name, '.')) {
+        if (in_array($mainNode, ['config', 'extra', 'scripts']) && false !== strpos($name, '.')) {
             list($name, $subName) = explode('.', $name, 2);
         }
 
@@ -584,7 +584,7 @@ class JsonManipulator
             }
 
             $out = '{' . $this->newline;
-            $elems = array();
+            $elems = [];
             foreach ($data as $key => $val) {
                 $elems[] = str_repeat($this->indent, $depth + 2) . JsonFile::encode($key). ': '.$this->format($val, $depth + 1);
             }

--- a/src/Composer/Json/JsonValidationException.php
+++ b/src/Composer/Json/JsonValidationException.php
@@ -28,7 +28,7 @@ class JsonValidationException extends Exception
      * @param string   $message
      * @param string[] $errors
      */
-    public function __construct(string $message, array $errors = array(), Exception $previous = null)
+    public function __construct(string $message, array $errors = [], Exception $previous = null)
     {
         $this->errors = $errors;
         parent::__construct((string) $message, 0, $previous);

--- a/src/Composer/Package/AliasPackage.php
+++ b/src/Composer/Package/AliasPackage.php
@@ -188,8 +188,8 @@ class AliasPackage extends BasePackage
             $prettyVersion = $this->aliasOf->getPrettyVersion();
         }
 
-        if (\in_array($linkType, array(Link::TYPE_CONFLICT, Link::TYPE_PROVIDE, Link::TYPE_REPLACE), true)) {
-            $newLinks = array();
+        if (\in_array($linkType, [Link::TYPE_CONFLICT, Link::TYPE_PROVIDE, Link::TYPE_REPLACE], true)) {
+            $newLinks = [];
             foreach ($links as $link) {
                 // link is self.version, but must be replacing also the replaced version
                 if ('self.version' === $link->getPrettyConstraint()) {

--- a/src/Composer/Package/Archiver/ArchivableFilesFilter.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFilter.php
@@ -18,7 +18,7 @@ use PharData;
 class ArchivableFilesFilter extends FilterIterator
 {
     /** @var string[] */
-    private $dirs = array();
+    private $dirs = [];
 
     /**
      * @return bool true if the current element is acceptable, otherwise false.

--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -47,12 +47,12 @@ class ArchivableFilesFinder extends \FilterIterator
         $sources = $fs->normalizePath(realpath($sources));
 
         if ($ignoreFilters) {
-            $filters = array();
+            $filters = [];
         } else {
-            $filters = array(
+            $filters = [
                 new GitExcludeFilter($sources),
                 new ComposerExcludeFilter($sources, $excludes),
-            );
+            ];
         }
 
         $this->finder = new Finder();

--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -35,7 +35,7 @@ class ArchiveManager
     /**
      * @var ArchiverInterface[]
      */
-    protected $archivers = array();
+    protected $archivers = [];
 
     /**
      * @var bool
@@ -89,7 +89,7 @@ class ArchiveManager
         } else {
             $baseName = Preg::replace('#[^a-z0-9-_]#i', '-', $package->getName());
         }
-        $nameParts = array($baseName);
+        $nameParts = [$baseName];
 
         if (null !== $package->getDistReference() && Preg::isMatch('{^[a-f0-9]{40}$}', $package->getDistReference())) {
             array_push($nameParts, $package->getDistReference(), $package->getDistType());

--- a/src/Composer/Package/Archiver/ArchiverInterface.php
+++ b/src/Composer/Package/Archiver/ArchiverInterface.php
@@ -30,7 +30,7 @@ interface ArchiverInterface
      *
      * @return string The path to the written archive file
      */
-    public function archive(string $sources, string $target, string $format, array $excludes = array(), bool $ignoreFilters = false): string;
+    public function archive(string $sources, string $target, string $format, array $excludes = [], bool $ignoreFilters = false): string;
 
     /**
      * Format supported by the archiver.

--- a/src/Composer/Package/Archiver/BaseExcludeFilter.php
+++ b/src/Composer/Package/Archiver/BaseExcludeFilter.php
@@ -36,7 +36,7 @@ abstract class BaseExcludeFilter
     public function __construct(string $sourcePath)
     {
         $this->sourcePath = $sourcePath;
-        $this->excludePatterns = array();
+        $this->excludePatterns = [];
     }
 
     /**
@@ -110,7 +110,7 @@ abstract class BaseExcludeFilter
      */
     protected function generatePatterns(array $rules): array
     {
-        $patterns = array();
+        $patterns = [];
         foreach ($rules as $rule) {
             $patterns[] = $this->generatePattern($rule);
         }
@@ -147,6 +147,6 @@ abstract class BaseExcludeFilter
         // remove delimiters as well as caret (^) and dollar sign ($) from the regex
         $rule = substr(Finder\Glob::toRegex($rule), 2, -2);
 
-        return array('{'.$pattern.$rule.'(?=$|/)}', $negate, false);
+        return ['{'.$pattern.$rule.'(?=$|/)}', $negate, false];
     }
 }

--- a/src/Composer/Package/Archiver/GitExcludeFilter.php
+++ b/src/Composer/Package/Archiver/GitExcludeFilter.php
@@ -37,7 +37,7 @@ class GitExcludeFilter extends BaseExcludeFilter
                 $this->excludePatterns,
                 $this->parseLines(
                     file($sourcePath.'/.gitattributes'),
-                    array($this, 'parseGitAttributesLine')
+                    [$this, 'parseGitAttributesLine']
                 )
             );
         }

--- a/src/Composer/Package/Archiver/PharArchiver.php
+++ b/src/Composer/Package/Archiver/PharArchiver.php
@@ -20,23 +20,23 @@ namespace Composer\Package\Archiver;
 class PharArchiver implements ArchiverInterface
 {
     /** @var array<string, int> */
-    protected static $formats = array(
+    protected static $formats = [
         'zip' => \Phar::ZIP,
         'tar' => \Phar::TAR,
         'tar.gz' => \Phar::TAR,
         'tar.bz2' => \Phar::TAR,
-    );
+    ];
 
     /** @var array<string, int> */
-    protected static $compressFormats = array(
+    protected static $compressFormats = [
         'tar.gz' => \Phar::GZ,
         'tar.bz2' => \Phar::BZ2,
-    );
+    ];
 
     /**
      * @inheritDoc
      */
-    public function archive(string $sources, string $target, string $format, array $excludes = array(), bool $ignoreFilters = false): string
+    public function archive(string $sources, string $target, string $format, array $excludes = [], bool $ignoreFilters = false): string
     {
         $sources = realpath($sources);
 

--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -21,14 +21,14 @@ use Composer\Util\Filesystem;
 class ZipArchiver implements ArchiverInterface
 {
     /** @var array<string, bool> */
-    protected static $formats = array(
+    protected static $formats = [
         'zip' => true,
-    );
+    ];
 
     /**
      * @inheritDoc
      */
-    public function archive(string $sources, string $target, string $format, array $excludes = array(), bool $ignoreFilters = false): string
+    public function archive(string $sources, string $target, string $format, array $excludes = [], bool $ignoreFilters = false): string
     {
         $fs = new Filesystem();
         $sources = $fs->normalizePath($sources);

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -26,13 +26,13 @@ abstract class BasePackage implements PackageInterface
      * @phpstan-var array<non-empty-string, array{description: string, method: Link::TYPE_*}>
      * @internal
      */
-    public static $supportedLinkTypes = array(
-        'require' => array('description' => 'requires', 'method' => Link::TYPE_REQUIRE),
-        'conflict' => array('description' => 'conflicts', 'method' => Link::TYPE_CONFLICT),
-        'provide' => array('description' => 'provides', 'method' => Link::TYPE_PROVIDE),
-        'replace' => array('description' => 'replaces', 'method' => Link::TYPE_REPLACE),
-        'require-dev' => array('description' => 'requires (for development)', 'method' => Link::TYPE_DEV_REQUIRE),
-    );
+    public static $supportedLinkTypes = [
+        'require' => ['description' => 'requires', 'method' => Link::TYPE_REQUIRE],
+        'conflict' => ['description' => 'conflicts', 'method' => Link::TYPE_CONFLICT],
+        'provide' => ['description' => 'provides', 'method' => Link::TYPE_PROVIDE],
+        'replace' => ['description' => 'replaces', 'method' => Link::TYPE_REPLACE],
+        'require-dev' => ['description' => 'requires (for development)', 'method' => Link::TYPE_DEV_REQUIRE],
+    ];
 
     public const STABILITY_STABLE = 0;
     public const STABILITY_RC = 5;
@@ -41,13 +41,13 @@ abstract class BasePackage implements PackageInterface
     public const STABILITY_DEV = 20;
 
     /** @var array<string, self::STABILITY_*> */
-    public static $stabilities = array(
+    public static $stabilities = [
         'stable' => self::STABILITY_STABLE,
         'RC' => self::STABILITY_RC,
         'beta' => self::STABILITY_BETA,
         'alpha' => self::STABILITY_ALPHA,
         'dev' => self::STABILITY_DEV,
-    );
+    ];
 
     /**
      * READ-ONLY: The package id, public for fast access in dependency solver
@@ -95,9 +95,9 @@ abstract class BasePackage implements PackageInterface
      */
     public function getNames($provides = true): array
     {
-        $names = array(
+        $names = [
             $this->getName() => true,
-        );
+        ];
 
         if ($provides) {
             foreach ($this->getProvides() as $link) {
@@ -204,7 +204,7 @@ abstract class BasePackage implements PackageInterface
     public function getFullPrettyVersion(bool $truncate = true, int $displayMode = PackageInterface::DISPLAY_SOURCE_REF_IF_DEV): string
     {
         if ($displayMode === PackageInterface::DISPLAY_SOURCE_REF_IF_DEV &&
-            (!$this->isDev() || !\in_array($this->getSourceType(), array('hg', 'git')))
+            (!$this->isDev() || !\in_array($this->getSourceType(), ['hg', 'git']))
         ) {
             return $this->getPrettyVersion();
         }

--- a/src/Composer/Package/Comparer/Comparer.php
+++ b/src/Composer/Package/Comparer/Comparer.php
@@ -82,7 +82,7 @@ class Comparer
             return '';
         }
 
-        $strings = array();
+        $strings = [];
         foreach ($changed as $sectionKey => $itemSection) {
             foreach ($itemSection as $itemKey => $item) {
                 $strings[] = $item."\r\n";
@@ -97,9 +97,9 @@ class Comparer
      */
     public function doCompare(): void
     {
-        $source = array();
-        $destination = array();
-        $this->changed = array();
+        $source = [];
+        $destination = [];
+        $this->changed = [];
         $currentDirectory = Platform::getCwd();
         chdir($this->source);
         $source = $this->doTree('.', $source);

--- a/src/Composer/Package/CompletePackage.php
+++ b/src/Composer/Package/CompletePackage.php
@@ -20,29 +20,29 @@ namespace Composer\Package;
 class CompletePackage extends Package implements CompletePackageInterface
 {
     /** @var mixed[] */
-    protected $repositories = array();
+    protected $repositories = [];
     /** @var string[] */
-    protected $license = array();
+    protected $license = [];
     /** @var string[] */
-    protected $keywords = array();
+    protected $keywords = [];
     /** @var array<array{name?: string, homepage?: string, email?: string, role?: string}> */
-    protected $authors = array();
+    protected $authors = [];
     /** @var ?string */
     protected $description = null;
     /** @var ?string */
     protected $homepage = null;
     /** @var array<string, string[]> Map of script name to array of handlers */
-    protected $scripts = array();
+    protected $scripts = [];
     /** @var array{issues?: string, forum?: string, wiki?: string, source?: string, email?: string, irc?: string, docs?: string, rss?: string, chat?: string} */
-    protected $support = array();
+    protected $support = [];
     /** @var array<array{url?: string, type?: string}> */
-    protected $funding = array();
+    protected $funding = [];
     /** @var bool|string */
     protected $abandoned = false;
     /** @var ?string */
     protected $archiveName = null;
     /** @var string[] */
-    protected $archiveExcludes = array();
+    protected $archiveExcludes = [];
 
     /**
      * @inheritDoc

--- a/src/Composer/Package/Dumper/ArrayDumper.php
+++ b/src/Composer/Package/Dumper/ArrayDumper.php
@@ -28,7 +28,7 @@ class ArrayDumper
      */
     public function dump(PackageInterface $package): array
     {
-        $keys = array(
+        $keys = [
             'binaries' => 'bin',
             'type',
             'extra',
@@ -37,9 +37,9 @@ class ArrayDumper
             'devAutoload' => 'autoload-dev',
             'notificationUrl' => 'notification-url',
             'includePaths' => 'include-path',
-        );
+        ];
 
-        $data = array();
+        $data = [];
         $data['name'] = $package->getPrettyName();
         $data['version'] = $package->getPrettyVersion();
         $data['version_normalized'] = $package->getVersion();
@@ -105,7 +105,7 @@ class ArrayDumper
                 $data['archive']['exclude'] = $package->getArchiveExcludes();
             }
 
-            $keys = array(
+            $keys = [
                 'scripts',
                 'license',
                 'authors',
@@ -115,7 +115,7 @@ class ArrayDumper
                 'repositories',
                 'support',
                 'funding',
-            );
+            ];
 
             $data = $this->dumpValues($package, $keys, $data);
 

--- a/src/Composer/Package/Link.php
+++ b/src/Composer/Package/Link.php
@@ -42,13 +42,13 @@ class Link
      * @var string[]
      * @phpstan-var array<self::TYPE_REQUIRE|self::TYPE_DEV_REQUIRE|self::TYPE_PROVIDE|self::TYPE_CONFLICT|self::TYPE_REPLACE>
      */
-    public static $TYPES = array(
+    public static $TYPES = [
         self::TYPE_REQUIRE,
         self::TYPE_DEV_REQUIRE,
         self::TYPE_PROVIDE,
         self::TYPE_CONFLICT,
         self::TYPE_REPLACE,
-    );
+    ];
 
     /**
      * @var string

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -83,8 +83,8 @@ class ArrayLoader implements LoaderInterface
      */
     public function loadPackages(array $versions): array
     {
-        $packages = array();
-        $linkCache = array();
+        $packages = [];
+        $linkCache = [];
 
         foreach ($versions as $version) {
             $package = $this->createObject($version, 'Composer\Package\CompletePackage');
@@ -159,7 +159,7 @@ class ArrayLoader implements LoaderInterface
 
         if (isset($config['bin'])) {
             if (!\is_array($config['bin'])) {
-                $config['bin'] = array($config['bin']);
+                $config['bin'] = [$config['bin']];
             }
             foreach ($config['bin'] as $key => $bin) {
                 $config['bin'][$key] = ltrim($bin, '/');
@@ -256,7 +256,7 @@ class ArrayLoader implements LoaderInterface
                 foreach ($config['scripts'] as $event => $listeners) {
                     $config['scripts'][$event] = (array) $listeners;
                 }
-                foreach (array('composer', 'php', 'putenv') as $reserved) {
+                foreach (['composer', 'php', 'putenv'] as $reserved) {
                     if (isset($config['scripts'][$reserved])) {
                         trigger_error('The `'.$reserved.'` script name is reserved for internal use, please avoid defining it', E_USER_DEPRECATED);
                     }
@@ -277,7 +277,7 @@ class ArrayLoader implements LoaderInterface
             }
 
             if (!empty($config['license'])) {
-                $package->setLicense(\is_array($config['license']) ? $config['license'] : array($config['license']));
+                $package->setLicense(\is_array($config['license']) ? $config['license'] : [$config['license']]);
             }
 
             if (!empty($config['authors']) && \is_array($config['authors'])) {
@@ -330,7 +330,7 @@ class ArrayLoader implements LoaderInterface
             if (isset($config[$type])) {
                 $method = 'set'.ucfirst($opts['method']);
 
-                $links = array();
+                $links = [];
                 foreach ($config[$type] as $prettyTarget => $constraint) {
                     $target = strtolower($prettyTarget);
 
@@ -343,7 +343,7 @@ class ArrayLoader implements LoaderInterface
                         $links[$target] = $this->createLink($name, $prettyVersion, $opts['method'], $target, $constraint);
                     } else {
                         if (!isset($linkCache[$name][$type][$target][$constraint])) {
-                            $linkCache[$name][$type][$target][$constraint] = array($target, $this->createLink($name, $prettyVersion, $opts['method'], $target, $constraint));
+                            $linkCache[$name][$type][$target][$constraint] = [$target, $this->createLink($name, $prettyVersion, $opts['method'], $target, $constraint)];
                         }
 
                         list($target, $link) = $linkCache[$name][$type][$target][$constraint];
@@ -368,7 +368,7 @@ class ArrayLoader implements LoaderInterface
      */
     public function parseLinks(string $source, string $sourceVersion, string $description, array $links): array
     {
-        $res = array();
+        $res = [];
         foreach ($links as $target => $constraint) {
             $target = strtolower((string) $target);
             $res[$target] = $this->createLink($source, $sourceVersion, $description, $target, $constraint);

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -100,16 +100,16 @@ class RootPackageLoader extends ArrayLoader
             }
 
             if ($commit) {
-                $config['source'] = array(
+                $config['source'] = [
                     'type' => '',
                     'url' => '',
                     'reference' => $commit,
-                );
-                $config['dist'] = array(
+                ];
+                $config['dist'] = [
                     'type' => '',
                     'url' => '',
                     'reference' => $commit,
-                );
+                ];
             }
         }
 
@@ -133,14 +133,14 @@ class RootPackageLoader extends ArrayLoader
             $realPackage->setMinimumStability(VersionParser::normalizeStability($config['minimum-stability']));
         }
 
-        $aliases = array();
-        $stabilityFlags = array();
-        $references = array();
-        foreach (array('require', 'require-dev') as $linkType) {
+        $aliases = [];
+        $stabilityFlags = [];
+        $references = [];
+        foreach (['require', 'require-dev'] as $linkType) {
             if (isset($config[$linkType])) {
                 $linkInfo = BasePackage::$supportedLinkTypes[$linkType];
                 $method = 'get'.ucfirst($linkInfo['method']);
-                $links = array();
+                $links = [];
                 foreach ($realPackage->$method() as $link) {
                     $links[$link->getTarget()] = $link->getConstraint()->getPrettyString();
                 }
@@ -196,12 +196,12 @@ class RootPackageLoader extends ArrayLoader
     {
         foreach ($requires as $reqName => $reqVersion) {
             if (Preg::isMatch('{^([^,\s#]+)(?:#[^ ]+)? +as +([^,\s]+)$}', $reqVersion, $match)) {
-                $aliases[] = array(
+                $aliases[] = [
                     'package' => strtolower($reqName),
                     'version' => $this->versionParser->normalize($match[1], $reqVersion),
                     'alias' => $match[2],
                     'alias_normalized' => $this->versionParser->normalize($match[2], $reqVersion),
-                );
+                ];
             } elseif (strpos($reqVersion, ' as ') !== false) {
                 throw new \UnexpectedValueException('Invalid alias definition in "'.$reqName.'": "'.$reqVersion.'". Aliases should be in the form "exact-version as other-exact-version".');
             }
@@ -228,7 +228,7 @@ class RootPackageLoader extends ArrayLoader
         /** @var int $minimumStability */
         $minimumStability = $stabilities[$minimumStability];
         foreach ($requires as $reqName => $reqVersion) {
-            $constraints = array();
+            $constraints = [];
 
             // extract all sub-constraints in case it is an OR/AND multi-constraint
             $orSplit = Preg::split('{\s*\|\|?\s*}', trim($reqVersion));

--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -61,8 +61,8 @@ class ValidatingArrayLoader implements LoaderInterface
      */
     public function load(array $config, string $class = 'Composer\Package\CompletePackage'): BasePackage
     {
-        $this->errors = array();
-        $this->warnings = array();
+        $this->errors = [];
+        $this->warnings = [];
         $this->config = $config;
 
         $this->validateString('name', true);
@@ -168,7 +168,7 @@ class ValidatingArrayLoader implements LoaderInterface
                     unset($this->config['authors'][$key]);
                     continue;
                 }
-                foreach (array('homepage', 'email', 'name', 'role') as $authorData) {
+                foreach (['homepage', 'email', 'name', 'role'] as $authorData) {
                     if (isset($author[$authorData]) && !is_string($author[$authorData])) {
                         $this->errors[] = 'authors.'.$key.'.'.$authorData.' : invalid value, must be a string';
                         unset($this->config['authors'][$key][$authorData]);
@@ -192,7 +192,7 @@ class ValidatingArrayLoader implements LoaderInterface
         }
 
         if ($this->validateArray('support') && !empty($this->config['support'])) {
-            foreach (array('issues', 'forum', 'wiki', 'source', 'email', 'irc', 'docs', 'rss', 'chat') as $key) {
+            foreach (['issues', 'forum', 'wiki', 'source', 'email', 'irc', 'docs', 'rss', 'chat'] as $key) {
                 if (isset($this->config['support'][$key]) && !is_string($this->config['support'][$key])) {
                     $this->errors[] = 'support.'.$key.' : invalid value, must be a string';
                     unset($this->config['support'][$key]);
@@ -204,12 +204,12 @@ class ValidatingArrayLoader implements LoaderInterface
                 unset($this->config['support']['email']);
             }
 
-            if (isset($this->config['support']['irc']) && !$this->filterUrl($this->config['support']['irc'], array('irc', 'ircs'))) {
+            if (isset($this->config['support']['irc']) && !$this->filterUrl($this->config['support']['irc'], ['irc', 'ircs'])) {
                 $this->warnings[] = 'support.irc : invalid value ('.$this->config['support']['irc'].'), must be a irc://<server>/<channel> or ircs:// URL';
                 unset($this->config['support']['irc']);
             }
 
-            foreach (array('issues', 'forum', 'wiki', 'source', 'docs', 'chat') as $key) {
+            foreach (['issues', 'forum', 'wiki', 'source', 'docs', 'chat'] as $key) {
                 if (isset($this->config['support'][$key]) && !$this->filterUrl($this->config['support'][$key])) {
                     $this->warnings[] = 'support.'.$key.' : invalid value ('.$this->config['support'][$key].'), must be an http/https URL';
                     unset($this->config['support'][$key]);
@@ -227,7 +227,7 @@ class ValidatingArrayLoader implements LoaderInterface
                     unset($this->config['funding'][$key]);
                     continue;
                 }
-                foreach (array('type', 'url') as $fundingData) {
+                foreach (['type', 'url'] as $fundingData) {
                     if (isset($fundingOption[$fundingData]) && !is_string($fundingOption[$fundingData])) {
                         $this->errors[] = 'funding.'.$key.'.'.$fundingData.' : invalid value, must be a string';
                         unset($this->config['funding'][$key][$fundingData]);
@@ -318,7 +318,7 @@ class ValidatingArrayLoader implements LoaderInterface
         }
 
         if ($this->validateArray('autoload') && !empty($this->config['autoload'])) {
-            $types = array('psr-0', 'psr-4', 'classmap', 'files', 'exclude-from-classmap');
+            $types = ['psr-0', 'psr-4', 'classmap', 'files', 'exclude-from-classmap'];
             foreach ($this->config['autoload'] as $type => $typeConfig) {
                 if (!in_array($type, $types)) {
                     $this->errors[] = 'autoload : invalid value ('.$type.'), must be one of '.implode(', ', $types);
@@ -341,7 +341,7 @@ class ValidatingArrayLoader implements LoaderInterface
             unset($this->config['autoload']['psr-4']);
         }
 
-        foreach (array('source', 'dist') as $srcType) {
+        foreach (['source', 'dist'] as $srcType) {
             if ($this->validateArray($srcType) && !empty($this->config[$srcType])) {
                 if (!isset($this->config[$srcType]['type'])) {
                     $this->errors[] = $srcType . '.type : must be present';
@@ -423,7 +423,7 @@ class ValidatingArrayLoader implements LoaderInterface
         }
 
         $package = $this->loader->load($this->config, $class);
-        $this->config = array();
+        $this->config = [];
 
         return $package;
     }
@@ -460,7 +460,7 @@ class ValidatingArrayLoader implements LoaderInterface
             return $name.' is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$".';
         }
 
-        $reservedNames = array('nul', 'con', 'prn', 'aux', 'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9', 'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9');
+        $reservedNames = ['nul', 'con', 'prn', 'aux', 'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9', 'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9'];
         $bits = explode('/', strtolower($name));
         if (in_array($bits[0], $reservedNames, true) || in_array($bits[1], $reservedNames, true)) {
             return $name.' is reserved, package and vendor names can not match any of: '.implode(', ', $reservedNames).'.';
@@ -639,7 +639,7 @@ class ValidatingArrayLoader implements LoaderInterface
      *
      * @return bool
      */
-    private function filterUrl($value, array $schemes = array('http', 'https')): bool
+    private function filterUrl($value, array $schemes = ['http', 'https']): bool
     {
         if ($value === '') {
             return true;

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -82,7 +82,7 @@ class Locker
     {
         $content = JsonFile::parseJson($composerFileContents, 'composer.json');
 
-        $relevantKeys = array(
+        $relevantKeys = [
             'name',
             'version',
             'require',
@@ -94,9 +94,9 @@ class Locker
             'prefer-stable',
             'repositories',
             'extra',
-        );
+        ];
 
-        $relevantContent = array();
+        $relevantContent = [];
 
         foreach (array_intersect($relevantKeys, array_keys($content)) as $key) {
             $relevantContent[$key] = $content[$key];
@@ -175,7 +175,7 @@ class Locker
         }
 
         if (isset($lockedPackages[0]['name'])) {
-            $packageByName = array();
+            $packageByName = [];
             foreach ($lockedPackages as $info) {
                 $package = $this->loader->load($info);
                 $packages->addPackage($package);
@@ -207,7 +207,7 @@ class Locker
      */
     public function getDevPackageNames(): array
     {
-        $names = array();
+        $names = [];
         $lockData = $this->getLockData();
         if (isset($lockData['packages-dev'])) {
             foreach ($lockData['packages-dev'] as $package) {
@@ -227,14 +227,14 @@ class Locker
     public function getPlatformRequirements(bool $withDevReqs = false): array
     {
         $lockData = $this->getLockData();
-        $requirements = array();
+        $requirements = [];
 
         if (!empty($lockData['platform'])) {
             $requirements = $this->loader->parseLinks(
                 '__root__',
                 '1.0.0',
                 Link::TYPE_REQUIRE,
-                $lockData['platform'] ?? array()
+                $lockData['platform'] ?? []
             );
         }
 
@@ -243,7 +243,7 @@ class Locker
                 '__root__',
                 '1.0.0',
                 Link::TYPE_REQUIRE,
-                $lockData['platform-dev'] ?? array()
+                $lockData['platform-dev'] ?? []
             );
 
             $requirements = array_merge($requirements, $devRequirements);
@@ -269,7 +269,7 @@ class Locker
     {
         $lockData = $this->getLockData();
 
-        return $lockData['stability-flags'] ?? array();
+        return $lockData['stability-flags'] ?? [];
     }
 
     /**
@@ -303,7 +303,7 @@ class Locker
     {
         $lockData = $this->getLockData();
 
-        return $lockData['platform-overrides'] ?? array();
+        return $lockData['platform-overrides'] ?? [];
     }
 
     /**
@@ -315,7 +315,7 @@ class Locker
     {
         $lockData = $this->getLockData();
 
-        return $lockData['aliases'] ?? array();
+        return $lockData['aliases'] ?? [];
     }
 
     /**
@@ -358,17 +358,17 @@ class Locker
         // keep old default branch names normalized to DEFAULT_BRANCH_ALIAS for BC as that is how Composer 1 outputs the lock file
         // when loading the lock file the version is anyway ignored in Composer 2, so it has no adverse effect
         $aliases = array_map(function ($alias): array {
-            if (in_array($alias['version'], array('dev-master', 'dev-trunk', 'dev-default'), true)) {
+            if (in_array($alias['version'], ['dev-master', 'dev-trunk', 'dev-default'], true)) {
                 $alias['version'] = VersionParser::DEFAULT_BRANCH_ALIAS;
             }
 
             return $alias;
         }, $aliases);
 
-        $lock = array(
-            '_readme' => array('This file locks the dependencies of your project to a known state',
+        $lock = [
+            '_readme' => ['This file locks the dependencies of your project to a known state',
                                'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies',
-                               'This file is @gener'.'ated automatically', ),
+                               'This file is @gener'.'ated automatically', ],
             'content-hash' => $this->contentHash,
             'packages' => null,
             'packages-dev' => null,
@@ -377,7 +377,7 @@ class Locker
             'stability-flags' => $stabilityFlags,
             'prefer-stable' => $preferStable,
             'prefer-lowest' => $preferLowest,
-        );
+        ];
 
         $lock['packages'] = $this->lockPackages($packages);
         if (null !== $devPackages) {
@@ -421,7 +421,7 @@ class Locker
      */
     private function lockPackages(array $packages): array
     {
-        $locked = array();
+        $locked = [];
 
         foreach ($packages as $package) {
             if ($package instanceof AliasPackage) {
@@ -487,7 +487,7 @@ class Locker
         $sourceType = $package->getSourceType();
         $datetime = null;
 
-        if ($path && in_array($sourceType, array('git', 'hg'))) {
+        if ($path && in_array($sourceType, ['git', 'hg'])) {
             $sourceRef = $package->getSourceReference() ?: $package->getDistReference();
             switch ($sourceType) {
                 case 'git':

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -57,9 +57,9 @@ class Package extends BasePackage
     /** @var ?\DateTimeInterface */
     protected $releaseDate;
     /** @var mixed[] */
-    protected $extra = array();
+    protected $extra = [];
     /** @var string[] */
-    protected $binaries = array();
+    protected $binaries = [];
     /** @var bool */
     protected $dev;
     /**
@@ -71,33 +71,33 @@ class Package extends BasePackage
     protected $notificationUrl;
 
     /** @var array<string, Link> */
-    protected $requires = array();
+    protected $requires = [];
     /** @var array<string, Link> */
-    protected $conflicts = array();
+    protected $conflicts = [];
     /** @var array<string, Link> */
-    protected $provides = array();
+    protected $provides = [];
     /** @var array<string, Link> */
-    protected $replaces = array();
+    protected $replaces = [];
     /** @var array<string, Link> */
-    protected $devRequires = array();
+    protected $devRequires = [];
     /** @var array<string, string> */
-    protected $suggests = array();
+    protected $suggests = [];
     /**
      * @var array
      * @phpstan-var AutoloadRules
      */
-    protected $autoload = array();
+    protected $autoload = [];
     /**
      * @var array
      * @phpstan-var DevAutoloadRules
      */
-    protected $devAutoload = array();
+    protected $devAutoload = [];
     /** @var string[] */
-    protected $includePaths = array();
+    protected $includePaths = [];
     /** @var bool */
     protected $isDefaultBranch = false;
     /** @var mixed[] */
-    protected $transportOptions = array();
+    protected $transportOptions = [];
 
     /**
      * Creates a new in memory package.
@@ -738,14 +738,14 @@ class Package extends BasePackage
     protected function getUrls(?string $url, ?array $mirrors, ?string $ref, ?string $type, string $urlType): array
     {
         if (!$url) {
-            return array();
+            return [];
         }
 
         if ($urlType === 'dist' && false !== strpos($url, '%')) {
             $url = ComposerMirror::processUrl($url, $this->name, $this->version, $ref, $type, $this->prettyVersion);
         }
 
-        $urls = array($url);
+        $urls = [$url];
         if ($mirrors) {
             foreach ($mirrors as $mirror) {
                 if ($urlType === 'dist') {
@@ -775,7 +775,7 @@ class Package extends BasePackage
     private function convertLinksToMap(array $links, string $source): array
     {
         trigger_error('Package::'.$source.' must be called with a map of lowercased package name => Link object, got a indexed array, this is deprecated and you should fix your usage.');
-        $newLinks = array();
+        $newLinks = [];
         foreach ($links as $link) {
             $newLinks[$link->getTarget()] = $link;
         }

--- a/src/Composer/Package/RootPackage.php
+++ b/src/Composer/Package/RootPackage.php
@@ -26,13 +26,13 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     /** @var bool */
     protected $preferStable = false;
     /** @var array<string, BasePackage::STABILITY_*> Map of package name to stability constant */
-    protected $stabilityFlags = array();
+    protected $stabilityFlags = [];
     /** @var mixed[] */
-    protected $config = array();
+    protected $config = [];
     /** @var array<string, string> Map of package name to reference/commit hash */
-    protected $references = array();
+    protected $references = [];
     /** @var array<array{package: string, version: string, alias: string, alias_normalized: string}> */
-    protected $aliases = array();
+    protected $aliases = [];
 
     /**
      * @inheritDoc

--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -147,7 +147,7 @@ class VersionGuesser
 
         // try to fetch current version from git branch
         if (0 === $this->process->execute(['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'], $output, $path)) {
-            $branches = array();
+            $branches = [];
             $isFeatureBranch = false;
 
             // find current branch and collect all branch names
@@ -209,10 +209,10 @@ class VersionGuesser
         }
 
         if ($featureVersion) {
-            return array('version' => $version, 'commit' => $commit, 'pretty_version' => $prettyVersion, 'feature_version' => $featureVersion, 'feature_pretty_version' => $featurePrettyVersion);
+            return ['version' => $version, 'commit' => $commit, 'pretty_version' => $prettyVersion, 'feature_version' => $featureVersion, 'feature_pretty_version' => $featurePrettyVersion];
         }
 
-        return array('version' => $version, 'commit' => $commit, 'pretty_version' => $prettyVersion);
+        return ['version' => $version, 'commit' => $commit, 'pretty_version' => $prettyVersion];
     }
 
     /**
@@ -227,7 +227,7 @@ class VersionGuesser
             try {
                 $version = $this->versionParser->normalize(trim($output));
 
-                return array('version' => $version, 'pretty_version' => trim($output));
+                return ['version' => $version, 'pretty_version' => trim($output)];
             } catch (\Exception $e) {
             }
         }
@@ -250,16 +250,16 @@ class VersionGuesser
             $isFeatureBranch = 0 === strpos($version, 'dev-');
 
             if (VersionParser::DEFAULT_BRANCH_ALIAS === $version) {
-                return array('version' => $version, 'commit' => null, 'pretty_version' => 'dev-'.$branch);
+                return ['version' => $version, 'commit' => null, 'pretty_version' => 'dev-'.$branch];
             }
 
             if (!$isFeatureBranch) {
-                return array('version' => $version, 'commit' => null, 'pretty_version' => $version);
+                return ['version' => $version, 'commit' => null, 'pretty_version' => $version];
             }
 
             // re-use the HgDriver to fetch branches (this properly includes bookmarks)
             $io = new NullIO();
-            $driver = new HgDriver(array('url' => $path), $io, $this->config, new HttpDownloader($io, $this->config), $this->process);
+            $driver = new HgDriver(['url' => $path], $io, $this->config, new HttpDownloader($io, $this->config), $this->process);
             $branches = array_map('strval', array_keys($driver->getBranches()));
 
             // try to find the best (nearest) version branch to assume this feature's version
@@ -299,7 +299,7 @@ class VersionGuesser
 
             // return directly, if branch is configured to be non-feature branch
             if (!$this->isFeatureBranch($packageConfig, $branch)) {
-                return array('version' => $version, 'pretty_version' => $prettyVersion);
+                return ['version' => $version, 'pretty_version' => $prettyVersion];
             }
 
             // sort local branches first then remote ones
@@ -327,7 +327,7 @@ class VersionGuesser
                         continue;
                     }
 
-                    $cmdLine = str_replace(array('%candidate%', '%branch%'), array($candidate, $branch), $scmCmdline);
+                    $cmdLine = str_replace(['%candidate%', '%branch%'], [$candidate, $branch], $scmCmdline);
                     $promises[] = $this->process->executeAsync($cmdLine, $path)->then(function (Process $process) use (&$length, &$version, &$prettyVersion, $candidateVersion, &$promises): void {
                         if (!$process->isSuccessful()) {
                             return;
@@ -355,7 +355,7 @@ class VersionGuesser
             }
         }
 
-        return array('version' => $version, 'pretty_version' => $prettyVersion);
+        return ['version' => $version, 'pretty_version' => $prettyVersion];
     }
 
     /**
@@ -400,7 +400,7 @@ class VersionGuesser
             }
         }
 
-        return array('version' => $version, 'commit' => '', 'pretty_version' => $prettyVersion);
+        return ['version' => $version, 'commit' => '', 'pretty_version' => $prettyVersion];
     }
 
     /**
@@ -427,7 +427,7 @@ class VersionGuesser
                     $version = $this->versionParser->normalizeBranch($matches[3]);
                     $prettyVersion = 'dev-' . $matches[3];
 
-                    return array('version' => $version, 'commit' => '', 'pretty_version' => $prettyVersion);
+                    return ['version' => $version, 'commit' => '', 'pretty_version' => $prettyVersion];
                 }
 
                 $prettyVersion = trim($matches[1]);
@@ -437,7 +437,7 @@ class VersionGuesser
                     $version = $this->versionParser->normalize($prettyVersion);
                 }
 
-                return array('version' => $version, 'commit' => '', 'pretty_version' => $prettyVersion);
+                return ['version' => $version, 'commit' => '', 'pretty_version' => $prettyVersion];
             }
         }
 

--- a/src/Composer/Package/Version/VersionParser.php
+++ b/src/Composer/Package/Version/VersionParser.php
@@ -23,7 +23,7 @@ class VersionParser extends SemverVersionParser
     public const DEFAULT_BRANCH_ALIAS = '9999999-dev';
 
     /** @var array<string, ConstraintInterface> Constraint parsing cache */
-    private static $constraints = array();
+    private static $constraints = [];
 
     /**
      * @inheritDoc
@@ -50,7 +50,7 @@ class VersionParser extends SemverVersionParser
     public function parseNameVersionPairs(array $pairs): array
     {
         $pairs = array_values($pairs);
-        $result = array();
+        $result = [];
 
         for ($i = 0, $count = count($pairs); $i < $count; $i++) {
             $pair = Preg::replace('{^([^=: ]+)[=: ](.*)$}', '$1 $2', trim($pairs[$i]));
@@ -61,9 +61,9 @@ class VersionParser extends SemverVersionParser
 
             if (strpos($pair, ' ')) {
                 list($name, $version) = explode(' ', $pair, 2);
-                $result[] = array('name' => $name, 'version' => $version);
+                $result[] = ['name' => $name, 'version' => $version];
             } else {
-                $result[] = array('name' => $pair);
+                $result[] = ['name' => $pair];
             }
         }
 
@@ -82,10 +82,10 @@ class VersionParser extends SemverVersionParser
             return true;
         }
 
-        if (in_array($normalizedFrom, array('dev-master', 'dev-trunk', 'dev-default'), true)) {
+        if (in_array($normalizedFrom, ['dev-master', 'dev-trunk', 'dev-default'], true)) {
             $normalizedFrom = VersionParser::DEFAULT_BRANCH_ALIAS;
         }
-        if (in_array($normalizedTo, array('dev-master', 'dev-trunk', 'dev-default'), true)) {
+        if (in_array($normalizedTo, ['dev-master', 'dev-trunk', 'dev-default'], true)) {
             $normalizedTo = VersionParser::DEFAULT_BRANCH_ALIAS;
         }
 
@@ -93,7 +93,7 @@ class VersionParser extends SemverVersionParser
             return true;
         }
 
-        $sorted = Semver::sort(array($normalizedTo, $normalizedFrom));
+        $sorted = Semver::sort([$normalizedTo, $normalizedFrom]);
 
         return $sorted[0] === $normalizedFrom;
     }

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -39,7 +39,7 @@ class VersionSelector
     private $repositorySet;
 
     /** @var array<string, ConstraintInterface[]> */
-    private $platformConstraints = array();
+    private $platformConstraints = [];
 
     /** @var VersionParser */
     private $parser;

--- a/src/Composer/Platform/Runtime.php
+++ b/src/Composer/Platform/Runtime.php
@@ -52,7 +52,7 @@ class Runtime
      *
      * @return mixed
      */
-    public function invoke(callable $callable, array $arguments = array())
+    public function invoke(callable $callable, array $arguments = [])
     {
         return call_user_func_array($callable, $arguments);
     }
@@ -74,7 +74,7 @@ class Runtime
      * @return object
      * @throws \ReflectionException
      */
-    public function construct(string $class, array $arguments = array()): object
+    public function construct(string $class, array $arguments = []): object
     {
         if (empty($arguments)) {
             return new $class;

--- a/src/Composer/Platform/Version.php
+++ b/src/Composer/Platform/Version.php
@@ -39,7 +39,7 @@ class Version
         }
 
         $isFips = strpos($matches['suffix'], 'fips') !== false;
-        $suffix = strtr('-'.ltrim($matches['suffix'], '-'), array('-fips' => '', '-pre' => '-alpha'));
+        $suffix = strtr('-'.ltrim($matches['suffix'], '-'), ['-fips' => '', '-pre' => '-alpha']);
 
         return rtrim($matches['version'].$patch.$suffix, '-');
     }

--- a/src/Composer/Plugin/CommandEvent.php
+++ b/src/Composer/Plugin/CommandEvent.php
@@ -48,7 +48,7 @@ class CommandEvent extends Event
      * @param mixed[]         $args        Arguments passed by the user
      * @param mixed[]         $flags       Optional flags to pass data not as argument
      */
-    public function __construct(string $name, string $commandName, InputInterface $input, OutputInterface $output, array $args = array(), array $flags = array())
+    public function __construct(string $name, string $commandName, InputInterface $input, OutputInterface $output, array $args = [], array $flags = [])
     {
         parent::__construct($name, $args, $flags);
         $this->commandName = $commandName;

--- a/src/Composer/Plugin/PreFileDownloadEvent.php
+++ b/src/Composer/Plugin/PreFileDownloadEvent.php
@@ -50,7 +50,7 @@ class PreFileDownloadEvent extends Event
     /**
      * @var mixed[]
      */
-    private $transportOptions = array();
+    private $transportOptions = [];
 
     /**
      * Constructor.

--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -42,7 +42,7 @@ class ArrayRepository implements RepositoryInterface
     /**
      * @param array<PackageInterface> $packages
      */
-    public function __construct(array $packages = array())
+    public function __construct(array $packages = [])
     {
         foreach ($packages as $package) {
             $this->addPackage($package);
@@ -57,12 +57,12 @@ class ArrayRepository implements RepositoryInterface
     /**
      * @inheritDoc
      */
-    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags, array $alreadyLoaded = array())
+    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags, array $alreadyLoaded = [])
     {
         $packages = $this->getPackages();
 
-        $result = array();
-        $namesFound = array();
+        $result = [];
+        $namesFound = [];
         foreach ($packages as $package) {
             if (array_key_exists($package->getName(), $packageNameMap)) {
                 if (
@@ -91,7 +91,7 @@ class ArrayRepository implements RepositoryInterface
             }
         }
 
-        return array('namesFound' => array_keys($namesFound), 'packages' => $result);
+        return ['namesFound' => array_keys($namesFound), 'packages' => $result];
     }
 
     /**
@@ -125,7 +125,7 @@ class ArrayRepository implements RepositoryInterface
     {
         // normalize name
         $name = strtolower($name);
-        $packages = array();
+        $packages = [];
 
         if (null !== $constraint && !$constraint instanceof ConstraintInterface) {
             $versionParser = new VersionParser();
@@ -155,7 +155,7 @@ class ArrayRepository implements RepositoryInterface
             $regex = '{(?:'.implode('|', Preg::split('{\s+}', $query)).')}i';
         }
 
-        $matches = array();
+        $matches = [];
         foreach ($this->getPackages() as $package) {
             $name = $package->getName();
             if ($mode === self::SEARCH_VENDOR) {
@@ -172,15 +172,15 @@ class ArrayRepository implements RepositoryInterface
                 || ($mode === self::SEARCH_FULLTEXT && $package instanceof CompletePackageInterface && Preg::isMatch($regex, implode(' ', (array) $package->getKeywords()) . ' ' . $package->getDescription()))
             ) {
                 if ($mode === self::SEARCH_VENDOR) {
-                    $matches[$name] = array(
+                    $matches[$name] = [
                         'name' => $name,
                         'description' => null,
-                    );
+                    ];
                 } else {
-                    $matches[$name] = array(
+                    $matches[$name] = [
                         'name' => $package->getPrettyName(),
                         'description' => $package instanceof CompletePackageInterface ? $package->getDescription() : null,
-                    );
+                    ];
 
                     if ($package instanceof CompletePackageInterface && $package->isAbandoned()) {
                         $matches[$name]['abandoned'] = $package->getReplacementPackage() ?: true;
@@ -198,7 +198,7 @@ class ArrayRepository implements RepositoryInterface
     public function hasPackage(PackageInterface $package)
     {
         if ($this->packageMap === null) {
-            $this->packageMap = array();
+            $this->packageMap = [];
             foreach ($this->getPackages() as $repoPackage) {
                 $this->packageMap[$repoPackage->getUniqueName()] = $repoPackage;
             }
@@ -239,7 +239,7 @@ class ArrayRepository implements RepositoryInterface
      */
     public function getProviders(string $packageName)
     {
-        $result = array();
+        $result = [];
 
         foreach ($this->getPackages() as $candidate) {
             if (isset($result[$candidate->getName()])) {
@@ -247,11 +247,11 @@ class ArrayRepository implements RepositoryInterface
             }
             foreach ($candidate->getProvides() as $link) {
                 if ($packageName === $link->getTarget()) {
-                    $result[$candidate->getName()] = array(
+                    $result[$candidate->getName()] = [
                         'name' => $candidate->getName(),
                         'description' => $candidate instanceof CompletePackageInterface ? $candidate->getDescription() : null,
                         'type' => $candidate->getType(),
-                    );
+                    ];
                     continue 2;
                 }
             }
@@ -339,6 +339,6 @@ class ArrayRepository implements RepositoryInterface
      */
     protected function initialize()
     {
-        $this->packages = array();
+        $this->packages = [];
     }
 }

--- a/src/Composer/Repository/ArtifactRepository.php
+++ b/src/Composer/Repository/ArtifactRepository.php
@@ -107,7 +107,7 @@ class ArtifactRepository extends ArrayRepository implements ConfigurableReposito
         $json = null;
         $fileType = null;
         $fileExtension = pathinfo($file->getPathname(), PATHINFO_EXTENSION);
-        if (in_array($fileExtension, array('gz', 'tar', 'tgz'), true)) {
+        if (in_array($fileExtension, ['gz', 'tar', 'tgz'], true)) {
             $fileType = 'tar';
         } elseif ($fileExtension === 'zip') {
             $fileType = 'zip';
@@ -130,11 +130,11 @@ class ArtifactRepository extends ArrayRepository implements ConfigurableReposito
         }
 
         $package = JsonFile::parseJson($json, $file->getPathname().'#composer.json');
-        $package['dist'] = array(
+        $package['dist'] = [
             'type' => $fileType,
             'url' => strtr($file->getPathname(), '\\', '/'),
             'shasum' => sha1_file($file->getRealPath()),
-        );
+        ];
 
         try {
             $package = $this->loader->load($package);

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -113,14 +113,14 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      *            useful for v2 metadata repositories with lazy providers
      * @phpstan-var array<string, true>
      */
-    private $freshMetadataUrls = array();
+    private $freshMetadataUrls = [];
 
     /**
      * @var array list of package names which returned a 404 and should not be re-fetched in case loadPackage is called several times
      *            useful for v2 metadata repositories with lazy providers
      * @phpstan-var array<string, true>
      */
-    private $packagesNotFoundCache = array();
+    private $packagesNotFoundCache = [];
 
     /**
      * @var VersionParser
@@ -150,7 +150,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         }
 
         if (!isset($repoConfig['options'])) {
-            $repoConfig['options'] = array();
+            $repoConfig['options'] = [];
         }
         if (isset($repoConfig['allow_ssl_downgrade']) && true === $repoConfig['allow_ssl_downgrade']) {
             $this->allowSslDowngrade = true;
@@ -208,7 +208,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 return null;
             }
 
-            $packages = $this->loadAsyncPackages(array($name => $constraint));
+            $packages = $this->loadAsyncPackages([$name => $constraint]);
 
             if (count($packages['packages']) > 0) {
                 return reset($packages['packages']);
@@ -249,10 +249,10 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
 
             if ($this->hasAvailablePackageList && !$this->lazyProvidersRepoContains($name)) {
-                return array();
+                return [];
             }
 
-            $result = $this->loadAsyncPackages(array($name => $constraint));
+            $result = $this->loadAsyncPackages([$name => $constraint]);
 
             return $result['packages'];
         }
@@ -264,7 +264,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 }
             }
 
-            return array();
+            return [];
         }
 
         return parent::findPackages($name, $constraint);
@@ -287,7 +287,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             return $packages;
         }
 
-        $filteredPackages = array();
+        $filteredPackages = [];
 
         foreach ($packages as $package) {
             $pkgConstraint = new Constraint('==', $package->getVersion());
@@ -314,7 +314,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         if ($this->lazyProvidersUrl) {
             if (is_array($this->availablePackages) && !$this->availablePackagePatterns) {
-                $packageMap = array();
+                $packageMap = [];
                 foreach ($this->availablePackages as $name) {
                     $packageMap[$name] = new MatchAllConstraint();
                 }
@@ -388,14 +388,14 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 return $filterResults(array_keys($this->partialPackagesByName));
             }
 
-            return array();
+            return [];
         }
 
         if ($hasProviders) {
             return $filterResults($this->getProviderNames());
         }
 
-        $names = array();
+        $names = [];
         foreach ($this->getPackages() as $package) {
             $names[] = $package->getPrettyName();
         }
@@ -418,7 +418,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         $names = $this->getPackageNames();
 
-        $uniques = array();
+        $uniques = [];
         foreach ($names as $name) {
             // @phpstan-ignore-next-line
             $uniques[substr($name, 0, strpos($name, '/'))] = true;
@@ -467,7 +467,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         return $result['packageNames'];
     }
 
-    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags, array $alreadyLoaded = array())
+    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags, array $alreadyLoaded = [])
     {
         // this call initializes loadRootServerFile which is needed for the rest below to work
         $hasProviders = $this->hasProviders();
@@ -476,12 +476,12 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             return parent::loadPackages($packageNameMap, $acceptableStabilities, $stabilityFlags, $alreadyLoaded);
         }
 
-        $packages = array();
-        $namesFound = array();
+        $packages = [];
+        $namesFound = [];
 
         if ($hasProviders || $this->hasPartialPackages()) {
             foreach ($packageNameMap as $name => $constraint) {
-                $matches = array();
+                $matches = [];
 
                 // if a repo has no providers but only partial packages and the partial packages are missing
                 // then we don't want to call whatProvides as it would try to load from the providers and fail
@@ -532,7 +532,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             $namesFound = array_merge($namesFound, $result['namesFound']);
         }
 
-        return array('namesFound' => array_keys($namesFound), 'packages' => $packages);
+        return ['namesFound' => array_keys($namesFound), 'packages' => $packages];
     }
 
     /**
@@ -543,15 +543,15 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         $this->loadRootServerFile(600);
 
         if ($this->searchUrl && $mode === self::SEARCH_FULLTEXT) {
-            $url = str_replace(array('%query%', '%type%'), array(urlencode($query), $type), $this->searchUrl);
+            $url = str_replace(['%query%', '%type%'], [urlencode($query), $type], $this->searchUrl);
 
             $search = $this->httpDownloader->get($url, $this->options)->decodeJson();
 
             if (empty($search['results'])) {
-                return array();
+                return [];
             }
 
-            $results = array();
+            $results = [];
             foreach ($search['results'] as $result) {
                 // do not show virtual packages in results as they are not directly useful from a composer perspective
                 if (!empty($result['virtual'])) {
@@ -565,12 +565,12 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         }
 
         if ($mode === self::SEARCH_VENDOR) {
-            $results = array();
+            $results = [];
             $regex = '{(?:'.implode('|', Preg::split('{\s+}', $query)).')}i';
 
             $vendorNames = $this->getVendorNames();
             foreach (Preg::grep($regex, $vendorNames) as $name) {
-                $results[] = array('name' => $name, 'description' => '');
+                $results[] = ['name' => $name, 'description' => ''];
             }
 
             return $results;
@@ -582,20 +582,20 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 $url = $this->listUrl . '?vendor='.urlencode($match['vendor']).'&filter='.urlencode($match['query'].'*');
                 $result = $this->httpDownloader->get($url, $this->options)->decodeJson();
 
-                $results = array();
+                $results = [];
                 foreach ($result['packageNames'] as $name) {
-                    $results[] = array('name' => $name, 'description' => '');
+                    $results[] = ['name' => $name, 'description' => ''];
                 }
 
                 return $results;
             }
 
-            $results = array();
+            $results = [];
             $regex = '{(?:'.implode('|', Preg::split('{\s+}', $query)).')}i';
 
             $packageNames = $this->getPackageNames();
             foreach (Preg::grep($regex, $packageNames) as $name) {
-                $results[] = array('name' => $name, 'description' => '');
+                $results[] = ['name' => $name, 'description' => ''];
             }
 
             return $results;
@@ -607,7 +607,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     public function getProviders(string $packageName)
     {
         $this->loadRootServerFile();
-        $result = array();
+        $result = [];
 
         if ($this->providersApiUrl) {
             $apiResult = $this->httpDownloader->get(str_replace('%package%', $packageName, $this->providersApiUrl), $this->options)->decodeJson();
@@ -628,11 +628,11 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     if (isset($result[$candidate['name']]) || !isset($candidate['provide'][$packageName])) {
                         continue;
                     }
-                    $result[$candidate['name']] = array(
+                    $result[$candidate['name']] = [
                         'name' => $candidate['name'],
                         'description' => $candidate['description'] ?? '',
                         'type' => $candidate['type'] ?? '',
-                    );
+                    ];
                 }
             }
         }
@@ -660,14 +660,14 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         if ($this->lazyProvidersUrl) {
             // Can not determine list of provided packages for lazy repositories
-            return array();
+            return [];
         }
 
         if (null !== $this->providersUrl && null !== $this->providerListing) {
             return array_keys($this->providerListing);
         }
 
-        return array();
+        return [];
     }
 
     protected function configurePackageTransportOptions(PackageInterface $package): void
@@ -701,13 +701,13 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      *
      * @return array<string, BasePackage>
      */
-    private function whatProvides(string $name, array $acceptableStabilities = null, array $stabilityFlags = null, array $alreadyLoaded = array()): array
+    private function whatProvides(string $name, array $acceptableStabilities = null, array $stabilityFlags = null, array $alreadyLoaded = []): array
     {
         $packagesSource = null;
         if (!$this->hasPartialPackages() || !isset($this->partialPackagesByName[$name])) {
             // skip platform packages, root package and composer-plugin-api
             if (PlatformRepository::isPlatformPackage($name) || '__root__' === $name) {
-                return array();
+                return [];
             }
 
             if (null === $this->providerListing) {
@@ -726,14 +726,14 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             } elseif ($this->providersUrl) {
                 // package does not exist in this repo
                 if (!isset($this->providerListing[$name])) {
-                    return array();
+                    return [];
                 }
 
                 $hash = $this->providerListing[$name]['sha256'];
-                $url = str_replace(array('%package%', '%hash%'), array($name, $hash), $this->providersUrl);
+                $url = str_replace(['%package%', '%hash%'], [$name, $hash], $this->providersUrl);
                 $cacheKey = 'provider-'.strtr($name, '/', '$').'.json';
             } else {
-                return array();
+                return [];
             }
 
             $packages = null;
@@ -761,8 +761,8 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     $packagesSource = 'downloaded file ('.Url::sanitize($url).')';
                 } catch (TransportException $e) {
                     // 404s are acceptable for lazy provider repos
-                    if ($this->lazyProvidersUrl && in_array($e->getStatusCode(), array(404, 499), true)) {
-                        $packages = array('packages' => array());
+                    if ($this->lazyProvidersUrl && in_array($e->getStatusCode(), [404, 499], true)) {
+                        $packages = ['packages' => []];
                         $packagesSource = 'not-found file ('.Url::sanitize($url).')';
                         if ($e->getStatusCode() === 499) {
                             $this->io->error('<warning>' . $e->getMessage() . '</warning>');
@@ -775,13 +775,13 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
             $loadingPartialPackage = false;
         } else {
-            $packages = array('packages' => array('versions' => $this->partialPackagesByName[$name]));
+            $packages = ['packages' => ['versions' => $this->partialPackagesByName[$name]]];
             $packagesSource = 'root file ('.Url::sanitize($this->getPackagesJsonUrl()).')';
             $loadingPartialPackage = true;
         }
 
-        $result = array();
-        $versionsToLoad = array();
+        $result = [];
+        $versionsToLoad = [];
         foreach ($packages['packages'] as $versions) {
             foreach ($versions as $version) {
                 $normalizedName = strtolower($version['name']);
@@ -872,13 +872,13 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      *
      * @return array{namesFound: array<string, true>, packages: array<string, BasePackage>}
      */
-    private function loadAsyncPackages(array $packageNames, array $acceptableStabilities = null, array $stabilityFlags = null, array $alreadyLoaded = array()): array
+    private function loadAsyncPackages(array $packageNames, array $acceptableStabilities = null, array $stabilityFlags = null, array $alreadyLoaded = []): array
     {
         $this->loadRootServerFile();
 
-        $packages = array();
-        $namesFound = array();
-        $promises = array();
+        $packages = [];
+        $namesFound = [];
+        $promises = [];
 
         if (!$this->lazyProvidersUrl) {
             throw new \LogicException('loadAsyncPackages only supports v2 protocol composer repos with a metadata-url');
@@ -886,7 +886,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         // load ~dev versions of the packages as well if needed
         foreach ($packageNames as $name => $constraint) {
-            if ($acceptableStabilities === null || $stabilityFlags === null || StabilityFilter::isPackageAcceptable($acceptableStabilities, $stabilityFlags, array($name), 'dev')) {
+            if ($acceptableStabilities === null || $stabilityFlags === null || StabilityFilter::isPackageAcceptable($acceptableStabilities, $stabilityFlags, [$name], 'dev')) {
                 $packageNames[$name.'~dev'] = $constraint;
             }
             // if only dev stability is requested, we skip loading the non dev file
@@ -933,7 +933,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     }
 
                     $namesFound[$realName] = true;
-                    $versionsToLoad = array();
+                    $versionsToLoad = [];
                     foreach ($versions as $version) {
                         if (!isset($version['version_normalized'])) {
                             $version['version_normalized'] = $this->versionParser->normalize($version['version']);
@@ -967,7 +967,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         $this->loop->wait($promises);
 
-        return array('namesFound' => $namesFound, 'packages' => $packages);
+        return ['namesFound' => $namesFound, 'packages' => $packages];
         // RepositorySet should call loadMetadata, getMetadata when all promises resolved, then metadataComplete when done so we can GC the loaded json and whatnot then as needed
     }
 
@@ -984,14 +984,14 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      */
     private function isVersionAcceptable(?ConstraintInterface $constraint, string $name, array $versionData, array $acceptableStabilities = null, array $stabilityFlags = null): bool
     {
-        $versions = array($versionData['version_normalized']);
+        $versions = [$versionData['version_normalized']];
 
         if ($alias = $this->loader->getBranchAlias($versionData)) {
             $versions[] = $alias;
         }
 
         foreach ($versions as $version) {
-            if (null !== $acceptableStabilities && null !== $stabilityFlags && !StabilityFilter::isPackageAcceptable($acceptableStabilities, $stabilityFlags, array($name), VersionParser::parseStability($version))) {
+            if (null !== $acceptableStabilities && null !== $stabilityFlags && !StabilityFilter::isPackageAcceptable($acceptableStabilities, $stabilityFlags, [$name], VersionParser::parseStability($version))) {
                 continue;
             }
 
@@ -1060,16 +1060,16 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         if (!empty($data['mirrors'])) {
             foreach ($data['mirrors'] as $mirror) {
                 if (!empty($mirror['git-url'])) {
-                    $this->sourceMirrors['git'][] = array('url' => $mirror['git-url'], 'preferred' => !empty($mirror['preferred']));
+                    $this->sourceMirrors['git'][] = ['url' => $mirror['git-url'], 'preferred' => !empty($mirror['preferred'])];
                 }
                 if (!empty($mirror['hg-url'])) {
-                    $this->sourceMirrors['hg'][] = array('url' => $mirror['hg-url'], 'preferred' => !empty($mirror['preferred']));
+                    $this->sourceMirrors['hg'][] = ['url' => $mirror['hg-url'], 'preferred' => !empty($mirror['preferred'])];
                 }
                 if (!empty($mirror['dist-url'])) {
-                    $this->distMirrors[] = array(
+                    $this->distMirrors[] = [
                         'url' => $this->canonicalizeUrl($mirror['dist-url']),
                         'preferred' => !empty($mirror['preferred']),
-                    );
+                    ];
                 }
             }
         }
@@ -1192,7 +1192,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     {
         if (isset($data['providers'])) {
             if (!is_array($this->providerListing)) {
-                $this->providerListing = array();
+                $this->providerListing = [];
             }
             $this->providerListing = array_merge($this->providerListing, $data['providers']);
         }
@@ -1201,7 +1201,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             $includes = $data['provider-includes'];
             foreach ($includes as $include => $metadata) {
                 $url = $this->baseUrl . '/' . str_replace('%hash%', $metadata['sha256'], $include);
-                $cacheKey = str_replace(array('%hash%','$'), '', $include);
+                $cacheKey = str_replace(['%hash%','$'], '', $include);
                 if ($this->cache->sha256($cacheKey) === $metadata['sha256']) {
                     $includedData = json_decode($this->cache->read($cacheKey), true);
                 } else {
@@ -1220,7 +1220,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      */
     private function loadIncludes(array $data): array
     {
-        $packages = array();
+        $packages = [];
 
         // legacy repo handling
         if (!isset($data['packages']) && !isset($data['includes'])) {
@@ -1271,7 +1271,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     private function createPackages(array $packages, ?string $source = null): array
     {
         if (!$packages) {
-            return array();
+            return [];
         }
 
         try {
@@ -1322,7 +1322,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             try {
                 $options = $this->options;
                 if ($this->eventDispatcher) {
-                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata', array('repository' => $this));
+                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata', ['repository' => $this]);
                     $preFileDownloadEvent->setTransportOptions($this->options);
                     $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
                     $filename = $preFileDownloadEvent->getProcessedUrl();
@@ -1350,7 +1350,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 }
 
                 if ($this->eventDispatcher) {
-                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, $sha256, $filename, 'metadata', array('response' => $response, 'repository' => $this));
+                    $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, $sha256, $filename, 'metadata', ['response' => $response, 'repository' => $this]);
                     $this->eventDispatcher->dispatch($postFileDownloadEvent->getName(), $postFileDownloadEvent);
                 }
 
@@ -1417,7 +1417,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         try {
             $options = $this->options;
             if ($this->eventDispatcher) {
-                $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata', array('repository' => $this));
+                $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata', ['repository' => $this]);
                 $preFileDownloadEvent->setTransportOptions($this->options);
                 $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
                 $filename = $preFileDownloadEvent->getProcessedUrl();
@@ -1435,7 +1435,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
 
             if ($this->eventDispatcher) {
-                $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $filename, 'metadata', array('response' => $response, 'repository' => $this));
+                $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $filename, 'metadata', ['response' => $response, 'repository' => $this]);
                 $this->eventDispatcher->dispatch($postFileDownloadEvent->getName(), $postFileDownloadEvent);
             }
 
@@ -1479,7 +1479,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     private function asyncFetchFile(string $filename, string $cacheKey, ?string $lastModifiedTime = null): PromiseInterface
     {
         if (isset($this->packagesNotFoundCache[$filename])) {
-            return \React\Promise\resolve(array('packages' => array()));
+            return \React\Promise\resolve(['packages' => []]);
         }
 
         if (isset($this->freshMetadataUrls[$filename]) && $lastModifiedTime) {
@@ -1490,7 +1490,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         $httpDownloader = $this->httpDownloader;
         $options = $this->options;
         if ($this->eventDispatcher) {
-            $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata', array('repository' => $this));
+            $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata', ['repository' => $this]);
             $preFileDownloadEvent->setTransportOptions($this->options);
             $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
             $filename = $preFileDownloadEvent->getProcessedUrl();
@@ -1518,7 +1518,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             if ($response->getStatusCode() === 404) {
                 $this->packagesNotFoundCache[$filename] = true;
 
-                return array('packages' => array());
+                return ['packages' => []];
             }
 
             $json = (string) $response->getBody();
@@ -1529,7 +1529,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
 
             if ($eventDispatcher) {
-                $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $filename, 'metadata', array('response' => $response, 'repository' => $this));
+                $postFileDownloadEvent = new PostFileDownloadEvent(PluginEvents::POST_FILE_DOWNLOAD, null, null, $filename, 'metadata', ['response' => $response, 'repository' => $this]);
                 $eventDispatcher->dispatch($postFileDownloadEvent->getName(), $postFileDownloadEvent);
             }
 
@@ -1564,12 +1564,12 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
             // if the file is in the cache, we fake a 304 Not Modified to allow the process to continue
             if ($lastModifiedTime) {
-                return $accept(new Response(array('url' => $url), 304, array(), ''));
+                return $accept(new Response(['url' => $url], 304, [], ''));
             }
 
             // special error code returned when network is being artificially disabled
             if ($e instanceof TransportException && $e->getStatusCode() === 499) {
-                return $accept(new Response(array('url' => $url), 404, array(), ''));
+                return $accept(new Response(['url' => $url], 404, [], ''));
             }
 
             throw $e;
@@ -1592,7 +1592,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             return;
         }
 
-        $this->partialPackagesByName = array();
+        $this->partialPackagesByName = [];
         foreach ($rootData['packages'] as $package => $versions) {
             foreach ($versions as $version) {
                 $versionPackageName = strtolower((string) ($version['name'] ?? ''));

--- a/src/Composer/Repository/CompositeRepository.php
+++ b/src/Composer/Repository/CompositeRepository.php
@@ -34,7 +34,7 @@ class CompositeRepository implements RepositoryInterface
      */
     public function __construct(array $repositories)
     {
-        $this->repositories = array();
+        $this->repositories = [];
         foreach ($repositories as $repo) {
             $this->addRepository($repo);
         }
@@ -93,22 +93,22 @@ class CompositeRepository implements RepositoryInterface
      */
     public function findPackages($name, $constraint = null): array
     {
-        $packages = array();
+        $packages = [];
         foreach ($this->repositories as $repository) {
             /* @var $repository RepositoryInterface */
             $packages[] = $repository->findPackages($name, $constraint);
         }
 
-        return $packages ? call_user_func_array('array_merge', $packages) : array();
+        return $packages ? call_user_func_array('array_merge', $packages) : [];
     }
 
     /**
      * @inheritDoc
      */
-    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags, array $alreadyLoaded = array()): array
+    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags, array $alreadyLoaded = []): array
     {
-        $packages = array();
-        $namesFound = array();
+        $packages = [];
+        $namesFound = [];
         foreach ($this->repositories as $repository) {
             /* @var $repository RepositoryInterface */
             $result = $repository->loadPackages($packageNameMap, $acceptableStabilities, $stabilityFlags, $alreadyLoaded);
@@ -116,10 +116,10 @@ class CompositeRepository implements RepositoryInterface
             $namesFound[] = $result['namesFound'];
         }
 
-        return array(
-            'packages' => $packages ? call_user_func_array('array_merge', $packages) : array(),
-            'namesFound' => $namesFound ? array_unique(call_user_func_array('array_merge', $namesFound)) : array(),
-        );
+        return [
+            'packages' => $packages ? call_user_func_array('array_merge', $packages) : [],
+            'namesFound' => $namesFound ? array_unique(call_user_func_array('array_merge', $namesFound)) : [],
+        ];
     }
 
     /**
@@ -127,13 +127,13 @@ class CompositeRepository implements RepositoryInterface
      */
     public function search(string $query, int $mode = 0, ?string $type = null): array
     {
-        $matches = array();
+        $matches = [];
         foreach ($this->repositories as $repository) {
             /* @var $repository RepositoryInterface */
             $matches[] = $repository->search($query, $mode, $type);
         }
 
-        return $matches ? call_user_func_array('array_merge', $matches) : array();
+        return $matches ? call_user_func_array('array_merge', $matches) : [];
     }
 
     /**
@@ -141,13 +141,13 @@ class CompositeRepository implements RepositoryInterface
      */
     public function getPackages(): array
     {
-        $packages = array();
+        $packages = [];
         foreach ($this->repositories as $repository) {
             /* @var $repository RepositoryInterface */
             $packages[] = $repository->getPackages();
         }
 
-        return $packages ? call_user_func_array('array_merge', $packages) : array();
+        return $packages ? call_user_func_array('array_merge', $packages) : [];
     }
 
     /**
@@ -155,13 +155,13 @@ class CompositeRepository implements RepositoryInterface
      */
     public function getProviders($packageName): array
     {
-        $results = array();
+        $results = [];
         foreach ($this->repositories as $repository) {
             /* @var $repository RepositoryInterface */
             $results[] = $repository->getProviders($packageName);
         }
 
-        return $results ? call_user_func_array('array_merge', $results) : array();
+        return $results ? call_user_func_array('array_merge', $results) : [];
     }
 
     /**

--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -120,7 +120,7 @@ class FilesystemRepository extends WritableArrayRepository
      */
     public function write(bool $devMode, InstallationManager $installationManager)
     {
-        $data = array('packages' => array(), 'dev' => $devMode, 'dev-package-names' => array());
+        $data = ['packages' => [], 'dev' => $devMode, 'dev-package-names' => []];
         $dumper = new ArrayDumper();
 
         // make sure the directory is created so we can realpath it
@@ -130,7 +130,7 @@ class FilesystemRepository extends WritableArrayRepository
         $this->filesystem->ensureDirectoryExists($repoDir);
 
         $repoDir = $this->filesystem->normalizePath(realpath($repoDir));
-        $installPaths = array();
+        $installPaths = [];
 
         foreach ($this->getCanonicalPackages() as $package) {
             $pkgArray = $dumper->dump($package);
@@ -176,7 +176,7 @@ class FilesystemRepository extends WritableArrayRepository
      *
      * @return string
      */
-    private function dumpToPhpCode(array $array = array(), int $level = 0): string
+    private function dumpToPhpCode(array $array = [], int $level = 0): string
     {
         $lines = "array(\n";
         $level++;
@@ -325,7 +325,7 @@ class FilesystemRepository extends WritableArrayRepository
             'reference' => $reference,
             'type' => $package->getType(),
             'install_path' => $installPath,
-            'aliases' => array(),
+            'aliases' => [],
             'dev_requirement' => isset($devPackages[$package->getName()]),
         ];
 

--- a/src/Composer/Repository/FilterRepository.php
+++ b/src/Composer/Repository/FilterRepository.php
@@ -103,7 +103,7 @@ class FilterRepository implements RepositoryInterface
     public function findPackages($name, $constraint = null): array
     {
         if (!$this->isAllowed($name)) {
-            return array();
+            return [];
         }
 
         return $this->repo->findPackages($name, $constraint);
@@ -112,7 +112,7 @@ class FilterRepository implements RepositoryInterface
     /**
      * @inheritDoc
      */
-    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags, array $alreadyLoaded = array()): array
+    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags, array $alreadyLoaded = []): array
     {
         foreach ($packageNameMap as $name => $constraint) {
             if (!$this->isAllowed($name)) {
@@ -121,12 +121,12 @@ class FilterRepository implements RepositoryInterface
         }
 
         if (!$packageNameMap) {
-            return array('namesFound' => array(), 'packages' => array());
+            return ['namesFound' => [], 'packages' => []];
         }
 
         $result = $this->repo->loadPackages($packageNameMap, $acceptableStabilities, $stabilityFlags, $alreadyLoaded);
         if (!$this->canonical) {
-            $result['namesFound'] = array();
+            $result['namesFound'] = [];
         }
 
         return $result;
@@ -137,7 +137,7 @@ class FilterRepository implements RepositoryInterface
      */
     public function search(string $query, int $mode = 0, ?string $type = null): array
     {
-        $result = array();
+        $result = [];
 
         foreach ($this->repo->search($query, $mode, $type) as $package) {
             if ($this->isAllowed($package['name'])) {
@@ -153,7 +153,7 @@ class FilterRepository implements RepositoryInterface
      */
     public function getPackages(): array
     {
-        $result = array();
+        $result = [];
         foreach ($this->repo->getPackages() as $package) {
             if ($this->isAllowed($package->getName())) {
                 $result[] = $package;
@@ -168,7 +168,7 @@ class FilterRepository implements RepositoryInterface
      */
     public function getProviders($packageName): array
     {
-        $result = array();
+        $result = [];
         foreach ($this->repo->getProviders($packageName) as $name => $provider) {
             if ($this->isAllowed($provider['name'])) {
                 $result[$name] = $provider;

--- a/src/Composer/Repository/InstalledRepository.php
+++ b/src/Composer/Repository/InstalledRepository.php
@@ -47,7 +47,7 @@ class InstalledRepository extends CompositeRepository
             $constraint = $versionParser->parseConstraints($constraint);
         }
 
-        $matches = array();
+        $matches = [];
         foreach ($this->getRepositories() as $repo) {
             foreach ($repo->getPackages() as $candidate) {
                 if ($name === $candidate->getName()) {
@@ -90,7 +90,7 @@ class InstalledRepository extends CompositeRepository
     public function getDependents($needle, ?ConstraintInterface $constraint = null, bool $invert = false, bool $recurse = true, array $packagesFound = null): array
     {
         $needles = array_map('strtolower', (array) $needle);
-        $results = array();
+        $results = [];
 
         // initialize the array with the needles before any recursion occurs
         if (null === $packagesFound) {
@@ -127,12 +127,12 @@ class InstalledRepository extends CompositeRepository
                             if ($constraint === null || ($link->getConstraint()->matches($constraint) === true)) {
                                 // already displayed this node's dependencies, cutting short
                                 if (in_array($link->getTarget(), $packagesInTree)) {
-                                    $results[] = array($package, $link, false);
+                                    $results[] = [$package, $link, false];
                                     continue;
                                 }
                                 $packagesInTree[] = $link->getTarget();
-                                $dependents = $recurse ? $this->getDependents($link->getTarget(), null, false, true, $packagesInTree) : array();
-                                $results[] = array($package, $link, $dependents);
+                                $dependents = $recurse ? $this->getDependents($link->getTarget(), null, false, true, $packagesInTree) : [];
+                                $results[] = [$package, $link, $dependents];
                                 $needles[] = $link->getTarget();
                             }
                         }
@@ -152,12 +152,12 @@ class InstalledRepository extends CompositeRepository
                         if ($constraint === null || ($link->getConstraint()->matches($constraint) === !$invert)) {
                             // already displayed this node's dependencies, cutting short
                             if (in_array($link->getSource(), $packagesInTree)) {
-                                $results[] = array($package, $link, false);
+                                $results[] = [$package, $link, false];
                                 continue;
                             }
                             $packagesInTree[] = $link->getSource();
-                            $dependents = $recurse ? $this->getDependents($link->getSource(), null, false, true, $packagesInTree) : array();
-                            $results[] = array($package, $link, $dependents);
+                            $dependents = $recurse ? $this->getDependents($link->getSource(), null, false, true, $packagesInTree) : [];
+                            $results[] = [$package, $link, $dependents];
                         }
                     }
                 }
@@ -169,7 +169,7 @@ class InstalledRepository extends CompositeRepository
                     foreach ($this->findPackages($link->getTarget()) as $pkg) {
                         $version = new Constraint('=', $pkg->getVersion());
                         if ($link->getConstraint()->matches($version) === $invert) {
-                            $results[] = array($package, $link, false);
+                            $results[] = [$package, $link, false];
                         }
                     }
                 }
@@ -181,7 +181,7 @@ class InstalledRepository extends CompositeRepository
                     foreach ($this->findPackages($link->getTarget()) as $pkg) {
                         $version = new Constraint('=', $pkg->getVersion());
                         if ($link->getConstraint()->matches($version) === $invert) {
-                            $results[] = array($package, $link, false);
+                            $results[] = [$package, $link, false];
                         }
                     }
                 }
@@ -197,7 +197,7 @@ class InstalledRepository extends CompositeRepository
 
                         $platformPkg = $this->findPackage($link->getTarget(), '*');
                         $description = $platformPkg ? 'but '.$platformPkg->getPrettyVersion().' is installed' : 'but it is missing';
-                        $results[] = array($package, new Link($package->getName(), $link->getTarget(), new MatchAllConstraint, Link::TYPE_REQUIRE, $link->getPrettyConstraint().' '.$description), false);
+                        $results[] = [$package, new Link($package->getName(), $link->getTarget(), new MatchAllConstraint, Link::TYPE_REQUIRE, $link->getPrettyConstraint().' '.$description), false];
 
                         continue;
                     }
@@ -224,17 +224,17 @@ class InstalledRepository extends CompositeRepository
                             if ($rootPackage) {
                                 foreach (array_merge($rootPackage->getRequires(), $rootPackage->getDevRequires()) as $rootReq) {
                                     if (in_array($rootReq->getTarget(), $pkg->getNames()) && !$rootReq->getConstraint()->matches($link->getConstraint())) {
-                                        $results[] = array($package, $link, false);
-                                        $results[] = array($rootPackage, $rootReq, false);
+                                        $results[] = [$package, $link, false];
+                                        $results[] = [$rootPackage, $rootReq, false];
                                         continue 3;
                                     }
                                 }
 
-                                $results[] = array($package, $link, false);
-                                $results[] = array($rootPackage, new Link($rootPackage->getName(), $link->getTarget(), new MatchAllConstraint, Link::TYPE_DOES_NOT_REQUIRE, 'but ' . $pkg->getPrettyVersion() . ' is installed'), false);
+                                $results[] = [$package, $link, false];
+                                $results[] = [$rootPackage, new Link($rootPackage->getName(), $link->getTarget(), new MatchAllConstraint, Link::TYPE_DOES_NOT_REQUIRE, 'but ' . $pkg->getPrettyVersion() . ' is installed'), false];
                             } else {
                                 // no root so let's just print whatever we found
-                                $results[] = array($package, $link, false);
+                                $results[] = [$package, $link, false];
                             }
                         }
 

--- a/src/Composer/Repository/PackageRepository.php
+++ b/src/Composer/Repository/PackageRepository.php
@@ -38,7 +38,7 @@ class PackageRepository extends ArrayRepository
 
         // make sure we have an array of package definitions
         if (!is_numeric(key($this->config))) {
-            $this->config = array($this->config);
+            $this->config = [$this->config];
         }
     }
 

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -122,7 +122,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
         $this->process = $process ?? new ProcessExecutor($io);
         $this->versionGuesser = new VersionGuesser($config, $this->process, new VersionParser());
         $this->repoConfig = $repoConfig;
-        $this->options = $repoConfig['options'] ?? array();
+        $this->options = $repoConfig['options'] ?? [];
         if (!isset($this->options['relative'])) {
             $filesystem = new Filesystem();
             $this->options['relative'] = !$filesystem->isAbsolutePath($this->url);
@@ -177,10 +177,10 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
             $json = file_get_contents($composerFilePath);
             $package = JsonFile::parseJson($json, $composerFilePath);
-            $package['dist'] = array(
+            $package['dist'] = [
                 'type' => 'path',
                 'url' => $url,
-            );
+            ];
             $reference = $this->options['reference'] ?? 'auto';
             if ('none' === $reference) {
                 $package['dist']['reference'] = null;
@@ -189,7 +189,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             }
 
             // copy symlink/relative options to transport options
-            $package['transport-options'] = array_intersect_key($this->options, array('symlink' => true, 'relative' => true));
+            $package['transport-options'] = array_intersect_key($this->options, ['symlink' => true, 'relative' => true]);
             // use the version provided as option if available
             if (isset($package['name'], $this->options['versions'][$package['name']])) {
                 $package['version'] = $this->options['versions'][$package['name']];

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -36,14 +36,14 @@ class RepositoryFactory
     public static function configFromString(IOInterface $io, Config $config, string $repository, bool $allowFilesystem = false)
     {
         if (0 === strpos($repository, 'http')) {
-            $repoConfig = array('type' => 'composer', 'url' => $repository);
+            $repoConfig = ['type' => 'composer', 'url' => $repository];
         } elseif ("json" === pathinfo($repository, PATHINFO_EXTENSION)) {
             $json = new JsonFile($repository, Factory::createHttpDownloader($io, $config));
             $data = $json->read();
             if (!empty($data['packages']) || !empty($data['includes']) || !empty($data['provider-includes'])) {
-                $repoConfig = array('type' => 'composer', 'url' => 'file://' . strtr(realpath($repository), '\\', '/'));
+                $repoConfig = ['type' => 'composer', 'url' => 'file://' . strtr(realpath($repository), '\\', '/')];
             } elseif ($allowFilesystem) {
-                $repoConfig = array('type' => 'filesystem', 'json' => $json);
+                $repoConfig = ['type' => 'filesystem', 'json' => $json];
             } else {
                 throw new \InvalidArgumentException("Invalid repository URL ($repository) given. This file does not contain a valid composer repository.");
             }
@@ -83,7 +83,7 @@ class RepositoryFactory
             @trigger_error('Not passing a repository manager when calling createRepo is deprecated since Composer 2.3.6', E_USER_DEPRECATED);
             $rm = static::manager($io, $config);
         }
-        $repos = self::createRepos($rm, array($repoConfig));
+        $repos = self::createRepos($rm, [$repoConfig]);
 
         return reset($repos);
     }
@@ -172,7 +172,7 @@ class RepositoryFactory
      */
     private static function createRepos(RepositoryManager $rm, array $repoConfigs): array
     {
-        $repos = array();
+        $repos = [];
 
         foreach ($repoConfigs as $index => $repo) {
             if (is_string($repo)) {

--- a/src/Composer/Repository/RepositoryInterface.php
+++ b/src/Composer/Repository/RepositoryInterface.php
@@ -81,7 +81,7 @@ interface RepositoryInterface extends \Countable
      * @phpstan-param  array<string, ConstraintInterface|null> $packageNameMap
      * @phpstan-return array{namesFound: array<string>, packages: array<BasePackage>}
      */
-    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags, array $alreadyLoaded = array());
+    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags, array $alreadyLoaded = []);
 
     /**
      * Searches the repository for packages containing the query

--- a/src/Composer/Repository/RepositoryManager.php
+++ b/src/Composer/Repository/RepositoryManager.php
@@ -31,9 +31,9 @@ class RepositoryManager
     /** @var InstalledRepositoryInterface */
     private $localRepository;
     /** @var list<RepositoryInterface> */
-    private $repositories = array();
+    private $repositories = [];
     /** @var array<string, class-string<RepositoryInterface>> */
-    private $repositoryClasses = array();
+    private $repositoryClasses = [];
     /** @var IOInterface */
     private $io;
     /** @var Config */
@@ -84,7 +84,7 @@ class RepositoryManager
      */
     public function findPackages(string $name, $constraint): array
     {
-        $packages = array();
+        $packages = [];
 
         foreach ($this->getRepositories() as $repository) {
             $packages = array_merge($packages, $repository->findPackages($name, $constraint));

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -53,7 +53,7 @@ class RepositorySet
     private $rootReferences;
 
     /** @var RepositoryInterface[] */
-    private $repositories = array();
+    private $repositories = [];
 
     /**
      * @var int[] array of stability => BasePackage::STABILITY_* value
@@ -99,12 +99,12 @@ class RepositorySet
      * @phpstan-param array<string, ConstraintInterface> $rootRequires
      * @param array<string, ConstraintInterface> $temporaryConstraints Runtime temporary constraints that will be used to filter packages
      */
-    public function __construct(string $minimumStability = 'stable', array $stabilityFlags = array(), array $rootAliases = array(), array $rootReferences = array(), array $rootRequires = array(), array $temporaryConstraints = [])
+    public function __construct(string $minimumStability = 'stable', array $stabilityFlags = [], array $rootAliases = [], array $rootReferences = [], array $rootRequires = [], array $temporaryConstraints = [])
     {
         $this->rootAliases = self::getRootAliasesPerPackage($rootAliases);
         $this->rootReferences = $rootReferences;
 
-        $this->acceptableStabilities = array();
+        $this->acceptableStabilities = [];
         foreach (BasePackage::$stabilities as $stability => $value) {
             if ($value <= BasePackage::$stabilities[$minimumStability]) {
                 $this->acceptableStabilities[$stability] = $value;
@@ -167,7 +167,7 @@ class RepositorySet
         if ($repo instanceof CompositeRepository) {
             $repos = $repo->getRepositories();
         } else {
-            $repos = array($repo);
+            $repos = [$repo];
         }
 
         foreach ($repos as $repo) {
@@ -190,14 +190,14 @@ class RepositorySet
         $ignoreStability = ($flags & self::ALLOW_UNACCEPTABLE_STABILITIES) !== 0;
         $loadFromAllRepos = ($flags & self::ALLOW_SHADOWED_REPOSITORIES) !== 0;
 
-        $packages = array();
+        $packages = [];
         if ($loadFromAllRepos) {
             foreach ($this->repositories as $repository) {
-                $packages[] = $repository->findPackages($name, $constraint) ?: array();
+                $packages[] = $repository->findPackages($name, $constraint) ?: [];
             }
         } else {
             foreach ($this->repositories as $repository) {
-                $result = $repository->loadPackages(array($name => $constraint), $ignoreStability ? BasePackage::$stabilities : $this->acceptableStabilities, $ignoreStability ? array() : $this->stabilityFlags);
+                $result = $repository->loadPackages([$name => $constraint], $ignoreStability ? BasePackage::$stabilities : $this->acceptableStabilities, $ignoreStability ? [] : $this->stabilityFlags);
 
                 $packages[] = $result['packages'];
                 foreach ($result['namesFound'] as $nameFound) {
@@ -209,14 +209,14 @@ class RepositorySet
             }
         }
 
-        $candidates = $packages ? call_user_func_array('array_merge', $packages) : array();
+        $candidates = $packages ? call_user_func_array('array_merge', $packages) : [];
 
         // when using loadPackages above (!$loadFromAllRepos) the repos already filter for stability so no need to do it again
         if ($ignoreStability || !$loadFromAllRepos) {
             return $candidates;
         }
 
-        $result = array();
+        $result = [];
         foreach ($candidates as $candidate) {
             if ($this->isPackageAcceptable($candidate->getNames(), $candidate->getStability())) {
                 $result[] = $candidate;
@@ -234,7 +234,7 @@ class RepositorySet
      */
     public function getProviders(string $packageName): array
     {
-        $providers = array();
+        $providers = [];
         foreach ($this->repositories as $repository) {
             if ($repoProviders = $repository->getProviders($packageName)) {
                 $providers = array_merge($providers, $repoProviders);
@@ -291,7 +291,7 @@ class RepositorySet
 
         $this->locked = true;
 
-        $packages = array();
+        $packages = [];
         foreach ($this->repositories as $repository) {
             foreach ($repository->getPackages() as $package) {
                 $packages[] = $package;
@@ -323,7 +323,7 @@ class RepositorySet
     public function createPoolForPackage(string $packageName, LockArrayRepository $lockedRepo = null): Pool
     {
         // TODO unify this with above in some simpler version without "request"?
-        return $this->createPoolForPackages(array($packageName), $lockedRepo);
+        return $this->createPoolForPackages([$packageName], $lockedRepo);
     }
 
     /**
@@ -354,13 +354,13 @@ class RepositorySet
      */
     private static function getRootAliasesPerPackage(array $aliases): array
     {
-        $normalizedAliases = array();
+        $normalizedAliases = [];
 
         foreach ($aliases as $alias) {
-            $normalizedAliases[$alias['package']][$alias['version']] = array(
+            $normalizedAliases[$alias['package']][$alias['version']] = [
                 'alias' => $alias['alias'],
                 'alias_normalized' => $alias['alias_normalized'],
-            );
+            ];
         }
 
         return $normalizedAliases;

--- a/src/Composer/Repository/RootPackageRepository.php
+++ b/src/Composer/Repository/RootPackageRepository.php
@@ -25,7 +25,7 @@ class RootPackageRepository extends ArrayRepository
 {
     public function __construct(RootPackageInterface $package)
     {
-        parent::__construct(array($package));
+        parent::__construct([$package]);
     }
 
     public function getRepoName(): string

--- a/src/Composer/Repository/Vcs/FossilDriver.php
+++ b/src/Composer/Repository/Vcs/FossilDriver.php
@@ -143,7 +143,7 @@ class FossilDriver extends VcsDriver
      */
     public function getSource(string $identifier): array
     {
-        return array('type' => 'fossil', 'url' => $this->getUrl(), 'reference' => $identifier);
+        return ['type' => 'fossil', 'url' => $this->getUrl(), 'reference' => $identifier];
     }
 
     /**
@@ -186,7 +186,7 @@ class FossilDriver extends VcsDriver
     public function getTags(): array
     {
         if (null === $this->tags) {
-            $tags = array();
+            $tags = [];
 
             $this->process->execute('fossil tag list', $output, $this->checkoutDir);
             foreach ($this->process->splitLines($output) as $tag) {
@@ -205,7 +205,7 @@ class FossilDriver extends VcsDriver
     public function getBranches(): array
     {
         if (null === $this->branches) {
-            $branches = array();
+            $branches = [];
 
             $this->process->execute('fossil branch list', $output, $this->checkoutDir);
             foreach ($this->process->splitLines($output) as $branch) {

--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -72,12 +72,12 @@ class GitBitbucketDriver extends VcsDriver
         $this->originUrl = 'bitbucket.org';
         $this->cache = new Cache(
             $this->io,
-            implode('/', array(
+            implode('/', [
                 $this->config->get('cache-repo-dir'),
                 $this->originUrl,
                 $this->owner,
                 $this->repository,
-            ))
+            ])
         );
         $this->cache->setReadOnly($this->config->get('cache-read-only'));
     }
@@ -108,7 +108,7 @@ class GitBitbucketDriver extends VcsDriver
             $this->owner,
             $this->repository,
             http_build_query(
-                array('fields' => '-project,-owner'),
+                ['fields' => '-project,-owner'],
                 '',
                 '&'
             )
@@ -269,7 +269,7 @@ class GitBitbucketDriver extends VcsDriver
             return $this->fallbackDriver->getSource($identifier);
         }
 
-        return array('type' => $this->vcsType, 'url' => $this->getUrl(), 'reference' => $identifier);
+        return ['type' => $this->vcsType, 'url' => $this->getUrl(), 'reference' => $identifier];
     }
 
     /**
@@ -288,7 +288,7 @@ class GitBitbucketDriver extends VcsDriver
             $identifier
         );
 
-        return array('type' => 'zip', 'url' => $url, 'reference' => $identifier, 'shasum' => '');
+        return ['type' => 'zip', 'url' => $url, 'reference' => $identifier, 'shasum' => ''];
     }
 
     /**
@@ -301,16 +301,16 @@ class GitBitbucketDriver extends VcsDriver
         }
 
         if (null === $this->tags) {
-            $tags = array();
+            $tags = [];
             $resource = sprintf(
                 '%s?%s',
                 $this->tagsUrl,
                 http_build_query(
-                    array(
+                    [
                         'pagelen' => 100,
                         'fields' => 'values.name,values.target.hash,next',
                         'sort' => '-target.date',
-                    ),
+                    ],
                     '',
                     '&'
                 )
@@ -344,16 +344,16 @@ class GitBitbucketDriver extends VcsDriver
         }
 
         if (null === $this->branches) {
-            $branches = array();
+            $branches = [];
             $resource = sprintf(
                 '%s?%s',
                 $this->branchesUrl,
                 http_build_query(
-                    array(
+                    [
                         'pagelen' => 100,
                         'fields' => 'values.name,values.target.hash,values.heads,next',
                         'sort' => '-target.date',
-                    ),
+                    ],
                     '',
                     '&'
                 )
@@ -394,7 +394,7 @@ class GitBitbucketDriver extends VcsDriver
         } catch (TransportException $e) {
             $bitbucketUtil = new Bitbucket($this->io, $this->config, $this->process, $this->httpDownloader);
 
-            if (in_array($e->getCode(), array(403, 404), true) || (401 === $e->getCode() && strpos($e->getMessage(), 'Could not authenticate against') === 0)) {
+            if (in_array($e->getCode(), [403, 404], true) || (401 === $e->getCode() && strpos($e->getMessage(), 'Could not authenticate against') === 0)) {
                 if (!$this->io->hasAuthentication($this->originUrl)
                     && $bitbucketUtil->authorizeOAuth($this->originUrl)
                 ) {
@@ -404,7 +404,7 @@ class GitBitbucketDriver extends VcsDriver
                 if (!$this->io->isInteractive() && $fetchingRepoData) {
                     $this->attemptCloneFallback();
 
-                    return new Response(array('url' => 'dummy'), 200, array(), 'null');
+                    return new Response(['url' => 'dummy'], 200, [], 'null');
                 }
             }
 
@@ -452,7 +452,7 @@ class GitBitbucketDriver extends VcsDriver
     protected function setupFallbackDriver(string $url): void
     {
         $this->fallbackDriver = new GitDriver(
-            array('url' => $url),
+            ['url' => $url],
             $this->io,
             $this->config,
             $this->httpDownloader,

--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -129,7 +129,7 @@ class GitDriver extends VcsDriver
      */
     public function getSource(string $identifier): array
     {
-        return array('type' => 'git', 'url' => $this->getUrl(), 'reference' => $identifier);
+        return ['type' => 'git', 'url' => $this->getUrl(), 'reference' => $identifier];
     }
 
     /**
@@ -178,7 +178,7 @@ class GitDriver extends VcsDriver
     public function getTags(): array
     {
         if (null === $this->tags) {
-            $this->tags = array();
+            $this->tags = [];
 
             $this->process->execute('git show-ref --tags --dereference', $output, $this->repoDir);
             foreach ($output = $this->process->splitLines($output) as $tag) {
@@ -197,7 +197,7 @@ class GitDriver extends VcsDriver
     public function getBranches(): array
     {
         if (null === $this->branches) {
-            $branches = array();
+            $branches = [];
 
             $this->process->execute('git branch --no-color --no-abbrev -v', $output, $this->repoDir);
             foreach ($this->process->splitLines($output) as $branch) {

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -143,7 +143,7 @@ class GitHubDriver extends VcsDriver
             $url = $this->getUrl();
         }
 
-        return array('type' => 'git', 'url' => $url, 'reference' => $identifier);
+        return ['type' => 'git', 'url' => $url, 'reference' => $identifier];
     }
 
     /**
@@ -153,7 +153,7 @@ class GitHubDriver extends VcsDriver
     {
         $url = $this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/zipball/'.$identifier;
 
-        return array('type' => 'zip', 'url' => $url, 'reference' => $identifier, 'shasum' => '');
+        return ['type' => 'zip', 'url' => $url, 'reference' => $identifier, 'shasum' => ''];
     }
 
     /**
@@ -212,11 +212,11 @@ class GitHubDriver extends VcsDriver
             return $this->fundingInfo = false;
         }
 
-        foreach (array($this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/contents/.github/FUNDING.yml', $this->getApiUrl() . '/repos/'.$this->owner.'/.github/contents/FUNDING.yml') as $file) {
+        foreach ([$this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/contents/.github/FUNDING.yml', $this->getApiUrl() . '/repos/'.$this->owner.'/.github/contents/FUNDING.yml'] as $file) {
             try {
-                $response = $this->httpDownloader->get($file, array(
+                $response = $this->httpDownloader->get($file, [
                     'retry-auth-failure' => false,
-                ))->decodeJson();
+                ])->decodeJson();
             } catch (TransportException $e) {
                 continue;
             }
@@ -229,7 +229,7 @@ class GitHubDriver extends VcsDriver
             return $this->fundingInfo = false;
         }
 
-        $result = array();
+        $result = [];
         $key = null;
         foreach (Preg::split('{\r?\n}', $funding) as $line) {
             $line = trim($line);
@@ -240,10 +240,10 @@ class GitHubDriver extends VcsDriver
                 }
                 if (Preg::isMatch('{^\[(.*)\](?:\s*#.*)?$}', $match[2], $match2)) {
                     foreach (array_map('trim', Preg::split('{[\'"]?\s*,\s*[\'"]?}', $match2[1])) as $item) {
-                        $result[] = array('type' => $match[1], 'url' => trim($item, '"\' '));
+                        $result[] = ['type' => $match[1], 'url' => trim($item, '"\' ')];
                     }
                 } elseif (Preg::isMatch('{^([^#].*?)(\s+#.*)?$}', $match[2], $match2)) {
-                    $result[] = array('type' => $match[1], 'url' => trim($match2[1], '"\' '));
+                    $result[] = ['type' => $match[1], 'url' => trim($match2[1], '"\' ')];
                 }
                 $key = null;
             } elseif (Preg::isMatch('{^(\w+)\s*:\s*#\s*$}', $line, $match)) {
@@ -252,7 +252,7 @@ class GitHubDriver extends VcsDriver
                 Preg::isMatch('{^-\s*(.+)(\s+#.*)?$}', $line, $match)
                 || Preg::isMatch('{^(.+),(\s*#.*)?$}', $line, $match)
             )) {
-                $result[] = array('type' => $key, 'url' => trim($match[1], '"\' '));
+                $result[] = ['type' => $key, 'url' => trim($match[1], '"\' ')];
             } elseif ($key && $line === ']') {
                 $key = null;
             }
@@ -342,7 +342,7 @@ class GitHubDriver extends VcsDriver
             return $this->gitDriver->getTags();
         }
         if (null === $this->tags) {
-            $tags = array();
+            $tags = [];
             $resource = $this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/tags?per_page=100';
 
             do {
@@ -370,7 +370,7 @@ class GitHubDriver extends VcsDriver
             return $this->gitDriver->getBranches();
         }
         if (null === $this->branches) {
-            $branches = array();
+            $branches = [];
             $resource = $this->getApiUrl() . '/repos/'.$this->owner.'/'.$this->repository.'/git/refs/heads?per_page=100';
 
             do {
@@ -468,11 +468,11 @@ class GitHubDriver extends VcsDriver
                     if (!$this->io->isInteractive()) {
                         $this->attemptCloneFallback();
 
-                        return new Response(array('url' => 'dummy'), 200, array(), 'null');
+                        return new Response(['url' => 'dummy'], 200, [], 'null');
                     }
 
-                    $scopesIssued = array();
-                    $scopesNeeded = array();
+                    $scopesIssued = [];
+                    $scopesNeeded = [];
                     if ($headers = $e->getHeaders()) {
                         if ($scopes = Response::findHeaderValue($headers, 'X-OAuth-Scopes')) {
                             $scopesIssued = explode(' ', $scopes);
@@ -498,7 +498,7 @@ class GitHubDriver extends VcsDriver
                     if (!$this->io->isInteractive() && $fetchingRepoData) {
                         $this->attemptCloneFallback();
 
-                        return new Response(array('url' => 'dummy'), 200, array(), 'null');
+                        return new Response(['url' => 'dummy'], 200, [], 'null');
                     }
 
                     $rateLimited = $gitHubUtil->isRateLimited((array) $e->getHeaders());
@@ -607,7 +607,7 @@ class GitHubDriver extends VcsDriver
     protected function setupGitDriver(string $url): void
     {
         $this->gitDriver = new GitDriver(
-            array('url' => $url),
+            ['url' => $url],
             $this->io,
             $this->config,
             $this->httpDownloader,

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -48,7 +48,7 @@ class GitLabDriver extends VcsDriver
     /**
      * @var array<string|int, mixed[]> Keeps commits returned by GitLab API as commit id => info
      */
-    private $commits = array();
+    private $commits = [];
 
     /** @var array<int|string, string> Map of tag name to identifier */
     private $tags;
@@ -113,7 +113,7 @@ class GitLabDriver extends VcsDriver
 
         if (is_string($protocol = $this->config->get('gitlab-protocol'))) {
             // https treated as a synonym for http.
-            if (!in_array($protocol, array('git', 'http', 'https'))) {
+            if (!in_array($protocol, ['git', 'http', 'https'])) {
                 throw new \RuntimeException('gitlab-protocol must be one of git, http.');
             }
             $this->protocol = $protocol === 'git' ? 'ssh' : 'http';
@@ -264,7 +264,7 @@ class GitLabDriver extends VcsDriver
     {
         $url = $this->getApiUrl().'/repository/archive.zip?sha='.$identifier;
 
-        return array('type' => 'zip', 'url' => $url, 'reference' => $identifier, 'shasum' => '');
+        return ['type' => 'zip', 'url' => $url, 'reference' => $identifier, 'shasum' => ''];
     }
 
     /**
@@ -276,7 +276,7 @@ class GitLabDriver extends VcsDriver
             return $this->gitDriver->getSource($identifier);
         }
 
-        return array('type' => 'git', 'url' => $this->getRepositoryUrl(), 'reference' => $identifier);
+        return ['type' => 'git', 'url' => $this->getRepositoryUrl(), 'reference' => $identifier];
     }
 
     /**
@@ -342,7 +342,7 @@ class GitLabDriver extends VcsDriver
         $encoded = '';
         for ($i = 0; isset($string[$i]); $i++) {
             $character = $string[$i];
-            if (!ctype_alnum($character) && !in_array($character, array('-', '_'), true)) {
+            if (!ctype_alnum($character) && !in_array($character, ['-', '_'], true)) {
                 $character = '%' . sprintf('%02X', ord($character));
             }
             $encoded .= $character;
@@ -361,7 +361,7 @@ class GitLabDriver extends VcsDriver
         $perPage = 100;
         $resource = $this->getApiUrl().'/repository/'.$type.'?per_page='.$perPage;
 
-        $references = array();
+        $references = [];
         do {
             $response = $this->getContents($resource);
             $data = $response->decodeJson();
@@ -459,7 +459,7 @@ class GitLabDriver extends VcsDriver
     protected function setupGitDriver(string $url): void
     {
         $this->gitDriver = new GitDriver(
-            array('url' => $url),
+            ['url' => $url],
             $this->io,
             $this->config,
             $this->httpDownloader,
@@ -502,7 +502,7 @@ class GitLabDriver extends VcsDriver
 
                         $this->attemptCloneFallback();
 
-                        return new Response(array('url' => 'dummy'), 200, array(), 'null');
+                        return new Response(['url' => 'dummy'], 200, [], 'null');
                     }
                 }
 
@@ -540,7 +540,7 @@ class GitLabDriver extends VcsDriver
                     if (!$this->io->isInteractive()) {
                         $this->attemptCloneFallback();
 
-                        return new Response(array('url' => 'dummy'), 200, array(), 'null');
+                        return new Response(['url' => 'dummy'], 200, [], 'null');
                     }
                     $this->io->writeError('<warning>Failed to download ' . $this->namespace . '/' . $this->repository . ':' . $e->getMessage() . '</warning>');
                     $gitLabUtil->authorizeOAuthInteractively($this->scheme, $this->originUrl, 'Your credentials are required to fetch private repository metadata (<info>'.$this->url.'</info>)');
@@ -555,7 +555,7 @@ class GitLabDriver extends VcsDriver
                     if (!$this->io->isInteractive() && $fetchingRepoData) {
                         $this->attemptCloneFallback();
 
-                        return new Response(array('url' => 'dummy'), 200, array(), 'null');
+                        return new Response(['url' => 'dummy'], 200, [], 'null');
                     }
 
                     throw $e;

--- a/src/Composer/Repository/Vcs/HgDriver.php
+++ b/src/Composer/Repository/Vcs/HgDriver.php
@@ -110,7 +110,7 @@ class HgDriver extends VcsDriver
      */
     public function getSource(string $identifier): array
     {
-        return array('type' => 'hg', 'url' => $this->getUrl(), 'reference' => $identifier);
+        return ['type' => 'hg', 'url' => $this->getUrl(), 'reference' => $identifier];
     }
 
     /**
@@ -163,7 +163,7 @@ class HgDriver extends VcsDriver
     public function getTags(): array
     {
         if (null === $this->tags) {
-            $tags = array();
+            $tags = [];
 
             $this->process->execute('hg tags', $output, $this->repoDir);
             foreach ($this->process->splitLines($output) as $tag) {
@@ -185,8 +185,8 @@ class HgDriver extends VcsDriver
     public function getBranches(): array
     {
         if (null === $this->branches) {
-            $branches = array();
-            $bookmarks = array();
+            $branches = [];
+            $bookmarks = [];
 
             $this->process->execute('hg branches', $output, $this->repoDir);
             foreach ($this->process->splitLines($output) as $branch) {

--- a/src/Composer/Repository/Vcs/PerforceDriver.php
+++ b/src/Composer/Repository/Vcs/PerforceDriver.php
@@ -123,12 +123,12 @@ class PerforceDriver extends VcsDriver
      */
     public function getSource(string $identifier): array
     {
-        return array(
+        return [
             'type' => 'perforce',
             'url' => $this->repoConfig['url'],
             'reference' => $identifier,
             'p4user' => $this->perforce->getUser(),
-        );
+        ];
     }
 
     /**

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -111,7 +111,7 @@ class SvnDriver extends VcsDriver
      */
     public function getSource(string $identifier): array
     {
-        return array('type' => 'svn', 'url' => $this->baseUrl, 'reference' => $identifier);
+        return ['type' => 'svn', 'url' => $this->baseUrl, 'reference' => $identifier];
     }
 
     /**
@@ -235,7 +235,7 @@ class SvnDriver extends VcsDriver
     public function getTags(): array
     {
         if (null === $this->tags) {
-            $tags = array();
+            $tags = [];
 
             if ($this->tagsPath !== false) {
                 $output = $this->execute('svn ls --verbose', $this->baseUrl . '/' . $this->tagsPath);
@@ -266,7 +266,7 @@ class SvnDriver extends VcsDriver
     public function getBranches(): array
     {
         if (null === $this->branches) {
-            $branches = array();
+            $branches = [];
 
             if (false === $this->trunkPath) {
                 $trunkParent = $this->baseUrl . '/';

--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -45,7 +45,7 @@ abstract class VcsDriver implements VcsDriverInterface
     /** @var HttpDownloader */
     protected $httpDownloader;
     /** @var array<int|string, mixed> */
-    protected $infoCache = array();
+    protected $infoCache = [];
     /** @var ?Cache */
     protected $cache;
 
@@ -171,7 +171,7 @@ abstract class VcsDriver implements VcsDriverInterface
      */
     protected function getContents(string $url): Response
     {
-        $options = $this->repoConfig['options'] ?? array();
+        $options = $this->repoConfig['options'] ?? [];
 
         return $this->httpDownloader->get($url, $options);
     }

--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -66,9 +66,9 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
     /** @var ?VersionCacheInterface */
     private $versionCache;
     /** @var string[] */
-    private $emptyReferences = array();
+    private $emptyReferences = [];
     /** @var array<'tags'|'branches', array<string, TransportException>> */
-    private $versionTransportExceptions = array();
+    private $versionTransportExceptions = [];
 
     /**
      * @param array{url: string, type?: string}&array<string, mixed> $repoConfig
@@ -77,7 +77,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
     public function __construct(array $repoConfig, IOInterface $io, Config $config, HttpDownloader $httpDownloader, EventDispatcher $dispatcher = null, ProcessExecutor $process = null, array $drivers = null, VersionCacheInterface $versionCache = null)
     {
         parent::__construct();
-        $this->drivers = $drivers ?: array(
+        $this->drivers = $drivers ?: [
             'github' => 'Composer\Repository\Vcs\GitHubDriver',
             'gitlab' => 'Composer\Repository\Vcs\GitLabDriver',
             'bitbucket' => 'Composer\Repository\Vcs\GitBitbucketDriver',
@@ -88,7 +88,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
             'fossil' => 'Composer\Repository\Vcs\FossilDriver',
             // svn must be last because identifying a subversion server for sure is practically impossible
             'svn' => 'Composer\Repository\Vcs\SvnDriver',
-        );
+        ];
 
         $this->url = $repoConfig['url'];
         $this->io = $io;
@@ -328,7 +328,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
         $branches = $driver->getBranches();
         // make sure the root identifier branch gets loaded first
         if ($hasRootIdentifierComposerJson && isset($branches[$driver->getRootIdentifier()])) {
-            $branches = array($driver->getRootIdentifier() => $branches[$driver->getRootIdentifier()]) + $branches;
+            $branches = [$driver->getRootIdentifier() => $branches[$driver->getRootIdentifier()]] + $branches;
         }
 
         foreach ($branches as $branch => $identifier) {
@@ -546,6 +546,6 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
      */
     private function shouldRethrowTransportException(TransportException $e): bool
     {
-        return in_array($e->getCode(), array(401, 403, 429), true) || $e->getCode() >= 500;
+        return in_array($e->getCode(), [401, 403, 429], true) || $e->getCode() >= 500;
     }
 }

--- a/src/Composer/Repository/WritableArrayRepository.php
+++ b/src/Composer/Repository/WritableArrayRepository.php
@@ -25,7 +25,7 @@ class WritableArrayRepository extends ArrayRepository implements WritableReposit
     /**
      * @var string[]
      */
-    protected $devPackageNames = array();
+    protected $devPackageNames = [];
 
     /** @var bool|null */
     private $devMode = null;
@@ -78,14 +78,14 @@ class WritableArrayRepository extends ArrayRepository implements WritableReposit
         $packages = $this->getPackages();
 
         // get at most one package of each name, preferring non-aliased ones
-        $packagesByName = array();
+        $packagesByName = [];
         foreach ($packages as $package) {
             if (!isset($packagesByName[$package->getName()]) || $packagesByName[$package->getName()] instanceof AliasPackage) {
                 $packagesByName[$package->getName()] = $package;
             }
         }
 
-        $canonicalPackages = array();
+        $canonicalPackages = [];
 
         // unfold aliased packages
         foreach ($packagesByName as $package) {

--- a/src/Composer/Script/Event.php
+++ b/src/Composer/Script/Event.php
@@ -54,7 +54,7 @@ class Event extends BaseEvent
      * @param array<string|int|float|bool|null> $args Arguments passed by the user
      * @param mixed[] $flags Optional flags to pass data not as argument
      */
-    public function __construct(string $name, Composer $composer, IOInterface $io, bool $devMode = false, array $args = array(), array $flags = array())
+    public function __construct(string $name, Composer $composer, IOInterface $io, bool $devMode = false, array $args = [], array $flags = [])
     {
         parent::__construct($name, $args, $flags);
         $this->composer = $composer;

--- a/src/Composer/SelfUpdate/Keys.php
+++ b/src/Composer/SelfUpdate/Keys.php
@@ -28,7 +28,7 @@ class Keys
     {
         $hash = strtoupper(hash('sha256', Preg::replace('{\s}', '', file_get_contents($path))));
 
-        return implode(' ', array(
+        return implode(' ', [
             substr($hash, 0, 8),
             substr($hash, 8, 8),
             substr($hash, 16, 8),
@@ -38,6 +38,6 @@ class Keys
             substr($hash, 40, 8),
             substr($hash, 48, 8),
             substr($hash, 56, 8),
-        ));
+        ]);
     }
 }

--- a/src/Composer/SelfUpdate/Versions.php
+++ b/src/Composer/SelfUpdate/Versions.php
@@ -57,7 +57,7 @@ class Versions
         $channelFile = $this->config->get('home').'/update-channel';
         if (file_exists($channelFile)) {
             $channel = trim(file_get_contents($channelFile));
-            if (in_array($channel, array('stable', 'preview', 'snapshot', '2.2'), true)) {
+            if (in_array($channel, ['stable', 'preview', 'snapshot', '2.2'], true)) {
                 return $this->channel = $channel;
             }
         }

--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -27,7 +27,7 @@ class AuthHelper
     /** @var Config */
     protected $config;
     /** @var array<string, string> Map of origins to message displayed */
-    private $displayedOriginAuthentications = array();
+    private $displayedOriginAuthentications = [];
 
     public function __construct(IOInterface $io, Config $config)
     {
@@ -52,7 +52,7 @@ class AuthHelper
                 'Do you want to store credentials for '.$origin.' in '.$configSource->getName().' ? [Yn] ',
                 function ($value): string {
                     $input = strtolower(substr(trim($value), 0, 1));
-                    if (in_array($input, array('y','n'))) {
+                    if (in_array($input, ['y','n'])) {
                         return $input;
                     }
                     throw new \RuntimeException('Please answer (y)es or (n)o');
@@ -84,7 +84,7 @@ class AuthHelper
      *                                retried, if storeAuth is true then on a successful retry the authentication should be persisted to auth.json
      * @phpstan-return array{retry: bool, storeAuth: 'prompt'|bool}
      */
-    public function promptAuthIfNeeded(string $url, string $origin, int $statusCode, ?string $reason = null, array $headers = array(), int $retryCount = 0): array
+    public function promptAuthIfNeeded(string $url, string $origin, int $statusCode, ?string $reason = null, array $headers = [], int $retryCount = 0): array
     {
         $storeAuth = false;
 
@@ -104,7 +104,7 @@ class AuthHelper
                 }
                 $this->io->ask('After authorizing your token, confirm that you would like to retry the request');
 
-                return array('retry' => true, 'storeAuth' => $storeAuth);
+                return ['retry' => true, 'storeAuth' => $storeAuth];
             }
 
             if ($rateLimited) {
@@ -141,7 +141,7 @@ class AuthHelper
             $auth = null;
             if ($this->io->hasAuthentication($origin)) {
                 $auth = $this->io->getAuthentication($origin);
-                if (in_array($auth['password'], array('gitlab-ci-token', 'private-token', 'oauth2'), true)) {
+                if (in_array($auth['password'], ['gitlab-ci-token', 'private-token', 'oauth2'], true)) {
                     throw new TransportException("Invalid credentials for '" . $url . "', aborting.", $statusCode);
                 }
             }
@@ -207,7 +207,7 @@ class AuthHelper
                 // if two or more requests are started together for the same host, and the first
                 // received authentication already, we let the others retry before failing them
                 if ($retryCount === 0) {
-                    return array('retry' => true, 'storeAuth' => false);
+                    return ['retry' => true, 'storeAuth' => false];
                 }
 
                 throw new TransportException("Invalid credentials for '" . $url . "', aborting.", $statusCode);
@@ -220,7 +220,7 @@ class AuthHelper
             $storeAuth = $this->config->get('store-auths');
         }
 
-        return array('retry' => true, 'storeAuth' => $storeAuth);
+        return ['retry' => true, 'storeAuth' => $storeAuth];
     }
 
     /**
@@ -245,7 +245,7 @@ class AuthHelper
                 }
             } elseif (
                 in_array($origin, $this->config->get('gitlab-domains'), true)
-                && in_array($auth['password'], array('oauth2', 'private-token', 'gitlab-ci-token'), true)
+                && in_array($auth['password'], ['oauth2', 'private-token', 'gitlab-ci-token'], true)
             ) {
                 if ($auth['password'] === 'oauth2') {
                     $headers[] = 'Authorization: Bearer '.$auth['username'];
@@ -273,7 +273,7 @@ class AuthHelper
                 $this->io->writeError($authenticationDisplayMessage, true, IOInterface::DEBUG);
                 $this->displayedOriginAuthentications[$origin] = $authenticationDisplayMessage;
             }
-        } elseif (in_array($origin, array('api.bitbucket.org', 'api.github.com'), true)) {
+        } elseif (in_array($origin, ['api.bitbucket.org', 'api.github.com'], true)) {
             return $this->addAuthenticationHeader($headers, str_replace('api.', '', $origin), $url);
         }
 

--- a/src/Composer/Util/Bitbucket.php
+++ b/src/Composer/Util/Bitbucket.php
@@ -95,13 +95,13 @@ class Bitbucket
     private function requestAccessToken(): bool
     {
         try {
-            $response = $this->httpDownloader->get(self::OAUTH2_ACCESS_TOKEN_URL, array(
+            $response = $this->httpDownloader->get(self::OAUTH2_ACCESS_TOKEN_URL, [
                 'retry-auth-failure' => false,
-                'http' => array(
+                'http' => [
                     'method' => 'POST',
                     'content' => 'grant_type=client_credentials',
-                ),
-            ));
+                ],
+            ]);
 
             $token = $response->decodeJson();
             if (!isset($token['expires_in']) || !isset($token['access_token'])) {
@@ -119,7 +119,7 @@ class Bitbucket
 
                 return false;
             }
-            if (in_array($e->getCode(), array(403, 401))) {
+            if (in_array($e->getCode(), [403, 401])) {
                 $this->io->writeError('<error>Invalid OAuth consumer provided.</error>');
                 $this->io->writeError('You can also add it manually later by using "composer config --global --auth bitbucket-oauth.bitbucket.org <consumer-key> <consumer-secret>"');
 
@@ -233,12 +233,12 @@ class Bitbucket
         }
 
         $time = null === $this->time ? time() : $this->time;
-        $consumer = array(
+        $consumer = [
             "consumer-key" => $consumerKey,
             "consumer-secret" => $consumerSecret,
             "access-token" => $this->token['access_token'],
             "access-token-expiration" => $time + $this->token['expires_in'],
-        );
+        ];
 
         $this->config->getAuthConfigSource()->addConfigSetting('bitbucket-oauth.'.$originUrl, $consumer);
     }
@@ -258,9 +258,9 @@ class Bitbucket
             return false;
         }
 
-        $this->token = array(
+        $this->token = [
             'access_token' => $authConfig[$originUrl]['access-token'],
-        );
+        ];
 
         return true;
     }

--- a/src/Composer/Util/ComposerMirror.php
+++ b/src/Composer/Util/ComposerMirror.php
@@ -38,8 +38,8 @@ class ComposerMirror
         }
         $version = strpos($version, '/') === false ? $version : md5($version);
 
-        $from = array('%package%', '%version%', '%reference%', '%type%');
-        $to = array($packageName, $version, $reference, $type);
+        $from = ['%package%', '%version%', '%reference%', '%type%'];
+        $to = [$packageName, $version, $reference, $type];
         if (null !== $prettyVersion) {
             $from[] = '%prettyVersion%';
             $to[] = $prettyVersion;
@@ -67,8 +67,8 @@ class ComposerMirror
         }
 
         return str_replace(
-            array('%package%', '%normalizedUrl%', '%type%'),
-            array($packageName, $url, $type),
+            ['%package%', '%normalizedUrl%', '%type%'],
+            [$packageName, $url, $type],
             $mirrorUrl
         );
     }

--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -52,9 +52,9 @@ class ConfigValidator
      */
     public function validate(string $file, int $arrayLoaderValidationFlags = ValidatingArrayLoader::CHECK_ALL, int $flags = self::CHECK_VERSION): array
     {
-        $errors = array();
-        $publishErrors = array();
-        $warnings = array();
+        $errors = [];
+        $publishErrors = [];
+        $warnings = [];
 
         // validate json schema
         $laxValid = false;
@@ -77,7 +77,7 @@ class ConfigValidator
         } catch (\Exception $e) {
             $errors[] = $e->getMessage();
 
-            return array($errors, $publishErrors, $warnings);
+            return [$errors, $publishErrors, $warnings];
         }
 
         if (is_array($manifest)) {
@@ -157,9 +157,9 @@ class ConfigValidator
         }
 
         // check for meaningless provide/replace satisfying requirements
-        foreach (array('provide', 'replace') as $linkType) {
+        foreach (['provide', 'replace'] as $linkType) {
             if (isset($manifest[$linkType])) {
-                foreach (array('require', 'require-dev') as $requireType) {
+                foreach (['require', 'require-dev'] as $requireType) {
                     if (isset($manifest[$requireType])) {
                         foreach ($manifest[$linkType] as $provide => $constraint) {
                             if (isset($manifest[$requireType][$provide])) {
@@ -172,8 +172,8 @@ class ConfigValidator
         }
 
         // check for commit references
-        $require = $manifest['require'] ?? array();
-        $requireDev = $manifest['require-dev'] ?? array();
+        $require = $manifest['require'] ?? [];
+        $requireDev = $manifest['require-dev'] ?? [];
         $packages = array_merge($require, $requireDev);
         foreach ($packages as $package => $version) {
             if (Preg::isMatch('/#/', $version)) {
@@ -185,8 +185,8 @@ class ConfigValidator
         }
 
         // report scripts-descriptions for non-existent scripts
-        $scriptsDescriptions = $manifest['scripts-descriptions'] ?? array();
-        $scripts = $manifest['scripts'] ?? array();
+        $scriptsDescriptions = $manifest['scripts-descriptions'] ?? [];
+        $scripts = $manifest['scripts'] ?? [];
         foreach ($scriptsDescriptions as $scriptName => $scriptDescription) {
             if (!array_key_exists($scriptName, $scripts)) {
                 $warnings[] = sprintf(
@@ -219,6 +219,6 @@ class ConfigValidator
 
         $warnings = array_merge($warnings, $loader->getWarnings());
 
-        return array($errors, $publishErrors, $warnings);
+        return [$errors, $publishErrors, $warnings];
     }
 }

--- a/src/Composer/Util/ErrorHandler.php
+++ b/src/Composer/Util/ErrorHandler.php
@@ -80,7 +80,7 @@ class ErrorHandler
      */
     public static function register(IOInterface $io = null): void
     {
-        set_error_handler(array(__CLASS__, 'handle'));
+        set_error_handler([__CLASS__, 'handle']);
         error_reporting(E_ALL | E_STRICT);
         self::$io = $io;
     }

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -569,7 +569,7 @@ class Filesystem
      */
     public function normalizePath(string $path)
     {
-        $parts = array();
+        $parts = [];
         $path = strtr($path, '\\', '/');
         $prefix = '';
         $absolute = '';

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -76,7 +76,7 @@ class Git
         $protocols = $this->config->get('github-protocols');
         // public github, autoswitch protocols
         if (Preg::isMatch('{^(?:https?|git)://' . self::getGitHubDomainsRegex($this->config) . '/(.*)}', $url, $match)) {
-            $messages = array();
+            $messages = [];
             foreach ($protocols as $protocol) {
                 if ('ssh' === $protocol) {
                     $protoUrl = "git@" . $match[1] . ":" . $match[2];
@@ -106,7 +106,7 @@ class Git
         $command = call_user_func($commandCallable, $url);
 
         $auth = null;
-        $credentials = array();
+        $credentials = [];
         if ($bypassSshForGitHub || 0 !== $this->process->execute($command, $commandOutput, $cwd)) {
             $errorMsg = $this->process->getErrorOutput();
             // private github repository without ssh key access, try https with auth
@@ -130,7 +130,7 @@ class Git
                         return;
                     }
 
-                    $credentials = array(rawurlencode($auth['username']), rawurlencode($auth['password']));
+                    $credentials = [rawurlencode($auth['username']), rawurlencode($auth['password'])];
                     $errorMsg = $this->process->getErrorOutput();
                 }
             } elseif (Preg::isMatch('{^https://(bitbucket\.org)/(.*?)(?:\.git)?$}i', $url, $match)) { //bitbucket oauth
@@ -165,7 +165,7 @@ class Git
                         return;
                     }
 
-                    $credentials = array(rawurlencode($auth['username']), rawurlencode($auth['password']));
+                    $credentials = [rawurlencode($auth['username']), rawurlencode($auth['password'])];
                     $errorMsg = $this->process->getErrorOutput();
                 } else { // Falling back to ssh
                     $sshUrl = 'git@bitbucket.org:' . $match[2] . '.git';
@@ -207,7 +207,7 @@ class Git
                         return;
                     }
 
-                    $credentials = array(rawurlencode($auth['username']), rawurlencode($auth['password']));
+                    $credentials = [rawurlencode($auth['username']), rawurlencode($auth['password'])];
                     $errorMsg = $this->process->getErrorOutput();
                 }
             } elseif ($this->isAuthenticationFailure($url, $match)) { // private non-github/gitlab/bitbucket repo that failed to authenticate
@@ -229,10 +229,10 @@ class Git
                     }
 
                     $this->io->writeError('    Authentication required (<info>' . $match[2] . '</info>):');
-                    $auth = array(
+                    $auth = [
                         'username' => $this->io->ask('      Username: ', $defaultUsername),
                         'password' => $this->io->askAndHideAnswer('      Password: '),
-                    );
+                    ];
                     $storeAuth = $this->config->get('store-auths');
                 }
 
@@ -248,7 +248,7 @@ class Git
                         return;
                     }
 
-                    $credentials = array(rawurlencode($auth['username']), rawurlencode($auth['password']));
+                    $credentials = [rawurlencode($auth['username']), rawurlencode($auth['password'])];
                     $errorMsg = $this->process->getErrorOutput();
                 }
             }
@@ -373,13 +373,13 @@ class Git
             return false;
         }
 
-        $authFailures = array(
+        $authFailures = [
             'fatal: Authentication failed',
             'remote error: Invalid username or password.',
             'error: 401 Unauthorized',
             'fatal: unable to access',
             'fatal: could not read Username',
-        );
+        ];
 
         $errorOutput = $this->process->getErrorOutput();
         foreach ($authFailures as $authFailure) {
@@ -509,10 +509,10 @@ class Git
      */
     private function maskCredentials(string $error, array $credentials): string
     {
-        $maskedCredentials = array();
+        $maskedCredentials = [];
 
         foreach ($credentials as $credential) {
-            if (in_array($credential, array('private-token', 'x-token-auth', 'oauth2', 'gitlab-ci-token', 'x-oauth-basic'))) {
+            if (in_array($credential, ['private-token', 'x-token-auth', 'oauth2', 'gitlab-ci-token', 'x-oauth-basic'])) {
                 $maskedCredentials[] = $credential;
             } elseif (strlen($credential) > 6) {
                 $maskedCredentials[] = substr($credential, 0, 3) . '...' . substr($credential, -3);

--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -115,11 +115,11 @@ class GitHub
         try {
             $apiUrl = ('github.com' === $originUrl) ? 'api.github.com/' : $originUrl . '/api/v3/';
 
-            $this->httpDownloader->get('https://'. $apiUrl, array(
+            $this->httpDownloader->get('https://'. $apiUrl, [
                 'retry-auth-failure' => false,
-            ));
+            ]);
         } catch (TransportException $e) {
-            if (in_array($e->getCode(), array(403, 401))) {
+            if (in_array($e->getCode(), [403, 401])) {
                 $this->io->writeError('<error>Invalid token provided.</error>');
                 $this->io->writeError('You can also add it manually later by using "composer config --global --auth github-oauth.github.com <token>"');
 
@@ -147,10 +147,10 @@ class GitHub
      */
     public function getRateLimit(array $headers): array
     {
-        $rateLimit = array(
+        $rateLimit = [
             'limit' => '?',
             'reset' => '?',
-        );
+        ];
 
         foreach ($headers as $header) {
             $header = trim($header);

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -95,7 +95,7 @@ class GitLab
 
             // Composer expects the GitLab token to be stored as username and 'private-token' or 'gitlab-ci-token' to be stored as password
             // Detect cases where this is reversed and resolve automatically resolve it
-            if (in_array($username, array('private-token', 'gitlab-ci-token',  'oauth2'), true)) {
+            if (in_array($username, ['private-token', 'gitlab-ci-token',  'oauth2'], true)) {
                 $this->io->setAuthentication($originUrl, $password, $username);
             } else {
                 $this->io->setAuthentication($originUrl, $username, $password);
@@ -136,7 +136,7 @@ class GitLab
             } catch (TransportException $e) {
                 // 401 is bad credentials,
                 // 403 is max login attempts exceeded
-                if (in_array($e->getCode(), array(403, 401))) {
+                if (in_array($e->getCode(), [403, 401])) {
                     if (401 === $e->getCode()) {
                         $response = json_decode($e->getResponse(), true);
                         if (isset($response['error']) && $response['error'] === 'invalid_grant') {
@@ -181,22 +181,22 @@ class GitLab
         $username = $this->io->ask('Username: ');
         $password = $this->io->askAndHideAnswer('Password: ');
 
-        $headers = array('Content-Type: application/x-www-form-urlencoded');
+        $headers = ['Content-Type: application/x-www-form-urlencoded'];
 
         $apiUrl = $originUrl;
-        $data = http_build_query(array(
+        $data = http_build_query([
             'username' => $username,
             'password' => $password,
             'grant_type' => 'password',
-        ), '', '&');
-        $options = array(
+        ], '', '&');
+        $options = [
             'retry-auth-failure' => false,
-            'http' => array(
+            'http' => [
                 'method' => 'POST',
                 'header' => $headers,
                 'content' => $data,
-            ),
-        );
+            ],
+        ];
 
         $token = $this->httpDownloader->get($scheme.'://'.$apiUrl.'/oauth/token', $options)->decodeJson();
 

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -38,7 +38,7 @@ class CurlDownloader
     /** @var ?resource */
     private $shareHandle;
     /** @var Job[] */
-    private $jobs = array();
+    private $jobs = [];
     /** @var IOInterface */
     private $io;
     /** @var Config */
@@ -56,22 +56,22 @@ class CurlDownloader
     /** @var bool */
     private $supportsSecureProxy;
     /** @var array<int, string[]> */
-    protected $multiErrors = array(
-        CURLM_BAD_HANDLE => array('CURLM_BAD_HANDLE', 'The passed-in handle is not a valid CURLM handle.'),
-        CURLM_BAD_EASY_HANDLE => array('CURLM_BAD_EASY_HANDLE', "An easy handle was not good/valid. It could mean that it isn't an easy handle at all, or possibly that the handle already is in used by this or another multi handle."),
-        CURLM_OUT_OF_MEMORY => array('CURLM_OUT_OF_MEMORY', 'You are doomed.'),
-        CURLM_INTERNAL_ERROR => array('CURLM_INTERNAL_ERROR', 'This can only be returned if libcurl bugs. Please report it to us!'),
-    );
+    protected $multiErrors = [
+        CURLM_BAD_HANDLE => ['CURLM_BAD_HANDLE', 'The passed-in handle is not a valid CURLM handle.'],
+        CURLM_BAD_EASY_HANDLE => ['CURLM_BAD_EASY_HANDLE', "An easy handle was not good/valid. It could mean that it isn't an easy handle at all, or possibly that the handle already is in used by this or another multi handle."],
+        CURLM_OUT_OF_MEMORY => ['CURLM_OUT_OF_MEMORY', 'You are doomed.'],
+        CURLM_INTERNAL_ERROR => ['CURLM_INTERNAL_ERROR', 'This can only be returned if libcurl bugs. Please report it to us!'],
+    ];
 
     /** @var mixed[] */
-    private static $options = array(
-        'http' => array(
+    private static $options = [
+        'http' => [
             'method' => CURLOPT_CUSTOMREQUEST,
             'content' => CURLOPT_POSTFIELDS,
             'header' => CURLOPT_HTTPHEADER,
             'timeout' => CURLOPT_TIMEOUT,
-        ),
-        'ssl' => array(
+        ],
+        'ssl' => [
             'cafile' => CURLOPT_CAINFO,
             'capath' => CURLOPT_CAPATH,
             'verify_peer' => CURLOPT_SSL_VERIFYPEER,
@@ -79,24 +79,24 @@ class CurlDownloader
             'local_cert' => CURLOPT_SSLCERT,
             'local_pk' => CURLOPT_SSLKEY,
             'passphrase' => CURLOPT_SSLKEYPASSWD,
-        ),
-    );
+        ],
+    ];
 
     /** @var array<string, true> */
-    private static $timeInfo = array(
+    private static $timeInfo = [
         'total_time' => true,
         'namelookup_time' => true,
         'connect_time' => true,
         'pretransfer_time' => true,
         'starttransfer_time' => true,
         'redirect_time' => true,
-    );
+    ];
 
     /**
      * @param mixed[] $options
      * @param bool    $disableTls
      */
-    public function __construct(IOInterface $io, Config $config, array $options = array(), bool $disableTls = false)
+    public function __construct(IOInterface $io, Config $config, array $options = [], bool $disableTls = false)
     {
         $this->io = $io;
         $this->config = $config;
@@ -136,7 +136,7 @@ class CurlDownloader
      */
     public function download(callable $resolve, callable $reject, string $origin, string $url, array $options, ?string $copyTo = null): int
     {
-        $attributes = array();
+        $attributes = [];
         if (isset($options['retry-auth-failure'])) {
             $attributes['retryAuthFailure'] = $options['retry-auth-failure'];
             unset($options['retry-auth-failure']);
@@ -157,7 +157,7 @@ class CurlDownloader
      *
      * @return int internal job id
      */
-    private function initDownload(callable $resolve, callable $reject, string $origin, string $url, array $options, ?string $copyTo = null, array $attributes = array()): int
+    private function initDownload(callable $resolve, callable $reject, string $origin, string $url, array $options, ?string $copyTo = null, array $attributes = []): int
     {
         // set defaults in a PHPStan-happy way (array_merge is not well supported)
         $attributes['retryAuthFailure'] = $attributes['retryAuthFailure'] ?? true;
@@ -211,10 +211,10 @@ class CurlDownloader
         }
 
         if (!isset($options['http']['header'])) {
-            $options['http']['header'] = array();
+            $options['http']['header'] = [];
         }
 
-        $options['http']['header'] = array_diff($options['http']['header'], array('Connection: close'));
+        $options['http']['header'] = array_diff($options['http']['header'], ['Connection: close']);
         $options['http']['header'][] = 'Connection: keep-alive';
 
         $version = curl_version();
@@ -259,7 +259,7 @@ class CurlDownloader
 
         $progress = array_diff_key(curl_getinfo($curlHandle), self::$timeInfo);
 
-        $this->jobs[(int) $curlHandle] = array(
+        $this->jobs[(int) $curlHandle] = [
             'url' => $url,
             'origin' => $origin,
             'attributes' => $attributes,
@@ -271,7 +271,7 @@ class CurlDownloader
             'bodyHandle' => $bodyHandle,
             'resolve' => $resolve,
             'reject' => $reject,
-        );
+        ];
 
         $usingProxy = $proxy->getFormattedUrl(' using proxy (%s)');
         $ifModified = false !== stripos(implode(',', $options['http']['header']), 'if-modified-since:') ? ' if modified' : '';
@@ -360,12 +360,12 @@ class CurlDownloader
                     if (
                         (!isset($job['options']['http']['method']) || $job['options']['http']['method'] === 'GET')
                         && (
-                            in_array($errno, array(7 /* CURLE_COULDNT_CONNECT */, 16 /* CURLE_HTTP2 */, 92 /* CURLE_HTTP2_STREAM */, 6 /* CURLE_COULDNT_RESOLVE_HOST */), true)
+                            in_array($errno, [7 /* CURLE_COULDNT_CONNECT */, 16 /* CURLE_HTTP2 */, 92 /* CURLE_HTTP2_STREAM */, 6 /* CURLE_COULDNT_RESOLVE_HOST */], true)
                             || ($errno === 35 /* CURLE_SSL_CONNECT_ERROR */ && false !== strpos($error, 'Connection reset by peer'))
                         ) && $job['attributes']['retries'] < $this->maxRetries
                     ) {
                         $this->io->writeError('Retrying ('.($job['attributes']['retries'] + 1).') ' . Url::sanitize($job['url']) . ' due to curl error '. $errno, true, IOInterface::DEBUG);
-                        $this->restartJobWithDelay($job, $job['url'], array('retries' => $job['attributes']['retries'] + 1));
+                        $this->restartJobWithDelay($job, $job['url'], ['retries' => $job['attributes']['retries'] + 1]);
                         continue;
                     }
 
@@ -392,7 +392,7 @@ class CurlDownloader
                         rewind($job['bodyHandle']);
                         $contents = stream_get_contents($job['bodyHandle']);
                     }
-                    $response = new CurlResponse(array('url' => $progress['url']), $statusCode, $headers, $contents, $progress);
+                    $response = new CurlResponse(['url' => $progress['url']], $statusCode, $headers, $contents, $progress);
                     $this->io->writeError('['.$statusCode.'] '.Url::sanitize($progress['url']), true, IOInterface::DEBUG);
                 } else {
                     $maxFileSize = $job['options']['max_file_size'] ?? null;
@@ -408,7 +408,7 @@ class CurlDownloader
                         $contents = stream_get_contents($job['bodyHandle']);
                     }
 
-                    $response = new CurlResponse(array('url' => $progress['url']), $statusCode, $headers, $contents, $progress);
+                    $response = new CurlResponse(['url' => $progress['url']], $statusCode, $headers, $contents, $progress);
                     $this->io->writeError('['.$statusCode.'] '.Url::sanitize($progress['url']), true, IOInterface::DEBUG);
                 }
                 fclose($job['bodyHandle']);
@@ -419,7 +419,7 @@ class CurlDownloader
 
                 $result = $this->isAuthenticatedRetryNeeded($job, $response);
                 if ($result['retry']) {
-                    $this->restartJob($job, $job['url'], array('storeAuth' => $result['storeAuth']));
+                    $this->restartJob($job, $job['url'], ['storeAuth' => $result['storeAuth']]);
                     continue;
                 }
 
@@ -427,7 +427,7 @@ class CurlDownloader
                 if ($statusCode >= 300 && $statusCode <= 399 && $statusCode !== 304 && $job['attributes']['redirects'] < $this->maxRedirects) {
                     $location = $this->handleRedirect($job, $response);
                     if ($location) {
-                        $this->restartJob($job, $location, array('redirects' => $job['attributes']['redirects'] + 1));
+                        $this->restartJob($job, $location, ['redirects' => $job['attributes']['redirects'] + 1]);
                         continue;
                     }
                 }
@@ -436,11 +436,11 @@ class CurlDownloader
                 if ($statusCode >= 400 && $statusCode <= 599) {
                     if (
                         (!isset($job['options']['http']['method']) || $job['options']['http']['method'] === 'GET')
-                        && in_array($statusCode, array(423, 425, 500, 502, 503, 504, 507, 510), true)
+                        && in_array($statusCode, [423, 425, 500, 502, 503, 504, 507, 510], true)
                         && $job['attributes']['retries'] < $this->maxRetries
                     ) {
                         $this->io->writeError('Retrying ('.($job['attributes']['retries'] + 1).') ' . Url::sanitize($job['url']) . ' due to status code '. $statusCode, true, IOInterface::DEBUG);
-                        $this->restartJobWithDelay($job, $job['url'], array('retries' => $job['attributes']['retries'] + 1));
+                        $this->restartJobWithDelay($job, $job['url'], ['retries' => $job['attributes']['retries'] + 1]);
                         continue;
                     }
 
@@ -542,7 +542,7 @@ class CurlDownloader
      */
     private function isAuthenticatedRetryNeeded(array $job, Response $response): array
     {
-        if (in_array($response->getStatusCode(), array(401, 403)) && $job['attributes']['retryAuthFailure']) {
+        if (in_array($response->getStatusCode(), [401, 403]) && $job['attributes']['retryAuthFailure']) {
             $result = $this->authHelper->promptAuthIfNeeded($job['url'], $job['origin'], $response->getStatusCode(), $response->getStatusMessage(), $response->getHeaders(), $job['attributes']['retries']);
 
             if ($result['retry']) {
@@ -575,7 +575,7 @@ class CurlDownloader
 
         if ($needsAuthRetry) {
             if ($job['attributes']['retryAuthFailure']) {
-                $result = $this->authHelper->promptAuthIfNeeded($job['url'], $job['origin'], 401, null, array(), $job['attributes']['retries']);
+                $result = $this->authHelper->promptAuthIfNeeded($job['url'], $job['origin'], 401, null, [], $job['attributes']['retries']);
                 if ($result['retry']) {
                     return $result;
                 }
@@ -584,7 +584,7 @@ class CurlDownloader
             throw $this->failResponse($job, $response, $needsAuthRetry);
         }
 
-        return array('retry' => false, 'storeAuth' => false);
+        return ['retry' => false, 'storeAuth' => false];
     }
 
     /**
@@ -595,7 +595,7 @@ class CurlDownloader
      *
      * @return void
      */
-    private function restartJob(array $job, string $url, array $attributes = array()): void
+    private function restartJob(array $job, string $url, array $attributes = []): void
     {
         if (null !== $job['filename']) {
             @unlink($job['filename'].'~');
@@ -638,7 +638,7 @@ class CurlDownloader
         }
 
         $details = '';
-        if (in_array(strtolower((string) $response->getHeader('content-type')), array('application/json', 'application/json; charset=utf-8'), true)) {
+        if (in_array(strtolower((string) $response->getHeader('content-type')), ['application/json', 'application/json; charset=utf-8'], true)) {
             $details = ':'.PHP_EOL.substr($response->getBody(), 0, 200).(strlen($response->getBody()) > 200 ? '...' : '');
         }
 

--- a/src/Composer/Util/Http/ProxyHelper.php
+++ b/src/Composer/Util/Http/ProxyHelper.php
@@ -34,27 +34,27 @@ class ProxyHelper
 
         // Handle http_proxy/HTTP_PROXY on CLI only for security reasons
         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
-            if ($env = self::getProxyEnv(array('http_proxy', 'HTTP_PROXY'), $name)) {
+            if ($env = self::getProxyEnv(['http_proxy', 'HTTP_PROXY'], $name)) {
                 $httpProxy = self::checkProxy($env, $name);
             }
         }
 
         // Prefer CGI_HTTP_PROXY if available
-        if ($env = self::getProxyEnv(array('CGI_HTTP_PROXY'), $name)) {
+        if ($env = self::getProxyEnv(['CGI_HTTP_PROXY'], $name)) {
             $httpProxy = self::checkProxy($env, $name);
         }
 
         // Handle https_proxy/HTTPS_PROXY
-        if ($env = self::getProxyEnv(array('https_proxy', 'HTTPS_PROXY'), $name)) {
+        if ($env = self::getProxyEnv(['https_proxy', 'HTTPS_PROXY'], $name)) {
             $httpsProxy = self::checkProxy($env, $name);
         } else {
             $httpsProxy = $httpProxy;
         }
 
         // Handle no_proxy
-        $noProxy = self::getProxyEnv(array('no_proxy', 'NO_PROXY'), $name);
+        $noProxy = self::getProxyEnv(['no_proxy', 'NO_PROXY'], $name);
 
-        return array($httpProxy, $httpsProxy, $noProxy);
+        return [$httpProxy, $httpsProxy, $noProxy];
     }
 
     /**
@@ -70,7 +70,7 @@ class ProxyHelper
 
         // Remove any authorization
         $proxyUrl = self::formatParsedUrl($proxy, false);
-        $proxyUrl = str_replace(array('http://', 'https://'), array('tcp://', 'ssl://'), $proxyUrl);
+        $proxyUrl = str_replace(['http://', 'https://'], ['tcp://', 'ssl://'], $proxyUrl);
 
         $options['http']['proxy'] = $proxyUrl;
 

--- a/src/Composer/Util/Http/ProxyManager.php
+++ b/src/Composer/Util/Http/ProxyManager.php
@@ -42,14 +42,14 @@ class ProxyManager
 
     private function __construct()
     {
-        $this->fullProxy = $this->safeProxy = array(
+        $this->fullProxy = $this->safeProxy = [
             'http' => null,
             'https' => null,
-        );
+        ];
 
-        $this->streams['http'] = $this->streams['https'] = array(
+        $this->streams['http'] = $this->streams['https'] = [
             'options' => null,
-        );
+        ];
 
         $this->hasProxy = false;
         $this->initProxyData();
@@ -91,10 +91,10 @@ class ProxyManager
 
         $scheme = parse_url($requestUrl, PHP_URL_SCHEME) ?: 'http';
         $proxyUrl = '';
-        $options = array();
+        $options = [];
         $formattedProxyUrl = '';
 
-        if ($this->hasProxy && in_array($scheme, array('http', 'https'), true) && $this->fullProxy[$scheme]) {
+        if ($this->hasProxy && in_array($scheme, ['http', 'https'], true) && $this->fullProxy[$scheme]) {
             if ($this->noProxy($requestUrl)) {
                 $formattedProxyUrl = 'excluded by no_proxy';
             } else {
@@ -143,7 +143,7 @@ class ProxyManager
             return;
         }
 
-        $info = array();
+        $info = [];
 
         if ($httpProxy) {
             $info[] = $this->setData($httpProxy, 'http');

--- a/src/Composer/Util/Loop.php
+++ b/src/Composer/Util/Loop.php
@@ -26,7 +26,7 @@ class Loop
     /** @var ProcessExecutor|null */
     private $processExecutor;
     /** @var PromiseInterface[][] */
-    private $currentPromises = array();
+    private $currentPromises = [];
     /** @var int */
     private $waitIndex = 0;
 

--- a/src/Composer/Util/NoProxyPattern.php
+++ b/src/Composer/Util/NoProxyPattern.php
@@ -23,12 +23,12 @@ class NoProxyPattern
     /**
      * @var string[]
      */
-    protected $hostNames = array();
+    protected $hostNames = [];
 
     /**
      * @var (null|object)[]
      */
-    protected $rules = array();
+    protected $rules = [];
 
     /**
      * @var bool
@@ -268,7 +268,7 @@ class NoProxyPattern
         $size = strlen($ip);
         $mapped = $this->ipMapTo6($ip, $size);
 
-        return array($mapped, $size);
+        return [$mapped, $size];
     }
 
     /**
@@ -324,7 +324,7 @@ class NoProxyPattern
             $net .= chr($ip[$i] & $mask[$i]);
         }
 
-        return array($net, $netmask);
+        return [$net, $netmask];
     }
 
     /**
@@ -356,12 +356,12 @@ class NoProxyPattern
      */
     private function makeData(string $host, int $port, ?stdClass $ipdata): stdClass
     {
-        return (object) array(
+        return (object) [
             'host' => $host,
             'name' => '.' . ltrim($host, '.'),
             'port' => $port,
             'ipdata' => $ipdata,
-        );
+        ];
     }
 
     /**
@@ -375,11 +375,11 @@ class NoProxyPattern
      */
     private function makeIpData(string $ip, int $size, ?string $netmask): stdClass
     {
-        return (object) array(
+        return (object) [
             'ip' => $ip,
             'size' => $size,
             'netmask' => $netmask,
-        );
+        ];
     }
 
     /**
@@ -392,7 +392,7 @@ class NoProxyPattern
     private function splitHostPort(string $hostName): array
     {
         // host, port, err
-        $error = array('', '', true);
+        $error = ['', '', true];
         $port = 0;
         $ip6 = '';
 
@@ -427,7 +427,7 @@ class NoProxyPattern
 
         $host = $ip6 . $hostName;
 
-        return array($host, $port, false);
+        return [$host, $port, false];
     }
 
     /**
@@ -441,12 +441,12 @@ class NoProxyPattern
      */
     private function validateInt(string $int, int $min, int $max): bool
     {
-        $options = array(
-            'options' => array(
+        $options = [
+            'options' => [
                 'min_range' => $min,
                 'max_range' => $max,
-            ),
-        );
+            ],
+        ];
 
         return false !== filter_var($int, FILTER_VALIDATE_INT, $options);
     }

--- a/src/Composer/Util/PackageSorter.php
+++ b/src/Composer/Util/PackageSorter.php
@@ -26,9 +26,9 @@ class PackageSorter
      * @param  array<string, int> $weights Pre-set weights for some packages to give them more (negative number) or less (positive) weight offsets
      * @return PackageInterface[] sorted array
      */
-    public static function sortPackages(array $packages, array $weights = array()): array
+    public static function sortPackages(array $packages, array $weights = []): array
     {
-        $usageList = array();
+        $usageList = [];
 
         foreach ($packages as $package) {
             $links = $package->getRequires();
@@ -40,8 +40,8 @@ class PackageSorter
                 $usageList[$target][] = $package->getName();
             }
         }
-        $computing = array();
-        $computed = array();
+        $computing = [];
+        $computed = [];
         $computeImportance = function ($name) use (&$computeImportance, &$computing, &$computed, $usageList, $weights) {
             // reusing computed importance
             if (isset($computed[$name])) {
@@ -68,12 +68,12 @@ class PackageSorter
             return $weight;
         };
 
-        $weightedPackages = array();
+        $weightedPackages = [];
 
         foreach ($packages as $index => $package) {
             $name = $package->getName();
             $weight = $computeImportance($name);
-            $weightedPackages[] = array('name' => $name, 'weight' => $weight, 'index' => $index);
+            $weightedPackages[] = ['name' => $name, 'weight' => $weight, 'index' => $index];
         }
 
         usort($weightedPackages, function (array $a, array $b): int {
@@ -84,7 +84,7 @@ class PackageSorter
             return strnatcasecmp($a['name'], $b['name']);
         });
 
-        $sortedPackages = array();
+        $sortedPackages = [];
 
         foreach ($weightedPackages as $pkg) {
             $sortedPackages[] = $packages[$pkg['index']];

--- a/src/Composer/Util/Perforce.php
+++ b/src/Composer/Util/Perforce.php
@@ -189,7 +189,7 @@ class Perforce
     public function getClient(): string
     {
         if (!isset($this->p4Client)) {
-            $cleanStreamName = str_replace(array('//', '/', '@'), array('', '_', ''), $this->getStream());
+            $cleanStreamName = str_replace(['//', '/', '@'], ['', '_', ''], $this->getStream());
             $this->p4Client = 'composer_perforce_' . $this->uniquePerforceClientName . '_' . $cleanStreamName;
         }
 
@@ -616,7 +616,7 @@ class Perforce
      */
     public function getBranches(): array
     {
-        $possibleBranches = array();
+        $possibleBranches = [];
         if (!$this->isStream()) {
             $possibleBranches[$this->p4Branch] = $this->getStream();
         } else {
@@ -640,7 +640,7 @@ class Perforce
         $lastCommitArr = explode(' ', $lastCommit);
         $lastCommitNum = $lastCommitArr[1];
 
-        return array('master' => $possibleBranches[$this->p4Branch] . '@'. $lastCommitNum);
+        return ['master' => $possibleBranches[$this->p4Branch] . '@'. $lastCommitNum];
     }
 
     /**
@@ -652,7 +652,7 @@ class Perforce
         $this->executeCommand($command);
         $result = $this->commandResult;
         $resArray = explode(PHP_EOL, $result);
-        $tags = array();
+        $tags = [];
         foreach ($resArray as $line) {
             if (strpos($line, 'Label') !== false) {
                 $fields = explode(' ', $line);

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -208,7 +208,7 @@ class Platform
 
         // detect msysgit/mingw and assume this is a tty because detection
         // does not work correctly, see https://github.com/composer/composer/issues/9690
-        if (in_array(strtoupper(self::getEnv('MSYSTEM') ?: ''), array('MINGW32', 'MINGW64'), true)) {
+        if (in_array(strtoupper(self::getEnv('MSYSTEM') ?: ''), ['MINGW32', 'MINGW64'], true)) {
             return true;
         }
 

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -44,7 +44,7 @@ class ProcessExecutor
     /**
      * @phpstan-var array<int, array<string, mixed>>
      */
-    private $jobs = array();
+    private $jobs = [];
     /** @var int */
     private $runningJobs = 0;
     /** @var int */
@@ -149,12 +149,12 @@ class ProcessExecutor
             throw new \LogicException('You must use the ProcessExecutor instance which is part of a Composer\Loop instance to be able to run async processes');
         }
 
-        $job = array(
+        $job = [
             'id' => $this->idGen++,
             'status' => self::STATUS_QUEUED,
             'command' => $command,
             'cwd' => $cwd,
-        );
+        ];
 
         $resolver = function ($resolve, $reject) use (&$job): void {
             $job['status'] = ProcessExecutor::STATUS_QUEUED;
@@ -360,7 +360,7 @@ class ProcessExecutor
     {
         $output = trim((string) $output);
 
-        return $output === '' ? array() : Preg::split('{\r?\n}', $output);
+        return $output === '' ? [] : Preg::split('{\r?\n}', $output);
     }
 
     /**

--- a/src/Composer/Util/Silencer.php
+++ b/src/Composer/Util/Silencer.php
@@ -22,7 +22,7 @@ class Silencer
     /**
      * @var int[] Unpop stack
      */
-    private static $stack = array();
+    private static $stack = [];
 
     /**
      * Suppresses given mask or errors.

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -37,13 +37,13 @@ final class StreamContextFactory
      * @throws \RuntimeException if https proxy required and OpenSSL uninstalled
      * @return resource          Default context
      */
-    public static function getContext(string $url, array $defaultOptions = array(), array $defaultParams = array())
+    public static function getContext(string $url, array $defaultOptions = [], array $defaultParams = [])
     {
-        $options = array('http' => array(
+        $options = ['http' => [
             // specify defaults again to try and work better with curlwrappers enabled
             'follow_location' => 1,
             'max_redirects' => 20,
-        ));
+        ]];
 
         $options = array_replace_recursive($options, self::initOptions($url, $defaultOptions));
         unset($defaultOptions['http']['header']);
@@ -67,7 +67,7 @@ final class StreamContextFactory
     {
         // Make sure the headers are in an array form
         if (!isset($options['http']['header'])) {
-            $options['http']['header'] = array();
+            $options['http']['header'] = [];
         }
         if (is_string($options['http']['header'])) {
             $options['http']['header'] = explode("\r\n", $options['http']['header']);
@@ -136,7 +136,7 @@ final class StreamContextFactory
      */
     public static function getTlsDefaults(array $options, LoggerInterface $logger = null): array
     {
-        $ciphers = implode(':', array(
+        $ciphers = implode(':', [
             'ECDHE-RSA-AES128-GCM-SHA256',
             'ECDHE-ECDSA-AES128-GCM-SHA256',
             'ECDHE-RSA-AES256-GCM-SHA384',
@@ -178,7 +178,7 @@ final class StreamContextFactory
             '!EDH-DSS-DES-CBC3-SHA',
             '!EDH-RSA-DES-CBC3-SHA',
             '!KRB5-DES-CBC3-SHA',
-        ));
+        ]);
 
         /**
          * CN_match and SNI_server_name are only known once a URL is passed.
@@ -186,15 +186,15 @@ final class StreamContextFactory
          *
          * cafile or capath can be overridden by passing in those options to constructor.
          */
-        $defaults = array(
-            'ssl' => array(
+        $defaults = [
+            'ssl' => [
                 'ciphers' => $ciphers,
                 'verify_peer' => true,
                 'verify_depth' => 7,
                 'SNI_enabled' => true,
                 'capture_peer_cert' => true,
-            ),
-        );
+            ],
+        ];
 
         if (isset($options['ssl'])) {
             $defaults['ssl'] = array_replace_recursive($defaults['ssl'], $options['ssl']);

--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -156,7 +156,7 @@ class Svn
         }
 
         $errorOutput = $this->process->getErrorOutput();
-        $fullOutput = trim(implode("\n", array($output, $errorOutput)));
+        $fullOutput = trim(implode("\n", [$output, $errorOutput]));
 
         // the error is not auth-related
         if (false === stripos($fullOutput, 'Could not authenticate to server:')
@@ -208,10 +208,10 @@ class Svn
         $this->io->writeError("The Subversion server ({$this->url}) requested credentials:");
 
         $this->hasAuth = true;
-        $this->credentials = array(
+        $this->credentials = [
             'username' => (string) $this->io->ask("Username: ", ''),
             'password' => (string) $this->io->askAndHideAnswer("Password: "),
-        );
+        ];
 
         $this->cacheCredentials = $this->io->askConfirmation("Should Subversion cache these credentials? (yes/no) ");
 
@@ -338,10 +338,10 @@ class Svn
 
         $host = parse_url($this->url, PHP_URL_HOST);
         if (isset($authConfig[$host])) {
-            $this->credentials = array(
+            $this->credentials = [
                 'username' => $authConfig[$host]['username'],
                 'password' => $authConfig[$host]['password'],
-            );
+            ];
 
             return $this->hasAuth = true;
         }
@@ -361,10 +361,10 @@ class Svn
             return $this->hasAuth = false;
         }
 
-        $this->credentials = array(
+        $this->credentials = [
             'username' => $uri['user'],
             'password' => !empty($uri['pass']) ? $uri['pass'] : '',
-        );
+        ];
 
         return $this->hasAuth = true;
     }

--- a/src/Composer/Util/SyncHelper.php
+++ b/src/Composer/Util/SyncHelper.php
@@ -64,7 +64,7 @@ class SyncHelper
     public static function await(Loop $loop, PromiseInterface $promise = null): void
     {
         if ($promise) {
-            $loop->wait(array($promise));
+            $loop->wait([$promise]);
         }
     }
 }

--- a/src/Composer/Util/Tar.php
+++ b/src/Composer/Util/Tar.php
@@ -46,7 +46,7 @@ class Tar
             return $phar['composer.json']->getContent();
         }
 
-        $topLevelPaths = array();
+        $topLevelPaths = [];
         foreach ($phar as $folderFile) {
             $name = $folderFile->getBasename();
 

--- a/src/Composer/Util/TlsHelper.php
+++ b/src/Composer/Util/TlsHelper.php
@@ -38,7 +38,7 @@ final class TlsHelper
             return false;
         }
 
-        $combinedNames = array_merge($names['san'], array($names['cn']));
+        $combinedNames = array_merge($names['san'], [$names['cn']]);
         $hostname = strtolower($hostname);
 
         foreach ($combinedNames as $certName) {
@@ -74,7 +74,7 @@ final class TlsHelper
         }
 
         $commonName = strtolower($info['subject']['commonName']);
-        $subjectAltNames = array();
+        $subjectAltNames = [];
 
         if (isset($info['extensions']['subjectAltName'])) {
             $subjectAltNames = Preg::split('{\s*,\s*}', $info['extensions']['subjectAltName']);
@@ -88,10 +88,10 @@ final class TlsHelper
             $subjectAltNames = array_values($subjectAltNames);
         }
 
-        return array(
+        return [
             'cn' => $commonName,
             'san' => $subjectAltNames,
-        );
+        ];
     }
 
     /**

--- a/src/Composer/Util/Zip.php
+++ b/src/Composer/Util/Zip.php
@@ -72,7 +72,7 @@ class Zip
             return $index;
         }
 
-        $topLevelPaths = array();
+        $topLevelPaths = [];
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $name = $zip->getNameIndex($i);
             $dirname = dirname($name);


### PR DESCRIPTION
PHP arrays should be declared using the short syntax.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
