### PR TITLE
Re-organized PoolOptimizer - reverting #9620 to fix #9393

### DIFF
--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-locked-replacer.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages-locked-replacer.test
@@ -56,5 +56,6 @@ Do not load packages into the pool that cannot meet the fixed/locked requirement
     "first/pkg-1.0.0.0 (locked)",
     "replacer/pkg-1.0.0.0 (locked)",
     "second/pkg-1.0.0.0",
-    "replacer/dep-1.0.1.0"
+    "replacer/dep-1.0.1.0",
+    "replacer/dep-2.0.0.0"
 ]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/filter-impossible-packages.test
@@ -51,5 +51,6 @@ Do not load packages into the pool that cannot meet the fixed/locked requirement
 [
     2,
     "some/pkg-1.0.4.0",
+    "dep/dep-1.0.2.0",
     "dep/dep-2.0.1.0"
 ]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repos-always-but-not-their-transitive-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixes-path-repos-always-but-not-their-transitive-deps.test
@@ -86,5 +86,6 @@ Partially updating one root requirement with transitive deps fully updates trans
    "symlinked/path-pkg-2.0.0.0",
    "root/update-1.0.4.0",
    "symlinked/transitive2-2.0.4.0",
-   "mirrored/transitive2-1.0.7.0"
+   "mirrored/transitive2-1.0.7.0",
+   "mirrored/transitive2-2.0.8.0"
 ]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-unfixing-locked-deps.test
@@ -55,5 +55,6 @@ locked packages still need to be taking into account for loading all necessary v
     "root/req2-1.0.0.0 (locked)",
     "dep/pkg2-1.0.0.0",
     "dep/pkg2-1.2.0.0",
-    "dep/pkg1-1.0.1.0"
+    "dep/pkg1-1.0.1.0",
+    "dep/pkg1-2.0.0.0"
 ]


### PR DESCRIPTION
Imho this should fix https://github.com/composer/composer/issues/9393 by reverting https://github.com/composer/composer/pull/9620.

The problem of https://github.com/composer/composer/pull/9620 is that it marks a package for removal although this has been previously marked to be kept. This causes the bug described in #9393. While debugging, I noticed that understanding the logic in the `PoolOptimizer` is not as easy because it's designed to 

* first mark all packages for removal
* then decide which ones of those should be kept

This was fine because it was the way it was initially designed when I first contributed the optimizer in https://github.com/composer/composer/pull/9261 which only consisted of `optimizeByIdenticalDependencies()`.

However, https://github.com/composer/composer/issues/9393 introduced a second optimization step (`optimizeImpossiblePackagesAway()`) in which additional packages are marked for removal even if the first step marked them as to be kept - causing the mentioned bug.

So what I did in this PR is invert the logic:

* mark all packages that need to be kept
* then remove all the remaining ones

@driskell - maybe you could try to re-implement your logic of https://github.com/composer/composer/pull/9620 on top of this PR? Basically instead of `markPackageForRemoval()` they should not even be marked as required to keep. 