### PR TITLE
Type specifying extension for ValidatingArrayLoader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Composer\\Test\\": "tests/Composer/Test"
+            "Composer\\Test\\": "tests/Composer/Test",
+            "PHPStan\\": "tests/PHPStan"
         }
     },
     "bin": [

--- a/phpstan/config.neon
+++ b/phpstan/config.neon
@@ -60,3 +60,9 @@ parameters:
         - Composer\Composer::VERSION
         - Composer\Composer::RELEASE_DATE
         - Composer\Composer::SOURCE_VERSION
+
+services:
+    -
+        class: PHPStan\ValidatingArrayLoaderTypeSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.methodTypeSpecifyingExtension

--- a/src/Composer/Package/Loader/LoaderInterface.php
+++ b/src/Composer/Package/Loader/LoaderInterface.php
@@ -28,7 +28,7 @@ interface LoaderInterface
     /**
      * Converts a package from an array to a real instance
      *
-     * @param  mixed[] $config package data
+     * @param  array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null>>>>>>> $config package data
      * @param  string  $class  FQCN to be instantiated
      *
      * @return CompletePackage|CompleteAliasPackage|RootPackage|RootAliasPackage

--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -36,7 +36,7 @@ class ValidatingArrayLoader implements LoaderInterface
     private $errors;
     /** @var string[] */
     private $warnings;
-    /** @var mixed[] */
+    /** @var array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null>>>>>>> */
     private $config;
     /** @var int One or more of self::CHECK_* constants */
     private $flags;

--- a/tests/PHPStan/ValidatingArrayLoaderTypeSpecifyingExtension.php
+++ b/tests/PHPStan/ValidatingArrayLoaderTypeSpecifyingExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PHPStan;
+
+use Composer\Package\Loader\ValidatingArrayLoader;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+use PHPStan\Type\TypeCombinator;
+
+class ValidatingArrayLoaderTypeSpecifyingExtension implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+	/** @var TypeSpecifier */
+	private $typeSpecifier;
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+	public function getClass(): string
+    {
+        return ValidatingArrayLoader::class;
+    }
+
+	public function isMethodSupported(MethodReflection $methodReflection, MethodCall $node,	TypeSpecifierContext $context): bool
+    {
+        return in_array($methodReflection->getName(), ['validateRegex', 'validateString', 'validateArray', 'validateFlatArray', 'validateUrl'], true);
+    }
+
+	public function specifyTypes(MethodReflection $methodReflection, MethodCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
+    {
+        $expr = $node->getArgs()[0]->value;
+        $key = $expr->value;
+
+        // TODO should set $this->config[$key] in Context to array|string|... if method returns true or UNSET if method returns false
+
+        $typeBefore = $scope->getType($expr);
+        $type = TypeCombinator::removeNull($typeBefore);
+
+        // Assuming extension implements \PHPStan\Analyser\TypeSpecifierAwareExtension
+
+        return $this->typeSpecifier->create($expr, $type, TypeSpecifierContext::createTruthy());
+    }
+}


### PR DESCRIPTION
If someone has enough phpstan knowledge and time to help here that would be great. 

See for example https://github.com/composer/composer/blob/main/src/Composer/Package/Loader/ValidatingArrayLoader.php#L533 if validateArray is called, and it returns true, `$this->config[$property]` should be `non-empty-array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null|array<int|string|bool|null>>>>>>>` 

if it returns false, it should be `UNSET`

If the return value is not checked, we can still narrow the type of `$this->config[$property]` to either UNSET or the non-empty-array type.

Same for `validateString` which would be `string|unset` etc.
