### PR TITLE
Combine consecutive issets

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -639,7 +639,7 @@ EOT
             if (isset($package['version']) && $writeVersion) {
                 $io->write(' ' . str_pad($package['version'], $versionLength, ' '), false);
             }
-            if (isset($package['latest']) && isset($package['latest-status']) && $writeLatest) {
+            if (isset($package['latest'], $package['latest-status'])   && $writeLatest) {
                 $latestVersion = $package['latest'];
                 $updateStatus = $package['latest-status'];
                 $style = $this->updateStatusToVersionStyle($updateStatus);


### PR DESCRIPTION
Using isset($var) && multiple times should be done in one call.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
