### PR TITLE
feat: allow installation of packages only from trusted vendors 

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -482,6 +482,41 @@ Example:
 }
 ```
 
+#### trusted <span>([root-only](04-schema.md#root-package))</span>
+
+The list of trusted packages that can be installed.
+If a required package (whether it is a direct or a transient dependency) is not in
+the "trusted" allow list, the installation will fail.
+
+This option is especially useful to prevent [supply chain attacks](https://dunglas.dev/2018/11/about-the-dependencies-of-symfony/).
+It allows detecting when dependencies coming from new, untrusted vendors are installed, for instance, when
+a dependency of the root package adds a new transient dependency.
+
+All packages from a specific vendor can be allowed by using the `vendor/*` special syntax.
+
+Example:
+
+```json
+{
+    "trusted": [
+        "api-platform/*",
+        "symfony/*",
+        "doctrine/*",
+        "psr/*",
+        "dunglas/doctrine-json-odm"
+    ]
+}
+```
+
+With the previous configuration, Composer will only allow installation of packages provided by the `api-platform`, `symfony`,
+`doctrine` and `psr` vendors as well as `dunglas/doctrine-json-odm` (but not other packages from `dunglas`).
+
+#### trusted-dev <span>([root-only](04-schema.md#root-package))</span>
+
+List of trusted packages that can be installed for developing.
+The syntax is the same as for the "trusted" property. Packages and vendors listed in the "trusted" can also always be
+installed for developing.
+
 ### autoload
 
 Autoload mapping for a PHP autoloader.

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -517,6 +517,8 @@ List of trusted packages that can be installed for developing.
 The syntax is the same as for the "trusted" property. Packages and vendors listed in the "trusted" can also always be
 installed for developing.
 
+Setting "trusted-dev" does nothing if "trusted" is not set.
+
 ### autoload
 
 Autoload mapping for a PHP autoloader.

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -666,6 +666,20 @@
             "additionalProperties": {
                 "type": "string"
             }
+        },
+        "trusted": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "description": "A list of trusted packages (wildcard supported to trust an entire vendor)."
+            }
+        },
+        "trusted-dev": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "description": "A list of trusted packages in development (wildcard supported to trust an entire vendor)."
+            }
         }
     },
     "definitions": {

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -428,8 +428,8 @@ class Installer
      *
      * @return string[]
      */
