### PR TITLE
Generate autoload files only when some config or package changed

### DIFF
--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -97,6 +97,13 @@ EOT
         $generator->setApcu($apcu, $apcuPrefix);
         $generator->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input));
         $classMap = $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
+
+        if ($classMap === null) {
+            $this->getIO()->write('<info>Skipped autoload generation, nothing changed</info>');
+
+            return 0;
+        }
+
         $numberOfClasses = count($classMap);
 
         if ($authoritative) {

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -348,7 +348,10 @@ class Installer
             $this->autoloadGenerator->setApcu($this->apcuAutoloader, $this->apcuAutoloaderPrefix);
             $this->autoloadGenerator->setRunScripts($this->runScripts);
             $this->autoloadGenerator->setPlatformRequirementFilter($this->platformRequirementFilter);
-            $this->autoloadGenerator->dump($this->config, $localRepo, $this->package, $this->installationManager, 'composer', $this->optimizeAutoloader);
+            $result = $this->autoloadGenerator->dump($this->config, $localRepo, $this->package, $this->installationManager, 'composer', $this->optimizeAutoloader);
+            if ($result === null) {
+                $this->io->writeError('<info>Skipped autoload generation, nothing changed</info>');
+            }
         }
 
         if ($this->install && $this->executeOperations) {


### PR DESCRIPTION
Fixes #10792

This is in theory a nice change IMO, minor perf boost when an `install` ends up not changing anything.

In practice however I worry this will miss changes. One problem I can think of is with `path` repositories, a symlink package may have some changes on disk which are not reflected by a reference change in installed.json, and will thus not be detected. This might be fixable by detecting whether any package has a dist type of `path`. 

So I don't know if it's worth going further.. Will there be other edge cases/regressions?

cc @btxtiger