### PR TITLE
Fix issue with TransportException

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -446,6 +446,7 @@ class Application extends BaseApplication
             // as http error codes are all beyond the 255 range of permitted exit codes
             if ($e instanceof TransportException) {
                 $reflProp = new \ReflectionProperty($e, 'code');
+                $reflProp->setAccessible(true);
                 $reflProp->setValue($e, Installer::ERROR_TRANSPORT_EXCEPTION);
             }
 


### PR DESCRIPTION
To enable to the TransportException code to be accessed in PHP < 8.1 make reflection property accessible

Without this change, I get this error in PHP versions below 8.1:

```
$ composer why-not [package name] [version]

In Application.php line 449:
                                                                                 
  Cannot access non-public member Composer\Downloader\TransportException::$code  
                                                                                 

prohibits [-r|--recursive] [-t|--tree] [--locked] [--] <package> <version>
```

This issue seems to have been introduced in [Composer 2.7.5](https://github.com/composer/composer/releases/tag/2.7.5).

This bug will not be present with PHP 8.1 +, according to [setAccessible docs](https://www.php.net/manual/en/reflectionproperty.setaccessible.php).
