### PR TITLE
docs: add binary dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ PHP versions 5.3.2 - 8.1 are still supported via the LTS releases of Composer (2
 run the installer or the `self-update` command the appropriate Composer version for your PHP
 should be automatically selected.
 
+#### Binary dependencies
+
+- `7z` (or `7zz`)
+- `gzip`
+- `tar`
+- `unrar`
+- `unzip`
+- `xz`
+- Fossil (`fossil`)
+- Git (`git`)
+- Mercurial (`hg`)
+- Perforce (`p4`)
+- Subversion (`svn`)
+- (optional) `hhvm`
+
 Authors
 -------
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ should be automatically selected.
 - Subversion (`svn`)
 - (optional) `hhvm`
 
+It's important to note that the need for these binary dependencies may vary
+depending on individual use cases. However, for most users, only 3 dependencies
+are essential for Composer: `7z` (or `7zz`), `unzip`, and `git`.
+
 Authors
 -------
 

--- a/README.md
+++ b/README.md
@@ -53,21 +53,20 @@ should be automatically selected.
 #### Binary dependencies
 
 - `7z` (or `7zz`)
+- `unzip` (if `7z` is missing)
 - `gzip`
 - `tar`
 - `unrar`
-- `unzip`
 - `xz`
-- Fossil (`fossil`)
 - Git (`git`)
 - Mercurial (`hg`)
+- Fossil (`fossil`)
 - Perforce (`p4`)
 - Subversion (`svn`)
-- (optional) `hhvm`
 
 It's important to note that the need for these binary dependencies may vary
-depending on individual use cases. However, for most users, only 3 dependencies
-are essential for Composer: `7z` (or `7zz`), `unzip`, and `git`.
+depending on individual use cases. However, for most users, only 2 dependencies
+are essential for Composer: `7z` (or `7zz` or `unzip`), and `git`.
 
 Authors
 -------

--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -39,8 +39,14 @@ a legacy PHP version. A few sensitive php settings and compile flags are also
 required, but when using the installer you will be warned about any
 incompatibilities.
 
-To install packages from sources instead of plain zip archives, you will need
-git, svn, fossil or hg depending on how the package is version-controlled.
+Composer needs several supporting applications to work effectively, making the
+process of handling package dependencies more efficient. For decompressing
+files, Composer relies on tools like `7z` (or `7zz`), `gzip`, `tar`, `unrar`,
+`unzip` and `xz`. As for version control systems, Composer integrates seamlessly
+with Fossil, Git, Mercurial, Perforce and Subversion, thereby ensuring the
+application's smooth operation and management of library repositories. Before
+using Composer, ensure that these dependencies are correctly installed on your
+system.
 
 Composer is multi-platform and we strive to make it run equally well on Windows,
 Linux and macOS.


### PR DESCRIPTION
Hi !

I'm currently working on improving the integration of Composer within the Nix ecosystem. I was looking for the dependencies it requires and I noted that it lacks a list of binary dependencies required for Composer to function optimally.

To bridge this gap, I created this pull request. It delineates the requisite input dependencies essential for Composer's operation. My primary aim is to provide users with a clear list, allowing them to pre-install these necessary dependencies, thereby facilitating a more efficient packaging and use of Composer.

To identify these dependencies, I examined the source code, specifically the strings `->execute(` and `->find(`.

I look forward to your feedback on this, let me know if I forgot anything.