### PR TITLE
Documentation clarification: COMPOSER_NO_DEV scope

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1276,8 +1276,9 @@ If set to `1`, it is the equivalent of passing the `--no-audit` option to `requi
 
 ### COMPOSER_NO_DEV
 
-If set to `1`, it is the equivalent of passing the `--no-dev` option to `install` or
-`update`. You can override this for a single command by setting `COMPOSER_NO_DEV=0`.
+If set to `1`, it is the equivalent of passing the `--update-no-dev` option to `require`
+ or the `--no-dev` option to `install` or `update`.  You can override this for a single
+command by setting `COMPOSER_NO_DEV=0`.
 
 ### COMPOSER_PREFER_STABLE
 


### PR DESCRIPTION
Updates documentation of COMPOSER_NO_DEV variable.

Further to: [10995](https://github.com/composer/composer/pull/10995)

Currently the --update-no-dev [option](https://github.com/composer/composer/blob/main/doc/03-cli.md#options-3) links to the documentation for COMPOSER_NO_DEV.

The documentation for COMPOSER_NO_DEV only references the --no-dev option for install and update.  The option above it (COMPOSER_NO_AUDIT) references require so it makes it seem as though perhaps this doesn't apply to require - although it would be strange if it did not.

Testing suggest that it does in fact work as indicated on the --update-no-dev option.

Before
![image](https://user-images.githubusercontent.com/9410526/235553449-e8a78ca1-95c2-4838-99b5-9103c44474af.png)

After
![image](https://user-images.githubusercontent.com/9410526/235554018-36451ed5-7ad3-4a2c-b280-0294e6746cc0.png)

Referenced require first as otherwise it seems less confusing with multiple levels of or.