### PR TITLE
chore(doc): add `_comment` documentation inside `composer.json` schema

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -971,6 +971,15 @@ Optional.
 
 Top level key used as a place to store comments (it can be a string or array of strings).
 
+```json
+{
+    "_comment": [
+        "The package foo/bar was required for business logic",
+        "Remove package foo/baz when removing foo/bar"
+    ]
+}
+```
+
 Defaults to empty.
 
 Optional.

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -967,6 +967,14 @@ Defaults to false.
 
 Optional.
 
+### _comment
+
+Top level key used as a place to store comments (it can be a string or array of strings).
+
+Defaults to empty.
+
+Optional.
+
 ### non-feature-branches
 
 A list of regex patterns of branch names that are non-numeric (e.g. "latest" or something),


### PR DESCRIPTION
I've asked a discussion on symfony slack and got this info, found it not documented so my I propose to add it

as per https://github.com/composer/composer/blob/d3aeb1357f8cb00474f0b640279d192301b3906f/CHANGELOG.md?plain=1#L1388