### PR TITLE
ArrayLoader: handle invalid support value

### DIFF
--- a/src/Composer/Package/Loader/ArrayLoader.php
+++ b/src/Composer/Package/Loader/ArrayLoader.php
@@ -282,7 +282,7 @@ class ArrayLoader implements LoaderInterface
                 $package->setAuthors($config['authors']);
             }
 
-            if (isset($config['support'])) {
+            if (isset($config['support']) && \is_array($config['support'])) {
                 $package->setSupport($config['support']);
             }
 

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -429,4 +429,16 @@ class ArrayLoaderTest extends TestCase
         $package = $this->loader->load($config);
         $this->assertCount(0, $package->getReplaces());
     }
+
+    public function testSupportStringValue(): void
+    {
+        $config = array(
+            'name' => 'acme/package',
+            'version' => 'dev-1',
+            'support' => 'https://example.org',
+        );
+
+        $package = $this->loader->load($config);
+        $this->assertSame([], $package->getSupport());
+    }
 }


### PR DESCRIPTION
Fixes `Uncaught Console Exception: Composer\Package\CompletePackage::setSupport(): Argument #1 ($support) must be of type array, string given, called in src/Composer/Package/Loader/ArrayLoader.php on line 286`