### PR TITLE
Verify 'versions' key existence

### DIFF
--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -53,7 +53,8 @@ class InstalledVersions
     {
         $packages = array();
         foreach (self::getInstalled() as $installed) {
-            $packages[] = array_keys($installed['versions']);
+            if (isset($installed['versions']))
+                $packages[] = array_keys($installed['versions']);
         }
 
         if (1 === \count($packages)) {


### PR DESCRIPTION
`self::getInstalled()` can return empty array. We should validate key existence to prevent exception like:
```
Exception: Notice: Undefined index: versions in /.../vendor/composer/composer/src/Composer/InstalledVersions.php on line 54 in /.../vendor/magento/framework/App/ErrorHandler.php:61
```
