### PR TITLE
Avoid PHPStan errors after running autoloader tests

### DIFF
--- a/phpstan/config.neon
+++ b/phpstan/config.neon
@@ -15,6 +15,7 @@ parameters:
     excludePaths:
        - '../tests/Composer/Test/Fixtures/*'
        - '../tests/Composer/Test/Autoload/Fixtures/*'
+       - '../tests/Composer/Test/Autoload/MinimumVersionSupport/vendor/'
        - '../tests/Composer/Test/Plugin/Fixtures/*'
        - '../tests/Composer/Test/PolyfillTestCase.php'
 

--- a/tests/Composer/Test/Autoload/MinimumVersionSupport/.gitignore
+++ b/tests/Composer/Test/Autoload/MinimumVersionSupport/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor/


### PR DESCRIPTION
When contributing to this project, I like to run the test suite locally to make sure that I'm not introducing regressions and that my changes are suitably covered by tests. I tend to run functional tests before stylistic checks because I think there's less value in making the code look pretty if it doesn't yet work as expected.

If I run the checks in https://github.com/composer/composer/blob/82bc8cf94e06e388f8917cbde3f0331453216481/.github/workflows/autoloader.yml before those in https://github.com/composer/composer/blob/82bc8cf94e06e388f8917cbde3f0331453216481/.github/workflows/phpstan.yml, I get errors. This pull request makes those errors go away, and tells Git to ignore the files newly created by the autoloader test.