### PR TITLE
Fix handling of upper-bound platform req ignores to not act on conflicts

### DIFF
--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -223,7 +223,7 @@ class RuleSetGenerator
                 if ($platformRequirementFilter->isIgnored($link->getTarget())) {
                     continue;
                 } elseif ($platformRequirementFilter instanceof IgnoreListPlatformRequirementFilter) {
-                    $constraint = $platformRequirementFilter->filterConstraint($link->getTarget(), $constraint);
+                    $constraint = $platformRequirementFilter->filterConstraint($link->getTarget(), $constraint, false);
                 }
 
                 $conflicts = $this->pool->whatProvides($link->getTarget(), $constraint);

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
@@ -69,7 +69,7 @@ final class IgnoreListPlatformRequirementFilter implements PlatformRequirementFi
             return $constraint;
         }
 
-        if (!Preg::isMatch($this->ignoreUpperBoundRegex, $req) || !$allowUpperBoundOverride) {
+        if (!$allowUpperBoundOverride || !Preg::isMatch($this->ignoreUpperBoundRegex, $req)) {
             return $constraint;
         }
 

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
@@ -60,13 +60,16 @@ final class IgnoreListPlatformRequirementFilter implements PlatformRequirementFi
         return Preg::isMatch($this->ignoreRegex, $req);
     }
 
-    public function filterConstraint(string $req, ConstraintInterface $constraint): ConstraintInterface
+    /**
+     * @param bool $allowUpperBoundOverride For conflicts we do not want the upper bound to be skipped
+     */
+    public function filterConstraint(string $req, ConstraintInterface $constraint, bool $allowUpperBoundOverride = true): ConstraintInterface
     {
         if (!PlatformRepository::isPlatformPackage($req)) {
             return $constraint;
         }
 
-        if (!Preg::isMatch($this->ignoreUpperBoundRegex, $req)) {
+        if (!Preg::isMatch($this->ignoreUpperBoundRegex, $req) || !$allowUpperBoundOverride) {
             return $constraint;
         }
 

--- a/tests/Composer/Test/Fixtures/installer/update-ignore-platform-package-requirement-list-upper-bounds.test
+++ b/tests/Composer/Test/Fixtures/installer/update-ignore-platform-package-requirement-list-upper-bounds.test
@@ -7,13 +7,15 @@ Update with ignore-platform-req list ignoring upper bound of a dependency
             "type": "package",
             "package": [
                 { "name": "a/a", "version": "1.0.1", "require": { "ext-foo-bar": "3.*" } },
-                { "name": "b/b", "version": "1.0.1", "require": { "ext-foo-bar": "10.*" } }
+                { "name": "b/b", "version": "1.0.1", "require": { "ext-foo-bar": "10.*" } },
+                { "name": "c/c", "version": "1.0.1", "conflict": { "ext-foo-bar": "4.0.0 - 4.0.2", "php": "3.0.*" } }
             ]
         }
     ],
     "require": {
         "a/a": "1.0.*",
         "b/b": "1.0.*",
+        "c/c": "1.0.*",
         "php": "^4.3",
         "ext-foo-baz": "9.0.0"
     },


### PR DESCRIPTION
fixes #11020

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
