### PR TITLE
bugfix preventing a warning when calling  class_exists("\\")

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -422,7 +422,7 @@ class ClassLoader
      */
     public function loadClass($class)
     {
-        if ($file = $this->findFile($class)) {
+        if ($class !== '' && $file = $this->findFile($class)) {
             $includeFile = self::$includeFile;
             $includeFile($file);
 


### PR DESCRIPTION
Calling following, minimal example

```php
<?php

ini_set('display_errors', 'true');
error_reporting(E_ALL);

include '../vendor/autoload.php';

var_dump(class_exists("\\"));
```

leads to following warning:

```
PHP Warning:  Uninitialized string offset 0 in /home/stefan/Documents/projects/php/composer_test/vendor/composer/ClassLoader.php on line 497
PHP Stack trace:
PHP   1. {main}() /home/stefan/Documents/projects/php/composer_test/src/index.php:0
PHP   2. class_exists($class = '\\') /home/stefan/Documents/projects/php/composer_test/src/index.php:8
PHP   3. Composer\Autoload\ClassLoader->loadClass($class = '') /home/stefan/Documents/projects/php/composer_test/src/index.php:8
PHP   4. Composer\Autoload\ClassLoader->findFile($class = '') /home/stefan/Documents/projects/php/composer_test/vendor/composer/ClassLoader.php:425
PHP   5. Composer\Autoload\ClassLoader->findFileWithExtension($class = '', $ext = '.php') /home/stefan/Documents/projects/php/composer_test/vendor/composer/ClassLoader.php:458
```

Even worse: Calling composer run-script with ```class_exist("\\")``` makes the script abort.
To make composer more resilient and preventing it from aborting I added the empty-string check