### PR TITLE
Correctly merge boolean flag of allow-plugin config

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -34,7 +34,7 @@ class Config
     public static $defaultConfig = array(
         'process-timeout' => 300,
         'use-include-path' => false,
-        'allow-plugins' => null, // null for BC for now, will become array() after July 2022
+        'allow-plugins' => array(),
         'use-parent-dir' => 'prompt',
         'preferred-install' => 'dist',
         'notify-on-install' => true,
@@ -119,11 +119,6 @@ class Config
         // load defaults
         $this->config = static::$defaultConfig;
 
-        // TODO after July 2022 remove this and update the default value above in self::$defaultConfig + remove note from 06-config.md
-        if (strtotime('2022-07-01') < time()) {
-            $this->config['allow-plugins'] = array();
-        }
-
         $this->repositories = static::$defaultRepositories;
         $this->useEnvironment = (bool) $useEnvironment;
         $this->baseDir = $baseDir;
@@ -188,7 +183,7 @@ class Config
                 } elseif (in_array($key, array('allow-plugins'), true) && isset($this->config[$key]) && is_array($this->config[$key]) && is_array($val)) {
                     // merging $val first to get the local config on top of the global one, then appending the global config,
                     // then merging local one again to make sure the values from local win over global ones for keys present in both
-                    $this->config[$key] = array_merge($val, $this->config[$key], $val);
+                    $this->config[$key] = array_values(array_merge($val, $this->config[$key], $val));
                     $this->setSourceOfConfigValue($val, $key, $source);
                 } elseif (in_array($key, array('gitlab-domains', 'github-domains'), true) && isset($this->config[$key])) {
                     $this->config[$key] = array_unique(array_merge($this->config[$key], $val));

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -183,7 +183,7 @@ class Config
                 } elseif (in_array($key, array('allow-plugins'), true) && isset($this->config[$key]) && is_array($this->config[$key]) && is_array($val)) {
                     // merging $val first to get the local config on top of the global one, then appending the global config,
                     // then merging local one again to make sure the values from local win over global ones for keys present in both
-                    $this->config[$key] = array_values(array_merge($val, $this->config[$key], $val));
+                    $this->config[$key] = array_merge($val, $this->config[$key], $val);
                     $this->setSourceOfConfigValue($val, $key, $source);
                 } elseif (in_array($key, array('gitlab-domains', 'github-domains'), true) && isset($this->config[$key])) {
                     $this->config[$key] = array_unique(array_merge($this->config[$key], $val));

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -185,7 +185,7 @@ class Config
                 if (in_array($key, array('bitbucket-oauth', 'github-oauth', 'gitlab-oauth', 'gitlab-token', 'http-basic', 'bearer'), true) && isset($this->config[$key])) {
                     $this->config[$key] = array_merge($this->config[$key], $val);
                     $this->setSourceOfConfigValue($val, $key, $source);
-                } elseif (in_array($key, array('allow-plugins'), true) && isset($this->config[$key]) && is_array($this->config[$key])) {
+                } elseif (in_array($key, array('allow-plugins'), true) && isset($this->config[$key]) && is_array($this->config[$key]) && is_array($val)) {
                     // merging $val first to get the local config on top of the global one, then appending the global config,
                     // then merging local one again to make sure the values from local win over global ones for keys present in both
                     $this->config[$key] = array_merge($val, $this->config[$key], $val);

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -378,7 +378,7 @@ class ConfigTest extends TestCase
         $config->merge(array('config' => array('allow-plugins' => array('some/plugin'))));
         $this->assertEquals(array('some/plugin'), $config->get('allow-plugins'));
 
-        $config->merge(array('config' => array('allow-plugins' => array('another/package'))));
+        $config->merge(array('config' => array('allow-plugins' => array('another/plugin'))));
         $this->assertEquals(array('some/plugin', 'another/plugin'), $config->get('allow-plugins'));
     }
 
@@ -388,7 +388,7 @@ class ConfigTest extends TestCase
         $config->merge(array('config' => array('allow-plugins' => true)));
         $this->assertEquals(true, $config->get('allow-plugins'));
 
-        $config->merge(array('config' => array('allow-plugins' => array('another/package'))));
+        $config->merge(array('config' => array('allow-plugins' => array('another/plugin'))));
         $this->assertEquals(array('another/plugin'), $config->get('allow-plugins'));
     }
 

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -375,11 +375,11 @@ class ConfigTest extends TestCase
     public function testMergesPluginConfig()
     {
         $config = new Config(false);
-        $config->merge(array('config' => array('allow-plugins' => array('some/plugin'))));
+        $config->merge(array('config' => array('allow-plugins' => array('some/plugin' => true))));
         $this->assertEquals(array('some/plugin'), $config->get('allow-plugins'));
 
-        $config->merge(array('config' => array('allow-plugins' => array('another/plugin'))));
-        $this->assertEquals(array('some/plugin', 'another/plugin'), $config->get('allow-plugins'));
+        $config->merge(array('config' => array('allow-plugins' => array('another/plugin' => true))));
+        $this->assertEquals(array('some/plugin' => true, 'another/plugin' => true), $config->get('allow-plugins'));
     }
 
     public function testOverridesGlobalBooleanPluginsConfig()
