### PR TITLE
Adds a test for Audit Command no dev

### DIFF
--- a/tests/Composer/Test/Command/AuditCommandTest.php
+++ b/tests/Composer/Test/Command/AuditCommandTest.php
@@ -57,4 +57,20 @@ class AuditCommandTest extends TestCase
             trim($appTester->getDisplay(true))
         );
     }
+
+    public function testAuditPackageWithNoDevOptionPassed(): void
+    {
+        $this->initTempComposer();
+        $devPackage = [self::getPackage()];
+        $this->createInstalledJson([], $devPackage);
+        $this->createComposerLock([], $devPackage);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'audit', '--no-dev' => true]);
+
+        self::assertStringContainsString(
+            'No packages - skipping audit.',
+            trim($appTester->getDisplay(true))
+        );
+    }
 }


### PR DESCRIPTION
Adds a single test case to cover running the Audit Command with `--no-dev` flag passed. This brings the command to 100% coverage.
