### PR TITLE
Minor Typo CHANGELOG.md 2.3.0-RC1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,7 +254,7 @@
   * Added abandoned flag to `show`/`outdated` commands JSON-formatted output (#10485)
   * Added config.reference option to `path` repositories to configure the way the reference is generated, and possibly reduce composer.lock conflicts (#10488)
   * Added automatic removal of allow-plugins rules when removing a plugin via the `remove` command (#10615)
-  * Added COMPOSER_IGNORE_PLATFOR_REQ & COMPOSER_IGNORE_PLATFOR_REQS env vars to configure the equivalent flags (#10616)
+  * Added `COMPOSER_IGNORE_PLATFORM_REQ` & `COMPOSER_IGNORE_PLATFORM_REQS` env vars to configure the equivalent flags (#10616)
   * Added support for Symfony 6.0 components
   * Added support for psr/log 3.x (#10454)
   * Fixed symlink creation in linux VM guest filesystems to be recognized by Windows (#10592)


### PR DESCRIPTION
- ..._PLATFOR_... -> ..._PLATFORM_... (missing M)

- Backticks style to streamlined with other environment parameters around.

Please squash in where it fits @Seldaek currently wrong on the website.

(Recently I filed PR #11564 with a different minor correction of the change log.)

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
