### PR TITLE
Php unit dedicate assert

### DIFF
--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -1820,7 +1820,7 @@ EOF;
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', true, '_1');
 
         if (null === $expectedFixture) {
-            $this->assertFalse(file_exists($this->vendorDir . '/composer/platform_check.php'));
+            $this->assertFileNotExists($this->vendorDir . '/composer/platform_check.php');
             $this->assertStringNotContainsString("require __DIR__ . '/platform_check.php';", (string) file_get_contents($this->vendorDir.'/composer/autoload_real.php'));
         } else {
             $this->assertFileContentEquals(__DIR__ . '/Fixtures/platform/' . $expectedFixture . '.php', $this->vendorDir . '/composer/platform_check.php');

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -1820,7 +1820,7 @@ EOF;
         $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', true, '_1');
 
         if (null === $expectedFixture) {
-            $this->assertFileNotExists($this->vendorDir . '/composer/platform_check.php');
+            $this->assertFileDoesNotExist($this->vendorDir . '/composer/platform_check.php');
             $this->assertStringNotContainsString("require __DIR__ . '/platform_check.php';", (string) file_get_contents($this->vendorDir.'/composer/autoload_real.php'));
         } else {
             $this->assertFileContentEquals(__DIR__ . '/Fixtures/platform/' . $expectedFixture . '.php', $this->vendorDir . '/composer/platform_check.php');

--- a/tests/Composer/Test/IO/NullIOTest.php
+++ b/tests/Composer/Test/IO/NullIOTest.php
@@ -42,7 +42,7 @@ class NullIOTest extends TestCase
     {
         $io = new NullIO();
 
-        $this->assertTrue(is_array($io->getAuthentications())); // @phpstan-ignore-line
+        $this->assertInternalType('array', $io->getAuthentications()); // @phpstan-ignore-line
         $this->assertEmpty($io->getAuthentications());
         $this->assertEquals(array('username' => null, 'password' => null), $io->getAuthentication('foo'));
     }

--- a/tests/Composer/Test/IO/NullIOTest.php
+++ b/tests/Composer/Test/IO/NullIOTest.php
@@ -42,7 +42,7 @@ class NullIOTest extends TestCase
     {
         $io = new NullIO();
 
-        $this->assertInternalType('array', $io->getAuthentications()); // @phpstan-ignore-line
+        $this->assertIsArray($io->getAuthentications()); // @phpstan-ignore-line
         $this->assertEmpty($io->getAuthentications());
         $this->assertEquals(array('username' => null, 'password' => null), $io->getAuthentication('foo'));
     }

--- a/tests/Composer/Test/Repository/CompositeRepositoryTest.php
+++ b/tests/Composer/Test/Repository/CompositeRepositoryTest.php
@@ -123,7 +123,7 @@ class CompositeRepositoryTest extends TestCase
 
         $repo = new CompositeRepository(array($arrayRepoOne, $arrayRepoTwo));
 
-        $this->assertEquals(2, count($repo), "Should return '2' for count(\$repo)");
+        $this->assertCount(2, $repo, "Should return '2' for count(\$repo)");
     }
 
     /**

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -345,13 +345,13 @@ class FilesystemTest extends TestCase
         $this->assertDirectoryExists($this->workingDir . '/foop', 'Not a directory: ' . $this->workingDir . '/foop');
         $this->assertDirectoryExists($this->workingDir . '/foop/bar', 'Not a directory: ' . $this->workingDir . '/foop/bar');
         $this->assertDirectoryExists($this->workingDir . '/foop/baz', 'Not a directory: ' . $this->workingDir . '/foop/baz');
-        $this->assertTrue(is_file($this->workingDir . '/foop/foo.file'), 'Not a file: ' . $this->workingDir . '/foop/foo.file');
-        $this->assertTrue(is_file($this->workingDir . '/foop/bar/foobar.file'), 'Not a file: ' . $this->workingDir . '/foop/bar/foobar.file');
-        $this->assertTrue(is_file($this->workingDir . '/foop/baz/foobaz.file'), 'Not a file: ' . $this->workingDir . '/foop/baz/foobaz.file');
+        $this->assertFileExists($this->workingDir . '/foop/foo.file', 'Not a file: ' . $this->workingDir . '/foop/foo.file');
+        $this->assertFileExists($this->workingDir . '/foop/bar/foobar.file', 'Not a file: ' . $this->workingDir . '/foop/bar/foobar.file');
+        $this->assertFileExists($this->workingDir . '/foop/baz/foobaz.file', 'Not a file: ' . $this->workingDir . '/foop/baz/foobaz.file');
 
         $result2 = $fs->copy($this->testFile, $this->workingDir . '/testfile.file');
         $this->assertTrue($result2);
-        $this->assertTrue(is_file($this->workingDir . '/testfile.file'));
+        $this->assertFileExists($this->workingDir . '/testfile.file');
     }
 
     public function testCopyThenRemove(): void
@@ -366,12 +366,12 @@ class FilesystemTest extends TestCase
         $fs = new Filesystem();
 
         $fs->copyThenRemove($this->testFile, $this->workingDir . '/testfile.file');
-        $this->assertFalse(is_file($this->testFile), 'Still a file: ' . $this->testFile);
+        $this->assertFileDoesNotExist($this->testFile, 'Still a file: ' . $this->testFile);
 
         $fs->copyThenRemove($this->workingDir . '/foo', $this->workingDir . '/foop');
-        $this->assertFalse(is_file($this->workingDir . '/foo/baz/foobaz.file'), 'Still a file: ' . $this->workingDir . '/foo/baz/foobaz.file');
-        $this->assertFalse(is_file($this->workingDir . '/foo/bar/foobar.file'), 'Still a file: ' . $this->workingDir . '/foo/bar/foobar.file');
-        $this->assertFalse(is_file($this->workingDir . '/foo/foo.file'), 'Still a file: ' . $this->workingDir . '/foo/foo.file');
+        $this->assertFileDoesNotExist($this->workingDir . '/foo/baz/foobaz.file', 'Still a file: ' . $this->workingDir . '/foo/baz/foobaz.file');
+        $this->assertFileDoesNotExist($this->workingDir . '/foo/bar/foobar.file', 'Still a file: ' . $this->workingDir . '/foo/bar/foobar.file');
+        $this->assertFileDoesNotExist($this->workingDir . '/foo/foo.file', 'Still a file: ' . $this->workingDir . '/foo/foo.file');
         $this->assertDirectoryDoesNotExist($this->workingDir . '/foo/baz', 'Still a directory: ' . $this->workingDir . '/foo/baz');
         $this->assertDirectoryDoesNotExist($this->workingDir . '/foo/bar', 'Still a directory: ' . $this->workingDir . '/foo/bar');
         $this->assertDirectoryDoesNotExist($this->workingDir . '/foo', 'Still a directory: ' . $this->workingDir . '/foo');

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -324,9 +324,9 @@ class FilesystemTest extends TestCase
         $this->assertTrue($fs->isJunction($junction . '/../junction'), $junction . '/../junction: is a junction');
 
         // Remove junction
-        $this->assertTrue(is_dir($junction), $junction . ' is a directory');
+        $this->assertDirectoryExists($junction, $junction . ' is a directory');
         $this->assertTrue($fs->removeJunction($junction), $junction . ' has been removed');
-        $this->assertFalse(is_dir($junction), $junction . ' is not a directory');
+        $this->assertDirectoryNotExists($junction, $junction . ' is not a directory');
     }
 
     public function testCopy(): void
@@ -342,9 +342,9 @@ class FilesystemTest extends TestCase
 
         $result1 = $fs->copy($this->workingDir . '/foo', $this->workingDir . '/foop');
         $this->assertTrue($result1, 'Copying directory failed.');
-        $this->assertTrue(is_dir($this->workingDir . '/foop'), 'Not a directory: ' . $this->workingDir . '/foop');
-        $this->assertTrue(is_dir($this->workingDir . '/foop/bar'), 'Not a directory: ' . $this->workingDir . '/foop/bar');
-        $this->assertTrue(is_dir($this->workingDir . '/foop/baz'), 'Not a directory: ' . $this->workingDir . '/foop/baz');
+        $this->assertDirectoryExists($this->workingDir . '/foop', 'Not a directory: ' . $this->workingDir . '/foop');
+        $this->assertDirectoryExists($this->workingDir . '/foop/bar', 'Not a directory: ' . $this->workingDir . '/foop/bar');
+        $this->assertDirectoryExists($this->workingDir . '/foop/baz', 'Not a directory: ' . $this->workingDir . '/foop/baz');
         $this->assertTrue(is_file($this->workingDir . '/foop/foo.file'), 'Not a file: ' . $this->workingDir . '/foop/foo.file');
         $this->assertTrue(is_file($this->workingDir . '/foop/bar/foobar.file'), 'Not a file: ' . $this->workingDir . '/foop/bar/foobar.file');
         $this->assertTrue(is_file($this->workingDir . '/foop/baz/foobaz.file'), 'Not a file: ' . $this->workingDir . '/foop/baz/foobaz.file');
@@ -372,8 +372,8 @@ class FilesystemTest extends TestCase
         $this->assertFalse(is_file($this->workingDir . '/foo/baz/foobaz.file'), 'Still a file: ' . $this->workingDir . '/foo/baz/foobaz.file');
         $this->assertFalse(is_file($this->workingDir . '/foo/bar/foobar.file'), 'Still a file: ' . $this->workingDir . '/foo/bar/foobar.file');
         $this->assertFalse(is_file($this->workingDir . '/foo/foo.file'), 'Still a file: ' . $this->workingDir . '/foo/foo.file');
-        $this->assertFalse(is_dir($this->workingDir . '/foo/baz'), 'Still a directory: ' . $this->workingDir . '/foo/baz');
-        $this->assertFalse(is_dir($this->workingDir . '/foo/bar'), 'Still a directory: ' . $this->workingDir . '/foo/bar');
-        $this->assertFalse(is_dir($this->workingDir . '/foo'), 'Still a directory: ' . $this->workingDir . '/foo');
+        $this->assertDirectoryNotExists($this->workingDir . '/foo/baz', 'Still a directory: ' . $this->workingDir . '/foo/baz');
+        $this->assertDirectoryNotExists($this->workingDir . '/foo/bar', 'Still a directory: ' . $this->workingDir . '/foo/bar');
+        $this->assertDirectoryNotExists($this->workingDir . '/foo', 'Still a directory: ' . $this->workingDir . '/foo');
     }
 }

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -326,7 +326,7 @@ class FilesystemTest extends TestCase
         // Remove junction
         $this->assertDirectoryExists($junction, $junction . ' is a directory');
         $this->assertTrue($fs->removeJunction($junction), $junction . ' has been removed');
-        $this->assertDirectoryNotExists($junction, $junction . ' is not a directory');
+        $this->assertDirectoryDoesNotExist($junction, $junction . ' is not a directory');
     }
 
     public function testCopy(): void
@@ -372,8 +372,8 @@ class FilesystemTest extends TestCase
         $this->assertFalse(is_file($this->workingDir . '/foo/baz/foobaz.file'), 'Still a file: ' . $this->workingDir . '/foo/baz/foobaz.file');
         $this->assertFalse(is_file($this->workingDir . '/foo/bar/foobar.file'), 'Still a file: ' . $this->workingDir . '/foo/bar/foobar.file');
         $this->assertFalse(is_file($this->workingDir . '/foo/foo.file'), 'Still a file: ' . $this->workingDir . '/foo/foo.file');
-        $this->assertDirectoryNotExists($this->workingDir . '/foo/baz', 'Still a directory: ' . $this->workingDir . '/foo/baz');
-        $this->assertDirectoryNotExists($this->workingDir . '/foo/bar', 'Still a directory: ' . $this->workingDir . '/foo/bar');
-        $this->assertDirectoryNotExists($this->workingDir . '/foo', 'Still a directory: ' . $this->workingDir . '/foo');
+        $this->assertDirectoryDoesNotExist($this->workingDir . '/foo/baz', 'Still a directory: ' . $this->workingDir . '/foo/baz');
+        $this->assertDirectoryDoesNotExist($this->workingDir . '/foo/bar', 'Still a directory: ' . $this->workingDir . '/foo/bar');
+        $this->assertDirectoryDoesNotExist($this->workingDir . '/foo', 'Still a directory: ' . $this->workingDir . '/foo');
     }
 }


### PR DESCRIPTION
PHPUnit assertions like assertInternalType, assertFileExists, should be used over assertTrue.

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
