### PR TITLE
Ensure we respect available-package-patterns and available-packages directives when fetching security advisories

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -637,6 +637,15 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
 
         $apiUrl = $this->securityAdvisoryConfig['api-url'];
 
+        // respect available-package-patterns / available-packages directives from the repo
+        if ($this->hasAvailablePackageList) {
+            foreach ($packageConstraintMap as $name => $constraint) {
+                if (!$this->lazyProvidersRepoContains(strtolower($name))) {
+                    unset($packageConstraintMap[$name]);
+                }
+            }
+        }
+
         $parser = new VersionParser();
         /**
          * @param array<mixed> $data


### PR DESCRIPTION
Fixes #11704

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
