### PR TITLE
[changelog] Add 2.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,13 @@
   * Fixed symlink creation in linux VM guest filesystems to be recognized by Windows (#10592)
   * Performance improvement in pool optimization step (#10585)
 
+### [2.2.18] 2022-08-20
+
+  * Fixed `COMPOSER_NO_DEV` so it also works with require and remove's `--update-no-dev` (#10995)
+  * Fixed duplicate missing extension warnings being displayed (#10938)
+  * Fixed hg version detection (#10955)
+  * Fixed git cache invalidation issue when a git tag gets created after the cache has loaded a given reference (#11004)
+
 ### [2.2.17] 2022-07-13
 
   * Fixed plugins from CWD/vendor being loaded in some cases like create-project or validate even though the target directory is outside of CWD (#10935)
@@ -1676,6 +1683,7 @@
 [2.3.0]: https://github.com/composer/composer/compare/2.3.0-RC2...2.3.0
 [2.3.0-RC2]: https://github.com/composer/composer/compare/2.3.0-RC1...2.3.0-RC2
 [2.3.0-RC1]: https://github.com/composer/composer/compare/2.2.9...2.3.0-RC1
+[2.2.18]: https://github.com/composer/composer/compare/2.2.17...2.2.18
 [2.2.17]: https://github.com/composer/composer/compare/2.2.16...2.2.17
 [2.2.16]: https://github.com/composer/composer/compare/2.2.15...2.2.16
 [2.2.15]: https://github.com/composer/composer/compare/2.2.14...2.2.15


### PR DESCRIPTION
https://getcomposer.org/changelog/2.2.18 was returning a 404, this should fix it.