### PR TITLE
COMPOSER_DISABLE_NETWORK aware `diagnose` checks

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -251,7 +251,7 @@ EOT
      */
     private function checkHttp(string $proto, Config $config)
     {
-        $result = $this->checkConnectivity();
+        $result = $this->checkConnectivityAndComposerNetworkHttpEnablement();
         if ($result !== true) {
             return $result;
         }
@@ -290,7 +290,7 @@ EOT
      */
     private function checkHttpProxy()
     {
-        $result = $this->checkConnectivity();
+        $result = $this->checkConnectivityAndComposerNetworkHttpEnablement();
         if ($result !== true) {
             return $result;
         }
@@ -318,7 +318,7 @@ EOT
      */
     private function checkGithubOauth(string $domain, string $token)
     {
-        $result = $this->checkConnectivity();
+        $result = $this->checkConnectivityAndComposerNetworkHttpEnablement();
         if ($result !== true) {
             return $result;
         }
@@ -348,7 +348,7 @@ EOT
      */
     private function getGithubRateLimit(string $domain, ?string $token = null)
     {
-        $result = $this->checkConnectivity();
+        $result = $this->checkConnectivityAndComposerNetworkHttpEnablement();
         if ($result !== true) {
             return $result;
         }
@@ -419,7 +419,7 @@ EOT
      */
     private function checkVersion(Config $config)
     {
-        $result = $this->checkConnectivity();
+        $result = $this->checkConnectivityAndComposerNetworkHttpEnablement();
         if ($result !== true) {
             return $result;
         }
@@ -733,7 +733,39 @@ EOT
     private function checkConnectivity()
     {
         if (!ini_get('allow_url_fopen')) {
-            return '<info>Skipped because allow_url_fopen is missing.</info>';
+            return '<info>SKIP</> <comment>Because allow_url_fopen is missing.</>';
+        }
+
+        return true;
+    }
+
+    /**
+     * @return string|true
+     */
+    private function checkConnectivityAndComposerNetworkHttpEnablement()
+    {
+        $result = $this->checkConnectivity();
+        if ($result !== true) {
+            return $result;
+        }
+
+        $result = $this->checkComposerNetworkHttpEnablement();
+        if ($result !== true) {
+            return $result;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if Composer network is enabled for HTTP/S
+     *
+     * @return string|true
+     */
+    private function checkComposerNetworkHttpEnablement()
+    {
+        if ((bool) Platform::getEnv('COMPOSER_DISABLE_NETWORK')) {
+            return '<info>SKIP</> <comment>Network is disabled by COMPOSER_DISABLE_NETWORK.</>';
         }
 
         return true;


### PR DESCRIPTION
Make `diagnose` checks aware of COMPOSER_DISABLE_NETWORK (true) and skip Composer network operations that would otherwise spill stack traces into diagnostic messages and taint the result as error while the check itself is not applicable/useful within the environment.

`COMPOSER_DISABLE_NETWORK` was released with [2.0.0-alpha1] and introduced in fc03ab9bb (Add COMPOSER_DISABLE_NETWORK env var for debugging, 2019-01-14).

The previous behaviour was to exit with a status of two (2), denoting an error.

The new behaviour is to exit with a status of zero (0), showing the successful skipping of diagnostics that can only be run when Composer network is enabled - not disabled.

## NOTE: The "prime" Value

It is irrelevant for diagnose checks, as all diagnostic checks that spilled were with the HTTP Downloader and the check is aligned (both "1" or "prime" values disable):

    (bool) Platform::getEnv('COMPOSER_DISABLE_NETWORK')

## NOTE: Not Affected

 * The `allow_url_fopen` diagnostic check, platform related
 * The `disable-tls` setting related HTTP Downloader creation warning

[2.0.0-alpha1]: <https://getcomposer.org/changelog/2.0.0-alpha1> "released 2020-06-03"

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
