### PR TITLE
Test json format on failed platform reqs

### DIFF
--- a/tests/Composer/Test/Command/CheckPlatformReqsCommandTest.php
+++ b/tests/Composer/Test/Command/CheckPlatformReqsCommandTest.php
@@ -167,6 +167,5 @@ ext-foobar 2.3.4   success'
 ]';
 
         $this->assertSame(trim($expected), trim($appTester->getDisplay(true)));
-        
     }
 }

--- a/tests/Composer/Test/Command/CheckPlatformReqsCommandTest.php
+++ b/tests/Composer/Test/Command/CheckPlatformReqsCommandTest.php
@@ -87,5 +87,34 @@ ext-foobar 2.3.4   success'
             ['--lock' => true],
             "Checking platform requirements using the lock file\next-barbaz 2.3.4.5   success \next-foobar 2.3.4     success"
         ];
+
+        yield 'Checks json format arg with no failed requirements' => [
+            [
+                'require' => [
+                    'ext-foobar' => '^2.3',
+                ],
+                'require-dev' => [
+                    'ext-barbaz' => '~2.0',
+                ]
+            ],
+            ['--format' => 'json'],
+            'Checking platform requirements for packages in the vendor dir
+[
+    {
+        "name": "ext-barbaz",
+        "version": "2.3.4.5",
+        "status": "success",
+        "failed_requirement": null,
+        "provider": null
+    },
+    {
+        "name": "ext-foobar",
+        "version": "2.3.4",
+        "status": "success",
+        "failed_requirement": null,
+        "provider": null
+    }
+]'
+        ];
     }
 }

--- a/tests/Composer/Test/Command/CheckPlatformReqsCommandTest.php
+++ b/tests/Composer/Test/Command/CheckPlatformReqsCommandTest.php
@@ -117,4 +117,56 @@ ext-foobar 2.3.4   success'
 ]'
         ];
     }
+
+    public function testFailedPlatformRequirement(): void 
+    {
+        $this->initTempComposer([
+            'require' => [
+                'ext-foobar' => '^0.3'
+            ],
+            'require-dev' => [
+                'ext-barbaz' => '^2.3'
+            ]
+        ]);
+
+        $packages = [
+            self::getPackage('ext-foobar', '2.3.4'),
+        ];
+        $devPackages = [
+            self::getPackage('ext-barbaz', '2.3.4.5')
+        ];
+
+        $this->createInstalledJson($packages, $devPackages);
+
+        $this->createComposerLock($packages, $devPackages);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'check-platform-reqs', '--format' => 'json']);
+
+        $expected = 'Checking platform requirements for packages in the vendor dir
+[
+    {
+        "name": "ext-barbaz",
+        "version": "2.3.4.5",
+        "status": "success",
+        "failed_requirement": null,
+        "provider": null
+    },
+    {
+        "name": "ext-foobar",
+        "version": "2.3.4",
+        "status": "failed",
+        "failed_requirement": {
+            "source": "__root__",
+            "type": "requires",
+            "target": "ext-foobar",
+            "constraint": "^0.3"
+        },
+        "provider": null
+    }
+]';
+
+        $this->assertSame(trim($expected), trim($appTester->getDisplay(true)));
+        
+    }
 }

--- a/tests/Composer/Test/Command/CheckPlatformReqsCommandTest.php
+++ b/tests/Composer/Test/Command/CheckPlatformReqsCommandTest.php
@@ -87,35 +87,6 @@ ext-foobar 2.3.4   success'
             ['--lock' => true],
             "Checking platform requirements using the lock file\next-barbaz 2.3.4.5   success \next-foobar 2.3.4     success"
         ];
-
-        yield 'Checks json format arg with no failed requirements' => [
-            [
-                'require' => [
-                    'ext-foobar' => '^2.3',
-                ],
-                'require-dev' => [
-                    'ext-barbaz' => '~2.0',
-                ]
-            ],
-            ['--format' => 'json'],
-            'Checking platform requirements for packages in the vendor dir
-[
-    {
-        "name": "ext-barbaz",
-        "version": "2.3.4.5",
-        "status": "success",
-        "failed_requirement": null,
-        "provider": null
-    },
-    {
-        "name": "ext-foobar",
-        "version": "2.3.4",
-        "status": "success",
-        "failed_requirement": null,
-        "provider": null
-    }
-]'
-        ];
     }
 
     public function testFailedPlatformRequirement(): void 


### PR DESCRIPTION
Adds a single test for covering failed requirements. I have passed the `--format=json` flag to this test to also cover off a branch of `CheckPlatformReqsCommand::printTable`.

Bumps coverage for this command from ~70% to ~90%.
