### PR TITLE
No alias functions

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -523,7 +523,7 @@ EOT
             explode('/', $packageName)
         );
 
-        return join('\\', $namespace);
+        return implode('\\', $namespace);
     }
 
     /**


### PR DESCRIPTION
Master functions shall be used instead of aliases.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
