### PR TITLE
Use lowercase Github ratelimit headers to determine the ratelimit limit and reset time

### DIFF
--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -154,11 +154,11 @@ class GitHub
 
         foreach ($headers as $header) {
             $header = trim($header);
-            if (false === strpos($header, 'x-ratelimit-')) {
+            if (false === stripos($header, 'x-ratelimit-')) {
                 continue;
             }
             [$type, $value] = explode(':', $header, 2);
-            switch ($type) {
+            switch (strtolower($type)) {
                 case 'x-ratelimit-limit':
                     $rateLimit['limit'] = (int) trim($value);
                     break;

--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -154,15 +154,15 @@ class GitHub
 
         foreach ($headers as $header) {
             $header = trim($header);
-            if (false === strpos($header, 'X-RateLimit-')) {
+            if (false === strpos($header, 'x-ratelimit-')) {
                 continue;
             }
             [$type, $value] = explode(':', $header, 2);
             switch ($type) {
-                case 'X-RateLimit-Limit':
+                case 'x-ratelimit-limit':
                     $rateLimit['limit'] = (int) trim($value);
                     break;
-                case 'X-RateLimit-Reset':
+                case 'x-ratelimit-reset':
                     $rateLimit['reset'] = date('Y-m-d H:i:s', (int) trim($value));
                     break;
             }


### PR DESCRIPTION
Currently, when hitting the github rate limit the following errors is shown, where the remaining requests and time are not displayed:

```diff
GitHub API limit (0 calls/hr) is exhausted, could not fetch https://api.github.com/repos/reponame. 
Review your configured GitHub OAuth token or enter a new one to go over the API rate limit. 
You can also wait until ? for the rate limit to reset.
```

This caused some confusion here, we were wondering if our token was expired and that's why the 0 calls/hr was displayed.

A while ago (februari 2nd 2022), the headers were corrected in the documentation though (https://github.com/github/docs/pull/14912). This PR makes it so the lower case header format is used, and the information is filled:

```diff
-GitHub API limit (0 calls/hr) is exhausted, could not fetch https://api.github.com/repos/reponame. 
+GitHub API limit (5000 calls/hr) is exhausted, could not fetch https://api.github.com/repos/reponame. 
Review your configured GitHub OAuth token or enter a new one to go over the API rate limit. 
-You can also wait until ? for the rate limit to reset.
+You can also wait until 2022-11-23 20:45:00 for the rate limit to reset.
```