### PR TITLE
[Docs] Explicit the version where script-aliases was included

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -425,7 +425,7 @@ To set an environment variable in a cross-platform way, you can use `@putenv`:
 }
 ```
 
-## Custom descriptions.
+## Custom descriptions
 
 You can set custom script descriptions with the following in your `composer.json`:
 
@@ -442,9 +442,9 @@ describe what the scripts do when the command is run.
 
 > **Note:** You can only set custom descriptions of custom commands.
 
-## Custom aliases.
+## Custom aliases
 
-You can set custom script aliases with the following in your `composer.json`:
+As of Composer 2.7, you can set custom script aliases with the following in your `composer.json`:
 
 ```json
 {


### PR DESCRIPTION
Since this was included in a minor version, it's nice to tell the user if this feature is available on the version they're running or if they need to upgrade. If it's not available, the only hint (besides the missing aliases on `composer list`) is the mild complaint at `composer validate`.

I also removed some dangling full stops on titles, since the other titles don't have that.

-----------

This was originally introduced at #11666.
