### PR TITLE
Exposing GitLab's project metadata

### DIFF
--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -43,7 +43,7 @@ class GitLabDriver extends VcsDriver
     /**
      * @var mixed[] Project data returned by GitLab API
      */
-    private $project;
+    private $project = null;
 
     /**
      * @var array<string|int, mixed[]> Keeps commits returned by GitLab API as commit id => info
@@ -381,7 +381,7 @@ class GitLabDriver extends VcsDriver
 
     protected function fetchProject(): void
     {
-        if ($this->project) {
+        if (!is_null($this->project)) {
             return;
         }
 

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -381,6 +381,10 @@ class GitLabDriver extends VcsDriver
 
     protected function fetchProject(): void
     {
+        if ($this->project) {
+            return;
+        }
+
         // we need to fetch the default branch from the api
         $resource = $this->getApiUrl();
         $this->project = $this->getContents($resource, true)->decodeJson();
@@ -579,6 +583,18 @@ class GitLabDriver extends VcsDriver
         }
 
         return true;
+    }
+
+    /**
+     * Gives back the loaded <gitlab-api>/projects/<owner>/<repo> result
+     *
+     * @return mixed[]|null
+     */
+    public function getRepoData(): ?array
+    {
+        $this->fetchProject();
+
+        return $this->project;
     }
 
     protected function getNextPage(Response $response): ?string


### PR DESCRIPTION
This permits to directly access project's metadata from the GitLab driver, exactly as it already happens with the GitHub's one.

The main purpose of this change is to be then leveraged in Packagist to grab addictional informations about stars, forks, open issues and more, to be displayed in the web interface or be used for internals (e.g. "popularity" evaluation based on project's stars).

cfr. https://github.com/composer/packagist/blob/main/src/Package/Updater.php#L564