### PR TITLE
Bump wildcard constraint

### DIFF
--- a/src/Composer/Package/Version/VersionBumper.php
+++ b/src/Composer/Package/Version/VersionBumper.php
@@ -40,6 +40,7 @@ class VersionBumper
      *  * ^3@dev + 3.2.99999-dev  -> ^3.2@dev
      *  * ~2 + 2.0-beta.1         -> ~2
      *  * dev-master + dev-master -> dev-master
+     *  * * + 1.2.3               -> >=1.2.3
      */
     public function bumpRequirement(ConstraintInterface $constraint, PackageInterface $package): string
     {
@@ -86,6 +87,7 @@ class VersionBumper
                 | ~'.$major.'(?:\.\d+){0,2} # e.g. ~2 or ~2.2 or ~2.2.2 but no more
                 | '.$major.'(?:\.[*x])+ # e.g. 2.* or 2.*.* or 2.x.x.x etc
                 | >=\d(?:\.\d+)* # e.g. >=2 or >=1.2 etc
+                | \* # full wildcard
             )
             (?=,|$|\ |\||@) # trailing separator
         }x';
@@ -99,7 +101,7 @@ class VersionBumper
                 }
                 if (str_starts_with($match[0], '~') && substr_count($match[0], '.') === 2) {
                     $replacement = '~'.$versionWithoutSuffix.$suffix;
-                } elseif (str_starts_with($match[0], '>=')) {
+                } elseif ($match[0] === '*' || str_starts_with($match[0], '>=')) {
                     $replacement = '>='.$versionWithoutSuffix.$suffix;
                 } else {
                     $replacement = $newPrettyConstraint.$suffix;

--- a/tests/Composer/Test/Package/Version/VersionBumperTest.php
+++ b/tests/Composer/Test/Package/Version/VersionBumperTest.php
@@ -67,5 +67,6 @@ class VersionBumperTest extends TestCase
         yield 'leave extra-only-tilde alone' => ['~2.2.3.1', '2.2.4.5', '~2.2.3.1'];
         yield 'upgrade bigger-or-eq to latest' => ['>=3.0', '3.4.5', '>=3.4.5'];
         yield 'leave bigger-than untouched' => ['>2.2.3', '2.2.6', '>2.2.3'];
+        yield 'upgrade full wildcard to bigger-or-eq' => ['*', '1.2.3', '>=1.2.3'];
     }
 }


### PR DESCRIPTION
I recently ran `composer bump` on a project which used a wildcard constraint (`*`) for a particular package.

The help text for the `bump` command reads:

> Increases the lower limit of your composer.json requirements to the currently installed versions

However the lower-limit for the wildcard constraint (`*`) was not changed. This pull request adds this functionality.

While I do not believe that unbound version constraints should be used generally, I recognise that others have different opinions and that there are valid use-cases for such constraints.