### PR TITLE
Match default choice to actual default

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -598,7 +598,7 @@ TAGSPUBKEY
         $helpMessage = 'Please run the self-update command as an Administrator.';
         $question = 'Complete this operation with Administrator privileges [<comment>Y,n</comment>]? ';
 
-        if (!$io->askConfirmation($question, false)) {
+        if (!$io->askConfirmation($question, true)) {
             $io->writeError('<warning>Operation cancelled. '.$helpMessage.'</warning>');
 
             return false;


### PR DESCRIPTION
The 'Y' is capital, so Yes should be the default choice and is what most people would want, but No was the default.