### PR TITLE
Add source link to composer packages

### DIFF
--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -182,8 +182,8 @@ abstract class BaseDependencyCommand extends BaseCommand
                 }
                 $doubles[$unique] = true;
                 $version = $package->getPrettyVersion() === RootPackage::DEFAULT_PRETTY_VERSION ? '-' : $package->getPrettyVersion();
-                $packageSource = PackageInfo::getViewSourceUrl($package) ?: $package->getHomepage();
-                $nameWithLink = $packageSource !== '' ? '<href=' . OutputFormatter::escape($packageSource) . '>' . $package->getPrettyName() . '</>' : $package->getPrettyName();
+                $packageUrl = PackageInfo::getViewSourceOrHomepageUrl($package);
+                $nameWithLink = $packageUrl !== null ? '<href=' . OutputFormatter::escape($packageUrl) . '>' . $package->getPrettyName() . '</>' : $package->getPrettyName();
                 $rows[] = [$nameWithLink, $version, $link->getDescription(), sprintf('%s (%s)', $link->getTarget(), $link->getPrettyConstraint())];
                 if ($children) {
                     $queue = array_merge($queue, $children);
@@ -233,8 +233,8 @@ abstract class BaseDependencyCommand extends BaseCommand
             $prevColor = $this->colors[($level - 1) % count($this->colors)];
             $isLast = (++$idx === $count);
             $versionText = $package->getPrettyVersion() === RootPackage::DEFAULT_PRETTY_VERSION ? '' : $package->getPrettyVersion();
-            $packageSource = PackageInfo::getViewSourceUrl($package) ?: $package->getHomepage();
-            $nameWithLink = $packageSource !== '' ? '<href=' . OutputFormatter::escape($packageSource) . '>' . $package->getPrettyName() . '</>' : $package->getPrettyName();
+            $packageUrl = PackageInfo::getViewSourceOrHomepageUrl($package);
+            $nameWithLink = $packageUrl !== null ? '<href=' . OutputFormatter::escape($packageUrl) . '>' . $package->getPrettyName() . '</>' : $package->getPrettyName();
             $packageText = rtrim(sprintf('<%s>%s</%1$s> %s', $color, $nameWithLink, $versionText));
             $linkText = sprintf('%s <%s>%s</%2$s> %s', $link->getDescription(), $prevColor, $link->getTarget(), $link->getPrettyConstraint());
             $circularWarn = $children === false ? '(circular dependency aborted here)' : '';

--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -24,10 +24,12 @@ use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryFactory;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Composer\Package\Version\VersionParser;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Composer\Util\PackageInfo;
 
 /**
  * Base implementation for commands mapping dependency relationships.
@@ -180,7 +182,9 @@ abstract class BaseDependencyCommand extends BaseCommand
                 }
                 $doubles[$unique] = true;
                 $version = $package->getPrettyVersion() === RootPackage::DEFAULT_PRETTY_VERSION ? '-' : $package->getPrettyVersion();
-                $rows[] = [$package->getPrettyName(), $version, $link->getDescription(), sprintf('%s (%s)', $link->getTarget(), $link->getPrettyConstraint())];
+                $packageSource = PackageInfo::getViewSourceUrl($package) ?: $package->getHomepage();
+                $nameWithLink = $packageSource !== '' ? '<href=' . OutputFormatter::escape($packageSource) . '>' . $package->getPrettyName() . '</>' : $package->getPrettyName();
+                $rows[] = [$nameWithLink, $version, $link->getDescription(), sprintf('%s (%s)', $link->getTarget(), $link->getPrettyConstraint())];
                 if ($children) {
                     $queue = array_merge($queue, $children);
                 }
@@ -229,7 +233,9 @@ abstract class BaseDependencyCommand extends BaseCommand
             $prevColor = $this->colors[($level - 1) % count($this->colors)];
             $isLast = (++$idx === $count);
             $versionText = $package->getPrettyVersion() === RootPackage::DEFAULT_PRETTY_VERSION ? '' : $package->getPrettyVersion();
-            $packageText = rtrim(sprintf('<%s>%s</%1$s> %s', $color, $package->getPrettyName(), $versionText));
+            $packageSource = PackageInfo::getViewSourceUrl($package) ?: $package->getHomepage();
+            $nameWithLink = $packageSource !== '' ? '<href=' . OutputFormatter::escape($packageSource) . '>' . $package->getPrettyName() . '</>' : $package->getPrettyName();
+            $packageText = rtrim(sprintf('<%s>%s</%1$s> %s', $color, $nameWithLink, $versionText));
             $linkText = sprintf('%s <%s>%s</%2$s> %s', $link->getDescription(), $prevColor, $link->getTarget(), $link->getPrettyConstraint());
             $circularWarn = $children === false ? '(circular dependency aborted here)' : '';
             $this->writeTreeLine(rtrim(sprintf("%s%s%s (%s) %s", $prefix, $isLast ? '└──' : '├──', $packageText, $linkText, $circularWarn)));

--- a/src/Composer/Util/PackageInfo.php
+++ b/src/Composer/Util/PackageInfo.php
@@ -19,7 +19,7 @@ class PackageInfo
 {
     public static function getViewSourceUrl(PackageInterface $package): ?string
     {
-        if ($package instanceof CompletePackageInterface && isset($package->getSupport()['source'])) {
+        if ($package instanceof CompletePackageInterface && isset($package->getSupport()['source']) && '' !== $package->getSupport()['source']) {
             return $package->getSupport()['source'];
         }
 
@@ -28,6 +28,12 @@ class PackageInfo
 
     public static function getViewSourceOrHomepageUrl(PackageInterface $package): ?string
     {
-        return self::getViewSourceUrl($package) ?? ($package instanceof CompletePackageInterface ? $package->getHomepage() : null);
+        $url = self::getViewSourceUrl($package) ?? ($package instanceof CompletePackageInterface ? $package->getHomepage() : null);
+
+        if ($url === '') {
+            return null;
+        }
+
+        return $url;
     }
 }


### PR DESCRIPTION
Hi!

This pull request adds a source/homepage link to packages when the aliases who depends on BaseDependencyCommand gets called. Currently "why" and "why-not".

Fixes https://github.com/composer/composer/issues/11289

I hope this can help,
Agostino.