### PR TITLE
Improve interactive package updates

### DIFF
--- a/tests/Composer/Test/Command/UpdateCommandTest.php
+++ b/tests/Composer/Test/Command/UpdateCommandTest.php
@@ -128,9 +128,47 @@ OUTPUT
         ];
     }
 
+    public function testInteractiveModeThrowsIfNoPackageToUpdate(): void
+    {
+        $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'root/req', 'version' => '1.0.0'],
+                    ],
+                ],
+            ],
+            'require' => [
+                'root/req' => '1.*',
+            ],
+        ]);
+        $this->createComposerLock([self::getPackage('root/req', '1.0.0')]);
+        self::expectExceptionMessage('Could not find any package with new versions available');
+
+        $appTester = $this->getApplicationTester();
+        $appTester->setInputs(['']);
+        $appTester->run(['command' => 'update', '--interactive' => true]);
+    }
+
     public function testInteractiveModeThrowsIfNoPackageEntered(): void
     {
-        $this->expectExceptionMessage('No package named "" is installed.');
+        $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'root/req', 'version' => '1.0.0'],
+                        ['name' => 'root/req', 'version' => '1.0.1'],
+                    ],
+                ],
+            ],
+            'require' => [
+                'root/req' => '1.*',
+            ],
+        ]);
+        $this->createComposerLock([self::getPackage('root/req', '1.0.0')]);
+        self::expectExceptionMessage('No package named "" is installed.');
 
         $appTester = $this->getApplicationTester();
         $appTester->setInputs(['']);

--- a/tests/Composer/Test/Command/UpdateCommandTest.php
+++ b/tests/Composer/Test/Command/UpdateCommandTest.php
@@ -130,8 +130,7 @@ OUTPUT
 
     public function testInteractiveModeThrowsIfNoPackageEntered(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('You must enter minimum one package.');
+        $this->expectExceptionMessage('No package named "" is installed.');
 
         $appTester = $this->getApplicationTester();
         $appTester->setInputs(['']);


### PR DESCRIPTION
An improvement on updating packages with the `--interactive` flag.

The last time I updated some dependencies, I had difficulty remembering which packages to update when running the update command. Adding a list of packages and their current and latest versions should help developers select the right package to update more easily.
