### PR TITLE
Update scripts.md

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -419,7 +419,7 @@ To set an environment variable in a cross-platform way, you can use `@putenv`:
     "scripts": {
         "install-phpstan": [
             "@putenv COMPOSER=phpstan-composer.json",
-            "composer install --prefer-dist"
+            "@composer install --prefer-dist"
         ]
     }
 }


### PR DESCRIPTION
Updates the 'Setting environment variables' example to call Composer using `@composer` in order to automatically resolve to whatever composer.phar is currently being used as detailed in the previous section on this same page.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
