### PR TITLE
Add arguments to command call output

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -201,11 +201,11 @@ class EventDispatcher
                         throw new \RuntimeException('Subscriber '.$className.'::'.$callable[1].' for event '.$event->getName().' is not callable, make sure the function is defined and public');
                     }
                     if (is_array($callable) && (is_string($callable[0]) || is_object($callable[0])) && is_string($callable[1])) {
-                        $this->io->writeError(sprintf('> %s: %s', $event->getName(), (is_object($callable[0]) ? get_class($callable[0]) : $callable[0]).'->'.$callable[1]), true, IOInterface::VERBOSE);
+                        $this->io->writeError(sprintf('> %s (%s): %s', $event->getName(), implode(',', $event->getArguments()), (is_object($callable[0]) ? get_class($callable[0]) : $callable[0]).'->'.$callable[1]), true, IOInterface::VERBOSE);
                     }
                     $return = false === $callable($event) ? 1 : 0;
                 } elseif ($this->isComposerScript($callable)) {
-                    $this->io->writeError(sprintf('> %s: %s', $event->getName(), $callable), true, IOInterface::VERBOSE);
+                    $this->io->writeError(sprintf('> %s (%s): %s', $event->getName(), implode(',', $event->getArguments()), $callable), true, IOInterface::VERBOSE);
 
                     $script = explode(' ', substr($callable, 1));
                     $scriptName = $script[0];

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -194,7 +194,7 @@ class EventDispatcher
                 $return = 0;
                 $this->ensureBinDirIsInPath();
 
-                $formattedEventNameWithArgs = $event->getName() . ($event->getArguments() !== [] ? ' (' . implode(',', $event->getArguments()) . ')' : '');
+                $formattedEventNameWithArgs = $event->getName() . ($event->getArguments() !== [] ? ' (' . implode(', ', $event->getArguments()) . ')' : '');
                 if (!is_string($callable)) {
                     if (!is_callable($callable)) {
                         $className = is_object($callable[0]) ? get_class($callable[0]) : $callable[0];

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -194,6 +194,7 @@ class EventDispatcher
                 $return = 0;
                 $this->ensureBinDirIsInPath();
 
+                $formattedEventNameWithArgs = $event->getName() . ($event->getArguments() !== [] ? ' (' . implode(',', $event->getArguments()) . ')' : '');
                 if (!is_string($callable)) {
                     if (!is_callable($callable)) {
                         $className = is_object($callable[0]) ? get_class($callable[0]) : $callable[0];
@@ -201,11 +202,11 @@ class EventDispatcher
                         throw new \RuntimeException('Subscriber '.$className.'::'.$callable[1].' for event '.$event->getName().' is not callable, make sure the function is defined and public');
                     }
                     if (is_array($callable) && (is_string($callable[0]) || is_object($callable[0])) && is_string($callable[1])) {
-                        $this->io->writeError(sprintf('> %s (%s): %s', $event->getName(), implode(',', $event->getArguments()), (is_object($callable[0]) ? get_class($callable[0]) : $callable[0]).'->'.$callable[1]), true, IOInterface::VERBOSE);
+                        $this->io->writeError(sprintf('> %s: %s', $formattedEventNameWithArgs, (is_object($callable[0]) ? get_class($callable[0]) : $callable[0]).'->'.$callable[1]), true, IOInterface::VERBOSE);
                     }
                     $return = false === $callable($event) ? 1 : 0;
                 } elseif ($this->isComposerScript($callable)) {
-                    $this->io->writeError(sprintf('> %s (%s): %s', $event->getName(), implode(',', $event->getArguments()), $callable), true, IOInterface::VERBOSE);
+                    $this->io->writeError(sprintf('> %s: %s', $formattedEventNameWithArgs, $callable), true, IOInterface::VERBOSE);
 
                     $script = explode(' ', substr($callable, 1));
                     $scriptName = $script[0];


### PR DESCRIPTION
When executing a script, arguments are not displayed for execution. For example with the following scripts:
```json
{
    "update": "FQN\\Update"
    "update-all": {
        "update-a": "@update A",
        "update-b": "@update B"
    }
}
```
results in the following output: when running `update-all`:
```bash
> FQN\\Update
> FQN\\Update
```

In this PR, the arguments supplied will be made visible:
```bash
> FQN\\Update (A)
> FQN\\Update (B)
```