@@ -388,14 +388,14 @@ class ConfigTest extends TestCase
         $config->merge(array('config' => array('allow-plugins' => true)));
         $this->assertEquals(true, $config->get('allow-plugins'));
 
-        $config->merge(array('config' => array('allow-plugins' => array('another/plugin'))));
-        $this->assertEquals(array('another/plugin'), $config->get('allow-plugins'));
+        $config->merge(array('config' => array('allow-plugins' => array('another/plugin' => true))));
+        $this->assertEquals(array('another/plugin' => true), $config->get('allow-plugins'));
     }
 
     public function testAllowsAllPluginsFromLocalBoolean()
     {
         $config = new Config(false);
-        $config->merge(array('config' => array('allow-plugins' => array('some/plugin'))));
+        $config->merge(array('config' => array('allow-plugins' => array('some/plugin' => true))));
         $this->assertEquals(array('some/plugin'), $config->get('allow-plugins'));
 
         $config->merge(array('config' => array('allow-plugins' => true)));

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -371,4 +371,34 @@ class ConfigTest extends TestCase
 
         $this->assertEquals('COMPOSER_HTACCESS_PROTECT', $result);
     }
+
+    public function testMergesPluginConfig()
+    {
+        $config = new Config(false);
+        $config->merge(array('config' => array('allow-plugins' => array('some/plugin'))));
+        $this->assertEquals(array('some/plugin'), $config->get('allow-plugins'));
+
+        $config->merge(array('config' => array('allow-plugins' => array('another/package'))));
+        $this->assertEquals(array('some/plugin', 'another/plugin'), $config->get('allow-plugins'));
+    }
+
+    public function testOverridesGlobalBooleanPluginsConfig()
+    {
+        $config = new Config(false);
+        $config->merge(array('config' => array('allow-plugins' => true)));
+        $this->assertEquals(true, $config->get('allow-plugins'));
+
+        $config->merge(array('config' => array('allow-plugins' => array('another/package'))));
+        $this->assertEquals(array('another/plugin'), $config->get('allow-plugins'));
+    }
+
+    public function testAllowsAllPluginsFromLocalBoolean()
+    {
+        $config = new Config(false);
+        $config->merge(array('config' => array('allow-plugins' => array('some/plugin'))));
+        $this->assertEquals(array('some/plugin'), $config->get('allow-plugins'));
+
+        $config->merge(array('config' => array('allow-plugins' => true)));
+        $this->assertEquals(true, $config->get('allow-plugins'));
+    }
 }

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -376,7 +376,7 @@ class ConfigTest extends TestCase
     {
         $config = new Config(false);
         $config->merge(array('config' => array('allow-plugins' => array('some/plugin' => true))));
-        $this->assertEquals(array('some/plugin'), $config->get('allow-plugins'));
+        $this->assertEquals(array('some/plugin' => true), $config->get('allow-plugins'));
 
         $config->merge(array('config' => array('allow-plugins' => array('another/plugin' => true))));
         $this->assertEquals(array('some/plugin' => true, 'another/plugin' => true), $config->get('allow-plugins'));
@@ -396,7 +396,7 @@ class ConfigTest extends TestCase
     {
         $config = new Config(false);
         $config->merge(array('config' => array('allow-plugins' => array('some/plugin' => true))));
-        $this->assertEquals(array('some/plugin'), $config->get('allow-plugins'));
+        $this->assertEquals(array('some/plugin' => true), $config->get('allow-plugins'));
 
         $config->merge(array('config' => array('allow-plugins' => true)));
         $this->assertEquals(true, $config->get('allow-plugins'));


### PR DESCRIPTION
This attempts to fix https://github.com/composer/composer/issues/10907

- if global config has `allow-plugins: true` and local has `allow-plugins: [some-array]`, only local would be allowed
- if local has `allow-plugins: true` and global has an array, local would win and allow everything

I guess that's how it's supposed to work?