### PR TITLE
Optimize PoolBuilder to not load replaced targets if not required

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -662,8 +662,10 @@ class PoolBuilder
                             foreach ($lockedPackage->getReplaces() as $replace) {
                                 if (isset($requires[$replace->getTarget()], $this->skippedLoad[$replace->getTarget()])) {
                                     $this->unlockPackage($request, $repositories, $replace->getTarget());
-                                    // Mark as optional - if no other package requires it, we don't need to load it
-                                    $this->markPackageNameForOptionalLoading($replace->getTarget());
+                                    // Do not call markPackageNameForOptionalLoading() here, we know that $lockedPackage is already
+                                    // part of $this->packages, and we check for $requires[$replace->getTarget()] so we're guaranteed
+                                    // to require this package.
+                                    $this->markPackageNameForLoading($request, $replace->getTarget(), $replace->getConstraint());
                                 }
                             }
                         }

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/load-replaced-package-if-replacer-dropped.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/load-replaced-package-if-replacer-dropped.test
@@ -1,0 +1,50 @@
+--TEST--
+Ensure that a package gets loaded which was previously skipped due to replacement
+
+--REQUEST--
+{
+    "require": {
+        "root/dep": "*",
+        "root/no-update": "*"
+    },
+    "locked": [
+        {"name": "root/dep", "version": "1.1.0", "require": {"replacer/pkg": "1.*"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}},
+        {"name": "root/no-update", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}}
+    ],
+    "allowList": [
+        "root/dep"
+    ],
+    "allowTransitiveDepsNoRootRequire": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name": "root/dep", "version": "1.2.0", "require": {"replacer/pkg": ">=1.1.0"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}},
+        {"name": "replacer/pkg", "version": "1.1.0"},
+        {"name": "replaced/pkg", "version": "1.0.0"},
+        {"name": "root/no-update", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}}
+    ]
+]
+
+--EXPECT--
+[
+    "root/no-update-1.0.0.0 (locked)",
+    "root/dep-1.2.0.0",
+    "replaced/pkg-1.0.0.0",
+    "replacer/pkg-1.1.0.0"
+]
+
+--EXPECT-OPTIMIZED--
+[
+    "root/no-update-1.0.0.0 (locked)",
+    "root/dep-1.2.0.0",
+    "replaced/pkg-1.0.0.0",
+    "replacer/pkg-1.1.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace-partial-update-all.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace-partial-update-all.test
@@ -101,7 +101,6 @@ Check that replacers from additional repositories are loaded when doing a partia
     "indirect/replacer-1.0.0.0",
     "replacer/package-1.2.0.0",
     "replacer/package-1.0.0.0",
-    "base/package-1.0.0.0",
     "shared/dep-1.0.0.0",
     "shared/dep-1.2.0.0"
 ]
@@ -112,6 +111,5 @@ Check that replacers from additional repositories are loaded when doing a partia
     "indirect/replacer-1.0.0.0",
     "replacer/package-1.2.0.0",
     "replacer/package-1.0.0.0",
-    "base/package-1.0.0.0",
     "shared/dep-1.2.0.0"
 ]

--- a/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
@@ -137,10 +137,14 @@ class PoolBuilderTest extends TestCase
 
         $result = $this->getPackageResultSet($pool, $packageIds);
 
+        sort($expect);
+        sort($result);
         $this->assertSame($expect, $result, 'Unoptimized pool does not match expected package set');
 
         $optimizer = new PoolOptimizer(new DefaultPolicy());
         $result = $this->getPackageResultSet($optimizer->optimize($request, $pool), $packageIds);
+        sort($expectOptimized);
+        sort($result);
         $this->assertSame($expectOptimized, $result, 'Optimized pool does not match expected package set');
 
         chdir($oldCwd);

--- a/tests/Composer/Test/Fixtures/installer/load-replaced-package-if-replacer-dropped.test
+++ b/tests/Composer/Test/Fixtures/installer/load-replaced-package-if-replacer-dropped.test
@@ -1,0 +1,45 @@
+--TEST--
+Ensure that a package gets loaded which was previously skipped due to replacement
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {"name": "root/dep", "version": "1.2.0", "require": {"replacer/pkg": ">=1.1.0"}},
+                {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}},
+                {"name": "replacer/pkg", "version": "1.1.0"},
+                {"name": "replaced/pkg", "version": "1.0.0"},
+                {"name": "root/no-update", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}}
+            ]
+        }
+    ],
+    "require": {
+        "root/dep": "*",
+        "root/no-update": "*"
+    }
+}
+--LOCK--
+{
+    "packages": [
+        {"name": "root/dep", "version": "1.1.0", "require": {"replacer/pkg": "1.*"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}},
+        {"name": "root/no-update", "version": "1.0.0", "require": {"replaced/pkg": "1.0.0"}}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--RUN--
+update root/dep --with-all-dependencies
+--EXPECT--
+Installing replacer/pkg (1.1.0)
+Installing root/dep (1.2.0)
+Installing replaced/pkg (1.0.0)
+Installing root/no-update (1.0.0)
+


### PR DESCRIPTION
Another attempt to fix https://github.com/composer/composer/pull/10410 and https://github.com/composer/composer/pull/9619.

The goal here is to not load replaced packages into the pool if no other package actually requires them. We have to treat all `replace` definitions as "optional packages".

/cc @driskell @stof @naderman @Seldaek 