### PR TITLE
Fix typo in composer-platform-dependencies.md

### DIFF
--- a/doc/articles/composer-platform-dependencies.md
+++ b/doc/articles/composer-platform-dependencies.md
@@ -61,7 +61,7 @@ autoloader are considered the application "runtime".
 Starting with version 2.0, Composer makes [additional features](../07-runtime.md) (besides registering the class autoloader) available to the application runtime environment.
 
 Similar to `composer-plugin-api`, not every Composer release adds new runtime features,
-thus the version of `composer-runtimeapi` is also increased independently from Composer's version.
+thus the version of `composer-runtime-api` is also increased independently from Composer's version.
 
 ## Composer package `composer`
 


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
