### PR TITLE
Update 01-basic-usage.md

### DIFF
--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-For our basic usage introduction, we will be installing `monolog/monolog`,
+For our basic usage introduction, we will be installing `monolog/monolog`
 a logging library. If you have not yet installed Composer, refer to the
 [Intro](00-intro.md) chapter.
 


### PR DESCRIPTION
Removed a comma after monolog/monolog

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
