### PR TITLE
Fixed base package replacers being removed incorrectly

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -669,9 +669,8 @@ class PoolBuilder
 
     private function markPackageNameForLoadingIfRequired(Request $request, string $name): void
     {
-        if (isset($request->getRequires()[$name])) {
+        if ($this->isRootRequire($request, $name)) {
             $this->markPackageNameForLoading($request, $name, $request->getRequires()[$name]);
-            return;
         }
 
         foreach ($this->packages as $package) {

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -669,6 +669,11 @@ class PoolBuilder
 
     private function markPackageNameForLoadingIfRequired(Request $request, string $name): void
     {
+        if (isset($request->getRequires()[$name])) {
+            $this->markPackageNameForLoading($request, $name, $request->getRequires()[$name]);
+            return;
+        }
+
         foreach ($this->packages as $package) {
             foreach ($package->getRequires() as $link) {
                 if ($name === $link->getTarget()) {

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/load-replaced-root-package-if-replacer-dropped.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/load-replaced-root-package-if-replacer-dropped.test
@@ -1,0 +1,49 @@
+--TEST--
+Ensure that a root package gets loaded which is replaced by old versions of another requirement
+
+--REQUEST--
+{
+    "require": {
+        "root/dep": "*",
+        "replaced/pkg": "1.0.0"
+    },
+    "locked": [
+        {"name": "root/dep", "version": "1.1.0", "require": {"replacer/pkg": "1.*"}},
+        {"name": "replacer/pkg", "version": "1.1.0"},
+        {"name": "replaced/pkg", "version": "1.0.0"}
+    ],
+    "allowList": [
+        "root/dep"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name": "root/dep", "version": "1.2.0", "require": {"replacer/pkg": "1.*"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"replaced/pkg": "1.0.0"}},
+        {"name": "replacer/pkg", "version": "1.1.0"},
+        {"name": "replaced/pkg", "version": "1.0.0"}
+    ]
+]
+
+--EXPECT--
+[
+    "replaced/pkg-1.0.0.0",
+    "replacer/pkg-1.0.0.0",
+    "replacer/pkg-1.1.0.0",
+    "root/dep-1.2.0.0"
+]
+
+--EXPECT-OPTIMIZED--
+[
+    "replaced/pkg-1.0.0.0",
+    "replacer/pkg-1.0.0.0",
+    "replacer/pkg-1.1.0.0",
+    "root/dep-1.2.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace-partial-update-all.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/multi-repo-replace-partial-update-all.test
@@ -97,6 +97,7 @@ Check that replacers from additional repositories are loaded when doing a partia
 
 --EXPECT--
 [
+    "base/package-1.0.0.0",
     "indirect/replacer-1.2.0.0",
     "indirect/replacer-1.0.0.0",
     "replacer/package-1.2.0.0",
@@ -107,6 +108,7 @@ Check that replacers from additional repositories are loaded when doing a partia
 
 --EXPECT-OPTIMIZED--
 [
+    "base/package-1.0.0.0",
     "indirect/replacer-1.2.0.0",
     "indirect/replacer-1.0.0.0",
     "replacer/package-1.2.0.0",


### PR DESCRIPTION
Fixes https://github.com/composer/composer/issues/11626

If the replaced package is part of the require request itself, we must also load it. We actually incorrectly adjusted the test in https://github.com/composer/composer/pull/11449.

I hope the changes are correct, requesting a review by @naderman :) 

