### PR TITLE
Improve ArrayLoader resilience against non-string reasons

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -209,7 +209,8 @@ class ArrayLoader implements LoaderInterface
 
         if (isset($config['suggest']) && \is_array($config['suggest'])) {
             foreach ($config['suggest'] as $target => $reason) {
-                if ('self.version' === trim($reason)) {
+                // Json may produce non-string reasons.
+                if ('self.version' === trim((string) $reason)) {
                     $config['suggest'][$target] = $package->getPrettyVersion();
                 }
             }


### PR DESCRIPTION
I have seen this happen in some package with the latest satis build The package was admittedly abusing the reason field with a version 3.0. This would deserialize to a float value which in turn crashes trim(). 

Arguably, we could improve resilience even further by ensuring the value is actually stringable - but I did not want to overdo it.
