### PR TITLE
No useless return

### DIFF
--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -470,7 +470,7 @@ EOT
 
     protected function interact(InputInterface $input, OutputInterface $output): void
     {
-        return;
+        
     }
 
     /**

--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -181,6 +181,6 @@ abstract class VcsDriver implements VcsDriverInterface
      */
     public function cleanup(): void
     {
-        return;
+        
     }
 }


### PR DESCRIPTION
There should not be an empty return statement at the end of a function.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
