### PR TITLE
Update OutdatedCommand.php: Adding `out` alias

### DIFF
--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -29,7 +29,8 @@ class OutdatedCommand extends BaseCommand
     {
         $this
             ->setName('outdated')
-            ->setDescription('[out] Shows a list of installed packages that have updates available, including their latest version')
+            ->setAliases(['out'])
+            ->setDescription('Shows a list of installed packages that have updates available, including their latest version')
             ->setDefinition([
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.', null, $this->suggestInstalledPackage(false)),
                 new InputOption('outdated', 'o', InputOption::VALUE_NONE, 'Show only packages that are outdated (this is the default, but present here for compat with `show`'),

--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -29,7 +29,7 @@ class OutdatedCommand extends BaseCommand
     {
         $this
             ->setName('outdated')
-            ->setDescription('Shows a list of installed packages that have updates available, including their latest version')
+            ->setDescription('[out] Shows a list of installed packages that have updates available, including their latest version')
             ->setDefinition([
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package to inspect. Or a name including a wildcard (*) to filter lists of packages instead.', null, $this->suggestInstalledPackage(false)),
                 new InputOption('outdated', 'o', InputOption::VALUE_NONE, 'Show only packages that are outdated (this is the default, but present here for compat with `show`'),


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
