### PR TITLE
[status command]check if package exists before compare

### DIFF
--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -500,12 +500,16 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             $this->install($package, $targetDir.'_compare', false);
             $this->process->wait();
 
-            $comparer = new Comparer();
-            $comparer->setSource($targetDir.'_compare');
-            $comparer->setUpdate($targetDir);
-            $comparer->doCompare();
-            $output = $comparer->getChangedAsString(true);
-            $this->filesystem->removeDirectory($targetDir.'_compare');
+            if (is_dir($targetDir.'_compare')) {
+                $comparer = new Comparer();
+                $comparer->setSource($targetDir.'_compare');
+                $comparer->setUpdate($targetDir);
+                $comparer->doCompare();
+                $output = $comparer->getChangedAsString(true);
+                $this->filesystem->removeDirectory($targetDir.'_compare');
+            } else {
+                $output = $package . ' can\'t be downloaded';
+            }
         } catch (\Exception $e) {
         }
 

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -508,7 +508,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
                 $output = $comparer->getChangedAsString(true);
                 $this->filesystem->removeDirectory($targetDir.'_compare');
             } else {
-                $output = $package . ' can\'t be downloaded';
+                $output = $package . ' could not be downloaded, aborting.';
             }
         } catch (\Exception $e) {
         }


### PR DESCRIPTION
If tag has been deleted from remote, download function will not create $targetDir . '_compare' folder and that make an Error : chdir(): No such file or directory (errno 2).
I suggest this update for prevent error and print to user that the reference disapear.