### PR TITLE
Allow storing credentials globally when 'local' auth.json file exists

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -102,6 +102,8 @@ class Config
     private $configSource;
     /** @var ConfigSourceInterface */
     private $authConfigSource;
+    /** @var ConfigSourceInterface|null */
+    private $localAuthConfigSource = null;
     /** @var bool */
     private $useEnvironment;
     /** @var array<string, true> */
@@ -151,6 +153,16 @@ class Config
     public function getAuthConfigSource(): ConfigSourceInterface
     {
         return $this->authConfigSource;
+    }
+
+    public function setLocalAuthConfigSource(ConfigSourceInterface $source): void
+    {
+        $this->localAuthConfigSource = $source;
+    }
+
+    public function getLocalAuthConfigSource(): ?ConfigSourceInterface
+    {
+        return $this->localAuthConfigSource;
     }
 
     /**

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -336,7 +336,7 @@ class Factory
                 $io->writeError('Loading config file ' . $localAuthFile->getPath(), true, IOInterface::DEBUG);
                 self::validateJsonSchema($io, $localAuthFile, JsonFile::AUTH_SCHEMA);
                 $config->merge(['config' => $localAuthFile->read()], $localAuthFile->getPath());
-                $config->setAuthConfigSource(new JsonConfigSource($localAuthFile, true));
+                $config->setLocalAuthConfigSource(new JsonConfigSource($localAuthFile, true));
             }
         }
 


### PR DESCRIPTION
When in interactive mode with missing credentials, the credentials are always stored in the local auth.json file if it exists, even though credentials in the auth.json might be shared through git and the user wants to store their credentials in their global auth.json:

```diff
Your GitHub credentials are required to fetch private repository metadata (https://github.com/vendor/package)
When working with _public_ GitHub repositories only, head to https://github.com/settings/tokens/new?scopes=&description=MachineName+TIMESTAMP to retrieve a token.
This token will have read-only permission for public information only.
When you need to access _private_ GitHub repositories as well, go to https://github.com/settings/tokens/new?scopes=repo&description=MachineName+TIMESTAMP
Note that such tokens have broad read/write permissions on your behalf, even if not needed by Composer.
Tokens will be stored in plain text in "~/user/.composer/auth.json" for future use by Composer.
For additional information, check https://getcomposer.org/doc/articles/authentication-for-private-packages.md#github-oauth
Token (hidden): 
```

This PR adds the ability to choose where to store this newly acquired token when such a local auth.json file exists before prompting for the token:

```diff
Your GitHub credentials are required to fetch private repository metadata (https://github.com/vendor/package)
When working with _public_ GitHub repositories only, head to https://github.com/settings/tokens/new?scopes=&description=MachineName+TIMESTAMP to retrieve a token.
This token will have read-only permission for public information only.
When you need to access _private_ GitHub repositories as well, go to https://github.com/settings/tokens/new?scopes=repo&description=MachineName+TIMESTAMP
Note that such tokens have broad read/write permissions on your behalf, even if not needed by Composer.
-Tokens will be stored in plain text in "~/user/.composer/auth.json" for future use by Composer.
+Tokens will be stored in plain text in "~/user/.composer/auth.json" OR "~/user/project/auth.json" for future use by Composer.
For additional information, check https://getcomposer.org/doc/articles/authentication-for-private-packages.md#github-oauth
-Token (hidden): 
+ A local auth config source was found, do you want to store the token there? [y]:
```

Also, in the Github and BitBucket authentication, existing keys were incorrectly removed from the composer.json file instead of the auth.json file. Those issues are also fixed in this PR.