### PR TITLE
Minor Typo CHANGELOG.md 2.5.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
   * Fixed regression in edge cases where root package gets added to a repository already during the install process (#11495)
   * Fixed EventDispatcher on windows picking bat files when using "@php binary" (#11490)
-  * Fixed ICU CDLR version parsing failing the whole process when ICU cannot initialize the resource bundle (#11492)
+  * Fixed ICU CLDR version parsing failing the whole process when ICU cannot initialize the resource bundle (#11492)
   * Fixed type declarations on ClassLoader (#11500)
 
 ### [2.5.7] 2023-05-24


### PR DESCRIPTION
ICU CDLR -> ICU CLDR (issue has correct title).

please squash in where it fits @Seldaek  currently wrong on the website.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
