### PR TITLE
Update `SyncHelper` - Remove 3 phpstan issues

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -4934,21 +4934,6 @@ parameters:
 			path: ../src/Composer/Util/Svn.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, Composer\\\\Package\\\\PackageInterface\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/Util/SyncHelper.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, React\\\\Promise\\\\PromiseInterface\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/Util/SyncHelper.php
-
-		-
-			message: "#^Parameter \\#2 \\$target of method Composer\\\\Downloader\\\\DownloaderInterface\\:\\:update\\(\\) expects Composer\\\\Package\\\\PackageInterface, Composer\\\\Package\\\\PackageInterface\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/Util/SyncHelper.php
-
-		-
 			message: "#^Only booleans are allowed in &&, array\\<int\\|string, true\\> given on the left side\\.$#"
 			count: 1
 			path: ../src/Composer/Util/Tar.php

--- a/src/Composer/Util/SyncHelper.php
+++ b/src/Composer/Util/SyncHelper.php
@@ -31,14 +31,14 @@ class SyncHelper
      */
     public static function downloadAndInstallPackageSync(Loop $loop, DownloaderInterface $downloader, string $path, PackageInterface $package, ?PackageInterface $prevPackage = null): void
     {
-        $type = $prevPackage ? 'update' : 'install';
+        $type = $prevPackage !== null ? 'update' : 'install';
 
         try {
             self::await($loop, $downloader->download($package, $path, $prevPackage));
 
             self::await($loop, $downloader->prepare($type, $package, $path, $prevPackage));
 
-            if ($type === 'update') {
+            if ($type === 'update' && $prevPackage !== null) {
                 self::await($loop, $downloader->update($package, $prevPackage, $path));
             } else {
                 self::await($loop, $downloader->install($package, $path));
@@ -58,7 +58,7 @@ class SyncHelper
      */
     public static function await(Loop $loop, ?PromiseInterface $promise = null): void
     {
-        if ($promise) {
+        if ($promise !== null) {
             $loop->wait([$promise]);
         }
     }


### PR DESCRIPTION
This PR:

- [x] Get rid of 3 PHPStan issues.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
