### PR TITLE
Fix: ValidatingArrayLoader [TypeError]: strcasecmp(): Argument #1() must be of type string, int given

### DIFF
--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -252,6 +252,7 @@ class ValidatingArrayLoader implements LoaderInterface
         foreach (array_keys(BasePackage::$supportedLinkTypes) as $linkType) {
             if ($this->validateArray($linkType) && isset($this->config[$linkType])) {
                 foreach ($this->config[$linkType] as $package => $constraint) {
+                    $package = (string) $package;
                     if (0 === strcasecmp($package, $this->config['name'])) {
                         $this->errors[] = $linkType.'.'.$package.' : a package cannot set a '.$linkType.' on itself';
                         unset($this->config[$linkType][$package]);

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -424,7 +424,7 @@ class ValidatingArrayLoaderTest extends TestCase
                     'name' => 'foo/bar',
                     'replace' => array('acme/bar'),
                 ),
-                array('replace.0 : invalid version constraint (Could not parse version constraint foo/Bar: Invalid version string "foo/Bar")')
+                array('replace.0 : invalid version constraint (Could not parse version constraint acme/bar: Invalid version string "acme/bar")')
             ),
         ));
     }

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -419,6 +419,13 @@ class ValidatingArrayLoaderTest extends TestCase
                     'dist.url : must be present',
                 ),
             ),
+            array(
+                array(
+                    'name' => 'foo/bar',
+                    'replace' => array('acme/bar'),
+                ),
+                array('require.0 : invalid version constraint (Could not parse version constraint foo/Bar: Invalid version string "foo/Bar")')
+            ),
         ));
     }
 

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -424,7 +424,7 @@ class ValidatingArrayLoaderTest extends TestCase
                     'name' => 'foo/bar',
                     'replace' => array('acme/bar'),
                 ),
-                array('require.0 : invalid version constraint (Could not parse version constraint foo/Bar: Invalid version string "foo/Bar")')
+                array('replace.0 : invalid version constraint (Could not parse version constraint foo/Bar: Invalid version string "foo/Bar")')
             ),
         ));
     }


### PR DESCRIPTION
Fixes https://github.com/composer/packagist/issues/1318