### PR TITLE
Fix preserving of major.minor.patch version when running `composer bump` and installed patch version is `0`, and add bumping of >=x to >=latest

### DIFF
--- a/src/Composer/Package/Version/VersionBumper.php
+++ b/src/Composer/Package/Version/VersionBumper.php
@@ -34,6 +34,7 @@ class VersionBumper
      * For example:
      *  * ^1.0 + 1.2.1            -> ^1.2.1
      *  * ^1.2 + 1.2.0            -> ^1.2
+     *  * ^1.2.0 + 1.3.0          -> ^1.3.0
      *  * ^1.2 || ^2.3 + 1.3.0    -> ^1.3 || ^2.3
      *  * ^1.2 || ^2.3 + 2.4.0    -> ^1.2 || ^2.4
      *  * ^3@dev + 3.2.99999-dev  -> ^3.2@dev
@@ -89,7 +90,11 @@ class VersionBumper
         if (Preg::isMatchAllWithOffsets($pattern, $prettyConstraint, $matches)) {
             $modified = $prettyConstraint;
             foreach (array_reverse($matches['constraint']) as $match) {
-                $modified = substr_replace($modified, $newPrettyConstraint, $match[1], Platform::strlen((string) $match[0]));
+                $suffix = '';
+                if (substr_count($match[0], '.') === 2 && substr_count($newPrettyConstraint, '.') === 1) {
+                    $suffix = '.0';
+                }
+                $modified = substr_replace($modified, $newPrettyConstraint.$suffix, $match[1], Platform::strlen((string) $match[0]));
             }
 
             // if it is strictly equal to the previous one then no need to change anything

--- a/src/Composer/Package/Version/VersionBumper.php
+++ b/src/Composer/Package/Version/VersionBumper.php
@@ -71,7 +71,8 @@ class VersionBumper
         }
 
         $major = Preg::replace('{^(\d+).*}', '$1', $version);
-        $newPrettyConstraint = '^'.Preg::replace('{(?:\.(?:0|9999999))+(-dev)?$}', '', $version);
+        $versionWithoutSuffix = Preg::replace('{(?:\.(?:0|9999999))+(-dev)?$}', '', $version);
+        $newPrettyConstraint = '^'.$versionWithoutSuffix;
 
         // not a simple stable version, abort
         if (!Preg::isMatch('{^\^\d+(\.\d+)*$}', $newPrettyConstraint)) {
@@ -84,17 +85,24 @@ class VersionBumper
                 \^'.$major.'(?:\.\d+)* # e.g. ^2.anything
                 | ~'.$major.'(?:\.\d+)? # e.g. ~2 or ~2.2 but no more
                 | '.$major.'(?:\.[*x])+ # e.g. 2.* or 2.*.* or 2.x.x.x etc
+                | >=\d(?:\.\d+)* # e.g. >=2 or >=1.2 etc
             )
             (?=,|$|\ |\||@) # trailing separator
         }x';
         if (Preg::isMatchAllWithOffsets($pattern, $prettyConstraint, $matches)) {
             $modified = $prettyConstraint;
             foreach (array_reverse($matches['constraint']) as $match) {
+                assert(is_string($match[0]));
                 $suffix = '';
-                if (substr_count($match[0], '.') === 2 && substr_count($newPrettyConstraint, '.') === 1) {
+                if (substr_count($match[0], '.') === 2 && substr_count($versionWithoutSuffix, '.') === 1) {
                     $suffix = '.0';
                 }
-                $modified = substr_replace($modified, $newPrettyConstraint.$suffix, $match[1], Platform::strlen((string) $match[0]));
+                if (str_starts_with($match[0], '>=')) {
+                    $replacement = '>='.$versionWithoutSuffix.$suffix;
+                } else {
+                    $replacement = $newPrettyConstraint.$suffix;
+                }
+                $modified = substr_replace($modified, $replacement, $match[1], Platform::strlen($match[0]));
             }
 
             // if it is strictly equal to the previous one then no need to change anything

--- a/tests/Composer/Test/Package/Version/VersionBumperTest.php
+++ b/tests/Composer/Test/Package/Version/VersionBumperTest.php
@@ -46,6 +46,8 @@ class VersionBumperTest extends TestCase
         yield 'upgrade caret' => ['^1.0', '1.2.1', '^1.2.1'];
         yield 'skip trailing .0s' => ['^1.0', '1.0.0', '^1.0'];
         yield 'skip trailing .0s/2' => ['^1.2', '1.2.0', '^1.2'];
+        yield 'preserve major.minor.patch format when installed minor is 0' => ['^1.0.0', '1.2.0', '^1.2.0'];
+        yield 'preserve major.minor.patch format when installed minor is 1' => ['^1.0.0', '1.2.1', '^1.2.1'];
         yield 'preserve multi constraints' => ['^1.2 || ^2.3', '1.3.2', '^1.3.2 || ^2.3'];
         yield 'preserve multi constraints/2' => ['^1.2 || ^2.3', '2.4.0', '^1.2 || ^2.4'];
         yield 'preserve multi constraints/3' => ['^1.2 || ^2.3 || ^2', '2.4.0', '^1.2 || ^2.4 || ^2.4'];

--- a/tests/Composer/Test/Package/Version/VersionBumperTest.php
+++ b/tests/Composer/Test/Package/Version/VersionBumperTest.php
@@ -64,5 +64,7 @@ class VersionBumperTest extends TestCase
         yield 'leave patch wildcard alone' => ['2.4.3.*', '2.4.3.2', '2.4.3.*'];
         yield 'upgrade tilde to caret when compatible' => ['~2.2', '2.4.3', '^2.4.3'];
         yield 'leave patch-only-tilde alone' => ['~2.2.3', '2.2.6', '~2.2.3'];
+        yield 'upgrade bigger-or-eq to latest' => ['>=3.0', '3.4.5', '>=3.4.5'];
+        yield 'leave bigger-than untouched' => ['>2.2.3', '2.2.6', '>2.2.3'];
     }
 }

