### PR TITLE
Config - always respect COMPOSER_DISCARD_CHANGES

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -376,7 +376,8 @@ class Config
                 return $value;
 
             case 'discard-changes':
-                if ($env = $this->getComposerEnv('COMPOSER_DISCARD_CHANGES')) {
+                $env = $this->getComposerEnv('COMPOSER_DISCARD_CHANGES');
+                if ($env !== false) {
                     if (!in_array($env, ['stash', 'true', 'false', '1', '0'], true)) {
                         throw new \RuntimeException(
                             "Invalid value for COMPOSER_DISCARD_CHANGES: {$env}. Expected 1, 0, true, false or stash"
@@ -519,7 +520,7 @@ class Config
      * This should be used to read COMPOSER_ environment variables
      * that overload config values.
      *
-     * @return string|bool
+     * @return string|false
      */
     private function getComposerEnv(string $var)
     {


### PR DESCRIPTION
If it was set to `'0'`, the config value would be read instead.