### PR TITLE
[Tests] Use static data providers

### DIFF
--- a/tests/Composer/Test/Advisory/AuditorTest.php
+++ b/tests/Composer/Test/Advisory/AuditorTest.php
@@ -25,7 +25,7 @@ use InvalidArgumentException;
 
 class AuditorTest extends TestCase
 {
-    public function auditProvider()
+    public static function auditProvider()
     {
         return [
             // Test no advisories returns 0

--- a/tests/Composer/Test/AllFunctionalTest.php
+++ b/tests/Composer/Test/AllFunctionalTest.php
@@ -179,7 +179,7 @@ class AllFunctionalTest extends TestCase
     /**
      * @return array<string, array<string>>
      */
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
         $tests = [];
         foreach (Finder::create()->in(__DIR__.'/Fixtures/functional')->name('*.test')->files() as $file) {

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -1830,7 +1830,7 @@ EOF;
     /**
      * @return array<string, mixed[]>
      */
-    public function platformCheckProvider(): array
+    public static function platformCheckProvider(): array
     {
         $versionParser = new VersionParser();
 

--- a/tests/Composer/Test/Autoload/ClassLoaderTest.php
+++ b/tests/Composer/Test/Autoload/ClassLoaderTest.php
@@ -42,7 +42,7 @@ class ClassLoaderTest extends TestCase
      *
      * @return array<array<string>> Array of parameter sets to test with.
      */
-    public function getLoadClassTests(): array
+    public static function getLoadClassTests(): array
     {
         return [
             ['Namespaced\\Foo'],

--- a/tests/Composer/Test/Command/BumpCommandTest.php
+++ b/tests/Composer/Test/Command/BumpCommandTest.php
@@ -28,11 +28,11 @@ class BumpCommandTest extends TestCase
         $this->initTempComposer($composerJson);
 
         $packages = [
-            $this->getPackage('first/pkg', '2.3.4'),
-            $this->getPackage('second/pkg', '3.4.0'),
+            self::getPackage('first/pkg', '2.3.4'),
+            self::getPackage('second/pkg', '3.4.0'),
         ];
         $devPackages = [
-            $this->getPackage('dev/pkg', '2.3.4.5'),
+            self::getPackage('dev/pkg', '2.3.4.5'),
         ];
 
         $this->createInstalledJson($packages, $devPackages);
@@ -71,7 +71,7 @@ class BumpCommandTest extends TestCase
         $this->assertStringContainsString("./composer.json is not writable.", $appTester->getErrorOutput());
     }
 
-    public function provideTests(): \Generator
+    public static function provideTests(): \Generator
     {
         yield 'bump all by default' => [
             [

--- a/tests/Composer/Test/Command/CheckPlatformReqsCommandTest.php
+++ b/tests/Composer/Test/Command/CheckPlatformReqsCommandTest.php
@@ -31,10 +31,10 @@ class CheckPlatformReqsCommandTest extends TestCase
         $this->initTempComposer($composerJson);
 
         $packages = [
-            $this->getPackage('ext-foobar', '2.3.4'),
+            self::getPackage('ext-foobar', '2.3.4'),
         ];
         $devPackages = [
-            $this->getPackage('ext-barbaz', '2.3.4.5')
+            self::getPackage('ext-barbaz', '2.3.4.5')
         ];
 
         $this->createInstalledJson($packages, $devPackages);
@@ -59,7 +59,7 @@ class CheckPlatformReqsCommandTest extends TestCase
         $appTester->run(['command' => 'check-platform-reqs']);
     }
 
-    public function caseProvider(): \Generator
+    public static function caseProvider(): \Generator
     {
         yield 'Disables checking of require-dev packages requirements.' => [
             [
@@ -85,9 +85,7 @@ ext-foobar 2.3.4   success'
                 ]
             ],
             ['--lock' => true],
-            'Checking platform requirements using the lock file
-ext-barbaz 2.3.4.5   success 
-ext-foobar 2.3.4     success'
+            "Checking platform requirements using the lock file\next-barbaz 2.3.4.5   success \next-foobar 2.3.4     success"
         ];
     }
 }

--- a/tests/Composer/Test/Command/ConfigCommandTest.php
+++ b/tests/Composer/Test/Command/ConfigCommandTest.php
@@ -34,7 +34,7 @@ class ConfigCommandTest extends TestCase
         $this->assertSame($expected, json_decode((string) file_get_contents('composer.json'), true));
     }
 
-    public function provideConfigUpdates(): \Generator
+    public static function provideConfigUpdates(): \Generator
     {
         yield 'set scripts' => [
             [],
@@ -101,7 +101,7 @@ class ConfigCommandTest extends TestCase
         $this->assertSame($composerJson, json_decode((string) file_get_contents('composer.json'), true), 'The composer.json should not be modified by config reads');
     }
 
-    public function provideConfigReads(): \Generator
+    public static function provideConfigReads(): \Generator
     {
         yield 'read description' => [
             ['description' => 'foo bar'],

--- a/tests/Composer/Test/Command/FundCommandTest.php
+++ b/tests/Composer/Test/Command/FundCommandTest.php
@@ -32,11 +32,11 @@ class FundCommandTest extends TestCase
         $this->initTempComposer($composerJson);
 
         $packages = [
-            'first/pkg' => $this->getPackage('first/pkg', '2.3.4'),
-            'stable/pkg' => $this->getPackage('stable/pkg', '1.0.0'),
+            'first/pkg' => self::getPackage('first/pkg', '2.3.4'),
+            'stable/pkg' => self::getPackage('stable/pkg', '1.0.0'),
         ];
         $devPackages = [
-            'dev/pkg' => $this->getPackage('dev/pkg', '2.3.4.5')
+            'dev/pkg' => self::getPackage('dev/pkg', '2.3.4.5')
         ];
 
         if (count($funding) !== 0) {
@@ -59,7 +59,7 @@ class FundCommandTest extends TestCase
         $this->assertSame(trim($expected), trim($appTester->getDisplay(true)));
     }
 
-    public function useCaseProvider(): Generator
+    public static function useCaseProvider(): Generator
     {
         yield 'no funding links present, locally or remotely' => [
             [

--- a/tests/Composer/Test/Command/LicensesCommandTest.php
+++ b/tests/Composer/Test/Command/LicensesCommandTest.php
@@ -34,16 +34,16 @@ class LicensesCommandTest extends TestCase
             ],
         ]);
 
-        $first = $this->getPackage('first/pkg', '2.3.4');
+        $first = self::getPackage('first/pkg', '2.3.4');
         $first->setLicense(['MIT']);
 
-        $second = $this->getPackage('second/pkg', '3.4.0');
+        $second = self::getPackage('second/pkg', '3.4.0');
         $second->setLicense(['LGPL-2.0-only']);
         $second->setHomepage('https://example.org');
 
-        $third = $this->getPackage('third/pkg', '1.5.4');
+        $third = self::getPackage('third/pkg', '1.5.4');
 
-        $dev = $this->getPackage('dev/pkg', '2.3.4.5');
+        $dev = self::getPackage('dev/pkg', '2.3.4.5');
         $dev->setLicense(['MIT']);
 
         $this->createInstalledJson([$first, $second, $third], [$dev]);

--- a/tests/Composer/Test/Command/RequireCommandTest.php
+++ b/tests/Composer/Test/Command/RequireCommandTest.php
@@ -60,7 +60,7 @@ class RequireCommandTest extends TestCase
         }
     }
 
-    public function provideRequire(): \Generator
+    public static function provideRequire(): \Generator
     {
         yield 'warn once for missing ext but a lower package matches' => [
             [

--- a/tests/Composer/Test/Command/RunScriptCommandTest.php
+++ b/tests/Composer/Test/Command/RunScriptCommandTest.php
@@ -182,7 +182,7 @@ outeropt: set
     }
 
     /** @return bool[][] **/
-    public function getDevOptions(): array
+    public static function getDevOptions(): array
     {
         return [
             [true, true],

--- a/tests/Composer/Test/Command/SearchCommandTest.php
+++ b/tests/Composer/Test/Command/SearchCommandTest.php
@@ -70,7 +70,7 @@ class SearchCommandTest extends TestCase
         $appTester->run(['command' => 'search', '--only-vendor' => true, '--only-name' => true, 'tokens' => ['test']]);
     }
 
-    public function provideSearch(): \Generator
+    public static function provideSearch(): \Generator
     {
         yield 'by name and description' => [
             ['tokens' => ['fancy']],

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -52,14 +52,14 @@ class ShowCommandTest extends TestCase
             'require' => $requires === [] ? new \stdClass : $requires,
         ]);
 
-        $pkg = $this->getPackage('vendor/package', '1.0.0');
+        $pkg = self::getPackage('vendor/package', '1.0.0');
         $pkg->setDescription('description of installed package');
 
         $this->createInstalledJson([
             $pkg,
-            $this->getPackage('outdated/major', '1.0.0'),
-            $this->getPackage('outdated/minor', '1.0.0'),
-            $this->getPackage('outdated/patch', '1.0.0'),
+            self::getPackage('outdated/major', '1.0.0'),
+            self::getPackage('outdated/minor', '1.0.0'),
+            self::getPackage('outdated/patch', '1.0.0'),
         ]);
 
         $appTester = $this->getApplicationTester();
@@ -67,7 +67,7 @@ class ShowCommandTest extends TestCase
         self::assertSame(trim($expected), trim($appTester->getDisplay(true)));
     }
 
-    public function provideShow(): \Generator
+    public static function provideShow(): \Generator
     {
         yield 'default shows installed with version and description' => [
             [],
@@ -192,7 +192,7 @@ outdated/patch 1.0.0 <highlight>! 1.0.1</highlight>',
         ]);
 
         $this->createInstalledJson([
-            $this->getPackage('vendor/package', '1.1.0'),
+            self::getPackage('vendor/package', '1.1.0'),
         ]);
 
         $appTester = $this->getApplicationTester();
@@ -241,7 +241,7 @@ vendor/package 1.1.0 ~ 1.0.0", trim($appTester->getDisplay(true)));
         ]);
 
         $this->createInstalledJson([
-            $this->getPackage('vendor/package', '1.1.0'),
+            self::getPackage('vendor/package', '1.1.0'),
         ]);
 
         $appTester = $this->getApplicationTester();
@@ -271,7 +271,7 @@ vendor/package 1.1.0 <highlight>! 1.2.0</highlight>", trim($appTester->getDispla
         ]);
 
         $this->createInstalledJson([
-            $this->getPackage('vendor/package', '1.0.0'),
+            self::getPackage('vendor/package', '1.0.0'),
         ]);
 
         $appTester = $this->getApplicationTester();
@@ -323,10 +323,10 @@ vendor/package 1.1.0 <highlight>! 1.2.0</highlight>", trim($appTester->getDispla
         ]);
 
         $this->createInstalledJson([
-            $this->getPackage('zerozero/major', '0.0.1'),
-            $this->getPackage('zero/major', '0.1.0'),
-            $this->getPackage('zero/minor', '0.1.0'),
-            $this->getPackage('zero/patch', '0.1.2'),
+            self::getPackage('zerozero/major', '0.0.1'),
+            self::getPackage('zero/major', '0.1.0'),
+            self::getPackage('zero/minor', '0.1.0'),
+            self::getPackage('zero/patch', '0.1.2'),
         ]);
 
         $appTester = $this->getApplicationTester();
@@ -369,13 +369,13 @@ zerozero/major 0.0.1 ~ 0.0.2', trim($appTester->getDisplay(true)));
             ],
         ]);
 
-        $pkg = $this->getPackage('vendor/installed', '2.0.0');
+        $pkg = self::getPackage('vendor/installed', '2.0.0');
         $pkg->setDescription('description of installed package');
         $this->createInstalledJson([
             $pkg,
         ]);
 
