### PR TITLE
Fix outdated package name regex pattern in documentation

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -35,7 +35,7 @@ separated by `/`. Examples:
 * igorw/event-source
 
 The name must be lowercase and consist of words separated by `-`, `.` or `_`.
-The complete name should match `^[a-z0-9]([_.-]?[a-z0-9]+)*\/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$`.
+The complete name should match `^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$`.
 
 The `name` property is required for published packages (libraries).
 

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -35,7 +35,7 @@ separated by `/`. Examples:
 * igorw/event-source
 
 The name must be lowercase and consist of words separated by `-`, `.` or `_`.
-The complete name should match `^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$`.
+The complete name should match `^[a-z0-9]([_.-]?[a-z0-9]+)*\/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$`.
 
 The `name` property is required for published packages (libraries).
 


### PR DESCRIPTION
The regular expression used to validate the package name in the `composer.json` as specified in https://getcomposer.org/schema.json differs from the example given in the documentation.

This PR seeks to update the documentation against the current pattern:

## schema.json
```json
"name": {
    "type": "string",
    "description": "Package name, including 'vendor-name/' prefix.",
    "pattern": "^[a-z0-9]([_.-]?[a-z0-9]+)*\/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$"
},
```