### PR TITLE
Fix broken junctions leads to installation failure

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -814,9 +814,10 @@ class Filesystem
         if (!is_dir($target)) {
             throw new IOException(sprintf('Cannot junction to "%s" as it is not a directory.', $target), 0, null, $target);
         }
-        //fix Cannot create a file when that file already exists.
-        if ($this->isJunction($junction)){
-            $this->removeJunction($junction);
+
+        // Removing any previously to ensure clean execution.
+        if (!is_dir($junction) or $this->isJunction($junction)) {
+            @rmdir($junction);
         }
 
         $cmd = sprintf(

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -815,7 +815,7 @@ class Filesystem
             throw new IOException(sprintf('Cannot junction to "%s" as it is not a directory.', $target), 0, null, $target);
         }
 
-        // Removing any previously to ensure clean execution.
+        // Removing any previously junction to ensure clean execution.
         if (!is_dir($junction) or $this->isJunction($junction)) {
             @rmdir($junction);
         }

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -814,6 +814,11 @@ class Filesystem
         if (!is_dir($target)) {
             throw new IOException(sprintf('Cannot junction to "%s" as it is not a directory.', $target), 0, null, $target);
         }
+        //fix Cannot create a file when that file already exists.
+        if ($this->isJunction($junction)){
+            $this->removeJunction($junction);
+        }
+
         $cmd = sprintf(
             'mklink /J %s %s',
             ProcessExecutor::escape(str_replace('/', DIRECTORY_SEPARATOR, $junction)),

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -816,7 +816,7 @@ class Filesystem
         }
 
         // Removing any previously junction to ensure clean execution.
-        if (!is_dir($junction) or $this->isJunction($junction)) {
+        if (!is_dir($junction) || $this->isJunction($junction)) {
             @rmdir($junction);
         }
 

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\Util;
 
+use Composer\Util\Platform;
 use Composer\Util\Filesystem;
 use Composer\Test\TestCase;
 
@@ -325,6 +326,38 @@ class FilesystemTest extends TestCase
         $this->assertTrue(is_dir($junction), $junction . ' is a directory');
         $this->assertTrue($fs->removeJunction($junction), $junction . ' has been removed');
         $this->assertFalse(is_dir($junction), $junction . ' is not a directory');
+    }
+
+    public function testOverrideJunctions()
+    {
+        if (!Platform::isWindows()) {
+            $this->markTestSkipped('Only runs on windows');
+        }
+
+        @mkdir($this->workingDir.'/real/nesting/testing', 0777, true);
+        $fs = new Filesystem();
+
+        $old_target = $this->workingDir.'/real/nesting/testing';
+        $target = $this->workingDir.'/real/../real/nesting';
+        $junction = $this->workingDir.'/junction';
+
+        // Override non-broken junction
+        $fs->junction($old_target, $junction);
+        $fs->junction($target, $junction);
+
+        $this->assertTrue($fs->isJunction($junction), $junction.': is a junction');
+        $this->assertTrue($fs->isJunction($target.'/../../junction'), $target.'/../../junction: is a junction');
+
+        //Remove junction
+        $this->assertTrue($fs->removeJunction($junction), $junction . ' has been removed');
+
+        // Override broken junction
+        $fs->junction($old_target, $junction);
+        $fs->removeDirectory($old_target);
+        $fs->junction($target, $junction);
+
+        $this->assertTrue($fs->isJunction($junction), $junction.': is a junction');
+        $this->assertTrue($fs->isJunction($target.'/../../junction'), $target.'/../../junction: is a junction');
     }
 
     public function testCopy()


### PR DESCRIPTION
Fixes #11549
Root Cause: When changing the project folder, existing junctions in Windows **(created using absolute paths)** become invalid. The "mklink /J" command used to create junctions results in an error ("Cannot create a file when that file already exists.") if a previous junction with a different target exists, as the junction is stored as an absolute path. This error causes package folders to have junctions with the wrong target directory, leading to [mkdir(): No such file or directory](https://github.com/composer/composer/issues/11549)

Windows Behavior: Windows prohibits creating a new junction if a file or junction with the same name already exists.

Solution: The bug fix ensures a clean execution by removing any previous junctions before creating new ones, regardless of whether they are broken or non-broken junctions. This resolves the installation failure caused by junctioning the package folder with the correct target directory.

Importance: This bug fix is crucial for Windows development environments. Developers may unknowingly encounter this issue when changing folder names or moving projects.