### PR TITLE
Update 05-repositories.md

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -16,7 +16,7 @@ code, but in theory it could be anything. And it contains a package
 description which has a name and a version. The name and the version are used
 to identify the package.
 
-In fact, internally Composer sees every version as a separate package. While
+In fact, internally, Composer sees every version as a separate package. While
 this distinction does not matter when you are using Composer, it's quite
 important when you want to change it.
 


### PR DESCRIPTION
The verb phrase is 'internally' is an adverb describing the sort of seeing that Composer is doing. IE: Composer internally sees. The sentence _is_ much clearer when the adverb is moved earlier in the sentence, but this mutation necessitates a comma separating the adverb from the noun.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
