### PR TITLE
Get class to class keyword

### DIFF
--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -187,7 +187,7 @@ EOT
         }
 
         if (!$package instanceof CompletePackageInterface) {
-            throw new \LogicException('Expected a CompletePackageInterface instance but found '.get_class($package));
+            throw new \LogicException('Expected a CompletePackageInterface instance but found '.$package::class);
         }
 
         return $package;

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -269,7 +269,7 @@ EOT
                 }
             }
 
-            $result[] = '<error>[' . get_class($e) . '] ' . $e->getMessage() . '</error>';
+            $result[] = '<error>[' . $e::class . '] ' . $e->getMessage() . '</error>';
         }
 
         if (isset($tlsWarning)) {
@@ -473,7 +473,7 @@ EOT
         $hadError = false;
         $hadWarning = false;
         if ($result instanceof \Exception) {
-            $result = '<error>['.get_class($result).'] '.$result->getMessage().'</error>';
+            $result = '<error>['.$result::class.'] '.$result->getMessage().'</error>';
         }
 
         if (!$result) {

--- a/src/Composer/Command/GlobalCommand.php
+++ b/src/Composer/Command/GlobalCommand.php
@@ -93,7 +93,7 @@ EOT
     {
         // TODO remove for Symfony 6+ as it is then in the interface
         if (!method_exists($input, '__toString')) { // @phpstan-ignore-line
-            throw new \LogicException('Expected an Input instance that is stringable, got '.get_class($input));
+            throw new \LogicException('Expected an Input instance that is stringable, got '.$input::class);
         }
 
         // extract real command name
@@ -122,7 +122,7 @@ EOT
     {
         // TODO remove for Symfony 6+ as it is then in the interface
         if (!method_exists($input, '__toString')) { // @phpstan-ignore-line
-            throw new \LogicException('Expected an Input instance that is stringable, got '.get_class($input));
+            throw new \LogicException('Expected an Input instance that is stringable, got '.$input::class);
         }
 
         // The COMPOSER env var should not apply to the global execution scope

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -211,7 +211,7 @@ class Application extends BaseApplication
             try {
                 foreach ($this->getPluginCommands() as $command) {
                     if ($this->has($command->getName())) {
-                        $io->writeError('<warning>Plugin command '.$command->getName().' ('.get_class($command).') would override a Composer command and has been skipped</warning>');
+                        $io->writeError('<warning>Plugin command '.$command->getName().' ('.$command::class.') would override a Composer command and has been skipped</warning>');
                     } else {
                         $this->add($command);
                     }
@@ -403,7 +403,7 @@ class Application extends BaseApplication
     {
         $io = $this->getIO();
 
-        if ((get_class($exception) === LogicException::class || $exception instanceof \Error) && $output->getVerbosity() < OutputInterface::VERBOSITY_VERBOSE) {
+        if (($exception::class === LogicException::class || $exception instanceof \Error) && $output->getVerbosity() < OutputInterface::VERBOSITY_VERBOSE) {
             $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
         }
 
@@ -602,11 +602,11 @@ class Application extends BaseApplication
             foreach ($pm->getPluginCapabilities('Composer\Plugin\Capability\CommandProvider', array('composer' => $composer, 'io' => $this->io)) as $capability) {
                 $newCommands = $capability->getCommands();
                 if (!is_array($newCommands)) {
-                    throw new \UnexpectedValueException('Plugin capability '.get_class($capability).' failed to return an array from getCommands');
+                    throw new \UnexpectedValueException('Plugin capability '.$capability::class.' failed to return an array from getCommands');
                 }
                 foreach ($newCommands as $command) {
                     if (!$command instanceof Command\BaseCommand) {
-                        throw new \UnexpectedValueException('Plugin capability '.get_class($capability).' returned an invalid value, we expected an array of Composer\Command\BaseCommand objects');
+                        throw new \UnexpectedValueException('Plugin capability '.$capability::class.' returned an invalid value, we expected an array of Composer\Command\BaseCommand objects');
                     }
                 }
                 $commands = array_merge($commands, $newCommands);

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -155,7 +155,7 @@ class DownloadManager
         if ($installationSource !== $downloader->getInstallationSource()) {
             throw new \LogicException(sprintf(
                 'Downloader "%s" is a %s type downloader and can not be used to download %s for package %s',
-                get_class($downloader),
+                $downloader::class,
                 $downloader->getInstallationSource(),
                 $installationSource,
                 $package

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -273,7 +273,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             array_shift($urls);
             if ($urls) {
                 if ($io->isDebug()) {
-                    $io->writeError('    Failed downloading '.$package->getName().': ['.get_class($e).'] '.$e->getCode().': '.$e->getMessage());
+                    $io->writeError('    Failed downloading '.$package->getName().': ['.$e::class.'] '.$e->getCode().': '.$e->getMessage());
                     $io->writeError('    Trying the next URL for '.$package->getName());
                 } else {
                     $io->writeError('    Failed downloading '.$package->getName().', trying the next URL ('.$e->getCode().': '.$e->getMessage().')');

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -77,7 +77,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
                     throw $e;
                 }
                 if ($this->io->isDebug()) {
-                    $this->io->writeError('Failed: ['.get_class($e).'] '.$e->getMessage());
+                    $this->io->writeError('Failed: ['.$e::class.'] '.$e->getMessage());
                 } elseif (count($urls)) {
                     $this->io->writeError('    Failed, trying the next URL');
                 }
@@ -142,7 +142,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
                     throw $e;
                 }
                 if ($this->io->isDebug()) {
-                    $this->io->writeError('Failed: ['.get_class($e).'] '.$e->getMessage());
+                    $this->io->writeError('Failed: ['.$e::class.'] '.$e->getMessage());
                 } elseif (count($urls)) {
                     $this->io->writeError('    Failed, trying the next URL');
                 }
@@ -181,7 +181,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
                     throw $exception;
                 }
                 if ($this->io->isDebug()) {
-                    $this->io->writeError('Failed: ['.get_class($exception).'] '.$exception->getMessage());
+                    $this->io->writeError('Failed: ['.$exception::class.'] '.$exception->getMessage());
                 } elseif (count($urls)) {
                     $this->io->writeError('    Failed, trying the next URL');
                 }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1010,7 +1010,7 @@ class Installer
         foreach ($packages as $key => $package) {
             if ($package instanceof AliasPackage) {
                 $alias = (string) $package->getAliasOf();
-                $className = get_class($package);
+                $className = $package::class;
                 $packages[$key] = new $className($packages[$alias], $package->getVersion(), $package->getPrettyVersion());
             }
         }

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -387,7 +387,7 @@ class PluginManager
         if ($sourcePackage === null) {
             trigger_error('Calling PluginManager::addPlugin without $sourcePackage is deprecated, if you are using this please get in touch with us to explain the use case', E_USER_DEPRECATED);
         } elseif (!$this->isPluginAllowed($sourcePackage->getName(), $isGlobalPlugin)) {
-            $this->io->writeError('Skipped loading "'.get_class($plugin).' from '.$sourcePackage->getName() . '" '.($isGlobalPlugin ? '(installed globally) ' : '').' as it is not in config.allow-plugins', true, IOInterface::DEBUG);
+            $this->io->writeError('Skipped loading "'.$plugin::class.' from '.$sourcePackage->getName() . '" '.($isGlobalPlugin ? '(installed globally) ' : '').' as it is not in config.allow-plugins', true, IOInterface::DEBUG);
 
             return;
         }
@@ -399,7 +399,7 @@ class PluginManager
         if ($isGlobalPlugin) {
             $details[] = 'installed globally';
         }
-        $this->io->writeError('Loading plugin '.get_class($plugin).($details ? ' ('.implode(', ', $details).')' : ''), true, IOInterface::DEBUG);
+        $this->io->writeError('Loading plugin '.$plugin::class.($details ? ' ('.implode(', ', $details).')' : ''), true, IOInterface::DEBUG);
         $this->plugins[] = $plugin;
         $plugin->activate($this->composer, $this->io);
 
@@ -426,7 +426,7 @@ class PluginManager
             return;
         }
 
-        $this->io->writeError('Unloading plugin '.get_class($plugin), true, IOInterface::DEBUG);
+        $this->io->writeError('Unloading plugin '.$plugin::class, true, IOInterface::DEBUG);
         unset($this->plugins[$index]);
         $plugin->deactivate($this->composer, $this->io);
 
@@ -446,7 +446,7 @@ class PluginManager
      */
     public function uninstallPlugin(PluginInterface $plugin): void
     {
-        $this->io->writeError('Uninstalling plugin '.get_class($plugin), true, IOInterface::DEBUG);
+        $this->io->writeError('Uninstalling plugin '.$plugin::class, true, IOInterface::DEBUG);
         $plugin->uninstall($this->composer, $this->io);
     }
 
@@ -586,7 +586,7 @@ class PluginManager
             array_key_exists($capability, $capabilities)
             && (empty($capabilities[$capability]) || !is_string($capabilities[$capability]) || !trim($capabilities[$capability]))
         ) {
-            throw new \UnexpectedValueException('Plugin '.get_class($plugin).' provided invalid capability class name(s), got '.var_export($capabilities[$capability], true));
+            throw new \UnexpectedValueException('Plugin '.$plugin::class.' provided invalid capability class name(s), got '.var_export($capabilities[$capability], true));
         }
 
         return null;
@@ -607,7 +607,7 @@ class PluginManager
     {
         if ($capabilityClass = $this->getCapabilityImplementationClassName($plugin, $capabilityClassName)) {
             if (!class_exists($capabilityClass)) {
-                throw new \RuntimeException("Cannot instantiate Capability, as class $capabilityClass from plugin ".get_class($plugin)." does not exist.");
+                throw new \RuntimeException("Cannot instantiate Capability, as class $capabilityClass from plugin ".$plugin::class." does not exist.");
             }
 
             $ctorArgs['plugin'] = $plugin;

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1293,7 +1293,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
             return $packageInstances;
         } catch (\Exception $e) {
-            throw new \RuntimeException('Could not load packages '.($packages[0]['name'] ?? json_encode($packages)).' in '.$this->getRepoName().($source ? ' from '.$source : '').': ['.get_class($e).'] '.$e->getMessage(), 0, $e);
+            throw new \RuntimeException('Could not load packages '.($packages[0]['name'] ?? json_encode($packages)).' in '.$this->getRepoName().($source ? ' from '.$source : '').': ['.$e::class.'] '.$e->getMessage(), 0, $e);
         }
     }
 

--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -99,7 +99,7 @@ class FilesystemRepository extends WritableArrayRepository
                 throw new \UnexpectedValueException('Could not parse package list from the repository');
             }
         } catch (\Exception $e) {
-            throw new InvalidRepositoryException('Invalid repository data in '.$this->file->getPath().', packages could not be loaded: ['.get_class($e).'] '.$e->getMessage());
+            throw new InvalidRepositoryException('Invalid repository data in '.$this->file->getPath().', packages could not be loaded: ['.$e::class.'] '.$e->getMessage());
         }
 
         $loader = new ArrayLoader(null, true);

--- a/src/Composer/Repository/InstalledRepository.php
+++ b/src/Composer/Repository/InstalledRepository.php
@@ -272,6 +272,6 @@ class InstalledRepository extends CompositeRepository
             return;
         }
 
-        throw new \LogicException('An InstalledRepository can not contain a repository of type '.get_class($repository).' ('.$repository->getRepoName().')');
+        throw new \LogicException('An InstalledRepository can not contain a repository of type '.$repository::class.' ('.$repository->getRepoName().')');
     }
 }

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -538,7 +538,7 @@ class PlatformRepository extends ArrayRepository
     public function addPackage(PackageInterface $package): void
     {
         if (!$package instanceof CompletePackage) {
-            throw new \UnexpectedValueException('Expected CompletePackage but got '.get_class($package));
+            throw new \UnexpectedValueException('Expected CompletePackage but got '.$package::class);
         }
 
         // Skip if overridden


### PR DESCRIPTION
Replace get_class calls on object variables with class keyword syntax.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
