### PR TITLE
Get realpath for `ZipArchive`

### DIFF
--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -31,7 +31,7 @@ class ZipArchiver implements ArchiverInterface
     public function archive(string $sources, string $target, string $format, array $excludes = [], bool $ignoreFilters = false): string
     {
         $fs = new Filesystem();
-        $sources = $fs->normalizePath($sources);
+        $sources = $fs->normalizePath(realpath($sources));
 
         $zip = new ZipArchive();
         $res = $zip->open($target, ZipArchive::CREATE);

--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -31,7 +31,12 @@ class ZipArchiver implements ArchiverInterface
     public function archive(string $sources, string $target, string $format, array $excludes = [], bool $ignoreFilters = false): string
     {
         $fs = new Filesystem();
-        $sources = $fs->normalizePath(realpath($sources) ?: $sources);
+        $sourcesRealpath = realpath($sources);
+        if (false !== $sourcesRealpath) {
+            $sources = $sourcesRealpath;
+        }
+        unset($sourcesRealpath);
+        $sources = $fs->normalizePath($sources);
 
         $zip = new ZipArchive();
         $res = $zip->open($target, ZipArchive::CREATE);

--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -31,7 +31,7 @@ class ZipArchiver implements ArchiverInterface
     public function archive(string $sources, string $target, string $format, array $excludes = [], bool $ignoreFilters = false): string
     {
         $fs = new Filesystem();
-        $sources = $fs->normalizePath(realpath($sources));
+        $sources = $fs->normalizePath(realpath($sources) ?: $sources);
 
         $zip = new ZipArchive();
         $res = $zip->open($target, ZipArchive::CREATE);


### PR DESCRIPTION
I came across a few open issues, notably #10099, and the fix commented by @Seldaek resolved the issue. However, it has yet to be PR'd since Satis is now replaced by [Private Packagist](https://packagist.com/).

Nonetheless, here is the PR to resolve the issue where the archive paths are incorrect due to `ZipArchive::archive` not using the `realpath()`. Notably on MacOS where `sys_get_temp_dir()` returns a symlinked path. This change is inline with `PharArchive::archive` as it uses `realpath()` [already](https://github.com/composer/composer/blob/main/src/Composer/Package/Archiver/PharArchiver.php#L41).

There are other instances in the codebase which use `sys_get_temp_dir()`. However, since they are only used for storage, and not pathing information, I don't believe they require changes.