### PR TITLE
Close style tags to avoid colour bleed

### DIFF
--- a/src/Composer/Command/PackageDiscoveryTrait.php
+++ b/src/Composer/Command/PackageDiscoveryTrait.php
@@ -96,7 +96,7 @@ trait PackageDiscoveryTrait
 
             foreach ($requires as $requirement) {
                 if (isset($requirement['version']) && Preg::isMatch('{^\d+(\.\d+)?$}', $requirement['version'])) {
-                    $io->writeError('<warning>The "'.$requirement['version'].'" constraint for "'.$requirement['name'].'" appears too strict and will likely not match what you want. See https://getcomposer.org/constraints');
+                    $io->writeError('<warning>The "'.$requirement['version'].'" constraint for "'.$requirement['name'].'" appears too strict and will likely not match what you want. See https://getcomposer.org/constraints</warning>');
                 }
 
                 if (!isset($requirement['version'])) {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -404,7 +404,7 @@ class Application extends BaseApplication
             }
 
             if (isset($startTime)) {
-                $io->writeError('<info>Memory usage: '.round(memory_get_usage() / 1024 / 1024, 2).'MiB (peak: '.round(memory_get_peak_usage() / 1024 / 1024, 2).'MiB), time: '.round(microtime(true) - $startTime, 2).'s');
+                $io->writeError('<info>Memory usage: '.round(memory_get_usage() / 1024 / 1024, 2).'MiB (peak: '.round(memory_get_peak_usage() / 1024 / 1024, 2).'MiB), time: '.round(microtime(true) - $startTime, 2).'s</info>');
             }
 
             if ($proxyManager->needsTransitionWarning()) {


### PR DESCRIPTION
When I ran `composer require vendor/package:version` in order to get a specific version of a package, I noticed that the colour of the "normal" text was different from when I ran `composer require vendor/package`. I have tracked this down to an unterminated Symfony style tag used in the warning message about specifying a "too strict" restraint. I then scanned all of `src/` and found one other instance of this. This pull request fixes both instances.

![Screenshot_2024-05-11_20-01-54](https://github.com/composer/composer/assets/334786/a7cf363c-082f-43f2-b3a1-eb84fa5d1d03)

