### PR TITLE
CheckPlatformReqs: basic json format support

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -413,6 +413,12 @@ Unlike update/install, this command will ignore config.platform settings and
 check the real platform packages so you can be certain you have the required
 platform dependencies.
 
+### Options
+
+* **--lock:** Checks requirements only from the lock file, not from installed packages.
+* **--no-dev:** Disables checking of require-dev packages requirements.
+* **--format (-f):** Format of the output: text (default) or json
+
 ## global
 
 The global command allows you to run other commands like `install`, `remove`, `require`

--- a/src/Composer/Command/CheckPlatformReqsCommand.php
+++ b/src/Composer/Command/CheckPlatformReqsCommand.php
@@ -129,7 +129,8 @@ EOT
                                     $candidate->getName() === $require ? $candidate->getPrettyName() : $require,
                                     $candidateConstraint->getPrettyString(),
                                     $link,
-                                    '<error>failed</error>'.($candidate->getName() === $require ? '' : ' <comment>provided by '.$candidate->getPrettyName().'</comment>'),
+                                    '<error>failed</error>',
+                                    $candidate->getName() === $require ? '' : '<comment>provided by '.$candidate->getPrettyName().'</comment>',
                                 );
 
                                 // skip to next candidate
@@ -141,7 +142,8 @@ EOT
                             $candidate->getName() === $require ? $candidate->getPrettyName() : $require,
                             $candidateConstraint->getPrettyString(),
                             null,
-                            '<info>success</info>'.($candidate->getName() === $require ? '' : ' <comment>provided by '.$candidate->getPrettyName().'</comment>'),
+                            '<info>success</info>',
+                            $candidate->getName() === $require ? '' : '<comment>provided by '.$candidate->getPrettyName().'</comment>',
                         );
 
                         // candidate matched, skip to next requirement
@@ -160,6 +162,7 @@ EOT
                     'n/a',
                     $links[0],
                     '<error>missing</error>',
+                    '',
                 );
 
                 $exitCode = max($exitCode, 2);
@@ -183,22 +186,28 @@ EOT
             /**
              * @var Link|null $link
              */
-            list($platformPackage, $version, $link, $status) = $result;
-            $link = $link ? sprintf('%s %s %s (%s)', $link->getSource(), $link->getDescription(), $link->getTarget(), $link->getPrettyConstraint()) : '';
+            list($platformPackage, $version, $link, $status, $provider) = $result;
 
             if ('json' === $format) {
                 $rows[] = array(
                     "name" => $platformPackage,
                     "version" => $version,
-                    "link" => $link,
-                    "status" => $status,
+                    "status" => strip_tags($status),
+                    "failed_requirement" => $link instanceof Link ? [
+                        'source' => $link->getSource(),
+                        'type' => $link->getDescription(),
+                        'target' => $link->getTarget(),
+                        'constraint' => $link->getPrettyConstraint(),
+                    ] : null,
+                    "provider" => $provider === '' ? null : strip_tags($provider),
                 );
             } else {
                 $rows[] = array(
                     $platformPackage,
                     $version,
                     $link,
-                    $status,
+                    $link ? sprintf('%s %s %s (%s)', $link->getSource(), $link->getDescription(), $link->getTarget(), $link->getPrettyConstraint()) : '',
+                    rtrim($status.' '.$provider),
                 );
             }
         }

--- a/src/Composer/Command/CheckPlatformReqsCommand.php
+++ b/src/Composer/Command/CheckPlatformReqsCommand.php
@@ -15,7 +15,7 @@ namespace Composer\Command;
 use Composer\Package\Link;
 use Composer\Semver\Constraint\Constraint;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
+use Composer\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RootPackageRepository;
@@ -34,7 +34,7 @@ class CheckPlatformReqsCommand extends BaseCommand
             ->setDefinition(array(
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables checking of require-dev packages requirements.'),
                 new InputOption('lock', null, InputOption::VALUE_NONE, 'Checks requirements only from the lock file, not from installed packages.'),
-                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text'),
+                new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text', ['json', 'text']),
             ))
             ->setHelp(
                 <<<EOT


### PR DESCRIPTION
Some very basic json output support for CheckPlatformReqs.
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
