### PR TITLE
Ternary to null coalescing

### DIFF
--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -235,7 +235,7 @@ class InstalledVersions
                 continue;
             }
 
-            return isset($installed['versions'][$packageName]['install_path']) ? $installed['versions'][$packageName]['install_path'] : null;
+            return $installed['versions'][$packageName]['install_path'] ?? null;
         }
 
         throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');


### PR DESCRIPTION
Use null coalescing operator ?? where possible.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
