### PR TITLE
Output more warnings about plugins being disabled to hint that it may cause problems

### DIFF
--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -94,8 +94,8 @@ class InstallationManager
     /**
      * Disables plugins.
      *
-     * We prevent any plugins from being instantiated by simply
-     * deactivating the installer for them. This ensure that no third-party
+     * We prevent any plugins from being instantiated by
+     * disabling the PluginManager. This ensures that no third-party
      * code is ever executed.
      */
     public function disablePlugins(): void
@@ -105,7 +105,7 @@ class InstallationManager
                 continue;
             }
 
-            unset($this->installers[$i]);
+            $installer->disablePlugins();
         }
     }
 

--- a/src/Composer/Installer/PluginInstaller.php
+++ b/src/Composer/Installer/PluginInstaller.php
@@ -43,6 +43,11 @@ class PluginInstaller extends LibraryInstaller
         return $packageType === 'composer-plugin' || $packageType === 'composer-installer';
     }
 
+    public function disablePlugins(): void
+    {
+        $this->getPluginManager()->disablePlugins();
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -153,6 +153,7 @@ class PluginManager
     public function registerPackage(PackageInterface $package, bool $failOnMissingClasses = false, bool $isGlobalPlugin = false): void
     {
         if ($this->arePluginsDisabled($isGlobalPlugin ? 'global' : 'local')) {
+            $this->io->writeError('<warning>The "'.$package->getName().'" plugin was not loaded as plugins are disabled.</warning>');
             return;
         }
 
@@ -654,6 +655,14 @@ class PluginManager
     public function arePluginsDisabled($type)
     {
         return $this->disablePlugins === true || $this->disablePlugins === $type;
+    }
+
+    /**
+     * @internal
+     */
+    public function disablePlugins(): void
+    {
+        $this->disablePlugins = true;
     }
 
     /**


### PR DESCRIPTION
Fixes #11839

This adds 3 warnings:

One during installation if plugins are disabled:

<img width="412" alt="image" src="https://github.com/composer/composer/assets/183678/5a32a186-2748-4f5d-9ed6-606e6f36d6d5">

One additional line before a command fails to be found if plugins are disabled:

<img width="545" alt="image" src="https://github.com/composer/composer/assets/183678/30510c81-215b-4a72-b2ae-88af700529d0">

And one generic `Plugins have been disabled automatically as you are running as root, this may be the cause of the following exception. See also https://getcomposer.org/root` line if plugins are disabled and you're running as root + non-interactive, also just before a thrown exception is displayed.