### PR TITLE
Lock down include wrappers to avoid abuse from third parties

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -42,6 +42,9 @@ namespace Composer\Autoload;
  */
 class ClassLoader
 {
+    /** @var \Closure(string):void */
+    private $includeFile;
+
     /** @var ?string */
     private $vendorDir;
 
@@ -106,6 +109,18 @@ class ClassLoader
     public function __construct($vendorDir = null)
     {
         $this->vendorDir = $vendorDir;
+
+        /**
+         * Scope isolated include.
+         *
+         * Prevents access to $this/self from included files.
+         *
+         * @param  string $file
+         * @return void
+         */
+        $this->includeFile = static function($file) {
+            include $file;
+        };
     }
 
     /**
@@ -425,7 +440,7 @@ class ClassLoader
     public function loadClass($class)
     {
         if ($file = $this->findFile($class)) {
-            includeFile($file);
+            ($this->includeFile)($file);
 
             return true;
         }
@@ -555,18 +570,4 @@ class ClassLoader
 
         return false;
     }
-}
-
-/**
- * Scope isolated include.
- *
- * Prevents access to $this/self from included files.
- *
- * @param  string $file
- * @return void
- * @private
- */
-function includeFile($file)
-{
-    include $file;
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -31,25 +31,18 @@ class ComposerAutoloaderInitFilesAutoloadOrder
 
         $loader->register(true);
 
-        $includeFiles = \Composer\Autoload\ComposerStaticInitFilesAutoloadOrder::$files;
-        foreach ($includeFiles as $fileIdentifier => $file) {
-            composerRequireFilesAutoloadOrder($fileIdentifier, $file);
+        $filesToLoad = \Composer\Autoload\ComposerStaticInitFilesAutoloadOrder::$files;
+        $requireFile = static function ($fileIdentifier, $file) {
+            if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
+                $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;
+
+                require $file;
+            }
+        };
+        foreach ($filesToLoad as $fileIdentifier => $file) {
+            ($requireFile)($fileIdentifier, $file);
         }
 
         return $loader;
-    }
-}
-
-/**
- * @param string $fileIdentifier
- * @param string $file
- * @return void
- */
-function composerRequireFilesAutoloadOrder($fileIdentifier, $file)
-{
-    if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
-        $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;
-
-        require $file;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -31,25 +31,18 @@ class ComposerAutoloaderInitFilesAutoload
 
         $loader->register(true);
 
-        $includeFiles = \Composer\Autoload\ComposerStaticInitFilesAutoload::$files;
-        foreach ($includeFiles as $fileIdentifier => $file) {
-            composerRequireFilesAutoload($fileIdentifier, $file);
+        $filesToLoad = \Composer\Autoload\ComposerStaticInitFilesAutoload::$files;
+        $requireFile = static function ($fileIdentifier, $file) {
+            if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
+                $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;
+
+                require $file;
+            }
+        };
+        foreach ($filesToLoad as $fileIdentifier => $file) {
+            ($requireFile)($fileIdentifier, $file);
         }
 
         return $loader;
-    }
-}
-
-/**
- * @param string $fileIdentifier
- * @param string $file
- * @return void
- */
-function composerRequireFilesAutoload($fileIdentifier, $file)
-{
-    if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
-        $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;
-
-        require $file;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
@@ -35,25 +35,18 @@ class ComposerAutoloaderInitFilesAutoload
 
         $loader->register(true);
 
-        $includeFiles = \Composer\Autoload\ComposerStaticInitFilesAutoload::$files;
-        foreach ($includeFiles as $fileIdentifier => $file) {
-            composerRequireFilesAutoload($fileIdentifier, $file);
+        $filesToLoad = \Composer\Autoload\ComposerStaticInitFilesAutoload::$files;
+        $requireFile = static function ($fileIdentifier, $file) {
+            if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
+                $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;
+
+                require $file;
+            }
+        };
+        foreach ($filesToLoad as $fileIdentifier => $file) {
+            ($requireFile)($fileIdentifier, $file);
         }
 
         return $loader;
-    }
-}
-
-/**
- * @param string $fileIdentifier
- * @param string $file
- * @return void
- */
-function composerRequireFilesAutoload($fileIdentifier, $file)
-{
-    if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
-        $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;
-
-        require $file;
     }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -33,9 +33,16 @@ class ComposerAutoloaderInitTargetDir
 
         $loader->register(true);
 
-        $includeFiles = \Composer\Autoload\ComposerStaticInitTargetDir::$files;
-        foreach ($includeFiles as $fileIdentifier => $file) {
-            composerRequireTargetDir($fileIdentifier, $file);
+        $filesToLoad = \Composer\Autoload\ComposerStaticInitTargetDir::$files;
+        $requireFile = static function ($fileIdentifier, $file) {
+            if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
+                $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;
+
+                require $file;
+            }
+        };
+        foreach ($filesToLoad as $fileIdentifier => $file) {
+            ($requireFile)($fileIdentifier, $file);
         }
 
         return $loader;
@@ -57,19 +64,5 @@ class ComposerAutoloaderInitTargetDir
 
             return true;
         }
-    }
-}
-
-/**
- * @param string $fileIdentifier
- * @param string $file
- * @return void
- */
-function composerRequireTargetDir($fileIdentifier, $file)
-{
-    if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
-        $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;
-
-        require $file;
     }
 }


### PR DESCRIPTION
It occurred to me that with static lambdas we can achieve the same effect as with those public functions, except we don't leave them open for use by third parties.

As a side-note @mir-hossein pointed out to me that it's sometimes used in attacks to bypass restrictions, I am not entirely sure how this would work but I guess some filtering may allow calls to `includeFile()` but not to include/require? In any case it seems like a good thing to close this potential vector.

I would target 2.5.0 with this because it may cause disruption to people using this function (even tho they really should not..) for "legit" cases, so I'd rather not have this in a patch release.