### PR TITLE
Use global constant if available for libpq version

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -449,6 +449,12 @@ class PlatformRepository extends ArrayRepository
                     break;
 
                 case 'pgsql':
+                    if ($this->runtime->hasConstant('PGSQL_LIBPQ_VERSION')) {
+                        $this->addLibrary('pgsql-libpq', $this->runtime->getConstant('PGSQL_LIBPQ_VERSION'), 'libpq for pgsql');
+                        break;
+                    }
+                // intentional fall-through to next case...
+
                 case 'pdo_pgsql':
                     $info = $this->runtime->getExtensionInfo($name);
 

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -998,6 +998,8 @@ pgsql.auto_reset_persistent => Off => Off
 pgsql.ignore_notice => Off => Off
 pgsql.log_notice => Off => Off',
                 ['lib-pgsql-libpq' => '12.2'],
+                [],
+                [['PGSQL_LIBPQ_VERSION', null, '12.2']],
             ],
             'pdo_pgsql' => [
                 'pdo_pgsql',


### PR DESCRIPTION
As suggested in https://github.com/composer/composer/issues/11683#issuecomment-1757311564, this pull request adds a performance optimisation for detecting the `libpq` version.