### PR TITLE
Add alias to require command

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -226,7 +226,7 @@ and this feature is only available for your root package dependencies.
 
 Specifying one of the words `mirrors`, `lock`, or `nothing` as an argument has the same effect as specifying the option `--lock`, for example `composer update mirrors` is exactly the same as `composer update --lock`.
 
-## require
+## require / r
 
 The `require` command adds new packages to the `composer.json` file from
 the current directory. If no file exists one will be created on the fly.

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -67,6 +67,7 @@ class RequireCommand extends BaseCommand
     {
         $this
             ->setName('require')
+            ->setAliases(array('r'))
             ->setDescription('Adds required packages to your composer.json and installs them.')
             ->setDefinition(array(
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Optional package name can also include a version constraint, e.g. foo/bar or foo/bar:1.0.0 or foo/bar=1.0.0 or "foo/bar 1.0.0"', null, $this->suggestAvailablePackageInclPlatform()),


### PR DESCRIPTION
I think `require` command is one of most frequency used by developers. Why do not create shortcut alias for it? 
Most commands like `install` or `update` already have shortcut aliases.
Much easy to write `composer r package:version` instead of `composer require package:version`. It will also pretend typo in `require` word within fast-writing cases. 

The PR kindly adds `r` alias to `require` command.