### PR TITLE
Load ProxyManager before running command to fix autoload order

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -379,6 +379,8 @@ class Application extends BaseApplication
         }
 
         try {
+            $proxyManager = ProxyManager::getInstance();
+
             if ($input->hasParameterOption('--profile')) {
                 $startTime = microtime(true);
                 $this->io->enableDebugging($startTime);
@@ -400,7 +402,7 @@ class Application extends BaseApplication
                 $io->writeError('<info>Memory usage: '.round(memory_get_usage() / 1024 / 1024, 2).'MiB (peak: '.round(memory_get_peak_usage() / 1024 / 1024, 2).'MiB), time: '.round(microtime(true) - $startTime, 2).'s');
             }
 
-            if (ProxyManager::getInstance()->needsTransitionWarning()) {
+            if ($proxyManager->needsTransitionWarning()) {
                 $io->writeError('');
                 $io->writeError('<warning>Composer now requires separate proxy environment variables for HTTP and HTTPS requests.</warning>');
                 $io->writeError('<warning>Please set `https_proxy` in addition to your existing proxy environment variables.</warning>');


### PR DESCRIPTION
Load the ProxyManager before running a command (eg the install or autoload), to make sure we load the internal class, not the application in which Composer is installed. Refs https://github.com/composer/composer/issues/11940