### PR TITLE
Issue in `composer.lock` generation ? 

### DIFF
--- a/src/Composer/DependencyResolver/LockTransaction.php
+++ b/src/Composer/DependencyResolver/LockTransaction.php
@@ -108,12 +108,12 @@ class LockTransaction extends Transaction
                 continue;
             }
 
-            $packages[] = $package;
-
             // if we're just updating mirrors we need to reset everything to the same as currently "present" packages' references to keep the lock file as-is
             if ($updateMirrors === true && !array_key_exists(spl_object_hash($package), $this->presentMap)) {
-                $packages[count($packages) - 1] = $this->updateMirrorAndUrls($package);
+                $package = $this->updateMirrorAndUrls($package);
             }
+
+            $packages[] = $package;
         }
 
         return $packages;

--- a/src/Composer/DependencyResolver/LockTransaction.php
+++ b/src/Composer/DependencyResolver/LockTransaction.php
@@ -15,6 +15,7 @@ namespace Composer\DependencyResolver;
 use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
 use Composer\Package\Package;
+use Composer\Package\PackageInterface;
 use Composer\Pcre\Preg;
 
 /**

--- a/src/Composer/DependencyResolver/LockTransaction.php
+++ b/src/Composer/DependencyResolver/LockTransaction.php
@@ -110,7 +110,7 @@ class LockTransaction extends Transaction
                 if ($updateMirrors && !isset($this->presentMap[spl_object_hash($package)])) {
                     foreach ($this->presentMap as $presentPackage) {
                         if ($package->getName() === $presentPackage->getName() && $package->getVersion() === $presentPackage->getVersion()) {
-                            if ($presentPackage->getSourceReference() && $presentPackage->getSourceType() === $package->getSourceType()) {
+                            if ($presentPackage->getSourceReference() && $presentPackage->getSourceType() === $package->getSourceType() && $presentPackage->getDistType() === $package->getDistType()) {
                                 $package->setSourceDistReferences($presentPackage->getSourceReference());
                                 // if the dist url is not one of those handled gracefully by setSourceDistReferences then we should overwrite it with the old one
                                 if ($package->getDistUrl() !== null && !Preg::isMatch('{^https?://(?:(?:www\.)?bitbucket\.org|(api\.)?github\.com|(?:www\.)?gitlab\.com)/}i', $package->getDistUrl())) {

--- a/tests/Composer/Test/Fixtures/installer/update-mirrors-changes-url.test
+++ b/tests/Composer/Test/Fixtures/installer/update-mirrors-changes-url.test
@@ -16,8 +16,9 @@ g/g is dev and installed in a different ref than the #ref, so it gets updated an
             "package": [
                 {
                     "name": "a/a", "version": "dev-master",
-                    "source": { "reference": "2222222222222222222222222222222222222222", "url": "https://github.com/a/newa", "type": "git" },
-                    "dist": { "reference": "2222222222222222222222222222222222222222", "url": "https://api.github.com/repos/a/newa/zipball/2222222222222222222222222222222222222222", "type": "zip" },
+                    "require": { "b/b": "^2.0.1" },
+                    "source": { "reference": "2222222222222222222222222222222222222222", "url": "https://github.com/a/newa", "type": "git", "mirrors": [{"url": "https://example.org/src/%package%/%version%/r%reference%.%type%", "preferred": true}] },
+                    "dist": { "reference": "2222222222222222222222222222222222222222", "url": "https://api.github.com/repos/a/newa/zipball/2222222222222222222222222222222222222222", "type": "zip", "mirrors": [{"url": "https://example.org/dists/%package%/%version%/r%reference%.%type%", "preferred": true}] },
                     "time": "2021-03-27T14:32:16+00:00"
                 },
                 {
@@ -67,6 +68,7 @@ g/g is dev and installed in a different ref than the #ref, so it gets updated an
 [
     {
         "name": "a/a", "version": "dev-master",
+        "require": { "b/b": "^2" },
         "source": { "reference": "1111111111111111111111111111111111111111", "url": "https://github.com/a/a", "type": "git" },
         "dist": { "reference": "1111111111111111111111111111111111111111", "url": "https://api.github.com/repos/a/a/zipball/1111111111111111111111111111111111111111", "type": "zip" },
         "time": "2021-03-14T16:24:37+00:00"
@@ -102,6 +104,7 @@ g/g is dev and installed in a different ref than the #ref, so it gets updated an
     "packages": [
         {
             "name": "a/a", "version": "dev-master",
+            "require": { "b/b": "^2" },
             "source": { "reference": "1111111111111111111111111111111111111111", "url": "https://github.com/a/a", "type": "git" },
             "dist": { "reference": "1111111111111111111111111111111111111111", "url": "https://api.github.com/repos/a/a/zipball/1111111111111111111111111111111111111111", "type": "zip" },
             "time": "2021-03-14T16:24:37+00:00",
@@ -152,8 +155,9 @@ g/g is dev and installed in a different ref than the #ref, so it gets updated an
     "packages": [
         {
             "name": "a/a", "version": "dev-master",
-            "source": { "reference": "1111111111111111111111111111111111111111", "url": "https://github.com/a/newa", "type": "git" },
-            "dist": { "reference": "1111111111111111111111111111111111111111", "url": "https://api.github.com/repos/a/newa/zipball/1111111111111111111111111111111111111111", "type": "zip" },
+            "require": { "b/b": "^2" },
+            "source": { "reference": "1111111111111111111111111111111111111111", "url": "https://github.com/a/newa", "type": "git", "mirrors": [{"url": "https://example.org/src/%package%/%version%/r%reference%.%type%", "preferred": true}] },
+            "dist": { "reference": "1111111111111111111111111111111111111111", "url": "https://api.github.com/repos/a/newa/zipball/1111111111111111111111111111111111111111", "type": "zip", "mirrors": [{"url": "https://example.org/dists/%package%/%version%/r%reference%.%type%", "preferred": true}] },
             "time": "2021-03-14T16:24:37+00:00",
             "type": "library"
         },


### PR DESCRIPTION
Hello,

Today I encountered an unexpected behaviour while attempting to upgrade from version 2.6.6 to 2.7.1. After making a thorough bisect, I pinpointed the introduction of the weird behaviour to this specific commit: [042a8c2](https://github.com/composer/composer/commit/042a8c212801aeac42b7a41b42cd1185ae28123a) (related to https://github.com/composer/composer/issues/11787).

Originally, this issue has been found while Composer is used in conjunction with a custom plugin: [nix-community/composer-local-repo-plugin](https://github.com/nix-community/composer-local-repo-plugin). Note, this issue cannot be reproduced (_pun intended!_) when using Composer < 2.7. 

<details>

<summary>Reproduce the issue with the Composer plugin</summary>

What makes this issue complicated is that the core of the problem involves a custom Composer plugin ([nix-community/composer-local-repo-plugin](https://github.com/nix-community/composer-local-repo-plugin)), which is essential for illustrating the encountered issue. This plugin plays a critical role in achieving total reproducibility for PHP/Composer-based projects within the Nix ecosystem (_introduced in https://github.com/NixOS/nixpkgs/pull/248184_).

The plugin works by generating a local Composer repository (https://getcomposer.org/doc/05-repositories.md#composer) from a project's `composer.json` and `composer.lock` files, including the `packages.json` file, then, update each package's `dist` information in `composer.lock` file to point to the local repository instead. This repository then serves as a `composer` repository type within `composer.json`. Our objective is to use this plugin to create a stable version of the files that will be of the `vendor` directory at the end (_using the Composer cache is not a valid option_). This stability is crucial for Nix, as it relies on predictable inputs (_in this case, the `composer` repository_) to calculate its hashes accurately. The development and implementation of this plugin were motivated by the necessity for predictable outputs to ensure the reproducibility of PHP/Composer based builds... and it was working super fine so far (_despite that I wish I could get rid of the plugin one day, ideas are welcome!_). The issue emerged following the aforementioned [commit](https://github.com/composer/composer/commit/042a8c212801aeac42b7a41b42cd1185ae28123a), affecting the plugin's operation and, consequently, the reproducibility of our PHP/Composer-based projects. This situation underscores the importance of that small plugin in the Nix ecosystem and the need for a resolution that maintains the integrity of our requirements. Find more details on how to install and use the plugin in the [README](https://github.com/nix-community/composer-local-repo-plugin?tab=readme-ov-file#usage) file of the project.

No Nix is needed to reproduce the issue locally, you can reproduce it:
1. By installing Composer >= 2.7.0
2. By installing the plugin: `composer global require nix-community/composer-local-repo-plugin`
3. By cloning the following [gist](https://gist.github.com/ab25340ea5fa46e3c2f49c1d9ed5eb71.git): `git clone https://gist.github.com/ab25340ea5fa46e3c2f49c1d9ed5eb71.git`
4. By running the shell script [`run.sh`](https://gist.github.com/drupol/ab25340ea5fa46e3c2f49c1d9ed5eb71#file-run-sh) from that gist

</details>

<details>

<summary>Reproduce the issue without the Composer plugin</summary>

Since many commands are required to reproduce the issue, I've set up a temporary repository at https://github.com/drupol/composer-issue-11850 containing the minimum required file to reproduce the issue. Follow the next steps to quickly reproduce it locally: 

1. Clone the repo: `git clone https://github.com/drupol/composer-issue-11850`
2. In that new directory, run the script: `./run.sh`

</details>

To summarize, this PR contains only 2 commits:
* The first commit fix (_or get rid?_) of the issue by adding a simple extra condition in the complex logic that generates the `composer.lock` file. I'm still a bit unsure of the proposed fix, this is the reason why I ask you to carefully review this. The fix add a simple checks on `$package->getDistType()` but maybe we should do further checks, perhaps we should also compare `$package->getDistUrl()` and `$package->getDistSha1Checksum()` and if any of those properties have changed. I had a first version implementing that, but I changed it until I have some feedback from you. 
* The second commit refactor that logic by just using early conditions to reduce the code indentation and give a better understanding on what is going on in the logic workflow. It is a no-op commit and totally opinionated, I can get rid of it if you don't like it.

Please, let me know what you think of that, as I'm willing to fix the issue in Nix and also contribute to making Composer better.

Thanks.