### PR TITLE
Fix self.version requirements failing the lock file integrity check if on a different version

### DIFF
--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -518,6 +518,9 @@ class Locker
                 if (PlatformRepository::isPlatformPackage($link->getTarget())) {
                     continue;
                 }
+                if ($link->getPrettyConstraint() === 'self.version') {
+                    continue;
+                }
                 if ($installedRepo->findPackagesWithReplacersAndProviders($link->getTarget(), $link->getConstraint()) === []) {
                     $results = $installedRepo->findPackagesWithReplacersAndProviders($link->getTarget());
                     if ($results !== []) {

--- a/tests/Composer/Test/Fixtures/installer/root-requirements-do-not-affect-locked-versions.test
+++ b/tests/Composer/Test/Fixtures/installer/root-requirements-do-not-affect-locked-versions.test
@@ -2,26 +2,30 @@
 The locked version will not get overwritten by an install but fails on invalid packages
 --COMPOSER--
 {
+    "version": "1.2.3",
     "repositories": [
         {
             "type": "package",
             "package": [
                 { "name": "foo/bar", "version": "1.0.0" },
                 { "name": "foo/baz", "version": "1.0.0" },
-                { "name": "foo/baz", "version": "2.0.0" }
+                { "name": "foo/baz", "version": "2.0.0" },
+                { "name": "foo/self", "version": "1.2.3" }
             ]
         }
     ],
     "require": {
         "foo/bar": "2.0.0",
-        "foo/baz": "2.0.0"
+        "foo/baz": "2.0.0",
+        "foo/self": "self.version"
     }
 }
 --LOCK--
 {
     "packages": [
         { "name": "foo/bar", "version": "1.0.0" },
-        { "name": "foo/baz", "version": "2.0.0" }
+        { "name": "foo/baz", "version": "2.0.0" },
+        { "name": "foo/self", "version": "1.2.2" }
     ],
     "packages-dev": [],
     "aliases": [],


### PR DESCRIPTION
Fixes #11274

I don't think it is worth it to check self.version here as the version is very likely to change and break things.