### PR TITLE
Add uopz warning from installer code

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -678,6 +678,12 @@ EOT
             $warnings['onedrive'] = PHP_VERSION;
         }
 
+        if (extension_loaded('uopz')
+            && !(filter_var(ini_get('uopz.disable'), FILTER_VALIDATE_BOOLEAN)
+            || filter_var(ini_get('uopz.exit'), FILTER_VALIDATE_BOOLEAN))) {
+            $warnings['uopz'] = true;
+        }
+
         if (!empty($errors)) {
             foreach ($errors as $error => $current) {
                 switch ($error) {
@@ -789,6 +795,11 @@ EOT
                     case 'onedrive':
                         $text = "The Windows OneDrive folder is not supported on PHP versions below 7.2.23 and 7.3.10.".PHP_EOL;
                         $text .= "Upgrade your PHP ({$current}) to use this location with Composer.".PHP_EOL;
+                        break;
+
+                    case 'uopz':
+                        $text = "The uopz extension ignores exit calls and may not work with all Composer commands.".PHP_EOL;
+                        $text .= "Disabling it when using Composer is recommended.";
                         break;
 
                     default:


### PR DESCRIPTION
Syncing from https://github.com/composer/getcomposer.org/blob/main/web/installer

We seemed to have missed this one.