### PR TITLE
Re-use precalculated information

### DIFF
--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -57,7 +57,7 @@ class DefaultPolicy implements PolicyInterface
         }
 
         // dev versions need to be compared as branches via matchSpecific's special treatment, the rest can be optimized with compiling matcher
-        if ($a->isDev() || $b->isDev()) {
+        if (($a->isDev() && str_starts_with($a->getVersion(), 'dev-')) || ($b->isDev() && str_starts_with($b->getVersion(), 'dev-'))) {
             $constraint = new Constraint($operator, $b->getVersion());
             $version = new Constraint('==', $a->getVersion());
 

--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -57,7 +57,7 @@ class DefaultPolicy implements PolicyInterface
         }
 
         // dev versions need to be compared as branches via matchSpecific's special treatment, the rest can be optimized with compiling matcher
-        if (strpos($a->getVersion(), 'dev-') === 0 || strpos($b->getVersion(), 'dev-') === 0) {
+        if ($a->isDev() || $b->isDev()) {
             $constraint = new Constraint($operator, $b->getVersion());
             $version = new Constraint('==', $a->getVersion());
 


### PR DESCRIPTION
No need for thousands of `strpos()` calls as we already have this information on the package itself. Shaves off about 0.1 seconds on the `PoolOptimizer` step in my case.