### PR TITLE
Fix json format of audit command missing affectedVersions, fix reportedAt format (BC BREAK!)

### DIFF
--- a/src/Composer/Advisory/PartialSecurityAdvisory.php
+++ b/src/Composer/Advisory/PartialSecurityAdvisory.php
@@ -14,8 +14,9 @@ namespace Composer\Advisory;
 
 use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Semver\VersionParser;
+use JsonSerializable;
 
-class PartialSecurityAdvisory
+class PartialSecurityAdvisory implements JsonSerializable
 {
     /**
      * @var string
@@ -54,5 +55,17 @@ class PartialSecurityAdvisory
         $this->advisoryId = $advisoryId;
         $this->packageName = $packageName;
         $this->affectedVersions = $affectedVersions;
+    }
+
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        $data = (array) $this;
+        $data['affectedVersions'] = $data['affectedVersions']->getPrettyString();
+
+        return $data;
     }
 }

--- a/src/Composer/Advisory/SecurityAdvisory.php
+++ b/src/Composer/Advisory/SecurityAdvisory.php
@@ -61,4 +61,16 @@ class SecurityAdvisory extends PartialSecurityAdvisory
         $this->cve = $cve;
         $this->link = $link;
     }
+
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        $data = parent::jsonSerialize();
+        $data['reportedAt'] = $data['reportedAt']->format(DATE_RFC3339);
+
+        return $data;
+    }
 }


### PR DESCRIPTION
Fixes #11104

This fixes the affectedVersions missing from the output, but also changes the reportedAt output from

```
                "reportedAt": {
                    "date": "2022-02-04 06:52:21.000000",
                    "timezone_type": 3,
                    "timezone": "UTC"
                },
```

to `"reportedAt": "2022-02-04T06:52:21+00:00"`

This is strictly speaking a BC break but the old format was kinda garbage so I think we rather fix this now while it's still early. It's an easy fix anyway and should trigger hard failures for anyone accessing the `reportedAt>date` field so it shouldn't get missed.