### PR TITLE
Do not apply non-array package links in ArrayLoader

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -55,20 +55,18 @@ class ArrayLoader implements LoaderInterface
         $package = $this->createObject($config, $class);
 
         foreach (BasePackage::$supportedLinkTypes as $type => $opts) {
-            if (isset($config[$type])) {
-                if (!is_array($config[$type])) {
-                    continue;
-                }
-                $method = 'set'.ucfirst($opts['method']);
-                $package->{$method}(
-                    $this->parseLinks(
-                        $package->getName(),
-                        $package->getPrettyVersion(),
-                        $opts['method'],
-                        $config[$type]
-                    )
-                );
+            if (!isset($config[$type]) || !is_array($config[$type])) {
+                continue;
             }
+            $method = 'set'.ucfirst($opts['method']);
+            $package->{$method}(
+                $this->parseLinks(
+                    $package->getName(),
+                    $package->getPrettyVersion(),
+                    $opts['method'],
+                    $config[$type]
+                )
+            );
         }
 
         $package = $this->configureObject($package, $config);

--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -56,6 +56,9 @@ class ArrayLoader implements LoaderInterface
 
         foreach (BasePackage::$supportedLinkTypes as $type => $opts) {
             if (isset($config[$type])) {
+                if (!is_array($config[$type])) {
+                    continue;
+                }
                 $method = 'set'.ucfirst($opts['method']);
                 $package->{$method}(
                     $this->parseLinks(

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -371,4 +371,31 @@ class ArrayLoaderTest extends TestCase
 
         $this->assertNull($this->loader->getBranchAlias($config));
     }
+
+    public function testPackageLinksReplace(): void
+    {
+        $config = array(
+            'name' => 'acme/package',
+            'version' => 'dev-1',
+            'replace' => [
+                'coyote/package' => 'self.version',
+            ],
+        );
+
+        $package = $this->loader->load($config);
+        $this->assertArrayHasKey('coyote/package', $package->getReplaces());
+        $this->assertSame('dev-1', $package->getReplaces()['coyote/package']->getConstraint()->getPrettyString());
+    }
+
+    public function testPackageLinksReplaceInvalid(): void
+    {
+        $config = array(
+            'name' => 'acme/package',
+            'version' => 'dev-1',
+            'replace' => 'coyote/package',
+        );
+
+        $package = $this->loader->load($config);
+        $this->assertCount(0, $package->getReplaces());
+    }
 }


### PR DESCRIPTION
Fix type error when a non-array package link is provided in config array.
Encountered when the following `composer.json` was submitted:

```json
{
    ...,
    "replace": "vendor/package"
}
```