### PR TITLE
Show package type with `show --format=json`

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -486,6 +486,7 @@ EOT
                         }
 
                         $packageViewData['name'] = $package->getPrettyName();
+                        $packageViewData['type'] = $package->getType();
                         $packageViewData['direct-dependency'] = in_array($package->getName(), $this->getRootRequires(), true);
                         if ($format !== 'json' || true !== $input->getOption('name-only')) {
                             $packageViewData['homepage'] = $package instanceof CompletePackageInterface ? $package->getHomepage() : null;


### PR DESCRIPTION
So...my team has a need to collect data on installed packages as JSON. We do this, currently, with `composer show --json`, and it works well, but with one major gap: if we want to get the package types (and we do), there's no way to get that without calling `composer show $PACKAGE_NAME --format=json` individually. For performance reasons, that won't fly.

This PR, then, adds the `type` property to the output of `composer show --json` for all packages.