### PR TITLE
Fopen flags

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -135,7 +135,7 @@ class Application extends BaseApplication
         $this->disablePluginsByDefault = $input->hasParameterOption('--no-plugins');
         $this->disableScriptsByDefault = $input->hasParameterOption('--no-scripts');
 
-        $stdin = defined('STDIN') ? STDIN : fopen('php://stdin', 'r');
+        $stdin = defined('STDIN') ? STDIN : fopen('php://stdin', 'rb');
         if (Platform::getEnv('COMPOSER_NO_INTERACTION') || $stdin === false || !Platform::isTty($stdin)) {
             $input->setInteractive(false);
         }

--- a/src/Composer/IO/BufferIO.php
+++ b/src/Composer/IO/BufferIO.php
@@ -40,7 +40,7 @@ class BufferIO extends ConsoleIO
         $input = new StringInput($input);
         $input->setInteractive(false);
 
-        $output = new StreamOutput(fopen('php://memory', 'rw'), $verbosity, $formatter ? $formatter->isDecorated() : false, $formatter);
+        $output = new StreamOutput(fopen('php://memory', 'rwb'), $verbosity, $formatter ? $formatter->isDecorated() : false, $formatter);
 
         parent::__construct($input, $output, new HelperSet(array(
             new QuestionHelper(),
@@ -94,7 +94,7 @@ class BufferIO extends ConsoleIO
      */
     private function createStream(array $inputs)
     {
-        $stream = fopen('php://memory', 'r+');
+        $stream = fopen('php://memory', 'r+b');
 
         foreach ($inputs as $input) {
             fwrite($stream, $input.PHP_EOL);

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -155,7 +155,7 @@ class BinaryInstaller
             return 'call';
         }
 
-        $handle = fopen($bin, 'r');
+        $handle = fopen($bin, 'rb');
         $line = fgets($handle);
         fclose($handle);
         if (Preg::isMatch('{^#!/(?:usr/bin/env )?(?:[^/]+/)*(.+)$}m', $line, $match)) {

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -915,9 +915,9 @@ class Filesystem
     public function safeCopy(string $source, string $target)
     {
         if (!file_exists($target) || !file_exists($source) || !$this->filesAreEqual($source, $target)) {
-            $sourceHandle = fopen($source, 'r');
+            $sourceHandle = fopen($source, 'rb');
             assert($sourceHandle !== false, 'Could not open "'.$source.'" for reading.');
-            $targetHandle = fopen($target, 'w+');
+            $targetHandle = fopen($target, 'w+b');
             assert($targetHandle !== false, 'Could not open "'.$target.'" for writing.');
 
             stream_copy_to_stream($sourceHandle, $targetHandle);

--- a/src/Composer/Util/Perforce.php
+++ b/src/Composer/Util/Perforce.php
@@ -482,7 +482,7 @@ class Perforce
     public function writeP4ClientSpec(): void
     {
         $clientSpec = $this->getP4ClientSpec();
-        $spec = fopen($clientSpec, 'w');
+        $spec = fopen($clientSpec, 'wb');
         try {
             $this->writeClientSpecToFile($spec);
         } catch (\Exception $e) {

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -200,7 +200,7 @@ class Platform
     public static function isTty($fd = null): bool
     {
         if ($fd === null) {
-            $fd = defined('STDOUT') ? STDOUT : fopen('php://stdout', 'w');
+            $fd = defined('STDOUT') ? STDOUT : fopen('php://stdout', 'wb');
             if ($fd === false) {
                 return false;
             }


### PR DESCRIPTION
The flags in fopen calls must omit t, and b must be omitted or included consistently.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
