### PR TITLE
Add rm alias to composer remove command

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -298,7 +298,7 @@ If you do not specify a package, Composer will prompt you to search for a packag
 * **--apcu-autoloader-prefix:** Use a custom prefix for the APCu autoloader cache.
   Implicitly enables `--apcu-autoloader`.
 
-## remove
+## remove / rm
 
 The `remove` command removes packages from the `composer.json` file from
 the current directory.

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -43,6 +43,7 @@ class RemoveCommand extends BaseCommand
     {
         $this
             ->setName('remove')
+            ->setAliases(['rm'])
             ->setDescription('Removes a package from the require or require-dev')
             ->setDefinition([
                 new InputArgument('packages', InputArgument::IS_ARRAY, 'Packages that should be removed.', null, $this->suggestRootRequirement()),

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -74,7 +74,7 @@ list of installed packages
 
 <info>php composer.phar remove</info>
 
-Read more at https://getcomposer.org/doc/03-cli.md#remove
+Read more at https://getcomposer.org/doc/03-cli.md#remove-rm
 EOT
             )
         ;


### PR DESCRIPTION
Inspired from #11163
As you know most `deleting|removing` commands have shortcut `rm`, for example, `rm a.txt`, `npm rm --help`.
So I think it will be great have the same keyboard shortcut here. 
p.s. `composer rem` is not easy to remember
