### PR TITLE
PlatformRepository library support for libpq (from ext-pq) and librdkafka (from ext-rdkafka)

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -450,6 +450,16 @@ class PlatformRepository extends ArrayRepository
                     }
                     break;
 
+                case 'pq':
+                    $info = $this->runtime->getExtensionInfo($name);
+
+                    // Used Library => Compiled => Linked
+                    // libpq => 14.3 (Ubuntu 14.3-1.pgdg22.04+1) => 15.0.2
+                    if (Preg::isMatch('/^libpq => (?<compiled>.+) => (?<linked>.+)$/im', $info, $matches)) {
+                        $this->addLibrary($name.'-libpq', $matches['linked'], 'libpq for '.$name);
+                    }
+                    break;
+
                 case 'libsodium':
                 case 'sodium':
                     if ($this->runtime->hasConstant('SODIUM_LIBRARY_VERSION')) {

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -460,6 +460,22 @@ class PlatformRepository extends ArrayRepository
                     }
                     break;
 
+                case 'rdkafka':
+                    if ($this->runtime->hasConstant('RD_KAFKA_VERSION')) {
+                        /**
+                         * Interpreted as hex \c MM.mm.rr.xx:
+                         *  - MM = Major
+                         *  - mm = minor
+                         *  - rr = revision
+                         *  - xx = pre-release id (0xff is the final release)
+                         *
+                         * pre-release ID in practice is always 0xff even for RCs etc, so we ignore it
+                         */
+                        $libRdKafkaVersionInt = $this->runtime->getConstant('RD_KAFKA_VERSION');
+                        $this->addLibrary($name.'-librdkafka', sprintf('%d.%d.%d', ($libRdKafkaVersionInt & 0xFF000000) >> 24, ($libRdKafkaVersionInt & 0x00FF0000) >> 16, ($libRdKafkaVersionInt & 0x0000FF00) >> 8), 'librdkafka for '.$name);
+                    }
+                    break;
+
                 case 'libsodium':
                 case 'sodium':
                     if ($this->runtime->hasConstant('SODIUM_LIBRARY_VERSION')) {

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -972,6 +972,13 @@ libpq => 14.3 (Ubuntu 14.3-1.pgdg22.04+1) => 15.0.2
                 ',
                 ['lib-pq-libpq' => '15.0.2'],
             ],
+            'rdkafka' => [
+                'rdkafka',
+                null,
+                ['lib-rdkafka-librdkafka' => '1.9.2'],
+                [],
+                [['RD_KAFKA_VERSION', null, 17367807]],
+            ],
             'libsodium' => [
                 'libsodium',
                 null,

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -960,6 +960,18 @@ Module version => 7.1.33
 Revision =>  $Id: 9c5f356c77143981d2e905e276e439501fe0f419 $',
                 ['lib-pdo_pgsql-libpq' => '12.1'],
             ],
+            'pq' => [
+                'pq',
+                'pq
+
+PQ Support => enabled
+Extension Version => 2.2.0
+
+Used Library => Compiled => Linked
+libpq => 14.3 (Ubuntu 14.3-1.pgdg22.04+1) => 15.0.2
+                ',
+                ['lib-pq-libpq' => '15.0.2'],
+            ],
             'libsodium' => [
                 'libsodium',
                 null,


### PR DESCRIPTION
Self-explanatory :)

Both info sources have been around in the respective extensions for many, many years, see https://github.com/m6w6/ext-pq/commit/6840072b9e4fe5269d0f36a9cb8cd9cde04525af (2015) and https://github.com/arnaud-lb/php-rdkafka/commit/a38b32e43c68dd796595c4daa44c487fc8acd117 (2016).