### PR TITLE
Tests bootstrap - remove require InstalledVersions

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,7 @@
  * file that was distributed with this source code.
  */
 
+use Composer\InstalledVersions;
 use Composer\Util\Platform;
 
 error_reporting(E_ALL);
@@ -19,7 +20,11 @@ if (function_exists('date_default_timezone_set') && function_exists('date_defaul
 }
 
 require __DIR__.'/../src/bootstrap.php';
-require __DIR__.'/../src/Composer/InstalledVersions.php';
+
+if (!class_exists(InstalledVersions::class, false)) {
+    require __DIR__.'/../src/Composer/InstalledVersions.php';
+}
+
 require __DIR__.'/Composer/Test/TestCase.php';
 
 Platform::putEnv('COMPOSER_TESTS_ARE_RUNNING', '1');


### PR DESCRIPTION
This causes issues for PHPStan in the latest version. Because PHPStan itself loads its own InstalledVersions from inside the PHAR, this bootstrap line makes it crash.

If we find out that loading this class is indeed necessary for Composer's test suite to run, I'll create a separate PHPStan bootstrap next to this one.