### PR TITLE
Add access token authentication for private Bitbucket repositories

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -198,7 +198,7 @@ Read more [here](articles/authentication-for-private-packages.md#bitbucket-oauth
 
 ## bitbucket-token
 
-A list of repository names with the particular (access token)[https://support.atlassian.com/bitbucket-cloud/docs/create-a-repository-access-token/].
+A list of repository names with the particular [access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-repository-access-token/).
 For example using `{"composer/composer": "example-access-token"}`.
 Read more [here](articles/authentication-for-private-packages.md#bitbucket-token).
 

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -196,6 +196,12 @@ A list of domain names and consumers. For example using `{"bitbucket.org":
 {"consumer-key": "myKey", "consumer-secret": "mySecret"}}`.
 Read more [here](articles/authentication-for-private-packages.md#bitbucket-oauth).
 
+## bitbucket-token
+
+A list of repository names with the particular (access token)[https://support.atlassian.com/bitbucket-cloud/docs/create-a-repository-access-token/].
+For example using `{"composer/composer": "example-access-token"}`.
+Read more [here](articles/authentication-for-private-packages.md#bitbucket-token).
+
 ## cafile
 
 Location of Certificate Authority file on local filesystem. In PHP 5.6+ you

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -199,7 +199,7 @@ Read more [here](articles/authentication-for-private-packages.md#bitbucket-oauth
 ## bitbucket-token
 
 A list of repository names with the particular [access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-repository-access-token/).
-For example using `{"composer/composer": "example-access-token"}`.
+For example using `{"workspace-name/repository-name": "repository-access-token"}`.
 Read more [here](articles/authentication-for-private-packages.md#bitbucket-token).
 
 ## cafile

--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -364,7 +364,7 @@ php composer.phar config [--global] --editor --auth
 
 ## bitbucket-token
 
-The BitBucket driver is also able to access your private repositories via the BitBucket REST APIs, using (Bitbucket Repository Access Tokens)[https://support.atlassian.com/bitbucket-cloud/docs/create-a-repository-access-token/].
+The Bitbucket driver is also able to access your private repositories via the Bitbucket REST APIs, using (Bitbucket Repository Access Tokens)[https://support.atlassian.com/bitbucket-cloud/docs/create-a-repository-access-token/].
 Please note that this token is not the same as the OAuth consumer key and secret. On the contrary of the OAuth consumer,
 this token is specific to a repository. That enables the possibility to restrict the access to a specific repository.
 

--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -370,10 +370,6 @@ this token is specific to a repository. That enables the possibility to restrict
 
 You can set up several tokens for each of your private Bitbucket repositories as shown below.
 
-> **Note:** Composer will try to download the repository as ZIP file but unfortunately Bitbucket does not support authentication
-> with access token. Therefore, Composer will fallback to cloning the repository using HTTPS and the access token as password.
-> The warning message `Failed to download ...` can be ignored.
-
 ### Manual bitbucket-oauth
 
 ```shell

--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -24,6 +24,7 @@ for credentials and save them (or a token if Composer is able to retrieve one).
 |[gitlab-token](#gitlab-token)|yes|
 |[github-oauth](#github-oauth)|yes|
 |[bitbucket-oauth](#bitbucket-oauth)|yes|
+|[bitbucket-oauth](#bitbucket-oauth)|no|
 
 Sometimes automatic authentication is not possible, or you may want to predefine
 authentication credentials.
@@ -357,6 +358,32 @@ php composer.phar config [--global] --editor --auth
              "consumer-key": "key",
              "consumer-secret": "secret"
         }
+    }
+}
+```
+
+## bitbucket-token
+
+The BitBucket driver is also able to access your private repositories via the BitBucket REST APIs, using (Bitbucket Repository Access Tokens)[https://support.atlassian.com/bitbucket-cloud/docs/create-a-repository-access-token/].
+Please note that this token is not the same as the OAuth consumer key and secret. On the contrary of the OAuth consumer,
+this token is specific to a repository. That enables the possibility to restrict the access to a specific repository.
+
+You can set up several tokens for each of your private Bitbucket repositories as shown below.
+
+> **Note:** Composer will try to download the repository as ZIP file but unfortunately Bitbucket does not support authentication
+> with access token. Therefore, Composer will fallback to cloning the repository using HTTPS and the access token as password.
+> The warning message `Failed to download ...` can be ignored.
+
+### Manual bitbucket-oauth
+
+```shell
+php composer.phar config [--global] --editor --auth
+```
+
+```json
+{
+    "bitbucket-token": {
+        "{workspace-name}/{repository-name}": "{repository access token}"
     }
 }
 ```

--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -24,7 +24,7 @@ for credentials and save them (or a token if Composer is able to retrieve one).
 |[gitlab-token](#gitlab-token)|yes|
 |[github-oauth](#github-oauth)|yes|
 |[bitbucket-oauth](#bitbucket-oauth)|yes|
-|[bitbucket-oauth](#bitbucket-oauth)|no|
+|[bitbucket-token](#bitbucket-token)|no|
 
 Sometimes automatic authentication is not possible, or you may want to predefine
 authentication credentials.

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -119,7 +119,17 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
 
         $this->io->writeError($msg);
 
-        $commandCallable = static function (string $url) use ($path, $command, $cachePath): string {
+        $io = $this->io;
+
+        $commandCallable = static function (string $url) use ($path, $command, $cachePath, $io): string {
+            if (Preg::isMatch('#^https?://bitbucket\.org/([^/]+)/([^/]+?)(?:\.git|/?)?$#i', $url)) {
+                $auth = $io->getAuthentication('bitbucket.org');
+
+                if (isset($auth['username']) && $auth['username'] === 'x-token-auth') {
+                    $url = Preg::replace('/bitbucket\.org/', $auth['username'].':'.$auth['password'].'@bitbucket.org', $url, 1);
+                }
+            }
+
             return str_replace(
                 ['%url%', '%path%', '%cachePath%', '%sanitizedUrl%'],
                 [

--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -390,6 +390,10 @@ class GitBitbucketDriver extends VcsDriver
      */
     protected function fetchWithOAuthCredentials(string $url, bool $fetchingRepoData = false): Response
     {
+        if (isset($this->repoConfig['accessToken'])) {
+            $this->io->setAuthentication($this->originUrl, 'x-token-auth', $this->repoConfig['access-token']);
+        }
+
         try {
             return parent::getContents($url);
         } catch (TransportException $e) {

--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -283,6 +283,11 @@ class GitBitbucketDriver extends VcsDriver
             return $this->fallbackDriver->getDist($identifier);
         }
 
+        if ($this->hasAccessToken()) {
+            // Authentication with access token is not supported for downloads
+            return null;
+        }
+
         $url = sprintf(
             'https://bitbucket.org/%s/%s/get/%s.zip',
             $this->owner,
@@ -533,5 +538,11 @@ class GitBitbucketDriver extends VcsDriver
 
             $this->io->setAuthentication($this->originUrl, 'x-token-auth', $bitbucketTokens[$this->owner . "/" . $this->repository]);
         }
+    }
+
+    private function hasAccessToken(): bool
+    {
+        return $this->config->has('bitbucket-token')
+            && isset($this->config->get('bitbucket-token')[$this->owner . "/" . $this->repository]);
     }
 }

--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -524,11 +524,6 @@ class GitBitbucketDriver extends VcsDriver
 
     private function authenticateAccessToken(): void
     {
-        if (isset($this->repoConfig['access-token'])) {
-            $this->io->setAuthentication($this->originUrl, 'x-token-auth', $this->repoConfig['access-token']);
-            return;
-        }
-
         if ($this->config->has('bitbucket-token')) {
             $bitbucketTokens = $this->config->get('bitbucket-token');
 

--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -390,7 +390,7 @@ class GitBitbucketDriver extends VcsDriver
      */
     protected function fetchWithOAuthCredentials(string $url, bool $fetchingRepoData = false): Response
     {
-        if (isset($this->repoConfig['accessToken'])) {
+        if (isset($this->repoConfig['access-token'])) {
             $this->io->setAuthentication($this->originUrl, 'x-token-auth', $this->repoConfig['access-token']);
         }
 


### PR DESCRIPTION
This PR adds access token authentication for Bitbucket repositories.

## Background

Composer already supports Bitbucket authentication with OAuth. Bitbucket's OAuth configuration has some down sites. Because the OAuth token is configured at workspace levels, it applies to all repositories in that workspace.

To have repository-based tokens, Bitbucket provides so-called "Access tokens", that can be found in the repository settings:

![image](https://github.com/composer/composer/assets/5526334/078c56fe-2a88-45ad-b8d5-77843ba26f96)

As a workaround you could set access token as OAuth token for the user "x-token-auth", but then only one is possible in the whole project.

## Configuration

This PR adds a new parameter group to auth json. A Bitbucket repository that uses access token authentication can be configured as followed in the `composer.json` file:

```
[...]
    "repositories": [
        {
            "type": "bitbucket",
            "url": "https://bitbucket.org/{workspace-name}/{repository-name}.git",
        }
    ],
[...]
```

And the access token will be stored in the `auth.json` file by defining for which repository it applies:

```
{
    "bitbucket-token": {
        "{workspace-name}/{repository-name}" : "{repository access token}"
    }
}
```

## Implementation

A few comments on the implementation. The authentication on the API with the bearer token is straightforward. Unfortunately, this does not affect the git authentication and that had to be updated to use the token in the git command as described in the [Bitbucket documentation](https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens#Include-the-Repository-Access-Token-in-the-URL). 

The authentication for the zip file that composer wants to download (dist) is not supported with access token. To avoid ugly warnings for the users, I added a check that returns null for the dist data. This way, composer will not try to download the dist and directly falls back to the git clone approach.

## Conclusion

This is my first PR for composer. So please let me know if I missed anything or if you have any concerns about this change. Thank you!
