### PR TITLE
Pre-commit hook to run composer validate

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,3 +7,11 @@
   language: system
   pass_filenames: false
   files: '^composer.(json|lock)$'
+
+- id: composer-validate-strict
+  name: composer validate (strict mode)
+  description: Validates composer.json and composer.lock with --strict mode enabled
+  entry: composer validate --strict
+  language: system
+  pass_filenames: false
+  files: '^composer.(json|lock)$'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+# See https://pre-commit.com/#new-hooks
+- id: composer-validate
+  name: composer validate
+  description: Validates composer.json and composer.lock
+  entry: bin/composer validate
+  language: script
+  pass_filenames: false
+  files: '^composer.(json|lock)$'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,9 @@
 # See https://pre-commit.com/#new-hooks
+# Requires composer to be installed locally
 - id: composer-validate
   name: composer validate
   description: Validates composer.json and composer.lock
-  entry: bin/composer validate
-  language: script
+  entry: composer validate
+  language: system
   pass_filenames: false
   files: '^composer.(json|lock)$'


### PR DESCRIPTION
Is it possible to add a [pre-commit](https://pre-commit.com/) hook to this repo ? [Several projects](https://pre-commit.com/hooks.html) do provide a hook.

Here is a hook that automatically validates `composer.json` and `composer.lock` when one modifies these files and tries to commit those.

How to test this PR:

#### 1. Get an environment with PHP, Composer, Git and Pre-commit

```sh
$ docker run --rm -it php:7.4-cli /bin/sh
$ apt-get update && apt-get install --yes git wget unzip pip vim
$ wget https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer -O - -q | php -- --quiet && mv composer.phar /usr/local/bin/composer
$ pip install pre-commit
$ git config --global user.email "foo@example.com"
$ git config --global user.name "Foo Bar"
```

#### 2. Create a new project with Composer (say, Laravel) and use our pre-commit hook

```sh
$ composer create-project laravel/laravel laravel 4.2.* --no-plugins
$ cd laravel/
$ git init
$ cat <<EOT >> .pre-commit-config.yaml
repos:
  # You would use https://github.com/composer/composer after this PR is merged
  - repo: https://github.com/fengtan/composer
    # You would use a tag after this PR is merged
    rev: cf70a2c62a76c2749ce75790b3519c01d2df2fb6
    hooks:
      - id: composer-validate
EOT
$ pre-commit install
```

#### 3. Simulate an invalid `composer.lock`

```
$ echo foo >> composer.lock
```

#### 4. Try to commit -- the hook will run and fail because of the invalid `composer.lock`

```
$ git add -A
$ git commit
[INFO] Initializing environment for https://github.com/fengtan/composer.
composer validate........................................................Failed
- hook id: composer-validate
- exit code: 1

In JsonFile.php line 349:
                                                 
  "./composer.lock" does not contain valid JSON  
  Parse error on line 2151:                      
  ...version": "2.3.0"}foo                       
  --------------------^                          
  Expected one of: 'EOF', '}', ',', ']'          
```

If/when this is merged we may want to request it to be documented at https://pre-commit.com/hooks.html