### PR TITLE
Ensure root requirements are loaded after being unlocked by a replace, even if they are not required by anything else

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -665,6 +665,11 @@ class PoolBuilder
                             }
                         }
                     }
+
+                    // make sure the unlocked package is loaded if it is a root requirement, even if nothing in the loop above triggered a load
+                    if ($this->isRootRequire($request, $name)) {
+                        $this->markPackageNameForLoading($request, $name, $request->getRequires()[$name]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #11626

Replaces #11629

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
