### PR TITLE
Implode call

### DIFF
--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -101,7 +101,7 @@ class Problem
             }
 
             if (empty($packages)) {
-                return "\n    ".implode(self::getMissingPackageReason($repositorySet, $request, $pool, $isVerbose, $packageName, $constraint));
+                return "\n    ".implode('', self::getMissingPackageReason($repositorySet, $request, $pool, $isVerbose, $packageName, $constraint));
             }
         }
 
@@ -370,7 +370,7 @@ class Problem
 
         if ($providers = $repositorySet->getProviders($packageName)) {
             $maxProviders = 20;
-            $providersStr = implode(array_map(function ($p): string {
+            $providersStr = implode('', array_map(function ($p): string {
                 $description = $p['description'] ? ' '.substr($p['description'], 0, 100) : '';
 
                 return '      - '.$p['name'].$description."\n";


### PR DESCRIPTION
Function implode must be called with 2 arguments in the documented order.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
