### PR TITLE
The package URLs change protection

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -582,6 +582,13 @@
                 "platform-check": {
                     "type": ["boolean", "string"],
                     "description": "Defaults to \"php-only\" which checks only the PHP version. Setting to true will also check the presence of required PHP extensions. If set to false, Composer will not create and require a platform_check.php file as part of the autoloader bootstrap."
+                },
+                "allowed-urls": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "A list of URL prefixes, from where Composer can download the source code."
+                    }
                 }
             }
         },

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -525,6 +525,10 @@ class Factory
             $dm->setPreferences($preferred);
         }
 
+        if (is_array($allowedUrls = $config->get('allowed-urls'))) {
+            $dm->setAllowedUrls($allowedUrls);
+        }
+
         $dm->setDownloader('git', new Downloader\GitDownloader($io, $config, $process, $fs));
         $dm->setDownloader('svn', new Downloader\SvnDownloader($io, $config, $process, $fs));
         $dm->setDownloader('fossil', new Downloader\FossilDownloader($io, $config, $process, $fs));


### PR DESCRIPTION
This PR adds a new feature to allow the download the code only from trusted sources.

It gives protection from attacks, like change url or supply chain attacks

1) If packagist.org maintainer account takeover https://blog.packagist.com/packagist-org-maintainer-account-takeover/
2) If the packagist.org secret was leaked
3) Dependency injection attack #11460 

Example usage

```json
    "config": {
        "allowed-urls": [
            "https://api.github.com/repos/dragonmantank/cron-expression/",
            "https://api.github.com/repos/php-fig/",
            "https://api.github.com/repos/symfony/" // the all symfony packages
        ]
    },
```
Installation will fail if untrusted source url of package is found. it is supported for dist/source/mirrors downloads

```
  The downloading of the following url have been requested, but is untrusted: "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991"
```