### PR TITLE
Update BinaryInstaller.php

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -401,7 +401,7 @@ if [ -n "\$bashSource" ]; then
     fi
 fi
 
-"\${dir}/$binFile" "\$@"
+sh "\${dir}/$binFile" "\$@"
 
 PROXY;
     }


### PR DESCRIPTION
https://github.com/composer/composer/blob/68b7a07187a62435e514324052d5a649b6662efb/src/Composer/Installer/BinaryInstaller.php#L404C4-L404C4

Change `"\${dir}/$binFile" "\$@"`
To `sh "\${dir}/$binFile" "\$@"`

The file being referenced by `"\${dir}/$binFile" "\$@"` isn't always chmod +x so in situation like running in gitlab-ci workflows, it throwing a Permission Denied error.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
