### PR TITLE
Add Global Command tests

### DIFF
--- a/tests/Composer/Test/Command/GlobalCommandTest.php
+++ b/tests/Composer/Test/Command/GlobalCommandTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Command;
+
+use Composer\Test\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+class GlobalCommandTest extends TestCase
+{
+    public function testExceptionRunningWithNoSubcommand(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "command-name").');
+
+        $appTester = $this->getApplicationTester();
+        $this->assertEquals(Command::FAILURE, $appTester->run(['command' => 'global']));
+    }
+
+    public function testExceptionRunningWithIncompleteSubcommand(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "packages").');
+
+        $appTester = $this->getApplicationTester();
+        $this->assertEquals(Command::FAILURE, $appTester->run(['command' => 'global', 'command-name' => 'remove'] ));
+    }
+}


### PR DESCRIPTION
Add Test for Global Command as it is required in https://github.com/composer/composer/issues/10796

This PR is still a work in progress as I try to acquire internal knowledge.

If anyone sees what is nice to test for the global command ;)  , I'm open to suggestions.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
