### PR TITLE
Failing test to outline problem in #9393

### DIFF
--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/bug-9393.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/bug-9393.test
@@ -1,0 +1,64 @@
+--TEST--
+Failing test case for https://github.com/composer/composer/issues/9393
+
+--REQUEST--
+{
+    "require": {
+        "drupal/core-recommended": "^10.1.7",
+        "drupal/viewsreference": "^2.0@beta"
+    },
+    "locked": [
+        {"name": "drupal/spamaway", "version": "2.0.0", "require": {"drupal/core": "^8 || ^9 || ^10", "drupal/webform": "*"}, "id": 1},
+        {"name": "drupal/webform", "version": "6.1.8", "require": {"drupal/core": "^9.3"}, "id": 2},
+        {"name": "drupal/viewsreference", "version": "1.8.0", "require": {"drupal/core": "^9.3"}, "id": 3}
+    ],
+    "allowList": [
+        "drupal/core",
+        "drupal/viewsreference"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    [
+        {"name":"drupal/core-recommended", "version": "10.1.7", "require": {"drupal/core": "10.1.7"}},
+        {"name":"drupal/core-recommended", "version": "10.2.0", "require": {"drupal/core": "10.2.0"}},
+        {"name":"drupal/viewsreference", "version": "2.0.0-beta2", "require": {"drupal/core": "^9.3 || ^10"}},
+        {"name":"drupal/viewsreference", "version": "2.0.0-beta1", "require": {"drupal/core": "^9.3 || ^10"}},
+        {"name":"drupal/spamaway", "version": "2.0.0", "require": {"drupal/core": "^8 || ^9 || ^10", "drupal/webform": "*"}},
+        {"name": "drupal/webform", "version": "6.1.8", "require": {"drupal/core": "^9.3"}},
+        {"name": "drupal/core", "version": "8.0.0"},
+        {"name": "drupal/core", "version": "9.0.0"},
+        {"name": "drupal/core", "version": "9.3.0"},
+        {"name": "drupal/core", "version": "9.3.1"},
+        {"name": "drupal/core", "version": "10.2.0"}
+    ]
+]
+
+--EXPECT--
+[
+    1,
+    2,
+    "drupal/core-8.0.0.0",
+    "drupal/core-9.0.0.0",
+    "drupal/core-9.3.0.0",
+    "drupal/core-9.3.1.0",
+    "drupal/core-10.2.0.0",
+    "drupal/core-recommended-10.1.7.0",
+    "drupal/core-recommended-10.2.0.0"
+]
+
+--EXPECT-OPTIMIZED--
+[
+    1,
+    2,
+    "drupal/core-9.3.1.0",
+    "drupal/core-10.2.0.0",
+    "drupal/core-recommended-10.1.7.0",
+    "drupal/core-recommended-10.2.0.0"
+]


### PR DESCRIPTION
Okay, managed to debug exactly on what's happening after way too many hours 😅 Here's the exact reason on what's happening in the case described by @Seldaek in https://github.com/composer/composer/issues/9393#issuecomment-1864405254:

* `drupal/webform` is locked at `6.1.8.0` but allowed to be updated/removed because of `-W`
* `PoolOptimizer::optimizeImpossiblePackagesAway()` removes `drupal/core` `10.2.0.0` because `drupal/webform` is locked at `6.1.8.0` and requires `drupal/core` in `^9.3`.

The problem is that `drupal/webform` itself is going to be removed during the update process so actually, its requirements should not be considered and thus the `drupal/core` `10.2.0.0` should not get removed.

This exact case was actually sort of considered in the `$isUnusedPackage` here: https://github.com/composer/composer/blob/8e62977cb5de315d5190c021a2b2bb4e59ee2f4f/src/Composer/DependencyResolver/PoolOptimizer.php#L404

However, this doesn't work properly because `$this->requireConstraintsPerPackage[$packageName])` actually **does** contain `drupal/webform` because this array is built before any optimizations are even applied. It is required by the root package `drupal/spamaway` `2.0.0.0` **which would also get removed**. 

So the bug happens because the `$this->requireConstraintsPerPackage` (and probably other things) are used as if this array were to contain a definitive list of what is **going to be** required. Something that we never know at the stage of the PoolOptimizer as this is what the Solver will do  - it's a typical problem of recursive optimizations.

So long story short: The current optimization step for locked packages is flawed because it is built on top of false assumptions. 