### PR TITLE
 Ensure stripos() receives a string in Platform::isWindowsSubsystemForLinux()

### DIFF
--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -148,7 +148,7 @@ class Platform
             if (
                 !ini_get('open_basedir')
                 && is_readable('/proc/version')
-                && false !== stripos(Silencer::call('file_get_contents', '/proc/version'), 'microsoft')
+                && false !== stripos((string)Silencer::call('file_get_contents', '/proc/version'), 'microsoft')
                 && !file_exists('/.dockerenv') // docker running inside WSL should not be seen as WSL
             ) {
                 return self::$isWindowsSubsystemForLinux = true;


### PR DESCRIPTION
`composer install` was failing on our server while installing codesniffer:

```
  - Installing squizlabs/php_codesniffer (3.7.2): Extracting archive
    Install of squizlabs/php_codesniffer failed

In Platform.php line 151:

  [TypeError]
  stripos(): Argument #1 ($haystack) must be of type string, bool given
```

Platform::isWindowsSubsystemForLinux() checks the contents of the file **/proc/version** on the system, but if this file is not found (like on our server, which uses a customized Linux distro, which I guess is the problem), file_get_contents() returns false and causes stripos() to throw a TypeError due to the introduction of strict_types in composer v2.3.0.

This PR fixes the issue by checking if the return value from file_get_contents() is false before using stripos() on it.

I have tested that `composer install` still works on my local environment (where this wasn't an issue) and that the issue has been fixed on our server.

Also, I took the liberty to refactor the rest of the logic a little bit so that it just uses one return statement after setting the `self::$isWindowsSubsystemForLinux` property.