### PR TITLE
Fix the heading levels for the doc about composer repositories

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -149,7 +149,7 @@ number.
 
 This field is optional.
 
-### metadata-url, available-packages and available-package-patterns
+#### metadata-url, available-packages and available-package-patterns
 
 The `metadata-url` field allows you to provide a URL template to serve all
 packages which are in the repository. It must contain the placeholder
@@ -204,7 +204,7 @@ every matching package name in this repository).
 
 This field is optional.
 
-### providers-api
+#### providers-api
 
 The `providers-api` field allows you to provide a URL template to serve all
 packages which provide a given package name, but not the package which has
@@ -222,7 +222,7 @@ monolog/monolog itself.
 
 This field is optional.
 
-### list
+#### list
 
 The `list` field allows you to return the names of packages which match a
 given field (or all names if no filter is present). It should accept an


### PR DESCRIPTION
The headings don't make sense before this change:

![image](https://user-images.githubusercontent.com/439401/187075544-f0ef9d1b-6be9-449c-9511-4ae165c58544.png)

