### PR TITLE
Fix 'composer show --platform <package>' erroring without composer.json

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -811,7 +811,7 @@ EOT
         $io->write('<info>homepage</info> : ' . $package->getHomepage());
         $io->write('<info>source</info>   : ' . sprintf('[%s] <comment>%s</comment> %s', $package->getSourceType(), $package->getSourceUrl(), $package->getSourceReference()));
         $io->write('<info>dist</info>     : ' . sprintf('[%s] <comment>%s</comment> %s', $package->getDistType(), $package->getDistUrl(), $package->getDistReference()));
-        if ($installedRepo->hasPackage($package)) {
+        if (!PlatformRepository::isPlatformPackage($package->getName()) && $installedRepo->hasPackage($package)) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
             if (is_string($path)) {
                 $io->write('<info>path</info>     : ' . realpath($path));
@@ -972,7 +972,7 @@ EOT
             ];
         }
 
-        if ($installedRepo->hasPackage($package)) {
+        if (!PlatformRepository::isPlatformPackage($package->getName()) && $installedRepo->hasPackage($package)) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
             if (is_string($path)) {
                 $path = realpath($path);

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -288,12 +288,19 @@ vendor/package 1.1.0 <highlight>! 1.2.0</highlight>", trim($appTester->getDispla
         unlink('./composer.json');
         unlink('./auth.json');
 
+        // listing packages
         $appTester = $this->getApplicationTester();
         $appTester->run(['command' => 'show', '-p' => true]);
         $output = trim($appTester->getDisplay(true));
         foreach (Regex::matchAll('{^(\w+)}m', $output)->matches as $m) {
             self::assertTrue(PlatformRepository::isPlatformPackage((string) $m[1]));
         }
+
+        // getting a single package
+        $appTester->run(['command' => 'show', '-p' => true, 'package' => 'php']);
+        $appTester->assertCommandIsSuccessful();
+        $appTester->run(['command' => 'show', '-p' => true, '-f' => 'json', 'package' => 'php']);
+        $appTester->assertCommandIsSuccessful();
     }
 
     public function testOutdatedWithZeroMajor(): void


### PR DESCRIPTION
Sort of related to #11046 (although this is not a regression, but didn't work before, either)

This now skips output of the `path` field entirely (it previously was always empty)... fine IMO, since this could happen previously (e.g. if `realpath()` failed in case of JSON output), and the path has always been `null` anyway for platform packages.

Also think this should maybe get backported to 2.2? Would you like me to rebase on top of that branch instead of `main`? Or should I target 2.5?