### PR TITLE
Fix exit code 5 on composer require/create-project command

### DIFF
--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -136,6 +136,7 @@ EOT
             ->setApcuAutoloader($apcu, $apcuPrefix)
             ->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input))
             ->setAudit($input->getOption('audit'))
+            ->setErrorOnAudit($input->getOption('audit'))
             ->setAuditFormat($this->getAuditFormat($input))
         ;
 

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -170,6 +170,8 @@ class Installer
     protected $executeOperations = true;
     /** @var bool */
     protected $audit = true;
+    /** @var bool */
+    protected $errorOnAudit = false;
     /** @var Auditor::FORMAT_* */
     protected $auditFormat = Auditor::FORMAT_SUMMARY;
 
@@ -402,7 +404,7 @@ class Installer
                         $repoSet->addRepository($repo);
                     }
 
-                    return $auditor->audit($this->io, $repoSet, $packages, $this->auditFormat, true, $this->config->get('audit')['ignore'] ?? []) > 0 ? self::ERROR_AUDIT_FAILED : 0;
+                    return $auditor->audit($this->io, $repoSet, $packages, $this->auditFormat, true, $this->config->get('audit')['ignore'] ?? []) > 0 && $this->errorOnAudit ? self::ERROR_AUDIT_FAILED : 0;
                 } catch (TransportException $e) {
                     $this->io->error('Failed to audit '.$target.' packages.');
                     if ($this->io->isVerbose()) {
@@ -1418,6 +1420,19 @@ class Installer
     public function setAudit(bool $audit): self
     {
         $this->audit = $audit;
+
+        return $this;
+    }
+
+    /**
+     * Should exit with status code 5 on audit error
+     *
+     * @param bool $errorOnAudit
+     * @return Installer
+     */
+    public function setErrorOnAudit(bool $errorOnAudit): self
+    {
+        $this->errorOnAudit = $errorOnAudit;
 
         return $this;
     }


### PR DESCRIPTION
After #11362, CI builds may fail with status code 5 if the composer command require/create-project is used.
This PR fix this BC break and the command will fail if the user has explicitly specified the `--audit` flag

```
composer install --audit
```