### PR TITLE
Tests for base dependency command

### DIFF
--- a/tests/Composer/Test/Command/BaseDependencyCommandTest.php
+++ b/tests/Composer/Test/Command/BaseDependencyCommandTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Composer\Test\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Composer\Test\TestCase;
+use RuntimeException;
+use Generator;
+
+/**
+ * @covers \Composer\Command\BaseDependencyCommand
+ * @covers \Composer\Command\DependsCommand
+ * @covers \Composer\Command\ProhibitsCommand
+ */
+class BaseDependencyCommandTest extends TestCase
+{
+    /**
+     * Test that SUT will throw an exception when there were not provided some parameters
+     *
+     * @dataProvider noParametersCaseProvider
+     *
+     * @param string $command
+     * @param array<mixed> $parameters
+     * @param string $expectedExceptionMessage
+     *
+     */
+    public function testExceptionWhenNoRequiredParameters(
+        string $command,
+        array $parameters,
+        string $expectedExceptionMessage
+    ): void {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $appTester = $this->getApplicationTester();
+        $this->assertEquals(Command::FAILURE, $appTester->run(['command' => $command] + $parameters));
+    }
+
+    /**
+     * @return Generator [$command, $parameters, $expectedExceptionMessage]
+     */
+    public function noParametersCaseProvider(): Generator
+    {
+        yield '`why` without package parameter' => [
+            'why',
+            [],
+            'Not enough arguments (missing: "package").'
+        ];
+
+        yield '`why-not` without package and version parameters' => [
+            'why-not',
+            [],
+            'Not enough arguments (missing: "package, version").'
+        ];
+
+        yield '`why-not` without package parameter' => [
+            'why-not',
+            ['version' => '*'],
+            'Not enough arguments (missing: "package").'
+        ];
+
+        yield '`why-not` without version parameter' => [
+            'why-not',
+            ['package' => 'vendor1/package1'],
+            'Not enough arguments (missing: "version").'
+        ];
+    }
+}

--- a/tests/Composer/Test/Command/BaseDependencyCommandTest.php
+++ b/tests/Composer/Test/Command/BaseDependencyCommandTest.php
@@ -14,6 +14,7 @@
 namespace Composer\Test\Command;
 
 use Symfony\Component\Console\Command\Command;
+use UnexpectedValueException;
 use Composer\Test\TestCase;
 use RuntimeException;
 use Generator;
