### PR TITLE
Docs: fix documention deep links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1567,7 +1567,7 @@
 ### [1.0.0-alpha6] - 2012-10-23
 
   * Schema: Added ability to pass additional options to repositories (i.e. ssh keys/client certificates to secure private repos)
-  * Schema: Added a new `~` operator that should be preferred over `>=`, see https://getcomposer.org/doc/01-basic-usage.md#package-versions
+  * Schema: Added a new `~` operator that should be preferred over `>=`, see https://getcomposer.org/doc/01-basic-usage.md#package-version-constraints
   * Schema: Version constraints `<x.y` are assumed to be `<x.y-dev` unless specified as `<x.y-stable` to reduce confusion
   * Added `config` command to edit/list config values, including --global switch for system config
   * Added OAuth token support for the GitHub API

--- a/src/Composer/Command/DependsCommand.php
+++ b/src/Composer/Command/DependsCommand.php
@@ -45,7 +45,7 @@ Displays detailed information about where a package is referenced.
 
 <info>php composer.phar depends composer/composer</info>
 
-Read more at https://getcomposer.org/doc/03-cli.md#depends-why-
+Read more at https://getcomposer.org/doc/03-cli.md#depends-why
 EOT
             )
         ;

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -47,7 +47,7 @@ class DumpAutoloadCommand extends BaseCommand
                 <<<EOT
 <info>php composer.phar dump-autoload</info>
 
-Read more at https://getcomposer.org/doc/03-cli.md#dump-autoload-dumpautoload-
+Read more at https://getcomposer.org/doc/03-cli.md#dump-autoload-dumpautoload
 EOT
             )
         ;

--- a/src/Composer/Command/ProhibitsCommand.php
+++ b/src/Composer/Command/ProhibitsCommand.php
@@ -46,7 +46,7 @@ Displays detailed information about why a package cannot be installed.
 
 <info>php composer.phar prohibits composer/composer</info>
 
-Read more at https://getcomposer.org/doc/03-cli.md#prohibits-why-not-
+Read more at https://getcomposer.org/doc/03-cli.md#prohibits-why-not
 EOT
             )
         ;

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -120,7 +120,7 @@ If you do not specify a version constraint, composer will choose a suitable one 
 
 If you do not want to install the new dependencies immediately you can call it with --no-update
 
-Read more at https://getcomposer.org/doc/03-cli.md#require
+Read more at https://getcomposer.org/doc/03-cli.md#require-r
 EOT
             )
         ;

--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -66,7 +66,7 @@ The <info>run-script</info> command runs scripts defined in composer.json:
 
 <info>php composer.phar run-script post-update-cmd</info>
 
-Read more at https://getcomposer.org/doc/03-cli.md#run-script
+Read more at https://getcomposer.org/doc/03-cli.md#run-script-run
 EOT
             )
         ;

--- a/src/Composer/Command/ScriptAliasCommand.php
+++ b/src/Composer/Command/ScriptAliasCommand.php
@@ -54,7 +54,7 @@ The <info>run-script</info> command runs scripts defined in composer.json:
 
 <info>php composer.phar run-script post-update-cmd</info>
 
-Read more at https://getcomposer.org/doc/03-cli.md#run-script
+Read more at https://getcomposer.org/doc/03-cli.md#run-script-run
 EOT
             )
         ;

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -66,7 +66,7 @@ versions of composer and if found, installs the latest.
 
 <info>php composer.phar self-update</info>
 
-Read more at https://getcomposer.org/doc/03-cli.md#self-update-selfupdate-
+Read more at https://getcomposer.org/doc/03-cli.md#self-update-selfupdate
 EOT
             )
         ;

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -110,7 +110,7 @@ class ShowCommand extends BaseCommand
 The show command displays detailed information about a package, or
 lists all packages available.
 
-Read more at https://getcomposer.org/doc/03-cli.md#show
+Read more at https://getcomposer.org/doc/03-cli.md#show-info
 EOT
             )
         ;

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -106,7 +106,7 @@ To run a partial update with more restrictive constraints you can use the shorth
 
 To select packages names interactively with auto-completion use <info>-i</info>.
 
-Read more at https://getcomposer.org/doc/03-cli.md#update-u
+Read more at https://getcomposer.org/doc/03-cli.md#update-u-upgrade
 EOT
             )
         ;

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -534,7 +534,7 @@ class Locker
         if ($missingRequirements) {
             $missingRequirementInfo[] = 'This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.';
             $missingRequirementInfo[] = 'Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md';
-            $missingRequirementInfo[] = 'and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require';
+            $missingRequirementInfo[] = 'and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r';
         }
 
         return $missingRequirementInfo;

--- a/tests/Composer/Test/Command/ValidateCommandTest.php
+++ b/tests/Composer/Test/Command/ValidateCommandTest.php
@@ -58,7 +58,7 @@ class ValidateCommandTest extends TestCase
 - Required package "root/req" is not present in the lock file.
 This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
 Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
-and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require
+and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
 OUTPUT;
 
         $this->assertSame(trim($expected), trim($appTester->getDisplay(true)));

--- a/tests/Composer/Test/Fixtures/installer/install-from-incomplete-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/install-from-incomplete-lock.test
@@ -36,7 +36,7 @@ Verifying lock file contents can be installed on current platform.
 - Required package "newly-required/pkg" is not present in the lock file.
 This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
 Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
-and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require
+and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
 --EXPECT-EXIT-CODE--
 4
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/root-requirements-do-not-affect-locked-versions.test
+++ b/tests/Composer/Test/Fixtures/installer/root-requirements-do-not-affect-locked-versions.test
@@ -43,7 +43,7 @@ Verifying lock file contents can be installed on current platform.
 - Required package "foo/bar" is in the lock file as "1.0.0" but that does not satisfy your constraint "2.0.0".
 This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
 Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
-and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require
+and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
 --EXPECT-EXIT-CODE--
 4
 --EXPECT--


### PR DESCRIPTION
Following the [Composer 2.5 release](https://github.com/composer/composer/releases/tag/2.5.0), I presented the interactive prompt run script https://github.com/composer/composer/pull/11157 to colleagues. In addition, I found that the deep links to the documentation website do not work properly.

Initially searched within `src/Composer/Command`, after that a refinement of the entire project.

**Before/after (diff)**

- ~https://getcomposer.org/doc/03-cli.md#run-script~
- https://getcomposer.org/doc/03-cli.md#run-script-run

```shell
composer run-script --help
```
```diff
Description:
  Runs the scripts defined in composer.json

Usage:
  run-script [options] [--] [<script> [<args>...]]
  run

Arguments:
  script                         Script name to run.
  args

Options:
      --timeout=TIMEOUT          Sets script timeout in seconds, or 0 for never.
      --dev                      Sets the dev mode.
      --no-dev                   Disables the dev mode.
  -l, --list                     List scripts.
  -h, --help                     Display help for the given command. When no command is given display help for the list command
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi|--no-ansi           Force (or disable --no-ansi) ANSI output
  -n, --no-interaction           Do not ask any interactive question
      --profile                  Display timing and memory usage information
      --no-plugins               Whether to disable plugins.
      --no-scripts               Skips the execution of all scripts defined in composer.json file.
  -d, --working-dir=WORKING-DIR  If specified, use the given directory as working directory.
      --no-cache                 Prevent use of the cache
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  The run-script command runs scripts defined in composer.json:

  php composer.phar run-script post-update-cmd

- Read more at https://getcomposer.org/doc/03-cli.md#run-script
+ Read more at https://getcomposer.org/doc/03-cli.md#run-script-run
```