### PR TITLE
feat: improve Composer's output reproducibility

### DIFF
--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -152,6 +152,13 @@ a Composer `install` to make sure the vendor directory is up in sync with your
 php composer.phar install
 ```
 
+Composer enables reproducible builds by default. This means that running the
+same command multiple times will produce a `vendor/` directory containing files
+that are identical (*except their timestamps*), including the autoloader files.
+It is especially beneficial for environments that require strict
+verification processes, as well as for Linux distributions aiming to package PHP
+applications in a secure and predictable manner.
+
 ## Updating dependencies to their latest versions
 
 As mentioned above, the `composer.lock` file prevents you from automatically getting

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -365,8 +365,10 @@ with other autoloaders.
 
 ## autoloader-suffix
 
-Defaults to `null`. Non-empty string to be used as a suffix for the generated
-Composer autoloader. When null a random one will be generated.
+Defaults to `null`. When set to a non-empty string, this value will be used as a
+suffix for the generated Composer autoloader. If set to `null`, the
+`content-hash` value from the `composer.lock` file will be used if available;
+otherwise, a random suffix will be generated.
 
 ## optimize-autoloader
 

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -33,6 +33,7 @@ use Composer\Util\Platform;
 use Composer\Script\ScriptEvents;
 use Composer\Util\PackageSorter;
 use Composer\Json\JsonFile;
+use Composer\Package\Locker;
 
 /**
  * @author Igor Wiedler <igor@wiedler.ch>
@@ -172,7 +173,7 @@ class AutoloadGenerator
      * @throws \Seld\JsonLint\ParsingException
      * @throws \RuntimeException
      */
-    public function dump(Config $config, InstalledRepositoryInterface $localRepo, RootPackageInterface $rootPackage, InstallationManager $installationManager, string $targetDir, bool $scanPsrPackages = false, ?string $suffix = null)
+    public function dump(Config $config, InstalledRepositoryInterface $localRepo, RootPackageInterface $rootPackage, InstallationManager $installationManager, Locker $locker, string $targetDir, bool $scanPsrPackages = false, ?string $suffix = null)
     {
         if ($this->classMapAuthoritative) {
             // Force scanPsrPackages when classmap is authoritative

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -406,9 +406,8 @@ EOF;
                 }
             }
 
-            // generate one if we still haven't got a suffix
             if (null === $suffix) {
-                $suffix = md5(uniqid('', true));
+                $suffix = $locker->isLocked() ? $locker->getLockData()['content-hash'] : md5(uniqid('', true));
             }
         }
 

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -100,7 +100,15 @@ EOT
         $generator->setRunScripts(true);
         $generator->setApcu($apcu, $apcuPrefix);
         $generator->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input));
-        $classMap = $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
+        $classMap = $generator->dump(
+            $config,
+            $localRepo,
+            $package,
+            $installationManager,
+            $composer->getLocker(),
+            'composer',
+            $optimize
+        );
         $numberOfClasses = count($classMap);
 
         if ($authoritative) {

--- a/src/Composer/Command/ReinstallCommand.php
+++ b/src/Composer/Command/ReinstallCommand.php
@@ -163,7 +163,15 @@ EOT
             $generator->setClassMapAuthoritative($authoritative);
             $generator->setApcu($apcu, $apcuPrefix);
             $generator->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input));
-            $generator->dump($config, $localRepo, $package, $installationManager, 'composer', $optimize);
+            $generator->dump(
+                $config,
+                $localRepo,
+                $package,
+                $installationManager,
+                $composer->getLocker(),
+                'composer',
+                $optimize
+            );
         }
 
         $eventDispatcher->dispatchScript(ScriptEvents::POST_INSTALL_CMD, $devMode);

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -349,7 +349,17 @@ class Installer
             $this->autoloadGenerator->setApcu($this->apcuAutoloader, $this->apcuAutoloaderPrefix);
             $this->autoloadGenerator->setRunScripts($this->runScripts);
             $this->autoloadGenerator->setPlatformRequirementFilter($this->platformRequirementFilter);
-            $this->autoloadGenerator->dump($this->config, $localRepo, $this->package, $this->installationManager, 'composer', $this->optimizeAutoloader);
+            $this
+                ->autoloadGenerator
+                ->dump(
+                    $this->config,
+                    $localRepo,
+                    $this->package,
+                    $this->installationManager,
+                    $this->locker,
+                    'composer',
+                    $this->optimizeAutoloader
+                );
         }
 
         if ($this->install && $this->executeOperations) {

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -874,10 +874,8 @@ class Filesystem
 
     /**
      * Copy file using stream_copy_to_stream to work around https://bugs.php.net/bug.php?id=6463
-     *
-     * @return void
      */
-    public function safeCopy(string $source, string $target)
+    public function safeCopy(string $source, string $target): void
     {
         if (!file_exists($target) || !file_exists($source) || !$this->filesAreEqual($source, $target)) {
             $sourceHandle = fopen($source, 'r');
@@ -888,6 +886,8 @@ class Filesystem
             stream_copy_to_stream($sourceHandle, $targetHandle);
             fclose($sourceHandle);
             fclose($targetHandle);
+
+            touch($target, (int) filemtime($source), (int) fileatime($source));
         }
     }
 

--- a/tests/Composer/Test/Command/DumpAutoloadCommandTest.php
+++ b/tests/Composer/Test/Command/DumpAutoloadCommandTest.php
@@ -102,4 +102,86 @@ class DumpAutoloadCommandTest extends TestCase
         $this->expectExceptionMessage('You can not use both --no-dev and --dev as they conflict with each other.');
         $appTester->run(['command' => 'dump-autoload', '--dev' => true, '--no-dev' => true]);
     }
+
+    public function testWithCustomAutoloaderSuffix(): void
+    {
+        $dir = $this->initTempComposer([
+            'config' => [
+                'autoloader-suffix' => 'Foobar',
+            ],
+        ]);
+
+        $appTester = $this->getApplicationTester();
+        $this->assertSame(0, $appTester->run(['command' => 'dump-autoload']));
+
+        self::assertStringContainsString('ComposerAutoloaderInitFoobar', (string) file_get_contents($dir . '/vendor/autoload.php'));
+    }
+
+    public function testWithExistingComposerLockAndAutoloaderSuffix(): void
+    {
+        $dir = $this->initTempComposer(
+            [
+                'config' => [
+                    'autoloader-suffix' => 'Foobar',
+                ],
+            ],
+            [],
+            [
+                "_readme" => [
+                    "This file locks the dependencies of your project to a known state",
+                    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+                    "This file is @generated automatically"
+                ],
+                "content-hash" => "d751713988987e9331980363e24189ce",
+                "packages" => [],
+                "packages-dev" => [],
+                "aliases" => [],
+                "minimum-stability" => "stable",
+                "stability-flags" => [],
+                "prefer-stable" => false,
+                "prefer-lowest" => false,
+                "platform" => [],
+                "platform-dev" => [],
+                "plugin-api-version" => "2.6.0"
+            ]
+        );
+
+        $appTester = $this->getApplicationTester();
+        $this->assertSame(0, $appTester->run(['command' => 'dump-autoload']));
+
+        self::assertStringContainsString('ComposerAutoloaderInitFoobar', (string) file_get_contents($dir . '/vendor/autoload.php'));
+    }
+
+    public function testWithExistingComposerLockWithoutAutoloaderSuffix(): void
+    {
+        $dir = $this->initTempComposer(
+            [
+                'name' => 'foo/bar',
+            ],
+            [],
+            [
+                "_readme" => [
+                    "This file locks the dependencies of your project to a known state",
+                    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+                    "This file is @generated automatically"
+                ],
+                "content-hash" => "2d4a6be9a93712c5d6a119b26734a047",
+                "packages" => [],
+                "packages-dev" => [],
+                "aliases" => [],
+                "minimum-stability" => "stable",
+                "stability-flags" => [],
+                "prefer-stable" => false,
+                "prefer-lowest" => false,
+                "platform" => [],
+                "platform-dev" => [],
+                "plugin-api-version" => "2.6.0"
+            ]
+        );
+
+        $appTester = $this->getApplicationTester();
+        $this->assertSame(0, $appTester->run(['command' => 'dump-autoload']));
+
+        self::assertStringContainsString('ComposerAutoloaderInit2d4a6be9a93712c5d6a119b26734a047', (string) file_get_contents($dir . '/vendor/autoload.php'));
+    }
 }

--- a/tests/Composer/Test/TestCase.php
+++ b/tests/Composer/Test/TestCase.php
@@ -122,9 +122,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @see getApplicationTester
      * @param mixed[] $composerJson
      * @param mixed[] $authJson
+     * @param mixed[] $composerLock
      * @return string the newly created temp dir
      */
-    public function initTempComposer(array $composerJson = [], array $authJson = []): string
+    public function initTempComposer(array $composerJson = [], array $authJson = [], array $composerLock = []): string
     {
         $dir = self::getUniqueTmpDirectory();
 
@@ -149,6 +150,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         chdir($dir);
         file_put_contents($dir.'/composer.json', JsonFile::encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
         file_put_contents($dir.'/auth.json', JsonFile::encode($authJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+        if ($composerLock !== []) {
+            file_put_contents($dir.'/composer.lock', JsonFile::encode($composerLock, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        }
 
         return $dir;
     }


### PR DESCRIPTION
This PR:

- [x] Improve reproducibility of Composer's output (_the `vendor` directory_). Currently, only the file content is guaranteed to be reproducible, the file time metadata are not (yet?) reproducible.
- [x] Should fix https://github.com/composer/composer/issues/7049

Reproduce this at home, inside the `composer` source directory:

![image](https://github.com/composer/composer/assets/252042/6f6a4911-f623-4bb6-be41-e7d3ef3c008c)

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
