### PR TITLE
Fix #11507: phpstan/rules.neon missing from archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,7 @@
 # Exclude non-essential files from dist
 /.github/ export-ignore
 /doc export-ignore
-/phpstan/ export-ignore
+/phpstan/* export-ignore
 /tests/ export-ignore
 /.editorconfig export-ignore
 /.gitattributes export-ignore


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
This fixes #11507 (for real this time 😄 )

#11508 was intended to fix #11507. However, I don't think it worked. If you exclude a directory via .gitattributes, you apparently can't later unexclude a file inside that directory.

The correct fix is to exclude the _contents_ of the directory rather than the directory itself. You can confirm this works locally by checking out this feature branch, running `git archive issue-11507 -o /tmp/composer.tar`, then inspecting the resulting archive to confirm phpstan/rules.neon (and _only_ phpstan/rules.neon) exists.

I was bit by this in https://github.com/acquia/cli/pull/1577 when upgrading to a Composer 2.x-dev release which included the new .gitattributes. Composer's rules.neon suddenly disappeared, producing errors like this:

> Config file /home/runner/work/cli/cli/vendor/composer/composer/phpstan/rules.neon does not exist or isn't readable