### PR TITLE
GH Actions: run against PHP 8.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -63,6 +63,18 @@ jobs:
             dependencies: highest-ignore
             os: ubuntu-latest
             experimental: false
+          - php-version: "8.3"
+            dependencies: locked
+            os: ubuntu-latest
+            experimental: true
+          - php-version: "8.3"
+            dependencies: lowest-ignore
+            os: ubuntu-latest
+            experimental: true
+          - php-version: "8.3"
+            dependencies: highest-ignore
+            os: ubuntu-latest
+            experimental: true
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,6 +31,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         dependencies: [locked]
         os: [ubuntu-latest]
         experimental: [false]
@@ -55,26 +56,14 @@ jobs:
             os: macos-latest
             dependencies: locked
             experimental: false
-          - php-version: "8.2"
-            dependencies: lowest-ignore
-            os: ubuntu-latest
-            experimental: false
-          - php-version: "8.2"
-            dependencies: highest-ignore
-            os: ubuntu-latest
-            experimental: false
-          - php-version: "8.3"
-            dependencies: locked
-            os: ubuntu-latest
-            experimental: true
           - php-version: "8.3"
             dependencies: lowest-ignore
             os: ubuntu-latest
-            experimental: true
+            experimental: false
           - php-version: "8.3"
             dependencies: highest-ignore
             os: ubuntu-latest
-            experimental: true
+            experimental: false
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
         php-version:
           - "7.2"
           - "latest"
+          - "8.3"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,6 @@ jobs:
         php-version:
           - "7.2"
           - "latest"
-          - "8.3"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
_Re: branch selection: as Composer 2.2 is marked as an LTS release, by rights, this PR should be pulled to the 2.2 branch, but the 2.2 branch isn't even being tested against PHP 8.2, which gives me the impression that the "LTS" is only about Composer native functionality, not about PHP version support._

_Might be a good idea to clarify this somewhere ?_

---

### GH Actions: run against PHP 8.3

What with PHP 8.3 being close to the first RC, I'd like to suggest enabling runs against PHP 8.3 for the linting and test runs.

* Linting passes on PHP 8.3, so I propose to not allow new failures to be introduced there.
* The test runs, however, do not pass against PHP 8.3, so I'm marking those as `experimental` for now to allow for fixing the issue(s).

As for the compatibility issues (based on the test runs):
* PR #11599 fixes all known deprecation notices.
* There is, however, one test failure, which I'm not exactly sure how to fix, so I'm leaving this for the maintainers to decide upon.
    Details:
    Prior to PHP 8.3, `ReflectionMethod` could set a `private` method on a parent class to accessible. This is no longer possible in PHP 8.3 since php/php-src#9470 and breaks the `Composer\Test\Repository\ComposerRepositoryTest::testWhatProvides` test.
    Also see: https://3v4l.org/8YcIk/rfc#vgit.master
