### PR TITLE
Composer update: filter packages with security advisories from pool

### DIFF
--- a/src/Composer/Advisory/AuditConfig.php
+++ b/src/Composer/Advisory/AuditConfig.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Advisory;
+
+use Composer\Config;
+
+class AuditConfig
+{
+    /**
+     * @var array<string>|array<string,string> List of advisory IDs, remote IDs or CVE IDs that reported but not listed as vulnerabilities.
+     */
+    public $ignoreList;
+
+    /**
+     * @var Auditor::ABANDONED_*
+     */
+    public $abandoned;
+
+    /**
+     * @param array<string>|array<string,string> $ignoreList
+     * @param Auditor::ABANDONED_* $abandoned
+    */
+    public function __construct(array $ignoreList, string $abandoned)
+    {
+        $this->ignoreList = $ignoreList;
+        $this->abandoned = $abandoned;
+    }
+
+    public static function fromConfig(Config $config): self
+    {
+        $auditConfig = $config->get('audit');
+
+        return new self(
+            $auditConfig['ignore'] ?? [],
+                $auditConfig['abandoned'] ?? Auditor::ABANDONED_FAIL
+        );
+    }
+}

--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -141,7 +141,7 @@ class Auditor
      * @param array<string>|array<string,string> $ignoreList List of advisory IDs, remote IDs or CVE IDs that reported but not listed as vulnerabilities.
      * @phpstan-return array{advisories: array<string, array<PartialSecurityAdvisory|SecurityAdvisory>>, ignoredAdvisories: array<string, array<PartialSecurityAdvisory|SecurityAdvisory>>}
      */
-    private function processAdvisories(array $allAdvisories, array $ignoreList): array
+    public function processAdvisories(array $allAdvisories, array $ignoreList): array
     {
         if ($ignoreList === []) {
             return ['advisories' => $allAdvisories, 'ignoredAdvisories' => []];

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Command;
 
+use Composer\Advisory\AuditConfig;
 use Composer\Composer;
 use Composer\Repository\RepositorySet;
 use Composer\Repository\RepositoryUtils;
@@ -63,9 +64,9 @@ EOT
             $repoSet->addRepository($repo);
         }
 
-        $auditConfig = $composer->getConfig()->get('audit');
+        $auditConfig = AuditConfig::fromConfig($composer->getConfig());
 
-        return min(255, $auditor->audit($this->getIO(), $repoSet, $packages, $this->getAuditFormat($input, 'format'), false, $auditConfig['ignore'] ?? [], $auditConfig['abandoned'] ?? Auditor::ABANDONED_FAIL));
+        return min(255, $auditor->audit($this->getIO(), $repoSet, $packages, $this->getAuditFormat($input, 'format'), false, $auditConfig->ignoreList, $auditConfig->abandoned));
     }
 
     /**

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -151,6 +151,9 @@ class PoolBuilder
     /** @var int */
     private $indexCounter = 0;
 
+    /** @var ?SecurityAdvisoryPoolFilter */
+    private $securityAdvisoryPoolFilter;
+
     /**
      * @param int[] $acceptableStabilities array of stability => BasePackage::STABILITY_* value
      * @phpstan-param array<string, BasePackage::STABILITY_*> $acceptableStabilities
@@ -162,7 +165,7 @@ class PoolBuilder
      * @phpstan-param array<string, string> $rootReferences
      * @param array<string, ConstraintInterface> $temporaryConstraints Runtime temporary constraints that will be used to filter packages
      */
