### PR TITLE
Fix bump command not bumping versions with a v prefix e.g. ^v2.4

### DIFF
--- a/src/Composer/Package/Version/VersionBumper.php
+++ b/src/Composer/Package/Version/VersionBumper.php
@@ -82,10 +82,10 @@ class VersionBumper
         $pattern = '{
             (?<=,|\ |\||^) # leading separator
             (?P<constraint>
-                \^'.$major.'(?:\.\d+)* # e.g. ^2.anything
-                | ~'.$major.'(?:\.\d+){0,2} # e.g. ~2 or ~2.2 or ~2.2.2 but no more
-                | '.$major.'(?:\.[*x])+ # e.g. 2.* or 2.*.* or 2.x.x.x etc
-                | >=\d(?:\.\d+)* # e.g. >=2 or >=1.2 etc
+                \^v?'.$major.'(?:\.\d+)* # e.g. ^2.anything
+                | ~v?'.$major.'(?:\.\d+){0,2} # e.g. ~2 or ~2.2 or ~2.2.2 but no more
+                | v?'.$major.'(?:\.[*x])+ # e.g. 2.* or 2.*.* or 2.x.x.x etc
+                | >=v?\d(?:\.\d+)* # e.g. >=2 or >=1.2 etc
             )
             (?=,|$|\ |\||@) # trailing separator
         }x';

--- a/tests/Composer/Test/Command/BumpCommandTest.php
+++ b/tests/Composer/Test/Command/BumpCommandTest.php
@@ -76,7 +76,7 @@ class BumpCommandTest extends TestCase
         yield 'bump all by default' => [
             [
                 'require' => [
-                    'first/pkg' => '^2.0',
+                    'first/pkg' => '^v2.0',
                     'second/pkg' => '3.*',
                 ],
                 'require-dev' => [

--- a/tests/Composer/Test/Package/Version/VersionBumperTest.php
+++ b/tests/Composer/Test/Package/Version/VersionBumperTest.php
@@ -44,6 +44,7 @@ class VersionBumperTest extends TestCase
     {
         // constraint, version, expected recommendation, [branch-alias]
         yield 'upgrade caret' => ['^1.0', '1.2.1', '^1.2.1'];
+        yield 'upgrade caret with v' => ['^v1.0', '1.2.1', '^1.2.1'];
         yield 'skip trailing .0s' => ['^1.0', '1.0.0', '^1.0'];
         yield 'skip trailing .0s/2' => ['^1.2', '1.2.0', '^1.2'];
         yield 'preserve major.minor.patch format when installed minor is 0' => ['^1.0.0', '1.2.0', '^1.2.0'];
@@ -58,6 +59,7 @@ class VersionBumperTest extends TestCase
         yield 'dev version does not upgrade' => ['^3.2', 'dev-main', '^3.2'];
         yield 'upgrade dev version if aliased' => ['^3.2', 'dev-main', '^3.3', '3.3.x-dev'];
         yield 'upgrade major wildcard to caret' => ['2.*', '2.4.0', '^2.4'];
+        yield 'upgrade major wildcard to caret with v' => ['v2.*', '2.4.0', '^2.4'];
         yield 'upgrade major wildcard as x to caret' => ['2.x', '2.4.0', '^2.4'];
         yield 'upgrade major wildcard as x to caret/2' => ['2.x.x', '2.4.0', '^2.4.0'];
         yield 'leave minor wildcard alone' => ['2.4.*', '2.4.3', '2.4.*'];
@@ -66,6 +68,7 @@ class VersionBumperTest extends TestCase
         yield 'update patch-only-tilde alone' => ['~2.2.3', '2.2.6', '~2.2.6'];
         yield 'leave extra-only-tilde alone' => ['~2.2.3.1', '2.2.4.5', '~2.2.3.1'];
         yield 'upgrade bigger-or-eq to latest' => ['>=3.0', '3.4.5', '>=3.4.5'];
+        yield 'upgrade bigger-or-eq to latest with v' => ['>=v3.0', '3.4.5', '>=3.4.5'];
         yield 'leave bigger-than untouched' => ['>2.2.3', '2.2.6', '>2.2.3'];
     }
 }


### PR DESCRIPTION
Fixes #11723

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
