### PR TITLE
Set $_SERVER['SCRIPT_NAME'] within proxy command

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -359,6 +359,11 @@ namespace Composer;
 
 $globalsCode
 $streamProxyCode
+
+if (__FILE__ === realpath(\$_SERVER['SCRIPT_NAME'])) {
+    \$_SERVER['SCRIPT_NAME'] = realpath($binPathExported);
+}
+
 return include $binPathExported;
 
 PROXY;

--- a/tests/Composer/Test/Installer/BinaryInstallerTest.php
+++ b/tests/Composer/Test/Installer/BinaryInstallerTest.php
@@ -112,6 +112,18 @@ EOL
 echo 'success '.$_SERVER['argv'][1];
 EOL
             ],
+            'php file which validates $_SERVER["SCRIPT_NAME"]' => [<<<'EOL'
+<?php
+if (__FILE__ === realpath($_SERVER['SCRIPT_NAME'])) {
+    echo 'success '.$_SERVER['argv'][1];
+} else {
+    fwrite(STDERR, "Test failure: __FILE__ does not match \$_SERVER['SCRIPT_NAME']\n");
+    fwrite(STDERR, "\t__FILE__:\t" . __FILE__ . "\n");
+    fwrite(STDERR, "\t\$_SERVER['SCRIPT_NAME']:\t" . $_SERVER['SCRIPT_NAME'] . "\n");
+    exit(1);
+}
+EOL
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes: https://github.com/composer/composer/issues/11555
Fixes: https://github.com/sebastianbergmann/phpunit/issues/5447

This produces something like the following. This specific example has been taken from the test suite.

```php
if (__FILE__ === realpath($_SERVER['SCRIPT_NAME'])) {
    $_SERVER['SCRIPT_NAME'] = realpath(__DIR__ . '/..'.'/vendor/foo/bar/binary');
}
```