### PR TITLE
Audit command docs: Remove currently restriction

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1004,7 +1004,7 @@ php composer.phar archive vendor/package 2.0.21 --format=zip
 ## audit
 
 This command is used to audit the packages you have installed
-for possible security issues. Currently this only checks for and
+for possible security issues. It checks for and
 lists security vulnerability advisories according to the
 [Packagist.org api](https://packagist.org/apidoc#list-security-advisories).
 


### PR DESCRIPTION
- No reason to state that the audit command "currently" only checks packagist.org. It should stay that way, if we need to add more sources, we can add them to packagist.org.