### PR TITLE
Audit: ignores configured repository options

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -685,14 +685,15 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         }
 
         if ($apiUrl !== null && count($packageConstraintMap) > 0) {
-            $options = [
-                'http' => [
-                    'method' => 'POST',
-                    'header' => ['Content-type: application/x-www-form-urlencoded'],
-                    'timeout' => 10,
-                    'content' => http_build_query(['packages' => array_keys($packageConstraintMap)]),
-                ],
-            ];
+            $options = $this->options;
+            $options['http']['method'] = 'POST';
+            if (isset($options['http']['header'])) {
+                $options['http']['header'] = (array) $options['http']['header'];
+            }
+            $options['http']['header'][] = 'Content-type: application/x-www-form-urlencoded';
+            $options['http']['timeout'] = 10;
+            $options['http']['content'] = http_build_query(['packages' => array_keys($packageConstraintMap)]);
+
             $response = $this->httpDownloader->get($apiUrl, $options);
             /** @var string $name */
             foreach ($response->decodeJson()['advisories'] as $name => $list) {

--- a/tests/Composer/Test/Mock/HttpDownloaderMock.php
+++ b/tests/Composer/Test/Mock/HttpDownloaderMock.php
@@ -112,8 +112,10 @@ class HttpDownloaderMock extends HttpDownloader
         }
 
         throw new AssertionFailedError(
-            'Received unexpected request for "'.$fileUrl.'"'.PHP_EOL.
-            (is_array($this->expectations) && count($this->expectations) > 0 ? 'Expected "'.$this->expectations[0]['url'].'" at this point.' : 'Expected no more calls at this point.').PHP_EOL.
+            'Received unexpected request for "'.$fileUrl.'" with options "'.json_encode($options).'"'.PHP_EOL.
+            (is_array($this->expectations) && count($this->expectations) > 0
+                ? 'Expected "'.$this->expectations[0]['url'].($this->expectations[0]['options'] !== null ? '" with options "'.json_encode($this->expectations[0]['options']) : '').'" at this point.'
+                : 'Expected no more calls at this point.').PHP_EOL.
             'Received calls:'.PHP_EOL.implode(PHP_EOL, array_slice($this->log, 0, -1))
         );
     }


### PR DESCRIPTION
`composer audit` ignore any configured repository options of repositories of type `composer`

Sample composer.json
```
{
    "repositories": {
        "packagist.org": false,
        "other": {
            "type": "composer",
            "url":  "https://packagist.org",
            "options": {
                "ssl": {
                    "verify_peer": false,
                    "verify_peer_name": false
                }
            }
        }
    },
    "require": {
        "symfony/debug": "^3.0"
    }
}
```

Expected output:
```
composer audit
Warning: Accessing packagist.org with verify_peer and verify_peer_name disabled.
No security vulnerability advisories found
```

Actual output:
```
composer audit
No security vulnerability advisories found
```
