### PR TITLE
GitHubDriver: stricter URL validation to avoid issues with undefined index owner

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -59,7 +59,7 @@ class GitHubDriver extends VcsDriver
      */
     public function initialize()
     {
-        if (!Preg::isMatch('#^(?:(?:https?|git)://([^/]+)/|git@([^:]+):/?)([^/]+)/(.+?)(?:\.git|/)?$#', $this->url, $match)) {
+        if (!Preg::isMatch('#^(?:(?:https?|git)://([^/]+)/|git@([^:]+):/?)([^/]+)/([^/]+?)(?:\.git|/)?$#', $this->url, $match)) {
             throw new \InvalidArgumentException(sprintf('The GitHub repository URL %s is invalid.', $this->url));
         }
 
@@ -390,7 +390,7 @@ class GitHubDriver extends VcsDriver
      */
     public static function supports(IOInterface $io, Config $config, $url, $deep = false)
     {
-        if (!Preg::isMatch('#^((?:https?|git)://([^/]+)/|git@([^:]+):/?)([^/]+)/(.+?)(?:\.git|/)?$#', $url, $matches)) {
+        if (!Preg::isMatch('#^((?:https?|git)://([^/]+)/|git@([^:]+):/?)([^/]+)/([^/]+?)(?:\.git|/)?$#', $url, $matches)) {
             return false;
         }
 

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -342,14 +342,16 @@ class GitHubDriverTest extends TestCase
     }
 
     /**
+     * @dataProvider invalidUrlProvider
+     * @param string $url
      * @return void
      */
-    public function initializeInvalidReoUrl()
+    public function testInitializeInvalidReoUrl($url)
     {
         $this->setExpectedException('\InvalidArgumentException');
 
         $repoConfig = array(
-            'url' => 'https://github.com/acme',
+            'url' => $url,
         );
 
         $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
@@ -359,6 +361,18 @@ class GitHubDriverTest extends TestCase
 
         $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $httpDownloader, new ProcessExecutorMock);
         $gitHubDriver->initialize();
+    }
+
+    /**
+     * @return list<array{bool, string}>
+     */
+    public function invalidUrlProvider()
+    {
+        return array(
+            array(false, 'https://github.com/acme'),
+            array(false, 'https://github.com/acme/repository/releases'),
+            array(false, 'https://github.com/acme/repository/pulls'),
+        );
     }
 
     /**
@@ -382,6 +396,8 @@ class GitHubDriverTest extends TestCase
             array(false, 'https://github.com/acme'),
             array(true, 'https://github.com/acme/repository'),
             array(true, 'git@github.com:acme/repository.git'),
+            array(false, 'https://github.com/acme/repository/releases'),
+            array(false, 'https://github.com/acme/repository/pulls'),
         );
     }
 


### PR DESCRIPTION
Example composer.json
```
{
    "repositories": [
        {"type": "vcs", "url":  "https://github.com/php-fig/log/releases"}
    ],
    "require": {
        "psr/log": "^3.0"
    }
}
```

composer update output with current stable:
```
composer update -vvv
Running 2.3.10 (2022-07-13 15:48:23) with PHP 8.1.8 on Darwin / 21.5.0
Reading ./composer.json (/tmp/update-error/composer.json)
Loading config file /Users/glaubinix/.composer/config.json
Loading config file /Users/glaubinix/.composer/auth.json
Loading config file ./composer.json (/tmp/update-error/composer.json)
Checked CA file /usr/local/etc/ca-certificates/cert.pem: valid
Executing command (/tmp/update-error): 'git' 'branch' '-a' '--no-color' '--no-abbrev' '-v'
Reading /Users/glaubinix/.composer/composer.json
Loading config file /Users/glaubinix/.composer/config.json
Loading config file /Users/glaubinix/.composer/auth.json
Loading config file /Users/glaubinix/.composer/composer.json (/Users/glaubinix/.composer/composer.json)
Loading config file /Users/glaubinix/.composer/auth.json
Reading /Users/glaubinix/.composer/auth.json
Reading ./composer.lock (/tmp/update-error/composer.lock)
Reading /Users/glaubinix/.composer/vendor/composer/installed.json
Loading composer repositories with package information
Using GitHub token authentication
Downloading https://api.github.com/repos/php-fig/log/releases
[200] https://api.github.com/repos/php-fig/log/releases

In GitHubDriver.php line 561:

  [ErrorException]
  Undefined array key "owner"


Exception trace:
  at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Repository/Vcs/GitHubDriver.php:561
 Composer\Util\ErrorHandler::handle() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Repository/Vcs/GitHubDriver.php:561
 Composer\Repository\Vcs\GitHubDriver->fetchRootIdentifier() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Repository/Vcs/GitHubDriver.php:81
 Composer\Repository\Vcs\GitHubDriver->initialize() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Repository/VcsRepository.php:149
 Composer\Repository\VcsRepository->getDriver() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Repository/VcsRepository.php:198
 Composer\Repository\VcsRepository->initialize() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Repository/ArrayRepository.php:311
 Composer\Repository\ArrayRepository->getPackages() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Repository/ArrayRepository.php:62
 Composer\Repository\ArrayRepository->loadPackages() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/DependencyResolver/PoolBuilder.php:391
 Composer\DependencyResolver\PoolBuilder->loadPackagesMarkedForLoading() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/DependencyResolver/PoolBuilder.php:240
 Composer\DependencyResolver\PoolBuilder->buildPool() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Repository/RepositorySet.php:334
 Composer\Repository\RepositorySet->createPool() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Installer.php:473
 Composer\Installer->doUpdate() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Installer.php:289
 Composer\Installer->run() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Command/UpdateCommand.php:243
 Composer\Command\UpdateCommand->execute() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/vendor/symfony/console/Command/Command.php:298
 Symfony\Component\Console\Command\Command->run() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/vendor/symfony/console/Application.php:1024
 Symfony\Component\Console\Application->doRunCommand() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/vendor/symfony/console/Application.php:299
 Symfony\Component\Console\Application->doRun() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Console/Application.php:343
 Composer\Console\Application->doRun() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/src/Composer/Console/Application.php:138
 Composer\Console\Application->run() at phar:///usr/local/Cellar/composer/2.3.10/bin/composer/bin/composer:88
 require() at /usr/local/Cellar/composer/2.3.10/bin/composer:30

update [--with WITH] [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--dev] [--no-dev] [--lock] [--no-install] [--no-audit] [--audit-format AUDIT-FORMAT] [--no-autoloader] [--no-suggest] [--no-progress] [-w|--with-dependencies] [-W|--with-all-dependencies] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [-i|--interactive] [--root-reqs] [--] [<packages>...]

```
