### PR TITLE
Use CompilingMatcher in DefaultPolicy for performance reasons

### DIFF
--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -15,6 +15,7 @@ namespace Composer\DependencyResolver;
 use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
 use Composer\Package\PackageInterface;
+use Composer\Semver\CompilingMatcher;
 use Composer\Semver\Constraint\Constraint;
 
 /**
@@ -49,10 +50,12 @@ class DefaultPolicy implements PolicyInterface
             return BasePackage::$stabilities[$stabA] < BasePackage::$stabilities[$stabB];
         }
 
-        $constraint = new Constraint($operator, $b->getVersion());
-        $version = new Constraint('==', $a->getVersion());
+        // TODO: Why is this not the case in CompilingMatcher?
+        if (false !== strpos($a->getVersion(), 'dev-') || false !== strpos($b->getVersion(), 'dev-')) {
+            return true;
+        }
 
-        return $constraint->matchSpecific($version, true);
+        return CompilingMatcher::match(new Constraint($operator, $b->getVersion()), Constraint::OP_EQ, $a->getVersion());
     }
 
     /**


### PR DESCRIPTION
This needs more investigation for sure but I wanted to leave it here so others can investigate too.

I noticed that in the `DefaultPolicy` we do not use the `CompilingMatcher` which causes all constraints to be dynamically evaluated over and over again. Since the introduction of the `PoolOptimizer`, the `DefaultPolicy` is heavily used to select the correct packages withing the dependency groups.

I did a few tests and this reduces the `PoolOptimizer` runtime by about 10%. The more packages in the pool, the higher the potential savings. In absolute times we're talking 0.2 - 0.5 seconds, maybe.

However, in order to make the tests pass, I had to add some `dev-` comparison which I'm a bit confused with. Things to clarify:

* Why is there `Constraint::matchSpecific()` and why is this a `public` method and not an implementation detail?
* Why does the `CompilingMatcher` handle this case differently - is this a bug in `composer/semver`? 