### PR TITLE
Add tests for `DumpAutoloadCommand`

### DIFF
--- a/tests/Composer/Test/Command/DumpAutoloadCommandTest.php
+++ b/tests/Composer/Test/Command/DumpAutoloadCommandTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Composer\Test\Command;
+
+use Composer\Test\TestCase;
+use InvalidArgumentException;
+
+class DumpAutoloadCommandTest extends TestCase
+{
+    public function testDumpAutoload(): void
+    {
+        $appTester = $this->getApplicationTester();
+        $this->assertSame(0, $appTester->run(['command' => 'dump-autoload']));
+
+        $output = $appTester->getDisplay(true);
+        $this->assertStringContainsString('Generating autoload files', $output);
+        $this->assertStringContainsString('Generated autoload files', $output);
+    }
+
+    public function testDumpDevAutoload(): void
+    {
+        $appTester = $this->getApplicationTester();
+        $this->assertSame(0, $appTester->run(['command' => 'dump-autoload', '--dev' => true]));
+
+        $output = $appTester->getDisplay(true);
+        $this->assertStringContainsString('Generating autoload files', $output);
+        $this->assertStringContainsString('Generated autoload files', $output);
+    }
+
+    public function testDumpNoDevAutoload(): void
+    {
+        $appTester = $this->getApplicationTester();
+        $this->assertSame(0, $appTester->run(['command' => 'dump-autoload', '--dev' => true]));
+
+        $output = $appTester->getDisplay(true);
+        $this->assertStringContainsString('Generating autoload files', $output);
+        $this->assertStringContainsString('Generated autoload files', $output);
+    }
+
+    public function testUsingOptimizeAndStrictPsr(): void
+    {
+        $appTester = $this->getApplicationTester();
+        $this->assertSame(0, $appTester->run(['command' => 'dump-autoload', '--optimize' => true, '--strict-psr' => true]));
+
+        $output = $appTester->getDisplay(true);
+        $this->assertStringContainsString('Generating optimized autoload files', $output);
+        $this->assertMatchesRegularExpression('/Generated optimized autoload files containing \d+ classes/', $output);
+    }
+
+    public function testUsingClassmapAuthoritative(): void
+    {
+        $appTester = $this->getApplicationTester();
+        $this->assertSame(0, $appTester->run(['command' => 'dump-autoload', '--classmap-authoritative' => true]));
+
+        $output = $appTester->getDisplay(true);
+        $this->assertStringContainsString('Generating optimized autoload files (authoritative)', $output);
+        $this->assertMatchesRegularExpression('/Generated optimized autoload files \(authoritative\) containing \d+ classes/', $output);
+    }
+
+    public function testStrictPsrDoesNotWorkWithoutOptimizedAutoloader(): void
+    {
+        $appTester = $this->getApplicationTester();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('--strict-psr mode only works with optimized autoloader, use --optimize if you want a strict return value.');
+        $appTester->run(['command' => 'dump-autoload', '--strict-psr' => true]);
+    }
+
+    public function testDevAndNoDevCannotBeCombined(): void
+    {
+        $appTester = $this->getApplicationTester();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You can not use both --no-dev and --dev as they conflict with each other.');
+        $appTester->run(['command' => 'dump-autoload', '--dev' => true, '--no-dev' => true]);
+    }
+}


### PR DESCRIPTION
I might have found a tiny bug in `DumpAutoloadCommand`, but before fixing it I wanted to add tests. I'm not well accustomed to Composer or Command tests in general, so I'm not a 100% sure about the changes here.

Kind of open things:
- Is it a good idea to use the default application / composer.json for this? (e.g. could be faster with a temp composer.json I guess)
- ~~Is it a good idea to hardcode the dumped amount of classes? (e.g. dependency/code changs will break this test) Any better ideas of ensuring that the full output is correct without this, e.g. regex?~~ changed to regex since it was already failing here..
- I don't think I can cover actual PSR violations with `--strict-psr` with such a test, can I? I think I'd need to have a temp composer.json AND temp code? https://github.com/composer/composer/blob/95dca79fc2e18c3a4e33f207c1fcaa7d5b559400/src/Composer/Command/DumpAutoloadCommand.php#L111 is the uncovered line