-    public function __construct(array $acceptableStabilities, array $stabilityFlags, array $rootAliases, array $rootReferences, IOInterface $io, ?EventDispatcher $eventDispatcher = null, ?PoolOptimizer $poolOptimizer = null, array $temporaryConstraints = [])
+    public function __construct(array $acceptableStabilities, array $stabilityFlags, array $rootAliases, array $rootReferences, IOInterface $io, ?EventDispatcher $eventDispatcher = null, ?PoolOptimizer $poolOptimizer = null, array $temporaryConstraints = [], ?SecurityAdvisoryPoolFilter $securityAdvisoryPoolFilter = null)
     {
         $this->acceptableStabilities = $acceptableStabilities;
         $this->stabilityFlags = $stabilityFlags;
@@ -172,6 +175,7 @@ class PoolBuilder
         $this->poolOptimizer = $poolOptimizer;
         $this->io = $io;
         $this->temporaryConstraints = $temporaryConstraints;
+        $this->securityAdvisoryPoolFilter = $securityAdvisoryPoolFilter;
     }
 
     /**
@@ -334,6 +338,7 @@ class PoolBuilder
 
         $this->io->debug('Built pool.');
 
+        $pool = $this->runSecurityAdvisoryFilter($pool, $repositories);
         $pool = $this->runOptimizer($request, $pool);
 
         Intervals::clear();
@@ -769,6 +774,39 @@ class PoolBuilder
         $this->io->write(sprintf('Pool optimizer completed in %.3f seconds', microtime(true) - $before), true, IOInterface::VERY_VERBOSE);
         $this->io->write(sprintf(
             '<info>Found %s package versions referenced in your dependency graph. %s (%d%%) were optimized away.</info>',
+            number_format($total),
+            number_format($filtered),
+            round(100 / $total * $filtered)
+        ), true, IOInterface::VERY_VERBOSE);
+
+        return $pool;
+    }
+
+    /**
+     * @param RepositoryInterface[] $repositories
+     */
+    private function runSecurityAdvisoryFilter(Pool $pool, array $repositories): Pool
+    {
+        if (null === $this->securityAdvisoryPoolFilter) {
+            return $pool;
+        }
+
+        $this->io->debug('Running security advisory pool filter.');
+
+        $before = microtime(true);
+        $total = \count($pool->getPackages());
+
+        $pool = $this->securityAdvisoryPoolFilter->filter($pool, $repositories);
+
+        $filtered = $total - \count($pool->getPackages());
+
+        if (0 === $filtered) {
+            return $pool;
+        }
+
+        $this->io->write(sprintf('Security advisory pool filter completed in %.3f seconds', microtime(true) - $before), true, IOInterface::VERY_VERBOSE);
+        $this->io->write(sprintf(
+            '<info>Found %s package versions referenced in your dependency graph. %s (%d%%) were filtered away.</info>',
             number_format($total),
             number_format($filtered),
             round(100 / $total * $filtered)

--- a/src/Composer/DependencyResolver/PoolOptimizer.php
+++ b/src/Composer/DependencyResolver/PoolOptimizer.php
@@ -173,7 +173,7 @@ class PoolOptimizer
             }
         }
 
-        $optimizedPool = new Pool($packages, $pool->getUnacceptableFixedOrLockedPackages(), $removedVersions, $this->removedVersionsByPackage);
+        $optimizedPool = new Pool($packages, $pool->getUnacceptableFixedOrLockedPackages(), $removedVersions, $this->removedVersionsByPackage, $pool->getAllSecurityRemovedPackageVersions());
 
         return $optimizedPool;
     }

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -303,6 +303,10 @@ class Problem
                 return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' in the lock file but not in remote repositories, make sure you avoid updating this package to keep the one from the lock file.'];
             }
 
+            if ($pool->isSecurityRemovedPackageVersion($packageName, $constraint)) {
+                return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but these were not loaded, because they have security advisories.'];
+            }
+
             return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but these were not loaded, likely because '.(self::hasMultipleNames($packages) ? 'they conflict' : 'it conflicts').' with another require.'];
         }
 

