### PR TITLE
Update gitlab fetch failure message with new path

### DIFF
--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -127,7 +127,7 @@ class GitLab
 
         $this->io->writeError(sprintf('A token will be created and stored in "%s", your password will never be stored', $this->config->getAuthConfigSource()->getName()));
         $this->io->writeError('To revoke access to this token you can visit '.$scheme.'://'.$originUrl.'/-/profile/applications');
-        $this->io->writeError('Alternatively you can setup an personal access token on  '.$scheme.'://'.$originUrl.'/-/profile/personal_access_token and store it under "gitlab-token" see https://getcomposer.org/doc/articles/authentication-for-private-packages.md#gitlab-token for more details.');
+        $this->io->writeError('Alternatively you can setup an personal access token on  '.$scheme.'://'.$originUrl.'/-/profile/personal_access_tokens and store it under "gitlab-token" see https://getcomposer.org/doc/articles/authentication-for-private-packages.md#gitlab-token for more details.');
 
         $attemptCounter = 0;
 


### PR DESCRIPTION
`https://gitlab.com/-/profile/personal_access_token` is not correct, the current URL for personal access token settings is `https://gitlab.com/-/profile/personal_access_tokens`. This is the only occurrence of the bad URL, we use the proper URL elsewhere.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
