### PR TITLE
test: Covers audit of pkg with no sec advisories

### DIFF
--- a/tests/Composer/Test/Command/AuditCommandTest.php
+++ b/tests/Composer/Test/Command/AuditCommandTest.php
@@ -41,4 +41,20 @@ class AuditCommandTest extends TestCase
         $appTester = $this->getApplicationTester();
         $appTester->run(['command' => 'audit', '--locked' => true]);
     }
+
+    public function testAuditPackageWithNoSecurityVulnerabilities(): void
+    {
+        $this->initTempComposer();
+        $packages = [self::getPackage()];
+        $this->createInstalledJson($packages);
+        $this->createComposerLock($packages);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'audit', '--locked' => true]);
+
+        self::assertStringContainsString(
+            'No security vulnerability advisories found.',
+            trim($appTester->getDisplay(true))
+        );
+    }
 }


### PR DESCRIPTION
Adds a test case for the happy path of the Audit Command where a given package has no security advisories.
