### PR TITLE
fix(Locker): don't store transport-options.ssl within the lock-file

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -2707,7 +2707,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 5
+			count: 6
 			path: ../src/Composer/Package/Locker.php
 
 		-

--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -2712,7 +2712,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 6
+			count: 5
 			path: ../src/Composer/Package/Locker.php
 
 		-

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -431,12 +431,11 @@ class Locker
 
             $spec = $this->dumper->dump($package);
             unset($spec['version_normalized']);
-            // remove `transport-options.ssl` from lock file to prevent storing registry configuration in the lock file
-            if (isset($spec['transport-options'])) {
-                if (isset($spec['transport-options']['ssl'])) {
-                    unset($spec['transport-options']['ssl']);
-                }
-                if (empty($spec['transport-options'])) {
+            // remove `transport-options.ssl` from lock file to prevent storing 
+            // local-filesystem repo config paths in the lock file as that makes it less portable
+            if (isset($spec['transport-options']['ssl'])) {
+                unset($spec['transport-options']['ssl']);
+                if (\count($spec['transport-options']) === 0) {
                     unset($spec['transport-options']);
                 }
             }

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -431,7 +431,7 @@ class Locker
 
             $spec = $this->dumper->dump($package);
             unset($spec['version_normalized']);
-            // remove transport-options.ssl from lock file
+            // remove `transport-options.ssl` from lock file to prevent storing registry configuration in the lock file
             if (isset($spec['transport-options'])) {
                 if (isset($spec['transport-options']['ssl'])) {
                     unset($spec['transport-options']['ssl']);

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -431,6 +431,15 @@ class Locker
 
             $spec = $this->dumper->dump($package);
             unset($spec['version_normalized']);
+            // remove transport-options.ssl from lock file
+            if (isset($spec['transport-options'])) {
+                if (isset($spec['transport-options']['ssl'])) {
+                    unset($spec['transport-options']['ssl']);
+                }
+                if (empty($spec['transport-options'])) {
+                    unset($spec['transport-options']);
+                }
+            }
 
             // always move time to the end of the package definition
             $time = $spec['time'] ?? null;


### PR DESCRIPTION
## Description
Don't store `transport-options.ssl` within the lock-file otherwise the installation or updates will (in most cases) fail for repositories that use client TLS certificates, because during installation `transport-options` from `composer.lock` will be used instead of repository settings (certificates) from composer configuration file.

<hr />

## Example

Minimal configuration for case "private registry with client-certificates" (`~/.composer/config.json`)
```json
{
    "repositories": {
        "private.registry": {
            "type": "composer",
            "url": "https://composer.registry.example.com",
            "options": {
                "ssl": {
                    "local_cert": "/home/user/.composer/certs.d/private.cert",
                    "local_key": "/home/user/.composer/certs.d/private.key"
                }
            }
        }
    }
}
```

Dummy project (`~/project/composer.json`)
```json
{
    "name": "exmaple/dummy",
    "type": "project",
    "require": {
        "private-repo/package": "^1.0"
    }
}
```

Dummy project lock (`~/project/compose.lock`) (with current composer)
```json
{
    "content-hash": "...",
    "packages": [
        {
            "name": "private-repo/package",
            "version": "1.0.0",
            "transport-options": {
                "ssl": {
                    "local_cert": "/home/user/.composer/certs.d/private.cert",
                    "local_key": "/home/user/.composer/certs.d/private.key"
                }
            }
        }
    ]
}
```

In this case installation/update will fail if the environment performing such task will have different configuration (`~/.composer/config.json`), because path to certificate will be different and that will lead to cURL error message ("wrong certificate").

Some uses cases when this will could happen:
 - storing `composer.log` within VCS and 2+ developers with different composer configurations
 - CI installations

<hr/>

## Fixed lock-file

With this change lock-file (`~/project/compose.lock`) will look like this:
```json
{
    "content-hash": "...",
    "packages": [
        {
            "name": "private-repo/package",
            "version": "1.0.0"
        }
    ]
}
```
So composer will use TLS transport-options from configuration and installation will succeed.

## Is it breaking change?

I suppose this change as non-breaking, because it may will break in only one case - composer.lock file is somehow in sync with tls certificates in all places calling `install`/`update` and at the same time composer configuration still contains repository configuration, but is out of sync with certificates path; for me this approach is looking quite strange for me because it is "forming install environment around lock-file".

## Is it tested? - Yes

 - local tests with different TLS-configurations and other transport options
 -  within my company CI (patched version)