### PR TITLE
Add test and documentation regarding audit command when no packages are required

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1041,6 +1041,8 @@ for possible security issues. It checks for and
 lists security vulnerability advisories according to the
 [Packagist.org api](https://packagist.org/apidoc#list-security-advisories).
 
+_The audit command returns successfully (0) when no packages are required in the project._
+
 ```shell
 php composer.phar audit
 ```

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1041,7 +1041,7 @@ for possible security issues. It checks for and
 lists security vulnerability advisories according to the
 [Packagist.org api](https://packagist.org/apidoc#list-security-advisories).
 
-_The audit command returns successfully (0) when no packages are required in the project._
+The audit command returns the amount of vulnerabilities found. `0` if successful, and up to `255` otherwise.
 
 ```shell
 php composer.phar audit

--- a/tests/Composer/Test/Command/AuditCommandTest.php
+++ b/tests/Composer/Test/Command/AuditCommandTest.php
@@ -16,7 +16,7 @@ use Composer\Test\TestCase;
 
 class AuditCommandTest extends TestCase
 {
-    public function testSuccessfullResponseCodeWhenNoPackagesAreRequired(): void
+    public function testSuccessfulResponseCodeWhenNoPackagesAreRequired(): void
     {
         $this->initTempComposer();
 

--- a/tests/Composer/Test/Command/AuditCommandTest.php
+++ b/tests/Composer/Test/Command/AuditCommandTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Command;
+
+use Composer\Test\TestCase;
+
+class AuditCommandTest extends TestCase
+{
+    public function testSuccessfullResponseCodeWhenNoPackagesAreRequired(): void
+    {
+        $this->initTempComposer();
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'audit']);
+
+        $appTester->assertCommandIsSuccessful();
+    }
+}


### PR DESCRIPTION
Related to #10796

I wanted to add tests to commands, and my thought was to add test to interesting behaviours that were worth validating. As far as I can tell, most code in the commands is related to output formatting or calling other components which implements the behaviours.

I found the audit command, which has a successful response code when no packages are required, and thought that it was a behaviour worth documenting/testing

Let me know what you think!