-     private function getUntrustedPackages(array $packages, array $patterns): array {
-         if (count($patterns) === 0) {
+     private function getUntrustedPackages(array $packages, ?array $patterns): array {
+         if ($patterns === null) {
              return [];
          }
 
@@ -544,8 +544,10 @@ class Installer
         $devPackages = $lockTransaction->getNewLockPackages(true, $this->updateMirrors);
 
         $trusted = $this->package->getTrusted();
+        $devTrusted = $this->package->getDevTrusted();
+
         $untrustedPackages = $this->getUntrustedPackages($packages, $trusted);
-        $untrustedDevPackages = array_diff($this->getUntrustedPackages($devPackages, array_merge($trusted, $this->package->getDevTrusted())), $untrustedPackages);
+        $untrustedDevPackages = $trusted === null || $devTrusted === null ? [] : array_diff($this->getUntrustedPackages($devPackages, array_merge($trusted, $devTrusted)), $untrustedPackages);
 
         $err = null;
         if (count($untrustedPackages) > 0) {

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -171,6 +171,14 @@ class RootPackageLoader extends ArrayLoader
             $realPackage->setPreferStable((bool) $config['prefer-stable']);
         }
 
+        if (isset($config['trusted'])) {
+            $realPackage->setTrusted($config['trusted']);
+        }
+
+        if (isset($config['trusted-dev'])) {
+            $realPackage->setDevTrusted($config['trusted-dev']);
+        }
+
         if (isset($config['config'])) {
             $realPackage->setConfig($config['config']);
         }

--- a/src/Composer/Package/RootAliasPackage.php
+++ b/src/Composer/Package/RootAliasPackage.php
@@ -220,4 +220,36 @@ class RootAliasPackage extends CompleteAliasPackage implements RootPackageInterf
         parent::__clone();
         $this->aliasOf = clone $this->aliasOf;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function setTrusted(array $trusted): void
+    {
+        $this->aliasOf->setTrusted($trusted);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTrusted(): array
+    {
+        return $this->aliasOf->getTrusted();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setDevTrusted(array $devTrusted): void
+    {
+        $this->aliasOf->setTrusted($devTrusted);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDevTrusted(): array
+    {
+        return $this->aliasOf->getDevTrusted();
+    }
 }

--- a/src/Composer/Package/RootAliasPackage.php
+++ b/src/Composer/Package/RootAliasPackage.php
@@ -224,7 +224,7 @@ class RootAliasPackage extends CompleteAliasPackage implements RootPackageInterf
     /**
      * @inheritDoc
      */
-    public function setTrusted(array $trusted): void
+    public function setTrusted(?array $trusted = null): void
     {
         $this->aliasOf->setTrusted($trusted);
     }
@@ -232,7 +232,7 @@ class RootAliasPackage extends CompleteAliasPackage implements RootPackageInterf
     /**
      * @inheritDoc
      */
-    public function getTrusted(): array
+    public function getTrusted(): ?array
     {
         return $this->aliasOf->getTrusted();
     }
@@ -240,7 +240,7 @@ class RootAliasPackage extends CompleteAliasPackage implements RootPackageInterf
     /**
      * @inheritDoc
      */
-    public function setDevTrusted(array $devTrusted): void
+    public function setDevTrusted(?array $devTrusted = null): void
     {
         $this->aliasOf->setDevTrusted($devTrusted);
     }
@@ -248,7 +248,7 @@ class RootAliasPackage extends CompleteAliasPackage implements RootPackageInterf
     /**
      * @inheritDoc
      */
-    public function getDevTrusted(): array
+    public function getDevTrusted(): ?array
     {
         return $this->aliasOf->getDevTrusted();
     }

--- a/src/Composer/Package/RootAliasPackage.php
+++ b/src/Composer/Package/RootAliasPackage.php
@@ -242,7 +242,7 @@ class RootAliasPackage extends CompleteAliasPackage implements RootPackageInterf
      */
     public function setDevTrusted(array $devTrusted): void
     {
-        $this->aliasOf->setTrusted($devTrusted);
+        $this->aliasOf->setDevTrusted($devTrusted);
     }
 
     /**

--- a/src/Composer/Package/RootPackage.php
+++ b/src/Composer/Package/RootPackage.php
@@ -33,6 +33,10 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     protected $references = [];
     /** @var list<array{package: string, version: string, alias: string, alias_normalized: string}> */
     protected $aliases = [];
+    /** @var string[] */
+    protected $trusted = [];
+    /** @var string[] */
+    protected $devTrusted = [];
 
     /**
      * @inheritDoc
@@ -128,5 +132,37 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     public function getAliases(): array
     {
         return $this->aliases;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setTrusted(array $trusted): void
+    {
+        $this->trusted = $trusted;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTrusted(): array
+    {
+        return $this->trusted;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setDevTrusted(array $devTrusted): void
+    {
+        $this->devTrusted = $devTrusted;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDevTrusted(): array
+    {
+        return $this->devTrusted;
     }
 }

--- a/src/Composer/Package/RootPackage.php
+++ b/src/Composer/Package/RootPackage.php
@@ -33,10 +33,10 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     protected $references = [];
     /** @var list<array{package: string, version: string, alias: string, alias_normalized: string}> */
     protected $aliases = [];
-    /** @var string[] */
-    protected $trusted = [];
-    /** @var string[] */
-    protected $devTrusted = [];
+    /** @var string[]|null */
+    protected $trusted = null;
+    /** @var string[]|null */
+    protected $devTrusted = null;
 
     /**
      * @inheritDoc
@@ -137,7 +137,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     /**
      * @inheritDoc
      */
-    public function setTrusted(array $trusted): void
+    public function setTrusted(?array $trusted = null): void
     {
         $this->trusted = $trusted;
     }
@@ -145,7 +145,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     /**
      * @inheritDoc
      */
-    public function getTrusted(): array
+    public function getTrusted(): ?array
     {
         return $this->trusted;
     }
@@ -153,7 +153,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     /**
      * @inheritDoc
      */
-    public function setDevTrusted(array $devTrusted): void
+    public function setDevTrusted(?array $devTrusted = null): void
     {
         $this->devTrusted = $devTrusted;
     }
@@ -161,7 +161,7 @@ class RootPackage extends CompletePackage implements RootPackageInterface
     /**
      * @inheritDoc
      */
-    public function getDevTrusted(): array
+    public function getDevTrusted(): ?array
     {
         return $this->devTrusted;
     }

--- a/src/Composer/Package/RootPackageInterface.php
+++ b/src/Composer/Package/RootPackageInterface.php
@@ -60,6 +60,34 @@ interface RootPackageInterface extends CompletePackageInterface
     public function getPreferStable(): bool;
 
     /**
+     * Sets the list of trusted packages.
+     *
+     * @param string[] $trusted
+     */
+    public function setTrusted(array $trusted): void;
+
+    /**
+     * Returns the list of trusted packages (a wildcard can be used to trust all packages from a specific vendor).
+     *
+     * @return string[]
+     */
+    public function getTrusted(): array;
+
+    /**
+     * Sets the list of trusted packages in dev.
+     *
+     * @param string[] $devTrusted
+     */
+    public function setDevTrusted(array $devTrusted): void;
+
+    /**
+     * Returns the list of packages trusted in dev (a wildcard can be used to trust all packages from a specific vendor).
+     *
+     * @return string[]
+     */
+    public function getDevTrusted(): array;
+
+    /**
      * Returns the root package's configuration
      *
      * @return mixed[]

--- a/src/Composer/Package/RootPackageInterface.php
+++ b/src/Composer/Package/RootPackageInterface.php
@@ -68,6 +68,7 @@ interface RootPackageInterface extends CompletePackageInterface
 
     /**
      * Returns the list of trusted packages (a wildcard can be used to trust all packages from a specific vendor).
+     * An empty array means that this feature is disabled, all packages can be installed.
      *
      * @return string[]
      */
@@ -82,6 +83,7 @@ interface RootPackageInterface extends CompletePackageInterface
 
     /**
      * Returns the list of packages trusted in dev (a wildcard can be used to trust all packages from a specific vendor).
+     * An empty array means that this feature is disabled, all packages can be installed.
      *
      * @return string[]
      */

--- a/src/Composer/Package/RootPackageInterface.php
+++ b/src/Composer/Package/RootPackageInterface.php
@@ -62,32 +62,32 @@ interface RootPackageInterface extends CompletePackageInterface
     /**
      * Sets the list of trusted packages.
      *
-     * @param string[] $trusted
+     * @param string[]|null $trusted
      */
-    public function setTrusted(array $trusted): void;
+    public function setTrusted(?array $trusted = null): void;
 
     /**
      * Returns the list of trusted packages (a wildcard can be used to trust all packages from a specific vendor).
-     * An empty array means that this feature is disabled, all packages can be installed.
+     * A null value means that this feature is disabled, all packages can be installed.
      *
-     * @return string[]
+     * @return string[]|null
      */
-    public function getTrusted(): array;
+    public function getTrusted(): ?array;
 
     /**
      * Sets the list of trusted packages in dev.
      *
-     * @param string[] $devTrusted
+     * @param string[]|null $devTrusted
      */
-    public function setDevTrusted(array $devTrusted): void;
+    public function setDevTrusted(?array $devTrusted = null): void;
 
     /**
      * Returns the list of packages trusted in dev (a wildcard can be used to trust all packages from a specific vendor).
-     * An empty array means that this feature is disabled, all packages can be installed.
+     * A null value means that this feature is disabled, all packages can be installed.
      *
-     * @return string[]
+     * @return string[]|null
      */
-    public function getDevTrusted(): array;
+    public function getDevTrusted(): ?array;
 
     /**
      * Returns the root package's configuration

--- a/tests/Composer/Test/Fixtures/installer/update-empty-trusted.test
+++ b/tests/Composer/Test/Fixtures/installer/update-empty-trusted.test
@@ -1,0 +1,26 @@
+--TEST--
+Install untrusted packages
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "dunglas/foo", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "dunglas/foo": "*"
+    },
+    "trusted": []
+}
+--RUN--
+update
+--EXPECT-EXIT-CODE--
+6
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+The installation of the following packages have been requested, but are untrusted: "dunglas/foo".
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/update-ignore-trusted-dev-if-no-trusted.test
+++ b/tests/Composer/Test/Fixtures/installer/update-ignore-trusted-dev-if-no-trusted.test
@@ -1,0 +1,25 @@
+--TEST--
+Install untrusted dev packages
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "dunglas/foo", "version": "1.0.0", "require": { "symfony/bar": "*" } },
+                { "name": "symfony/bar", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "dunglas/foo": "*"
+    },
+    "trusted-dev": [
+        "acme/*"
+    ]
+}
+--RUN--
+update
+--EXPECT--
+Installing symfony/bar (1.0.0)
+Installing dunglas/foo (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/update-trusted.test
+++ b/tests/Composer/Test/Fixtures/installer/update-trusted.test
@@ -1,0 +1,26 @@
+--TEST--
+Install untrusted packages
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "dunglas/foo", "version": "1.0.0", "require": { "symfony/bar": "*" } },
+                { "name": "symfony/bar", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "dunglas/foo": "*"
+    },
+    "trusted": [
+        "dunglas/*",
+        "symfony/bar"
+    ]
+}
+--RUN--
+update
+--EXPECT--
+Installing symfony/bar (1.0.0)
+Installing dunglas/foo (1.0.0)

--- a/tests/Composer/Test/Fixtures/installer/update-untrusted-dev.test
+++ b/tests/Composer/Test/Fixtures/installer/update-untrusted-dev.test
@@ -10,18 +10,15 @@ Install untrusted dev packages
                 { "name": "symfony/bar", "version": "1.0.0", "require": { "evil/pkg": "*", "symf0n1/evil": "*" } },
                 { "name": "evil/pkg", "version": "1.0.0" },
                 { "name": "symf0n1/evil", "version": "1.0.0" }
+            ],
+            "only": [
+                "dunglas/foo"
             ]
         }
     ],
     "require-dev": {
         "dunglas/foo": "*"
-    },
-    "trusted": [
-        "dunglas/foo"
-    ],
-    "trusted-dev": [
-        "symfony/*"
-    ]
+    }
 }
 --RUN--
 update

--- a/tests/Composer/Test/Fixtures/installer/update-untrusted-dev.test
+++ b/tests/Composer/Test/Fixtures/installer/update-untrusted-dev.test
@@ -1,0 +1,34 @@
+--TEST--
+Install untrusted dev packages
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "dunglas/foo", "version": "1.0.0", "require": { "symfony/bar": "*" } },
+                { "name": "symfony/bar", "version": "1.0.0", "require": { "evil/pkg": "*", "symf0n1/evil": "*" } },
+                { "name": "evil/pkg", "version": "1.0.0" },
+                { "name": "symf0n1/evil", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require-dev": {
+        "dunglas/foo": "*"
+    },
+    "trusted": [
+        "dunglas/foo"
+    ],
+    "trusted-dev": [
+        "symfony/*"
+    ]
+}
+--RUN--
+update
+--EXPECT-EXIT-CODE--
+6
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+The installation of the following dev packages have been requested, but are untrusted: "evil/pkg", "symf0n1/evil".
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/update-untrusted-dev.test
+++ b/tests/Composer/Test/Fixtures/installer/update-untrusted-dev.test
@@ -10,15 +10,18 @@ Install untrusted dev packages
                 { "name": "symfony/bar", "version": "1.0.0", "require": { "evil/pkg": "*", "symf0n1/evil": "*" } },
                 { "name": "evil/pkg", "version": "1.0.0" },
                 { "name": "symf0n1/evil", "version": "1.0.0" }
-            ],
-            "only": [
-                "dunglas/foo"
             ]
         }
     ],
     "require-dev": {
         "dunglas/foo": "*"
-    }
+    },
+    "trusted": [
+        "dunglas/foo"
+    ],
+    "trusted-dev": [
+        "symfony/*"
+    ]
 }
 --RUN--
 update

--- a/tests/Composer/Test/Fixtures/installer/update-untrusted.test
+++ b/tests/Composer/Test/Fixtures/installer/update-untrusted.test
@@ -1,0 +1,29 @@
+--TEST--
+Install untrusted packages
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "dunglas/foo", "version": "1.0.0", "require": { "symfony/bar": "*" } },
+                { "name": "symfony/bar", "version": "1.0.0" }
+            ]
+        }
+    ],
+    "require": {
+        "dunglas/foo": "*"
+    },
+    "trusted": [
+        "dunglas/*"
+    ]
+}
+--RUN--
+update
+--EXPECT-EXIT-CODE--
+6
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+The installation of the following packages have been requested, but are untrusted: "symfony/bar".
+--EXPECT--


### PR DESCRIPTION
This patch adds a new feature to allow the installation of packages only from trusted vendors.
If a required package (whether it is a direct or a transient dependency) is not in the "trusted" allow list, the installation will fail.

This option is especially useful to prevent [supply chain attacks](https://dunglas.dev/2018/11/about-the-dependencies-of-symfony/).
It allows detecting when dependencies coming from new, untrusted vendors are installed, for instance, when
a dependency of the root package adds a new transient dependency.

All packages from a specific vendor can be allowed by using the `vendor/*` special syntax.

Example:

```json
{
    "trusted": [
        "api-platform/*",
        "symfony/*",
        "doctrine/*",
        "psr/*",
        "dunglas/doctrine-json-odm"
    ]
}
```

With the previous configuration, Composer will only allow installation of packages provided by the `api-platform`, `symfony`,
`doctrine` and `psr` vendors as well as `dunglas/doctrine-json-odm` (but not other packages from `dunglas`).

We plan to use this new feature in Symfony and API Platform to ensure that our CI fails when a new, unaudited, package pops up because one of our dependencies now requires it.

This is also useful for all other security-sensitive projects when you want to be sure of what is installed and executed.

I first discussed this feature with @Seldaek and @nicolas-grekas during SymfonyCon 2022, and I'll present this feature in-depth on Friday during AFUPday 2023.