### PR TITLE
Allow the 'composer remove --unused' command to run in non-interactive mode

### DIFF
--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -129,9 +129,8 @@ EOT
 
             if (count($packages) === 0) {
                 $this->getIO()->writeError('<info>No unused packages to remove</info>');
-                $this->setCode(static function (): int {
-                    return 0;
-                });
+
+                return 0;
             }
         }
 


### PR DESCRIPTION
Currently, the command 'composer remove --unused' doesn't work in non-interactive mode. This prevents it from being run in github actions for example;

```
COMPOSER_NO_INTERACTION=true composer remove --unused
```

```
Error: Not enough arguments (missing: "packages").

                                               
  Not enough arguments (missing: "packages").  
                                               

remove [--dev] [--dry-run] [--no-progress] [--no-update] [--no-install] [--no-audit] [--audit-format AUDIT-FORMAT] [--update-no-dev] [-w|--update-with-dependencies] [-W|--update-with-all-dependencies] [--with-all-dependencies] [--no-update-with-dependencies] [--unused] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--] <packages>...

Error: Process completed with exit code 1.
```

There is nothing actually interacting with a user in the command, as far as I can see it is only run in the interact method to circumvent the required validation of the packages argument. Instead of this, we can make the packages argument not required in the InputArgument definition and check if either the 'packages' argument is present or the '--unused' flag is given.