### PR TITLE
Update link text to runtime page in documentation

### DIFF
--- a/doc/08-community.md
+++ b/doc/08-community.md
@@ -33,4 +33,4 @@ For paid support, we do provide Composer-related support via chat and email to
 [Private Packagist](https://packagist.com) customers.
 
 
-&larr; [Config](07-runtime.md)
+&larr; [Runtime](07-runtime.md)


### PR DESCRIPTION
This PR updates the link text that links to the "Runtime" page on the "Community" page.