### PR TITLE
Fix authentication issues with multiple private bitbucket repos

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -28,6 +28,8 @@ class AuthHelper
     protected $config;
     /** @var array<string, string> Map of origins to message displayed */
     private $displayedOriginAuthentications = array();
+    /** @var array<string, int> */
+    private $bitbucketRetry = array();
 
     public function __construct(IOInterface $io, Config $config)
     {
@@ -169,6 +171,9 @@ class AuthHelper
                         $this->io->setAuthentication($origin, 'x-token-auth', $accessToken);
                         $askForOAuthToken = false;
                     }
+                } elseif (!isset($this->bitbucketRetry[$url])) {
+                    $askForOAuthToken = false;
+                    $this->bitbucketRetry[$url] = 1;
                 } else {
                     throw new TransportException('Could not authenticate against ' . $origin, 401);
                 }


### PR DESCRIPTION
This PR fixes an issue with installing multiple packages from private bitbucket repositories.

**What happens now?**
In case multiple dependencies are needed from private bitbucket repositories, only one will succeed in downloading the dist file, all others will fail and fall back to a git clone.

```
  - Downloading vendor/package1 (2.0.7)
  - Downloading vendor/package2 (2.1.2)
  - Downloading vendor/package3 (1.1.2)
  - Downloading vendor/package4 (1.0.6)
    Failed to download vendor/package2 from dist: Could not authenticate against bitbucket.org
    Now trying to download from source
  - Syncing vendor/package2 (2.1.2) into cache
    Failed to download vendor/package1 from dist: Could not authenticate against bitbucket.org
    Now trying to download from source
  - Syncing vendor/package1 (2.0.7) into cache
    Failed to download vendor/package4 from dist: Could not authenticate against bitbucket.org
    Now trying to download from source
  - Syncing vendor/package4 (1.0.6) into cache
  - Installing php-http/discovery (1.18.0): Extracting archive
...
  - Installing vendor/package1 (2.0.7): Cloning c3e03c4b13 from cache
  - Installing vendor/package2 (2.1.2): Cloning 7ce55140aa from cache
  - Installing vendor/package3 (1.1.2): Extracting archive
  - Installing vendor/package4 (1.0.6): Cloning b66a675165 from cache
```

**Why does this happen?**
All requests to download the dist files use basic authentication with the client id and client secret (when set) and are executed in parallel. As this is not the correct authentication for downloads from private repositories, they will all fail and will be retried with authentication.

The code detects that (for the first failed download that is retried) the username is not `x-token-auth` which is expected to be used with authentication with a bitbucket access token. It will fetch the access token from the config (or fetch a new access token) and set that as the new authentication for the origin bitbucket.org.

For the second and consecutive downloads the code will detect the username is `x-token-auth` and assume the correct authentication was used, when it was not.

**What does this fix do?**
This fix will allow each download to be tried once more with authentication.
In practise this fix will be for the second and consecutive downloads, but if the stored credentials are incorrect, also the first download will be retried once more before falling back to a git clone.

```
  - Downloading vendor/package1 (2.0.7)
  - Downloading vendor/package2 (2.1.2)
  - Downloading vendor/package3 (1.1.2)
  - Downloading vendor/package4 (1.0.6)
  - Installing php-http/discovery (1.18.0): Extracting archive
...
  - Installing vendor/package1 (2.0.7): Extracting archive
  - Installing vendor/package2 (2.1.2): Extracting archive
  - Installing vendor/package3 (1.1.2): Extracting archive
  - Installing vendor/package4 (1.0.6): Extracting archive
```