### PR TITLE
Error suppression

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -143,7 +143,7 @@ class AutoloadGenerator
      */
     public function setIgnorePlatformRequirements($ignorePlatformReqs)
     {
-        trigger_error('AutoloadGenerator::setIgnorePlatformRequirements is deprecated since Composer 2.2, use setPlatformRequirementFilter instead.', E_USER_DEPRECATED);
+        @trigger_error('AutoloadGenerator::setIgnorePlatformRequirements is deprecated since Composer 2.2, use setPlatformRequirementFilter instead.', E_USER_DEPRECATED);
 
         $this->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
     }

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -391,7 +391,7 @@ class Config
                 }
 
                 if ($value === 'symlink') {
-                    trigger_error('config.bin-compat "symlink" is deprecated since Composer 2.2, use auto, full (for Windows compatibility) or proxy instead.', E_USER_DEPRECATED);
+                    @trigger_error('config.bin-compat "symlink" is deprecated since Composer 2.2, use auto, full (for Windows compatibility) or proxy instead.', E_USER_DEPRECATED);
                 }
 
                 return $value;

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1298,7 +1298,7 @@ class Installer
      */
     public function setIgnorePlatformRequirements($ignorePlatformReqs): self
     {
-        trigger_error('Installer::setIgnorePlatformRequirements is deprecated since Composer 2.2, use setPlatformRequirementFilter instead.', E_USER_DEPRECATED);
+        @trigger_error('Installer::setIgnorePlatformRequirements is deprecated since Composer 2.2, use setPlatformRequirementFilter instead.', E_USER_DEPRECATED);
 
         return $this->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs));
     }

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -52,7 +52,7 @@ class ArrayLoader implements LoaderInterface
     public function load(array $config, string $class = 'Composer\Package\CompletePackage'): BasePackage
     {
         if ($class !== 'Composer\Package\CompletePackage' && $class !== 'Composer\Package\RootPackage') {
-            trigger_error('The $class arg is deprecated, please reach out to Composer maintainers ASAP if you still need this.', E_USER_DEPRECATED);
+            @trigger_error('The $class arg is deprecated, please reach out to Composer maintainers ASAP if you still need this.', E_USER_DEPRECATED);
         }
 
         $package = $this->createObject($config, $class);
@@ -258,7 +258,7 @@ class ArrayLoader implements LoaderInterface
                 }
                 foreach (array('composer', 'php', 'putenv') as $reserved) {
                     if (isset($config['scripts'][$reserved])) {
-                        trigger_error('The `'.$reserved.'` script name is reserved for internal use, please avoid defining it', E_USER_DEPRECATED);
+                        @trigger_error('The `'.$reserved.'` script name is reserved for internal use, please avoid defining it', E_USER_DEPRECATED);
                     }
                 }
                 $package->setScripts($config['scripts']);

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -70,7 +70,7 @@ class RootPackageLoader extends ArrayLoader
     public function load(array $config, string $class = 'Composer\Package\RootPackage', ?string $cwd = null): BasePackage
     {
         if ($class !== 'Composer\Package\RootPackage') {
-            trigger_error('The $class arg is deprecated, please reach out to Composer maintainers ASAP if you still need this.', E_USER_DEPRECATED);
+            @trigger_error('The $class arg is deprecated, please reach out to Composer maintainers ASAP if you still need this.', E_USER_DEPRECATED);
         }
 
         if (!isset($config['name'])) {

--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -52,7 +52,7 @@ class ValidatingArrayLoader implements LoaderInterface
         $this->flags = $flags;
 
         if ($strictName !== true) { // @phpstan-ignore-line
-            trigger_error('$strictName must be set to true in ValidatingArrayLoader\'s constructor as of 2.2, and it will be removed in 3.0', E_USER_DEPRECATED);
+            @trigger_error('$strictName must be set to true in ValidatingArrayLoader\'s constructor as of 2.2, and it will be removed in 3.0', E_USER_DEPRECATED);
         }
     }
 

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -78,7 +78,7 @@ class VersionSelector
         if (null === $platformRequirementFilter) {
             $platformRequirementFilter = PlatformRequirementFilterFactory::ignoreNothing();
         } elseif (!($platformRequirementFilter instanceof PlatformRequirementFilterInterface)) {
-            trigger_error('VersionSelector::findBestCandidate with ignored platform reqs as bool|array is deprecated since Composer 2.2, use an instance of PlatformRequirementFilterInterface instead.', E_USER_DEPRECATED);
+            @trigger_error('VersionSelector::findBestCandidate with ignored platform reqs as bool|array is deprecated since Composer 2.2, use an instance of PlatformRequirementFilterInterface instead.', E_USER_DEPRECATED);
             $platformRequirementFilter = PlatformRequirementFilterFactory::fromBoolOrList($platformRequirementFilter);
         }
 

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -385,7 +385,7 @@ class PluginManager
     public function addPlugin(PluginInterface $plugin, bool $isGlobalPlugin = false, PackageInterface $sourcePackage = null): void
     {
         if ($sourcePackage === null) {
-            trigger_error('Calling PluginManager::addPlugin without $sourcePackage is deprecated, if you are using this please get in touch with us to explain the use case', E_USER_DEPRECATED);
+            @trigger_error('Calling PluginManager::addPlugin without $sourcePackage is deprecated, if you are using this please get in touch with us to explain the use case', E_USER_DEPRECATED);
         } elseif (!$this->isPluginAllowed($sourcePackage->getName(), $isGlobalPlugin)) {
             $this->io->writeError('Skipped loading "'.get_class($plugin).' from '.$sourcePackage->getName() . '" '.($isGlobalPlugin ? '(installed globally) ' : '').' as it is not in config.allow-plugins', true, IOInterface::DEBUG);
 

--- a/src/Composer/Plugin/PostFileDownloadEvent.php
+++ b/src/Composer/Plugin/PostFileDownloadEvent.php
@@ -63,7 +63,7 @@ class PostFileDownloadEvent extends Event
         if ($context === null && $type instanceof PackageInterface) {
             $context = $type;
             $type = 'package';
-            trigger_error('PostFileDownloadEvent::__construct should receive a $type=package and the package object in $context since Composer 2.1.', E_USER_DEPRECATED);
+            @trigger_error('PostFileDownloadEvent::__construct should receive a $type=package and the package object in $context since Composer 2.1.', E_USER_DEPRECATED);
         }
 
         parent::__construct($name);
@@ -129,7 +129,7 @@ class PostFileDownloadEvent extends Event
      */
     public function getPackage(): ?PackageInterface
     {
-        trigger_error('PostFileDownloadEvent::getPackage is deprecated since Composer 2.1, use getContext instead.', E_USER_DEPRECATED);
+        @trigger_error('PostFileDownloadEvent::getPackage is deprecated since Composer 2.1, use getContext instead.', E_USER_DEPRECATED);
         $context = $this->getContext();
 
         return $context instanceof PackageInterface ? $context : null;


### PR DESCRIPTION
Error control operator should be added to deprecation notices and/or removed from other cases.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
