### PR TITLE
[WIP] Add @onWindows @onLinux @onDarwin platform specific dispatcher

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -254,6 +254,24 @@ class EventDispatcher
                 } else {
                     $args = implode(' ', array_map(array('Composer\Util\ProcessExecutor', 'escape'), $event->getArguments()));
 
+                    // run on specific platform only
+                    if (strpos($callable, '@onWindows ') === 0) {
+                        if (!Platform::isWindows()) {
+                            continue;
+                        };
+                        $callable = str_replace('@onWindows ', '', $callable);
+                    } elseif(strpos($callable, '@onLinux ') === 0) {
+                        if (PHP_OS !== 'Linux') {
+                            continue;
+                        };
+                        $callable = str_replace('@onLinux ', '', $callable);
+                    } elseif(strpos($callable, '@onDarwin ') === 0) {
+                        if (PHP_OS !== 'Darwin') {
+                            continue;
+                        };
+                        $callable = str_replace('@onDarwin ', '', $callable);
+                    }
+
                     // @putenv does not receive arguments
                     if (strpos($callable, '@putenv ') === 0) {
                         $exec = $callable;
@@ -289,6 +307,7 @@ class EventDispatcher
 
                         continue;
                     }
+
                     if (strpos($exec, '@php ') === 0) {
                         $pathAndArgs = substr($exec, 5);
                         if (Platform::isWindows()) {
@@ -542,7 +561,12 @@ class EventDispatcher
      */
     protected function isComposerScript(string $callable): bool
     {
-        return strpos($callable, '@') === 0 && strpos($callable, '@php ') !== 0 && strpos($callable, '@putenv ') !== 0;
+        return strpos($callable, '@') === 0
+            && strpos($callable, '@php ') !== 0
+            && strpos($callable, '@putenv ') !== 0
+            && strpos($callable, '@onWindows ') !== 0
+            && strpos($callable, '@onLinux ') !== 0
+            && strpos($callable, '@onDarwin ') !== 0;
     }
 
     /**

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -256,7 +256,7 @@ class ArrayLoader implements LoaderInterface
                 foreach ($config['scripts'] as $event => $listeners) {
                     $config['scripts'][$event] = (array) $listeners;
                 }
-                foreach (array('composer', 'php', 'putenv') as $reserved) {
+                foreach (array('composer', 'php', 'putenv', 'onWindows', 'onLinux', 'onDarwin') as $reserved) {
                     if (isset($config['scripts'][$reserved])) {
                         trigger_error('The `'.$reserved.'` script name is reserved for internal use, please avoid defining it', E_USER_DEPRECATED);
                     }

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -286,6 +286,21 @@ class EventDispatcherTest extends TestCase
         $this->assertEquals($expected, $io->getOutput());
     }
 
+    public function testDispatcherOnlyRunOnWindows(): void
+    {
+        $this->markTestSkipped('TODO: add test for @onWindows command');
+    }
+
+    public function testDispatcherOnlyRunOnLinux(): void
+    {
+        $this->markTestSkipped('TODO: add test for @onLinux command');
+    }
+
+    public function testDispatcherOnlyRunOnDarwin(): void
+    {
+        $this->markTestSkipped('TODO: add test for @onDarwin command');
+    }
+
     public function testDispatcherAppendsDirBinOnPathForEveryListener(): void
     {
         $currentDirectoryBkp = Platform::getCwd();


### PR DESCRIPTION
Recently, i came accross a problem that some of my composer script only works on specific platform. 

Here is an example:

```jsonc
"scripts": {
  // this only works on linux
  "seed": "php artisan db:seed --class=\\\\Main\\\\Database\\\\Seeders\\\\DatabaseSeeder",
  // this only works on windows
  "seed": "php artisan db:seed --class=\\Main\\Database\\Seeders\\DatabaseSeeder",
}
```
To resolve that issue, i propose this PR which add new composer `@command`:

* `@onWindows`: only run the script on windows
* `@onLinux`: only run the script on linux
* `@onDarwin`: only run the script on darwin/macos

So the script will look like this:

```jsonc
"scripts": {
  "seed": [
    "@onLinux php artisan db:seed --class=\\\\Main\\\\Database\\\\Seeders\\\\DatabaseSeeder",
    "@onWindows php artisan db:seed --class=\\Main\\Database\\Seeders\\DatabaseSeeder",
  ]
}
```

What do you think? If this is acceptable, i will add tests, docs and code more as needed.

Feel free to drop or accept this PR thoo, cheers.