### PR TITLE
#10796 Add test for ExecCommand

### DIFF
--- a/tests/Composer/Test/Command/ExecCommandTest.php
+++ b/tests/Composer/Test/Command/ExecCommandTest.php
@@ -50,14 +50,11 @@ class ExecCommandTest extends TestCase
         $output = $appTester->getDisplay(true);
 
         $this->assertSame(
-            <<<OUTPUT
-Available binaries:
+            'Available binaries:
 - b
 - c
-- a (local)
-
-OUTPUT,
-            $output
+- a (local)',
+            trim($output)
         );
     }
 }

--- a/tests/Composer/Test/Command/ExecCommandTest.php
+++ b/tests/Composer/Test/Command/ExecCommandTest.php
@@ -14,7 +14,6 @@ namespace Composer\Test\Command;
 
 use Composer\Test\TestCase;
 
-/** @group now */
 class ExecCommandTest extends TestCase
 {
     public function testListThrowsIfNoBinariesExist(): void

--- a/tests/Composer/Test/Command/ExecCommandTest.php
+++ b/tests/Composer/Test/Command/ExecCommandTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Command;
+
+use Composer\Test\TestCase;
+
+/** @group now */
+class ExecCommandTest extends TestCase
+{
+    public function testListThrowsIfNoBinariesExist(): void
+    {
+        $composerDir = $this->initTempComposer();
+
+        $composerBinDir = "$composerDir/vendor/bin";
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            "No binaries found in composer.json or in bin-dir ($composerBinDir)"
+        );
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'exec', '--list' => true]);
+    }
+
+    public function testList(): void
+    {
+        $composerDir = $this->initTempComposer([
+            'bin' => [
+                'a'
+            ]
+        ]);
+
+        $vendorBinDir = "$composerDir/vendor/bin";
+        mkdir($vendorBinDir, 0777, true);
+        touch($vendorBinDir . '/b');
+        touch($vendorBinDir . '/b.bat');
+        touch($vendorBinDir . '/c');
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'exec', '--list' => true]);
+
+        $output = $appTester->getDisplay(true);
+
+        $this->assertSame(
+            <<<OUTPUT
+Available binaries:
+- b
+- c
+- a (local)
+
+OUTPUT,
+            $output
+        );
+    }
+}

--- a/tests/Composer/Test/Command/ExecCommandTest.php
+++ b/tests/Composer/Test/Command/ExecCommandTest.php
@@ -38,11 +38,11 @@ class ExecCommandTest extends TestCase
             ]
         ]);
 
-        $vendorBinDir = "$composerDir/vendor/bin";
-        mkdir($vendorBinDir, 0777, true);
-        touch($vendorBinDir . '/b');
-        touch($vendorBinDir . '/b.bat');
-        touch($vendorBinDir . '/c');
+        $composerBinDir = "$composerDir/vendor/bin";
+        mkdir($composerBinDir, 0777, true);
+        touch($composerBinDir . '/b');
+        touch($composerBinDir . '/b.bat');
+        touch($composerBinDir . '/c');
 
         $appTester = $this->getApplicationTester();
         $appTester->run(['command' => 'exec', '--list' => true]);


### PR DESCRIPTION
This PR belongs to #10796
This increases the line coverage of ExecCommand to 80%.
At the moment this test only affects the listing of binaries, but not the execution. 

![grafik](https://user-images.githubusercontent.com/7249788/193418530-04ff2e3c-3985-4f38-8cde-37ae895a47c2.png)

