### PR TITLE
BlockedIPs: reject download jobs like other exceptions

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -492,7 +492,7 @@ class CurlDownloader
                         is_callable($this->jobs[$i]['options']['prevent_ip_access_callable']) &&
                         $this->jobs[$i]['options']['prevent_ip_access_callable']($progress['primary_ip'])
                     ) {
-                        throw new TransportException(sprintf('IP "%s" is blocked for "%s".', $progress['primary_ip'], $progress['url']));
+                        $this->rejectJob($this->jobs[$i], new TransportException(sprintf('IP "%s" is blocked for "%s".', $progress['primary_ip'], $progress['url'])));
                     }
 
                     $this->jobs[$i]['primaryIp'] = (string) $progress['primary_ip'];


### PR DESCRIPTION
Just adjusting the blocked IP handling to match `MaxFileSizeExceededException`.