### PR TITLE
curl: Retry download if error 55 is encountered

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -357,6 +357,13 @@ class CurlDownloader
                         continue;
                     }
 
+                    // TODO: Remove this as soon as https://github.com/curl/curl/issues/10591 is resolved
+                    if ($errno === 55 /* CURLE_SEND_ERROR */) {
+                        $this->io->writeError('Retrying ('.($job['attributes']['retries'] + 1).') ' . Url::sanitize($job['url']) . ' due to curl error '. $errno, true, IOInterface::DEBUG);
+                        $this->restartJobWithDelay($job, $job['url'], ['retries' => $job['attributes']['retries'] + 1]);
+                        continue;
+                    }
+
                     if ($errno === 28 /* CURLE_OPERATION_TIMEDOUT */ && PHP_VERSION_ID >= 70300 && $progress['namelookup_time'] === 0.0 && !$timeoutWarning) {
                         $timeoutWarning = true;
                         $this->io->writeError('<warning>A connection timeout was encountered. If you intend to run Composer without connecting to the internet, run the command again prefixed with COMPOSER_DISABLE_NETWORK=1 to make Composer run in offline mode.</warning>');


### PR DESCRIPTION
With the latest curl release I sometimes encounter the following error:

> curl error 55 while downloading [PACKAGE_JSON_URL]: Failed sending data to the peer

This seems to happen because of a curl issue with HTTP/2: https://github.com/curl/curl/issues/10591

In order to work around this issue I tried two things and noticed they both worked equally as well:
1. Retry the download job and downgrade to HTTP/1.1
2. Retry the download job, but don't change the HTTP version

This PR adds a new check for for curl error 55 and restarts the download job if it was encountered, so composer doesn't error and finish the update/install command as expected.
I added a separate if-statement for that, since this can be removed again, once the curl issue is resolved.

Let me know what you think about this! This is my first PR to composer, so I'm not sure if this counts as a "bug fix", but I'm targeting 2.5, since that's where I encountered the issue the first time.