### PR TITLE
[nit] Simplify property assignment

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -114,7 +114,7 @@ class AutoloadGenerator
     public function setApcu(bool $apcu, ?string $apcuPrefix = null)
     {
         $this->apcu = $apcu;
-        $this->apcuPrefix = $apcuPrefix !== null ? $apcuPrefix : $apcuPrefix;
+        $this->apcuPrefix = $apcuPrefix;
     }
 
     /**


### PR DESCRIPTION
While reading through the auto-loader code today, I was initially confused by this line. I determined that it was simply setting the property to the value of the variable, however the code style slowed me down. I've had a look and can see that the code has progressed sensibly over the years, but its current form is equivalent to a simple assignment.

<details><summary>Code samples showing progression</summary>

Let's start with the version from https://github.com/composer/composer/commit/0b6abf3b9669047e4003ae5fd01fd2ee2cba139f (where a single property was split into two separate properties):
```php
    public function setApcu($apcu, $apcuPrefix = null)
    {
        $this->apcu = (bool) $apcu;
        $this->apcuPrefix = $apcuPrefix !== null ? (string) $apcuPrefix : $apcuPrefix;
    }
```

This was changed in https://github.com/composer/composer/commit/6da38f83a0d5acc71793f337b525fa2faff9468e to add type declarations (these were already in the DocBlock):
```php
    public function setApcu(bool $apcu, ?string $apcuPrefix = null)
    {
        $this->apcu = (bool) $apcu;
        $this->apcuPrefix = $apcuPrefix !== null ? (string) $apcuPrefix : $apcuPrefix;
    }
```

This was changed in https://github.com/composer/composer/commit/be4b70ce79b34762acf1647e63108fdcca7f758b to fix a complaint from phpstan about the unnecessary type cast:
```php
    public function setApcu(bool $apcu, ?string $apcuPrefix = null)
    {
        $this->apcu = $apcu;
        $this->apcuPrefix = $apcuPrefix !== null ? $apcuPrefix : $apcuPrefix;
    }
```

Which is now equivalent to the change suggested in this pull request (which I find much easier to read):
```php
    public function setApcu(bool $apcu, ?string $apcuPrefix = null)
    {
        $this->apcu = $apcu;
        $this->apcuPrefix = $apcuPrefix;
    }
```

</details>