### PR TITLE
Fix warnings incorrectly being shown when using require with upper bound ignored on platform requirements

### DIFF
--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilter.php
@@ -20,4 +20,9 @@ final class IgnoreAllPlatformRequirementFilter implements PlatformRequirementFil
     {
         return PlatformRepository::isPlatformPackage($req);
     }
+
+    public function isUpperBoundIgnored(string $req): bool
+    {
+        return $this->isIgnored($req);
+    }
 }

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilter.php
@@ -60,6 +60,15 @@ final class IgnoreListPlatformRequirementFilter implements PlatformRequirementFi
         return Preg::isMatch($this->ignoreRegex, $req);
     }
 
+    public function isUpperBoundIgnored(string $req): bool
+    {
+        if (!PlatformRepository::isPlatformPackage($req)) {
+            return false;
+        }
+
+        return $this->isIgnored($req) || Preg::isMatch($this->ignoreUpperBoundRegex, $req);
+    }
+
     /**
      * @param bool $allowUpperBoundOverride For conflicts we do not want the upper bound to be skipped
      */

--- a/src/Composer/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilter.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilter.php
@@ -21,4 +21,12 @@ final class IgnoreNothingPlatformRequirementFilter implements PlatformRequiremen
     {
         return false;
     }
+
+    /**
+     * @return false
+     */
+    public function isUpperBoundIgnored(string $req): bool
+    {
+        return false;
+    }
 }

--- a/src/Composer/Filter/PlatformRequirementFilter/PlatformRequirementFilterInterface.php
+++ b/src/Composer/Filter/PlatformRequirementFilter/PlatformRequirementFilterInterface.php
@@ -15,4 +15,6 @@ namespace Composer\Filter\PlatformRequirementFilter;
 interface PlatformRequirementFilterInterface
 {
     public function isIgnored(string $req): bool;
+
+    public function isUpperBoundIgnored(string $req): bool;
 }

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -13,6 +13,7 @@
 namespace Composer\Package\Version;
 
 use Composer\Filter\PlatformRequirementFilter\IgnoreAllPlatformRequirementFilter;
+use Composer\Filter\PlatformRequirementFilter\IgnoreListPlatformRequirementFilter;
 use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterInterface;
 use Composer\IO\IOInterface;
@@ -129,6 +130,13 @@ class VersionSelector
                             if ($link->getConstraint()->matches($providedConstraint)) {
                                 // constraint satisfied, go to next require
                                 continue 2;
+                            }
+                            if ($platformRequirementFilter instanceof IgnoreListPlatformRequirementFilter && $platformRequirementFilter->isUpperBoundIgnored($name)) {
+                                $filteredConstraint = $platformRequirementFilter->filterConstraint($name, $link->getConstraint());
+                                if ($filteredConstraint->matches($providedConstraint)) {
+                                    // constraint satisfied with the upper bound ignored, go to next require
+                                    continue 2;
+                                }
                             }
                         }
 

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreAllPlatformRequirementFilterTest.php
@@ -25,6 +25,7 @@ final class IgnoreAllPlatformRequirementFilterTest extends TestCase
         $platformRequirementFilter = new IgnoreAllPlatformRequirementFilter();
 
         $this->assertSame($expectIgnored, $platformRequirementFilter->isIgnored($req));
+        $this->assertSame($expectIgnored, $platformRequirementFilter->isUpperBoundIgnored($req));
     }
 
     /**

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreListPlatformRequirementFilterTest.php
@@ -48,4 +48,37 @@ final class IgnoreListPlatformRequirementFilterTest extends TestCase
             'list entries are not completing each other' => [['ext-', 'foo'], 'ext-foo', false],
         ];
     }
+
+    /**
+     * @dataProvider dataIsUpperBoundIgnored
+     *
+     * @param string[] $reqList
+     */
+    public function testIsUpperBoundIgnored(array $reqList, string $req, bool $expectIgnored): void
+    {
+        $platformRequirementFilter = new IgnoreListPlatformRequirementFilter($reqList);
+
+        $this->assertSame($expectIgnored, $platformRequirementFilter->isUpperBoundIgnored($req));
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    public static function dataIsUpperBoundIgnored(): array
+    {
+        return [
+            'ext-json is ignored if listed and fully ignored' => [['ext-json', 'monolog/monolog'], 'ext-json', true],
+            'ext-json is ignored if listed and upper bound ignored' => [['ext-json+', 'monolog/monolog'], 'ext-json', true],
+            'php is not ignored if not listed' => [['ext-json+', 'monolog/monolog'], 'php', false],
+            'monolog/monolog is not ignored even if listed' => [['monolog/monolog'], 'monolog/monolog', false],
+            'ext-json is ignored if ext-* is listed' => [['ext-*+'], 'ext-json', true],
+            'php is ignored if php* is listed' => [['ext-*+', 'php*+'], 'php', true],
+            'ext-json is ignored if * is listed' => [['foo', '*+'], 'ext-json', true],
+            'php is ignored if * is listed' => [['*+', 'foo'], 'php', true],
+            'monolog/monolog is not ignored even if * or monolog/* are listed' => [['*+', 'monolog/*+'], 'monolog/monolog', false],
+            'empty list entry does not ignore' => [[''], 'ext-foo', false],
+            'empty array does not ignore' => [[], 'ext-foo', false],
+            'list entries are not completing each other' => [['ext-', 'foo'], 'ext-foo', false],
+        ];
+    }
 }

--- a/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilterTest.php
+++ b/tests/Composer/Test/Filter/PlatformRequirementFilter/IgnoreNothingPlatformRequirementFilterTest.php
@@ -25,6 +25,7 @@ final class IgnoreNothingPlatformRequirementFilterTest extends TestCase
         $platformRequirementFilter = new IgnoreNothingPlatformRequirementFilter();
 
         $this->assertFalse($platformRequirementFilter->isIgnored($req)); // @phpstan-ignore-line
+        $this->assertFalse($platformRequirementFilter->isUpperBoundIgnored($req)); // @phpstan-ignore-line
     }
 
     /**


### PR DESCRIPTION
fixes #11722

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
