### PR TITLE
Only show warning about default version when not "project" type

### DIFF
--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -99,7 +99,7 @@ class RootPackageLoader extends ArrayLoader
             }
 
             if (!isset($config['version'])) {
-                if ($this->io !== null && $config['name'] !== '__root__') {
+                if ($this->io !== null && $config['name'] !== '__root__' && 'project' !== ($config['type'] ?? '')) {
                     $this->io->warning(
                         sprintf(
                             "Composer could not detect the root package (%s) version, defaulting to '1.0.0'. See https://getcomposer.org/root-version",


### PR DESCRIPTION
https://github.com/composer/composer/pull/11858 is too broad imho because for a lot of project skeletons that you'd use `create-project` for, this will now show a warning. However, if you are of `type` `project`, it's extremely unlikely  ou have circular deps on yourself then. The warning only confuses people in this case.