### PR TITLE
Don't show root warning for Podman containers

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -217,7 +217,11 @@ class Application extends BaseApplication
         $needsSudoCheck = !Platform::isWindows()
             && function_exists('exec')
             && !Platform::getEnv('COMPOSER_ALLOW_SUPERUSER')
-            && (ini_get('open_basedir') || !file_exists('/.dockerenv'));
+            && (ini_get('open_basedir') || (
+                !file_exists('/.dockerenv')
+                && !file_exists('/run/.containerenv')
+                && !file_exists('/var/run/.containerenv')
+            ));
         $isNonAllowedRoot = false;
 
         // Clobber sudo credentials if COMPOSER_ALLOW_SUPERUSER is not set before loading plugins

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -152,7 +152,9 @@ class Platform
                 !ini_get('open_basedir')
                 && is_readable('/proc/version')
                 && false !== stripos((string)Silencer::call('file_get_contents', '/proc/version'), 'microsoft')
-                && !file_exists('/.dockerenv') // docker running inside WSL should not be seen as WSL
+                && !file_exists('/.dockerenv') // Docker and Podman running inside WSL should not be seen as WSL
+                && !file_exists('/run/.containerenv')
+                && !file_exists('/var/run/.containerenv')
             ) {
                 return self::$isWindowsSubsystemForLinux = true;
             }


### PR DESCRIPTION
Podman creates the file `/run/.containerenv` (or `/var/run/.containerenv`) instead of /.dockerenv, so I added these two paths to the existing checks.

> Additionally, a container environment file is created in each container to indicate to programs they are running in a container. This file is located at `/run/.containerenv` (or `/var/run/.containerenv` for FreeBSD containers).

https://docs.podman.io/en/latest/markdown/podman-run.1.html

Follow up of #8395 