### PR TITLE
Add `dumpautoload --dry-run` option

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -134,14 +134,10 @@ class AutoloadGenerator
 
     /**
      * Whether to run in drymode or not
-     *
-     * @return AutoloadGenerator
      */
-    public function setDryRun(bool $dryRun = true): self
+    public function setDryRun(bool $dryRun = true): void
     {
         $this->dryRun = $dryRun;
-
-        return $this;
     }
 
     /**
@@ -415,47 +411,49 @@ EOF;
             }
         }
 
-        if (!$this->dryRun) {
-            $filesystem->filePutContentsIfModified($targetDir.'/autoload_namespaces.php', $namespacesFile);
-            $filesystem->filePutContentsIfModified($targetDir.'/autoload_psr4.php', $psr4File);
-            $filesystem->filePutContentsIfModified($targetDir.'/autoload_classmap.php', $classmapFile);
-            $includePathFilePath = $targetDir.'/include_paths.php';
-            if ($includePathFileContents = $this->getIncludePathsFile($packageMap, $filesystem, $basePath, $vendorPath, $vendorPathCode, $appBaseDirCode)) {
-                $filesystem->filePutContentsIfModified($includePathFilePath, $includePathFileContents);
-            } elseif (file_exists($includePathFilePath)) {
-                unlink($includePathFilePath);
-            }
-            $includeFilesFilePath = $targetDir.'/autoload_files.php';
-            if ($includeFilesFileContents = $this->getIncludeFilesFile($autoloads['files'], $filesystem, $basePath, $vendorPath, $vendorPathCode, $appBaseDirCode)) {
-                $filesystem->filePutContentsIfModified($includeFilesFilePath, $includeFilesFileContents);
-            } elseif (file_exists($includeFilesFilePath)) {
-                unlink($includeFilesFilePath);
-            }
-            $filesystem->filePutContentsIfModified($targetDir.'/autoload_static.php', $this->getStaticFile($suffix, $targetDir, $vendorPath, $basePath));
-            $checkPlatform = $config->get('platform-check') !== false && !($this->platformRequirementFilter instanceof IgnoreAllPlatformRequirementFilter);
-            $platformCheckContent = null;
-            if ($checkPlatform) {
-                $platformCheckContent = $this->getPlatformCheck($packageMap, $config->get('platform-check'), $devPackageNames);
-                if (null === $platformCheckContent) {
-                    $checkPlatform = false;
-                }
-            }
-            if ($checkPlatform) {
-                $filesystem->filePutContentsIfModified($targetDir.'/platform_check.php', $platformCheckContent);
-            } elseif (file_exists($targetDir.'/platform_check.php')) {
-                unlink($targetDir.'/platform_check.php');
-            }
-            $filesystem->filePutContentsIfModified($vendorPath.'/autoload.php', $this->getAutoloadFile($vendorPathToTargetDirCode, $suffix));
-            $filesystem->filePutContentsIfModified($targetDir.'/autoload_real.php', $this->getAutoloadRealFile(true, (bool) $includePathFileContents, $targetDirLoader, (bool) $includeFilesFileContents, $vendorPathCode, $appBaseDirCode, $suffix, $useGlobalIncludePath, $prependAutoloader, $checkPlatform));
+        if ($this->dryRun) {
+            return $classMap;
+        }
 
-            $filesystem->safeCopy(__DIR__.'/ClassLoader.php', $targetDir.'/ClassLoader.php');
-            $filesystem->safeCopy(__DIR__.'/../../../LICENSE', $targetDir.'/LICENSE');
-
-            if ($this->runScripts) {
-                $this->eventDispatcher->dispatchScript(ScriptEvents::POST_AUTOLOAD_DUMP, $this->devMode, [], [
-                    'optimize' => $scanPsrPackages,
-                ]);
+        $filesystem->filePutContentsIfModified($targetDir.'/autoload_namespaces.php', $namespacesFile);
+        $filesystem->filePutContentsIfModified($targetDir.'/autoload_psr4.php', $psr4File);
+        $filesystem->filePutContentsIfModified($targetDir.'/autoload_classmap.php', $classmapFile);
+        $includePathFilePath = $targetDir.'/include_paths.php';
+        if ($includePathFileContents = $this->getIncludePathsFile($packageMap, $filesystem, $basePath, $vendorPath, $vendorPathCode, $appBaseDirCode)) {
+            $filesystem->filePutContentsIfModified($includePathFilePath, $includePathFileContents);
+        } elseif (file_exists($includePathFilePath)) {
+            unlink($includePathFilePath);
+        }
+        $includeFilesFilePath = $targetDir.'/autoload_files.php';
+        if ($includeFilesFileContents = $this->getIncludeFilesFile($autoloads['files'], $filesystem, $basePath, $vendorPath, $vendorPathCode, $appBaseDirCode)) {
+            $filesystem->filePutContentsIfModified($includeFilesFilePath, $includeFilesFileContents);
+        } elseif (file_exists($includeFilesFilePath)) {
+            unlink($includeFilesFilePath);
+        }
+        $filesystem->filePutContentsIfModified($targetDir.'/autoload_static.php', $this->getStaticFile($suffix, $targetDir, $vendorPath, $basePath));
+        $checkPlatform = $config->get('platform-check') !== false && !($this->platformRequirementFilter instanceof IgnoreAllPlatformRequirementFilter);
+        $platformCheckContent = null;
+        if ($checkPlatform) {
+            $platformCheckContent = $this->getPlatformCheck($packageMap, $config->get('platform-check'), $devPackageNames);
+            if (null === $platformCheckContent) {
+                $checkPlatform = false;
             }
+        }
+        if ($checkPlatform) {
+            $filesystem->filePutContentsIfModified($targetDir.'/platform_check.php', $platformCheckContent);
+        } elseif (file_exists($targetDir.'/platform_check.php')) {
+            unlink($targetDir.'/platform_check.php');
+        }
+        $filesystem->filePutContentsIfModified($vendorPath.'/autoload.php', $this->getAutoloadFile($vendorPathToTargetDirCode, $suffix));
+        $filesystem->filePutContentsIfModified($targetDir.'/autoload_real.php', $this->getAutoloadRealFile(true, (bool) $includePathFileContents, $targetDirLoader, (bool) $includeFilesFileContents, $vendorPathCode, $appBaseDirCode, $suffix, $useGlobalIncludePath, $prependAutoloader, $checkPlatform));
+
+        $filesystem->safeCopy(__DIR__.'/ClassLoader.php', $targetDir.'/ClassLoader.php');
+        $filesystem->safeCopy(__DIR__.'/../../../LICENSE', $targetDir.'/LICENSE');
+
+        if ($this->runScripts) {
+            $this->eventDispatcher->dispatchScript(ScriptEvents::POST_AUTOLOAD_DUMP, $this->devMode, [], [
+                'optimize' => $scanPsrPackages,
+            ]);
         }
 
         return $classMap;

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -37,6 +37,7 @@ class DumpAutoloadCommand extends BaseCommand
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.'),
                 new InputOption('apcu', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
                 new InputOption('apcu-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu'),
+                new InputOption('dry-run', null, InputOption::VALUE_NONE, 'Outputs the operations but will not execute anything.'),
                 new InputOption('dev', null, InputOption::VALUE_NONE, 'Enables autoload-dev rules. Composer will by default infer this automatically according to the last install or update --no-dev state.'),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables autoload-dev rules. Composer will by default infer this automatically according to the last install or update --no-dev state.'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
@@ -83,6 +84,9 @@ EOT
         }
 
         $generator = $composer->getAutoloadGenerator();
+        if ($input->getOption('dry-run')) {
+            $generator->setDryRun(true);
+        }
         if ($input->getOption('no-dev')) {
             $generator->setDevMode(false);
         }


### PR DESCRIPTION
Fixes https://github.com/composer/composer/issues/11580.

Note: Because this indents a large block of code without actually changing it, I recommend reviewing the changes with whitespace hidden to reduce noise ([like so](https://github.com/composer/composer/pull/11608/files?w=1)).