### PR TITLE
Gitlab ci job token

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -251,6 +251,9 @@ class AuthHelper
                 if ($auth['password'] === 'oauth2') {
                     $headers[] = 'Authorization: Bearer '.$auth['username'];
                     $authenticationDisplayMessage = 'Using GitLab OAuth token authentication';
+                } elseif ($auth['password'] === 'gitlab-ci-token') {
+                    $headers[] = 'JOB-TOKEN: '.$auth['username'];
+                    $authenticationDisplayMessage = 'Using GitLab CI Job token authentication';
                 } else {
                     $headers[] = 'PRIVATE-TOKEN: '.$auth['username'];
                     $authenticationDisplayMessage = 'Using GitLab private token authentication';


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->

GitLab CI Job token requires the token to be set with the `JOB-TOKEN` header, instead of the `PRIVATE-TOKEN` header