### PR TITLE
Make possible return type in `IOInterface::select()` more explicit

### DIFF
--- a/src/Composer/IO/IOInterface.php
+++ b/src/Composer/IO/IOInterface.php
@@ -191,7 +191,7 @@ interface IOInterface extends LoggerInterface
      * @param bool        $multiselect  Select more than one value separated by comma
      *
      * @throws \InvalidArgumentException
-     * @return int|string|string[]|bool     The selected value or values (the key of the choices array)
+     * @return int|string|list<string>|bool     The selected value or values (the key of the choices array)
      */
     public function select(string $question, array $choices, $default, $attempts = false, string $errorMessage = 'Value "%s" is invalid', bool $multiselect = false);
 


### PR DESCRIPTION
`IOInterface::select()` either returns any of `int`, `string`, `bool` or an array of `string` values. However, since the returned array is always a list, we can safely change the return type annotation to `list<string>`, making it more explicit in terms of static code analysis.