### PR TITLE
allow bumping for patch level version constraints (fixes #11579)

### DIFF
--- a/src/Composer/Package/Version/VersionBumper.php
+++ b/src/Composer/Package/Version/VersionBumper.php
@@ -83,7 +83,7 @@ class VersionBumper
             (?<=,|\ |\||^) # leading separator
             (?P<constraint>
                 \^'.$major.'(?:\.\d+)* # e.g. ^2.anything
-                | ~'.$major.'(?:\.\d+)? # e.g. ~2 or ~2.2 but no more
+                | ~'.$major.'(?:\.\d+){0,2} # e.g. ~2 or ~2.2 or ~2.2.2 but no more
                 | '.$major.'(?:\.[*x])+ # e.g. 2.* or 2.*.* or 2.x.x.x etc
                 | >=\d(?:\.\d+)* # e.g. >=2 or >=1.2 etc
             )
@@ -97,7 +97,9 @@ class VersionBumper
                 if (substr_count($match[0], '.') === 2 && substr_count($versionWithoutSuffix, '.') === 1) {
                     $suffix = '.0';
                 }
-                if (str_starts_with($match[0], '>=')) {
+                if (str_starts_with($match[0], '~') && substr_count($match[0], '.') === 2) {
+                    $replacement = '~'.$versionWithoutSuffix.$suffix;
+                } elseif (str_starts_with($match[0], '>=')) {
                     $replacement = '>='.$versionWithoutSuffix.$suffix;
                 } else {
                     $replacement = $newPrettyConstraint.$suffix;

--- a/tests/Composer/Test/Package/Version/VersionBumperTest.php
+++ b/tests/Composer/Test/Package/Version/VersionBumperTest.php
@@ -63,7 +63,8 @@ class VersionBumperTest extends TestCase
         yield 'leave minor wildcard alone' => ['2.4.*', '2.4.3', '2.4.*'];
         yield 'leave patch wildcard alone' => ['2.4.3.*', '2.4.3.2', '2.4.3.*'];
         yield 'upgrade tilde to caret when compatible' => ['~2.2', '2.4.3', '^2.4.3'];
-        yield 'leave patch-only-tilde alone' => ['~2.2.3', '2.2.6', '~2.2.3'];
+        yield 'update patch-only-tilde alone' => ['~2.2.3', '2.2.6', '~2.2.6'];
+        yield 'leave extra-only-tilde alone' => ['~2.2.3.1', '2.2.4.5', '~2.2.3.1'];
         yield 'upgrade bigger-or-eq to latest' => ['>=3.0', '3.4.5', '>=3.4.5'];
         yield 'leave bigger-than untouched' => ['>2.2.3', '2.2.6', '>2.2.3'];
     }


### PR DESCRIPTION
hi,

i think this is quite a straight forward thing and i think its very benefical to support bumping patch level constraints.
this will enable the mentioned constraint from #11579 to be updated

```json
{
  "require-dev": {
    "phpstan/phpstan": "~1.10.0"
  }
}
```

what do you think?