### PR TITLE
Allow comments for root project composer.json

### DIFF
--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -154,7 +154,7 @@ EOT
             file_put_contents($this->file, "{\n}\n");
         }
 
-        $this->json = new JsonFile($this->file);
+        $this->json = new JsonFile($this->file, null, null, JsonFile::ALLOW_COMMENTS);
         $this->lock = Factory::getLockFile($this->file);
         $this->composerBackup = file_get_contents($this->json->getPath());
         $this->lockBackup = file_exists($this->lock) ? file_get_contents($this->lock) : null;

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -298,7 +298,7 @@ class Factory
         if (is_string($localConfig)) {
             $composerFile = $localConfig;
 
-            $file = new JsonFile($localConfig, null, $io);
+            $file = new JsonFile($localConfig, null, $io, JsonFile::ALLOW_COMMENTS);
 
             if (!$file->exists()) {
                 if ($localConfig === './composer.json' || $localConfig === 'composer.json') {

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -59,7 +59,7 @@ class JsonManipulator
 
     public function addLink(string $type, string $package, string $constraint, bool $sortPackages = false): bool
     {
-        $decoded = JsonFile::parseJson($this->contents);
+        $decoded = JsonFile::parseJson($this->contents, null, JsonFile::ALLOW_COMMENTS);
 
         // no link of that type yet
         if (!isset($decoded[$type])) {

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -79,7 +79,7 @@ class Locker
      */
     public static function getContentHash(string $composerFileContents): string
     {
-        $content = JsonFile::parseJson($composerFileContents, 'composer.json');
+        $content = JsonFile::parseJson($composerFileContents, 'composer.json', JsonFile::ALLOW_COMMENTS);
 
         $relevantKeys = [
             'name',


### PR DESCRIPTION
## Proposal
This PR proposes to allow the use of comments in the root composer.json of project. At the same time for vendor packages comments in `composer.json` are not allowed (as before). Today we have such tools `docker-compose`, for example, where possible fast disable the some configuration via comments in yaml. 

This feature allows the users to quickly change `composer.json` in local development environment for debug purposes:
```
{
    "repositories": [
        {"type": "composer", "url": "https://example.com/mirror/org1/"}
       // {"packagist": false}
    ],
    "require": {
        "php": ">=8.1",
        "ext-redis": "*",
        "firebase/php-jwt": "^6.0",
      //  "babdev/pagerfanta-bundle": "^3.7",
        "babdev/pagerfanta-bundle": "^2.0",
        "cebe/markdown": "^1.1"
    }
}
```

### New composer commands behaviour if JSON is not valid.

| The Command       | behaviour                       |
|-------------------|----------------------------------------------------------|
| composer install  | ignore comments                                          |
| composer update   | ignore comments                                          |
| composer require  | ignore comments and dump composer.json without comments  |
| composer validate | not allow comments                                       |

composer `depends`, `suggests`, `run-script`, `reinstall` etc. ignore comments too

Composer validate example
![validate](https://user-images.githubusercontent.com/21358010/216739344-8499a204-c2c6-45b0-8213-d50319464950.png)

### Examples comment format

Allowed `// ...` and `/* ... */` 

### Packagist support?

This is major BC break, so the repository implementors MUST **not allow** to use comments for vendors composer.json files. The metadata should be easily extracted from `composer.json` using the standard json lib function.

### Impact on performance.

No impact. Before reading `composer.json` with a new json parser we try to read json file with standard `json_decode` function 

## Backward Incompatible Changes

No backwards incompatible changes. 

## Todo List

- [x] Create PR https://github.com/Seldaek/jsonlint/pull/81  
- [x] Added supporting comments to composer
- [ ] Test cover (blocked by PR 1)
- [ ] Documentation usage notices   
