### PR TITLE
feat: make sure the APCU autoloader prefix is deterministic when a `composer.lock` file is available

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -354,7 +354,12 @@ class Installer
             }
 
             $this->autoloadGenerator->setClassMapAuthoritative($this->classMapAuthoritative);
-            $this->autoloadGenerator->setApcu($this->apcuAutoloader, $this->apcuAutoloaderPrefix);
+            $this->autoloadGenerator->setApcu(
+                $this->apcuAutoloader,
+                $this->apcuAutoloaderPrefix === null
+                ? ($this->locker !== null && $this->locker->isLocked() ? $this->locker->getLockData()['content-hash'] : null)
+                : $this->apcuAutoloaderPrefix
+            );
             $this->autoloadGenerator->setRunScripts($this->runScripts);
             $this->autoloadGenerator->setPlatformRequirementFilter($this->platformRequirementFilter);
             $this

--- a/tests/Composer/Test/Fixtures/installer/install-from-lock-removes-package.test
+++ b/tests/Composer/Test/Fixtures/installer/install-from-lock-removes-package.test
@@ -21,6 +21,7 @@ Install from a lock file that deleted a package
 }
 --LOCK--
 {
+    "content-hash": "4c3b9426f087ef6dc15cc81ef697f162",
     "packages": [
         { "name": "allowed/pkg", "version": "1.1.0" },
         { "name": "fixed/dependency", "version": "1.0.0" }

--- a/tests/Composer/Test/Fixtures/installer/install-missing-alias-from-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/install-missing-alias-from-lock.test
@@ -21,6 +21,7 @@ Installing an old alias that doesn't exist anymore from a lock is possible
 }
 --LOCK--
 {
+    "content-hash": "4c3b9426f087ef6dc15cc81ef697f162",
     "packages": [
         {
             "name": "a/a", "version": "dev-master", "version_normalized": "9999999-dev",

--- a/tests/Composer/Test/Fixtures/installer/suggest-prod.test
+++ b/tests/Composer/Test/Fixtures/installer/suggest-prod.test
@@ -16,6 +16,7 @@ Suggestions are not displayed for when not updating the lock file
 }
 --LOCK--
 {
+    "content-hash": "4c3b9426f087ef6dc15cc81ef697f162",
     "packages": [
         { "name": "a/a", "version": "1.0.0", "suggest": { "b/b": "an obscure reason" } }
     ],
@@ -33,6 +34,7 @@ install
 --EXPECT-OUTPUT--
 Installing dependencies from lock file (including require-dev)
 Verifying lock file contents can be installed on current platform.
+<warning>Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.</warning>
 Package operations: 1 install, 0 updates, 0 removals
 Generating autoload files
 

--- a/tests/Composer/Test/Fixtures/installer/updating-dev-from-lock-removes-old-deps.test
+++ b/tests/Composer/Test/Fixtures/installer/updating-dev-from-lock-removes-old-deps.test
@@ -9,6 +9,7 @@ Installing locked dev packages should remove old dependencies
 }
 --LOCK--
 {
+    "content-hash": "4c3b9426f087ef6dc15cc81ef697f162",
     "packages": [
         {
             "name": "a/devpackage", "version": "dev-master",


### PR DESCRIPTION
Hello!

Context PR: https://github.com/composer/composer/pull/11663

This PR make sure the APCU prefix is deterministic only when 2 conditions are met:
1. When a `composer.lock` file is available
2. When there's no `--apcu-autoloader-prefix` command line option set.

It will be predictable by reusing the `content-hash` key from `composer.lock` file.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
