### PR TITLE
Make use of new PHP 8.4.0 function to replace implicit $http_response_header var

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -2046,11 +2046,6 @@ parameters:
 			path: ../src/Composer/Installer.php
 
 		-
-			message: "#^Casting to bool something that's already bool\\.$#"
-			count: 1
-			path: ../src/Composer/Installer.php
-
-		-
 			message: "#^Only booleans are allowed in &&, array\\<array\\<string, string\\>\\> given on the right side\\.$#"
 			count: 1
 			path: ../src/Composer/Installer.php
@@ -4354,6 +4349,16 @@ parameters:
 			path: ../src/Composer/Util/RemoteFilesystem.php
 
 		-
+			message: "#^Function http_clear_last_response_headers not found\\.$#"
+			count: 1
+			path: ../src/Composer/Util/RemoteFilesystem.php
+
+		-
+			message: "#^Function http_get_last_response_headers not found\\.$#"
+			count: 1
+			path: ../src/Composer/Util/RemoteFilesystem.php
+
+		-
 			message: "#^Method Composer\\\\Util\\\\RemoteFilesystem\\:\\:copy\\(\\) should return bool but returns bool\\|string\\.$#"
 			count: 1
 			path: ../src/Composer/Util/RemoteFilesystem.php
@@ -5095,4 +5100,3 @@ parameters:
 			message: "#^Only booleans are allowed in a ternary operator condition, array\\<string\\> given\\.$#"
 			count: 1
 			path: ../tests/Composer/Test/Util/TlsHelperTest.php
-

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1329,7 +1329,7 @@ class Installer
      */
     public function setRunScripts(bool $runScripts = true): self
     {
-        $this->runScripts = (bool) $runScripts;
+        $this->runScripts = $runScripts;
 
         return $this;
     }

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -533,7 +533,12 @@ class RemoteFilesystem
         }
 
         // https://www.php.net/manual/en/reserved.variables.httpresponseheader.php
-        $responseHeaders = $http_response_header ?? [];
+        if (PHP_VERSION_ID >= 80400) {
+            $responseHeaders = http_get_last_response_headers();
+            http_clear_last_response_headers();
+        } else {
+            $responseHeaders = $http_response_header ?? [];
+        }
 
         if (null !== $e) {
             throw $e;


### PR DESCRIPTION
Requires a new PHPStan release with https://github.com/phpstan/phpstan-src/pull/3221