### PR TITLE
chore: remove `composer.lock` from `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,7 +19,6 @@
 /.php-cs-fixer.php export-ignore
 /CHANGELOG.md export-ignore
 /CODE_OF_CONDUCT.md export-ignore
-/composer.lock export-ignore
 /phpunit.xml.dist export-ignore
 /PORTING_INFO export-ignore
 /README.md export-ignore


### PR DESCRIPTION
This PR is mostly useful (_at first glance_) for the Nix community. This will allow us to improve the way Composer is being built on Nix by downloading a snapshot of Composer instead of downloading the whole git repository. It will also save some bandwidth on the Network.

This PR:

- [x] Let the file `composer.lock` be exported in the archive when using `git archive` and thus let the `composer.lock` file be exported when downloading a snapshot from Github. 
- [x] Is related to https://github.com/NixOS/nixpkgs/pull/258281#issuecomment-1746931135
