### PR TITLE
Allow other CLIs (like satis in standalone mode) to re-brand composer.

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -84,10 +84,12 @@ class Application extends BaseApplication
     /** @var SignalHandler */
     private $signalHandler;
 
-    public function __construct()
+    public function __construct(string $name = 'Composer', string $version = '')
     {
         static $shutdownRegistered = false;
-
+        if ($version === '') {
+            $version = Composer::getVersion();
+        }
         if (function_exists('ini_set') && extension_loaded('xdebug')) {
             ini_set('xdebug.show_exception_trace', '0');
             ini_set('xdebug.scream', '0');
@@ -121,7 +123,7 @@ class Application extends BaseApplication
 
         $this->initialWorkingDirectory = getcwd();
 
-        parent::__construct('Composer', Composer::getVersion());
+        parent::__construct($name, $version);
     }
 
     public function __destruct()


### PR DESCRIPTION
This affects the banner at the head of the help screen and the version info. Symfony's base object offers the same signature but composer does not allow to override it in constructor.
Yet there are public setter methods to change both after initializing the object. This is the workaround satis cli currently uses.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
