### PR TITLE
[PHP 8.4] Fix for implicit nullability deprecation

### DIFF
--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -298,7 +298,7 @@ class Git
         return true;
     }
 
-    public function fetchRefOrSyncMirror(string $url, string $dir, string $ref, string $prettyVersion = null): bool
+    public function fetchRefOrSyncMirror(string $url, string $dir, string $ref, ?string $prettyVersion = null): bool
     {
         if ($this->checkRefIsInMirror($dir, $ref)) {
             if (Preg::isMatch('{^[a-f0-9]{40}$}', $ref) && $prettyVersion !== null) {


### PR DESCRIPTION
Fixes a issue that emits a deprecation notice on PHP 8.4.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)


