### PR TITLE
Allow --strict-psr in `DumpAutoloadCommand` also with --classmap-authoritative

### DIFF
--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -70,8 +70,8 @@ EOT
         $apcuPrefix = $input->getOption('apcu-prefix');
         $apcu = $apcuPrefix !== null || $input->getOption('apcu') || $config->get('apcu-autoloader');
 
-        if ($input->getOption('strict-psr') && !$optimize) {
-            throw new \InvalidArgumentException('--strict-psr mode only works with optimized autoloader, use --optimize if you want a strict return value.');
+        if ($input->getOption('strict-psr') && !$optimize && !$authoritative) {
+            throw new \InvalidArgumentException('--strict-psr mode only works with optimized autoloader, use --optimize or --classmap-authoritative if you want a strict return value.');
         }
 
         if ($authoritative) {

--- a/tests/Composer/Test/Command/DumpAutoloadCommandTest.php
+++ b/tests/Composer/Test/Command/DumpAutoloadCommandTest.php
@@ -57,12 +57,22 @@ class DumpAutoloadCommandTest extends TestCase
         $this->assertMatchesRegularExpression('/Generated optimized autoload files \(authoritative\) containing \d+ classes/', $output);
     }
 
+    public function testUsingClassmapAuthoritativeAndStrictPsr(): void
+    {
+        $appTester = $this->getApplicationTester();
+        $this->assertSame(0, $appTester->run(['command' => 'dump-autoload', '--classmap-authoritative' => true, '--strict-psr' => true]));
+
+        $output = $appTester->getDisplay(true);
+        $this->assertStringContainsString('Generating optimized autoload files', $output);
+        $this->assertMatchesRegularExpression('/Generated optimized autoload files \(authoritative\) containing \d+ classes/', $output);
+    }
+
     public function testStrictPsrDoesNotWorkWithoutOptimizedAutoloader(): void
     {
         $appTester = $this->getApplicationTester();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('--strict-psr mode only works with optimized autoloader, use --optimize if you want a strict return value.');
+        $this->expectExceptionMessage('--strict-psr mode only works with optimized autoloader, use --optimize or --classmap-authoritative if you want a strict return value.');
         $appTester->run(['command' => 'dump-autoload', '--strict-psr' => true]);
     }
 


### PR DESCRIPTION
The "bug" I mentioned in https://github.com/composer/composer/pull/11581

Since `--classmap-authoritative` automatically enables level 1 optimisations (https://getcomposer.org/doc/articles/autoloader-optimization.md#what-does-it-do--2) `--strict-psr` should be useable too without having to pass `--optimise` again.