### PR TITLE
Revert "Set $_SERVER['SCRIPT_NAME'] within proxy command"

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -359,11 +359,6 @@ namespace Composer;
 
 $globalsCode
 $streamProxyCode
-
-if (__FILE__ === realpath(\$_SERVER['SCRIPT_NAME'])) {
-    \$_SERVER['SCRIPT_NAME'] = realpath($binPathExported);
-}
-
 return include $binPathExported;
 
 PROXY;

--- a/tests/Composer/Test/Installer/BinaryInstallerTest.php
+++ b/tests/Composer/Test/Installer/BinaryInstallerTest.php
@@ -112,18 +112,6 @@ EOL
 echo 'success '.$_SERVER['argv'][1];
 EOL
             ],
-            'php file which validates $_SERVER["SCRIPT_NAME"]' => [<<<'EOL'
-<?php
-if (__FILE__ === realpath($_SERVER['SCRIPT_NAME'])) {
-    echo 'success '.$_SERVER['argv'][1];
-} else {
-    fwrite(STDERR, "Test failure: __FILE__ does not match \$_SERVER['SCRIPT_NAME']\n");
-    fwrite(STDERR, "\t__FILE__:\t" . __FILE__ . "\n");
-    fwrite(STDERR, "\t\$_SERVER['SCRIPT_NAME']:\t" . $_SERVER['SCRIPT_NAME'] . "\n");
-    exit(1);
-}
-EOL
-            ],
         ];
     }
 


### PR DESCRIPTION
reverts #11562

fixes #11615

why the PR should be reverted?

- `$_SERVER['SCRIPT_NAME']` is expected to be the entry file, this is a php-src convenction and it should be safe to assume it no matter how the script is started
- the entry file path must match the first path in a backtrace, otherwise shortening backtraces might not work (as in #11615)
- original problem #5447 mentioned https://github.com/sebastianbergmann/phpunit/blob/15a89f123d/build/templates/binary-phar-autoload.php.in#L58-L62 - so the fix was done to fix this - incorrect/not always valid assumption - and the proper fix should be to fix sebastianbergmann/phpunit instead (and possibly with some added global/API in composer like "entry target file" in https://github.com/mvorisek/composer/blob/6200985c2a/src/Composer/Installer/BinaryInstaller.php#L224)