### PR TITLE
Return null for install path for metapackages instead of an empty string as path

### DIFF
--- a/doc/articles/custom-installers.md
+++ b/doc/articles/custom-installers.md
@@ -157,9 +157,8 @@ source for the exact signature):
   invoked with the update argument.
 * **uninstall()**, here you can determine the actions that need to be executed
   when the package needs to be removed.
-* **getInstallPath()**, this method should return the location where the
-  package is to be installed, _relative from the location of composer.json._
-  The path _must not end with a slash._
+* **getInstallPath()**, this method should return the absolute path where the
+  package is to be installed. The path _must not end with a slash._
 
 Example:
 

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -485,10 +485,14 @@ EOF;
                 continue;
             }
             $this->validatePackage($package);
+            $installPath = $installationManager->getInstallPath($package);
+            if ($installPath === null) {
+                continue;
+            }
 
             $packageMap[] = [
                 $package,
-                $installationManager->getInstallPath($package),
+                $installPath,
             ];
         }
 

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -99,6 +99,9 @@ EOT
         foreach ($installedRepo->getCanonicalPackages() as $package) {
             $downloader = $dm->getDownloaderForPackage($package);
             $targetDir = $im->getInstallPath($package);
+            if ($targetDir === null) {
+                continue;
+            }
 
             if ($downloader instanceof ChangeReportInterface) {
                 if (is_link($targetDir)) {

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -112,6 +112,9 @@ EOT
             $localRepo = $composer->getRepositoryManager()->getLocalRepository();
             foreach ($localRepo->getPackages() as $package) {
                 $path = $composer->getInstallationManager()->getInstallPath($package);
+                if (null === $path) {
+                    continue;
+                }
                 $file = $path . '/composer.json';
                 if (is_dir($path) && file_exists($file)) {
                     [$errors, $publishErrors, $warnings] = $validator->validate($file, $checkAll, $checkVersion);

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -549,9 +549,9 @@ class InstallationManager
     /**
      * Returns the installation path of a package
      *
-     * @return string           path
+     * @return string|null absolute path to install to, which does not end with a slash, or null if the package does not have anything installed on disk
      */
-    public function getInstallPath(PackageInterface $package): string
+    public function getInstallPath(PackageInterface $package): ?string
     {
         $installer = $this->getInstaller($package->getType());
 

--- a/src/Composer/Installer/InstallerInterface.php
+++ b/src/Composer/Installer/InstallerInterface.php
@@ -112,7 +112,7 @@ interface InstallerInterface
     /**
      * Returns the absolute installation path of a package.
      *
-     * @return string           absolute path to install to, which MUST not end with a slash
+     * @return string|null absolute path to install to, which MUST not end with a slash, or null if the package does not have anything installed on disk
      */
     public function getInstallPath(PackageInterface $package);
 }

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -227,6 +227,8 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
 
     /**
      * @inheritDoc
+     *
+     * @return string
      */
     public function getInstallPath(PackageInterface $package)
     {

--- a/src/Composer/Installer/MetapackageInstaller.php
+++ b/src/Composer/Installer/MetapackageInstaller.php
@@ -124,9 +124,11 @@ class MetapackageInstaller implements InstallerInterface
 
     /**
      * @inheritDoc
+     *
+     * @return null
      */
     public function getInstallPath(PackageInterface $package)
     {
-        return '';
+        return null;
     }
 }

--- a/src/Composer/Installer/ProjectInstaller.php
+++ b/src/Composer/Installer/ProjectInstaller.php
@@ -115,7 +115,7 @@ class ProjectInstaller implements InstallerInterface
     /**
      * Returns the installation path of a package
      *
-     * @return string           path
+     * @return string configured install path
      */
     public function getInstallPath(PackageInterface $package): string
     {

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -473,7 +473,11 @@ class Locker
             return null;
         }
 
-        $path = realpath($this->installationManager->getInstallPath($package));
+        $path = $this->installationManager->getInstallPath($package);
+        if ($path === null) {
+            return null;
+        }
+        $path = realpath($path);
         $sourceType = $package->getSourceType();
         $datetime = null;
 

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -236,8 +236,11 @@ class PluginManager
                 continue;
             }
 
-            $downloadPath = $this->getInstallPath($autoloadPackage, $globalRepo && $globalRepo->hasPackage($autoloadPackage));
-            $autoloads[] = [$autoloadPackage, $downloadPath];
+            $installPath = $this->getInstallPath($autoloadPackage, $globalRepo && $globalRepo->hasPackage($autoloadPackage));
+            if ($installPath === null) {
+                continue;
+            }
+            $autoloads[] = [$autoloadPackage, $installPath];
         }
 
         $map = $generator->parseAutoloads($autoloads, $rootPackage);
@@ -524,9 +527,9 @@ class PluginManager
      *
      * @param bool             $global  Whether this is a global package
      *
-     * @return string Install path
+     * @return string|null Install path
      */
-    private function getInstallPath(PackageInterface $package, bool $global = false): string
+    private function getInstallPath(PackageInterface $package, bool $global = false): ?string
     {
         if (!$global) {
             return $this->composer->getInstallationManager()->getInstallPath($package);


### PR DESCRIPTION
As the empty string then resolves to the root package's path when used with realpath()

Fixes #11389

The good news is this does not impact InstalledVersions::getInstallPath which was already correctly returning null

The bad news is this may impact plugins or other integrators relying on getInstallPath if they have strict types enabled and do not cover the null case. So I'm not sure if this should be shipped in a bugfix release..