### PR TITLE
GitHubDriver: better handle empty composer.json file

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -310,7 +310,7 @@ class GitHubDriver extends VcsDriver
             $resource = $this->getContents($resource['git_url'])->decodeJson();
         }
 
-        if (empty($resource['content']) || $resource['encoding'] !== 'base64' || !($content = base64_decode($resource['content']))) {
+        if (!isset($resource['content']) || $resource['encoding'] !== 'base64' || false === ($content = base64_decode($resource['content']))) {
             throw new \RuntimeException('Could not retrieve ' . $file . ' for '.$identifier);
         }
 

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -401,6 +401,34 @@ class GitHubDriverTest extends TestCase
         ];
     }
 
+    public function testGetEmptyFileContent(): void
+    {
+        $repoUrl = 'http://github.com/composer/packagist';
+
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $io->expects($this->any())
+            ->method('isInteractive')
+            ->will($this->returnValue(true));
+
+        $httpDownloader = $this->getHttpDownloaderMock($io, $this->config);
+        $httpDownloader->expects(
+            [
+                ['url' => 'https://api.github.com/repos/composer/packagist', 'body' => '{"master_branch": "test_master", "owner": {"login": "composer"}, "name": "packagist", "archived": true}'],
+                ['url' => 'https://api.github.com/repos/composer/packagist/contents/composer.json?ref=main', 'body' => '{"encoding":"base64","content":""}'],
+            ],
+            true
+        );
+
+        $repoConfig = [
+            'url' => $repoUrl,
+        ];
+
+        $gitHubDriver = new GitHubDriver($repoConfig, $io, $this->config, $httpDownloader, $this->getProcessExecutorMock());
+        $gitHubDriver->initialize();
+
+        $this->assertSame('', $gitHubDriver->getFileContent('composer.json', 'main'));
+    }
+
     /**
      * @param string|object $object
      * @param mixed         $value


### PR DESCRIPTION
Having a GitHub repository with an empty composer.json file in the default branch currently fails with `\RuntimeException('Could not retrieve composer.json for main')`. This PR changes the behavior to match all other VCS drivers, where an empty composer.json file is treated the same as if there were no composer.json file.

Example GitHub response for empty files: https://api.github.com/repos/pcom-test-group/empty-composer-json/contents/composer.json?ref=main