-        $pkg = $this->getPackage('vendor/locked', '3.0.0');
+        $pkg = self::getPackage('vendor/locked', '3.0.0');
         $pkg->setDescription('description of locked package');
         $this->createComposerLock([
             $pkg,

--- a/tests/Composer/Test/Command/UpdateCommandTest.php
+++ b/tests/Composer/Test/Command/UpdateCommandTest.php
@@ -31,7 +31,7 @@ class UpdateCommandTest extends TestCase
         $this->assertSame(trim($expected), trim($appTester->getDisplay(true)));
     }
 
-    public function provideUpdates(): \Generator
+    public static function provideUpdates(): \Generator
     {
         $rootDepAndTransitiveDep = [
             'repositories' => [

--- a/tests/Composer/Test/Command/ValidateCommandTest.php
+++ b/tests/Composer/Test/Command/ValidateCommandTest.php
@@ -103,7 +103,7 @@ OUTPUT;
         ],
     ];
 
-    public function provideValidateTests(): \Generator
+    public static function provideValidateTests(): \Generator
     {
     
         yield 'validation passing' => [

--- a/tests/Composer/Test/CompletionFunctionalTest.php
+++ b/tests/Composer/Test/CompletionFunctionalTest.php
@@ -25,7 +25,7 @@ class CompletionFunctionalTest extends TestCase
     /**
      * @return iterable<array<string|string[]|null>>
      */
-    public function getCommandSuggestions(): iterable
+    public static function getCommandSuggestions(): iterable
     {
         $randomVendor = 'a/';
         $installedPackages = ['composer/semver', 'psr/log'];

--- a/tests/Composer/Test/Config/JsonConfigSourceTest.php
+++ b/tests/Composer/Test/Config/JsonConfigSourceTest.php
@@ -24,7 +24,7 @@ class JsonConfigSourceTest extends TestCase
     /** @var string */
     private $workingDir;
 
-    protected function fixturePath(string $name): string
+    protected static function fixturePath(string $name): string
     {
         return __DIR__.'/Fixtures/'.$name;
     }
@@ -46,17 +46,17 @@ class JsonConfigSourceTest extends TestCase
     public function testAddRepository(): void
     {
         $config = $this->workingDir.'/composer.json';
-        copy($this->fixturePath('composer-repositories.json'), $config);
+        copy(self::fixturePath('composer-repositories.json'), $config);
         $jsonConfigSource = new JsonConfigSource(new JsonFile($config));
         $jsonConfigSource->addRepository('example_tld', ['type' => 'git', 'url' => 'example.tld']);
 
-        $this->assertFileEquals($this->fixturePath('config/config-with-exampletld-repository.json'), $config);
+        $this->assertFileEquals(self::fixturePath('config/config-with-exampletld-repository.json'), $config);
     }
 
     public function testAddRepositoryWithOptions(): void
     {
         $config = $this->workingDir.'/composer.json';
-        copy($this->fixturePath('composer-repositories.json'), $config);
+        copy(self::fixturePath('composer-repositories.json'), $config);
         $jsonConfigSource = new JsonConfigSource(new JsonFile($config));
         $jsonConfigSource->addRepository('example_tld', [
             'type' => 'composer',
@@ -68,37 +68,37 @@ class JsonConfigSourceTest extends TestCase
             ],
         ]);
 
-        $this->assertFileEquals($this->fixturePath('config/config-with-exampletld-repository-and-options.json'), $config);
+        $this->assertFileEquals(self::fixturePath('config/config-with-exampletld-repository-and-options.json'), $config);
     }
 
     public function testRemoveRepository(): void
     {
         $config = $this->workingDir.'/composer.json';
-        copy($this->fixturePath('config/config-with-exampletld-repository.json'), $config);
+        copy(self::fixturePath('config/config-with-exampletld-repository.json'), $config);
         $jsonConfigSource = new JsonConfigSource(new JsonFile($config));
         $jsonConfigSource->removeRepository('example_tld');
 
-        $this->assertFileEquals($this->fixturePath('composer-repositories.json'), $config);
+        $this->assertFileEquals(self::fixturePath('composer-repositories.json'), $config);
     }
 
     public function testAddPackagistRepositoryWithFalseValue(): void
     {
         $config = $this->workingDir.'/composer.json';
-        copy($this->fixturePath('composer-repositories.json'), $config);
+        copy(self::fixturePath('composer-repositories.json'), $config);
         $jsonConfigSource = new JsonConfigSource(new JsonFile($config));
         $jsonConfigSource->addRepository('packagist', false);
 
-        $this->assertFileEquals($this->fixturePath('config/config-with-packagist-false.json'), $config);
+        $this->assertFileEquals(self::fixturePath('config/config-with-packagist-false.json'), $config);
     }
 
     public function testRemovePackagist(): void
     {
         $config = $this->workingDir.'/composer.json';
-        copy($this->fixturePath('config/config-with-packagist-false.json'), $config);
+        copy(self::fixturePath('config/config-with-packagist-false.json'), $config);
         $jsonConfigSource = new JsonConfigSource(new JsonFile($config));
         $jsonConfigSource->removeRepository('packagist');
 
-        $this->assertFileEquals($this->fixturePath('composer-repositories.json'), $config);
+        $this->assertFileEquals(self::fixturePath('composer-repositories.json'), $config);
     }
 
     /**
@@ -149,50 +149,50 @@ class JsonConfigSourceTest extends TestCase
      *
      * @phpstan-return array{string, string, string, string, string}
      */
-    protected function addLinkDataArguments(string $type, string $name, string $value, string $fixtureBasename, string $before): array
+    protected static function addLinkDataArguments(string $type, string $name, string $value, string $fixtureBasename, string $before): array
     {
         return [
             $before,
             $type,
             $name,
             $value,
-            $this->fixturePath('addLink/'.$fixtureBasename.'.json'),
+            self::fixturePath('addLink/'.$fixtureBasename.'.json'),
         ];
     }
 
     /**
      * Provide data for testAddLink
      */
-    public function provideAddLinkData(): array
+    public static function provideAddLinkData(): array
     {
-        $empty = $this->fixturePath('composer-empty.json');
-        $oneOfEverything = $this->fixturePath('composer-one-of-everything.json');
-        $twoOfEverything = $this->fixturePath('composer-two-of-everything.json');
+        $empty = self::fixturePath('composer-empty.json');
+        $oneOfEverything = self::fixturePath('composer-one-of-everything.json');
+        $twoOfEverything = self::fixturePath('composer-two-of-everything.json');
 
         return [
-            $this->addLinkDataArguments('require', 'my-vend/my-lib', '1.*', 'require-from-empty', $empty),
-            $this->addLinkDataArguments('require', 'my-vend/my-lib', '1.*', 'require-from-oneOfEverything', $oneOfEverything),
-            $this->addLinkDataArguments('require', 'my-vend/my-lib', '1.*', 'require-from-twoOfEverything', $twoOfEverything),
+            self::addLinkDataArguments('require', 'my-vend/my-lib', '1.*', 'require-from-empty', $empty),
+            self::addLinkDataArguments('require', 'my-vend/my-lib', '1.*', 'require-from-oneOfEverything', $oneOfEverything),
+            self::addLinkDataArguments('require', 'my-vend/my-lib', '1.*', 'require-from-twoOfEverything', $twoOfEverything),
 
-            $this->addLinkDataArguments('require-dev', 'my-vend/my-lib-tests', '1.*', 'require-dev-from-empty', $empty),
-            $this->addLinkDataArguments('require-dev', 'my-vend/my-lib-tests', '1.*', 'require-dev-from-oneOfEverything', $oneOfEverything),
-            $this->addLinkDataArguments('require-dev', 'my-vend/my-lib-tests', '1.*', 'require-dev-from-twoOfEverything', $twoOfEverything),
+            self::addLinkDataArguments('require-dev', 'my-vend/my-lib-tests', '1.*', 'require-dev-from-empty', $empty),
+            self::addLinkDataArguments('require-dev', 'my-vend/my-lib-tests', '1.*', 'require-dev-from-oneOfEverything', $oneOfEverything),
+            self::addLinkDataArguments('require-dev', 'my-vend/my-lib-tests', '1.*', 'require-dev-from-twoOfEverything', $twoOfEverything),
 
-            $this->addLinkDataArguments('provide', 'my-vend/my-lib-interface', '1.*', 'provide-from-empty', $empty),
-            $this->addLinkDataArguments('provide', 'my-vend/my-lib-interface', '1.*', 'provide-from-oneOfEverything', $oneOfEverything),
-            $this->addLinkDataArguments('provide', 'my-vend/my-lib-interface', '1.*', 'provide-from-twoOfEverything', $twoOfEverything),
+            self::addLinkDataArguments('provide', 'my-vend/my-lib-interface', '1.*', 'provide-from-empty', $empty),
+            self::addLinkDataArguments('provide', 'my-vend/my-lib-interface', '1.*', 'provide-from-oneOfEverything', $oneOfEverything),
+            self::addLinkDataArguments('provide', 'my-vend/my-lib-interface', '1.*', 'provide-from-twoOfEverything', $twoOfEverything),
 
-            $this->addLinkDataArguments('suggest', 'my-vend/my-optional-extension', '1.*', 'suggest-from-empty', $empty),
-            $this->addLinkDataArguments('suggest', 'my-vend/my-optional-extension', '1.*', 'suggest-from-oneOfEverything', $oneOfEverything),
-            $this->addLinkDataArguments('suggest', 'my-vend/my-optional-extension', '1.*', 'suggest-from-twoOfEverything', $twoOfEverything),
+            self::addLinkDataArguments('suggest', 'my-vend/my-optional-extension', '1.*', 'suggest-from-empty', $empty),
+            self::addLinkDataArguments('suggest', 'my-vend/my-optional-extension', '1.*', 'suggest-from-oneOfEverything', $oneOfEverything),
+            self::addLinkDataArguments('suggest', 'my-vend/my-optional-extension', '1.*', 'suggest-from-twoOfEverything', $twoOfEverything),
 
-            $this->addLinkDataArguments('replace', 'my-vend/other-app', '1.*', 'replace-from-empty', $empty),
-            $this->addLinkDataArguments('replace', 'my-vend/other-app', '1.*', 'replace-from-oneOfEverything', $oneOfEverything),
-            $this->addLinkDataArguments('replace', 'my-vend/other-app', '1.*', 'replace-from-twoOfEverything', $twoOfEverything),
+            self::addLinkDataArguments('replace', 'my-vend/other-app', '1.*', 'replace-from-empty', $empty),
+            self::addLinkDataArguments('replace', 'my-vend/other-app', '1.*', 'replace-from-oneOfEverything', $oneOfEverything),
+            self::addLinkDataArguments('replace', 'my-vend/other-app', '1.*', 'replace-from-twoOfEverything', $twoOfEverything),
 
-            $this->addLinkDataArguments('conflict', 'my-vend/my-old-app', '1.*', 'conflict-from-empty', $empty),
-            $this->addLinkDataArguments('conflict', 'my-vend/my-old-app', '1.*', 'conflict-from-oneOfEverything', $oneOfEverything),
-            $this->addLinkDataArguments('conflict', 'my-vend/my-old-app', '1.*', 'conflict-from-twoOfEverything', $twoOfEverything),
+            self::addLinkDataArguments('conflict', 'my-vend/my-old-app', '1.*', 'conflict-from-empty', $empty),
+            self::addLinkDataArguments('conflict', 'my-vend/my-old-app', '1.*', 'conflict-from-oneOfEverything', $oneOfEverything),
+            self::addLinkDataArguments('conflict', 'my-vend/my-old-app', '1.*', 'conflict-from-twoOfEverything', $twoOfEverything),
         ];
     }
 
@@ -201,48 +201,48 @@ class JsonConfigSourceTest extends TestCase
      *
      * @phpstan-return array{string, string, string, string}
      */
-    protected function removeLinkDataArguments(string $type, string $name, string $fixtureBasename, ?string $after = null): array
+    protected static function removeLinkDataArguments(string $type, string $name, string $fixtureBasename, ?string $after = null): array
     {
         return [
-            $this->fixturePath('removeLink/'.$fixtureBasename.'.json'),
+            self::fixturePath('removeLink/'.$fixtureBasename.'.json'),
             $type,
             $name,
-            $after ?: $this->fixturePath('removeLink/'.$fixtureBasename.'-after.json'),
+            $after ?: self::fixturePath('removeLink/'.$fixtureBasename.'-after.json'),
         ];
     }
 
     /**
      * Provide data for testRemoveLink
      */
-    public function provideRemoveLinkData(): array
+    public static function provideRemoveLinkData(): array
     {
-        $oneOfEverything = $this->fixturePath('composer-one-of-everything.json');
-        $twoOfEverything = $this->fixturePath('composer-two-of-everything.json');
+        $oneOfEverything = self::fixturePath('composer-one-of-everything.json');
+        $twoOfEverything = self::fixturePath('composer-two-of-everything.json');
 
         return [
-            $this->removeLinkDataArguments('require', 'my-vend/my-lib', 'require-to-empty'),
-            $this->removeLinkDataArguments('require', 'my-vend/my-lib', 'require-to-oneOfEverything', $oneOfEverything),
-            $this->removeLinkDataArguments('require', 'my-vend/my-lib', 'require-to-twoOfEverything', $twoOfEverything),
+            self::removeLinkDataArguments('require', 'my-vend/my-lib', 'require-to-empty'),
+            self::removeLinkDataArguments('require', 'my-vend/my-lib', 'require-to-oneOfEverything', $oneOfEverything),
+            self::removeLinkDataArguments('require', 'my-vend/my-lib', 'require-to-twoOfEverything', $twoOfEverything),
 
-            $this->removeLinkDataArguments('require-dev', 'my-vend/my-lib-tests', 'require-dev-to-empty'),
-            $this->removeLinkDataArguments('require-dev', 'my-vend/my-lib-tests', 'require-dev-to-oneOfEverything', $oneOfEverything),
-            $this->removeLinkDataArguments('require-dev', 'my-vend/my-lib-tests', 'require-dev-to-twoOfEverything', $twoOfEverything),
+            self::removeLinkDataArguments('require-dev', 'my-vend/my-lib-tests', 'require-dev-to-empty'),
+            self::removeLinkDataArguments('require-dev', 'my-vend/my-lib-tests', 'require-dev-to-oneOfEverything', $oneOfEverything),
+            self::removeLinkDataArguments('require-dev', 'my-vend/my-lib-tests', 'require-dev-to-twoOfEverything', $twoOfEverything),
 
-            $this->removeLinkDataArguments('provide', 'my-vend/my-lib-interface', 'provide-to-empty'),
-            $this->removeLinkDataArguments('provide', 'my-vend/my-lib-interface', 'provide-to-oneOfEverything', $oneOfEverything),
-            $this->removeLinkDataArguments('provide', 'my-vend/my-lib-interface', 'provide-to-twoOfEverything', $twoOfEverything),
+            self::removeLinkDataArguments('provide', 'my-vend/my-lib-interface', 'provide-to-empty'),
+            self::removeLinkDataArguments('provide', 'my-vend/my-lib-interface', 'provide-to-oneOfEverything', $oneOfEverything),
+            self::removeLinkDataArguments('provide', 'my-vend/my-lib-interface', 'provide-to-twoOfEverything', $twoOfEverything),
 
-            $this->removeLinkDataArguments('suggest', 'my-vend/my-optional-extension', 'suggest-to-empty'),
-            $this->removeLinkDataArguments('suggest', 'my-vend/my-optional-extension', 'suggest-to-oneOfEverything', $oneOfEverything),
-            $this->removeLinkDataArguments('suggest', 'my-vend/my-optional-extension', 'suggest-to-twoOfEverything', $twoOfEverything),
+            self::removeLinkDataArguments('suggest', 'my-vend/my-optional-extension', 'suggest-to-empty'),
+            self::removeLinkDataArguments('suggest', 'my-vend/my-optional-extension', 'suggest-to-oneOfEverything', $oneOfEverything),
+            self::removeLinkDataArguments('suggest', 'my-vend/my-optional-extension', 'suggest-to-twoOfEverything', $twoOfEverything),
 
-            $this->removeLinkDataArguments('replace', 'my-vend/other-app', 'replace-to-empty'),
-            $this->removeLinkDataArguments('replace', 'my-vend/other-app', 'replace-to-oneOfEverything', $oneOfEverything),
-            $this->removeLinkDataArguments('replace', 'my-vend/other-app', 'replace-to-twoOfEverything', $twoOfEverything),
+            self::removeLinkDataArguments('replace', 'my-vend/other-app', 'replace-to-empty'),
+            self::removeLinkDataArguments('replace', 'my-vend/other-app', 'replace-to-oneOfEverything', $oneOfEverything),
+            self::removeLinkDataArguments('replace', 'my-vend/other-app', 'replace-to-twoOfEverything', $twoOfEverything),
 
-            $this->removeLinkDataArguments('conflict', 'my-vend/my-old-app', 'conflict-to-empty'),
-            $this->removeLinkDataArguments('conflict', 'my-vend/my-old-app', 'conflict-to-oneOfEverything', $oneOfEverything),
-            $this->removeLinkDataArguments('conflict', 'my-vend/my-old-app', 'conflict-to-twoOfEverything', $twoOfEverything),
+            self::removeLinkDataArguments('conflict', 'my-vend/my-old-app', 'conflict-to-empty'),
+            self::removeLinkDataArguments('conflict', 'my-vend/my-old-app', 'conflict-to-oneOfEverything', $oneOfEverything),
+            self::removeLinkDataArguments('conflict', 'my-vend/my-old-app', 'conflict-to-twoOfEverything', $twoOfEverything),
         ];
     }
 }

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -35,7 +35,7 @@ class ConfigTest extends TestCase
         $this->assertEquals($expected, $config->getRepositories());
     }
 
-    public function dataAddPackagistRepository(): array
+    public static function dataAddPackagistRepository(): array
     {
         $data = [];
         $data['local config inherits system defaults'] = [
@@ -266,7 +266,7 @@ class ConfigTest extends TestCase
     /**
      * @return string[][] List of test URLs that should pass strict security
      */
-    public function allowedUrlProvider(): array
+    public static function allowedUrlProvider(): array
     {
         $urls = [
             'https://packagist.org',
@@ -287,7 +287,7 @@ class ConfigTest extends TestCase
     /**
      * @return string[][] List of test URLs that should not pass strict security
      */
-    public function prohibitedUrlProvider(): array
+    public static function prohibitedUrlProvider(): array
     {
         $urls = [
             'http://packagist.org',

--- a/tests/Composer/Test/DependencyResolver/DefaultPolicyTest.php
+++ b/tests/Composer/Test/DependencyResolver/DefaultPolicyTest.php
@@ -43,7 +43,7 @@ class DefaultPolicyTest extends TestCase
 
     public function testSelectSingle(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
         $this->repositorySet->addRepository($this->repo);
 
         $pool = $this->repositorySet->createPoolForPackage('A', $this->repoLocked);
@@ -58,8 +58,8 @@ class DefaultPolicyTest extends TestCase
 
     public function testSelectNewest(): void
     {
-        $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageA2 = $this->getPackage('A', '2.0'));
+        $this->repo->addPackage($packageA1 = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageA2 = self::getPackage('A', '2.0'));
         $this->repositorySet->addRepository($this->repo);
 
         $pool = $this->repositorySet->createPoolForPackage('A', $this->repoLocked);
@@ -74,8 +74,8 @@ class DefaultPolicyTest extends TestCase
 
     public function testSelectNewestPicksLatest(): void
     {
-        $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0.0'));
-        $this->repo->addPackage($packageA2 = $this->getPackage('A', '1.0.1-alpha'));
+        $this->repo->addPackage($packageA1 = self::getPackage('A', '1.0.0'));
+        $this->repo->addPackage($packageA2 = self::getPackage('A', '1.0.1-alpha'));
         $this->repositorySet->addRepository($this->repo);
 
         $pool = $this->repositorySet->createPoolForPackage('A', $this->repoLocked);
@@ -90,8 +90,8 @@ class DefaultPolicyTest extends TestCase
 
     public function testSelectNewestPicksLatestStableWithPreferStable(): void
     {
-        $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0.0'));
-        $this->repo->addPackage($packageA2 = $this->getPackage('A', '1.0.1-alpha'));
+        $this->repo->addPackage($packageA1 = self::getPackage('A', '1.0.0'));
+        $this->repo->addPackage($packageA2 = self::getPackage('A', '1.0.1-alpha'));
         $this->repositorySet->addRepository($this->repo);
 
         $pool = $this->repositorySet->createPoolForPackage('A', $this->repoLocked);
@@ -107,8 +107,8 @@ class DefaultPolicyTest extends TestCase
 
     public function testSelectNewestWithDevPicksNonDev(): void
     {
-        $this->repo->addPackage($packageA1 = $this->getPackage('A', 'dev-foo'));
-        $this->repo->addPackage($packageA2 = $this->getPackage('A', '1.0.0'));
+        $this->repo->addPackage($packageA1 = self::getPackage('A', 'dev-foo'));
+        $this->repo->addPackage($packageA2 = self::getPackage('A', '1.0.0'));
         $this->repositorySet->addRepository($this->repo);
 
         $pool = $this->repositorySet->createPoolForPackage('A', $this->repoLocked);
@@ -126,10 +126,10 @@ class DefaultPolicyTest extends TestCase
         $repo1 = new ArrayRepository;
         $repo2 = new ArrayRepository;
 
-        $repo1->addPackage($package1 = $this->getPackage('A', '1.0'));
-        $repo1->addPackage($package2 = $this->getPackage('A', '1.1'));
-        $repo2->addPackage($package3 = $this->getPackage('A', '1.1'));
-        $repo2->addPackage($package4 = $this->getPackage('A', '1.2'));
+        $repo1->addPackage($package1 = self::getPackage('A', '1.0'));
+        $repo1->addPackage($package2 = self::getPackage('A', '1.1'));
+        $repo2->addPackage($package3 = self::getPackage('A', '1.1'));
+        $repo2->addPackage($package4 = self::getPackage('A', '1.2'));
 
         $this->repositorySet->addRepository($repo1);
         $this->repositorySet->addRepository($repo2);
@@ -158,11 +158,11 @@ class DefaultPolicyTest extends TestCase
     {
         $repoImportant = new ArrayRepository;
 
-        $this->repo->addPackage($packageA = $this->getPackage('A', 'dev-master'));
+        $this->repo->addPackage($packageA = self::getPackage('A', 'dev-master'));
         $this->repo->addPackage($packageAAlias = new AliasPackage($packageA, '2.1.9999999.9999999-dev', '2.1.x-dev'));
-        $repoImportant->addPackage($packageAImportant = $this->getPackage('A', 'dev-feature-a'));
+        $repoImportant->addPackage($packageAImportant = self::getPackage('A', 'dev-feature-a'));
         $repoImportant->addPackage($packageAAliasImportant = new AliasPackage($packageAImportant, '2.1.9999999.9999999-dev', '2.1.x-dev'));
-        $repoImportant->addPackage($packageA2Important = $this->getPackage('A', 'dev-master'));
+        $repoImportant->addPackage($packageA2Important = self::getPackage('A', 'dev-master'));
         $repoImportant->addPackage($packageA2AliasImportant = new AliasPackage($packageA2Important, '2.1.9999999.9999999-dev', '2.1.x-dev'));
         $packageAAliasImportant->setRootPackageAlias(true);
 
@@ -187,8 +187,8 @@ class DefaultPolicyTest extends TestCase
 
     public function testSelectAllProviders(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '2.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '2.0'));
 
         $packageA->setProvides(['x' => new Link('A', 'X', new Constraint('==', '1.0'), Link::TYPE_PROVIDE)]);
         $packageB->setProvides(['x' => new Link('B', 'X', new Constraint('==', '1.0'), Link::TYPE_PROVIDE)]);
@@ -207,8 +207,8 @@ class DefaultPolicyTest extends TestCase
 
     public function testPreferNonReplacingFromSameRepo(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '2.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '2.0'));
 
         $packageB->setReplaces(['a' => new Link('B', 'A', new Constraint('==', '1.0'), Link::TYPE_REPLACE)]);
 
@@ -227,8 +227,8 @@ class DefaultPolicyTest extends TestCase
     public function testPreferReplacingPackageFromSameVendor(): void
     {
         // test with default order
-        $this->repo->addPackage($packageB = $this->getPackage('vendor-b/replacer', '1.0'));
-        $this->repo->addPackage($packageA = $this->getPackage('vendor-a/replacer', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('vendor-b/replacer', '1.0'));
+        $this->repo->addPackage($packageA = self::getPackage('vendor-a/replacer', '1.0'));
 
         $packageA->setReplaces(['vendor-a/package' => new Link('vendor-a/replacer', 'vendor-a/package', new Constraint('==', '1.0'), Link::TYPE_REPLACE)]);
         $packageB->setReplaces(['vendor-a/package' => new Link('vendor-b/replacer', 'vendor-a/package', new Constraint('==', '1.0'), Link::TYPE_REPLACE)]);
@@ -264,8 +264,8 @@ class DefaultPolicyTest extends TestCase
     {
         $policy = new DefaultPolicy(false, true);
 
-        $this->repo->addPackage($packageA1 = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageA2 = $this->getPackage('A', '2.0'));
+        $this->repo->addPackage($packageA1 = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageA2 = self::getPackage('A', '2.0'));
         $this->repositorySet->addRepository($this->repo);
 
         $pool = $this->repositorySet->createPoolForPackage('A', $this->repoLocked);

--- a/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
@@ -185,9 +185,9 @@ class PoolBuilderTest extends TestCase
     /**
      * @return array<string, array<string>>
      */
-    public function getIntegrationTests(): array
+    public static function getIntegrationTests(): array
     {
-        $fixturesDir = realpath(__DIR__.'/Fixtures/poolbuilder/');
+        $fixturesDir = (string) realpath(__DIR__.'/Fixtures/poolbuilder/');
         $tests = [];
         foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($fixturesDir), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
             $file = (string) $file;
@@ -197,7 +197,7 @@ class PoolBuilderTest extends TestCase
             }
 
             try {
-                $testData = $this->readTestFile($file, $fixturesDir);
+                $testData = self::readTestFile($file, $fixturesDir);
 
                 $message = $testData['TEST'];
 
@@ -224,7 +224,7 @@ class PoolBuilderTest extends TestCase
     /**
      * @return array<string, string>
      */
-    protected function readTestFile(string $file, string $fixturesDir): array
+    protected static function readTestFile(string $file, string $fixturesDir): array
     {
         $tokens = Preg::split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file), -1, PREG_SPLIT_DELIM_CAPTURE);
 

--- a/tests/Composer/Test/DependencyResolver/PoolOptimizerTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolOptimizerTest.php
@@ -42,12 +42,12 @@ class PoolOptimizerTest extends TestCase
 
         if (isset($requestData['locked'])) {
             foreach ($requestData['locked'] as $package) {
-                $request->lockPackage($this->loadPackage($package));
+                $request->lockPackage(self::loadPackage($package));
             }
         }
         if (isset($requestData['fixed'])) {
             foreach ($requestData['fixed'] as $package) {
-                $request->fixPackage($this->loadPackage($package));
+                $request->fixPackage(self::loadPackage($package));
             }
         }
 
@@ -70,9 +70,9 @@ class PoolOptimizerTest extends TestCase
         );
     }
 
-    public function provideIntegrationTests(): array
+    public static function provideIntegrationTests(): array
     {
-        $fixturesDir = realpath(__DIR__.'/Fixtures/pooloptimizer/');
+        $fixturesDir = (string) realpath(__DIR__.'/Fixtures/pooloptimizer/');
         $tests = [];
         foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($fixturesDir), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
             $file = (string) $file;
@@ -82,11 +82,11 @@ class PoolOptimizerTest extends TestCase
             }
 
             try {
-                $testData = $this->readTestFile($file, $fixturesDir);
+                $testData = self::readTestFile($file, $fixturesDir);
                 $message = $testData['TEST'];
                 $requestData = JsonFile::parseJson($testData['REQUEST']);
-                $packagesBefore = $this->loadPackages(JsonFile::parseJson($testData['POOL-BEFORE']));
-                $expectedPackages = $this->loadPackages(JsonFile::parseJson($testData['POOL-AFTER']));
+                $packagesBefore = self::loadPackages(JsonFile::parseJson($testData['POOL-BEFORE']));
+                $expectedPackages = self::loadPackages(JsonFile::parseJson($testData['POOL-AFTER']));
             } catch (\Exception $e) {
                 die(sprintf('Test "%s" is not valid: '.$e->getMessage(), str_replace($fixturesDir.'/', '', $file)));
             }
@@ -100,7 +100,7 @@ class PoolOptimizerTest extends TestCase
     /**
      * @return mixed[]
      */
-    protected function readTestFile(string $file, string $fixturesDir): array
+    protected static function readTestFile(string $file, string $fixturesDir): array
     {
         $tokens = Preg::split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file), -1, PREG_SPLIT_DELIM_CAPTURE);
 
@@ -171,12 +171,12 @@ class PoolOptimizerTest extends TestCase
      * @param mixed[][] $packagesData
      * @return BasePackage[]
      */
-    private function loadPackages(array $packagesData): array
+    private static function loadPackages(array $packagesData): array
     {
         $packages = [];
 
         foreach ($packagesData as $packageData) {
-            $packages[] = $package = $this->loadPackage($packageData);
+            $packages[] = $package = self::loadPackage($packageData);
             if ($package instanceof AliasPackage) {
                 $packages[] = $package->getAliasOf();
             }
@@ -188,7 +188,7 @@ class PoolOptimizerTest extends TestCase
     /**
      * @param mixed[] $packageData
      */
-    private function loadPackage(array $packageData): BasePackage
+    private static function loadPackage(array $packageData): BasePackage
     {
         $loader = new ArrayLoader();
 

--- a/tests/Composer/Test/DependencyResolver/PoolTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolTest.php
@@ -19,7 +19,7 @@ class PoolTest extends TestCase
 {
     public function testPool(): void
     {
-        $package = $this->getPackage('foo', '1');
+        $package = self::getPackage('foo', '1');
 
         $pool = $this->createPool([$package]);
 
@@ -29,8 +29,8 @@ class PoolTest extends TestCase
 
     public function testWhatProvidesPackageWithConstraint(): void
     {
-        $firstPackage = $this->getPackage('foo', '1');
-        $secondPackage = $this->getPackage('foo', '2');
+        $firstPackage = self::getPackage('foo', '1');
+        $secondPackage = self::getPackage('foo', '2');
 
         $pool = $this->createPool([
             $firstPackage,
@@ -38,12 +38,12 @@ class PoolTest extends TestCase
         ]);
 
         $this->assertEquals([$firstPackage, $secondPackage], $pool->whatProvides('foo'));
-        $this->assertEquals([$secondPackage], $pool->whatProvides('foo', $this->getVersionConstraint('==', '2')));
+        $this->assertEquals([$secondPackage], $pool->whatProvides('foo', self::getVersionConstraint('==', '2')));
     }
 
     public function testPackageById(): void
     {
-        $package = $this->getPackage('foo', '1');
+        $package = self::getPackage('foo', '1');
 
         $pool = $this->createPool([$package]);
 

--- a/tests/Composer/Test/DependencyResolver/RequestTest.php
+++ b/tests/Composer/Test/DependencyResolver/RequestTest.php
@@ -22,9 +22,9 @@ class RequestTest extends TestCase
     public function testRequestInstall(): void
     {
         $repo = new ArrayRepository;
-        $foo = $this->getPackage('foo', '1');
-        $bar = $this->getPackage('bar', '1');
-        $foobar = $this->getPackage('foobar', '1');
+        $foo = self::getPackage('foo', '1');
+        $bar = self::getPackage('bar', '1');
+        $foobar = self::getPackage('foobar', '1');
 
         $repo->addPackage($foo);
         $repo->addPackage($bar);
@@ -46,14 +46,14 @@ class RequestTest extends TestCase
         $repo1 = new ArrayRepository;
         $repo2 = new ArrayRepository;
 
-        $foo1 = $this->getPackage('foo', '1');
-        $foo2 = $this->getPackage('foo', '1');
+        $foo1 = self::getPackage('foo', '1');
+        $foo2 = self::getPackage('foo', '1');
 
         $repo1->addPackage($foo1);
         $repo2->addPackage($foo2);
 
         $request = new Request();
-        $request->requireName('foo', $constraint = $this->getVersionConstraint('=', '1'));
+        $request->requireName('foo', $constraint = self::getVersionConstraint('=', '1'));
 
         $this->assertEquals(
             [

--- a/tests/Composer/Test/DependencyResolver/RuleSetTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleSetTest.php
@@ -139,7 +139,7 @@ class RuleSetTest extends TestCase
     public function testPrettyString(): void
     {
         $pool = new Pool([
-            $p = $this->getPackage('foo', '2.1'),
+            $p = self::getPackage('foo', '2.1'),
         ]);
 
         $repositorySetMock = $this->getMockBuilder('Composer\Repository\RepositorySet')->disableOriginalConstructor()->getMock();

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -94,8 +94,8 @@ class RuleTest extends TestCase
     public function testPrettyString(): void
     {
         $pool = new Pool([
-            $p1 = $this->getPackage('foo', '2.1'),
-            $p2 = $this->getPackage('baz', '1.1'),
+            $p1 = self::getPackage('foo', '2.1'),
+            $p2 = self::getPackage('baz', '1.1'),
         ]);
 
         $repositorySetMock = $this->getMockBuilder('Composer\Repository\RepositorySet')->disableOriginalConstructor()->getMock();

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -61,7 +61,7 @@ class SolverTest extends TestCase
 
     public function testSolverInstallSingle(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
         $this->reposComplete();
 
         $this->request->requireName('A');
@@ -73,7 +73,7 @@ class SolverTest extends TestCase
 
     public function testSolverRemoveIfNotRequested(): void
     {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
         $this->reposComplete();
 
         $this->checkSolverResult([
@@ -83,10 +83,10 @@ class SolverTest extends TestCase
 
     public function testInstallNonExistingPackageFails(): void
     {
-        $this->repo->addPackage($this->getPackage('A', '1.0'));
+        $this->repo->addPackage(self::getPackage('A', '1.0'));
         $this->reposComplete();
 
-        $this->request->requireName('B', $this->getVersionConstraint('==', '1'));
+        $this->request->requireName('B', self::getVersionConstraint('==', '1'));
 
         $this->createSolver();
         try {
@@ -105,8 +105,8 @@ class SolverTest extends TestCase
         $repo1 = new ArrayRepository;
         $repo2 = new ArrayRepository;
 
-        $repo1->addPackage($foo1 = $this->getPackage('foo', '1'));
-        $repo2->addPackage($foo2 = $this->getPackage('foo', '1'));
+        $repo1->addPackage($foo1 = self::getPackage('foo', '1'));
+        $repo2->addPackage($foo2 = self::getPackage('foo', '1'));
 
         $this->repoSet->addRepository($repo1);
         $this->repoSet->addRepository($repo2);
@@ -120,11 +120,11 @@ class SolverTest extends TestCase
 
     public function testSolverInstallWithDeps(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($newPackageB = $this->getPackage('B', '1.1'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($newPackageB = self::getPackage('B', '1.1'));
 
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('<', '1.1'), Link::TYPE_REQUIRE)]);
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('<', '1.1'), Link::TYPE_REQUIRE)]);
 
         $this->reposComplete();
 
@@ -138,17 +138,17 @@ class SolverTest extends TestCase
 
     public function testSolverInstallHonoursNotEqualOperator(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($newPackageB11 = $this->getPackage('B', '1.1'));
-        $this->repo->addPackage($newPackageB12 = $this->getPackage('B', '1.2'));
-        $this->repo->addPackage($newPackageB13 = $this->getPackage('B', '1.3'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($newPackageB11 = self::getPackage('B', '1.1'));
+        $this->repo->addPackage($newPackageB12 = self::getPackage('B', '1.2'));
+        $this->repo->addPackage($newPackageB13 = self::getPackage('B', '1.3'));
 
         $packageA->setRequires([
             'b' => new Link('A', 'B', new MultiConstraint([
-                $this->getVersionConstraint('<=', '1.3'),
-                $this->getVersionConstraint('<>', '1.3'),
-                $this->getVersionConstraint('!=', '1.2'),
+                self::getVersionConstraint('<=', '1.3'),
+                self::getVersionConstraint('<>', '1.3'),
+                self::getVersionConstraint('!=', '1.2'),
             ]), Link::TYPE_REQUIRE),
         ]);
 
@@ -164,16 +164,16 @@ class SolverTest extends TestCase
 
     public function testSolverInstallWithDepsInOrder(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($packageC = $this->getPackage('C', '1.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($packageC = self::getPackage('C', '1.0'));
 
         $packageB->setRequires([
-            'a' => new Link('B', 'A', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
-            'c' => new Link('B', 'C', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'a' => new Link('B', 'A', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'c' => new Link('B', 'C', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
         ]);
         $packageC->setRequires([
-            'a' => new Link('C', 'A', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'a' => new Link('C', 'A', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
         ]);
 
         $this->reposComplete();
@@ -210,21 +210,21 @@ class SolverTest extends TestCase
      */
     public function testSolverMultiPackageNameVersionResolutionDependsOnRequireOrder(): void
     {
-        $this->repo->addPackage($php74 = $this->getPackage('ourcustom/PHP', '7.4.23'));
-        $this->repo->addPackage($php80 = $this->getPackage('ourcustom/PHP', '8.0.10'));
-        $this->repo->addPackage($extForPhp74 = $this->getPackage('ourcustom/ext-foobar', '1.0'));
-        $this->repo->addPackage($extForPhp80 = $this->getPackage('ourcustom/ext-foobar', '1.0'));
+        $this->repo->addPackage($php74 = self::getPackage('ourcustom/PHP', '7.4.23'));
+        $this->repo->addPackage($php80 = self::getPackage('ourcustom/PHP', '8.0.10'));
+        $this->repo->addPackage($extForPhp74 = self::getPackage('ourcustom/ext-foobar', '1.0'));
+        $this->repo->addPackage($extForPhp80 = self::getPackage('ourcustom/ext-foobar', '1.0'));
 
         $extForPhp74->setRequires([
             'ourcustom/php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint([
-                $this->getVersionConstraint('>=', '7.4.0'),
-                $this->getVersionConstraint('<', '7.5.0'),
+                self::getVersionConstraint('>=', '7.4.0'),
+                self::getVersionConstraint('<', '7.5.0'),
             ]), Link::TYPE_REQUIRE),
         ]);
         $extForPhp80->setRequires([
             'ourcustom/php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint([
-                $this->getVersionConstraint('>=', '8.0.0'),
-                $this->getVersionConstraint('<', '8.1.0'),
+                self::getVersionConstraint('>=', '8.0.0'),
+                self::getVersionConstraint('<', '8.1.0'),
             ]), Link::TYPE_REQUIRE),
         ]);
 
@@ -259,21 +259,21 @@ class SolverTest extends TestCase
      */
     public function testSolverMultiPackageNameVersionResolutionIsIndependentOfRequireOrderIfOrderedDescendingByRequirement(): void
     {
-        $this->repo->addPackage($php74 = $this->getPackage('ourcustom/PHP', '7.4'));
-        $this->repo->addPackage($php80 = $this->getPackage('ourcustom/PHP', '8.0'));
-        $this->repo->addPackage($extForPhp80 = $this->getPackage('ourcustom/ext-foobar', '1.0')); // note we are inserting this one into the repo first, unlike in the previous test
-        $this->repo->addPackage($extForPhp74 = $this->getPackage('ourcustom/ext-foobar', '1.0'));
+        $this->repo->addPackage($php74 = self::getPackage('ourcustom/PHP', '7.4'));
+        $this->repo->addPackage($php80 = self::getPackage('ourcustom/PHP', '8.0'));
+        $this->repo->addPackage($extForPhp80 = self::getPackage('ourcustom/ext-foobar', '1.0')); // note we are inserting this one into the repo first, unlike in the previous test
+        $this->repo->addPackage($extForPhp74 = self::getPackage('ourcustom/ext-foobar', '1.0'));
 
         $extForPhp80->setRequires([
             'ourcustom/php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint([
-                $this->getVersionConstraint('>=', '8.0.0'),
-                $this->getVersionConstraint('<', '8.1.0'),
+                self::getVersionConstraint('>=', '8.0.0'),
+                self::getVersionConstraint('<', '8.1.0'),
             ]), Link::TYPE_REQUIRE),
         ]);
         $extForPhp74->setRequires([
             'ourcustom/php' => new Link('ourcustom/ext-foobar', 'ourcustom/PHP', new MultiConstraint([
-                $this->getVersionConstraint('>=', '7.4.0'),
-                $this->getVersionConstraint('<', '7.5.0'),
+                self::getVersionConstraint('>=', '7.4.0'),
+                self::getVersionConstraint('<', '7.5.0'),
             ]), Link::TYPE_REQUIRE),
         ]);
 
@@ -300,7 +300,7 @@ class SolverTest extends TestCase
 
     public function testSolverFixLocked(): void
     {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
         $this->reposComplete();
 
         $this->request->fixPackage($packageA);
@@ -310,8 +310,8 @@ class SolverTest extends TestCase
 
     public function testSolverFixLockedWithAlternative(): void
     {
-        $this->repo->addPackage($this->getPackage('A', '1.0'));
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
+        $this->repo->addPackage(self::getPackage('A', '1.0'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
         $this->reposComplete();
 
         $this->request->fixPackage($packageA);
@@ -321,15 +321,15 @@ class SolverTest extends TestCase
 
     public function testSolverUpdateDoesOnlyUpdate(): void
     {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repoLocked->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($newPackageB = $this->getPackage('B', '1.1'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repoLocked->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($newPackageB = self::getPackage('B', '1.1'));
         $this->reposComplete();
 
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0.0.0'), Link::TYPE_REQUIRE)]);
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('>=', '1.0.0.0'), Link::TYPE_REQUIRE)]);
 
         $this->request->fixPackage($packageA);
-        $this->request->requireName('B', $this->getVersionConstraint('=', '1.1.0.0'));
+        $this->request->requireName('B', self::getVersionConstraint('=', '1.1.0.0'));
 
         $this->checkSolverResult([
             ['job' => 'update', 'from' => $packageB, 'to' => $newPackageB],
@@ -338,8 +338,8 @@ class SolverTest extends TestCase
 
     public function testSolverUpdateSingle(): void
     {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($newPackageA = $this->getPackage('A', '1.1'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($newPackageA = self::getPackage('A', '1.1'));
         $this->reposComplete();
 
         $this->request->requireName('A');
@@ -351,10 +351,10 @@ class SolverTest extends TestCase
 
     public function testSolverUpdateAll(): void
     {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repoLocked->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($newPackageA = $this->getPackage('A', '1.1'));
-        $this->repo->addPackage($newPackageB = $this->getPackage('B', '1.1'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repoLocked->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($newPackageA = self::getPackage('A', '1.1'));
+        $this->repo->addPackage($newPackageB = self::getPackage('B', '1.1'));
 
         $packageA->setRequires(['b' => new Link('A', 'B', new MatchAllConstraint(), Link::TYPE_REQUIRE)]);
         $newPackageA->setRequires(['b' => new Link('A', 'B', new MatchAllConstraint(), Link::TYPE_REQUIRE)]);
@@ -371,8 +371,8 @@ class SolverTest extends TestCase
 
     public function testSolverUpdateCurrent(): void
     {
-        $this->repoLocked->addPackage($this->getPackage('A', '1.0'));
-        $this->repo->addPackage($this->getPackage('A', '1.0'));
+        $this->repoLocked->addPackage(self::getPackage('A', '1.0'));
+        $this->repo->addPackage(self::getPackage('A', '1.0'));
         $this->reposComplete();
 
         $this->request->requireName('A');
@@ -382,10 +382,10 @@ class SolverTest extends TestCase
 
     public function testSolverUpdateOnlyUpdatesSelectedPackage(): void
     {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repoLocked->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($packageAnewer = $this->getPackage('A', '1.1'));
-        $this->repo->addPackage($packageBnewer = $this->getPackage('B', '1.1'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repoLocked->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($packageAnewer = self::getPackage('A', '1.1'));
+        $this->repo->addPackage($packageBnewer = self::getPackage('B', '1.1'));
 
         $this->reposComplete();
 
@@ -399,12 +399,12 @@ class SolverTest extends TestCase
 
     public function testSolverUpdateConstrained(): void
     {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($newPackageA = $this->getPackage('A', '1.2'));
-        $this->repo->addPackage($this->getPackage('A', '2.0'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($newPackageA = self::getPackage('A', '1.2'));
+        $this->repo->addPackage(self::getPackage('A', '2.0'));
         $this->reposComplete();
 
-        $this->request->requireName('A', $this->getVersionConstraint('<', '2.0.0.0'));
+        $this->request->requireName('A', self::getVersionConstraint('<', '2.0.0.0'));
 
         $this->checkSolverResult([[
             'job' => 'update',
@@ -415,12 +415,12 @@ class SolverTest extends TestCase
 
     public function testSolverUpdateFullyConstrained(): void
     {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($newPackageA = $this->getPackage('A', '1.2'));
-        $this->repo->addPackage($this->getPackage('A', '2.0'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($newPackageA = self::getPackage('A', '1.2'));
+        $this->repo->addPackage(self::getPackage('A', '2.0'));
         $this->reposComplete();
 
-        $this->request->requireName('A', $this->getVersionConstraint('<', '2.0.0.0'));
+        $this->request->requireName('A', self::getVersionConstraint('<', '2.0.0.0'));
 
         $this->checkSolverResult([[
             'job' => 'update',
@@ -431,13 +431,13 @@ class SolverTest extends TestCase
 
     public function testSolverUpdateFullyConstrainedPrunesInstalledPackages(): void
     {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repoLocked->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($newPackageA = $this->getPackage('A', '1.2'));
-        $this->repo->addPackage($this->getPackage('A', '2.0'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repoLocked->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($newPackageA = self::getPackage('A', '1.2'));
+        $this->repo->addPackage(self::getPackage('A', '2.0'));
         $this->reposComplete();
 
-        $this->request->requireName('A', $this->getVersionConstraint('<', '2.0.0.0'));
+        $this->request->requireName('A', self::getVersionConstraint('<', '2.0.0.0'));
 
         $this->checkSolverResult([
             [
@@ -454,15 +454,15 @@ class SolverTest extends TestCase
 
     public function testSolverAllJobs(): void
     {
-        $this->repoLocked->addPackage($packageD = $this->getPackage('D', '1.0'));
-        $this->repoLocked->addPackage($oldPackageC = $this->getPackage('C', '1.0'));
+        $this->repoLocked->addPackage($packageD = self::getPackage('D', '1.0'));
+        $this->repoLocked->addPackage($oldPackageC = self::getPackage('C', '1.0'));
 
-        $this->repo->addPackage($packageA = $this->getPackage('A', '2.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($newPackageB = $this->getPackage('B', '1.1'));
-        $this->repo->addPackage($packageC = $this->getPackage('C', '1.1'));
-        $this->repo->addPackage($this->getPackage('D', '1.0'));
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('<', '1.1'), Link::TYPE_REQUIRE)]);
+        $this->repo->addPackage($packageA = self::getPackage('A', '2.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($newPackageB = self::getPackage('B', '1.1'));
+        $this->repo->addPackage($packageC = self::getPackage('C', '1.1'));
+        $this->repo->addPackage(self::getPackage('D', '1.0'));
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('<', '1.1'), Link::TYPE_REQUIRE)]);
 
         $this->reposComplete();
 
@@ -479,12 +479,12 @@ class SolverTest extends TestCase
 
     public function testSolverThreeAlternativeRequireAndConflict(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '2.0'));
-        $this->repo->addPackage($middlePackageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($newPackageB = $this->getPackage('B', '1.1'));
-        $this->repo->addPackage($oldPackageB = $this->getPackage('B', '0.9'));
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('<', '1.1'), Link::TYPE_REQUIRE)]);
-        $packageA->setConflicts(['b' => new Link('A', 'B', $this->getVersionConstraint('<', '1.0'), Link::TYPE_CONFLICT)]);
+        $this->repo->addPackage($packageA = self::getPackage('A', '2.0'));
+        $this->repo->addPackage($middlePackageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($newPackageB = self::getPackage('B', '1.1'));
+        $this->repo->addPackage($oldPackageB = self::getPackage('B', '0.9'));
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('<', '1.1'), Link::TYPE_REQUIRE)]);
+        $packageA->setConflicts(['b' => new Link('A', 'B', self::getVersionConstraint('<', '1.0'), Link::TYPE_CONFLICT)]);
 
         $this->reposComplete();
 
@@ -498,8 +498,8 @@ class SolverTest extends TestCase
 
     public function testSolverObsolete(): void
     {
-        $this->repoLocked->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
+        $this->repoLocked->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
         $packageB->setReplaces(['a' => new Link('B', 'A', new MatchAllConstraint())]);
 
         $this->reposComplete();
@@ -514,8 +514,8 @@ class SolverTest extends TestCase
 
     public function testInstallOneOfTwoAlternatives(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('A', '1.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('A', '1.0'));
 
         $this->reposComplete();
 
@@ -528,10 +528,10 @@ class SolverTest extends TestCase
 
     public function testInstallProvider(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageQ = $this->getPackage('Q', '1.0'));
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
-        $packageQ->setProvides(['b' => new Link('Q', 'B', $this->getVersionConstraint('=', '1.0'), Link::TYPE_PROVIDE)]);
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageQ = self::getPackage('Q', '1.0'));
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
+        $packageQ->setProvides(['b' => new Link('Q', 'B', self::getVersionConstraint('=', '1.0'), Link::TYPE_PROVIDE)]);
 
         $this->reposComplete();
 
@@ -545,11 +545,11 @@ class SolverTest extends TestCase
 
     public function testSkipReplacerOfExistingPackage(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageQ = $this->getPackage('Q', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
-        $packageQ->setReplaces(['b' => new Link('Q', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE)]);
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageQ = self::getPackage('Q', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
+        $packageQ->setReplaces(['b' => new Link('Q', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE)]);
 
         $this->reposComplete();
 
@@ -563,10 +563,10 @@ class SolverTest extends TestCase
 
     public function testNoInstallReplacerOfMissingPackage(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageQ = $this->getPackage('Q', '1.0'));
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
-        $packageQ->setReplaces(['b' => new Link('Q', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE)]);
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageQ = self::getPackage('Q', '1.0'));
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
+        $packageQ->setReplaces(['b' => new Link('Q', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE)]);
 
         $this->reposComplete();
 
@@ -579,11 +579,11 @@ class SolverTest extends TestCase
 
     public function testSkipReplacedPackageIfReplacerIsSelected(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageQ = $this->getPackage('Q', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
-        $packageQ->setReplaces(['b' => new Link('Q', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE)]);
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageQ = self::getPackage('Q', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
+        $packageQ->setReplaces(['b' => new Link('Q', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE)]);
 
         $this->reposComplete();
 
@@ -598,29 +598,29 @@ class SolverTest extends TestCase
 
     public function testPickOlderIfNewerConflicts(): void
     {
-        $this->repo->addPackage($packageX = $this->getPackage('X', '1.0'));
+        $this->repo->addPackage($packageX = self::getPackage('X', '1.0'));
         $packageX->setRequires([
-            'a' => new Link('X', 'A', $this->getVersionConstraint('>=', '2.0.0.0'), Link::TYPE_REQUIRE),
-            'b' => new Link('X', 'B', $this->getVersionConstraint('>=', '2.0.0.0'), Link::TYPE_REQUIRE),
+            'a' => new Link('X', 'A', self::getVersionConstraint('>=', '2.0.0.0'), Link::TYPE_REQUIRE),
+            'b' => new Link('X', 'B', self::getVersionConstraint('>=', '2.0.0.0'), Link::TYPE_REQUIRE),
         ]);
 
-        $this->repo->addPackage($packageA = $this->getPackage('A', '2.0.0'));
-        $this->repo->addPackage($newPackageA = $this->getPackage('A', '2.1.0'));
-        $this->repo->addPackage($newPackageB = $this->getPackage('B', '2.1.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '2.0.0'));
+        $this->repo->addPackage($newPackageA = self::getPackage('A', '2.1.0'));
+        $this->repo->addPackage($newPackageB = self::getPackage('B', '2.1.0'));
 
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('>=', '2.0.0.0'), Link::TYPE_REQUIRE)]);
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('>=', '2.0.0.0'), Link::TYPE_REQUIRE)]);
 
         // new package A depends on version of package B that does not exist
         // => new package A is not installable
-        $newPackageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('>=', '2.2.0.0'), Link::TYPE_REQUIRE)]);
+        $newPackageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('>=', '2.2.0.0'), Link::TYPE_REQUIRE)]);
 
         // add a package S replacing both A and B, so that S and B or S and A cannot be simultaneously installed
         // but an alternative option for A and B both exists
         // this creates a more difficult so solve conflict
-        $this->repo->addPackage($packageS = $this->getPackage('S', '2.0.0'));
+        $this->repo->addPackage($packageS = self::getPackage('S', '2.0.0'));
         $packageS->setReplaces([
-            'a' => new Link('S', 'A', $this->getVersionConstraint('>=', '2.0.0.0'), Link::TYPE_REPLACE),
-            'b' => new Link('S', 'B', $this->getVersionConstraint('>=', '2.0.0.0'), Link::TYPE_REPLACE),
+            'a' => new Link('S', 'A', self::getVersionConstraint('>=', '2.0.0.0'), Link::TYPE_REPLACE),
+            'b' => new Link('S', 'B', self::getVersionConstraint('>=', '2.0.0.0'), Link::TYPE_REPLACE),
         ]);
 
         $this->reposComplete();
@@ -636,11 +636,11 @@ class SolverTest extends TestCase
 
     public function testInstallCircularRequire(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB1 = $this->getPackage('B', '0.9'));
-        $this->repo->addPackage($packageB2 = $this->getPackage('B', '1.1'));
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
-        $packageB2->setRequires(['a' => new Link('B', 'A', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB1 = self::getPackage('B', '0.9'));
+        $this->repo->addPackage($packageB2 = self::getPackage('B', '1.1'));
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
+        $packageB2->setRequires(['a' => new Link('B', 'A', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
 
         $this->reposComplete();
 
@@ -654,17 +654,17 @@ class SolverTest extends TestCase
 
     public function testInstallAlternativeWithCircularRequire(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($packageC = $this->getPackage('C', '1.0'));
-        $this->repo->addPackage($packageD = $this->getPackage('D', '1.0'));
-        $packageA->setRequires(['b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
-        $packageB->setRequires(['virtual' => new Link('B', 'Virtual', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
-        $packageC->setProvides(['virtual' => new Link('C', 'Virtual', $this->getVersionConstraint('==', '1.0'), Link::TYPE_PROVIDE)]);
-        $packageD->setProvides(['virtual' => new Link('D', 'Virtual', $this->getVersionConstraint('==', '1.0'), Link::TYPE_PROVIDE)]);
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($packageC = self::getPackage('C', '1.0'));
+        $this->repo->addPackage($packageD = self::getPackage('D', '1.0'));
+        $packageA->setRequires(['b' => new Link('A', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
+        $packageB->setRequires(['virtual' => new Link('B', 'Virtual', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE)]);
+        $packageC->setProvides(['virtual' => new Link('C', 'Virtual', self::getVersionConstraint('==', '1.0'), Link::TYPE_PROVIDE)]);
+        $packageD->setProvides(['virtual' => new Link('D', 'Virtual', self::getVersionConstraint('==', '1.0'), Link::TYPE_PROVIDE)]);
 
-        $packageC->setRequires(['a' => new Link('C', 'A', $this->getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE)]);
-        $packageD->setRequires(['a' => new Link('D', 'A', $this->getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE)]);
+        $packageC->setRequires(['a' => new Link('C', 'A', self::getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE)]);
+        $packageD->setRequires(['a' => new Link('D', 'A', self::getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE)]);
 
         $this->reposComplete();
 
@@ -684,24 +684,24 @@ class SolverTest extends TestCase
      */
     public function testUseReplacerIfNecessary(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($packageD = $this->getPackage('D', '1.0'));
-        $this->repo->addPackage($packageD2 = $this->getPackage('D', '1.1'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($packageD = self::getPackage('D', '1.0'));
+        $this->repo->addPackage($packageD2 = self::getPackage('D', '1.1'));
 
         $packageA->setRequires([
-            'b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
-            'c' => new Link('A', 'C', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'b' => new Link('A', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'c' => new Link('A', 'C', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
         ]);
 
         $packageD->setReplaces([
-            'b' => new Link('D', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE),
-            'c' => new Link('D', 'C', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE),
+            'b' => new Link('D', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE),
+            'c' => new Link('D', 'C', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE),
         ]);
 
         $packageD2->setReplaces([
-            'b' => new Link('D', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE),
-            'c' => new Link('D', 'C', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE),
+            'b' => new Link('D', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE),
+            'c' => new Link('D', 'C', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REPLACE),
         ]);
 
         $this->reposComplete();
@@ -717,32 +717,32 @@ class SolverTest extends TestCase
 
     public function testIssue265(): void
     {
-        $this->repo->addPackage($packageA1 = $this->getPackage('A', '2.0.999999-dev'));
-        $this->repo->addPackage($packageA2 = $this->getPackage('A', '2.1-dev'));
-        $this->repo->addPackage($packageA3 = $this->getPackage('A', '2.2-dev'));
-        $this->repo->addPackage($packageB1 = $this->getPackage('B', '2.0.10'));
-        $this->repo->addPackage($packageB2 = $this->getPackage('B', '2.0.9'));
-        $this->repo->addPackage($packageC = $this->getPackage('C', '2.0-dev'));
-        $this->repo->addPackage($packageD = $this->getPackage('D', '2.0.9'));
+        $this->repo->addPackage($packageA1 = self::getPackage('A', '2.0.999999-dev'));
+        $this->repo->addPackage($packageA2 = self::getPackage('A', '2.1-dev'));
+        $this->repo->addPackage($packageA3 = self::getPackage('A', '2.2-dev'));
+        $this->repo->addPackage($packageB1 = self::getPackage('B', '2.0.10'));
+        $this->repo->addPackage($packageB2 = self::getPackage('B', '2.0.9'));
+        $this->repo->addPackage($packageC = self::getPackage('C', '2.0-dev'));
+        $this->repo->addPackage($packageD = self::getPackage('D', '2.0.9'));
 
         $packageC->setRequires([
-            'a' => new Link('C', 'A', $this->getVersionConstraint('>=', '2.0'), Link::TYPE_REQUIRE),
-            'd' => new Link('C', 'D', $this->getVersionConstraint('>=', '2.0'), Link::TYPE_REQUIRE),
+            'a' => new Link('C', 'A', self::getVersionConstraint('>=', '2.0'), Link::TYPE_REQUIRE),
+            'd' => new Link('C', 'D', self::getVersionConstraint('>=', '2.0'), Link::TYPE_REQUIRE),
         ]);
 
         $packageD->setRequires([
-            'a' => new Link('D', 'A', $this->getVersionConstraint('>=', '2.1'), Link::TYPE_REQUIRE),
-            'b' => new Link('D', 'B', $this->getVersionConstraint('>=', '2.0-dev'), Link::TYPE_REQUIRE),
+            'a' => new Link('D', 'A', self::getVersionConstraint('>=', '2.1'), Link::TYPE_REQUIRE),
+            'b' => new Link('D', 'B', self::getVersionConstraint('>=', '2.0-dev'), Link::TYPE_REQUIRE),
         ]);
 
-        $packageB1->setRequires(['a' => new Link('B', 'A', $this->getVersionConstraint('==', '2.1.0.0-dev'), Link::TYPE_REQUIRE)]);
-        $packageB2->setRequires(['a' => new Link('B', 'A', $this->getVersionConstraint('==', '2.1.0.0-dev'), Link::TYPE_REQUIRE)]);
+        $packageB1->setRequires(['a' => new Link('B', 'A', self::getVersionConstraint('==', '2.1.0.0-dev'), Link::TYPE_REQUIRE)]);
+        $packageB2->setRequires(['a' => new Link('B', 'A', self::getVersionConstraint('==', '2.1.0.0-dev'), Link::TYPE_REQUIRE)]);
 
-        $packageB2->setReplaces(['d' => new Link('B', 'D', $this->getVersionConstraint('==', '2.0.9.0'), Link::TYPE_REPLACE)]);
+        $packageB2->setReplaces(['d' => new Link('B', 'D', self::getVersionConstraint('==', '2.0.9.0'), Link::TYPE_REPLACE)]);
 
         $this->reposComplete();
 
-        $this->request->requireName('C', $this->getVersionConstraint('==', '2.0.0.0-dev'));
+        $this->request->requireName('C', self::getVersionConstraint('==', '2.0.0.0-dev'));
 
         self::expectException('Composer\DependencyResolver\SolverProblemsException');
 
@@ -752,10 +752,10 @@ class SolverTest extends TestCase
 
     public function testConflictResultEmpty(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
         $packageA->setConflicts([
-            'b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_CONFLICT),
+            'b' => new Link('A', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_CONFLICT),
         ]);
 
         $this->reposComplete();
@@ -785,11 +785,11 @@ class SolverTest extends TestCase
 
     public function testUnsatisfiableRequires(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
 
         $packageA->setRequires([
-            'b' => new Link('A', 'B', $this->getVersionConstraint('>=', '2.0'), Link::TYPE_REQUIRE),
+            'b' => new Link('A', 'B', self::getVersionConstraint('>=', '2.0'), Link::TYPE_REQUIRE),
         ]);
 
         $this->reposComplete();
@@ -815,23 +815,23 @@ class SolverTest extends TestCase
 
     public function testRequireMismatchException(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($packageB2 = $this->getPackage('B', '0.9'));
-        $this->repo->addPackage($packageC = $this->getPackage('C', '1.0'));
-        $this->repo->addPackage($packageD = $this->getPackage('D', '1.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($packageB2 = self::getPackage('B', '0.9'));
+        $this->repo->addPackage($packageC = self::getPackage('C', '1.0'));
+        $this->repo->addPackage($packageD = self::getPackage('D', '1.0'));
 
         $packageA->setRequires([
-            'b' => new Link('A', 'B', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'b' => new Link('A', 'B', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
         ]);
         $packageB->setRequires([
-            'c' => new Link('B', 'C', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'c' => new Link('B', 'C', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
         ]);
         $packageC->setRequires([
-            'd' => new Link('C', 'D', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'd' => new Link('C', 'D', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
         ]);
         $packageD->setRequires([
-            'b' => new Link('D', 'B', $this->getVersionConstraint('<', '1.0'), Link::TYPE_REQUIRE),
+            'b' => new Link('D', 'B', self::getVersionConstraint('<', '1.0'), Link::TYPE_REQUIRE),
         ]);
 
         $this->reposComplete();
@@ -863,18 +863,18 @@ class SolverTest extends TestCase
 
     public function testLearnLiteralsWithSortedRuleLiterals(): void
     {
-        $this->repo->addPackage($packageTwig2 = $this->getPackage('twig/twig', '2.0'));
-        $this->repo->addPackage($packageTwig16 = $this->getPackage('twig/twig', '1.6'));
-        $this->repo->addPackage($packageTwig15 = $this->getPackage('twig/twig', '1.5'));
-        $this->repo->addPackage($packageSymfony = $this->getPackage('symfony/symfony', '2.0'));
-        $this->repo->addPackage($packageTwigBridge = $this->getPackage('symfony/twig-bridge', '2.0'));
+        $this->repo->addPackage($packageTwig2 = self::getPackage('twig/twig', '2.0'));
+        $this->repo->addPackage($packageTwig16 = self::getPackage('twig/twig', '1.6'));
+        $this->repo->addPackage($packageTwig15 = self::getPackage('twig/twig', '1.5'));
+        $this->repo->addPackage($packageSymfony = self::getPackage('symfony/symfony', '2.0'));
+        $this->repo->addPackage($packageTwigBridge = self::getPackage('symfony/twig-bridge', '2.0'));
 
         $packageTwigBridge->setRequires([
-            'twig/twig' => new Link('symfony/twig-bridge', 'twig/twig', $this->getVersionConstraint('<', '2.0'), Link::TYPE_REQUIRE),
+            'twig/twig' => new Link('symfony/twig-bridge', 'twig/twig', self::getVersionConstraint('<', '2.0'), Link::TYPE_REQUIRE),
         ]);
 
         $packageSymfony->setReplaces([
-            'symfony/twig-bridge' => new Link('symfony/symfony', 'symfony/twig-bridge', $this->getVersionConstraint('==', '2.0'), Link::TYPE_REPLACE),
+            'symfony/twig-bridge' => new Link('symfony/symfony', 'symfony/twig-bridge', self::getVersionConstraint('==', '2.0'), Link::TYPE_REPLACE),
         ]);
 
         $this->reposComplete();
@@ -890,22 +890,22 @@ class SolverTest extends TestCase
 
     public function testInstallRecursiveAliasDependencies(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '2.0'));
-        $this->repo->addPackage($packageA2 = $this->getPackage('A', '2.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '2.0'));
+        $this->repo->addPackage($packageA2 = self::getPackage('A', '2.0'));
 
         $packageA2->setRequires([
-            'b' => new Link('A', 'B', $this->getVersionConstraint('==', '2.0'), Link::TYPE_REQUIRE, '== 2.0'),
+            'b' => new Link('A', 'B', self::getVersionConstraint('==', '2.0'), Link::TYPE_REQUIRE, '== 2.0'),
         ]);
         $packageB->setRequires([
-            'a' => new Link('B', 'A', $this->getVersionConstraint('>=', '2.0'), Link::TYPE_REQUIRE),
+            'a' => new Link('B', 'A', self::getVersionConstraint('>=', '2.0'), Link::TYPE_REQUIRE),
         ]);
 
-        $this->repo->addPackage($packageA2Alias = $this->getAliasPackage($packageA2, '1.1'));
+        $this->repo->addPackage($packageA2Alias = self::getAliasPackage($packageA2, '1.1'));
 
         $this->reposComplete();
 
-        $this->request->requireName('A', $this->getVersionConstraint('==', '1.1.0.0'));
+        $this->request->requireName('A', self::getVersionConstraint('==', '1.1.0.0'));
 
         $this->checkSolverResult([
             ['job' => 'install', 'package' => $packageB],
@@ -916,18 +916,18 @@ class SolverTest extends TestCase
 
     public function testInstallDevAlias(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '2.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '2.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
 
         $packageB->setRequires([
-            'a' => new Link('B', 'A', $this->getVersionConstraint('<', '2.0'), Link::TYPE_REQUIRE),
+            'a' => new Link('B', 'A', self::getVersionConstraint('<', '2.0'), Link::TYPE_REQUIRE),
         ]);
 
-        $this->repo->addPackage($packageAAlias = $this->getAliasPackage($packageA, '1.1'));
+        $this->repo->addPackage($packageAAlias = self::getAliasPackage($packageA, '1.1'));
 
         $this->reposComplete();
 
-        $this->request->requireName('A', $this->getVersionConstraint('==', '2.0'));
+        $this->request->requireName('A', self::getVersionConstraint('==', '2.0'));
         $this->request->requireName('B');
 
         $this->checkSolverResult([
@@ -940,22 +940,22 @@ class SolverTest extends TestCase
     public function testInstallRootAliasesIfAliasOfIsInstalled(): void
     {
         // root aliased, required
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageAAlias = $this->getAliasPackage($packageA, '1.1'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageAAlias = self::getAliasPackage($packageA, '1.1'));
         $packageAAlias->setRootPackageAlias(true);
         // root aliased, not required, should still be installed as it is root alias
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($packageBAlias = $this->getAliasPackage($packageB, '1.1'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($packageBAlias = self::getAliasPackage($packageB, '1.1'));
         $packageBAlias->setRootPackageAlias(true);
         // regular alias, not required, alias should not be installed
-        $this->repo->addPackage($packageC = $this->getPackage('C', '1.0'));
-        $this->repo->addPackage($packageCAlias = $this->getAliasPackage($packageC, '1.1'));
+        $this->repo->addPackage($packageC = self::getPackage('C', '1.0'));
+        $this->repo->addPackage($packageCAlias = self::getAliasPackage($packageC, '1.1'));
 
         $this->reposComplete();
 
-        $this->request->requireName('A', $this->getVersionConstraint('==', '1.1'));
-        $this->request->requireName('B', $this->getVersionConstraint('==', '1.0'));
-        $this->request->requireName('C', $this->getVersionConstraint('==', '1.0'));
+        $this->request->requireName('A', self::getVersionConstraint('==', '1.1'));
+        $this->request->requireName('B', self::getVersionConstraint('==', '1.0'));
+        $this->request->requireName('C', self::getVersionConstraint('==', '1.0'));
 
         $this->checkSolverResult([
             ['job' => 'install', 'package' => $packageA],
@@ -978,42 +978,42 @@ class SolverTest extends TestCase
      */
     public function testLearnPositiveLiteral(): void
     {
-        $this->repo->addPackage($packageA = $this->getPackage('A', '1.0'));
-        $this->repo->addPackage($packageB = $this->getPackage('B', '1.0'));
-        $this->repo->addPackage($packageC1 = $this->getPackage('C', '1.0'));
-        $this->repo->addPackage($packageC2 = $this->getPackage('C', '2.0'));
-        $this->repo->addPackage($packageD = $this->getPackage('D', '1.0'));
-        $this->repo->addPackage($packageE = $this->getPackage('E', '1.0'));
-        $this->repo->addPackage($packageF1 = $this->getPackage('F', '1.0'));
-        $this->repo->addPackage($packageF2 = $this->getPackage('F', '2.0'));
-        $this->repo->addPackage($packageG1 = $this->getPackage('G', '1.0'));
-        $this->repo->addPackage($packageG2 = $this->getPackage('G', '2.0'));
-        $this->repo->addPackage($packageG3 = $this->getPackage('G', '3.0'));
+        $this->repo->addPackage($packageA = self::getPackage('A', '1.0'));
+        $this->repo->addPackage($packageB = self::getPackage('B', '1.0'));
+        $this->repo->addPackage($packageC1 = self::getPackage('C', '1.0'));
+        $this->repo->addPackage($packageC2 = self::getPackage('C', '2.0'));
+        $this->repo->addPackage($packageD = self::getPackage('D', '1.0'));
+        $this->repo->addPackage($packageE = self::getPackage('E', '1.0'));
+        $this->repo->addPackage($packageF1 = self::getPackage('F', '1.0'));
+        $this->repo->addPackage($packageF2 = self::getPackage('F', '2.0'));
+        $this->repo->addPackage($packageG1 = self::getPackage('G', '1.0'));
+        $this->repo->addPackage($packageG2 = self::getPackage('G', '2.0'));
+        $this->repo->addPackage($packageG3 = self::getPackage('G', '3.0'));
 
         $packageA->setRequires([
-            'b' => new Link('A', 'B', $this->getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE),
-            'c' => new Link('A', 'C', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
-            'd' => new Link('A', 'D', $this->getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE),
+            'b' => new Link('A', 'B', self::getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE),
+            'c' => new Link('A', 'C', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'd' => new Link('A', 'D', self::getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE),
         ]);
 
         $packageB->setRequires([
-            'e' => new Link('B', 'E', $this->getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE),
+            'e' => new Link('B', 'E', self::getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE),
         ]);
 
         $packageC1->setRequires([
-            'f' => new Link('C', 'F', $this->getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE),
+            'f' => new Link('C', 'F', self::getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE),
         ]);
         $packageC2->setRequires([
-            'f' => new Link('C', 'F', $this->getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE),
-            'g' => new Link('C', 'G', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'f' => new Link('C', 'F', self::getVersionConstraint('==', '1.0'), Link::TYPE_REQUIRE),
+            'g' => new Link('C', 'G', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
         ]);
 
         $packageD->setRequires([
-            'f' => new Link('D', 'F', $this->getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
+            'f' => new Link('D', 'F', self::getVersionConstraint('>=', '1.0'), Link::TYPE_REQUIRE),
         ]);
 
         $packageE->setRequires([
-            'g' => new Link('E', 'G', $this->getVersionConstraint('<=', '2.0'), Link::TYPE_REQUIRE),
+            'g' => new Link('E', 'G', self::getVersionConstraint('<=', '2.0'), Link::TYPE_REQUIRE),
         ]);
 
         $this->reposComplete();

--- a/tests/Composer/Test/DependencyResolver/TransactionTest.php
+++ b/tests/Composer/Test/DependencyResolver/TransactionTest.php
@@ -31,29 +31,29 @@ class TransactionTest extends TestCase
     public function testTransactionGenerationAndSorting(): void
     {
         $presentPackages = [
-            $packageA = $this->getPackage('a/a', 'dev-master'),
-            $packageAalias = $this->getAliasPackage($packageA, '1.0.x-dev'),
-            $packageB = $this->getPackage('b/b', '1.0.0'),
-            $packageE = $this->getPackage('e/e', 'dev-foo'),
-            $packageEalias = $this->getAliasPackage($packageE, '1.0.x-dev'),
-            $packageC = $this->getPackage('c/c', '1.0.0'),
+            $packageA = self::getPackage('a/a', 'dev-master'),
+            $packageAalias = self::getAliasPackage($packageA, '1.0.x-dev'),
+            $packageB = self::getPackage('b/b', '1.0.0'),
+            $packageE = self::getPackage('e/e', 'dev-foo'),
+            $packageEalias = self::getAliasPackage($packageE, '1.0.x-dev'),
+            $packageC = self::getPackage('c/c', '1.0.0'),
         ];
         $resultPackages = [
             $packageA,
             $packageAalias,
-            $packageBnew = $this->getPackage('b/b', '2.1.3'),
-            $packageD = $this->getPackage('d/d', '1.2.3'),
-            $packageF = $this->getPackage('f/f', '1.0.0'),
-            $packageFalias1 = $this->getAliasPackage($packageF, 'dev-foo'),
-            $packageG = $this->getPackage('g/g', '1.0.0'),
-            $packageA0first = $this->getPackage('a0/first', '1.2.3'),
-            $packageFalias2 = $this->getAliasPackage($packageF, 'dev-bar'),
-            $plugin = $this->getPackage('x/plugin', '1.0.0'),
-            $plugin2Dep = $this->getPackage('x/plugin2-dep', '1.0.0'),
-            $plugin2 = $this->getPackage('x/plugin2', '1.0.0'),
-            $dlModifyingPlugin = $this->getPackage('x/downloads-modifying', '1.0.0'),
-            $dlModifyingPlugin2Dep = $this->getPackage('x/downloads-modifying2-dep', '1.0.0'),
-            $dlModifyingPlugin2 = $this->getPackage('x/downloads-modifying2', '1.0.0'),
+            $packageBnew = self::getPackage('b/b', '2.1.3'),
+            $packageD = self::getPackage('d/d', '1.2.3'),
+            $packageF = self::getPackage('f/f', '1.0.0'),
+            $packageFalias1 = self::getAliasPackage($packageF, 'dev-foo'),
+            $packageG = self::getPackage('g/g', '1.0.0'),
+            $packageA0first = self::getPackage('a0/first', '1.2.3'),
+            $packageFalias2 = self::getAliasPackage($packageF, 'dev-bar'),
+            $plugin = self::getPackage('x/plugin', '1.0.0'),
+            $plugin2Dep = self::getPackage('x/plugin2-dep', '1.0.0'),
+            $plugin2 = self::getPackage('x/plugin2', '1.0.0'),
+            $dlModifyingPlugin = self::getPackage('x/downloads-modifying', '1.0.0'),
+            $dlModifyingPlugin2Dep = self::getPackage('x/downloads-modifying2-dep', '1.0.0'),
+            $dlModifyingPlugin2 = self::getPackage('x/downloads-modifying2', '1.0.0'),
         ];
 
         $plugin->setType('composer-installer');
@@ -62,19 +62,19 @@ class TransactionTest extends TestCase
         }
 
         $plugin2->setRequires([
-            'x/plugin2-dep' => new Link('x/plugin2', 'x/plugin2-dep', $this->getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE),
+            'x/plugin2-dep' => new Link('x/plugin2', 'x/plugin2-dep', self::getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE),
         ]);
         $dlModifyingPlugin2->setRequires([
-            'x/downloads-modifying2-dep' => new Link('x/downloads-modifying2', 'x/downloads-modifying2-dep', $this->getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE),
+            'x/downloads-modifying2-dep' => new Link('x/downloads-modifying2', 'x/downloads-modifying2-dep', self::getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE),
         ]);
         $dlModifyingPlugin->setExtra(['plugin-modifies-downloads' => true]);
         $dlModifyingPlugin2->setExtra(['plugin-modifies-downloads' => true]);
 
         $packageD->setRequires([
-            'f/f' => new Link('d/d', 'f/f', $this->getVersionConstraint('>', '0.2'), Link::TYPE_REQUIRE),
-            'g/provider' => new Link('d/d', 'g/provider', $this->getVersionConstraint('>', '0.2'), Link::TYPE_REQUIRE),
+            'f/f' => new Link('d/d', 'f/f', self::getVersionConstraint('>', '0.2'), Link::TYPE_REQUIRE),
+            'g/provider' => new Link('d/d', 'g/provider', self::getVersionConstraint('>', '0.2'), Link::TYPE_REQUIRE),
         ]);
-        $packageG->setProvides(['g/provider' => new Link('g/g', 'g/provider', $this->getVersionConstraint('==', '1.0.0'), Link::TYPE_PROVIDE)]);
+        $packageG->setProvides(['g/provider' => new Link('g/g', 'g/provider', self::getVersionConstraint('==', '1.0.0'), Link::TYPE_PROVIDE)]);
 
         $expectedOperations = [
             ['job' => 'uninstall', 'package' => $packageC],

--- a/tests/Composer/Test/DocumentationTest.php
+++ b/tests/Composer/Test/DocumentationTest.php
@@ -49,7 +49,7 @@ class DocumentationTest extends TestCase
         return $name;
     }
 
-    public function provideCommandCases(): \Generator
+    public static function provideCommandCases(): \Generator
     {
         $application = new Application();
         $application->setAutoExit(false);

--- a/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
@@ -114,7 +114,7 @@ class ArchiveDownloaderTest extends TestCase
         $this->assertEquals($expected, $url);
     }
 
-    public function provideUrls(): array
+    public static function provideUrls(): array
     {
         return [
             ['https://api.github.com/repos/composer/composer/zipball/master'],
@@ -151,7 +151,7 @@ class ArchiveDownloaderTest extends TestCase
         $this->assertEquals($expected, $url);
     }
 
-    public function provideBitbucketUrls(): array
+    public static function provideBitbucketUrls(): array
     {
         return [
             ['https://bitbucket.org/davereid/drush-virtualhost/get/77ca490c26ac818e024d1138aa8bd3677d1ef21f', 'zip'],

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -55,7 +55,7 @@ class FileDownloaderTest extends TestCase
 
     public function testDownloadForPackageWithoutDistReference(): void
     {
-        $package = $this->getPackage();
+        $package = self::getPackage();
 
         self::expectException('InvalidArgumentException');
 
@@ -65,7 +65,7 @@ class FileDownloaderTest extends TestCase
 
     public function testDownloadToExistingFile(): void
     {
-        $package = $this->getPackage();
+        $package = self::getPackage();
         $package->setDistUrl('url');
 
         $path = $this->createTempFile(self::getUniqueTmpDirectory());
@@ -88,7 +88,7 @@ class FileDownloaderTest extends TestCase
 
     public function testGetFileName(): void
     {
-        $package = $this->getPackage();
+        $package = self::getPackage();
         $package->setDistUrl('http://example.com/script.js');
 
         $config = $this->getConfig(['vendor-dir' => '/vendor']);
@@ -101,7 +101,7 @@ class FileDownloaderTest extends TestCase
 
     public function testDownloadButFileIsUnsaved(): void
     {
-        $package = $this->getPackage();
+        $package = self::getPackage();
         $package->setDistUrl('http://example.com/script.js');
 
         $path = self::getUniqueTmpDirectory();
@@ -143,10 +143,10 @@ class FileDownloaderTest extends TestCase
     {
         $path = self::getUniqueTmpDirectory();
 
-        $package = $this->getPackage();
+        $package = self::getPackage();
         $package->setDistUrl('url');
 
-        $rootPackage = $this->getRootPackage();
+        $rootPackage = self::getRootPackage();
 
         $config = $this->getConfig([
             'vendor-dir' => $path.'/vendor',
@@ -226,10 +226,10 @@ class FileDownloaderTest extends TestCase
     {
         $path = self::getUniqueTmpDirectory();
 
-        $package = $this->getPackage();
+        $package = self::getPackage();
         $package->setDistUrl('url');
 
-        $rootPackage = $this->getRootPackage();
+        $rootPackage = self::getRootPackage();
 
         $config = $this->getConfig([
             'vendor-dir' => $path.'/vendor',
@@ -332,7 +332,7 @@ class FileDownloaderTest extends TestCase
 
     public function testDownloadFileWithInvalidChecksum(): void
     {
-        $package = $this->getPackage();
+        $package = self::getPackage();
         $package->setDistUrl($distUrl = 'http://example.com/script.js');
         $package->setDistSha1Checksum('invalid');
 
@@ -371,8 +371,8 @@ class FileDownloaderTest extends TestCase
 
     public function testDowngradeShowsAppropriateMessage(): void
     {
-        $oldPackage = $this->getPackage('dummy/pkg', '1.2.0');
-        $newPackage = $this->getPackage('dummy/pkg', '1.0.0');
+        $oldPackage = self::getPackage('dummy/pkg', '1.2.0');
+        $newPackage = self::getPackage('dummy/pkg', '1.0.0');
         $newPackage->setDistUrl($distUrl = 'http://example.com/script.js');
 
         $ioMock = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();

--- a/tests/Composer/Test/Downloader/FossilDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FossilDownloaderTest.php
@@ -76,9 +76,9 @@ class FossilDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->getCmd('fossil clone -- \'http://fossil.kd2.org/kd2fw/\' \''.$this->workingDir.'.fossil\''),
-            $this->getCmd('fossil open --nested -- \''.$this->workingDir.'.fossil\''),
-            $this->getCmd('fossil update -- \'trunk\''),
+            self::getCmd('fossil clone -- \'http://fossil.kd2.org/kd2fw/\' \''.$this->workingDir.'.fossil\''),
+            self::getCmd('fossil open --nested -- \''.$this->workingDir.'.fossil\''),
+            self::getCmd('fossil update -- \'trunk\''),
         ], true);
 
         $downloader = $this->getDownloaderMock(null, null, $process);
@@ -123,8 +123,8 @@ class FossilDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->getCmd("fossil changes"),
-            $this->getCmd("fossil pull && fossil up 'trunk'"),
+            self::getCmd("fossil changes"),
+            self::getCmd("fossil pull && fossil up 'trunk'"),
         ], true);
 
         $downloader = $this->getDownloaderMock(null, null, $process);
@@ -143,7 +143,7 @@ class FossilDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->getCmd('fossil changes'),
+            self::getCmd('fossil changes'),
         ], true);
 
         $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -217,7 +217,7 @@ class GitDownloaderTest extends TestCase
         $downloader->cleanup('install', $packageMock, 'composerPath');
     }
 
-    public function pushUrlProvider(): array
+    public static function pushUrlProvider(): array
     {
         return [
             // ssh proto should use git@ all along
@@ -644,7 +644,7 @@ composer https://github.com/old/url (push)
             $cmd = str_replace('cd ', 'cd /D ', $cmd);
             $cmd = str_replace('composerPath', Platform::getCwd().'/composerPath', $cmd);
 
-            return $this->getCmd($cmd);
+            return self::getCmd($cmd);
         }
 
         return $cmd;

--- a/tests/Composer/Test/Downloader/HgDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/HgDownloaderTest.php
@@ -76,8 +76,8 @@ class HgDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->getCmd('hg clone -- \'https://mercurial.dev/l3l0/composer\' \''.$this->workingDir.'\''),
-            $this->getCmd('hg up -- \'ref\''),
+            self::getCmd('hg clone -- \'https://mercurial.dev/l3l0/composer\' \''.$this->workingDir.'\''),
+            self::getCmd('hg up -- \'ref\''),
         ], true);
 
         $downloader = $this->getDownloaderMock(null, null, $process);
@@ -117,8 +117,8 @@ class HgDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->getCmd('hg st'),
-            $this->getCmd("hg pull -- 'https://github.com/l3l0/composer' && hg up -- 'ref'"),
+            self::getCmd('hg st'),
+            self::getCmd("hg pull -- 'https://github.com/l3l0/composer' && hg up -- 'ref'"),
         ], true);
 
         $downloader = $this->getDownloaderMock(null, null, $process);
@@ -135,7 +135,7 @@ class HgDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->getCmd('hg st'),
+            self::getCmd('hg st'),
         ], true);
 
         $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();

--- a/tests/Composer/Test/Downloader/XzDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/XzDownloaderTest.php
@@ -51,7 +51,7 @@ class XzDownloaderTest extends TestCase
 
     public function testErrorMessages(): void
     {
-        $package = $this->getPackage();
+        $package = self::getPackage();
         $package->setDistUrl($distUrl = 'file://'.__FILE__);
 
         $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -116,7 +116,7 @@ class EventDispatcherTest extends TestCase
         $dispatcher->hasEventListeners($event);
     }
 
-    public function provideDevModes(): array
+    public static function provideDevModes(): array
     {
         return [
             [true],
@@ -428,7 +428,7 @@ class EventDispatcherTest extends TestCase
 
         $dispatcher->dispatch('helloWorld', new ScriptEvent('helloWorld', $composer, $io));
         $expected = "> helloWorld: @hello World".PHP_EOL.
-            "> hello: echo Hello " .$this->getCmd("'World'").PHP_EOL;
+            "> hello: echo Hello " .self::getCmd("'World'").PHP_EOL;
 
         $this->assertEquals($expected, $io->getOutput());
     }
@@ -487,7 +487,7 @@ class EventDispatcherTest extends TestCase
         return $dispatcher;
     }
 
-    public function provideValidCommands(): array
+    public static function provideValidCommands(): array
     {
         return [
             ['phpunit'],

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilterTest.php
@@ -30,7 +30,7 @@ final class IgnoreAllPlatformRequirementFilterTest extends TestCase
     /**
      * @return array<string, mixed[]>
      */
-    public function dataIsIgnored(): array
+    public static function dataIsIgnored(): array
     {
         return [
             'php is ignored' => ['php', true],

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilterTest.php
@@ -32,7 +32,7 @@ final class IgnoreListPlatformRequirementFilterTest extends TestCase
     /**
      * @return array<string, mixed[]>
      */
-    public function dataIsIgnored(): array
+    public static function dataIsIgnored(): array
     {
         return [
             'ext-json is ignored if listed' => [['ext-json', 'monolog/monolog'], 'ext-json', true],

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilterTest.php
@@ -30,7 +30,7 @@ final class IgnoreNothingPlatformRequirementFilterTest extends TestCase
     /**
      * @return array<string, mixed[]>
      */
-    public function dataIsIgnored(): array
+    public static function dataIsIgnored(): array
     {
         return [
             'php is not ignored' => ['php'],

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/PlatformRequirementFilterFactoryTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/PlatformRequirementFilterFactoryTest.php
@@ -31,7 +31,7 @@ final class PlatformRequirementFilterFactoryTest extends TestCase
     /**
      * @return array<string, mixed[]>
      */
-    public function dataFromBoolOrList(): array
+    public static function dataFromBoolOrList(): array
     {
         return [
             'true creates IgnoreAllFilter' => [true, 'Composer\Filter\PlatformRequirementFilter\IgnoreAllPlatformRequirementFilter'],

--- a/tests/Composer/Test/Installer/BinaryInstallerTest.php
+++ b/tests/Composer/Test/Installer/BinaryInstallerTest.php
@@ -86,7 +86,7 @@ class BinaryInstallerTest extends TestCase
         $this->assertEquals('success arg', $output);
     }
 
-    public function executableBinaryProvider(): array
+    public static function executableBinaryProvider(): array
     {
         return [
             'simple php file' => [<<<'EOL'

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -122,7 +122,7 @@ class LibraryInstallerTest extends TestCase
     public function testIsInstalled(): void
     {
         $library = new LibraryInstaller($this->io, $this->composer);
-        $package = $this->getPackage('test/pkg', '1.0.0');
+        $package = self::getPackage('test/pkg', '1.0.0');
 
         $repository = new InstalledArrayRepository();
         $this->assertFalse($library->isInstalled($repository, $package));
@@ -146,7 +146,7 @@ class LibraryInstallerTest extends TestCase
     public function testInstall(): void
     {
         $library = new LibraryInstaller($this->io, $this->composer);
-        $package = $this->getPackage('some/package', '1.0.0');
+        $package = self::getPackage('some/package', '1.0.0');
 
         $this->dm
             ->expects($this->once())
@@ -177,8 +177,8 @@ class LibraryInstallerTest extends TestCase
           ->method('rename')
           ->with($this->vendorDir.'/vendor/package1/oldtarget', $this->vendorDir.'/vendor/package1/newtarget');
 
-        $initial = $this->getPackage('vendor/package1', '1.0.0');
-        $target = $this->getPackage('vendor/package1', '2.0.0');
+        $initial = self::getPackage('vendor/package1', '1.0.0');
+        $target = self::getPackage('vendor/package1', '2.0.0');
 
         $initial->setTargetDir('oldtarget');
         $target->setTargetDir('newtarget');
@@ -217,7 +217,7 @@ class LibraryInstallerTest extends TestCase
     public function testUninstall(): void
     {
         $library = new LibraryInstaller($this->io, $this->composer);
-        $package = $this->getPackage('vendor/pkg', '1.0.0');
+        $package = self::getPackage('vendor/pkg', '1.0.0');
 
         $this->repository
             ->expects($this->exactly(2))
@@ -246,7 +246,7 @@ class LibraryInstallerTest extends TestCase
     public function testGetInstallPathWithoutTargetDir(): void
     {
         $library = new LibraryInstaller($this->io, $this->composer);
-        $package = $this->getPackage('Vendor/Pkg', '1.0.0');
+        $package = self::getPackage('Vendor/Pkg', '1.0.0');
 
         $this->assertEquals($this->vendorDir.'/'.$package->getPrettyName(), $library->getInstallPath($package));
     }
@@ -254,7 +254,7 @@ class LibraryInstallerTest extends TestCase
     public function testGetInstallPathWithTargetDir(): void
     {
         $library = new LibraryInstaller($this->io, $this->composer);
-        $package = $this->getPackage('Foo/Bar', '1.0.0');
+        $package = self::getPackage('Foo/Bar', '1.0.0');
         $package->setTargetDir('Some/Namespace');
 
         $this->assertEquals($this->vendorDir.'/'.$package->getPrettyName().'/Some/Namespace', $library->getInstallPath($package));
@@ -271,7 +271,7 @@ class LibraryInstallerTest extends TestCase
             ->getMock();
 
         $library = new LibraryInstaller($this->io, $this->composer, 'library', null, $binaryInstallerMock);
-        $package = $this->getPackage('foo/bar', '1.0.0');
+        $package = self::getPackage('foo/bar', '1.0.0');
 
         $binaryInstallerMock
             ->expects($this->never())

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -172,20 +172,20 @@ class InstallerTest extends TestCase
         return $comparable;
     }
 
-    public function provideInstaller(): array
+    public static function provideInstaller(): array
     {
         $cases = [];
 
         // when A requires B and B requires A, and A is a non-published root package
         // the install of B should succeed
 
-        $a = $this->getPackage('A', '1.0.0', 'Composer\Package\RootPackage');
+        $a = self::getPackage('A', '1.0.0', 'Composer\Package\RootPackage');
         $a->setRequires([
-            'b' => new Link('A', 'B', $v = $this->getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE, $v->getPrettyString()),
+            'b' => new Link('A', 'B', $v = self::getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE, $v->getPrettyString()),
         ]);
-        $b = $this->getPackage('B', '1.0.0');
+        $b = self::getPackage('B', '1.0.0');
         $b->setRequires([
-            'a' => new Link('B', 'A', $v = $this->getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE, $v->getPrettyString()),
+            'a' => new Link('B', 'A', $v = self::getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE, $v->getPrettyString()),
         ]);
 
         $cases[] = [
@@ -199,13 +199,13 @@ class InstallerTest extends TestCase
         // #480: when A requires B and B requires A, and A is a published root package
         // only B should be installed, as A is the root
 
-        $a = $this->getPackage('A', '1.0.0', 'Composer\Package\RootPackage');
+        $a = self::getPackage('A', '1.0.0', 'Composer\Package\RootPackage');
         $a->setRequires([
-            'b' => new Link('A', 'B', $v = $this->getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE, $v->getPrettyString()),
+            'b' => new Link('A', 'B', $v = self::getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE, $v->getPrettyString()),
         ]);
-        $b = $this->getPackage('B', '1.0.0');
+        $b = self::getPackage('B', '1.0.0');
         $b->setRequires([
-            'a' => new Link('B', 'A', $v = $this->getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE, $v->getPrettyString()),
+            'a' => new Link('B', 'A', $v = self::getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE, $v->getPrettyString()),
         ]);
 
         $cases[] = [
@@ -476,22 +476,22 @@ class InstallerTest extends TestCase
         }
     }
 
-    public function provideSlowIntegrationTests(): array
+    public static function provideSlowIntegrationTests(): array
     {
-        return $this->loadIntegrationTests('installer-slow/');
+        return self::loadIntegrationTests('installer-slow/');
     }
 
-    public function provideIntegrationTests(): array
+    public static function provideIntegrationTests(): array
     {
-        return $this->loadIntegrationTests('installer/');
+        return self::loadIntegrationTests('installer/');
     }
 
     /**
      * @return mixed[]
      */
-    public function loadIntegrationTests(string $path): array
+    public static function loadIntegrationTests(string $path): array
     {
-        $fixturesDir = realpath(__DIR__.'/Fixtures/'.$path);
+        $fixturesDir = (string) realpath(__DIR__.'/Fixtures/'.$path);
         $tests = [];
 
         foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($fixturesDir), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
@@ -502,7 +502,7 @@ class InstallerTest extends TestCase
             }
 
             try {
-                $testData = $this->readTestFile($file, $fixturesDir);
+                $testData = self::readTestFile($file, $fixturesDir);
 
                 $installed = [];
                 $installedDev = [];
@@ -576,7 +576,7 @@ class InstallerTest extends TestCase
     /**
      * @return mixed[]
      */
-    protected function readTestFile(string $file, string $fixturesDir): array
+    protected static function readTestFile(string $file, string $fixturesDir): array
     {
         $tokens = Preg::split('#(?:^|\n*)--([A-Z-]+)--\n#', file_get_contents($file), -1, PREG_SPLIT_DELIM_CAPTURE);
 

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -27,7 +27,7 @@ class JsonManipulatorTest extends TestCase
         $this->assertEquals($expected, $manipulator->getContents());
     }
 
-    public function linkProvider(): array
+    public static function linkProvider(): array
     {
         return [
             [
@@ -1297,7 +1297,7 @@ class JsonManipulatorTest extends TestCase
         $this->assertEquals($expected, $manipulator->getContents());
     }
 
-    public function providerAddLinkAndSortPackages(): array
+    public static function providerAddLinkAndSortPackages(): array
     {
         return [
             [
@@ -1380,7 +1380,7 @@ class JsonManipulatorTest extends TestCase
         }
     }
 
-    public function removeSubNodeProvider(): array
+    public static function removeSubNodeProvider(): array
     {
         return [
             'works on simple ones first' => [

--- a/tests/Composer/Test/Json/JsonValidationExceptionTest.php
+++ b/tests/Composer/Test/Json/JsonValidationExceptionTest.php
@@ -35,7 +35,7 @@ class JsonValidationExceptionTest extends TestCase
         $this->assertEquals([], $object->getErrors());
     }
 
-    public function errorProvider(): array
+    public static function errorProvider(): array
     {
         return [
             ['test message', [], 'test message', []],

--- a/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
+++ b/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
@@ -29,7 +29,7 @@ class GitExcludeFilterTest extends TestCase
         $this->assertEquals($expected, $filter->parseGitAttributesLine($ignore));
     }
 
-    public function providePatterns(): array
+    public static function providePatterns(): array
     {
         return [
             ['app/config/parameters.yml export-ignore', ['{(?=[^\.])app/(?=[^\.])config/(?=[^\.])parameters\.yml(?=$|/)}', false, false]],

--- a/tests/Composer/Test/Package/Archiver/ZipArchiverTest.php
+++ b/tests/Composer/Test/Package/Archiver/ZipArchiverTest.php
@@ -29,7 +29,7 @@ class ZipArchiverTest extends ArchiverTest
         ]);
     }
 
-    public function provideGitignoreExcludeNegationTestCases(): array
+    public static function provideGitignoreExcludeNegationTestCases(): array
     {
         return [
             ['!/docs'],

--- a/tests/Composer/Test/Package/BasePackageTest.php
+++ b/tests/Composer/Test/Package/BasePackageTest.php
@@ -46,14 +46,20 @@ class BasePackageTest extends TestCase
     /**
      * @dataProvider provideFormattedVersions
      */
-    public function testFormatVersionForDevPackage(BasePackage $package, bool $truncate, string $expected): void
+    public function testFormatVersionForDevPackage(string $sourceReference, bool $truncate, string $expected): void
     {
+        $package = $this->getMockForAbstractClass('\Composer\Package\BasePackage', [], '', false);
+        $package->expects($this->once())->method('isDev')->will($this->returnValue(true));
+        $package->expects($this->any())->method('getSourceType')->will($this->returnValue('git'));
+        $package->expects($this->once())->method('getPrettyVersion')->will($this->returnValue('PrettyVersion'));
+        $package->expects($this->any())->method('getSourceReference')->will($this->returnValue($sourceReference));
+
         $this->assertSame($expected, $package->getFullPrettyVersion($truncate));
     }
 
-    public function provideFormattedVersions(): array
+    public static function provideFormattedVersions(): array
     {
-        $data = [
+        return [
             [
                 'sourceReference' => 'v2.1.0-RC2',
                 'truncate' => true,
@@ -75,18 +81,6 @@ class BasePackageTest extends TestCase
                 'expected' => 'PrettyVersion bbf527a27356414bfa9bf520f018c5cb7af67c77',
             ],
         ];
-
-        $createPackage = function ($arr): array {
-            $package = $this->getMockForAbstractClass('\Composer\Package\BasePackage', [], '', false);
-            $package->expects($this->once())->method('isDev')->will($this->returnValue(true));
-            $package->expects($this->any())->method('getSourceType')->will($this->returnValue('git'));
-            $package->expects($this->once())->method('getPrettyVersion')->will($this->returnValue('PrettyVersion'));
-            $package->expects($this->any())->method('getSourceReference')->will($this->returnValue($arr['sourceReference']));
-
-            return [$package, $arr['truncate'], $arr['expected']];
-        };
-
-        return array_map($createPackage, $data);
     }
 
     /**
@@ -105,7 +99,7 @@ class BasePackageTest extends TestCase
     /**
      * @return mixed[][]
      */
-    public function dataPackageNamesToRegexp(): array
+    public static function dataPackageNamesToRegexp(): array
     {
         return [
             [

--- a/tests/Composer/Test/Package/CompletePackageTest.php
+++ b/tests/Composer/Test/Package/CompletePackageTest.php
@@ -23,7 +23,7 @@ class CompletePackageTest extends TestCase
      *
      * demonstrates several versioning schemes
      */
-    public function providerVersioningSchemes(): array
+    public static function providerVersioningSchemes(): array
     {
         $provider[] = ['foo',              '1-beta'];
         $provider[] = ['node',             '0.5.6'];

--- a/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
+++ b/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
@@ -31,7 +31,7 @@ class ArrayDumperTest extends TestCase
 
     public function testRequiredInformation(): void
     {
-        $config = $this->dumper->dump($this->getPackage());
+        $config = $this->dumper->dump(self::getPackage());
         $this->assertEquals(
             [
                 'name' => 'dummy/pkg',
@@ -45,7 +45,7 @@ class ArrayDumperTest extends TestCase
 
     public function testRootPackage(): void
     {
-        $package = $this->getRootPackage();
+        $package = self::getRootPackage();
         $package->setMinimumStability('dev');
 
         $config = $this->dumper->dump($package);
@@ -54,7 +54,7 @@ class ArrayDumperTest extends TestCase
 
     public function testDumpAbandoned(): void
     {
-        $package = $this->getPackage();
+        $package = self::getPackage();
         $package->setAbandoned(true);
         $config = $this->dumper->dump($package);
 
@@ -63,7 +63,7 @@ class ArrayDumperTest extends TestCase
 
     public function testDumpAbandonedReplacement(): void
     {
-        $package = $this->getPackage();
+        $package = self::getPackage();
         $package->setAbandoned('foo/bar');
         $config = $this->dumper->dump($package);
 
@@ -79,7 +79,7 @@ class ArrayDumperTest extends TestCase
      */
     public function testKeys(string $key, $value, ?string $method = null, $expectedValue = null): void
     {
-        $package = $this->getRootPackage();
+        $package = self::getRootPackage();
 
         // @phpstan-ignore-next-line
         $package->{'set'.ucfirst($method ?: $key)}($value);
@@ -89,7 +89,7 @@ class ArrayDumperTest extends TestCase
         $this->assertSame($expectedValue ?: $value, $config[$key]);
     }
 
-    public function provideKeys(): array
+    public static function provideKeys(): array
     {
         return [
             [

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -84,7 +84,7 @@ class ArrayLoaderTest extends TestCase
         $this->assertEquals('1.2.3.4', $package->getVersion());
     }
 
-    public function parseDumpProvider(): array
+    public static function parseDumpProvider(): array
     {
         $validConfig = [
             'name' => 'A/B',
@@ -273,7 +273,7 @@ class ArrayLoaderTest extends TestCase
         $this->assertFalse($package->isAbandoned());
     }
 
-    public function providePluginApiVersions(): array
+    public static function providePluginApiVersions(): array
     {
         return [
             ['1.0'],

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -35,7 +35,7 @@ class ValidatingArrayLoaderTest extends TestCase
         $loader->load($config);
     }
 
-    public function successProvider(): array
+    public static function successProvider(): array
     {
         return [
             [ // minimal
@@ -269,7 +269,7 @@ class ValidatingArrayLoaderTest extends TestCase
         $loader->load($config);
     }
 
-    public function errorProvider(): array
+    public static function errorProvider(): array
     {
         $invalidNames = [
             'foo',
@@ -428,7 +428,7 @@ class ValidatingArrayLoaderTest extends TestCase
         ]);
     }
 
-    public function warningProvider(): array
+    public static function warningProvider(): array
     {
         return [
             [

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -93,8 +93,8 @@ class LockerTest extends TestCase
         $jsonContent = $this->getJsonContent() . '  ';
         $locker = new Locker(new NullIO, $json, $inst, $jsonContent);
 
-        $package1 = $this->getPackage('pkg1', '1.0.0-beta');
-        $package2 = $this->getPackage('pkg2', '0.1.10');
+        $package1 = self::getPackage('pkg1', '1.0.0-beta');
+        $package2 = self::getPackage('pkg2', '0.1.10');
 
         $contentHash = md5(trim($jsonContent));
 

--- a/tests/Composer/Test/Package/Version/VersionBumperTest.php
+++ b/tests/Composer/Test/Package/Version/VersionBumperTest.php
@@ -40,7 +40,7 @@ class VersionBumperTest extends TestCase
         $this->assertSame($expectedRequirement, $newConstraint);
     }
 
-    public function provideBumpRequirementTests(): Generator
+    public static function provideBumpRequirementTests(): Generator
     {
         // constraint, version, expected recommendation, [branch-alias]
         yield 'upgrade caret' => ['^1.0', '1.2.1', '^1.2.1'];

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -30,7 +30,7 @@ class VersionParserTest extends TestCase
         $this->assertSame($result, $versionParser->parseNameVersionPairs($pairs));
     }
 
-    public function provideParseNameVersionPairsData(): array
+    public static function provideParseNameVersionPairsData(): array
     {
         return [
             [['php:^7.0'], [['name' => 'php', 'version' => '^7.0']]],
@@ -49,7 +49,7 @@ class VersionParserTest extends TestCase
         $this->assertSame($expected, VersionParser::isUpgrade($from, $to));
     }
 
-    public function provideIsUpgradeTests(): array
+    public static function provideIsUpgradeTests(): array
     {
         return [
             ['0.9.0.0', '1.0.0.0', true],

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -33,9 +33,9 @@ class VersionSelectorTest extends TestCase
     {
         $packageName = 'foo/bar';
 
-        $package1 = $this->getPackage('foo/bar', '1.2.1');
-        $package2 = $this->getPackage('foo/bar', '1.2.2');
-        $package3 = $this->getPackage('foo/bar', '1.2.0');
+        $package1 = self::getPackage('foo/bar', '1.2.1');
+        $package2 = self::getPackage('foo/bar', '1.2.2');
+        $package3 = self::getPackage('foo/bar', '1.2.0');
         $packages = [$package1, $package2, $package3];
 
         $repositorySet = $this->createMockRepositorySet();
@@ -60,13 +60,13 @@ class VersionSelectorTest extends TestCase
         $versionSelector = new VersionSelector($repositorySet, $platform);
 
         $parser = new VersionParser;
-        $package0 = $this->getPackage('foo/bar', '0.9.0');
+        $package0 = self::getPackage('foo/bar', '0.9.0');
         $package0->setRequires(['php' => new Link($packageName, 'php', $parser->parseConstraints('>=5.6'), Link::TYPE_REQUIRE, '>=5.6')]);
-        $package1 = $this->getPackage('foo/bar', '1.0.0');
+        $package1 = self::getPackage('foo/bar', '1.0.0');
         $package1->setRequires(['php' => new Link($packageName, 'php', $parser->parseConstraints('>=5.4'), Link::TYPE_REQUIRE, '>=5.4')]);
-        $package2 = $this->getPackage('foo/bar', '2.0.0');
+        $package2 = self::getPackage('foo/bar', '2.0.0');
         $package2->setRequires(['php' => new Link($packageName, 'php', $parser->parseConstraints('>=5.6'), Link::TYPE_REQUIRE, '>=5.6')]);
-        $package3 = $this->getPackage('foo/bar', '2.1.0');
+        $package3 = self::getPackage('foo/bar', '2.1.0');
         $package3->setRequires(['php' => new Link($packageName, 'php', $parser->parseConstraints('>=5.6'), Link::TYPE_REQUIRE, '>=5.6')]);
         $packages = [$package0, $package1, $package2, $package3];
 
@@ -102,9 +102,9 @@ class VersionSelectorTest extends TestCase
         $versionSelector = new VersionSelector($repositorySet, $platform);
 
         $parser = new VersionParser;
-        $package1 = $this->getPackage('foo/bar', '1.0.0');
+        $package1 = self::getPackage('foo/bar', '1.0.0');
         $package1->setRequires(['ext-zip' => new Link($packageName, 'ext-zip', $parser->parseConstraints('^5.2'), Link::TYPE_REQUIRE, '^5.2')]);
-        $package2 = $this->getPackage('foo/bar', '2.0.0');
+        $package2 = self::getPackage('foo/bar', '2.0.0');
         $package2->setRequires(['ext-zip' => new Link($packageName, 'ext-zip', $parser->parseConstraints('^5.4'), Link::TYPE_REQUIRE, '^5.4')]);
         $packages = [$package1, $package2];
 
@@ -128,8 +128,8 @@ class VersionSelectorTest extends TestCase
         $versionSelector = new VersionSelector($repositorySet, $platform);
 
         $parser = new VersionParser;
-        $package1 = $this->getPackage('foo/bar', '1.0.0');
-        $package2 = $this->getPackage('foo/bar', '2.0.0');
+        $package1 = self::getPackage('foo/bar', '1.0.0');
+        $package2 = self::getPackage('foo/bar', '2.0.0');
         $package2->setRequires(['ext-barfoo' => new Link($packageName, 'ext-barfoo', $parser->parseConstraints('*'), Link::TYPE_REQUIRE, '*')]);
         $packages = [$package1, $package2];
 
@@ -153,9 +153,9 @@ class VersionSelectorTest extends TestCase
         $versionSelector = new VersionSelector($repositorySet, $platform);
 
         $parser = new VersionParser;
-        $package1 = $this->getPackage('foo/bar', '1.0.0');
+        $package1 = self::getPackage('foo/bar', '1.0.0');
         $package1->setRequires(['composer-runtime-api' => new Link($packageName, 'composer-runtime-api', $parser->parseConstraints('^1.0'), Link::TYPE_REQUIRE, '^1.0')]);
-        $package2 = $this->getPackage('foo/bar', '1.1.0');
+        $package2 = self::getPackage('foo/bar', '1.1.0');
         $package2->setRequires(['composer-runtime-api' => new Link($packageName, 'composer-runtime-api', $parser->parseConstraints('^2.0'), Link::TYPE_REQUIRE, '^2.0')]);
         $packages = [$package1, $package2];
 
@@ -174,8 +174,8 @@ class VersionSelectorTest extends TestCase
     {
         $packageName = 'foo/bar';
 
-        $package1 = $this->getPackage('foo/bar', '1.0.0');
-        $package2 = $this->getPackage('foo/bar', '1.1.0-beta');
+        $package1 = self::getPackage('foo/bar', '1.0.0');
+        $package2 = self::getPackage('foo/bar', '1.1.0-beta');
         $packages = [$package1, $package2];
 
         $repositorySet = $this->createMockRepositorySet();
@@ -194,8 +194,8 @@ class VersionSelectorTest extends TestCase
     {
         $packageName = 'foo/bar';
 
-        $package1 = $this->getPackage('foo/bar', '2.x-dev');
-        $package2 = $this->getPackage('foo/bar', '2.0.0-beta3');
+        $package1 = self::getPackage('foo/bar', '2.x-dev');
+        $package2 = self::getPackage('foo/bar', '2.0.0-beta3');
         $packages = [$package1, $package2];
 
         $repositorySet = $this->createMockRepositorySet();
@@ -219,8 +219,8 @@ class VersionSelectorTest extends TestCase
     {
         $packageName = 'foo/bar';
 
-        $package1 = $this->getPackage('foo/bar', '1.0.0');
-        $package2 = $this->getPackage('foo/bar', '1.1.0-beta');
+        $package1 = self::getPackage('foo/bar', '1.0.0');
+        $package2 = self::getPackage('foo/bar', '1.1.0-beta');
         $packages = [$package1, $package2];
 
         $repositorySet = $this->createMockRepositorySet();
@@ -239,9 +239,9 @@ class VersionSelectorTest extends TestCase
     {
         $packageName = 'foo/bar';
 
-        $package1 = $this->getPackage('foo/bar', '1.0.0');
-        $package2 = $this->getPackage('foo/bar', '1.1.0-beta');
-        $package3 = $this->getPackage('foo/bar', '1.2.0-alpha');
+        $package1 = self::getPackage('foo/bar', '1.0.0');
+        $package2 = self::getPackage('foo/bar', '1.1.0-beta');
+        $package3 = self::getPackage('foo/bar', '1.2.0-alpha');
         $packages = [$package1, $package2, $package3];
 
         $repositorySet = $this->createMockRepositorySet();
@@ -260,8 +260,8 @@ class VersionSelectorTest extends TestCase
     {
         $packageName = 'foo/bar';
 
-        $package2 = $this->getPackage('foo/bar', '1.1.0-beta');
-        $package3 = $this->getPackage('foo/bar', '1.2.0-alpha');
+        $package2 = self::getPackage('foo/bar', '1.1.0-beta');
+        $package3 = self::getPackage('foo/bar', '1.2.0-alpha');
         $packages = [$package2, $package3];
 
         $repositorySet = $this->createMockRepositorySet();
@@ -280,8 +280,8 @@ class VersionSelectorTest extends TestCase
     {
         $packageName = 'foo/bar';
 
-        $package = $this->getPackage('foo/bar', '1.1.0-beta');
-        $package2 = $this->getPackage('foo/bar', 'dev-main');
+        $package = self::getPackage('foo/bar', '1.1.0-beta');
+        $package2 = self::getPackage('foo/bar', 'dev-main');
         $package2Alias = new AliasPackage($package2, VersionParser::DEFAULT_BRANCH_ALIAS, VersionParser::DEFAULT_BRANCH_ALIAS);
         $packages = [$package, $package2Alias];
 
@@ -330,7 +330,7 @@ class VersionSelectorTest extends TestCase
         $this->assertSame($expectedVersion, $recommended);
     }
 
-    public function provideRecommendedRequireVersionPackages(): array
+    public static function provideRecommendedRequireVersionPackages(): array
     {
         return [
             // real version, expected recommendation, [branch-alias], [pkg name]

--- a/tests/Composer/Test/Platform/VersionTest.php
+++ b/tests/Composer/Test/Platform/VersionTest.php
@@ -88,7 +88,7 @@ class VersionTest extends TestCase
         self::assertSame($normalizedVersion, $this->getVersionParser()->normalize($parsedVersion));
     }
 
-    public function provideLibJpegVersions(): array
+    public static function provideLibJpegVersions(): array
     {
         return [
             ['9', '9.0'],
@@ -107,7 +107,7 @@ class VersionTest extends TestCase
         self::assertSame($parsedVersion, Version::parseLibjpeg($input));
     }
 
-    public function provideZoneinfoVersions(): array
+    public static function provideZoneinfoVersions(): array
     {
         return [
             ['2019c', '2019.3'],

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -303,7 +303,7 @@ class PluginInstallerTest extends TestCase
                  ->method('getPluginApiVersion')
                  ->will($this->returnValue($newPluginApiVersion));
 
-        $plugApiInternalPackage = $this->getPackage(
+        $plugApiInternalPackage = self::getPackage(
             'composer-plugin-api',
             $newPluginApiVersion,
             'Composer\Package\CompletePackage'
@@ -417,7 +417,7 @@ class PluginInstallerTest extends TestCase
     }
 
     /** @return mixed[] */
-    public function invalidImplementationClassNames(): array
+    public static function invalidImplementationClassNames(): array
     {
         return [
             [null],
@@ -471,7 +471,7 @@ class PluginInstallerTest extends TestCase
     }
 
     /** @return mixed[] */
-    public function nonExistingOrInvalidImplementationClassTypes(): array
+    public static function nonExistingOrInvalidImplementationClassTypes(): array
     {
         return [
             ['\stdClass'],

--- a/tests/Composer/Test/Question/StrictConfirmationQuestionTest.php
+++ b/tests/Composer/Test/Question/StrictConfirmationQuestionTest.php
@@ -30,7 +30,7 @@ class StrictConfirmationQuestionTest extends TestCase
      *
      * @phpstan-return list<array{non-empty-string}>
      */
-    public function getAskConfirmationBadData(): array
+    public static function getAskConfirmationBadData(): array
     {
         return [
             ['not correct'],
@@ -71,7 +71,7 @@ class StrictConfirmationQuestionTest extends TestCase
      *
      * @phpstan-return list<array{string, bool}>|list<array{string, bool, bool}>
      */
-    public function getAskConfirmationData(): array
+    public static function getAskConfirmationData(): array
     {
         return [
             ['', true],

--- a/tests/Composer/Test/Repository/ArrayRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ArrayRepositoryTest.php
@@ -21,22 +21,22 @@ class ArrayRepositoryTest extends TestCase
     public function testAddPackage(): void
     {
         $repo = new ArrayRepository;
-        $repo->addPackage($this->getPackage('foo', '1'));
+        $repo->addPackage(self::getPackage('foo', '1'));
 
         $this->assertCount(1, $repo);
     }
 
     public function testRemovePackage(): void
     {
-        $package = $this->getPackage('bar', '2');
+        $package = self::getPackage('bar', '2');
 
         $repo = new ArrayRepository;
-        $repo->addPackage($this->getPackage('foo', '1'));
+        $repo->addPackage(self::getPackage('foo', '1'));
         $repo->addPackage($package);
 
         $this->assertCount(2, $repo);
 
-        $repo->removePackage($this->getPackage('foo', '1'));
+        $repo->removePackage(self::getPackage('foo', '1'));
 
         $this->assertCount(1, $repo);
         $this->assertEquals([$package], $repo->getPackages());
@@ -45,19 +45,19 @@ class ArrayRepositoryTest extends TestCase
     public function testHasPackage(): void
     {
         $repo = new ArrayRepository;
-        $repo->addPackage($this->getPackage('foo', '1'));
-        $repo->addPackage($this->getPackage('bar', '2'));
+        $repo->addPackage(self::getPackage('foo', '1'));
+        $repo->addPackage(self::getPackage('bar', '2'));
 
-        $this->assertTrue($repo->hasPackage($this->getPackage('foo', '1')));
-        $this->assertFalse($repo->hasPackage($this->getPackage('bar', '1')));
+        $this->assertTrue($repo->hasPackage(self::getPackage('foo', '1')));
+        $this->assertFalse($repo->hasPackage(self::getPackage('bar', '1')));
     }
 
     public function testFindPackages(): void
     {
         $repo = new ArrayRepository();
-        $repo->addPackage($this->getPackage('foo', '1'));
-        $repo->addPackage($this->getPackage('bar', '2'));
-        $repo->addPackage($this->getPackage('bar', '3'));
+        $repo->addPackage(self::getPackage('foo', '1'));
+        $repo->addPackage(self::getPackage('bar', '2'));
+        $repo->addPackage(self::getPackage('bar', '3'));
 
         $foo = $repo->findPackages('foo');
         $this->assertCount(1, $foo);
@@ -72,14 +72,14 @@ class ArrayRepositoryTest extends TestCase
     {
         $repo = new ArrayRepository();
 
-        $package = $this->getPackage('foo', '1');
-        $alias = $this->getAliasPackage($package, '2');
+        $package = self::getPackage('foo', '1');
+        $alias = self::getAliasPackage($package, '2');
 
         $repo->addPackage($alias);
 
         $this->assertCount(2, $repo);
-        $this->assertTrue($repo->hasPackage($this->getPackage('foo', '1')));
-        $this->assertTrue($repo->hasPackage($this->getPackage('foo', '2')));
+        $this->assertTrue($repo->hasPackage(self::getPackage('foo', '1')));
+        $this->assertTrue($repo->hasPackage(self::getPackage('foo', '2')));
 
         $repo->removePackage($alias);
 
@@ -90,8 +90,8 @@ class ArrayRepositoryTest extends TestCase
     {
         $repo = new ArrayRepository();
 
-        $repo->addPackage($this->getPackage('foo', '1'));
-        $repo->addPackage($this->getPackage('bar', '1'));
+        $repo->addPackage(self::getPackage('foo', '1'));
+        $repo->addPackage(self::getPackage('bar', '1'));
 
         $this->assertSame(
             [['name' => 'foo', 'description' => null]],
@@ -112,10 +112,10 @@ class ArrayRepositoryTest extends TestCase
     {
         $repo = new ArrayRepository();
 
-        $repo->addPackage($this->getPackage('foo', '1', 'Composer\Package\CompletePackage'));
-        $repo->addPackage($this->getPackage('bar', '1', 'Composer\Package\CompletePackage'));
+        $repo->addPackage(self::getPackage('foo', '1', 'Composer\Package\CompletePackage'));
+        $repo->addPackage(self::getPackage('bar', '1', 'Composer\Package\CompletePackage'));
 
-        $package = $this->getPackage('foobar', '1', 'Composer\Package\CompletePackage');
+        $package = self::getPackage('foobar', '1', 'Composer\Package\CompletePackage');
         $package->setType('composer-plugin');
         $repo->addPackage($package);
 
@@ -136,10 +136,10 @@ class ArrayRepositoryTest extends TestCase
     {
         $repo = new ArrayRepository();
 
-        $package1 = $this->getPackage('foo1', '1');
+        $package1 = self::getPackage('foo1', '1');
         $package1->setAbandoned(true);
         $repo->addPackage($package1);
-        $package2 = $this->getPackage('foo2', '1');
+        $package2 = self::getPackage('foo2', '1');
         $package2->setAbandoned('bar');
         $repo->addPackage($package2);
 

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -61,7 +61,7 @@ class ComposerRepositoryTest extends TestCase
         }
     }
 
-    public function loadDataProvider(): array
+    public static function loadDataProvider(): array
     {
         return [
             // Old repository format
@@ -301,7 +301,7 @@ class ComposerRepositoryTest extends TestCase
         $this->assertSame($expected, $method->invoke($repository, $url));
     }
 
-    public function provideCanonicalizeUrlTestCases(): array
+    public static function provideCanonicalizeUrlTestCases(): array
     {
         return [
             [

--- a/tests/Composer/Test/Repository/CompositeRepositoryTest.php
+++ b/tests/Composer/Test/Repository/CompositeRepositoryTest.php
@@ -21,27 +21,27 @@ class CompositeRepositoryTest extends TestCase
     public function testHasPackage(): void
     {
         $arrayRepoOne = new ArrayRepository;
-        $arrayRepoOne->addPackage($this->getPackage('foo', '1'));
+        $arrayRepoOne->addPackage(self::getPackage('foo', '1'));
 
         $arrayRepoTwo = new ArrayRepository;
-        $arrayRepoTwo->addPackage($this->getPackage('bar', '1'));
+        $arrayRepoTwo->addPackage(self::getPackage('bar', '1'));
 
         $repo = new CompositeRepository([$arrayRepoOne, $arrayRepoTwo]);
 
-        $this->assertTrue($repo->hasPackage($this->getPackage('foo', '1')), "Should have package 'foo/1'");
-        $this->assertTrue($repo->hasPackage($this->getPackage('bar', '1')), "Should have package 'bar/1'");
+        $this->assertTrue($repo->hasPackage(self::getPackage('foo', '1')), "Should have package 'foo/1'");
+        $this->assertTrue($repo->hasPackage(self::getPackage('bar', '1')), "Should have package 'bar/1'");
 
-        $this->assertFalse($repo->hasPackage($this->getPackage('foo', '2')), "Should not have package 'foo/2'");
-        $this->assertFalse($repo->hasPackage($this->getPackage('bar', '2')), "Should not have package 'bar/2'");
+        $this->assertFalse($repo->hasPackage(self::getPackage('foo', '2')), "Should not have package 'foo/2'");
+        $this->assertFalse($repo->hasPackage(self::getPackage('bar', '2')), "Should not have package 'bar/2'");
     }
 
     public function testFindPackage(): void
     {
         $arrayRepoOne = new ArrayRepository;
-        $arrayRepoOne->addPackage($this->getPackage('foo', '1'));
+        $arrayRepoOne->addPackage(self::getPackage('foo', '1'));
 
         $arrayRepoTwo = new ArrayRepository;
-        $arrayRepoTwo->addPackage($this->getPackage('bar', '1'));
+        $arrayRepoTwo->addPackage(self::getPackage('bar', '1'));
 
         $repo = new CompositeRepository([$arrayRepoOne, $arrayRepoTwo]);
 
@@ -55,14 +55,14 @@ class CompositeRepositoryTest extends TestCase
     public function testFindPackages(): void
     {
         $arrayRepoOne = new ArrayRepository;
-        $arrayRepoOne->addPackage($this->getPackage('foo', '1'));
-        $arrayRepoOne->addPackage($this->getPackage('foo', '2'));
-        $arrayRepoOne->addPackage($this->getPackage('bat', '1'));
+        $arrayRepoOne->addPackage(self::getPackage('foo', '1'));
+        $arrayRepoOne->addPackage(self::getPackage('foo', '2'));
+        $arrayRepoOne->addPackage(self::getPackage('bat', '1'));
 
         $arrayRepoTwo = new ArrayRepository;
-        $arrayRepoTwo->addPackage($this->getPackage('bar', '1'));
-        $arrayRepoTwo->addPackage($this->getPackage('bar', '2'));
-        $arrayRepoTwo->addPackage($this->getPackage('foo', '3'));
+        $arrayRepoTwo->addPackage(self::getPackage('bar', '1'));
+        $arrayRepoTwo->addPackage(self::getPackage('bar', '2'));
+        $arrayRepoTwo->addPackage(self::getPackage('foo', '3'));
 
         $repo = new CompositeRepository([$arrayRepoOne, $arrayRepoTwo]);
 
@@ -82,10 +82,10 @@ class CompositeRepositoryTest extends TestCase
     public function testGetPackages(): void
     {
         $arrayRepoOne = new ArrayRepository;
-        $arrayRepoOne->addPackage($this->getPackage('foo', '1'));
+        $arrayRepoOne->addPackage(self::getPackage('foo', '1'));
 
         $arrayRepoTwo = new ArrayRepository;
-        $arrayRepoTwo->addPackage($this->getPackage('bar', '1'));
+        $arrayRepoTwo->addPackage(self::getPackage('bar', '1'));
 
         $repo = new CompositeRepository([$arrayRepoOne, $arrayRepoTwo]);
 
@@ -100,12 +100,12 @@ class CompositeRepositoryTest extends TestCase
     public function testAddRepository(): void
     {
         $arrayRepoOne = new ArrayRepository;
-        $arrayRepoOne->addPackage($this->getPackage('foo', '1'));
+        $arrayRepoOne->addPackage(self::getPackage('foo', '1'));
 
         $arrayRepoTwo = new ArrayRepository;
-        $arrayRepoTwo->addPackage($this->getPackage('bar', '1'));
-        $arrayRepoTwo->addPackage($this->getPackage('bar', '2'));
-        $arrayRepoTwo->addPackage($this->getPackage('bar', '3'));
+        $arrayRepoTwo->addPackage(self::getPackage('bar', '1'));
+        $arrayRepoTwo->addPackage(self::getPackage('bar', '2'));
+        $arrayRepoTwo->addPackage(self::getPackage('bar', '3'));
 
         $repo = new CompositeRepository([$arrayRepoOne]);
         $this->assertCount(1, $repo, "Composite repository should have just one package before addRepository() is called");
@@ -116,10 +116,10 @@ class CompositeRepositoryTest extends TestCase
     public function testCount(): void
     {
         $arrayRepoOne = new ArrayRepository;
-        $arrayRepoOne->addPackage($this->getPackage('foo', '1'));
+        $arrayRepoOne->addPackage(self::getPackage('foo', '1'));
 
         $arrayRepoTwo = new ArrayRepository;
-        $arrayRepoTwo->addPackage($this->getPackage('bar', '1'));
+        $arrayRepoTwo->addPackage(self::getPackage('bar', '1'));
 
         $repo = new CompositeRepository([$arrayRepoOne, $arrayRepoTwo]);
 
@@ -137,7 +137,7 @@ class CompositeRepositoryTest extends TestCase
         $this->assertEquals([], call_user_func_array([$repo, $method], $args));
     }
 
-    public function provideMethodCalls(): array
+    public static function provideMethodCalls(): array
     {
         return [
             ['findPackages', ['foo']],

--- a/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
@@ -119,8 +119,8 @@ class FilesystemRepositoryTest extends TestCase
             ]);
 
         $repository->setDevPackageNames(['mypkg2']);
-        $repository->addPackage($this->getPackage('mypkg2', '1.2.3'));
-        $repository->addPackage($this->getPackage('mypkg', '0.1.10'));
+        $repository->addPackage(self::getPackage('mypkg2', '1.2.3'));
+        $repository->addPackage(self::getPackage('mypkg', '0.1.10'));
         $repository->write(true, $im);
     }
 
@@ -131,36 +131,36 @@ class FilesystemRepositoryTest extends TestCase
 
         $json = new JsonFile($dir.'/installed.json');
 
-        $rootPackage = $this->getRootPackage('__root__', 'dev-master');
+        $rootPackage = self::getRootPackage('__root__', 'dev-master');
         $rootPackage->setSourceReference('sourceref-by-default');
         $rootPackage->setDistReference('distref');
-        $this->configureLinks($rootPackage, ['provide' => ['foo/impl' => '2.0']]);
-        $rootPackage = $this->getAliasPackage($rootPackage, '1.10.x-dev');
+        self::configureLinks($rootPackage, ['provide' => ['foo/impl' => '2.0']]);
+        $rootPackage = self::getAliasPackage($rootPackage, '1.10.x-dev');
 
         $repository = new FilesystemRepository($json, true, $rootPackage);
         $repository->setDevPackageNames(['c/c']);
-        $pkg = $this->getPackage('a/provider', '1.1');
-        $this->configureLinks($pkg, ['provide' => ['foo/impl' => '^1.1', 'foo/impl2' => '2.0']]);
+        $pkg = self::getPackage('a/provider', '1.1');
+        self::configureLinks($pkg, ['provide' => ['foo/impl' => '^1.1', 'foo/impl2' => '2.0']]);
         $pkg->setDistReference('distref-as-no-source');
         $repository->addPackage($pkg);
 
-        $pkg = $this->getPackage('a/provider2', '1.2');
-        $this->configureLinks($pkg, ['provide' => ['foo/impl' => 'self.version', 'foo/impl2' => '2.0']]);
+        $pkg = self::getPackage('a/provider2', '1.2');
+        self::configureLinks($pkg, ['provide' => ['foo/impl' => 'self.version', 'foo/impl2' => '2.0']]);
         $pkg->setSourceReference('sourceref');
         $pkg->setDistReference('distref-as-installed-from-dist');
         $pkg->setInstallationSource('dist');
         $repository->addPackage($pkg);
 
-        $repository->addPackage($this->getAliasPackage($pkg, '1.4'));
+        $repository->addPackage(self::getAliasPackage($pkg, '1.4'));
 
-        $pkg = $this->getPackage('b/replacer', '2.2');
-        $this->configureLinks($pkg, ['replace' => ['foo/impl2' => 'self.version', 'foo/replaced' => '^3.0']]);
+        $pkg = self::getPackage('b/replacer', '2.2');
+        self::configureLinks($pkg, ['replace' => ['foo/impl2' => 'self.version', 'foo/replaced' => '^3.0']]);
         $repository->addPackage($pkg);
 
-        $pkg = $this->getPackage('c/c', '3.0');
+        $pkg = self::getPackage('c/c', '3.0');
         $repository->addPackage($pkg);
 
-        $pkg = $this->getPackage('meta/package', '3.0');
+        $pkg = self::getPackage('meta/package', '3.0');
         $pkg->setType('metapackage');
         $repository->addPackage($pkg);
 

--- a/tests/Composer/Test/Repository/FilterRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilterRepositoryTest.php
@@ -28,10 +28,10 @@ class FilterRepositoryTest extends TestCase
     public function setUp(): void
     {
         $this->arrayRepo = new ArrayRepository();
-        $this->arrayRepo->addPackage($this->getPackage('foo/aaa', '1.0.0'));
-        $this->arrayRepo->addPackage($this->getPackage('foo/bbb', '1.0.0'));
-        $this->arrayRepo->addPackage($this->getPackage('bar/xxx', '1.0.0'));
-        $this->arrayRepo->addPackage($this->getPackage('baz/yyy', '1.0.0'));
+        $this->arrayRepo->addPackage(self::getPackage('foo/aaa', '1.0.0'));
+        $this->arrayRepo->addPackage(self::getPackage('foo/bbb', '1.0.0'));
+        $this->arrayRepo->addPackage(self::getPackage('bar/xxx', '1.0.0'));
+        $this->arrayRepo->addPackage(self::getPackage('baz/yyy', '1.0.0'));
     }
 
     /**

--- a/tests/Composer/Test/Repository/InstalledRepositoryTest.php
+++ b/tests/Composer/Test/Repository/InstalledRepositoryTest.php
@@ -24,12 +24,12 @@ class InstalledRepositoryTest extends TestCase
     public function testFindPackagesWithReplacersAndProviders(): void
     {
         $arrayRepoOne = new InstalledArrayRepository;
-        $arrayRepoOne->addPackage($foo = $this->getPackage('foo', '1'));
-        $arrayRepoOne->addPackage($foo2 = $this->getPackage('foo', '2'));
+        $arrayRepoOne->addPackage($foo = self::getPackage('foo', '1'));
+        $arrayRepoOne->addPackage($foo2 = self::getPackage('foo', '2'));
 
         $arrayRepoTwo = new InstalledArrayRepository;
-        $arrayRepoTwo->addPackage($bar = $this->getPackage('bar', '1'));
-        $arrayRepoTwo->addPackage($bar2 = $this->getPackage('bar', '2'));
+        $arrayRepoTwo->addPackage($bar = self::getPackage('bar', '1'));
+        $arrayRepoTwo->addPackage($bar2 = self::getPackage('bar', '2'));
 
         $foo->setReplaces(['provided' => new Link('foo', 'provided', new MatchAllConstraint())]);
         $bar2->setProvides(['provided' => new Link('bar', 'provided', new MatchAllConstraint())]);

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -37,7 +37,7 @@ class PathRepositoryTest extends TestCase
         $repository->getPackages();
 
         $this->assertSame(1, $repository->count());
-        $this->assertTrue($repository->hasPackage($this->getPackage('test/path-versioned', '0.0.2')));
+        $this->assertTrue($repository->hasPackage(self::getPackage('test/path-versioned', '0.0.2')));
     }
 
     public function testLoadPackageFromFileSystemWithoutVersion(): void

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -36,7 +36,7 @@ class PlatformRepositoryTest extends TestCase
         self::assertSame('2.1.0', $hhvm->getPrettyVersion());
     }
 
-    public function providePhpFlavorTestCases(): array
+    public static function providePhpFlavorTestCases(): array
     {
         return [
             [
@@ -1202,7 +1202,7 @@ Linked Version => 1.2.11',
         foreach ($links as $link) {
             self::assertSame($sourcePackage->getName(), $link->getSource());
             self::assertContains($link->getTarget(), $expectedLinks, sprintf('%s: package %s not in %s', $context, $link->getTarget(), var_export($expectedLinks, true)));
-            self::assertTrue($link->getConstraint()->matches($this->getVersionConstraint('=', $sourcePackage->getVersion())));
+            self::assertTrue($link->getConstraint()->matches(self::getVersionConstraint('=', $sourcePackage->getVersion())));
         }
     }
 

--- a/tests/Composer/Test/Repository/RepositoryFactoryTest.php
+++ b/tests/Composer/Test/Repository/RepositoryFactoryTest.php
@@ -63,7 +63,7 @@ class RepositoryFactoryTest extends TestCase
         $this->assertSame($expected, RepositoryFactory::generateRepositoryName($index, $config, $existingRepos));
     }
 
-    public function generateRepositoryNameProvider(): array
+    public static function generateRepositoryNameProvider(): array
     {
         return [
             [0, [], [], '0'],

--- a/tests/Composer/Test/Repository/RepositoryManagerTest.php
+++ b/tests/Composer/Test/Repository/RepositoryManagerTest.php
@@ -89,7 +89,7 @@ class RepositoryManagerTest extends TestCase
         $this->assertInstanceOf('Composer\Repository\RepositoryInterface', $rm->createRepository($type, $options));
     }
 
-    public function provideRepoCreationTestCases(): array
+    public static function provideRepoCreationTestCases(): array
     {
         $cases = [
             ['composer', ['url' => 'http://example.org']],

--- a/tests/Composer/Test/Repository/RepositoryUtilsTest.php
+++ b/tests/Composer/Test/Repository/RepositoryUtilsTest.php
@@ -36,22 +36,22 @@ class RepositoryUtilsTest extends TestCase
     /**
      * @return array<PackageInterface>
      */
-    private function getPackages(): array
+    private static function getPackages(): array
     {
-        $packageA = $this->getPackage('required/a');
-        $packageB = $this->getPackage('required/b');
-        $this->configureLinks($packageB, ['require' => ['required/c' => '*']]);
-        $packageC = $this->getPackage('required/c');
-        $packageCAlias = $this->getAliasPackage($packageC, '2.0.0');
+        $packageA = self::getPackage('required/a');
+        $packageB = self::getPackage('required/b');
+        self::configureLinks($packageB, ['require' => ['required/c' => '*']]);
+        $packageC = self::getPackage('required/c');
+        $packageCAlias = self::getAliasPackage($packageC, '2.0.0');
 
-        $packageCircular = $this->getPackage('required/circular');
-        $this->configureLinks($packageCircular, ['require' => ['required/circular-b' => '*']]);
-        $packageCircularB = $this->getPackage('required/circular-b');
-        $this->configureLinks($packageCircularB, ['require' => ['required/circular' => '*']]);
+        $packageCircular = self::getPackage('required/circular');
+        self::configureLinks($packageCircular, ['require' => ['required/circular-b' => '*']]);
+        $packageCircularB = self::getPackage('required/circular-b');
+        self::configureLinks($packageCircularB, ['require' => ['required/circular' => '*']]);
 
         return [
-            $this->getPackage('dummy/pkg'),
-            $this->getPackage('dummy/pkg2', '2.0.0'),
+            self::getPackage('dummy/pkg'),
+            self::getPackage('dummy/pkg2', '2.0.0'),
             'a' => $packageA,
             'b' => $packageB,
             'c' => $packageC,
@@ -61,31 +61,31 @@ class RepositoryUtilsTest extends TestCase
         ];
     }
 
-    public function provideFilterRequireTests(): Generator
+    public static function provideFilterRequireTests(): Generator
     {
-        $pkgs = $this->getPackages();
+        $pkgs = self::getPackages();
 
-        $requirer = $this->getPackage('requirer/pkg');
+        $requirer = self::getPackage('requirer/pkg');
         yield 'no require' => [$pkgs, $requirer, []];
 
-        $requirer = $this->getPackage('requirer/pkg');
-        $this->configureLinks($requirer, ['require-dev' => ['required/a' => '*']]);
+        $requirer = self::getPackage('requirer/pkg');
+        self::configureLinks($requirer, ['require-dev' => ['required/a' => '*']]);
         yield 'require-dev has no effect' => [$pkgs, $requirer, []];
 
-        $requirer = $this->getPackage('requirer/pkg');
-        $this->configureLinks($requirer, ['require' => ['required/a' => '*']]);
+        $requirer = self::getPackage('requirer/pkg');
+        self::configureLinks($requirer, ['require' => ['required/a' => '*']]);
         yield 'simple require' => [$pkgs, $requirer, ['a']];
 
-        $requirer = $this->getPackage('requirer/pkg');
-        $this->configureLinks($requirer, ['require' => ['required/a' => 'dev-lala']]);
+        $requirer = self::getPackage('requirer/pkg');
+        self::configureLinks($requirer, ['require' => ['required/a' => 'dev-lala']]);
         yield 'require constraint is irrelevant' => [$pkgs, $requirer, ['a']];
 
-        $requirer = $this->getPackage('requirer/pkg');
-        $this->configureLinks($requirer, ['require' => ['required/b' => '*']]);
+        $requirer = self::getPackage('requirer/pkg');
+        self::configureLinks($requirer, ['require' => ['required/b' => '*']]);
         yield 'require transitive deps and aliases are included' => [$pkgs, $requirer, ['b', 'c', 'c-alias']];
 
-        $requirer = $this->getPackage('requirer/pkg');
-        $this->configureLinks($requirer, ['require' => ['required/circular' => '*']]);
+        $requirer = self::getPackage('requirer/pkg');
+        self::configureLinks($requirer, ['require' => ['required/circular' => '*']]);
         yield 'circular deps are no problem' => [$pkgs, $requirer, ['circular', 'circular-b']];
     }
 }

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -330,7 +330,7 @@ class GitHubDriverTest extends TestCase
     /**
      * @return list<array{string}>
      */
-    public function invalidUrlProvider()
+    public static function invalidUrlProvider()
     {
         return [
             ['https://github.com/acme'],
@@ -352,7 +352,7 @@ class GitHubDriverTest extends TestCase
     /**
      * @return list<array{bool, string}>
      */
-    public function supportsProvider(): array
+    public static function supportsProvider(): array
     {
         return [
             [false, 'https://github.com/acme'],

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -75,7 +75,7 @@ class GitLabDriverTest extends TestCase
         $fs->removeDirectory($this->home);
     }
 
-    public function provideInitializeUrls(): array
+    public static function provideInitializeUrls(): array
     {
         return [
             ['https://gitlab.com/mygroup/myproject', 'https://gitlab.com/api/v4/projects/mygroup%2Fmyproject'],
@@ -441,7 +441,7 @@ JSON;
         $this->assertSame($expected, GitLabDriver::supports($this->io, $this->config, $url));
     }
 
-    public function dataForTestSupports(): array
+    public static function dataForTestSupports(): array
     {
         return [
             ['http://gitlab.com/foo/bar', true],

--- a/tests/Composer/Test/Repository/Vcs/HgDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/HgDriverTest.php
@@ -55,7 +55,7 @@ class HgDriverTest extends TestCase
         );
     }
 
-    public function supportsDataProvider(): array
+    public static function supportsDataProvider(): array
     {
         return [
             ['ssh://bitbucket.org/user/repo'],

--- a/tests/Composer/Test/TestCase.php
+++ b/tests/Composer/Test/TestCase.php
@@ -206,7 +206,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * @param Constraint::STR_OP_* $operator
      */
-    protected function getVersionConstraint($operator, string $version): Constraint
+    protected static function getVersionConstraint($operator, string $version): Constraint
     {
         $constraint = new Constraint(
             $operator,
@@ -228,14 +228,14 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @phpstan-param class-string<PackageClass> $class
      * @phpstan-return PackageClass
      */
-    protected function getPackage(string $name = 'dummy/pkg', string $version = '1.0.0', string $class = 'Composer\Package\CompletePackage'): BasePackage
+    protected static function getPackage(string $name = 'dummy/pkg', string $version = '1.0.0', string $class = 'Composer\Package\CompletePackage'): BasePackage
     {
         $normVersion = self::getVersionParser()->normalize($version);
 
         return new $class($name, $normVersion, $version);
     }
 
-    protected function getRootPackage(string $name = '__root__', string $version = '1.0.0'): RootPackage
+    protected static function getRootPackage(string $name = '__root__', string $version = '1.0.0'): RootPackage
     {
         $normVersion = self::getVersionParser()->normalize($version);
 
@@ -245,7 +245,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * @return ($package is RootPackage ? RootAliasPackage : ($package is CompletePackage ? CompleteAliasPackage : AliasPackage))
      */
-    protected function getAliasPackage(Package $package, string $version): AliasPackage
+    protected static function getAliasPackage(Package $package, string $version): AliasPackage
     {
         $normVersion = self::getVersionParser()->normalize($version);
 
@@ -262,7 +262,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * @param array<string, array<string, string>> $config
      */
-    protected function configureLinks(PackageInterface $package, array $config): void
+    protected static function configureLinks(PackageInterface $package, array $config): void
     {
         $arrayLoader = new ArrayLoader();
 
@@ -327,7 +327,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @return string The transformed command
      */
-    protected function getCmd(string $cmd): string
+    protected static function getCmd(string $cmd): string
     {
         if (Platform::isWindows()) {
             $cmd = Preg::replaceCallback("/('[^']*')/", static function ($m) {

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -145,7 +145,7 @@ class AuthHelperTest extends TestCase
         );
     }
 
-    public function gitlabPrivateTokenProvider(): array
+    public static function gitlabPrivateTokenProvider(): array
     {
         return [
           ['private-token'],
@@ -220,7 +220,7 @@ class AuthHelperTest extends TestCase
         );
     }
 
-    public function bitbucketPublicUrlProvider(): array
+    public static function bitbucketPublicUrlProvider(): array
     {
         return [
             ['https://bitbucket.org/user/repo/downloads/whatever'],
@@ -256,7 +256,7 @@ class AuthHelperTest extends TestCase
         );
     }
 
-    public function basicHttpAuthenticationProvider(): array
+    public static function basicHttpAuthenticationProvider(): array
     {
         return [
             [

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -59,7 +59,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals($expected, $fs->findShortestPathCode($a, $b, $directory, $static));
     }
 
-    public function providePathCouplesAsCode(): array
+    public static function providePathCouplesAsCode(): array
     {
         return [
             ['/foo/bar', '/foo/bar', false, "__FILE__"],
@@ -118,7 +118,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals($expected, $fs->findShortestPath($a, $b, $directory));
     }
 
-    public function providePathCouples(): array
+    public static function providePathCouples(): array
     {
         return [
             ['/foo/bar', '/foo/bar', "./bar"],
@@ -201,7 +201,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals($expected, $fs->normalizePath($actual));
     }
 
-    public function provideNormalizedPaths(): array
+    public static function provideNormalizedPaths(): array
     {
         return [
             ['../foo', '../foo'],

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -59,7 +59,7 @@ class GitTest extends TestCase
         $this->git->runCommand($commandCallable, 'https://github.com/acme/repo', null, true);
     }
 
-    public function publicGithubNoCredentialsProvider(): array
+    public static function publicGithubNoCredentialsProvider(): array
     {
         return [
             ['ssh', 'git@github.com:acme/repo'],
@@ -126,7 +126,7 @@ class GitTest extends TestCase
         $this->git->runCommand($commandCallable, $gitUrl, null, true);
     }
 
-    public function privateGithubWithCredentialsProvider(): array
+    public static function privateGithubWithCredentialsProvider(): array
     {
         return [
             ['git@github.com:acme/repo.git', 'ssh', 'MY_GITHUB_TOKEN', 'https://token:MY_GITHUB_TOKEN@github.com/acme/repo.git', 1],

--- a/tests/Composer/Test/Util/Http/ProxyHelperTest.php
+++ b/tests/Composer/Test/Util/Http/ProxyHelperTest.php
@@ -55,7 +55,7 @@ class ProxyHelperTest extends TestCase
         ProxyHelper::getProxyData();
     }
 
-    public function dataMalformed(): array
+    public static function dataMalformed(): array
     {
         return [
             'no-host' => ['localhost'],
@@ -74,7 +74,7 @@ class ProxyHelperTest extends TestCase
         $this->assertSame($expected, $httpProxy);
     }
 
-    public function dataFormatting(): array
+    public static function dataFormatting(): array
     {
         // url, expected
         return [
@@ -97,7 +97,7 @@ class ProxyHelperTest extends TestCase
         $this->assertSame($expected, $list[$index]);
     }
 
-    public function dataCaseOverrides(): array
+    public static function dataCaseOverrides(): array
     {
         // server, expected, list index
         return [
@@ -120,7 +120,7 @@ class ProxyHelperTest extends TestCase
         $this->assertSame($expected, $list[$index]);
     }
 
-    public function dataCGIOverrides(): array
+    public static function dataCGIOverrides(): array
     {
         // server, expected, list index
         return [
@@ -157,7 +157,7 @@ class ProxyHelperTest extends TestCase
         $this->assertEquals($expected, ProxyHelper::getContextOptions($url));
     }
 
-    public function dataContextOptions(): array
+    public static function dataContextOptions(): array
     {
         // url, expected
         return [
@@ -187,7 +187,7 @@ class ProxyHelperTest extends TestCase
         $this->assertEquals($expected, $options);
     }
 
-    public function dataRequestFullUri(): array
+    public static function dataRequestFullUri(): array
     {
         $options = ['http' => ['request_fulluri' => true]];
 

--- a/tests/Composer/Test/Util/Http/ProxyManagerTest.php
+++ b/tests/Composer/Test/Util/Http/ProxyManagerTest.php
@@ -97,7 +97,7 @@ class ProxyManagerTest extends TestCase
         $this->assertTrue($condition, 'lastProxy check');
     }
 
-    public function dataRequest(): array
+    public static function dataRequest(): array
     {
         $server = [
             'http_proxy' => 'http://user:p%40ss@proxy.com',
@@ -151,7 +151,7 @@ class ProxyManagerTest extends TestCase
         $this->assertTrue($condition, 'message check');
     }
 
-    public function dataStatus(): array
+    public static function dataStatus(): array
     {
         // server, expectedStatus, expectedMessage
         return [

--- a/tests/Composer/Test/Util/Http/RequestProxyTest.php
+++ b/tests/Composer/Test/Util/Http/RequestProxyTest.php
@@ -27,7 +27,7 @@ class RequestProxyTest extends TestCase
         $this->assertSame($expectedSecure, $proxy->isSecure());
     }
 
-    public function dataSecure(): array
+    public static function dataSecure(): array
     {
         // url, secure
         return [
@@ -48,7 +48,7 @@ class RequestProxyTest extends TestCase
         $this->assertSame($expected, $message);
     }
 
-    public function dataProxyUrl(): array
+    public static function dataProxyUrl(): array
     {
         $format = 'proxy (%s)';
 

--- a/tests/Composer/Test/Util/NoProxyPatternTest.php
+++ b/tests/Composer/Test/Util/NoProxyPatternTest.php
@@ -27,7 +27,7 @@ class NoProxyPatternTest extends TestCase
         $this->assertEquals($expected, $matcher->test($url));
     }
 
-    public function dataHostName(): array
+    public static function dataHostName(): array
     {
         $noproxy = 'foobar.com, .barbaz.net';
 
@@ -54,7 +54,7 @@ class NoProxyPatternTest extends TestCase
         $this->assertEquals($expected, $matcher->test($url));
     }
 
-    public function dataIpAddress(): array
+    public static function dataIpAddress(): array
     {
         $noproxy = '192.168.1.1, 2001:db8::52:0:1';
 
@@ -79,7 +79,7 @@ class NoProxyPatternTest extends TestCase
         $this->assertEquals($expected, $matcher->test($url));
     }
 
-    public function dataIpRange(): array
+    public static function dataIpRange(): array
     {
         $noproxy = '10.0.0.0/30, 2002:db8:a::45/121';
 
@@ -104,7 +104,7 @@ class NoProxyPatternTest extends TestCase
         $this->assertEquals($expected, $matcher->test($url));
     }
 
-    public function dataPort(): array
+    public static function dataPort(): array
     {
         $noproxy = '192.168.1.2:81, 192.168.1.3:80, [2001:db8::52:0:2]:443, [2001:db8::52:0:3]:80';
 

--- a/tests/Composer/Test/Util/PackageSorterTest.php
+++ b/tests/Composer/Test/Util/PackageSorterTest.php
@@ -22,25 +22,25 @@ class PackageSorterTest extends TestCase
 {
     public function testSortingDoesNothingWithNoDependencies(): void
     {
-        $packages[] = $this->createPackage('foo/bar1', []);
-        $packages[] = $this->createPackage('foo/bar2', []);
-        $packages[] = $this->createPackage('foo/bar3', []);
-        $packages[] = $this->createPackage('foo/bar4', []);
+        $packages[] = self::createPackage('foo/bar1', []);
+        $packages[] = self::createPackage('foo/bar2', []);
+        $packages[] = self::createPackage('foo/bar3', []);
+        $packages[] = self::createPackage('foo/bar4', []);
 
         $sortedPackages = PackageSorter::sortPackages($packages);
 
         self::assertSame($packages, $sortedPackages);
     }
 
-    public function sortingOrdersDependenciesHigherThanPackageDataProvider(): array
+    public static function sortingOrdersDependenciesHigherThanPackageDataProvider(): array
     {
         return [
             'one package is dep' => [
                 [
-                    $this->createPackage('foo/bar1', ['foo/bar4']),
-                    $this->createPackage('foo/bar2', ['foo/bar4']),
-                    $this->createPackage('foo/bar3', ['foo/bar4']),
-                    $this->createPackage('foo/bar4', []),
+                    self::createPackage('foo/bar1', ['foo/bar4']),
+                    self::createPackage('foo/bar2', ['foo/bar4']),
+                    self::createPackage('foo/bar3', ['foo/bar4']),
+                    self::createPackage('foo/bar4', []),
                 ],
                 [
                     'foo/bar4',
@@ -51,10 +51,10 @@ class PackageSorterTest extends TestCase
             ],
             'one package has more deps' => [
                 [
-                    $this->createPackage('foo/bar1', ['foo/bar2']),
-                    $this->createPackage('foo/bar2', ['foo/bar4']),
-                    $this->createPackage('foo/bar3', ['foo/bar4']),
-                    $this->createPackage('foo/bar4', []),
+                    self::createPackage('foo/bar1', ['foo/bar2']),
+                    self::createPackage('foo/bar2', ['foo/bar4']),
+                    self::createPackage('foo/bar3', ['foo/bar4']),
+                    self::createPackage('foo/bar4', []),
                 ],
                 [
                     'foo/bar4',
@@ -65,12 +65,12 @@ class PackageSorterTest extends TestCase
             ],
             'package is required by many, but requires one other' => [
                 [
-                    $this->createPackage('foo/bar1', ['foo/bar3']),
-                    $this->createPackage('foo/bar2', ['foo/bar3']),
-                    $this->createPackage('foo/bar3', ['foo/bar4']),
-                    $this->createPackage('foo/bar4', []),
-                    $this->createPackage('foo/bar5', ['foo/bar3']),
-                    $this->createPackage('foo/bar6', ['foo/bar3']),
+                    self::createPackage('foo/bar1', ['foo/bar3']),
+                    self::createPackage('foo/bar2', ['foo/bar3']),
+                    self::createPackage('foo/bar3', ['foo/bar4']),
+                    self::createPackage('foo/bar4', []),
+                    self::createPackage('foo/bar5', ['foo/bar3']),
+                    self::createPackage('foo/bar6', ['foo/bar3']),
                 ],
                 [
                     'foo/bar4',
@@ -83,12 +83,12 @@ class PackageSorterTest extends TestCase
             ],
             'one package has many requires' => [
                 [
-                    $this->createPackage('foo/bar1', ['foo/bar2']),
-                    $this->createPackage('foo/bar2', []),
-                    $this->createPackage('foo/bar3', ['foo/bar4']),
-                    $this->createPackage('foo/bar4', []),
-                    $this->createPackage('foo/bar5', ['foo/bar2']),
-                    $this->createPackage('foo/bar6', ['foo/bar2']),
+                    self::createPackage('foo/bar1', ['foo/bar2']),
+                    self::createPackage('foo/bar2', []),
+                    self::createPackage('foo/bar3', ['foo/bar4']),
+                    self::createPackage('foo/bar4', []),
+                    self::createPackage('foo/bar5', ['foo/bar2']),
+                    self::createPackage('foo/bar6', ['foo/bar2']),
                 ],
                 [
                     'foo/bar2',
@@ -101,10 +101,10 @@ class PackageSorterTest extends TestCase
             ],
             'circular deps sorted alphabetically if weighted equally' => [
                 [
-                    $this->createPackage('foo/bar1', ['circular/part1']),
-                    $this->createPackage('foo/bar2', ['circular/part2']),
-                    $this->createPackage('circular/part1', ['circular/part2']),
-                    $this->createPackage('circular/part2', ['circular/part1']),
+                    self::createPackage('foo/bar1', ['circular/part1']),
+                    self::createPackage('foo/bar2', ['circular/part2']),
+                    self::createPackage('circular/part1', ['circular/part2']),
+                    self::createPackage('circular/part2', ['circular/part1']),
                 ],
                 [
                     'circular/part1',
@@ -115,10 +115,10 @@ class PackageSorterTest extends TestCase
             ],
             'equal weight sorted alphabetically' => [
                 [
-                    $this->createPackage('foo/bar10', ['foo/dep']),
-                    $this->createPackage('foo/bar2', ['foo/dep']),
-                    $this->createPackage('foo/baz', ['foo/dep']),
-                    $this->createPackage('foo/dep', []),
+                    self::createPackage('foo/bar10', ['foo/dep']),
+                    self::createPackage('foo/bar2', ['foo/dep']),
+                    self::createPackage('foo/baz', ['foo/dep']),
+                    self::createPackage('foo/dep', []),
                 ],
                 [
                     'foo/dep',
@@ -129,10 +129,10 @@ class PackageSorterTest extends TestCase
             ],
             'pre-weighted packages bumped to top incl their deps' => [
                 [
-                    $this->createPackage('foo/bar', ['foo/dep']),
-                    $this->createPackage('foo/bar2', ['foo/dep2']),
-                    $this->createPackage('foo/dep', []),
-                    $this->createPackage('foo/dep2', []),
+                    self::createPackage('foo/bar', ['foo/dep']),
+                    self::createPackage('foo/bar2', ['foo/dep2']),
+                    self::createPackage('foo/dep', []),
+                    self::createPackage('foo/dep2', []),
                 ],
                 [
                     'foo/dep',
@@ -167,7 +167,7 @@ class PackageSorterTest extends TestCase
     /**
      * @param string[] $requires
      */
-    private function createPackage(string $name, array $requires): Package
+    private static function createPackage(string $name, array $requires): Package
     {
         $package = new Package($name, '1.0.0.0', '1.0.0');
 

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -77,7 +77,7 @@ class ProcessExecutorTest extends TestCase
         $this->assertEquals('Executing command (CWD): ' . $expectedCommandOutput, trim($buffer->getOutput()));
     }
 
-    public function hidePasswordProvider(): array
+    public static function hidePasswordProvider(): array
     {
         return [
             ['echo https://foo:bar@example.org/', 'echo https://foo:***@example.org/'],
@@ -147,7 +147,7 @@ class ProcessExecutorTest extends TestCase
      * Each named test is an array of:
      *   argument, win-expected, unix-expected
      */
-    public function dataEscapeArguments(): array
+    public static function dataEscapeArguments(): array
     {
         return [
             // empty argument - must be quoted

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -265,7 +265,7 @@ class RemoteFilesystemTest extends TestCase
      *
      * @return string[][]
      */
-    public function provideBitbucketPublicDownloadUrls(): array
+    public static function provideBitbucketPublicDownloadUrls(): array
     {
         return [
             ['https://bitbucket.org/seldaek/composer-live-test-repo/downloads/composer-unit-test-download-me.txt', '1234'],

--- a/tests/Composer/Test/Util/StreamContextFactoryTest.php
+++ b/tests/Composer/Test/Util/StreamContextFactoryTest.php
@@ -49,7 +49,7 @@ class StreamContextFactoryTest extends TestCase
         $this->assertEquals($expectedParams, $params);
     }
 
-    public function dataGetContext(): array
+    public static function dataGetContext(): array
     {
         return [
             [
@@ -189,7 +189,7 @@ class StreamContextFactoryTest extends TestCase
         }
     }
 
-    public function dataSSLProxy(): array
+    public static function dataSSLProxy(): array
     {
         return [
             ['ssl://proxyserver:443', 'https://proxyserver/'],

--- a/tests/Composer/Test/Util/SvnTest.php
+++ b/tests/Composer/Test/Util/SvnTest.php
@@ -36,12 +36,12 @@ class SvnTest extends TestCase
         $this->assertEquals($expect, $reflMethod->invoke($svn));
     }
 
-    public function urlProvider(): array
+    public static function urlProvider(): array
     {
         return [
-            ['http://till:test@svn.example.org/', $this->getCmd(" --username 'till' --password 'test' ")],
+            ['http://till:test@svn.example.org/', self::getCmd(" --username 'till' --password 'test' ")],
             ['http://svn.apache.org/', ''],
-            ['svn://johndoe@example.org', $this->getCmd(" --username 'johndoe' --password '' ")],
+            ['svn://johndoe@example.org', self::getCmd(" --username 'johndoe' --password '' ")],
         ];
     }
 
@@ -54,7 +54,7 @@ class SvnTest extends TestCase
         $reflMethod->setAccessible(true);
 
         $this->assertEquals(
-            $this->getCmd("svn ls --non-interactive  -- 'http://svn.example.org'"),
+            self::getCmd("svn ls --non-interactive  -- 'http://svn.example.org'"),
             $reflMethod->invokeArgs($svn, ['svn ls', $url])
         );
     }
@@ -76,7 +76,7 @@ class SvnTest extends TestCase
         $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialString');
         $reflMethod->setAccessible(true);
 
-        $this->assertEquals($this->getCmd(" --username 'foo' --password 'bar' "), $reflMethod->invoke($svn));
+        $this->assertEquals(self::getCmd(" --username 'foo' --password 'bar' "), $reflMethod->invoke($svn));
     }
 
     public function testCredentialsFromConfigWithCacheCredentialsTrue(): void
@@ -99,7 +99,7 @@ class SvnTest extends TestCase
         $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialString');
         $reflMethod->setAccessible(true);
 
-        $this->assertEquals($this->getCmd(" --username 'foo' --password 'bar' "), $reflMethod->invoke($svn));
+        $this->assertEquals(self::getCmd(" --username 'foo' --password 'bar' "), $reflMethod->invoke($svn));
     }
 
     public function testCredentialsFromConfigWithCacheCredentialsFalse(): void
@@ -122,6 +122,6 @@ class SvnTest extends TestCase
         $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialString');
         $reflMethod->setAccessible(true);
 
-        $this->assertEquals($this->getCmd(" --no-auth-cache --username 'foo' --password 'bar' "), $reflMethod->invoke($svn));
+        $this->assertEquals(self::getCmd(" --no-auth-cache --username 'foo' --password 'bar' "), $reflMethod->invoke($svn));
     }
 }

--- a/tests/Composer/Test/Util/TlsHelperTest.php
+++ b/tests/Composer/Test/Util/TlsHelperTest.php
@@ -39,7 +39,7 @@ class TlsHelperTest extends TestCase
         }
     }
 
-    public function dataCheckCertificateHost(): array
+    public static function dataCheckCertificateHost(): array
     {
         return [
             [true, 'getcomposer.org', ['getcomposer.org']],


### PR DESCRIPTION
Non-static data providers are deprecated since PHPUnit 10 and will be removed in v11.

Most helper methods in `TestCase` like `getCmd()`, `getVersionConstraint()`, `getPackage()`, etc became static too.