### PR TITLE
Fix Git Driver to use supported Git VCS driver URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.6-dev"
+            "dev-main": "2.7-dev"
         },
         "phpstan": {
             "includes": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4bceaf933dcf6bc05808134e78d21496",
+    "content-hash": "5ecfd05f35343c3780b3a896c59e6cb0",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -46,7 +46,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $composer = $this->requireComposer();
         $packages = $this->getPackages($composer, $input);

--- a/src/Composer/Command/BumpCommand.php
+++ b/src/Composer/Command/BumpCommand.php
@@ -70,7 +70,7 @@ EOT
     /**
      * @throws \Seld\JsonLint\ParsingException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @readonly */
         $composerJsonPath = Factory::getComposerFile();

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -67,7 +67,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $composer = $this->tryComposer();
         $io = $this->getIO();

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -54,7 +54,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $composer = $this->requireComposer();
 

--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -75,7 +75,7 @@ EOT
         $input->setArgument('binary', $binaries[$binary]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $composer = $this->requireComposer();
         if ($input->getOption('list') || null === $input->getArgument('binary')) {

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -82,7 +82,7 @@ EOT
     /**
      * @throws \Seld\JsonLint\ParsingException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getIO();
 

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -79,7 +79,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getIO();
         if ($input->getOption('dev')) {

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -83,7 +83,7 @@ EOT
     /**
      * @throws \Seld\JsonLint\ParsingException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getArgument('packages') === [] && !$input->getOption('unused')) {
             throw new InvalidArgumentException('Not enough arguments (missing: "packages").');

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -129,7 +129,7 @@ EOT
     /**
      * @throws \Seld\JsonLint\ParsingException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->file = Factory::getComposerFile();
         $io = $this->getIO();

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -131,7 +131,7 @@ EOT
         };
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->versionParser = new VersionParser;
         if ($input->getOption('tree')) {

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -112,7 +112,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getIO();
         if ($input->getOption('dev')) {

--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -54,7 +54,7 @@ class Composer extends PartialComposer
     public const VERSION = '@package_version@';
     public const BRANCH_ALIAS_VERSION = '@package_branch_alias_version@';
     public const RELEASE_DATE = '@release_date@';
-    public const SOURCE_VERSION = '2.6.999-dev+source';
+    public const SOURCE_VERSION = '2.7.999-dev+source';
 
     /**
      * Version number of the internal composer-runtime-api package

--- a/src/Composer/Package/Version/VersionBumper.php
+++ b/src/Composer/Package/Version/VersionBumper.php
@@ -40,6 +40,7 @@ class VersionBumper
      *  * ^3@dev + 3.2.99999-dev  -> ^3.2@dev
      *  * ~2 + 2.0-beta.1         -> ~2
      *  * dev-master + dev-master -> dev-master
+     *  * * + 1.2.3               -> >=1.2.3
      */
     public function bumpRequirement(ConstraintInterface $constraint, PackageInterface $package): string
     {
@@ -86,6 +87,7 @@ class VersionBumper
                 | ~'.$major.'(?:\.\d+){0,2} # e.g. ~2 or ~2.2 or ~2.2.2 but no more
                 | '.$major.'(?:\.[*x])+ # e.g. 2.* or 2.*.* or 2.x.x.x etc
                 | >=\d(?:\.\d+)* # e.g. >=2 or >=1.2 etc
+                | \* # full wildcard
             )
             (?=,|$|\ |\||@) # trailing separator
         }x';
@@ -99,7 +101,7 @@ class VersionBumper
                 }
                 if (str_starts_with($match[0], '~') && substr_count($match[0], '.') === 2) {
                     $replacement = '~'.$versionWithoutSuffix.$suffix;
-                } elseif (str_starts_with($match[0], '>=')) {
+                } elseif ($match[0] === '*' || str_starts_with($match[0], '>=')) {
                     $replacement = '>='.$versionWithoutSuffix.$suffix;
                 } else {
                     $replacement = $newPrettyConstraint.$suffix;

--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -91,7 +91,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
             'svn' => 'Composer\Repository\Vcs\SvnDriver',
         ];
 
-        $this->url = Platform::expandPath($repoConfig['url']);
+        $this->url = $repoConfig['url'] = Platform::expandPath($repoConfig['url']);
         $this->io = $io;
         $this->type = $repoConfig['type'] ?? 'vcs';
         $this->isVerbose = $io->isVerbose();

--- a/tests/Composer/Test/Package/Version/VersionBumperTest.php
+++ b/tests/Composer/Test/Package/Version/VersionBumperTest.php
@@ -67,5 +67,6 @@ class VersionBumperTest extends TestCase
         yield 'leave extra-only-tilde alone' => ['~2.2.3.1', '2.2.4.5', '~2.2.3.1'];
         yield 'upgrade bigger-or-eq to latest' => ['>=3.0', '3.4.5', '>=3.4.5'];
         yield 'leave bigger-than untouched' => ['>2.2.3', '2.2.6', '>2.2.3'];
+        yield 'upgrade full wildcard to bigger-or-eq' => ['*', '1.2.3', '>=1.2.3'];
     }
 }


### PR DESCRIPTION
Otherwise the URL may not be supported since 3bb191a46 (Add support for env vars and ~ (for HOME) in repo paths for vcs and artifact repositories, fixes #11409 (#11453), 2023-05-07)

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
