### PR TITLE
Add prompt suggesting using --dev when require command is used with dev packages

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -119,6 +119,10 @@ Examples:
 - redis
 - templating
 
+> **Note**: Some special keywords trigger `composer require` to prompt
+> the user if they would not rather add these packages to `require-dev` in case
+> the command is run without `--dev`. These are: `dev`, `testing`, `static analysis`.
+
 Optional.
 
 ### homepage

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -119,9 +119,9 @@ Examples:
 - redis
 - templating
 
-> **Note**: Some special keywords trigger `composer require` to prompt
-> the user if they would not rather add these packages to `require-dev` in case
-> the command is run without `--dev`. These are: `dev`, `testing`, `static analysis`.
+> **Note**: Some special keywords trigger `composer require` without the
+> `--dev` option to prompt users if they would like to add these packages to
+> `require-dev` instead of `require`. These are: `dev`, `testing`, `static analysis`.
 
 Optional.
 

--- a/src/Composer/Util/PackageSorter.php
+++ b/src/Composer/Util/PackageSorter.php
@@ -18,6 +18,34 @@ use Composer\Package\RootPackageInterface;
 class PackageSorter
 {
     /**
+     * Returns the most recent version of a set of packages
+     *
+     * This is ideally the default branch version, or failing that it will return the package with the highest version
+     *
+     * @template T of PackageInterface
+     * @param array<T> $packages
+     * @return ($packages is non-empty-array<T> ? T : T|null)
+     */
+    public static function getMostCurrentVersion(array $packages): ?PackageInterface
+    {
+        return array_reduce($packages, function ($carry, $pkg) {
+            if ($carry === null) {
+                return $pkg;
+            }
+
+            if ($pkg->isDefaultBranch()) {
+                return $pkg;
+            }
+
+            if (!$carry->isDefaultBranch() && version_compare($carry->getVersion(), $pkg->getVersion(), '<')) {
+                return $pkg;
+            }
+
+            return $carry;
+        });
+    }
+
+    /**
      * Sorts packages by name
      *
      * @template T of PackageInterface


### PR DESCRIPTION
First suggested in https://github.com/composer/composer/discussions/10939

This implements the idea discussed here tho https://github.com/composer/composer/discussions/10939#discussioncomment-3156267

Currently taking `dev`, `testing`, `static analysis` tags as indicator that a package is meant to be in require-dev, then it does this:

<img width="581" alt="image" src="https://user-images.githubusercontent.com/183678/180196760-daacf9e7-bc0d-4ce2-9936-0c3490bdb86c.png">

IMO `testing` and `static analysis` are fairly safe bets. `dev` is almost unused atm, and I took a look at all the top download packages there and only one is arguably not meant to be in require-dev, but they can fix that by removing the tag from the default branch.