--- a/src/Composer/DependencyResolver/SecurityAdvisoryPoolFilter.php
+++ b/src/Composer/DependencyResolver/SecurityAdvisoryPoolFilter.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\DependencyResolver;
+
+use Composer\Advisory\AuditConfig;
+use Composer\Advisory\Auditor;
+use Composer\Advisory\PartialSecurityAdvisory;
+use Composer\Advisory\SecurityAdvisory;
+use Composer\Package\PackageInterface;
+use Composer\Package\RootPackageInterface;
+use Composer\Repository\RepositoryInterface;
+use Composer\Repository\RepositorySet;
+use Composer\Semver\Constraint\Constraint;
+
+class SecurityAdvisoryPoolFilter
+{
+    /** @var Auditor */
+    private $auditor;
+    /** @var AuditConfig $auditConfig */
+    private $auditConfig;
+
+    public function __construct(
+        Auditor $auditor,
+        AuditConfig $auditConfig
+    ) {
+        $this->auditor = $auditor;
+        $this->auditConfig = $auditConfig;
+    }
+
+    /**
+     * @param array<RepositoryInterface> $repositories
+     */
+    public function filter(Pool $pool, array $repositories): Pool
+    {
+        $repoSet = new RepositorySet();
+        foreach ($repositories as $repo) {
+            $repoSet->addRepository($repo);
+        }
+
+        $packagesForAdvisories = [];
+        foreach ($pool->getPackages() as $package) {
+            // @todo Pool contains a list of ext-/lib-/php/composer/composer-plugin-api/composer-runtime-api that need to be filtered out before fetching security advisories. Is there a better way?
+            if (! $package instanceof RootPackageInterface && str_contains($package->getName(), '/')) {
+                $packagesForAdvisories[] = $package;
+            }
+        }
+
+        $allAdvisories = $repoSet->getMatchingSecurityAdvisories($packagesForAdvisories, true);
+        $advisoryMap = $this->auditor->processAdvisories($allAdvisories, $this->auditConfig->ignoreList)['advisories'];
+
+        $packages = [];
+        $securityRemovedVersions = [];
+        foreach ($pool->getPackages() as $package) {
+            if ($this->doesPackageMatchAdvisories($package, $advisoryMap)) {
+                foreach ($package->getNames(false) as $packageName) {
+                    $securityRemovedVersions[$packageName][$package->getVersion()] = $package->getPrettyVersion();
+                }
+            } else {
+                $packages[] = $package;
+            }
+        }
+
+        return new Pool($packages, $pool->getUnacceptableFixedOrLockedPackages(), [], [], $securityRemovedVersions);
+    }
+
+    /**
+     * @param array<string, array<PartialSecurityAdvisory|SecurityAdvisory>> $advisoryMap
+     */
+    private function doesPackageMatchAdvisories(PackageInterface $package, array $advisoryMap): bool
+    {
+        if ($package->isDev()) {
+            return false;
+        }
+
+        foreach ($package->getNames(false) as $packageName) {
+            if (! isset($advisoryMap[$packageName])) {
+                return false;
+            }
+
+            $packageConstraint = new Constraint(Constraint::STR_OP_EQ, $package->getVersion());
+            foreach ($advisoryMap[$packageName] as $advisory) {
+                if ($advisory->affectedVersions->matches($packageConstraint)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -12,6 +12,7 @@
 
 namespace Composer;
 
+use Composer\Advisory\AuditConfig;
 use Composer\Autoload\AutoloadGenerator;
 use Composer\Console\GithubActionError;
 use Composer\DependencyResolver\DefaultPolicy;
@@ -23,6 +24,7 @@ use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\PoolOptimizer;
 use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
+use Composer\DependencyResolver\SecurityAdvisoryPoolFilter;
 use Composer\DependencyResolver\Solver;
 use Composer\DependencyResolver\SolverProblemsException;
 use Composer\DependencyResolver\PolicyInterface;
@@ -429,9 +431,9 @@ class Installer
                         $repoSet->addRepository($repo);
                     }
 
-                    $auditConfig = $this->config->get('audit');
+                    $auditConfig = AuditConfig::fromConfig($this->config);
 
-                    return $auditor->audit($this->io, $repoSet, $packages, $this->auditFormat, true, $auditConfig['ignore'] ?? [], $auditConfig['abandoned'] ?? Auditor::ABANDONED_FAIL) > 0 && $this->errorOnAudit ? self::ERROR_AUDIT_FAILED : 0;
+                    return $auditor->audit($this->io, $repoSet, $packages, $this->auditFormat, true, $auditConfig->ignoreList, $auditConfig->abandoned) > 0 && $this->errorOnAudit ? self::ERROR_AUDIT_FAILED : 0;
                 } catch (TransportException $e) {
                     $this->io->error('Failed to audit '.$target.' packages.');
                     if ($this->io->isVerbose()) {
@@ -496,7 +498,7 @@ class Installer
             $request->setUpdateAllowList($this->updateAllowList, $this->updateAllowTransitiveDependencies);
         }
 
-        $pool = $repositorySet->createPool($request, $this->io, $this->eventDispatcher, $this->createPoolOptimizer($policy), $this->ignoredTypes, $this->allowedTypes);
+        $pool = $repositorySet->createPool($request, $this->io, $this->eventDispatcher, $this->createPoolOptimizer($policy), $this->ignoredTypes, $this->allowedTypes, $this->createSecurityAuditPoolFilter());
 
         $this->io->writeError('<info>Updating dependencies</info>');
 
@@ -1085,6 +1087,11 @@ class Installer
         }
 
         return new PoolOptimizer($policy);
+    }
+
+    private function createSecurityAuditPoolFilter(): SecurityAdvisoryPoolFilter
+    {
+        return new SecurityAdvisoryPoolFilter(new Auditor(), AuditConfig::fromConfig($this->config));
     }
 
     /**

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -16,6 +16,7 @@ use Composer\DependencyResolver\PoolOptimizer;
 use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\PoolBuilder;
 use Composer\DependencyResolver\Request;
+use Composer\DependencyResolver\SecurityAdvisoryPoolFilter;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\Advisory\SecurityAdvisory;
 use Composer\Advisory\PartialSecurityAdvisory;
@@ -314,9 +315,9 @@ class RepositorySet
      * @param list<string>      $ignoredTypes Packages of those types are ignored
      * @param list<string>|null $allowedTypes Only packages of those types are allowed if set to non-null
      */
-    public function createPool(Request $request, IOInterface $io, ?EventDispatcher $eventDispatcher = null, ?PoolOptimizer $poolOptimizer = null, array $ignoredTypes = [], ?array $allowedTypes = null): Pool
+    public function createPool(Request $request, IOInterface $io, ?EventDispatcher $eventDispatcher = null, ?PoolOptimizer $poolOptimizer = null, array $ignoredTypes = [], ?array $allowedTypes = null, ?SecurityAdvisoryPoolFilter $securityAdvisoryPoolFilter = null): Pool
     {
-        $poolBuilder = new PoolBuilder($this->acceptableStabilities, $this->stabilityFlags, $this->rootAliases, $this->rootReferences, $io, $eventDispatcher, $poolOptimizer, $this->temporaryConstraints);
+        $poolBuilder = new PoolBuilder($this->acceptableStabilities, $this->stabilityFlags, $this->rootAliases, $this->rootReferences, $io, $eventDispatcher, $poolOptimizer, $this->temporaryConstraints, $securityAdvisoryPoolFilter);
         $poolBuilder->setIgnoredTypes($ignoredTypes);
         $poolBuilder->setAllowedTypes($allowedTypes);
 

--- a/tests/Composer/Test/Fixtures/installer/update-security-advisory-matching-direct-dependency.test
+++ b/tests/Composer/Test/Fixtures/installer/update-security-advisory-matching-direct-dependency.test
@@ -1,0 +1,60 @@
+--TEST--
+Security advisory matching direct dependency preventing a successful update.
+--COMPOSER--
+{
+    "name": "acme/project",
+    "version": "1.0.0",
+    "require": {
+        "acme/library": "1.0.0"
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0.0",
+                    "source": { "reference": "some.branch", "type": "git", "url": "" }
+                }
+            ],
+            "security-advisories": {
+                "acme/library": [
+                    {
+                        "advisoryId": "PKSA-1234-abcd-1234",
+                        "packageName": "acme/library",
+                        "remoteId": "test",
+                        "title": "Security Advisory",
+                        "link": null,
+                        "cve": null,
+                        "affectedVersions": ">=1.0.0,<1.1.0",
+                        "source": "Tests",
+                        "reportedAt": "2024-04-31 12:37:47",
+                        "composerRepository": "Package Repository",
+                        "severity": "high",
+                        "sources": [
+                            {
+                                "name": "Security Advisory",
+                                "remoteId": "test"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}
+--RUN--
+update -v
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires acme/library 1.0.0 (exact version match: 1.0.0 or 1.0.0.0), found acme/library[1.0.0] but these were not loaded, because they have security advisories.
+
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/update-security-advisory-matching-indirect-dependency.test
+++ b/tests/Composer/Test/Fixtures/installer/update-security-advisory-matching-indirect-dependency.test
@@ -1,0 +1,69 @@
+--TEST--
+Security advisory matching indirect dependency preventing a successful update.
+--COMPOSER--
+{
+    "name": "acme/project",
+    "version": "1.0.0",
+    "require": {
+        "acme/library": "1.0.0"
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0.0",
+                    "source": { "reference": "some.branch", "type": "git", "url": "" },
+                    "require": {
+                        "acme/library-dependency": "^1.0"
+                    }
+                },
+                {
+                    "name": "acme/library-dependency",
+                    "version": "1.0.0",
+                    "source": { "reference": "some.branch", "type": "git", "url": "" }
+                }
+            ],
+            "security-advisories": {
+                "acme/library-dependency": [
+                    {
+                        "advisoryId": "PKSA-1234-abcd-1234",
+                        "packageName": "acme/library-dependency",
+                        "remoteId": "test",
+                        "title": "Security Advisory",
+                        "link": null,
+                        "cve": null,
+                        "affectedVersions": ">=1.0.0,<1.1.0",
+                        "source": "Tests",
+                        "reportedAt": "2024-04-31 12:37:47",
+                        "composerRepository": "Package Repository",
+                        "severity": "high",
+                        "sources": [
+                            {
+                                "name": "Security Advisory",
+                                "remoteId": "test"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}
+--RUN--
+update -v
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires acme/library 1.0.0 -> satisfiable by acme/library[1.0.0].
+    - acme/library 1.0.0 requires acme/library-dependency ^1.0 -> found acme/library-dependency[1.0.0] but these were not loaded, because they have security advisories.
+
+--EXPECT--

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -92,6 +92,7 @@ class InstallerTest extends TestCase
                     case 'notify-on-install':
                         return true;
                     case 'platform':
+                    case 'audit':
                         return [];
                 }
 


### PR DESCRIPTION
Please note, this is still a very rough draft missing tests, cleanup and taking a few shortcuts. However, feedback is already appreciated.

### Idea

Composer already has an audit functionality that reports any package used by a project with security advisories as part of an install/update/audit command. This PR takes this one step further and filters any packages with security advisories from the pool of available packages during a `composer update`command before the pool get optimized.

The functionality uses cached metadata files wherever possible. However, it is possible that it will trigger a call to the security advisories API endpoint on packagist.org if multiple Composer repositories are defined and not all of them are looked up on packagist.org.

This could potentially replace the need for projects to install a special package defining conflicts with packages that have security advisories.

### Sample composer.json
```
{
    "name": "acme/project",
    "version": "1.0",
    "repositories": [
    ],
    "require": {
        "doctrine/cache": "<=1.3.0,>=1.0.0"
    }
}
```

### How this currently looks in Composer with verbose output
```
Running 2.7.999-dev+source (@release_date@) with PHP
Reading ./composer.json (/tmp/composer.json)
Loading config file ~/.composer/config.json
Loading config file ~/.composer/auth.json
Loading config file ./composer.json (/tmp/composer.json)
Checked CA file /opt/homebrew/etc/ca-certificates/cert.pem: valid
Reading ~/.composer/composer.json
Loading config file ~/.composer/config.json
Loading config file ~/.composer/auth.json
Loading config file ~/.composer/composer.json (~/.composer/composer.json)
Loading config file ~/.composer/auth.json
Reading ~/.composer/auth.json
Reading ./composer.lock (/tmp/composer.lock)
Reading /tmp/vendor/composer/installed.json
Reading ~/.composer/vendor/composer/installed.json
Loading composer repositories with package information
Reading ~/Library/Caches/composer/repo/https---repo.packagist.org/packages.json from cache
Downloading https://repo.packagist.org/packages.json if modified
[200] https://repo.packagist.org/packages.json
Writing ~/Library/Caches/composer/repo/https---repo.packagist.org/packages.json into cache
Downloading https://repo.packagist.org/p2/doctrine/cache.json
[200] https://repo.packagist.org/p2/doctrine/cache.json
Writing ~/composer-cache/repo/https---repo.packagist.org/provider-doctrine~cache.json into cache
Built pool.
Running security advisory pool filter.
Reading ~/composer-cache/repo/https---repo.packagist.org/provider-doctrine~cache.json from cache
Security advisory pool filter completed in 0.001 seconds
Found 105 package versions referenced in your dependency graph. 1 (1%) were filtered away.
Running pool optimizer.
Updating dependencies
Generating rules
Resolving dependencies through SAT
Looking at all rules.

Dependency resolution completed in 0.000 seconds
Reading ~/composer-cache/repo/https---repo.packagist.org/provider-doctrine~cache.json from cache
Your requirements could not be resolved to an installable set of packages.

Problem 1
  Problem 1
    - Root composer.json requires doctrine/cache <=1.3.0,>=1.0.0, found doctrine/cache[v1.0, v1.1, v1.2.0, v1.3.0] but these were not loaded, because they have security advisories.

```

### Questions
* [ ] Should this step be optional
* [ ] Should this also consider the audit abandoned config and filter those packages too