### PR TITLE
performance: Do not create a local cache repo for local repos

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -60,6 +60,11 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
      */
     protected function doDownload(PackageInterface $package, string $path, string $url, PackageInterface $prevPackage = null): PromiseInterface
     {
+        // Do not create an extra local cache when repository is already local
+        if(Filesystem::isLocalPath($url)){
+            return \React\Promise\resolve(null);
+        }
+
         GitUtil::cleanEnv();
 
         $cachePath = $this->config->get('cache-vcs-dir').'/'.Preg::replace('{[^a-z0-9.]}i', '-', $url).'/';

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -61,7 +61,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
     protected function doDownload(PackageInterface $package, string $path, string $url, PackageInterface $prevPackage = null): PromiseInterface
     {
         // Do not create an extra local cache when repository is already local
-        if(Filesystem::isLocalPath($url)){
+        if (Filesystem::isLocalPath($url)) {
             return \React\Promise\resolve(null);
         }
 


### PR DESCRIPTION
performance: Do not create a local cache repo for local repos

<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
