### PR TITLE
PHP 8.3 | ComposerRepositoryTest: fix test failure

### DIFF
--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -160,7 +160,7 @@ class ComposerRepositoryTest extends TestCase
                 ],
             ]));
 
-        $reflMethod = new \ReflectionMethod($repo, 'whatProvides');
+        $reflMethod = new \ReflectionMethod(ComposerRepository::class, 'whatProvides');
         $reflMethod->setAccessible(true);
         $packages = $reflMethod->invoke($repo, 'a');
 


### PR DESCRIPTION
Prior to PHP 8.3, `ReflectionMethod` could set a private method on a parent class to accessible. This is no longer possible in PHP 8.3 since php/php-src#9470 and breaks the `Composer\Test\Repository\ComposerRepositoryTest::testWhatProvides` test.
Also see: https://3v4l.org/8YcIk/rfc#vgit.master

Fixed now.
