### PR TITLE
Integer literal case

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -561,7 +561,7 @@ EOT
             $errors['openssl'] = true;
         }
 
-        if (extension_loaded('openssl') && OPENSSL_VERSION_NUMBER < 0x1000100f) {
+        if (extension_loaded('openssl') && OPENSSL_VERSION_NUMBER < 0x1000100F) {
             $warnings['openssl_version'] = true;
         }
 

--- a/src/Composer/Util/NoProxyPattern.php
+++ b/src/Composer/Util/NoProxyPattern.php
@@ -288,7 +288,7 @@ class NoProxyPattern
         }
 
         if ($remainder = $prefix % 8) {
-            $mask .= chr(0xff ^ (0xff >> $remainder));
+            $mask .= chr(0xFF ^ (0xFF >> $remainder));
         }
 
         $mask = str_pad($mask, $size, chr(0));


### PR DESCRIPTION
Integer literals must be in correct case.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
