### PR TITLE
PHP 8.3 | Tests: fix deprecation notices

### DIFF
--- a/tests/Composer/Test/Downloader/ZipDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ZipDownloaderTest.php
@@ -65,11 +65,7 @@ class ZipDownloaderTest extends TestCase
         $reflectionClass = new \ReflectionClass('Composer\Downloader\ZipDownloader');
         $reflectedProperty = $reflectionClass->getProperty($name);
         $reflectedProperty->setAccessible(true);
-        if ($obj === null) {
-            $reflectedProperty->setValue($value);
-        } else {
-            $reflectedProperty->setValue($obj, $value);
-        }
+        $reflectedProperty->setValue($obj, $value);
     }
 
     public function testErrorMessages(): void

--- a/tests/Composer/Test/InstalledVersionsTest.php
+++ b/tests/Composer/Test/InstalledVersionsTest.php
@@ -33,14 +33,14 @@ class InstalledVersionsTest extends TestCase
         $prop = new \ReflectionProperty('Composer\Autoload\ClassLoader', 'registeredLoaders');
         $prop->setAccessible(true);
         self::$previousRegisteredLoaders = $prop->getValue();
-        $prop->setValue([]);
+        $prop->setValue(null, []);
     }
 
     public static function tearDownAfterClass(): void
     {
         $prop = new \ReflectionProperty('Composer\Autoload\ClassLoader', 'registeredLoaders');
         $prop->setAccessible(true);
-        $prop->setValue(self::$previousRegisteredLoaders);
+        $prop->setValue(null, self::$previousRegisteredLoaders);
         InstalledVersions::reload(null); // @phpstan-ignore-line
     }
 


### PR DESCRIPTION
_Re: branch selection: as Composer 2.2 is marked as an LTS release, by rights, this PR should be pulled to the 2.2 branch, but the 2.2 branch isn't being tested against PHP 8.2, which gives me the impression that the "LTS" is only about Composer native functionality, not about PHP version support._

_Might be a good idea to clarify this somewhere ?_

---



### PHP 8.3 | ZipDownloaderTest: fix deprecation notice

Calling `ReflectionProperty::setValue()` with only one argument (to set a static property) is deprecated.
Passing `null` as the first (`$object`) parameter will work cross-version.

As the `ZipDownloaderTest::setPrivateProperty()` method has a `null` default value for the `$obj` parameter anyway, this means the if/else toggle can be removed.

Ref: https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#reflectionpropertysetvalue

### PHP 8.3 | InstalledVersionsTest: fix deprecation notice

Calling `ReflectionProperty::setValue()` with only one argument (to set a static property) is deprecated.
Passing `null` as the first (`$object`) parameter will work cross-version.

Ref: https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#reflectionpropertysetvalue