### PR TITLE
Allow for SSH URLs when using hg repository type

### DIFF
--- a/src/Composer/Util/Hg.php
+++ b/src/Composer/Util/Hg.php
@@ -58,10 +58,17 @@ class Hg
         }
 
         // Try with the authentication information available
-        if (Preg::isMatch('{^(https?)://((.+)(?:\:(.+))?@)?([^/]+)(/.*)?}mi', $url, $match) && $this->io->hasAuthentication((string) $match[5])) {
-            $auth = $this->io->getAuthentication((string) $match[5]);
-            $authenticatedUrl = $match[1] . '://' . rawurlencode($auth['username']) . ':' . rawurlencode($auth['password']) . '@' . $match[5] . $match[6];
-
+        if (Preg::isMatch('{^(ssh|https?)://(([^:@]+):?([^:@]+)?@)?([^/]+)(/.*)?}mi', $url, $matches)
+            && $this->io->hasAuthentication((string) $matches[5]))
+        {
+            list($fullURL, $protocol, $credentials, $user, $password, $domain, $path) = $matches;
+            if ($protocol === 'ssh') {
+                if($user !== '') $user = rawurlencode((string)$user) . '@';
+                $authenticatedUrl = $protocol.'://'.$user.$domain.$path;
+            } else {
+                $auth = $this->io->getAuthentication((string)$domain);
+                $authenticatedUrl = $protocol.'://'.rawurlencode($auth['username']).':'.rawurlencode($auth['password']).'@'.$domain.$path;
+            }
             $command = $commandCallable($authenticatedUrl);
 
             if (0 === $this->process->execute($command, $ignoredOutput, $cwd)) {
@@ -70,10 +77,10 @@ class Hg
 
             $error = $this->process->getErrorOutput();
         } else {
-            $error = 'The given URL (' . $url . ') does not match the required format (http(s)://(username:password@)example.com/path-to-repository)';
+            $error = 'The given URL (' .$url. ') does not match the required format (ssh|http(s)://(username:password@)example.com/path-to-repository)';
         }
 
-        $this->throwException('Failed to clone ' . $url . ', ' . "\n\n" . $error, $url);
+        $this->throwException("Failed to clone $url, \n\n" . $error, $url);
     }
 
     /**
@@ -84,7 +91,9 @@ class Hg
     private function throwException($message, string $url): void
     {
         if (null === self::getVersion($this->process)) {
-            throw new \RuntimeException(Url::sanitize('Failed to clone ' . $url . ', hg was not found, check that it is installed and in your PATH env.' . "\n\n" . $this->process->getErrorOutput()));
+            throw new \RuntimeException(Url::sanitize(
+                'Failed to clone ' . $url . ', hg was not found, check that it is installed and in your PATH env.' . "\n\n" . $this->process->getErrorOutput()
+            ));
         }
 
         throw new \RuntimeException(Url::sanitize($message));


### PR DESCRIPTION
This fixes ticket #11874

It was declared a feature, so I've chosen the main branch. I also applied a few minor fixups to docblocks for example. I hope that's ok, otherwise let me know and I'll remove them.

For the fix itself, I basically just adjusted the regex to allow "ssh" and to grab the password more reliably, even though the latter isn't even used. Worked fine with the repo I'm using, if the SSH key is set up in both the repo and the workstation you're issuing the pull from.