### PR TITLE
Added time of composer.lock generation

### DIFF
--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -365,11 +365,15 @@ class Locker
             return $alias;
         }, $aliases);
 
+        $time = !isset($this->getLockData()['_time']) ?
+            $this->now->format(\DateTimeInterface::ATOM) :
+            ($this->isFresh() ? $this->getLockData()['_time'] : $this->now->format(\DateTimeInterface::ATOM));
+
         $lock = [
             '_readme' => ['This file locks the dependencies of your project to a known state',
                                'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies',
                                'This file is @gener'.'ated automatically', ],
-            '_time' => $this->now->format(\DateTimeInterface::ATOM),
+            '_time' => $time,
             'content-hash' => $this->contentHash,
             'packages' => null,
             'packages-dev' => null,

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -365,11 +365,17 @@ class Locker
             return $alias;
         }, $aliases);
 
+        try {
+            $time = $this->getLockData()['_time'] ?? $this->now->format(\DateTimeInterface::ATOM);
+        } catch (\Exception $e) {
+            $time = $this->now->format(\DateTimeInterface::ATOM);
+        }
+
         $lock = [
             '_readme' => ['This file locks the dependencies of your project to a known state',
                                'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies',
                                'This file is @gener'.'ated automatically', ],
-            '_time' => $this->getLockData()['_time'] ?? $this->now->format(\DateTimeInterface::ATOM),
+            '_time' => $time,
             'content-hash' => $this->contentHash,
             'packages' => null,
             'packages-dev' => null,

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -53,6 +53,8 @@ class Locker
     private $lockDataCache = null;
     /** @var bool */
     private $virtualFileWritten = false;
+    /** @var \DateTimeImmutable */
+    private $now;
 
     /**
      * Initializes packages locker.
@@ -70,6 +72,7 @@ class Locker
         $this->loader = new ArrayLoader(null, true);
         $this->dumper = new ArrayDumper();
         $this->process = $process ?? new ProcessExecutor($io);
+        $this->now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
     }
 
     /**
@@ -291,6 +294,13 @@ class Locker
         return $lockData['platform-overrides'] ?? [];
     }
 
+    public function setNow(\DateTimeImmutable $now): self
+    {
+        $this->now = $now;
+
+        return $this;
+    }
+
     /**
      * @return string[][]
      *
@@ -359,6 +369,7 @@ class Locker
             '_readme' => ['This file locks the dependencies of your project to a known state',
                                'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies',
                                'This file is @gener'.'ated automatically', ],
+            '_time' => $this->now->format(\DateTimeInterface::ATOM),
             'content-hash' => $this->contentHash,
             'packages' => null,
             'packages-dev' => null,

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -365,15 +365,11 @@ class Locker
             return $alias;
         }, $aliases);
 
-        $time = !isset($this->getLockData()['_time']) ?
-            $this->now->format(\DateTimeInterface::ATOM) :
-            ($this->isFresh() ? $this->getLockData()['_time'] : $this->now->format(\DateTimeInterface::ATOM));
-
         $lock = [
             '_readme' => ['This file locks the dependencies of your project to a known state',
                                'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies',
                                'This file is @gener'.'ated automatically', ],
-            '_time' => $time,
+            '_time' => $this->getLockData()['_time'] ?? $this->now->format(\DateTimeInterface::ATOM),
             'content-hash' => $this->contentHash,
             'packages' => null,
             'packages-dev' => null,
@@ -402,6 +398,7 @@ class Locker
             $isLocked = false;
         }
         if (!$isLocked || $lock !== $this->getLockData()) {
+            $lock['_time'] = $this->now->format(\DateTimeInterface::ATOM);
             if ($write) {
                 $this->lockFile->write($lock);
                 $this->lockDataCache = null;

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -443,7 +443,7 @@ class InstallerTest extends TestCase
         $output = str_replace("\r", '', $io->getOutput());
         $this->assertEquals($expectResult, $result, $output . stream_get_contents($appOutput));
         if ($expectLock && isset($actualLock)) {
-            unset($actualLock['hash'], $actualLock['content-hash'], $actualLock['_readme'], $actualLock['plugin-api-version']);
+            unset($actualLock['hash'], $actualLock['content-hash'], $actualLock['_readme'], $actualLock['_time'], $actualLock['plugin-api-version']);
             $this->assertEquals($expectLock, $actualLock);
         }
 

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -89,9 +89,11 @@ class LockerTest extends TestCase
     {
         $json = $this->createJsonFileMock();
         $inst = $this->createInstallationManagerMock();
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
         $jsonContent = $this->getJsonContent() . '  ';
         $locker = new Locker(new NullIO, $json, $inst, $jsonContent);
+        $locker->setNow($now);
 
         $package1 = self::getPackage('pkg1', '1.0.0-beta');
         $package2 = self::getPackage('pkg2', '0.1.10');
@@ -105,6 +107,7 @@ class LockerTest extends TestCase
                 '_readme' => ['This file locks the dependencies of your project to a known state',
                                    'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies',
                                    'This file is @gener'.'ated automatically', ],
+                '_time' => $now->format(\DateTimeInterface::ATOM),
                 'content-hash' => $contentHash,
                 'packages' => [
                     ['name' => 'pkg1', 'version' => '1.0.0-beta', 'type' => 'library'],


### PR DESCRIPTION
Sometimes I would like to know when a `composer.lock` was generated. This would ease debugging as `mtime` is often not accurate (containers and stuff). This could help finding out why a certain constellation of packages resulted as maybe one remembers that a certain package was only published after `<time>` or whatever. 

Just a little helper - anyway, let me know what you think :) 