### PR TITLE
Pick higher revision number to guarantee successful file retrieval

### DIFF
--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -236,14 +236,19 @@ class SvnDriver extends VcsDriver
             if ($this->tagsPath !== false) {
                 $output = $this->execute('svn ls --verbose', $this->baseUrl . '/' . $this->tagsPath);
                 if ($output) {
+                    $lastRev = null;
                     foreach ($this->process->splitLines($output) as $line) {
                         $line = trim($line);
                         if ($line && Preg::isMatch('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
-                            if (isset($match[1], $match[2]) && $match[2] !== './') {
-                                $tags[rtrim($match[2], '/')] = $this->buildIdentifier(
-                                    '/' . $this->tagsPath . '/' . $match[2],
-                                    $match[1]
-                                );
+                            if (isset($match[1], $match[2])) {
+                                if ($match[2] === './') {
+                                    $lastRev = $match[1];
+                                } else {
+                                    $tags[rtrim($match[2], '/')] = $this->buildIdentifier(
+                                        '/' . $this->tagsPath . '/' . $match[2],
+                                        max($lastRev, $match[1])
+                                    );
+                                }
                             }
                         }
                     }
@@ -291,14 +296,19 @@ class SvnDriver extends VcsDriver
             if ($this->branchesPath !== false) {
                 $output = $this->execute('svn ls --verbose', $this->baseUrl . '/' . $this->branchesPath);
                 if ($output) {
+                    $lastRev = null;
                     foreach ($this->process->splitLines(trim($output)) as $line) {
                         $line = trim($line);
                         if ($line && Preg::isMatch('{^\s*(\S+).*?(\S+)\s*$}', $line, $match)) {
-                            if (isset($match[1], $match[2]) && $match[2] !== './') {
-                                $branches[rtrim($match[2], '/')] = $this->buildIdentifier(
-                                    '/' . $this->branchesPath . '/' . $match[2],
-                                    $match[1]
-                                );
+                            if (isset($match[1], $match[2])) {
+                                if ($match[2] === './') {
+                                    $lastRev = $match[1];
+                                } else {
+                                    $branches[rtrim($match[2], '/')] = $this->buildIdentifier(
+                                        '/' . $this->branchesPath . '/' . $match[2],
+                                        max($lastRev, $match[1])
+                                    );
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
`SvnDriver::getTags` and `SvnDriver::getBranches` both fail to compose valid reference to `composer.json` if repository root was moved after their creation. Pick highest available revision from the list to raise chances for success.