### PR TITLE
Force CreateProjectCommand to use the installed composer.json

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -469,6 +469,7 @@ EOT
         $io->writeError('<info>Created project in ' . $directory . '</info>');
         chdir($directory);
 
+        Platform::putEnv('COMPOSER', $directory.'/composer.json');
         Platform::putEnv('COMPOSER_ROOT_VERSION', $package->getPrettyVersion());
 
         // once the root project is fully initialized, we do not need to wipe everything on user abort anymore even if it happens during deps install

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -469,6 +469,9 @@ EOT
         $io->writeError('<info>Created project in ' . $directory . '</info>');
         chdir($directory);
 
+        // ensure that the env var being set does not interfere with create-project
+        // as it is probably not meant to be used here, so we do not use it if a composer.json can be found
+        // in the project
         if (file_exists($directory.'/composer.json')) {
             Platform::putEnv('COMPOSER', $directory.'/composer.json');
         }

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -469,7 +469,10 @@ EOT
         $io->writeError('<info>Created project in ' . $directory . '</info>');
         chdir($directory);
 
-        Platform::putEnv('COMPOSER', $directory.'/composer.json');
+        if (file_exists($directory.'/composer.json')) {
+            Platform::putEnv('COMPOSER', $directory.'/composer.json');
+        }
+
         Platform::putEnv('COMPOSER_ROOT_VERSION', $package->getPrettyVersion());
 
         // once the root project is fully initialized, we do not need to wipe everything on user abort anymore even if it happens during deps install


### PR DESCRIPTION
In my local environment ([Contao Manager](https://github.com/contao/contao-manager)), I always have the `COMPOSER` environment variable set to the root of my project directory. When using the `create-project` command with an new, empty directory target (because my project dir is not empty), Composer correctly downloads the files into the new directory, but then fails when calling [`Factory::create`](https://github.com/composer/composer/blob/main/src/Composer/Command/CreateProjectCommand.php#L205) because that uses the `COMPOSER` environment variable instead of the newly downloaded files.

I'm not sure what implications this could have on a running command, but I would assume that the variable is gone as soon as the `create-project` command is finished?