### PR TITLE
Platform::getCwd() always return the real path for the current working directory

### DIFF
--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -38,6 +38,8 @@ class Platform
         // fallback to realpath('') just in case this works but odds are it would break as well if we are in a case where getcwd fails
         if (false === $cwd) {
             $cwd = realpath('');
+        } else {
+            $cwd = realpath($cwd);
         }
 
         // crappy state, assume '' and hopefully relative paths allow things to continue


### PR DESCRIPTION
For php files, Composer generates a PHP proxy instead of a shell proxy, for example for phpunit.

And when a project folder is a symlink to another folder, Composer writes the absolute path of its autoloader into the $GLOBALS['_composer_autoload_path'] variable instead of a relative one.

The reason for this is the \Composer\Util\Platform::getCwd method, which always returns the current working directory without regard to the real path (i.e. without resolving a symlink to a real path). And when Composer forms the path to its autoloader in a php proxy script, it compares if there is a common path in a current working directory and a project folder ($vendor_dir) in the \Composer\Util\Filesystem::findShortestPathCode method. It finds no commonality and forms the absolute path to its autoloader for the project. This destroys a project's portability, especially when running in Docker. Docker does not know the absolute path on the host machine.

The Platform::getCwd method is the only method in Composer that does not care about the real path. All other methods care about it.

So my suggestion is to correct the behavior of this method with this small patch: it alsways return the real path of the current working directory.