--- a/tests/Composer/Test/Package/Version/VersionBumperTest.php
+++ b/tests/Composer/Test/Package/Version/VersionBumperTest.php
@@ -51,13 +51,15 @@ class VersionBumperTest extends TestCase
         yield 'preserve multi constraints' => ['^1.2 || ^2.3', '1.3.2', '^1.3.2 || ^2.3'];
         yield 'preserve multi constraints/2' => ['^1.2 || ^2.3', '2.4.0', '^1.2 || ^2.4'];
         yield 'preserve multi constraints/3' => ['^1.2 || ^2.3 || ^2', '2.4.0', '^1.2 || ^2.4 || ^2.4'];
+        yield 'preserve multi constraints/4' => ['^1.2 || ^2.3.3 || ^2', '2.4.0', '^1.2 || ^2.4.0 || ^2.4'];
         yield '@dev is preserved' => ['^3@dev', '3.2.x-dev', '^3.2@dev'];
         yield 'non-stable versions abort upgrades' => ['~2', '2.1-beta.1', '~2'];
         yield 'dev reqs are skipped' => ['dev-main', 'dev-foo', 'dev-main'];
         yield 'dev version does not upgrade' => ['^3.2', 'dev-main', '^3.2'];
         yield 'upgrade dev version if aliased' => ['^3.2', 'dev-main', '^3.3', '3.3.x-dev'];
         yield 'upgrade major wildcard to caret' => ['2.*', '2.4.0', '^2.4'];
-        yield 'upgrade major wildcard as x to caret' => ['2.x.x', '2.4.0', '^2.4'];
+        yield 'upgrade major wildcard as x to caret' => ['2.x', '2.4.0', '^2.4'];
+        yield 'upgrade major wildcard as x to caret/2' => ['2.x.x', '2.4.0', '^2.4.0'];
         yield 'leave minor wildcard alone' => ['2.4.*', '2.4.3', '2.4.*'];
         yield 'leave patch wildcard alone' => ['2.4.3.*', '2.4.3.2', '2.4.3.*'];
         yield 'upgrade tilde to caret when compatible' => ['~2.2', '2.4.3', '^2.4.3'];


### PR DESCRIPTION
This pull request

- [x] adds a failing test case to prevent the `VersionBumper` from dropping the `.0` patch version when `major.minor.patch` version is used in version constraint and the installed patch version is `0`

See #11220.