### PR TITLE
Do not apply non-string package link constraints in ArrayLoader

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -364,6 +364,9 @@ class ArrayLoader implements LoaderInterface
     {
         $res = [];
         foreach ($links as $target => $constraint) {
+            if (!is_string($constraint)) {
+                continue;
+            }
             $target = strtolower((string) $target);
             $res[$target] = $this->createLink($source, $sourceVersion, $description, $target, $constraint);
         }

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -371,4 +371,35 @@ class ArrayLoaderTest extends TestCase
 
         $this->assertNull($this->loader->getBranchAlias($config));
     }
+
+    public function testPackageLinksRequire(): void
+    {
+        $config = array(
+            'name' => 'acme/package',
+            'version' => 'dev-1',
+            'require' => [
+                'foo/bar' => '1.0',
+            ],
+        );
+
+        $package = $this->loader->load($config);
+        $this->assertArrayHasKey('foo/bar', $package->getRequires());
+        $this->assertSame('1.0', $package->getRequires()['foo/bar']->getConstraint()->getPrettyString());
+    }
+
+    public function testPackageLinksRequireInvalid(): void
+    {
+        $config = array(
+            'name' => 'acme/package',
+            'version' => 'dev-1',
+            'require' => [
+                'foo/bar' => [
+                    'random-string' => '1.0',
+                ],
+            ],
+        );
+
+        $package = $this->loader->load($config);
+        $this->assertCount(0, $package->getRequires());
+    }
 }


### PR DESCRIPTION
Fix type error when a non-array package link is provided in config array.
Encountered when the following `composer.json` was submitted:

```json
{
    ...,
    "require": {
        "psr/log": {
            "random-string": ""
        }
    }
}
```