### PR TITLE
Tests for empty or absent repository filters

### DIFF
--- a/tests/Composer/Test/Repository/FilterRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilterRepositoryTest.php
@@ -59,7 +59,20 @@ class FilterRepositoryTest extends TestCase
             // make sure sub-patterns are not matched without wildcard
             [['foo/aaa', 'foo/bbb', 'bar/xxx', 'baz/yyy'], ['exclude' => ['foo/aa', 'az/yyy']]],
             [[], ['only' => ['foo/aa', 'az/yyy']]],
+            // empty "only" means no packages allowed
+            [[], ['only' => []]],
+            // absent "only" means all packages allowed
+            [['foo/aaa', 'foo/bbb', 'bar/xxx', 'baz/yyy'], []],
+            // empty or absent "exclude" have the same effect: none
+            [['foo/aaa', 'foo/bbb', 'bar/xxx', 'baz/yyy'], ['exclude' => []]],
+            [['foo/aaa', 'foo/bbb', 'bar/xxx', 'baz/yyy'], []],
         ];
+    }
+
+    public function testBothFiltersDisallowed(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new FilterRepository($this->arrayRepo, ['only' => [], 'exclude' => []]);
     }
 
     public function testSecurityAdvisoriesDisabledInChild(): void


### PR DESCRIPTION
The behavior in `FilterRepository` is currently correct, but not explicitly tested.

Also add a test that ensures both filters can't be there simultaneously.
