### PR TITLE
Replace deprecated `PSR-2` with `PSR-12`

### DIFF
--- a/doc/08-community.md
+++ b/doc/08-community.md
@@ -19,7 +19,7 @@ The most important guidelines are described as follows:
 > Fork the project, create a feature branch, and send us a pull request.
 >
 > To ensure a consistent code base, you should make sure the code follows
-> the [PSR-2 Coding Standards](https://www.php-fig.org/psr/psr-2/).
+> the [PSR-12 Coding Standards](https://www.php-fig.org/psr/psr-12/).
 
 ## Support
 


### PR DESCRIPTION
At the top of https://www.php-fig.org/psr/psr-2/, it says:
> Deprecated - As of 2019-08-10 PSR-2 has been marked as deprecated. PSR-12 is now recommended as an alternative.

Looking at the PSR-12 docs, the summary of changes implies that they mostly took PSR-2 and extended it to clarify new language features.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
