### PR TITLE
Also bump match all constraint

### DIFF
--- a/tests/Composer/Test/Package/Version/VersionBumperTest.php
+++ b/tests/Composer/Test/Package/Version/VersionBumperTest.php
@@ -60,5 +60,6 @@ class VersionBumperTest extends TestCase
         yield 'leave patch wildcard alone' => ['2.4.3.*', '2.4.3.2', '2.4.3.*'];
         yield 'upgrade tilde to caret when compatible' => ['~2.2', '2.4.3', '^2.4.3'];
         yield 'leave patch-only-tilde alone' => ['~2.2.3', '2.2.6', '~2.2.3'];
+        yield 'upgrade match all constraint' => ['*', '1.2.1', '>= 1.2.1'];
     }
 }


### PR DESCRIPTION
Currently `composer bump` ignores `*` constraints.
I think this is inconsistent because the way I understand the bump command (maybe I'm wrong and that's the issue? :D), it's supposed to ensure that it does not downgrade any already existing package which would currently happen for `*` requirements.