### PR TITLE
ValidatingArrayLoader: fix link validation with missing name

### DIFF
--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -251,7 +251,7 @@ class ValidatingArrayLoader implements LoaderInterface
             if ($this->validateArray($linkType) && isset($this->config[$linkType])) {
                 foreach ($this->config[$linkType] as $package => $constraint) {
                     $package = (string) $package;
-                    if (0 === strcasecmp($package, $this->config['name'])) {
+                    if (isset($this->config['name']) && 0 === strcasecmp($package, $this->config['name'])) {
                         $this->errors[] = $linkType.'.'.$package.' : a package cannot set a '.$linkType.' on itself';
                         unset($this->config[$linkType][$package]);
                         continue;

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -426,6 +426,12 @@ class ValidatingArrayLoaderTest extends TestCase
                 ],
                 ['replace.0 : invalid version constraint (Could not parse version constraint acme/bar: Invalid version string "acme/bar")'],
             ],
+            [
+                [
+                    'require' => ['acme/bar' => '^1.0']
+                ],
+                ['name : must be present'],
+            ]
         ]);
     }
 


### PR DESCRIPTION
Fixes `Undefined array key "name"`

Wasn't sure if there is going to be another 2.6 release but commit can be applied on main too.