### PR TITLE
Unify command names in the docs

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -134,7 +134,7 @@ resolution.
   requires `php: ^7`, then the option `--ignore-platform-req=php+` would allow installing on PHP 8,
   but installation on PHP 5.6 would still fail.
 
-## update / u
+## update / u / upgrade
 
 In order to get the latest versions of the dependencies and to update the
 `composer.lock` file, you should use the `update` command. This command is also
@@ -473,7 +473,7 @@ You can also search for more than one term by passing multiple arguments.
   for Packagist.org search results and other repositories may return more or less
   data.
 
-## show
+## show / info
 
 To list all of the available packages, you can use the `show` command.
 
@@ -629,7 +629,7 @@ get machine-readable output.
 
 * **--format (-f):** Lets you pick between text (default) or json output format.
 
-## depends (why)
+## depends / why
 
 The `depends` command tells you which other packages depend on a certain
 package. As with installation `require-dev` relationships are only considered
@@ -667,7 +667,7 @@ psr/log 1.1.4 Common interface for logging libraries
 * **--recursive (-r):** Recursively resolves up to the root package.
 * **--tree (-t):** Prints the results as a nested tree, implies -r.
 
-## prohibits (why-not)
+## prohibits / why-not
 
 The `prohibits` command tells you which packages are blocking a given package
 from being installed. Specify a version constraint to verify whether upgrades
@@ -741,7 +741,7 @@ vendor/seld/jsonlint:
     M README.mdown
 ```
 
-## self-update (selfupdate)
+## self-update / selfupdate
 
 To update Composer itself to the latest version, run the `self-update`
 command. It will replace your `composer.phar` with the latest version.
@@ -932,7 +932,7 @@ By default the command checks for the packages on packagist.org.
   does not fulfill it. Multiple requirements can be ignored via wildcard.
 * **--ask:** Ask the user to provide a target directory for the new project.
 
-## dump-autoload (dumpautoload)
+## dump-autoload / dumpautoload
 
 If you need to update the autoloader because of new classes in a classmap
 package for example, you can use `dump-autoload` to do that without having to
@@ -985,7 +985,7 @@ Lists the name, version and license of every package installed. Use
 * **--format:** Format of the output: text, json or summary (default: "text")
 * **--no-dev:** Remove dev dependencies from the output
 
-## run-script
+## run-script / run
 
 ### Options
 

--- a/tests/Composer/Test/DocumentationTest.php
+++ b/tests/Composer/Test/DocumentationTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test;
+
+use Composer\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Descriptor\ApplicationDescription;
+
+class DocumentationTest extends TestCase
+{
+    /**
+     * @dataProvider provideCommandCases
+     */
+    public function testCommand(Command $command): void
+    {
+        static $docContent = null;
+        if ($docContent === null) {
+            $docContent = file_get_contents(__DIR__ . '/../../../doc/03-cli.md');
+        }
+
+        self::assertStringContainsString(
+            sprintf(
+                "\n## %s\n\n",
+                $this->getCommandName($command)
+                // TODO: test description
+                // TODO: test options
+            ),
+            $docContent
+        );
+    }
+
+    private function getCommandName(Command $command): string
+    {
+        $name = (string) $command->getName();
+        foreach ($command->getAliases() as $alias) {
+            $name .= ' / ' . $alias;
+        }
+
+        return $name;
+    }
+
+    public function provideCommandCases(): \Generator
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        $description = new ApplicationDescription($application);
+
+        foreach ($description->getCommands() as $command) {
+            if (in_array($command->getName(), ['about', 'completion', 'list'], true)) {
+                continue;
+            }
+            yield [$command];
+        }
+    }
+}


### PR DESCRIPTION
It would be great to have the CLI docs consistent, as currently some aliases of commands are skipped, some are in parenthesis, and some are with a slash.

Maybe the better format would be to use parenthesis e.g. `## update (u, upgrade)`, but that's up to @Seldaek to decide.

Both TODOs will be done in separate PRs - if this one goes through.