### PR TITLE
Introduce COMPOSER_AUDIT_ABANDONED env var (for 2.6)

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -143,6 +143,8 @@ Defaults to `report` in Composer 2.6, and defaults to `fail` from Composer 2.7 o
 - `report` means abandoned packages are reported as an error but do not cause the command to exit with a non-zero code.
 - `fail` means abandoned packages will cause audits to fail with a non-zero code.
 
+Since Composer 2.6.7 the default and the configuration in composer.json can be overriden via the `COMPOSER_AUDIT_ABANDONED` environmant variable.
+
 ## use-parent-dir
 
 When running Composer in a directory where there is no composer.json, if there

--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -19,6 +19,7 @@ use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;
 use Composer\Repository\RepositorySet;
 use Composer\Util\PackageInfo;
+use Composer\Util\Platform;
 use InvalidArgumentException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 
@@ -58,6 +59,10 @@ class Auditor
      */
     public function audit(IOInterface $io, RepositorySet $repoSet, array $packages, string $format, bool $warningOnly = true, array $ignoreList = [], string $abandoned = self::ABANDONED_REPORT): int
     {
+        if (Platform::getEnv('COMPOSER_AUDIT_ABANDONED') !== FALSE) {
+            $abandoned = Platform::getEnv('COMPOSER_AUDIT_ABANDONED');
+        }
+
         if ($abandoned === 'default' && $format !== self::FORMAT_SUMMARY) {
             $io->writeError('<warning>The new audit.abandoned setting (currently defaulting to "report" will default to "fail" in Composer 2.7, make sure to set it to "report" or "ignore" explicitly by then if you do not want this.</warning>');
         }

--- a/tests/Composer/Test/Advisory/AuditorTest.php
+++ b/tests/Composer/Test/Advisory/AuditorTest.php
@@ -23,6 +23,7 @@ use Composer\Repository\ComposerRepository;
 use Composer\Repository\RepositorySet;
 use Composer\Test\TestCase;
 use Composer\Advisory\Auditor;
+use Composer\Util\Platform;
 use InvalidArgumentException;
 
 class AuditorTest extends TestCase
@@ -142,6 +143,29 @@ Found 2 abandoned packages:
     }
 }',
         ];
+
+        yield 'abandoned packages reporting mode override via env var' => [
+            'data' => [
+                'packages' => [
+                    $abandonedWithReplacement,
+                    $abandonedNoReplacement,
+                ],
+                'warningOnly' => false,
+                'abandoned' => Auditor::ABANDONED_FAIL,
+                'abandoned_via_env_var' => Auditor::ABANDONED_REPORT,
+                'format' => Auditor::FORMAT_TABLE,
+            ],
+            'expected' => 0,
+            'output' => 'No security vulnerability advisories found.
+Found 2 abandoned packages:
++-------------------+----------------------------------------------------------------------------------+
+| Abandoned Package | Suggested Replacement                                                            |
++-------------------+----------------------------------------------------------------------------------+
+| vendor/abandoned  | foo/bar                                                                          |
+| vendor/abandoned2 | none                                                                             |
++-------------------+----------------------------------------------------------------------------------+',
+        ];
+
     }
 
     /**
@@ -154,9 +178,13 @@ Found 2 abandoned packages:
             $this->expectException(InvalidArgumentException::class);
         }
         $auditor = new Auditor();
+        if (array_key_exists('abandoned_via_env_var', $data)) {
+            Platform::putEnv('COMPOSER_AUDIT_ABANDONED', $data['abandoned_via_env_var']);
+        }
         $result = $auditor->audit($io = new BufferIO(), $this->getRepoSet(), $data['packages'], $data['format'] ?? Auditor::FORMAT_PLAIN, $data['warningOnly'], [], $data['abandoned'] ?? Auditor::ABANDONED_IGNORE);
         $this->assertSame($expected, $result);
         $this->assertSame($output, trim(str_replace("\r", '', $io->getOutput())));
+        Platform::clearEnv('COMPOSER_AUDIT_ABANDONED');
     }
 
     public function ignoredIdsProvider(): \Generator {


### PR DESCRIPTION
Closes #11792 for the 2.6 branch.