### PR TITLE
Add `uninstall` as alias to `composer remove`.

### DIFF
--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -43,7 +43,7 @@ class RemoveCommand extends BaseCommand
     {
         $this
             ->setName('remove')
-            ->setAliases(['rm'])
+            ->setAliases(['rm', 'uninstall'])
             ->setDescription('Removes a package from the require or require-dev')
             ->setDefinition([
                 new InputArgument('packages', InputArgument::IS_ARRAY, 'Packages that should be removed.', null, $this->suggestRootRequirement()),


### PR DESCRIPTION
I've looked through the repository and realized I've never actually seen this proposed either in issue or pull request form.

Some package managers use `uninstall` as the convention for removing/uninstalling dependencies, and as a result I've found myself in the habit of typing `composer uninstall (packagename)` instead of `composer remove (packagename)`.

Composer doesn't currently handle this all that gracefully...it suggests "Did you mean install/reinstall?" without suggesting the actual proper `remove` command.

I think, perhaps to save folks like me the trouble, Composer can follow in the footsteps of package managers like NPM and make `remove` and `uninstall` refer to the same command, so there's no retyping involved if you slip up and forget which is which.