### PR TITLE
Diagnose command: Add GitHub OAuth token expiration date information

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -349,16 +349,7 @@ EOT
                 return '<info>OK</> <comment>does not expire</>';
             }
 
-            try {
-                if (\DateTime::createFromFormat('Y-m-d h:i:s O', $expiration) !== false) {
-                    return '<info>OK</> <comment>expires on '. $expiration .'</>';
-                }
-
-                return '<info>OK</> <comment>returned unexpected expiration date format</>';
-            }
-            catch (\Throwable $exception) {
-                return '<info>OK</> <comment>error parsing returned expiration date</>';
-            }
+            return '<info>OK</> <comment>expires on '. $expiration .'</>';
         } catch (\Exception $e) {
             if ($e instanceof TransportException && $e->getCode() === 401) {
                 return '<comment>The oauth token for '.$domain.' seems invalid, run "composer config --global --unset github-oauth.'.$domain.'" to remove it</comment>';

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -326,7 +326,7 @@ EOT
     }
 
     /**
-     * @return string|true|\Exception
+     * @return string|\Exception
      */
     private function checkGithubOauth(string $domain, string $token)
     {
@@ -339,11 +339,26 @@ EOT
         try {
             $url = $domain === 'github.com' ? 'https://api.'.$domain.'/' : 'https://'.$domain.'/api/v3/';
 
-            $this->httpDownloader->get($url, [
+            $response = $this->httpDownloader->get($url, [
                 'retry-auth-failure' => false,
             ]);
 
-            return true;
+            $expiration = $response->getHeader('github-authentication-token-expiration');
+
+            if ($expiration === null) {
+                return '<info>OK</> <comment>does not expire</>';
+            }
+
+            try {
+                if (\DateTime::createFromFormat('Y-m-d h:i:s O', $expiration) !== false) {
+                    return '<info>OK</> <comment>expires on '. $expiration .'</>';
+                }
+
+                return '<info>OK</> <comment>returned unexpected expiration date format</>';
+            }
+            catch (\Throwable $exception) {
+                return '<info>OK</> <comment>error parsing returned expiration date</>';
+            }
         } catch (\Exception $e) {
             if ($e instanceof TransportException && $e->getCode() === 401) {
                 return '<comment>The oauth token for '.$domain.' seems invalid, run "composer config --global --unset github-oauth.'.$domain.'" to remove it</comment>';


### PR DESCRIPTION
GitHub's new fine-grained tokens have a cumpulsory expiration date, and their classic tokens also support an expiration date.

https://github.blog/changelog/2021-07-26-expiration-options-for-personal-access-tokens/

This improves the `composer diagnose` command to display the expiration date and time if it is provided by the response headers (via `GitHub-Authentication-Token-Expiration`).