### PR TITLE
BUG#AC-5897:Allure reports are not generated for composer builds when…

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -700,7 +700,7 @@ class PluginManager
 
         // This is a BC mode for lock files created pre-Composer-2.2 where the expectation of
         // an allow-plugins config being present cannot be made.
-        if ($rules === null) {
+        if (empty($rules)) {
             if (!$this->io->isInteractive()) {
                 $this->io->writeError('<warning>For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins</warning>');
                 $this->io->writeError('<warning>This warning will become an exception once you run composer update!</warning>');


### PR DESCRIPTION
… running from repo

        - Error while running MFTF test magento 2.4.4-p1 and magento-2.4.5 - magento/composer-dependency-version-audit-plugin contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
