### PR TITLE
Document recovering from invalid merges on composer.lock and composer.json

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -339,6 +339,7 @@ uninstalled.
 * **--apcu-autoloader:** Use APCu to cache found/not-found classes.
 * **--apcu-autoloader-prefix:** Use a custom prefix for the APCu autoloader cache.
   Implicitly enables `--apcu-autoloader`.
+* **--unused** Remove unused packages that are not a direct or indirect dependency (anymore)
 
 ## bump
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -311,6 +311,8 @@ After removing the requirements, the modified requirements will be
 uninstalled.
 
 ### Options
+
+* **--unused** Remove unused packages that are not a direct or indirect dependency (anymore)
 * **--dev:** Remove packages from `require-dev`.
 * **--dry-run:** Simulate the command without actually doing anything.
 * **--no-progress:** Removes the progress display that can mess with some
@@ -339,7 +341,6 @@ uninstalled.
 * **--apcu-autoloader:** Use APCu to cache found/not-found classes.
 * **--apcu-autoloader-prefix:** Use a custom prefix for the APCu autoloader cache.
   Implicitly enables `--apcu-autoloader`.
-* **--unused** Remove unused packages that are not a direct or indirect dependency (anymore)
 
 ## bump
 

--- a/doc/articles/resolving-merge-conflicts.md
+++ b/doc/articles/resolving-merge-conflicts.md
@@ -77,7 +77,7 @@ There are two things that can happen here:
 
 1. There are packages in the `require` or `require-dev` section of the `composer.json` file that are not in the lock file and as a result never installed
 
-> **Note:** Starting from Composer release 2.5, packages that are required but not locked will result in an error when running ```composer install```
+> **Note:** Starting from Composer release 2.5, having packages that are required but not present in `composer.lock` results in an error when running `install`
 
 2. There are packages in the `composer.lock` file that are not a direct or indirect dependency of any of the packages required. As a result, a package is installed, even though running `composer why vendor/package` says it is not required.
 

--- a/doc/articles/resolving-merge-conflicts.md
+++ b/doc/articles/resolving-merge-conflicts.md
@@ -43,8 +43,8 @@ Before committing, make sure the resulting `composer.json` and `composer.lock` f
 To do this, run the following commands:
 
 ```shell
-composer validate
-composer install [--dry-run]
+php composer.phar validate
+php composer.phar install [--dry-run]
 ```
 
 ## Automating merge conflict resolving with git
@@ -104,7 +104,7 @@ There is an option to recover from a discrepancy between the `composer.json` and
 To detect any package that is required but not installed, you can simply run:
 
 ```shell
-composer validate
+php composer.phar validate
 ```
 
 If there are packages that are required but not installed, you should get output similar to this:
@@ -129,7 +129,7 @@ To recover from this, simply run `composer update vendor/package-name` for each 
 To detect and fix packages that are locked but not a direct/indirect dependency, you can run the following command:
 
 ```shell
-composer remove --unused
+php composer.phar remove --unused
 ```
 
 If there are no packages locked that are not a dependency, the command will have the following output:

--- a/doc/articles/resolving-merge-conflicts.md
+++ b/doc/articles/resolving-merge-conflicts.md
@@ -69,7 +69,11 @@ that merging branches does not break anything by accidentally updating a depende
 
 # Recovering from incorrectly resolved merge conflicts
 
-If the above steps aren't followed and text based merges have been done anyway, your Composer project might be in a state where unexpected behaviour is observed because the `composer.lock` file is not (fully) in sync with the `composer.json` file. There are two things that can happen here:
+If the above steps aren't followed and text based merges have been done anyway,
+your Composer project might be in a state where unexpected behaviour is observed
+because the `composer.lock` file is not (fully) in sync with the `composer.json` file.
+
+There are two things that can happen here:
 
 1. There are packages in the `require` or `require-dev` section of the `composer.json` file that are not in the lock file and as a result never installed
 

--- a/doc/articles/resolving-merge-conflicts.md
+++ b/doc/articles/resolving-merge-conflicts.md
@@ -73,6 +73,8 @@ If the above steps aren't followed and text based merges have been done anyway, 
 
 1. There are packages in the `require` or `require-dev` section of the `composer.json` file that are not in the lock file and as a result never installed
 
+> **Note:** Starting from Composer release 2.5, packages that are required but not locked will result in an error when running ```composer install```
+
 2. There are packages in the `composer.lock` file that are not a direct or indirect dependency of any of the packages required. As a result, a package is installed, even though running `composer why vendor/package` says it is not required.
 
 There are several ways to fix these issues;


### PR DESCRIPTION
Hi @Seldaek, It's been a while since my previous PR regarding documenting correctly resolving merge conflicts in #9386 and subsequently detecting missing packages after incorrect merges in #9899, but I now work at a different company and I am once again trying to recover from an incorrect merge without walking through months of git logs or removing the lock file. ;)

When walking through code from #9386 and trying to figure out if there is an easy way to check unused packages in the validate command, I noticed there was already code present for an undocumented feature added in #8786 where the remove command can be run with the '--unused' flag to remove unused packages.

Would you be open to use the code in the 'interact' method in the 'removeCommand' to also display errors when running 'composer validate' with packages that are locked but not required? I can open a PR for that.

Meanwhile, I decided to add some documentation about the --unused flag and recovering from incorrect merges. Do you agree with the content here?