### PR TITLE
Changing colors of success messages

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -608,18 +608,18 @@ EOT
                     if (\count($directDeps) > 0) {
                         $this->printPackages($io, $directDeps, $indent, $versionFits, $latestFits, $descriptionFits, $width, $versionLength, $nameLength, $latestLength);
                     } else {
-                        $io->writeError('Everything up to date');
+                        $io->writeError('<info>Everything up to date</>');
                     }
                     $io->writeError('');
                     $io->writeError('<info>Transitive dependencies not required in composer.json:</>');
                     if (\count($transitiveDeps) > 0) {
                         $this->printPackages($io, $transitiveDeps, $indent, $versionFits, $latestFits, $descriptionFits, $width, $versionLength, $nameLength, $latestLength);
                     } else {
-                        $io->writeError('Everything up to date');
+                        $io->writeError('<info>Everything up to date</>');
                     }
                 } else {
                     if ($writeLatest && \count($packages) === 0) {
-                        $io->writeError('All your direct dependencies are up to date');
+                        $io->writeError('<info>All your direct dependencies are up to date</>');
                     } else {
                         $this->printPackages($io, $packages, $indent, $versionFits, $latestFits, $descriptionFits, $width, $versionLength, $nameLength, $latestLength);
                     }


### PR DESCRIPTION
IMO, green should only be used for *success* messages. So everything that's currently green (in the output of `composer outdated`) should be changed to some other (neutral) color (what about blue?) => But I don't know how to do this :-(