### PR TITLE
Verify size of installed packages array

### DIFF
--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -52,11 +52,8 @@ class InstalledVersions
     public static function getInstalledPackages()
     {
         $packages = array();
-        $installed = self::getInstalled();
-        if ((0 < \count($installed) && (\count(\array_keys($installed[0])) > 0))) {
-            foreach ($installed as $one) {
-                $packages[] = array_keys($one['versions']);
-            }
+        foreach (self::getInstalled() as $installed) {
+            $packages[] = array_keys($installed['versions']);
         }
 
         if (1 === \count($packages)) {
@@ -344,11 +341,11 @@ class InstalledVersions
             // and not from its source location in the composer/composer package, see https://github.com/composer/composer/issues/9937
             if (substr(__DIR__, -8, 1) !== 'C') {
                 self::$installed = require __DIR__ . '/installed.php';
-            } else {
-                self::$installed = array();
             }
+            // don't set as empty array on 'else' to prevent 'Undefined index: versions'
+            // exception in `self::getInstalledPackages()` (see https://github.com/composer/composer/pull/11304)
         }
-        $installed[] = self::$installed;
+        if(null !== self::$installed) $installed[] = self::$installed;
 
         return $installed;
     }

--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -342,10 +342,12 @@ class InstalledVersions
             if (substr(__DIR__, -8, 1) !== 'C') {
                 self::$installed = require __DIR__ . '/installed.php';
             }
-            // don't set as empty array on 'else' to prevent 'Undefined index: versions'
-            // exception in `self::getInstalledPackages()` (see https://github.com/composer/composer/pull/11304)
+            // don't set as empty array on 'else' to prevent 'Undefined index: versions' exception in `self::getInstalledPackages()`
+            // (see https://github.com/composer/composer/pull/11304)
         }
-        if(null !== self::$installed) $installed[] = self::$installed;
+        if (null !== self::$installed) {
+            $installed[] = self::$installed;
+        }
 
         return $installed;
     }

--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -52,9 +52,11 @@ class InstalledVersions
     public static function getInstalledPackages()
     {
         $packages = array();
-        foreach (self::getInstalled() as $installed) {
-            if (isset($installed['versions']))
-                $packages[] = array_keys($installed['versions']);
+        $installed = self::getInstalled();
+        if (0 < \count($installed)) {
+            foreach ($installed as $one) {
+                $packages[] = array_keys($one['versions']);
+            }
         }
 
         if (1 === \count($packages)) {

--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -53,7 +53,7 @@ class InstalledVersions
     {
         $packages = array();
         $installed = self::getInstalled();
-        if (0 < \count($installed)) {
+        if ((0 < \count($installed) && (\count(\array_keys($installed[0])) > 0))) {
             foreach ($installed as $one) {
                 $packages[] = array_keys($one['versions']);
             }

--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -53,7 +53,8 @@ class InstalledVersions
     {
         $packages = array();
         foreach (self::getInstalled() as $installed) {
-            $packages[] = array_keys($installed['versions']);
+            if (isset($installed['versions']))
+                $packages[] = array_keys($installed['versions']);
         }
 
         if (1 === \count($packages)) {


### PR DESCRIPTION
`self::getInstalled()` can return -empty array- array with empty array. We should validate key existence to prevent exception like:
```
Exception: Notice: Undefined index: versions in /.../vendor/composer/composer/src/Composer/InstalledVersions.php on line 54 in /.../vendor/magento/framework/App/ErrorHandler.php:61
```