### PR TITLE
Fix new platform requirements from composer.json not being checked when composer.lock is outdated

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -749,9 +749,22 @@ class Installer
                 $request->fixLockedPackage($package);
             }
 
-            foreach ($this->locker->getPlatformRequirements($this->devMode) as $link) {
-                $request->requireName($link->getTarget(), $link->getConstraint());
+            $rootRequires = $this->package->getRequires();
+            if ($this->devMode) {
+                $rootRequires = array_merge($rootRequires, $this->package->getDevRequires());
             }
+            foreach ($rootRequires as $link) {
+                if (PlatformRepository::isPlatformPackage($link->getTarget())) {
+                    $request->requireName($link->getTarget(), $link->getConstraint());
+                }
+            }
+
+            foreach ($this->locker->getPlatformRequirements($this->devMode) as $link) {
+                if (!isset($rootRequires[$link->getTarget()])) {
+                    $request->requireName($link->getTarget(), $link->getConstraint());
+                }
+            }
+            unset($rootRequires, $link);
 
             $pool = $repositorySet->createPool($request, $this->io, $this->eventDispatcher, null, $this->ignoredTypes, $this->allowedTypes);
 

--- a/tests/Composer/Test/Fixtures/installer/outdated-lock-file-fails-install.test
+++ b/tests/Composer/Test/Fixtures/installer/outdated-lock-file-fails-install.test
@@ -1,0 +1,39 @@
+--TEST--
+Test that install checks missing requirements from both composer.json if the lock file is outdated.
+--COMPOSER--
+{
+    "require": {
+        "some/dep": "dev-main",
+        "some/dep2": "dev-main"
+    }
+}
+--LOCK--
+{
+    "content-hash": "old",
+    "packages": [
+        {"name": "some/dep", "version": "dev-foo"}
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+--RUN--
+install
+--EXPECT-EXIT-CODE--
+4
+--EXPECT-OUTPUT--
+Installing dependencies from lock file (including require-dev)
+Verifying lock file contents can be installed on current platform.
+<warning>Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.</warning>
+- Required package "some/dep" is in the lock file as "dev-foo" but that does not satisfy your constraint "dev-main".
+- Required package "some/dep2" is not present in the lock file.
+This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
+Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
+and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
+
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/outdated-lock-file-with-new-platform-reqs-fails.test
+++ b/tests/Composer/Test/Fixtures/installer/outdated-lock-file-with-new-platform-reqs-fails.test
@@ -1,0 +1,46 @@
+--TEST--
+Test that install checks platform requirements from both composer.json AND composer.lock even if the lock file is outdated.
+Platform requires appearing in both lock and composer.json will be checked using the composer.json as source of truth (see ext-foo).
+--COMPOSER--
+{
+    "require": {
+        "php-64bit": "^25",
+        "ext-foo": "^10"
+    }
+}
+--LOCK--
+{
+    "content-hash": "old",
+    "packages": [
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {"php": "^20", "ext-foo": "^5"},
+    "platform-dev": []
+}
+--RUN--
+install
+--EXPECT-EXIT-CODE--
+2
+--EXPECT-OUTPUT--
+Installing dependencies from lock file (including require-dev)
+Verifying lock file contents can be installed on current platform.
+<warning>Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.</warning>
+Your lock file does not contain a compatible set of packages. Please run composer update.
+
+  Problem 1
+    - Root composer.json requires php-64bit ^25 but your php-64bit version (%s) does not satisfy that requirement.
+  Problem 2
+    - Root composer.json requires PHP extension ext-foo ^10 but it is missing from your system. Install or enable PHP's foo extension.
+  Problem 3
+    - Root composer.json requires php ^20 but your php version (%s) does not satisfy that requirement.
+
+To enable extensions, verify that they are enabled in your .ini files:
+__inilist__
+You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
+Alternatively, you can run Composer with `--ignore-platform-req=ext-foo` to temporarily ignore these required extensions.
+--EXPECT--


### PR DESCRIPTION
Fixes #11989

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
