### PR TITLE
Do not show error that plugins have been disabled when they are already disabled

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -292,7 +292,7 @@ class Application extends BaseApplication
             $this->hasPluginCommands = true;
         }
 
-        if ($isNonAllowedRoot && !$io->isInteractive()) {
+        if (!$this->disablePluginsByDefault && $isNonAllowedRoot && !$io->isInteractive()) {
             $io->writeError('<error>Composer plugins have been disabled for safety in this non-interactive session. Set COMPOSER_ALLOW_SUPERUSER=1 if you want to allow plugins to run as root/super user.</error>');
             $this->disablePluginsByDefault = true;
         }


### PR DESCRIPTION
Current behaviour is to, no matter `--no-plugins` is used or not, to show the error, this is from `main` branch:
```cli
$ ./bin/compile
$ sudo php composer.phar -n --version
Composer plugins have been disabled for safety in this non-interactive session. Set COMPOSER_ALLOW_SUPERUSER=1 if you want to allow plugins to run as root/super user.
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Composer version 2.7-dev+4e5be9ee7d924d8efc58d676439b0c7bd18a9ce4 (2.7-dev) 2024-01-12 13:20:59
$ sudo php composer.phar -n --version --no-plugins
Composer plugins have been disabled for safety in this non-interactive session. Set COMPOSER_ALLOW_SUPERUSER=1 if you want to allow plugins to run as root/super user.
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Composer version 2.7-dev+4e5be9ee7d924d8efc58d676439b0c7bd18a9ce4 (2.7-dev) 2024-01-12 13:20:59
```

After this change only when `--no-plugins` is NOT used, to show the error:
```cli
$ ./bin/compile
$ sudo php composer.phar -n --version
Composer plugins have been disabled for safety in this non-interactive session. Set COMPOSER_ALLOW_SUPERUSER=1 if you want to allow plugins to run as root/super user.
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Composer version 2.7-dev+4e5be9ee7d924d8efc58d676439b0c7bd18a9ce4 (2.7-dev) 2024-01-12 13:20:59
$ sudo php composer.phar -n --version --no-plugins
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Composer version 2.7-dev+4e5be9ee7d924d8efc58d676439b0c7bd18a9ce4 (2.7-dev) 2024-01-12 13:20:59
```