### PR TITLE
Add post-outdated-cmd and pre-outdated-cmd events

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -638,6 +638,14 @@
                     "type": ["array", "string"],
                     "description": "Occurs after the update command is executed, contains one or more Class::method callables or shell commands."
                 },
+                "pre-outdated-cmd": {
+                    "type": ["array", "string"],
+                    "description": "Occurs before the outdated command is executed, contains one or more Class::method callables or shell commands."
+                },
+                "post-outdated-cmd": {
+                    "type": ["array", "string"],
+                    "description": "Occurs after the outdated command is executed, contains one or more Class::method callables or shell commands."
+                },
                 "pre-status-cmd": {
                     "type": ["array", "string"],
                     "description": "Occurs before the status command is executed, contains one or more Class::method callables or shell commands."

--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -116,7 +116,7 @@ EOT
         $composer = $this->tryComposer();
 
         if ($composer !== null) {
-            $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'archive', $input, $output);
+            $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'outdated', $input, $output);
             $eventDispatcher = $composer->getEventDispatcher();
             $eventDispatcher->dispatch($commandEvent->getName(), $commandEvent);
             $eventDispatcher->dispatchScript(ScriptEvents::PRE_OUTDATED_CMD);

--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -113,10 +113,9 @@ EOT
 
         $input = new ArrayInput($args);
 
-
         $composer = $this->tryComposer();
 
-        if ($composer) {
+        if ($composer !== null) {
             $commandEvent = new CommandEvent(PluginEvents::COMMAND, 'archive', $input, $output);
             $eventDispatcher = $composer->getEventDispatcher();
             $eventDispatcher->dispatch($commandEvent->getName(), $commandEvent);
@@ -125,7 +124,7 @@ EOT
 
         $returnCode = $this->getApplication()->run($input, $output);
 
-        if (0 === $returnCode && $composer) {
+        if (0 === $returnCode && $composer !== null) {
             $composer->getEventDispatcher()->dispatchScript(ScriptEvents::POST_OUTDATED_CMD);
         }
 

--- a/src/Composer/Script/ScriptEvents.php
+++ b/src/Composer/Script/ScriptEvents.php
@@ -128,4 +128,22 @@ class ScriptEvents
      * @var string
      */
     public const POST_ARCHIVE_CMD = 'post-archive-cmd';
+
+    /**
+     * The PRE_OUTDATED_CMD event occurs before the outdated command is executed.
+     *
+     * The event listener method receives a Composer\Script\Event instance.
+     *
+     * @var string
+     */
+    public const PRE_OUTDATED_CMD = 'pre-outdated-cmd';
+
+    /**
+     * The POST_OUTDATED_CMD event occurs after the outdated command is executed.
+     *
+     * The event listener method receives a Composer\Script\Event instance.
+     *
+     * @var string
+     */
+    public const POST_OUTDATED_CMD = 'post-outdated-cmd';
 }


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->

I use a root composer.json inside my monorepository and forward commands to run in all subpackages. Beside install and update, I would like todo that also for the `outdated` command here:  https://github.com/schranz-search/schranz-search/blob/6e84eb2692ea257397d9ebe7b67fce1753cdba98/composer.json#L15

So I thought I could add new events to achieve this.

Example Usage:

```json
{
    "type": "project",
    "license": "MIT",
    "require-dev": {
        "schranz/mono": "^2.0.1"
    },
    "scripts": {
        "post-outdated-cmd": "@php vendor/bin/mono run composer outdated"
    }
}
```

Let me know what you think about this new events?