### PR TITLE
Octal notation

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -98,7 +98,7 @@ class Cache
             $this->enabled = true;
 
             if (
-                (!is_dir($this->root) && !Silencer::call('mkdir', $this->root, 0777, true))
+                (!is_dir($this->root) && !Silencer::call('mkdir', $this->root, 0o777, true))
                 || !is_writable($this->root)
             ) {
                 $this->io->writeError('<warning>Cannot create cache directory ' . $this->root . ', or directory is not writable. Proceeding without cache</warning>');

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -194,12 +194,12 @@ EOT
         if ($input->getOption('global') && !$this->configFile->exists()) {
             touch($this->configFile->getPath());
             $this->configFile->write(array('config' => new \ArrayObject));
-            Silencer::call('chmod', $this->configFile->getPath(), 0600);
+            Silencer::call('chmod', $this->configFile->getPath(), 0o600);
         }
         if ($input->getOption('global') && !$this->authConfigFile->exists()) {
             touch($this->authConfigFile->getPath());
             $this->authConfigFile->write(array('bitbucket-oauth' => new \ArrayObject, 'github-oauth' => new \ArrayObject, 'gitlab-oauth' => new \ArrayObject, 'gitlab-token' => new \ArrayObject, 'http-basic' => new \ArrayObject, 'bearer' => new \ArrayObject));
-            Silencer::call('chmod', $this->authConfigFile->getPath(), 0600);
+            Silencer::call('chmod', $this->authConfigFile->getPath(), 0o600);
         }
 
         if (!$this->configFile->exists()) {

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -442,7 +442,7 @@ EOT
 
         // handler Ctrl+C for unix-like systems
         if (function_exists('pcntl_async_signals') && function_exists('pcntl_signal')) {
-            @mkdir($directory, 0777, true);
+            @mkdir($directory, 0o777, true);
             if ($realDir = realpath($directory)) {
                 pcntl_async_signals(true);
                 pcntl_signal(SIGINT, function () use ($realDir): void {
@@ -454,7 +454,7 @@ EOT
         }
         // handler Ctrl+C for Windows on PHP 7.4+
         if (function_exists('sapi_windows_set_ctrl_handler') && PHP_SAPI === 'cli') {
-            @mkdir($directory, 0777, true);
+            @mkdir($directory, 0o777, true);
             if ($realDir = realpath($directory)) {
                 sapi_windows_set_ctrl_handler(function () use ($realDir): void {
                     $fs = new Filesystem();

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -286,7 +286,7 @@ class JsonConfigSource implements ConfigSourceInterface
         }
 
         if ($newFile) {
-            Silencer::call('chmod', $this->file->getPath(), 0600);
+            Silencer::call('chmod', $this->file->getPath(), 0o600);
         }
     }
 

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -350,7 +350,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             // so we make sure if the file is a binary that it is executable
             foreach ($package->getBinaries() as $bin) {
                 if (file_exists($path . '/' . $bin) && !is_executable($path . '/' . $bin)) {
-                    Silencer::call('chmod', $path . '/' . $bin, 0777 & ~umask());
+                    Silencer::call('chmod', $path . '/' . $bin, 0o777 & ~umask());
                 }
             }
         }

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -199,7 +199,7 @@ class Factory
             foreach ($dirs as $dir) {
                 if (!file_exists($dir . '/.htaccess')) {
                     if (!is_dir($dir)) {
-                        Silencer::call('mkdir', $dir, 0777, true);
+                        Silencer::call('mkdir', $dir, 0o777, true);
                     }
                     Silencer::call('file_put_contents', $dir . '/.htaccess', 'Deny from all');
                 }

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -113,7 +113,7 @@ class BinaryInstaller
             } else {
                 $this->installUnixyProxyBinaries($binPath, $link);
             }
-            Silencer::call('chmod', $binPath, 0777 & ~umask());
+            Silencer::call('chmod', $binPath, 0o777 & ~umask());
         }
     }
 
@@ -192,7 +192,7 @@ class BinaryInstaller
         }
         if (!file_exists($link)) {
             file_put_contents($link, $this->generateWindowsProxyCode($binPath, $link));
-            Silencer::call('chmod', $link, 0777 & ~umask());
+            Silencer::call('chmod', $link, 0o777 & ~umask());
         }
     }
 
@@ -205,7 +205,7 @@ class BinaryInstaller
     protected function installUnixyProxyBinaries(string $binPath, string $link): void
     {
         file_put_contents($link, $this->generateUnixyProxyCode($binPath, $link));
-        Silencer::call('chmod', $link, 0777 & ~umask());
+        Silencer::call('chmod', $link, 0o777 & ~umask());
     }
 
     /**

--- a/src/Composer/Installer/ProjectInstaller.php
+++ b/src/Composer/Installer/ProjectInstaller.php
@@ -72,7 +72,7 @@ class ProjectInstaller implements InstallerInterface
             throw new \InvalidArgumentException("Project directory $installPath is not empty.");
         }
         if (!is_dir($installPath)) {
-            mkdir($installPath, 0777, true);
+            mkdir($installPath, 0o777, true);
         }
 
         return $this->downloadManager->download($package, $installPath, $prevPackage);

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -144,7 +144,7 @@ class JsonFile
                     realpath($dir).' exists and is not a directory.'
                 );
             }
-            if (!@mkdir($dir, 0777, true)) {
+            if (!@mkdir($dir, 0o777, true)) {
                 throw new \UnexpectedValueException(
                     $dir.' does not exist and could not be created.'
                 );

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -264,7 +264,7 @@ class Filesystem
                     $directory.' exists and is not a directory.'
                 );
             }
-            if (!@mkdir($directory, 0777, true)) {
+            if (!@mkdir($directory, 0o777, true)) {
                 throw new \RuntimeException(
                     $directory.' does not exist and could not be created.'
                 );

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -225,7 +225,7 @@ class Platform
 
         $stat = @fstat($fd);
         // Check if formatted mode is S_IFCHR
-        return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
+        return $stat ? 0o020000 === ($stat['mode'] & 0o170000) : false;
     }
 
     /**


### PR DESCRIPTION
Literal octal must be in 0o notation.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
