### PR TITLE
Add support for a tmp-dir config item

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1111,6 +1111,12 @@ and following the
 By setting this option you can change the `bin` ([Vendor Binaries](articles/vendor-binaries.md))
 directory to something other than `vendor/bin`.
 
+### COMPOSER_TMP_DIR
+
+By setting this option you can change the `tmp` directory to something other than `vendor/composer`.
+
+This can help speed up installation on NFS volumes by fetching, unpacking and cleaning files on a local disk.
+
 ### COMPOSER_CACHE_DIR
 
 The `COMPOSER_CACHE_DIR` var allows you to change the Composer cache directory,

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -252,6 +252,10 @@ Defaults to `vendor`. You can install dependencies into a different directory if
 you want to. `$HOME` and `~` will be replaced by your home directory's path in
 vendor-dir and all `*-dir` options below.
 
+## tmp-dir
+
+Defaults to `vendor/composer`.
+
 ## bin-dir
 
 Defaults to `vendor/bin`. If a project includes binaries, they will be symlinked

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -438,6 +438,10 @@
                     "type": "string",
                     "description": "The location where all packages are installed, defaults to \"vendor\"."
                 },
+                "tmp-dir": {
+                    "type": "string",
+                    "description": "The location where all packages are extracted, defaults to \"vendor/composer\"."
+                },
                 "bin-dir": {
                     "type": "string",
                     "description": "The location where all binaries are linked, defaults to \"vendor/bin\"."

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -362,6 +362,9 @@ EOT
             'vendor-dir' => ['is_string', static function ($val) {
                 return $val;
             }],
+            'tmp-dir' => ['is_string', static function ($val) {
+                return $val;
+            }],
             'bin-dir' => ['is_string', static function ($val) {
                 return $val;
             }],

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -41,6 +41,7 @@ class Config
         'github-protocols' => ['https', 'ssh', 'git'],
         'gitlab-protocol' => null,
         'vendor-dir' => 'vendor',
+        'tmp-dir' => '{$vendor-dir}/composer',
         'bin-dir' => '{$vendor-dir}/bin',
         'cache-dir' => '{$home}/cache',
         'data-dir' => '{$home}',
@@ -262,6 +263,7 @@ class Config
         switch ($key) {
             // strings/paths with env var and {$refs} support
             case 'vendor-dir':
+            case 'tmp-dir':
             case 'bin-dir':
             case 'process-timeout':
             case 'data-dir':

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -68,7 +68,7 @@ abstract class ArchiveDownloader extends FileDownloader
         }
 
         do {
-            $temporaryDir = $vendorDir.'/composer/'.substr(md5(uniqid('', true)), 0, 8);
+            $temporaryDir = $this->config->get('tmp-dir').'/'.substr(md5(uniqid('', true)), 0, 8);
         } while (is_dir($temporaryDir));
 
         $this->addCleanupPath($package, $temporaryDir);

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -311,6 +311,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             $this->config->get('vendor-dir').'/'.explode('/', $package->getPrettyName())[0],
             $this->config->get('vendor-dir').'/composer/',
             $this->config->get('vendor-dir'),
+            $this->config->get('tmp-dir'),
         ];
 
         if (isset($this->additionalCleanupPaths[$package->getName()])) {
@@ -417,7 +418,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
      */
     protected function getFileName(PackageInterface $package, string $path): string
     {
-        return rtrim($this->config->get('vendor-dir').'/composer/tmp-'.md5($package.spl_object_hash($package)).'.'.pathinfo(parse_url(strtr((string) $package->getDistUrl(), '\\', '/'), PHP_URL_PATH), PATHINFO_EXTENSION), '.');
+        return rtrim($this->config->get('tmp-dir').'/tmp-'.md5($package.spl_object_hash($package)).'.'.pathinfo(parse_url(strtr((string) $package->getDistUrl(), '\\', '/'), PHP_URL_PATH), PATHINFO_EXTENSION), '.');
     }
 
     /**

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -190,6 +190,7 @@ class ConfigTest extends TestCase
         $config->merge(['config' => [
             'bin-dir' => '$HOME/foo',
             'cache-dir' => '/baz/',
+            'tmp-dir' => '/build/',
             'vendor-dir' => 'vendor',
         ]]);
 
@@ -197,6 +198,7 @@ class ConfigTest extends TestCase
         $this->assertEquals('/foo/bar/vendor', $config->get('vendor-dir'));
         $this->assertEquals($home.'/foo', $config->get('bin-dir'));
         $this->assertEquals('/baz', $config->get('cache-dir'));
+        $this->assertEquals('/build', $config->get('tmp-dir'));
     }
 
     public function testStreamWrapperDirs(): void
@@ -219,6 +221,7 @@ class ConfigTest extends TestCase
 
         $this->assertEquals('/foo/bar/vendor', $config->get('vendor-dir'));
         $this->assertEquals('/foo/bar/vendor/foo', $config->get('bin-dir'));
+        $this->assertEquals('/foo/bar/vendor/composer', $config->get('tmp-dir'));
         $this->assertEquals('vendor', $config->get('vendor-dir', Config::RELATIVE_PATHS));
         $this->assertEquals('vendor/foo', $config->get('bin-dir', Config::RELATIVE_PATHS));
     }

--- a/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
@@ -33,8 +33,8 @@ class ArchiveDownloaderTest extends TestCase
 
         $this->config->expects($this->any())
             ->method('get')
-            ->with('vendor-dir')
-            ->will($this->returnValue('/vendor'));
+            ->with('tmp-dir')
+            ->will($this->returnValue('/vendor/composer'));
 
         $first = $method->invoke($downloader, $packageMock, '/path');
         $this->assertMatchesRegularExpression('#/vendor/composer/tmp-[a-z0-9]+\.js#', $first);

--- a/tests/Composer/Test/Downloader/ZipDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ZipDownloaderTest.php
@@ -80,8 +80,18 @@ class ZipDownloaderTest extends TestCase
 
         $this->config->expects($this->any())
             ->method('get')
-            ->with('vendor-dir')
-            ->will($this->returnValue($this->testDir));
+            ->withConsecutive(
+                ['tmp-dir'],
+                ['vendor-dir'],
+                ['tmp-dir'],
+                ['tmp-dir']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->returnValue($this->testDir . '/composer'),
+                $this->returnValue($this->testDir),
+                $this->returnValue($this->testDir . '/composer'),
+                $this->returnValue($this->testDir . '/composer')
+            );
 
         $this->package->expects($this->any())
             ->method('getDistUrl')

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,3 +33,4 @@ Platform::putEnv('COMPOSER_TESTS_ARE_RUNNING', '1');
 Platform::clearEnv('COMPOSER');
 Platform::clearEnv('COMPOSER_VENDOR_DIR');
 Platform::clearEnv('COMPOSER_BIN_DIR');
+Platform::clearEnv('COMPOSER_TMP_DIR');


### PR DESCRIPTION
This can help speed up installation on NFS volumes by fetching, unpacking and cleaning files on a local disk.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
