### PR TITLE
PHPStan: Fixed handling of union types in ConfigReturnTypeExtension

### DIFF
--- a/src/Composer/PHPStan/ConfigReturnTypeExtension.php
+++ b/src/Composer/PHPStan/ConfigReturnTypeExtension.php
@@ -72,11 +72,11 @@ final class ConfigReturnTypeExtension implements DynamicMethodReturnTypeExtensio
         }
 
         $keyType = $scope->getType($args[0]->value);
-        if (method_exists($keyType, 'getConstantStrings')) {
+        if (method_exists($keyType, 'getConstantStrings')) { // @phpstan-ignore-line - depending on PHPStan version, this method will always exist, or not.
             $strings = $keyType->getConstantStrings();
         } else {
             // for compat with old phpstan versions, we use a deprecated phpstan method.
-            $strings = TypeUtils::getConstantStrings($keyType);
+            $strings = TypeUtils::getConstantStrings($keyType); // @phpstan-ignore-line ignore deprecation
         }
         if ($strings !== []) {
             $types = [];

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -398,7 +398,7 @@ class ConfigTest extends TestCase
         ];
         foreach ($keys as $key) {
             $value = $config->get($key);
-            $this->assertIsArray($value);
+            $this->assertIsArray($value); // @phpstan-ignore-line - PHPStan knows that its an array for all given keys
             $this->assertCount(0, $value);
         }
     }


### PR DESCRIPTION
see https://phpstan.org/blog/why-is-instanceof-type-wrong-and-getting-deprecated

after this fix the PHPStan extension supports cases like

```php
if (..) {
  $property = 'license';
} else {
  $property = 'description';
}

$value = Config::get($property);
```

which it did not before