### PR TITLE
PHP 8.4 nullable type deprecation

### DIFF
--- a/tests/Composer/Test/Fixtures/functional/installed-versions2/vendor/symfony/filesystem/Exception/FileNotFoundException.php
+++ b/tests/Composer/Test/Fixtures/functional/installed-versions2/vendor/symfony/filesystem/Exception/FileNotFoundException.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Filesystem\Exception;
  */
 class FileNotFoundException extends IOException
 {
-    public function __construct(string $message = null, int $code = 0, \Throwable $previous = null, string $path = null)
+    public function __construct(?string $message = null, int $code = 0, ?\Throwable $previous = null, ?string $path = null)
     {
         if (null === $message) {
             if (null === $path) {

--- a/tests/Composer/Test/Fixtures/functional/installed-versions2/vendor/symfony/filesystem/Exception/IOException.php
+++ b/tests/Composer/Test/Fixtures/functional/installed-versions2/vendor/symfony/filesystem/Exception/IOException.php
@@ -22,7 +22,7 @@ class IOException extends \RuntimeException implements IOExceptionInterface
 {
     private $path;
 
-    public function __construct(string $message, int $code = 0, \Throwable $previous = null, string $path = null)
+    public function __construct(string $message, int $code = 0, ?\Throwable $previous = null, ?string $path = null)
     {
         $this->path = $path;
 

--- a/tests/Composer/Test/Fixtures/functional/installed-versions2/vendor/symfony/filesystem/Filesystem.php
+++ b/tests/Composer/Test/Fixtures/functional/installed-versions2/vendor/symfony/filesystem/Filesystem.php
@@ -133,12 +133,12 @@ class Filesystem
      * Sets access and modification time of file.
      *
      * @param string|iterable $files A filename, an array of files, or a \Traversable instance to create
-     * @param int|null        $time  The touch time as a Unix timestamp, if not supplied the current system time is used
-     * @param int|null        $atime The access time as a Unix timestamp, if not supplied the current system time is used
+     * @param ?int            $time  The touch time as a Unix timestamp, if not supplied the current system time is used
+     * @param ?int            $atime The access time as a Unix timestamp, if not supplied the current system time is used
      *
      * @throws IOException When touch fails
      */
-    public function touch($files, int $time = null, int $atime = null)
+    public function touch($files, ?int $time = null, ?int $atime = null)
     {
         foreach ($this->toIterable($files) as $file) {
             $touch = $time ? @touch($file, $time, $atime) : @touch($file);
@@ -506,7 +506,7 @@ class Filesystem
      *
      * @throws IOException When file type is unknown
      */
-    public function mirror(string $originDir, string $targetDir, \Traversable $iterator = null, array $options = [])
+    public function mirror(string $originDir, string $targetDir, ?\Traversable $iterator = null, array $options = [])
     {
         $targetDir = rtrim($targetDir, '/\\');
         $originDir = rtrim($originDir, '/\\');


### PR DESCRIPTION
To avoid deprecation notices in PHP 8.4, use explicitly nullable types.

Similarly to the [pull request in the composer/pcre project](https://github.com/composer/pcre/pull/23), we get a deprecation notice for using `null` as a default value for non-nullable types in PHP 8.4.