### PR TITLE
Add "--dry-run" to bump command

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -355,6 +355,7 @@ are local to the library and do not affect consumers of the package.
 
 * **--dev-only:** Only bump requirements in "require-dev".
 * **--no-dev-only:** Only bump requirements in "require".
+* **--dry-run:** Outputs the packages to bump, but will not execute anything.
 
 ## reinstall
 

--- a/src/Composer/Command/BumpCommand.php
+++ b/src/Composer/Command/BumpCommand.php
@@ -196,7 +196,11 @@ EOT
             $lock->write($lockData);
         }
 
-        return $dryRun && $changeCount > 0 ? self::ERROR_GENERIC : 0;
+        if ($dryRun && $changeCount > 0) {
+            return self::ERROR_GENERIC;
+        }
+
+        return 0;
     }
 
     /**

--- a/tests/Composer/Test/Command/BumpCommandTest.php
+++ b/tests/Composer/Test/Command/BumpCommandTest.php
@@ -23,7 +23,7 @@ class BumpCommandTest extends TestCase
      * @param array<mixed> $command
      * @param array<mixed> $expected
      */
-    public function testBump(array $composerJson, array $command, array $expected, bool $lock = true): void
+    public function testBump(array $composerJson, array $command, array $expected, bool $lock = true, int $exitCode = 0): void
     {
         $this->initTempComposer($composerJson);
 
@@ -41,7 +41,7 @@ class BumpCommandTest extends TestCase
         }
 
         $appTester = $this->getApplicationTester();
-        $appTester->run(array_merge(['command' => 'bump'], $command));
+        $this->assertSame($exitCode, $appTester->run(array_merge(['command' => 'bump'], $command)));
 
         $json = new JsonFile('./composer.json');
         $this->assertSame($expected, $json->read());
@@ -130,6 +130,54 @@ class BumpCommandTest extends TestCase
                 ],
             ],
             false,
+        ];
+
+        yield 'bump with --dry-run with packages to bump' => [
+            [
+                'require' => [
+                    'first/pkg' => '^2.0',
+                    'second/pkg' => '3.*',
+                ],
+                'require-dev' => [
+                    'dev/pkg' => '~2.0',
+                ],
+            ],
+            ['--dry-run' => true],
+            [
+                'require' => [
+                    'first/pkg' => '^2.0',
+                    'second/pkg' => '3.*',
+                ],
+                'require-dev' => [
+                    'dev/pkg' => '~2.0',
+                ],
+            ],
+            true,
+            1,
+        ];
+
+        yield 'bump with --dry-run without packages to bump' => [
+            [
+                'require' => [
+                    'first/pkg' => '^2.3.4',
+                    'second/pkg' => '^3.4',
+                ],
+                'require-dev' => [
+                    'dev/pkg' => '^2.3.4.5',
+                ],
+            ],
+            ['--dry-run' => true],
+            [
+                'require' => [
+                    'first/pkg' => '^2.3.4',
+                    'second/pkg' => '^3.4',
+                ],
+                'require-dev' => [
+                    'dev/pkg' => '^2.3.4.5',
+                ],
+            ],
+            true,
+            0,
         ];
     }
 }


### PR DESCRIPTION
With this flag it would be possible to run `composer bump --dry-run` as a part of CI - to keep synced `composer.json` and `composer.lock`.

When run on this repo:
```console
$ php ./bin/compile 
$ php composer.phar bump --dry-run
Warning: Bumping dependency constraints is not recommended for libraries as it will narrow down your dependencies and may cause problems for your users.
./composer.json would be updated with:
 - require.composer/ca-bundle: ^1.3.3
 - require.composer/semver: ^3.3.2
 - require.justinrainbow/json-schema: ^5.2.12
 - require.psr/log: ^1.1.4 || ^2.0 || ^3.0
 - require.seld/jsonlint: ^1.9
 - require.seld/phar-utils: ^1.2.1
 - require.symfony/console: ^5.4.12 || ^6.0.11
 - require.symfony/filesystem: ^5.4.12 || ^6.0
 - require.symfony/finder: ^5.4.11 || ^6.0
 - require.symfony/process: ^5.4.11 || ^6.0
 - require.react/promise: ^2.9
 - require.symfony/polyfill-php73: ^1.26
 - require.symfony/polyfill-php80: ^1.26
 - require.seld/signal-handler: ^2.0.1
 - require-dev.symfony/phpunit-bridge: ^6.1.3
 - require-dev.phpstan/phpstan: ^1.8.3
 - require-dev.phpstan/phpstan-phpunit: ^1.1.1
 - require-dev.phpstan/phpstan-strict-rules: ^1.4.3
 - require-dev.phpstan/phpstan-symfony: ^1.2.13
$ echo $?
1
```

I've swapped the order of `if (!$input->getOption('dev-only'))` and `if (!$input->getOption('no-dev-only'))`, so when there are packages in both to update then `require` is shown first.