### PR TITLE
Fix find excutable function execute exception when command option treated as executable file

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -350,7 +350,7 @@ class EventDispatcher
                         }
                         // match somename (not in quote, and not a qualified path) and if it is not a valid path from CWD then try to find it
                         // in $PATH. This allows support for `@php foo` where foo is a binary name found in PATH but not an actual relative path
-                        $matched = Preg::isMatchStrictGroups('{^[^\'"\s/\\\\]+}', $pathAndArgs, $match);
+                        $matched = Preg::isMatchStrictGroups('{^[^-\'"\s/\\\\]+}', $pathAndArgs, $match);
                         if ($matched && !file_exists($match[0])) {
                             $finder = new ExecutableFinder;
                             if ($pathToExec = $finder->find($match[0])) {

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -350,7 +350,7 @@ class EventDispatcher
                         }
                         // match somename (not in quote, and not a qualified path) and if it is not a valid path from CWD then try to find it
                         // in $PATH. This allows support for `@php foo` where foo is a binary name found in PATH but not an actual relative path
-                        $matched = Preg::isMatchStrictGroups('{^[^-\'"\s/\\\\]+}', $pathAndArgs, $match);
+                        $matched = Preg::isMatchStrictGroups('{^(?!-)[^\'"\s/\\\\]+}', $pathAndArgs, $match);
                         if ($matched && !file_exists($match[0])) {
                             $finder = new ExecutableFinder;
                             if ($pathToExec = $finder->find($match[0])) {


### PR DESCRIPTION
### How to reproduce
In my Laravel project composer.json file, script defined a few script like that

```json
"post-update-cmd": [
            "@php -r \"file_put_contents('storage/local/last-composer-lock-hash', md5_file('composer.lock'));\""
        ],
```
when I run `composer run script post-update-cmd` the composer package will remove the prefix `@php`  and extract `-r` to determine if the file is executable, and then in the  `find()` method of `symfony/process` the exec('command -v') will execute that `exec('command -v -r')` and output a message that 

https://github.com/symfony/symfony/blob/4328f5b16852b8daefc957d370c08ee0bfbf3dbc/src/Symfony/Component/Process/ExecutableFinder.php#L72

```sh
symfony/porcess > v6.4
➜   composer run-script post-update-cmd 
php-http/discovery contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "php-http/discovery" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] d
> @php -r "file_put_contents('storage/local/last-composer-lock-hash', md5_file('composer.lock'));"
sh: line 0: command: -r: invalid option
command: usage: command [-pVv] command [arg ...]

```
