### PR TITLE
Update keywords documentation

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -126,6 +126,10 @@ Examples:
 > `--dev` option to prompt users if they would like to add these packages to
 > `require-dev` instead of `require`. These are: `dev`, `testing`, `static analysis`.
 
+> **Note**: The range of characters allowed inside the string is restricted to
+> unicode letters or numbers, space `" "`, dot `.`, underscore `_` and dash `-`. (Regex: `'{^[\p{N}\p{L} ._-]+$}u'`)
+> Using other characters will emit a warning when running `composer validate` and will likely mess with keyword indexing on Packagist.
+
 Optional.
 
 ### homepage

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -128,7 +128,8 @@ Examples:
 
 > **Note**: The range of characters allowed inside the string is restricted to
 > unicode letters or numbers, space `" "`, dot `.`, underscore `_` and dash `-`. (Regex: `'{^[\p{N}\p{L} ._-]+$}u'`)
-> Using other characters will emit a warning when running `composer validate` and will likely mess with keyword indexing on Packagist.
+> Using other characters will emit a warning when running `composer validate` and
+> will cause the package to fail updating on Packagist.org.
 
 Optional.
 


### PR DESCRIPTION
The character set for keywords is limited due to Packagist indexing.

Fixes #11897.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
