### PR TITLE
Repositories docs reference

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -548,6 +548,14 @@ Here is an example for the smarty template engine:
 
 Typically, you would leave the source part off, as you don't really need it.
 
+If a source key is included, the reference field should be a reference to the version that will be installed.
+Where the type field is `git`, this will the be the commit id, branch or tag name.
+
+**Note**: It is not recommended to use a git branch name for the reference field. While this is valid as it is supported by `git checkout`,
+branch names are mutable and thus cannot be locked.
+
+Where the type field is `svn`, the  reference field should contain the reference that gets appended to the URL when running `svn co`.
+
 > **Note**: This repository type has a few limitations and should be avoided
 > whenever possible:
 >

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -551,8 +551,8 @@ Typically, you would leave the source part off, as you don't really need it.
 If a source key is included, the reference field should be a reference to the version that will be installed.
 Where the type field is `git`, this will the be the commit id, branch or tag name.
 
-**Note**: It is not recommended to use a git branch name for the reference field. While this is valid as it is supported by `git checkout`,
-branch names are mutable and thus cannot be locked.
+**Note**: It is not recommended to use a git branch name for the reference field. While this is valid since it is supported by `git checkout`,
+branch names are mutable so cannot be locked.
 
 Where the type field is `svn`, the reference field should contain the reference that gets appended to the URL when running `svn co`.
 

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -554,7 +554,7 @@ Where the type field is `git`, this will the be the commit id, branch or tag nam
 **Note**: It is not recommended to use a git branch name for the reference field. While this is valid as it is supported by `git checkout`,
 branch names are mutable and thus cannot be locked.
 
-Where the type field is `svn`, the  reference field should contain the reference that gets appended to the URL when running `svn co`.
+Where the type field is `svn`, the reference field should contain the reference that gets appended to the URL when running `svn co`.
 
 > **Note**: This repository type has a few limitations and should be avoided
 > whenever possible:


### PR DESCRIPTION
Adds a small section to the repositories page of the docs based on [a comment](https://github.com/composer/composer/issues/11735#issuecomment-1830251947) from @stof on #11735
