### PR TITLE
Load plugin commands for autocompletion

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -237,7 +237,7 @@ class Application extends BaseApplication
                 || in_array($commandName, ['', 'list', 'help'], true)
                 // autocompletion requires plugin commands but if we are running as root without COMPOSER_ALLOW_SUPERUSER
                 // we'd rather not autocomplete plugins than abort autocompletion entirely, so we avoid loading plugins in this case
-                || $commandName === '_complete' && !$isNonAllowedRoot
+                || ($commandName === '_complete' && !$isNonAllowedRoot)
             );
 
         if ($mayNeedPluginCommand && !$this->disablePluginsByDefault && !$this->hasPluginCommands) {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -234,7 +234,7 @@ class Application extends BaseApplication
                 // not a composer command, so try loading plugin ones
                 false === $commandName
                 // list command requires plugin commands to show them
-                || in_array($commandName, ['', 'list', 'help'], true)
+                || in_array($commandName, ['', 'list', 'help', '_complete'], true)
             );
 
         if ($mayNeedPluginCommand && !$this->disablePluginsByDefault && !$this->hasPluginCommands) {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -234,7 +234,10 @@ class Application extends BaseApplication
                 // not a composer command, so try loading plugin ones
                 false === $commandName
                 // list command requires plugin commands to show them
-                || in_array($commandName, ['', 'list', 'help', '_complete'], true)
+                || in_array($commandName, ['', 'list', 'help'], true)
+                // autocompletion requires plugin commands but if we are running as root without COMPOSER_ALLOW_SUPERUSER
+                // we'd rather not autocomplete plugins than abort autocompletion entirely, so we avoid loading plugins in this case
+                || $commandName === '_complete' && !$isNonAllowedRoot
             );
 
         if ($mayNeedPluginCommand && !$this->disablePluginsByDefault && !$this->hasPluginCommands) {


### PR DESCRIPTION
To allow autocompletion for commands provided by plugins, the plugin commands should also be loaded in the completion step.

This results in both the completion for the command name itself as well as - if configured - completion for arguments and values for said command.
