### PR TITLE
redownload if zip file is error

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -208,7 +208,15 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
                 }
 
                 if ($checksum && hash_file('sha1', $fileName) !== $checksum) {
-                    throw new \UnexpectedValueException('The checksum verification of the file failed (downloaded from '.$url['base'].')');
+                    // try redownload with file_get_contents
+                    $content = file_get_contents($url['base']);
+                    file_put_contents($fileName, $content);
+                    $newChecksum = hash_file('sha1', $fileName);
+
+                    if ($newChecksum !== $checksum) {
+                        $msgfmt = 'The checksum verification of the file failed (downloaded from %s),expected checksum=%s but actual= %s';
+                        throw new \UnexpectedValueException(sprintf($msgfmt, $url['base'], $checksum, $newChecksum));
+                    }
                 }
 
                 if ($eventDispatcher) {

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -207,15 +207,18 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
                         .' directory is writable and you have internet connectivity');
                 }
 
-                if ($checksum && hash_file('sha1', $fileName) !== $checksum) {
+                $actualHash = hash_file('sha1', $fileName);
+                if ($checksum && $actualHash !== $checksum) {
                     // try redownload with file_get_contents
-                    $content = file_get_contents($url['base']);
-                    file_put_contents($fileName, $content);
-                    $newChecksum = hash_file('sha1', $fileName);
+                    $content = @file_get_contents($url['base']);
+                    if ($content !== false) {
+                        file_put_contents($fileName, $content);
+                        $actualHash = hash_file('sha1', $fileName);
+                    }
 
-                    if ($newChecksum !== $checksum) {
+                    if ($actualHash !== $checksum) {
                         $msgfmt = 'The checksum verification of the file failed (downloaded from %s),expected checksum=%s but actual= %s';
-                        throw new \UnexpectedValueException(sprintf($msgfmt, $url['base'], $checksum, $newChecksum));
+                        throw new \UnexpectedValueException(sprintf($msgfmt, $url['base'], $checksum, $actualHash));
                     }
                 }
 

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -170,8 +170,10 @@ class ZipDownloader extends ArchiveDownloader
                     $output = str_replace(', '.$file.'.zip or '.$file.'.ZIP', '', $output);
 
                     // try redownload with file_get_contents
-                    $content = file_get_contents($package->getDistUrl());
-                    file_put_contents($file, $content);
+                    if ($package->getDistUrl()) {
+                        $content = file_get_contents($package->getDistUrl());
+                        file_put_contents($file, $content);
+                    }
 
                     return $tryFallback(new \RuntimeException('Failed to extract '.$package->getName().': ('.$process->getExitCode().') '.$command."\n\n".$output));
                 }

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -170,7 +170,7 @@ class ZipDownloader extends ArchiveDownloader
                     $output = str_replace(', '.$file.'.zip or '.$file.'.ZIP', '', $output);
 
                     // try redownload with file_get_contents
-                    if (!empty($package->getDistUrl())) {
+                    if (is_string($package->getDistUrl())) {
                         $content = file_get_contents($package->getDistUrl());
                         file_put_contents($file, $content);
                     }

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -170,7 +170,7 @@ class ZipDownloader extends ArchiveDownloader
                     $output = str_replace(', '.$file.'.zip or '.$file.'.ZIP', '', $output);
 
                     // try redownload with file_get_contents
-                    if ($package->getDistUrl()) {
+                    if (!empty($package->getDistUrl())) {
                         $content = file_get_contents($package->getDistUrl());
                         file_put_contents($file, $content);
                     }

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -171,8 +171,10 @@ class ZipDownloader extends ArchiveDownloader
 
                     // try redownload with file_get_contents
                     if (is_string($package->getDistUrl())) {
-                        $content = file_get_contents($package->getDistUrl());
-                        file_put_contents($file, $content);
+                        $content = @file_get_contents($package->getDistUrl());
+                        if ($content !== false) {
+                            file_put_contents($file, $content);
+                        }
                     }
 
                     return $tryFallback(new \RuntimeException('Failed to extract '.$package->getName().': ('.$process->getExitCode().') '.$command."\n\n".$output));

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -169,6 +169,10 @@ class ZipDownloader extends ArchiveDownloader
                     $output = $process->getErrorOutput();
                     $output = str_replace(', '.$file.'.zip or '.$file.'.ZIP', '', $output);
 
+                    // try redownload with file_get_contents
+                    $content = file_get_contents($package->getDistUrl());
+                    file_put_contents($file, $content);
+
                     return $tryFallback(new \RuntimeException('Failed to extract '.$package->getName().': ('.$process->getExitCode().') '.$command."\n\n".$output));
                 }
             });


### PR DESCRIPTION
We found that the services deployed in Europe were wrong when implementing composer install to download dependency from our private nexus. There are two errors, one is that the downloaded code is not a legal zip package, and the other is that the code package checksum is incorrect. We carefully checked the package on nexus, and confirmed that there is no problem with the package. 
Platform infos:
 PHP 7.3
composer 2.2.7

We tried to upgrade to the latest version of composer, but the problem is still there.

Finally, it was solved by re-download the code package when there was an error which is the code of this merge request.