@@ -52,28 +53,69 @@ class BaseDependencyCommandTest extends TestCase
      */
     public function noParametersCaseProvider(): Generator
     {
-        yield '`why` without package parameter' => [
+        yield '`why` command without package parameter' => [
             'why',
             [],
             'Not enough arguments (missing: "package").'
         ];
 
-        yield '`why-not` without package and version parameters' => [
+        yield '`why-not` command without package and version parameters' => [
             'why-not',
             [],
             'Not enough arguments (missing: "package, version").'
         ];
 
-        yield '`why-not` without package parameter' => [
+        yield '`why-not` command without package parameter' => [
             'why-not',
             ['version' => '*'],
             'Not enough arguments (missing: "package").'
         ];
 
-        yield '`why-not` without version parameter' => [
+        yield '`why-not` command without version parameter' => [
             'why-not',
             ['package' => 'vendor1/package1'],
             'Not enough arguments (missing: "version").'
+        ];
+    }
+
+    /**
+     * Test that SUT will throw an exception when there is not a provided locked file alongside `--locked` parameter
+     *
+     * @dataProvider noLockedFileCaseProvider
+     *
+     * @param string $command
+     * @param array<mixed> $parameters
+     */
+    public function testExceptionWhenRunningLockedWithoutLockFile(string $command, array $parameters): void
+    {
+        $this->initTempComposer();
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('A valid composer.lock file is required to run this command with --locked');
+
+        $appTester = $this->getApplicationTester();
+        $this->assertEquals(
+            Command::FAILURE,
+            $appTester->run(['command' => $command] + $parameters + ['--locked' => true]
+            )
+        );
+    }
+
+    /**
+     * @return Generator [$command, $parameters]
+     */
+    public function noLockedFileCaseProvider(): Generator
+    {
+        yield '`why` command without locked filename' => [
+            'why',
+            ['package' => 'vendor1/package1'],
+            'Not enough arguments (missing: "package").'
+        ];
+
+        yield '`why-not` command without locked filename' => [
+            'why-not',
+            ['package' => 'vendor1/package1', 'version' => '1.*'],
+            'Not enough arguments (missing: "package").'
         ];
     }
 }

--- a/tests/Composer/Test/Command/BaseDependencyCommandTest.php
+++ b/tests/Composer/Test/Command/BaseDependencyCommandTest.php
@@ -25,7 +25,7 @@ use Generator;
 class BaseDependencyCommandTest extends TestCase
 {
     /**
-     * Test that SUT will throw an exception when there were not provided some parameters
+     * Test that an exception is throw when there weren't provided some parameters
      *
      * @covers       \Composer\Command\BaseDependencyCommand
      * @covers       \Composer\Command\DependsCommand
@@ -33,10 +33,7 @@ class BaseDependencyCommandTest extends TestCase
      *
      * @dataProvider noParametersCaseProvider
      *
-     * @param string $command
-     * @param array<mixed> $parameters
-     * @param string $expectedExceptionMessage
-     *
+     * @param array<string, string> $parameters
      */
     public function testExceptionWhenNoRequiredParameters(
         string $command,
@@ -51,9 +48,9 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * @return Generator<string, array<string|string[]>> [string $command, array $parameters, array $expectedExceptionMessage]
+     * @return Generator<string, array{string, array<string, string>, string}>
      */
-    public function noParametersCaseProvider(): Generator
+    public static function noParametersCaseProvider(): Generator
     {
         yield '`why` command without package parameter' => [
             'why',
@@ -81,7 +78,7 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * Test that SUT will throw an exception when there is not a provided locked file alongside `--locked` parameter
+     * Test that an exception is throw when there wasn't provided the locked file alongside `--locked` parameter
      *
      * @covers       \Composer\Command\BaseDependencyCommand
      * @covers       \Composer\Command\DependsCommand
@@ -89,8 +86,7 @@ class BaseDependencyCommandTest extends TestCase
      *
      * @dataProvider caseProvider
      *
-     * @param string $command
-     * @param array<mixed> $parameters
+     * @param array<string, string> $parameters
      */
     public function testExceptionWhenRunningLockedWithoutLockFile(string $command, array $parameters): void
     {
@@ -108,7 +104,7 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * Test that SUT will throw an exception when the provided package to be inspected is not required by the project
+     * Test that an exception is throw when the provided package to be inspected isn't required by the project
      *
      * @covers       \Composer\Command\BaseDependencyCommand
      * @covers       \Composer\Command\DependsCommand
@@ -116,8 +112,7 @@ class BaseDependencyCommandTest extends TestCase
      *
      * @dataProvider caseProvider
      *
-     * @param string $command
-     * @param array<mixed> $parameters
+     * @param array<string, string> $parameters
      */
     public function testExceptionWhenItCouldNotFoundThePackage(string $command, array $parameters): void
     {
@@ -136,7 +131,7 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * Test that SUT should show a warning message when the package to be inspected was not found in the project
+     * Test that it shows a warning message when the package to be inspected wasn't found in the project
      *
      * @covers       \Composer\Command\BaseDependencyCommand
      * @covers       \Composer\Command\DependsCommand
@@ -144,8 +139,7 @@ class BaseDependencyCommandTest extends TestCase
      *
      * @dataProvider caseProvider
      *
-     * @param string $command
-     * @param array<mixed> $parameters
+     * @param array<string, string> $parameters
      */
     public function testExceptionWhenPackageWasNotFoundInProject(string $command, array $parameters): void
     {
@@ -173,7 +167,7 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * Test that SUT should show a warning message when dependencies have not been installed yet
+     * Test that it shows a warning message when the dependencies haven't been installed yet
      *
      * @covers       \Composer\Command\BaseDependencyCommand
      * @covers       \Composer\Command\DependsCommand
@@ -181,8 +175,7 @@ class BaseDependencyCommandTest extends TestCase
      *
      * @dataProvider caseProvider
      *
-     * @param string $command
-     * @param array<mixed> $parameters
+     * @param array<string, string> $parameters
      */
     public function testWarningWhenDependenciesAreNotInstalled(string $command, array $parameters): void
     {
@@ -209,9 +202,9 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * @return Generator<string, array<string|string[]>> [string $command, array $parameters]
+     * @return Generator<string, array{string, array<string, string>}>
      */
-    public function caseProvider(): Generator
+    public static function caseProvider(): Generator
     {
         yield '`why` command' => [
             'why',
@@ -225,15 +218,14 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * Test that SUT should finish successfully and show some outputs depending on different command parameters
+     * Test that it finishes successfully and show some expected outputs depending on different command parameters
      *
      * @covers       \Composer\Command\BaseDependencyCommand
      * @covers       \Composer\Command\DependsCommand
      *
      * @dataProvider caseWhyProvider
      *
-     * @param array<mixed> $parameters
-     * @param string $expectedOutput
+     * @param array<string, string|bool> $parameters
      */
     public function testWhyCommandOutputs(array $parameters, string $expectedOutput): void
     {
@@ -307,9 +299,9 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * @return Generator<string, array<string[]|bool[]|string>> [array $parameters, string $expectedMessages]
+     * @return Generator<string, array{array<string, string|bool>, string}>
      */
-    public function caseWhyProvider(): Generator
+    public static function caseWhyProvider(): Generator
     {
         yield 'there is no installed package depending on the package' => [
             ['package' => 'vendor1/package1'],
@@ -352,15 +344,14 @@ OUTPUT
     }
 
     /**
-     * Test that SUT should finish successfully and show some outputs depending on different command parameters
+     * Test that it finishes successfully and show some expected outputs depending on different command parameters
      *
      * @covers       \Composer\Command\BaseDependencyCommand
      * @covers       \Composer\Command\ProhibitsCommand
      *
      * @dataProvider caseWhyNotProvider
      *
-     * @param array<mixed> $parameters
-     * @param string $expectedOutput
+     * @param array<string, string> $parameters
      */
     public function testWhyNotCommandOutputs(array $parameters, string $expectedOutput): void
     {
@@ -403,7 +394,7 @@ OUTPUT
     }
 
     /**
-     * @return Generator<string, array<string[]|string>> [array $parameters, string $expectedMessages]
+     * @return Generator<string, array{array<string, string>, string}>
      */
     public function caseWhyNotProvider(): Generator
     {

--- a/tests/Composer/Test/Command/BaseDependencyCommandTest.php
+++ b/tests/Composer/Test/Command/BaseDependencyCommandTest.php
@@ -15,6 +15,7 @@ namespace Composer\Test\Command;
 
 use Symfony\Component\Console\Command\Command;
 use UnexpectedValueException;
+use InvalidArgumentException;
 use Composer\Test\TestCase;
 use RuntimeException;
 use Generator;
@@ -102,16 +103,40 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
+     * Test that SUT will throw an exception when the provided package to be inspected is not required by the project
+     *
+     * @dataProvider caseProvider
+     *
+     * @param string $command
+     * @param array<mixed> $parameters
+     */
+    public function testExceptionWhenItCouldNotFoundThePackage(string $command, array $parameters): void
+    {
+        $packageToBeInspected = $parameters['package'];
+
+        $this->initTempComposer();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Could not find package "%s" in your project', $packageToBeInspected));
+
+        $appTester = $this->getApplicationTester();
+        $this->assertEquals(
+            Command::FAILURE,
+            $appTester->run(['command' => $command] + $parameters)
+        );
+    }
+
+    /**
      * @return Generator [$command, $parameters]
      */
     public function caseProvider(): Generator
     {
-        yield '`why` command without locked filename' => [
+        yield '`why` command' => [
             'why',
             ['package' => 'vendor1/package1']
         ];
 
-        yield '`why-not` command without locked filename' => [
+        yield '`why-not` command' => [
             'why-not',
             ['package' => 'vendor1/package1', 'version' => '1.*']
         ];

--- a/tests/Composer/Test/Command/BaseDependencyCommandTest.php
+++ b/tests/Composer/Test/Command/BaseDependencyCommandTest.php
@@ -136,7 +136,6 @@ class BaseDependencyCommandTest extends TestCase
      */
     public function testWarningWhenDependenciesAreNotInstalled(string $command, array $parameters): void
     {
-        $packageToBeInspected = $parameters['package'];
         $expectedWarningMessage = <<<OUTPUT
 <warning>No dependencies installed. Try running composer install or update, or use --locked.</warning>
 OUTPUT;
@@ -156,11 +155,7 @@ OUTPUT;
         $this->createComposerLock([$someRequiredPackage], [$someRequiredDevPackage]);
 
         $appTester = $this->getApplicationTester();
-        $appTester->run([
-                'command' => 'depends',
-                'package' => $packageToBeInspected
-            ]
-        );
+        $appTester->run(['command' => $command] + $parameters);
 
         $this->assertSame($expectedWarningMessage, trim($appTester->getDisplay(true)));
     }

--- a/tests/Composer/Test/Command/BaseDependencyCommandTest.php
+++ b/tests/Composer/Test/Command/BaseDependencyCommandTest.php
@@ -186,9 +186,7 @@ class BaseDependencyCommandTest extends TestCase
      */
     public function testWarningWhenDependenciesAreNotInstalled(string $command, array $parameters): void
     {
-        $expectedWarningMessage = <<<OUTPUT
-<warning>No dependencies installed. Try running composer install or update, or use --locked.</warning>
-OUTPUT;
+        $expectedWarningMessage = '<warning>No dependencies installed. Try running composer install or update, or use --locked.</warning>';
 
         $this->initTempComposer([
             'require' => [
@@ -259,7 +257,7 @@ OUTPUT;
             ]
         ]);
 
-        $firstRequiredPackage = self::getPackage('vendor1/package1','1.3.0');
+        $firstRequiredPackage = self::getPackage('vendor1/package1', '1.3.0');
         $firstRequiredPackage->setRequires([
             'vendor1/package2' => new Link(
                 'vendor1/package1',
@@ -370,26 +368,18 @@ OUTPUT;
         yield 'it could not found the package with a specific version' => [
             ['package' => 'vendor1/package1', 'version' => '3.*'],
             [
-                <<<OUTPUT
-Package "vendor1/package1" could not be found with constraint "3.*", results below will most likely be incomplete.
-OUTPUT,
+                'Package "vendor1/package1" could not be found with constraint "3.*", results below will most likely be incomplete.',
                 '__root__ - requires vendor1/package1 (1.*) ',
-                <<<OUTPUT
-Not finding what you were looking for? Try calling `composer update "vendor1/package1:3.*" --dry-run` to get another view on the problem.
-OUTPUT
+                'Not finding what you were looking for? Try calling `composer update "vendor1/package1:3.*" --dry-run` to get another view on the problem.'
             ]
         ];
 
         yield 'it could not found the package and there is no installed package with a specific version' => [
             ['package' => 'vendor1/package1', 'version' => '^1.4'],
             [
-                <<<OUTPUT
-Package "vendor1/package1" could not be found with constraint "^1.4", results below will most likely be incomplete.
-OUTPUT,
+                'Package "vendor1/package1" could not be found with constraint "^1.4", results below will most likely be incomplete.',
                 'There is no installed package depending on "vendor1/package1" in versions not matching ^1.4',
-                <<<OUTPUT
-Not finding what you were looking for? Try calling `composer update "vendor1/package1:^1.4" --dry-run` to get another view on the problem.
-OUTPUT
+                'Not finding what you were looking for? Try calling `composer update "vendor1/package1:^1.4" --dry-run` to get another view on the problem.'
             ]
         ];
 
@@ -397,9 +387,7 @@ OUTPUT
             ['package' => 'vendor1/package1', 'version' => '^1.3'],
             [
                 'There is no installed package depending on "vendor1/package1" in versions not matching ^1.3',
-                <<<OUTPUT
-Not finding what you were looking for? Try calling `composer update "vendor1/package1:^1.3" --dry-run` to get another view on the problem.
-OUTPUT
+                'Not finding what you were looking for? Try calling `composer update "vendor1/package1:^1.3" --dry-run` to get another view on the problem.'
             ]
         ];
     }

--- a/tests/Composer/Test/Command/BaseDependencyCommandTest.php
+++ b/tests/Composer/Test/Command/BaseDependencyCommandTest.php
@@ -81,7 +81,7 @@ class BaseDependencyCommandTest extends TestCase
     /**
      * Test that SUT will throw an exception when there is not a provided locked file alongside `--locked` parameter
      *
-     * @dataProvider noLockedFileCaseProvider
+     * @dataProvider caseProvider
      *
      * @param string $command
      * @param array<mixed> $parameters
@@ -104,18 +104,16 @@ class BaseDependencyCommandTest extends TestCase
     /**
      * @return Generator [$command, $parameters]
      */
-    public function noLockedFileCaseProvider(): Generator
+    public function caseProvider(): Generator
     {
         yield '`why` command without locked filename' => [
             'why',
-            ['package' => 'vendor1/package1'],
-            'Not enough arguments (missing: "package").'
+            ['package' => 'vendor1/package1']
         ];
 
         yield '`why-not` command without locked filename' => [
             'why-not',
-            ['package' => 'vendor1/package1', 'version' => '1.*'],
-            'Not enough arguments (missing: "package").'
+            ['package' => 'vendor1/package1', 'version' => '1.*']
         ];
     }
 }

--- a/tests/Composer/Test/Command/BaseDependencyCommandTest.php
+++ b/tests/Composer/Test/Command/BaseDependencyCommandTest.php
@@ -259,7 +259,7 @@ OUTPUT;
             ]
         ]);
 
-        $firstRequiredPackage = self::getPackage('vendor1/package1');
+        $firstRequiredPackage = self::getPackage('vendor1/package1','1.3.0');
         $firstRequiredPackage->setRequires([
             'vendor1/package2' => new Link(
                 'vendor1/package1',
@@ -269,7 +269,7 @@ OUTPUT;
                 '^2'
             )
         ]);
-        $secondRequiredPackage = self::getPackage('vendor1/package2', '1.1.0');
+        $secondRequiredPackage = self::getPackage('vendor1/package2', '2.3.0');
         $someDevRequiredPackage = self::getPackage('vendor2/package1');
         $this->createComposerLock([$firstRequiredPackage, $secondRequiredPackage], [$someDevRequiredPackage]);
         $this->createInstalledJson([$firstRequiredPackage, $secondRequiredPackage], [$someDevRequiredPackage]);
@@ -300,7 +300,7 @@ OUTPUT;
             ['package' => 'vendor1/package2'],
             [
                 '__root__         -     requires vendor1/package2 (2.0.1) ',
-                'vendor1/package1 1.0.0 requires vendor1/package2 (^2)'
+                'vendor1/package1 1.3.0 requires vendor1/package2 (^2)'
             ]
         ];
 
@@ -346,8 +346,8 @@ OUTPUT;
             ]
         ]);
 
-        $someRequiredPackage = self::getPackage('vendor1/package1');
-        $someDevRequiredPackage = self::getPackage('vendor2/package1');
+        $someRequiredPackage = self::getPackage('vendor1/package1', '1.3.0');
+        $someDevRequiredPackage = self::getPackage('vendor2/package1', '1.0.0');
         $this->createComposerLock([$someRequiredPackage], [$someDevRequiredPackage]);
         $this->createInstalledJson([$someRequiredPackage], [$someDevRequiredPackage]);
 

--- a/tests/Composer/Test/Command/BaseDependencyCommandTest.php
+++ b/tests/Composer/Test/Command/BaseDependencyCommandTest.php
@@ -17,6 +17,7 @@ use Composer\Semver\Constraint\MatchAllConstraint;
 use Symfony\Component\Console\Command\Command;
 use UnexpectedValueException;
 use InvalidArgumentException;
+use Composer\Util\Platform;
 use Composer\Test\TestCase;
 use Composer\Package\Link;
 use RuntimeException;
@@ -51,7 +52,7 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * @return Generator [$command, $parameters, $expectedExceptionMessage]
+     * @return Generator<string, array<string|string[]>> [string $command, array $parameters, array $expectedExceptionMessage]
      */
     public function noParametersCaseProvider(): Generator
     {
@@ -136,7 +137,7 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * Test that SUT should show a warning message when the provided package was not found in the project
+     * Test that SUT should show a warning message when the package to be inspected was not found in the project
      *
      * @covers       \Composer\Command\BaseDependencyCommand
      * @covers       \Composer\Command\DependsCommand
@@ -209,7 +210,7 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * @return Generator [$command, $parameters]
+     * @return Generator<string, array<string|string[]>> [string $command, array $parameters]
      */
     public function caseProvider(): Generator
     {
@@ -225,7 +226,7 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * Test that SUT should finish successfully and show some outputs depending different command parameters
+     * Test that SUT should finish successfully and show some outputs depending on different command parameters
      *
      * @covers       \Composer\Command\BaseDependencyCommand
      * @covers       \Composer\Command\DependsCommand
@@ -279,11 +280,14 @@ class BaseDependencyCommandTest extends TestCase
         ]);
 
         $appTester->assertCommandIsSuccessful();
-        $this->assertSame(implode(PHP_EOL, $expectedMessages), trim($appTester->getDisplay(true)));
+
+        $expectedOutput = implode(Platform::isWindows() ? "\r\n" : PHP_EOL, $expectedMessages);
+        $actualOutput = trim($appTester->getDisplay(true));
+        $this->assertSame($expectedOutput, $actualOutput);
     }
 
     /**
-     * @return Generator [$parameters, $expectedMessages]
+     * @return Generator<string, array<string[]>> [array $parameters, array $expectedMessages]
      */
     public function caseWhyProvider(): Generator
     {
@@ -294,7 +298,7 @@ class BaseDependencyCommandTest extends TestCase
             ]
         ];
 
-        yield 'a simple package dependency' => [
+        yield 'a nested package dependency' => [
             ['package' => 'vendor1/package2'],
             [
                 '__root__         -     requires vendor1/package2 (2.0.1) ',
@@ -311,7 +315,7 @@ class BaseDependencyCommandTest extends TestCase
     }
 
     /**
-     * Test that SUT should finish successfully and show some outputs depending different command parameters
+     * Test that SUT should finish successfully and show some outputs depending on different command parameters
      *
      * @covers       \Composer\Command\BaseDependencyCommand
      * @covers       \Composer\Command\ProhibitsCommand
@@ -357,11 +361,14 @@ class BaseDependencyCommandTest extends TestCase
         ]);
 
         $appTester->assertCommandIsSuccessful();
-        $this->assertSame(implode(PHP_EOL, $expectedMessages), trim($appTester->getDisplay(true)));
+
+        $expectedOutput = implode(Platform::isWindows() ? "\r\n" : PHP_EOL, $expectedMessages);
+        $actualOutput = trim($appTester->getDisplay(true));
+        $this->assertSame($expectedOutput, $actualOutput);
     }
 
     /**
-     * @return Generator [$parameters, $expectedMessages]
+     * @return Generator<string, array<string[]>> [array $parameters, array $expectedMessages]
      */
     public function caseWhyNotProvider(): Generator
     {


### PR DESCRIPTION
This PR adds test cases for `why` and `why-not` as mentioned in #10796

- It adds 20 test cases (now from 198 to 218)
- It increases the test coverage for `BaseDependencyCommand` from 0% to 97%
- It adds full coverage to the `DependsCommand` command (`why` command)
- It adds full coverage to the `ProhibitsCommand` command (`why-not` command)
- It adds poor coverage to `CompletionTrait`, maybe it could be addressed in other PR

Thanks in advantage for your feedback.
