### PR TITLE
refactor: update `SyncHelper::downloadAndInstallPackageSync`

### DIFF
--- a/src/Composer/Plugin/PluginInterface.php
+++ b/src/Composer/Plugin/PluginInterface.php
@@ -32,7 +32,7 @@ interface PluginInterface
      *
      * @var string
      */
-    public const PLUGIN_API_VERSION = '2.3.0';
+    public const PLUGIN_API_VERSION = '2.6.0';
 
     /**
      * Apply plugin modifications to Composer

--- a/src/Composer/Util/SyncHelper.php
+++ b/src/Composer/Util/SyncHelper.php
@@ -13,6 +13,7 @@
 namespace Composer\Util;
 
 use Composer\Downloader\DownloaderInterface;
+use Composer\Downloader\DownloadManager;
 use Composer\Package\PackageInterface;
 use React\Promise\PromiseInterface;
 
@@ -23,14 +24,16 @@ class SyncHelper
      *
      * This executes all the required steps and waits for promises to complete
      *
-     * @param Loop                  $loop        Loop instance which you can get from $composer->getLoop()
-     * @param DownloaderInterface   $downloader  Downloader instance you can get from $composer->getDownloadManager()->getDownloader('zip') for example
-     * @param string                $path        the installation path for the package
-     * @param PackageInterface      $package     the package to install
-     * @param PackageInterface|null $prevPackage the previous package if this is an update and not an initial installation
+     * @param Loop                                $loop        Loop instance which you can get from $composer->getLoop()
+     * @param DownloaderInterface|DownloadManager $downloader  DownloadManager instance or Downloader instance you can get from $composer->getDownloadManager()->getDownloader('zip') for example
+     * @param string                              $path        The installation path for the package
+     * @param PackageInterface                    $package     The package to install
+     * @param PackageInterface|null               $prevPackage The previous package if this is an update and not an initial installation
      */
-    public static function downloadAndInstallPackageSync(Loop $loop, DownloaderInterface $downloader, string $path, PackageInterface $package, ?PackageInterface $prevPackage = null): void
+    public static function downloadAndInstallPackageSync(Loop $loop, $downloader, string $path, PackageInterface $package, ?PackageInterface $prevPackage = null): void
     {
+        assert($downloader instanceof DownloaderInterface || $downloader instanceof DownloadManager);
+
         $type = $prevPackage !== null ? 'update' : 'install';
 
         try {


### PR DESCRIPTION
This PR:

- [x] is a proposal, originating from [a custom plugin](https://github.com/drupol/composer-local-repo-plugin/) I made
- [x] widen a single parameter of `SyncHelper::downloadAndInstallPackageSync`

This simple change would prevent duplicating code related to the download logic in `DownloadManager::download` where the source of the package is automatically detected (_this would also prevent me from copying the complete function [in my plugin](https://github.com/drupol/composer-local-repo-plugin/blob/main/src/Service/RepoBuilder.php#L24) and modify its signature only_).

WDYT ?