### PR TITLE
GH Actions: update the CI workflow for the release of PHP 8.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,26 +44,26 @@ jobs:
             dependencies: lowest
             os: ubuntu-latest
             experimental: false
-          - php-version: "8.1"
+          - php-version: "8.3"
             dependencies: highest
             os: ubuntu-latest
             experimental: false
-          - php-version: "8.1"
+          - php-version: "8.3"
             os: windows-latest
             dependencies: locked
             experimental: false
-          - php-version: "8.1"
+          - php-version: "8.3"
             os: macos-latest
             dependencies: locked
             experimental: false
-          - php-version: "8.3"
+          - php-version: "8.4"
             dependencies: lowest-ignore
             os: ubuntu-latest
-            experimental: false
-          - php-version: "8.3"
+            experimental: true
+          - php-version: "8.4"
             dependencies: highest-ignore
             os: ubuntu-latest
-            experimental: false
+            experimental: true
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Suggested change for the CI workflow what with the PHP 8.3 release expected later today.

PHP 8.4 has been added as experimental.
And the "high" PHP builds for the variations have been updated to use PHP 8.3.
