### PR TITLE
Fix TypeError

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -342,7 +342,7 @@ EOT
                     return;
                 }
                 $value = $value ?: $author;
-                $author = $this->parseAuthorString($value);
+                $author = $this->parseAuthorString($value ?? '');
 
                 if ($author['email'] === null) {
                     return $author['name'];


### PR DESCRIPTION
Fix string type requirement in case of NULL value:

    [TypeError]                                                                                                                                                                  
    Composer\Command\InitCommand::parseAuthorString(): Argument #1 ($author) must be of type string, null given, called in phar:///composer.phar/src/Composer/Command/InitCommand.php on line 345

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
