### PR TITLE
Combine consecutive unsets

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -682,12 +682,12 @@ class PoolBuilder
     {
         $repoIndex = array_search($package->getRepository(), $repositories, true);
 
-        unset($this->loadedPerRepo[$repoIndex][$package->getName()][$package->getVersion()]);
-        unset($this->packages[$index]);
+        unset($this->loadedPerRepo[$repoIndex][$package->getName()][$package->getVersion()], $this->packages[$index]);
+        
         if (isset($this->aliasMap[spl_object_hash($package)])) {
             foreach ($this->aliasMap[spl_object_hash($package)] as $aliasIndex => $aliasPackage) {
-                unset($this->loadedPerRepo[$repoIndex][$aliasPackage->getName()][$aliasPackage->getVersion()]);
-                unset($this->packages[$aliasIndex]);
+                unset($this->loadedPerRepo[$repoIndex][$aliasPackage->getName()][$aliasPackage->getVersion()], $this->packages[$aliasIndex]);
+                
             }
             unset($this->aliasMap[spl_object_hash($package)]);
         }


### PR DESCRIPTION
Calling unset on multiple items should be done in one call.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
