### PR TITLE
Void return

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -89,7 +89,7 @@ class AutoloadGenerator
      * @param bool $devMode
      * @return void
      */
-    public function setDevMode(bool $devMode = true)
+    public function setDevMode(bool $devMode = true): void
     {
         $this->devMode = $devMode;
     }
@@ -100,7 +100,7 @@ class AutoloadGenerator
      * @param bool $classMapAuthoritative
      * @return void
      */
-    public function setClassMapAuthoritative(bool $classMapAuthoritative)
+    public function setClassMapAuthoritative(bool $classMapAuthoritative): void
     {
         $this->classMapAuthoritative = $classMapAuthoritative;
     }
@@ -112,7 +112,7 @@ class AutoloadGenerator
      * @param string|null $apcuPrefix
      * @return void
      */
-    public function setApcu(bool $apcu, ?string $apcuPrefix = null)
+    public function setApcu(bool $apcu, ?string $apcuPrefix = null): void
     {
         $this->apcu = $apcu;
         $this->apcuPrefix = $apcuPrefix !== null ? $apcuPrefix : $apcuPrefix;
@@ -124,7 +124,7 @@ class AutoloadGenerator
      * @param bool $runScripts
      * @return void
      */
-    public function setRunScripts(bool $runScripts = true)
+    public function setRunScripts(bool $runScripts = true): void
     {
         $this->runScripts = $runScripts;
     }
@@ -141,7 +141,7 @@ class AutoloadGenerator
      *
      * @deprecated use setPlatformRequirementFilter instead
      */
-    public function setIgnorePlatformRequirements($ignorePlatformReqs)
+    public function setIgnorePlatformRequirements($ignorePlatformReqs): void
     {
         trigger_error('AutoloadGenerator::setIgnorePlatformRequirements is deprecated since Composer 2.2, use setPlatformRequirementFilter instead.', E_USER_DEPRECATED);
 
@@ -151,7 +151,7 @@ class AutoloadGenerator
     /**
      * @return void
      */
-    public function setPlatformRequirementFilter(PlatformRequirementFilterInterface $platformRequirementFilter)
+    public function setPlatformRequirementFilter(PlatformRequirementFilterInterface $platformRequirementFilter): void
     {
         $this->platformRequirementFilter = $platformRequirementFilter;
     }
@@ -525,7 +525,7 @@ EOF;
      * @return void
      * @throws \InvalidArgumentException Throws an exception, if the package has illegal settings.
      */
-    protected function validatePackage(PackageInterface $package)
+    protected function validatePackage(PackageInterface $package): void
     {
         $autoload = $package->getAutoload();
         if (!empty($autoload['psr-4']) && null !== $package->getTargetDir()) {

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -162,7 +162,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function addClassMap(array $classMap)
+    public function addClassMap(array $classMap): void
     {
         if ($this->classMap) {
             $this->classMap = array_merge($this->classMap, $classMap);
@@ -181,7 +181,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function add($prefix, $paths, $prepend = false)
+    public function add($prefix, $paths, $prepend = false): void
     {
         if (!$prefix) {
             if ($prepend) {
@@ -230,7 +230,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function addPsr4($prefix, $paths, $prepend = false)
+    public function addPsr4($prefix, $paths, $prepend = false): void
     {
         if (!$prefix) {
             // Register directories for the root namespace.
@@ -277,7 +277,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function set($prefix, $paths)
+    public function set($prefix, $paths): void
     {
         if (!$prefix) {
             $this->fallbackDirsPsr0 = (array) $paths;
@@ -297,7 +297,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function setPsr4($prefix, $paths)
+    public function setPsr4($prefix, $paths): void
     {
         if (!$prefix) {
             $this->fallbackDirsPsr4 = (array) $paths;
@@ -318,7 +318,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function setUseIncludePath($useIncludePath)
+    public function setUseIncludePath($useIncludePath): void
     {
         $this->useIncludePath = $useIncludePath;
     }
@@ -342,7 +342,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function setClassMapAuthoritative($classMapAuthoritative)
+    public function setClassMapAuthoritative($classMapAuthoritative): void
     {
         $this->classMapAuthoritative = $classMapAuthoritative;
     }
@@ -364,7 +364,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function setApcuPrefix($apcuPrefix)
+    public function setApcuPrefix($apcuPrefix): void
     {
         $this->apcuPrefix = function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) ? $apcuPrefix : null;
     }
@@ -386,7 +386,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function register($prepend = false)
+    public function register($prepend = false): void
     {
         spl_autoload_register(array($this, 'loadClass'), true, $prepend);
 
@@ -407,7 +407,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function unregister()
+    public function unregister(): void
     {
         spl_autoload_unregister(array($this, 'loadClass'));
 
@@ -566,7 +566,7 @@ class ClassLoader
  * @return void
  * @private
  */
-function includeFile($file)
+function includeFile($file): void
 {
     include $file;
 }

--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -66,7 +66,7 @@ class Cache
      *
      * @return void
      */
-    public function setReadOnly(bool $readOnly)
+    public function setReadOnly(bool $readOnly): void
     {
         $this->readOnly = (bool) $readOnly;
     }

--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -133,7 +133,7 @@ abstract class BaseCommand extends Command
     /**
      * @return void
      */
-    public function setComposer(Composer $composer)
+    public function setComposer(Composer $composer): void
     {
         $this->composer = $composer;
     }
@@ -143,7 +143,7 @@ abstract class BaseCommand extends Command
      *
      * @return void
      */
-    public function resetComposer()
+    public function resetComposer(): void
     {
         $this->composer = null;
         $this->getApplication()->resetComposer();
@@ -181,7 +181,7 @@ abstract class BaseCommand extends Command
     /**
      * @return void
      */
-    public function setIO(IOInterface $io)
+    public function setIO(IOInterface $io): void
     {
         $this->io = $io;
     }
@@ -217,7 +217,7 @@ abstract class BaseCommand extends Command
      *
      * @return void
      */
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         // initialize a plugin-enabled Composer instance, either local or global
         $disablePlugins = $input->hasParameterOption('--no-plugins');
@@ -382,7 +382,7 @@ abstract class BaseCommand extends Command
      *
      * @return void
      */
-    protected function renderTable(array $table, OutputInterface $output)
+    protected function renderTable(array $table, OutputInterface $output): void
     {
         $renderer = new Table($output);
         $renderer->setStyle('compact');

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -26,7 +26,7 @@ class DumpAutoloadCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('dump-autoload')

--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -25,7 +25,7 @@ class ExecCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('exec')

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -48,7 +48,7 @@ class InitCommand extends BaseCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('init')
@@ -215,7 +215,7 @@ EOT
      *
      * @return void
      */
-    protected function interact(InputInterface $input, OutputInterface $output)
+    protected function interact(InputInterface $input, OutputInterface $output): void
     {
         $git = $this->getGitConfig();
         $io = $this->getIO();

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -34,7 +34,7 @@ class InstallCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('install')

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -37,7 +37,7 @@ class RemoveCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('remove')
@@ -78,7 +78,7 @@ EOT
     /**
      * @return void
      */
-    protected function interact(InputInterface $input, OutputInterface $output)
+    protected function interact(InputInterface $input, OutputInterface $output): void
     {
         if ($input->getOption('unused')) {
             $composer = $this->requireComposer();

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -62,7 +62,7 @@ class RequireCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('require')
@@ -146,9 +146,9 @@ EOT
 
         if (function_exists('pcntl_async_signals') && function_exists('pcntl_signal')) {
             pcntl_async_signals(true);
-            pcntl_signal(SIGINT, function () { $this->revertComposerFile(); });
-            pcntl_signal(SIGTERM, function () { $this->revertComposerFile(); });
-            pcntl_signal(SIGHUP, function () { $this->revertComposerFile(); });
+            pcntl_signal(SIGINT, function (): void { $this->revertComposerFile(); });
+            pcntl_signal(SIGTERM, function (): void { $this->revertComposerFile(); });
+            pcntl_signal(SIGHUP, function (): void { $this->revertComposerFile(); });
         }
 
         // check for writability by writing to the file as is_writable can not be trusted on network-mounts

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -70,7 +70,7 @@ class ShowCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('show')

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -43,7 +43,7 @@ class UpdateCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('update')

--- a/src/Composer/DependencyResolver/PoolOptimizer.php
+++ b/src/Composer/DependencyResolver/PoolOptimizer.php
@@ -459,7 +459,7 @@ class PoolOptimizer
      * @param ConstraintInterface $constraint
      * @return void
      */
-    private function extractRequireConstraintsPerPackage($package, ConstraintInterface $constraint)
+    private function extractRequireConstraintsPerPackage($package, ConstraintInterface $constraint): void
     {
         foreach ($this->expandDisjunctiveMultiConstraints($constraint) as $expanded) {
             $this->requireConstraintsPerPackage[$package][(string) $expanded] = $expanded;
@@ -475,7 +475,7 @@ class PoolOptimizer
      * @param ConstraintInterface $constraint
      * @return void
      */
-    private function extractConflictConstraintsPerPackage($package, ConstraintInterface $constraint)
+    private function extractConflictConstraintsPerPackage($package, ConstraintInterface $constraint): void
     {
         foreach ($this->expandDisjunctiveMultiConstraints($constraint) as $expanded) {
             $this->conflictConstraintsPerPackage[$package][(string) $expanded] = $expanded;

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -93,7 +93,7 @@ abstract class ArchiveDownloader extends FileDownloader
 
         $filesystem = $this->filesystem;
 
-        $cleanup = function () use ($path, $filesystem, $temporaryDir, $package) {
+        $cleanup = function () use ($path, $filesystem, $temporaryDir, $package): void {
             // remove cache if the file was corrupted
             $this->clearLastCacheWrite($package);
 
@@ -146,7 +146,7 @@ abstract class ArchiveDownloader extends FileDownloader
              * @param  string $to   Directory
              * @return void
              */
-            $renameRecursively = function ($from, $to) use ($filesystem, $getFolderContent, $package, &$renameRecursively) {
+            $renameRecursively = function ($from, $to) use ($filesystem, $getFolderContent, $package, &$renameRecursively): void {
                 $contentDir = $getFolderContent($from);
 
                 // move files back out of the temp dir
@@ -199,11 +199,11 @@ abstract class ArchiveDownloader extends FileDownloader
 
             $promise = $filesystem->removeDirectoryAsync($temporaryDir);
 
-            return $promise->then(function () use ($package, $path, $temporaryDir) {
+            return $promise->then(function () use ($package, $path, $temporaryDir): void {
                 $this->removeCleanupPath($package, $temporaryDir);
                 $this->removeCleanupPath($package, $path);
             });
-        }, function ($e) use ($cleanup) {
+        }, function ($e) use ($cleanup): void {
             $cleanup();
 
             throw $e;

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -228,7 +228,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
 
         $promise = $this->filesystem->removeDirectoryAsync($path);
 
-        return $promise->then(function (bool $result) use ($path) {
+        return $promise->then(function (bool $result) use ($path): void {
             if (!$result) {
                 throw new \RuntimeException('Could not completely delete '.$path.', aborting.');
             }

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -33,7 +33,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @return void
      */
-    public function resetAuthentications()
+    public function resetAuthentications(): void
     {
         $this->authentications = array();
     }
@@ -61,7 +61,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function setAuthentication($repositoryName, $username, $password = null)
+    public function setAuthentication($repositoryName, $username, $password = null): void
     {
         $this->authentications[$repositoryName] = array('username' => $username, 'password' => $password);
     }
@@ -69,7 +69,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function writeRaw($messages, bool $newline = true, int $verbosity = self::NORMAL)
+    public function writeRaw($messages, bool $newline = true, int $verbosity = self::NORMAL): void
     {
         $this->write($messages, $newline, $verbosity);
     }
@@ -77,7 +77,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function writeErrorRaw($messages, bool $newline = true, int $verbosity = self::NORMAL)
+    public function writeErrorRaw($messages, bool $newline = true, int $verbosity = self::NORMAL): void
     {
         $this->writeError($messages, $newline, $verbosity);
     }
@@ -91,7 +91,7 @@ abstract class BaseIO implements IOInterface
      *
      * @return void
      */
-    protected function checkAndSetAuthentication(string $repositoryName, string $username, string $password = null)
+    protected function checkAndSetAuthentication(string $repositoryName, string $username, string $password = null): void
     {
         if ($this->hasAuthentication($repositoryName)) {
             $auth = $this->getAuthentication($repositoryName);
@@ -112,7 +112,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function loadConfiguration(Config $config)
+    public function loadConfiguration(Config $config): void
     {
         $bitbucketOauth = $config->get('bitbucket-oauth');
         $githubOauth = $config->get('github-oauth');

--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -71,7 +71,7 @@ class ConsoleIO extends BaseIO
      *
      * @return void
      */
-    public function enableDebugging(float $startTime)
+    public function enableDebugging(float $startTime): void
     {
         $this->startTime = $startTime;
     }
@@ -119,7 +119,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function write($messages, bool $newline = true, int $verbosity = self::NORMAL)
+    public function write($messages, bool $newline = true, int $verbosity = self::NORMAL): void
     {
         $this->doWrite($messages, $newline, false, $verbosity);
     }
@@ -127,7 +127,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function writeError($messages, bool $newline = true, int $verbosity = self::NORMAL)
+    public function writeError($messages, bool $newline = true, int $verbosity = self::NORMAL): void
     {
         $this->doWrite($messages, $newline, true, $verbosity);
     }
@@ -135,7 +135,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function writeRaw($messages, bool $newline = true, int $verbosity = self::NORMAL)
+    public function writeRaw($messages, bool $newline = true, int $verbosity = self::NORMAL): void
     {
         $this->doWrite($messages, $newline, false, $verbosity, true);
     }
@@ -143,7 +143,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function writeErrorRaw($messages, bool $newline = true, int $verbosity = self::NORMAL)
+    public function writeErrorRaw($messages, bool $newline = true, int $verbosity = self::NORMAL): void
     {
         $this->doWrite($messages, $newline, true, $verbosity, true);
     }
@@ -194,7 +194,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function overwrite($messages, bool $newline = true, ?int $size = null, int $verbosity = self::NORMAL)
+    public function overwrite($messages, bool $newline = true, ?int $size = null, int $verbosity = self::NORMAL): void
     {
         $this->doOverwrite($messages, $newline, $size, false, $verbosity);
     }
@@ -202,7 +202,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function overwriteError($messages, bool $newline = true, ?int $size = null, int $verbosity = self::NORMAL)
+    public function overwriteError($messages, bool $newline = true, ?int $size = null, int $verbosity = self::NORMAL): void
     {
         $this->doOverwrite($messages, $newline, $size, true, $verbosity);
     }

--- a/src/Composer/IO/IOInterface.php
+++ b/src/Composer/IO/IOInterface.php
@@ -72,7 +72,7 @@ interface IOInterface extends LoggerInterface
      *
      * @return void
      */
-    public function write($messages, bool $newline = true, int $verbosity = self::NORMAL);
+    public function write($messages, bool $newline = true, int $verbosity = self::NORMAL): void;
 
     /**
      * Writes a message to the error output.
@@ -83,7 +83,7 @@ interface IOInterface extends LoggerInterface
      *
      * @return void
      */
-    public function writeError($messages, bool $newline = true, int $verbosity = self::NORMAL);
+    public function writeError($messages, bool $newline = true, int $verbosity = self::NORMAL): void;
 
     /**
      * Writes a message to the output, without formatting it.
@@ -94,7 +94,7 @@ interface IOInterface extends LoggerInterface
      *
      * @return void
      */
-    public function writeRaw($messages, bool $newline = true, int $verbosity = self::NORMAL);
+    public function writeRaw($messages, bool $newline = true, int $verbosity = self::NORMAL): void;
 
     /**
      * Writes a message to the error output, without formatting it.
@@ -105,7 +105,7 @@ interface IOInterface extends LoggerInterface
      *
      * @return void
      */
-    public function writeErrorRaw($messages, bool $newline = true, int $verbosity = self::NORMAL);
+    public function writeErrorRaw($messages, bool $newline = true, int $verbosity = self::NORMAL): void;
 
     /**
      * Overwrites a previous message to the output.
@@ -117,7 +117,7 @@ interface IOInterface extends LoggerInterface
      *
      * @return void
      */
-    public function overwrite($messages, bool $newline = true, ?int $size = null, int $verbosity = self::NORMAL);
+    public function overwrite($messages, bool $newline = true, ?int $size = null, int $verbosity = self::NORMAL): void;
 
     /**
      * Overwrites a previous message to the error output.
@@ -129,7 +129,7 @@ interface IOInterface extends LoggerInterface
      *
      * @return void
      */
-    public function overwriteError($messages, bool $newline = true, ?int $size = null, int $verbosity = self::NORMAL);
+    public function overwriteError($messages, bool $newline = true, ?int $size = null, int $verbosity = self::NORMAL): void;
 
     /**
      * Asks a question to the user.
@@ -229,7 +229,7 @@ interface IOInterface extends LoggerInterface
      *
      * @return void
      */
-    public function setAuthentication(string $repositoryName, string $username, ?string $password = null);
+    public function setAuthentication(string $repositoryName, string $username, ?string $password = null): void;
 
     /**
      * Loads authentications from a config instance
@@ -238,5 +238,5 @@ interface IOInterface extends LoggerInterface
      *
      * @return void
      */
-    public function loadConfiguration(Config $config);
+    public function loadConfiguration(Config $config): void;
 }

--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -305,7 +305,7 @@ class InstalledVersions
      *
      * @psalm-param array{root: array{name: string, pretty_version: string, version: string, reference: string|null, type: string, install_path: string, aliases: string[], dev: bool}, versions: array<string, array{pretty_version?: string, version?: string, reference?: string|null, type?: string, install_path?: string, aliases?: string[], dev_requirement: bool, replaced?: string[], provided?: string[]}>} $data
      */
-    public static function reload($data)
+    public static function reload($data): void
     {
         self::$installed = $data;
         self::$installedByVendor = array();

--- a/src/Composer/Installer/BinaryPresenceInterface.php
+++ b/src/Composer/Installer/BinaryPresenceInterface.php
@@ -28,5 +28,5 @@ interface BinaryPresenceInterface
      *
      * @return void
      */
-    public function ensureBinariesPresence(PackageInterface $package);
+    public function ensureBinariesPresence(PackageInterface $package): void;
 }

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -246,7 +246,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
      *
      * @param PackageInterface $package Package instance
      */
-    public function ensureBinariesPresence(PackageInterface $package)
+    public function ensureBinariesPresence(PackageInterface $package): void
     {
         $this->binaryInstaller->installBinaries($package, $this->getInstallPath($package), false);
     }
@@ -329,7 +329,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
     /**
      * @return void
      */
-    protected function initializeVendorDir()
+    protected function initializeVendorDir(): void
     {
         $this->filesystem->ensureDirectoryExists($this->vendorDir);
         $this->vendorDir = realpath($this->vendorDir);

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -129,7 +129,7 @@ class JsonFile
      * @throws \UnexpectedValueException|\Exception
      * @return void
      */
-    public function write(array $hash, int $options = JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+    public function write(array $hash, int $options = JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE): void
     {
         if ($this->path === 'php://memory') {
             file_put_contents($this->path, static::encode($hash, $options));

--- a/src/Composer/Plugin/PluginInterface.php
+++ b/src/Composer/Plugin/PluginInterface.php
@@ -42,7 +42,7 @@ interface PluginInterface
      *
      * @return void
      */
-    public function activate(Composer $composer, IOInterface $io);
+    public function activate(Composer $composer, IOInterface $io): void;
 
     /**
      * Remove any hooks from Composer
@@ -56,7 +56,7 @@ interface PluginInterface
      *
      * @return void
      */
-    public function deactivate(Composer $composer, IOInterface $io);
+    public function deactivate(Composer $composer, IOInterface $io): void;
 
     /**
      * Prepare the plugin to be uninstalled
@@ -68,5 +68,5 @@ interface PluginInterface
      *
      * @return void
      */
-    public function uninstall(Composer $composer, IOInterface $io);
+    public function uninstall(Composer $composer, IOInterface $io): void;
 }

--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -212,7 +212,7 @@ class ArrayRepository implements RepositoryInterface
      *
      * @return void
      */
-    public function addPackage(PackageInterface $package)
+    public function addPackage(PackageInterface $package): void
     {
         if (!$package instanceof BasePackage) {
             throw new \InvalidArgumentException('Only subclasses of BasePackage are supported');
@@ -286,7 +286,7 @@ class ArrayRepository implements RepositoryInterface
      *
      * @return void
      */
-    public function removePackage(PackageInterface $package)
+    public function removePackage(PackageInterface $package): void
     {
         $packageId = $package->getUniqueName();
 
@@ -337,7 +337,7 @@ class ArrayRepository implements RepositoryInterface
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         $this->packages = array();
     }

--- a/src/Composer/Repository/ArtifactRepository.php
+++ b/src/Composer/Repository/ArtifactRepository.php
@@ -61,7 +61,7 @@ class ArtifactRepository extends ArrayRepository implements ConfigurableReposito
         return $this->repoConfig;
     }
 
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -840,7 +840,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     /**
      * @inheritDoc
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
 
@@ -856,7 +856,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      *
      * @param PackageInterface $package
      */
-    public function addPackage(PackageInterface $package)
+    public function addPackage(PackageInterface $package): void
     {
         parent::addPackage($package);
         $this->configurePackageTransportOptions($package);

--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -72,7 +72,7 @@ class FilesystemRepository extends WritableArrayRepository
     /**
      * Initializes repository (reads file, or remote address).
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
 
@@ -109,7 +109,7 @@ class FilesystemRepository extends WritableArrayRepository
         }
     }
 
-    public function reload()
+    public function reload(): void
     {
         $this->packages = null;
         $this->initialize();
@@ -118,7 +118,7 @@ class FilesystemRepository extends WritableArrayRepository
     /**
      * Writes writable repository.
      */
-    public function write(bool $devMode, InstallationManager $installationManager)
+    public function write(bool $devMode, InstallationManager $installationManager): void
     {
         $data = array('packages' => array(), 'dev' => $devMode, 'dev-package-names' => array());
         $dumper = new ArrayDumper();

--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -188,7 +188,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
         return $this->versionTransportExceptions;
     }
 
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
 

--- a/src/Composer/Repository/WritableArrayRepository.php
+++ b/src/Composer/Repository/WritableArrayRepository.php
@@ -41,7 +41,7 @@ class WritableArrayRepository extends ArrayRepository implements WritableReposit
     /**
      * @inheritDoc
      */
-    public function setDevPackageNames(array $devPackageNames)
+    public function setDevPackageNames(array $devPackageNames): void
     {
         $this->devPackageNames = $devPackageNames;
     }
@@ -57,7 +57,7 @@ class WritableArrayRepository extends ArrayRepository implements WritableReposit
     /**
      * @inheritDoc
      */
-    public function write(bool $devMode, InstallationManager $installationManager)
+    public function write(bool $devMode, InstallationManager $installationManager): void
     {
         $this->devMode = $devMode;
     }
@@ -65,7 +65,7 @@ class WritableArrayRepository extends ArrayRepository implements WritableReposit
     /**
      * @inheritDoc
      */
-    public function reload()
+    public function reload(): void
     {
         $this->devMode = null;
     }

--- a/src/Composer/Repository/WritableRepositoryInterface.php
+++ b/src/Composer/Repository/WritableRepositoryInterface.php
@@ -28,7 +28,7 @@ interface WritableRepositoryInterface extends RepositoryInterface
      * @param bool $devMode Whether dev requirements were included or not in this installation
      * @return void
      */
-    public function write(bool $devMode, InstallationManager $installationManager);
+    public function write(bool $devMode, InstallationManager $installationManager): void;
 
     /**
      * Adds package to the repository.
@@ -36,7 +36,7 @@ interface WritableRepositoryInterface extends RepositoryInterface
      * @param PackageInterface $package package instance
      * @return void
      */
-    public function addPackage(PackageInterface $package);
+    public function addPackage(PackageInterface $package): void;
 
     /**
      * Removes package from the repository.
@@ -44,7 +44,7 @@ interface WritableRepositoryInterface extends RepositoryInterface
      * @param PackageInterface $package package instance
      * @return void
      */
-    public function removePackage(PackageInterface $package);
+    public function removePackage(PackageInterface $package): void;
 
     /**
      * Get unique packages (at most one package of each name), with aliases resolved and removed.
@@ -58,13 +58,13 @@ interface WritableRepositoryInterface extends RepositoryInterface
      *
      * @return void
      */
-    public function reload();
+    public function reload(): void;
 
     /**
      * @param string[] $devPackageNames
      * @return void
      */
-    public function setDevPackageNames(array $devPackageNames);
+    public function setDevPackageNames(array $devPackageNames): void;
 
     /**
      * @return string[] Names of dependencies installed through require-dev

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -74,7 +74,7 @@ class Filesystem
      *
      * @return void
      */
-    public function emptyDirectory(string $dir, bool $ensureDirectoryExists = true)
+    public function emptyDirectory(string $dir, bool $ensureDirectoryExists = true): void
     {
         if (is_link($dir) && file_exists($dir)) {
             $this->unlink($dir);
@@ -256,7 +256,7 @@ class Filesystem
      *
      * @return void
      */
-    public function ensureDirectoryExists(string $directory)
+    public function ensureDirectoryExists(string $directory): void
     {
         if (!is_dir($directory)) {
             if (file_exists($directory)) {
@@ -345,7 +345,7 @@ class Filesystem
      *
      * @return void
      */
-    public function copyThenRemove(string $source, string $target)
+    public function copyThenRemove(string $source, string $target): void
     {
         $this->copy($source, $target);
         if (!is_dir($source)) {
@@ -393,7 +393,7 @@ class Filesystem
      *
      * @return void
      */
-    public function rename(string $source, string $target)
+    public function rename(string $source, string $target): void
     {
         if (true === @rename($source, $target)) {
             return;
@@ -811,7 +811,7 @@ class Filesystem
      *
      * @return void
      */
-    public function junction(string $target, string $junction)
+    public function junction(string $target, string $junction): void
     {
         if (!Platform::isWindows()) {
             throw new \LogicException(sprintf('Function %s is not available on non-Windows platform', __CLASS__));
@@ -912,7 +912,7 @@ class Filesystem
      *
      * @return void
      */
-    public function safeCopy(string $source, string $target)
+    public function safeCopy(string $source, string $target): void
     {
         if (!file_exists($target) || !file_exists($source) || !$this->filesAreEqual($source, $target)) {
             $sourceHandle = fopen($source, 'r');

--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -180,7 +180,7 @@ class HttpDownloader
      * @param  mixed[] $options
      * @return void
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): void
     {
         $this->options = array_replace_recursive($this->options, $options);
     }
@@ -341,7 +341,7 @@ class HttpDownloader
      *
      * @return void
      */
-    public function wait(?int $index = null)
+    public function wait(?int $index = null): void
     {
         do {
             $jobCount = $this->countActiveJobs($index);

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -142,7 +142,7 @@ class RemoteFilesystem
      * @param  mixed[] $options
      * @return void
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): void
     {
         $this->options = array_replace_recursive($this->options, $options);
     }
@@ -554,7 +554,7 @@ class RemoteFilesystem
      *
      * @throws TransportException
      */
-    protected function callbackGet(int $notificationCode, int $severity, ?string $message, int $messageCode, int $bytesTransferred, int $bytesMax)
+    protected function callbackGet(int $notificationCode, int $severity, ?string $message, int $messageCode, int $bytesTransferred, int $bytesMax): void
     {
         switch ($notificationCode) {
             case STREAM_NOTIFY_FAILURE:
@@ -592,7 +592,7 @@ class RemoteFilesystem
      *
      * @return void
      */
-    protected function promptAuthAndRetry($httpStatus, ?string $reason = null, array $headers = array())
+    protected function promptAuthAndRetry($httpStatus, ?string $reason = null, array $headers = array()): void
     {
         $result = $this->authHelper->promptAuthIfNeeded($this->fileUrl, $this->originUrl, $httpStatus, $reason, $headers, 1 /** always pass 1 as RemoteFilesystem is single threaded there is no race condition possible */);
 


### PR DESCRIPTION
Add void return type to functions with missing or empty return statements, but priority is given to @return annotations.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
