### PR TITLE
Include PHP information when showing Composer version verbosely

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -608,12 +608,18 @@ class Application extends BaseApplication
             $branchAliasString = sprintf(' (%s)', Composer::BRANCH_ALIAS_VERSION);
         }
 
+        $phpVersionString = '';
+        if ($this->getIO()->isVerbose()) {
+            $phpVersionString = "\n" . sprintf('<info>PHP</info> version <comment>%s</comment> (%s)', \PHP_VERSION, \PHP_BINARY);
+        }
+
         return sprintf(
-            '<info>%s</info> version <comment>%s%s</comment> %s',
+            '<info>%s</info> version <comment>%s%s</comment> %s%s',
             $this->getName(),
             $this->getVersion(),
             $branchAliasString,
-            Composer::RELEASE_DATE
+            Composer::RELEASE_DATE,
+            $phpVersionString
         );
     }
 

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -383,6 +383,11 @@ class Application extends BaseApplication
 
             $result = parent::doRun($input, $output);
 
+            if (true === $input->hasParameterOption(['--version', '-V'], true)) {
+                $io->writeError(sprintf('<info>PHP</info> version <comment>%s</comment> (%s)', \PHP_VERSION, \PHP_BINARY));
+                $io->writeError('Run the "diagnose" command to get more detailed diagnostics output.');
+            }
+
             // chdir back to $oldWorkingDir if set
             if (isset($oldWorkingDir) && '' !== $oldWorkingDir) {
                 Silencer::call('chdir', $oldWorkingDir);
@@ -608,18 +613,12 @@ class Application extends BaseApplication
             $branchAliasString = sprintf(' (%s)', Composer::BRANCH_ALIAS_VERSION);
         }
 
-        $phpVersionString = '';
-        if ($this->getIO()->isVerbose()) {
-            $phpVersionString = "\n" . sprintf('<info>PHP</info> version <comment>%s</comment> (%s)', \PHP_VERSION, \PHP_BINARY);
-        }
-
         return sprintf(
-            '<info>%s</info> version <comment>%s%s</comment> %s%s',
+            '<info>%s</info> version <comment>%s%s</comment> %s',
             $this->getName(),
             $this->getVersion(),
             $branchAliasString,
-            Composer::RELEASE_DATE,
-            $phpVersionString
+            Composer::RELEASE_DATE
         );
     }
 


### PR DESCRIPTION
I spend a lot of time on Stack Overflow, and confusion about which version of PHP being used is a big driver of questions. This PR adds that information when calling `composer --version --verbose`. e.g.:
```none
Composer version 2.7.999-dev+source @release_date@
PHP version 8.3.2 (/usr/local/bin/php83)
```
I would prefer if it were shown by default, but I figured modifying any existing behaviour would reduce the chance of acceptance.