### PR TITLE
Fix typo for IO tests

### DIFF
--- a/tests/Composer/Test/IO/ConsoleIOTest.php
+++ b/tests/Composer/Test/IO/ConsoleIOTest.php
@@ -255,7 +255,7 @@ class ConsoleIOTest extends TestCase
         self::assertEquals(['1'], $result);
     }
 
-    public function testSetAndgetAuthentication(): void
+    public function testSetAndGetAuthentication(): void
     {
         $inputMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
         $outputMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();

--- a/tests/Composer/Test/IO/NullIOTest.php
+++ b/tests/Composer/Test/IO/NullIOTest.php
@@ -24,7 +24,7 @@ class NullIOTest extends TestCase
         self::assertFalse($io->isInteractive());
     }
 
-    public function testhasAuthentication(): void
+    public function testHasAuthentication(): void
     {
         $io = new NullIO();
 
@@ -38,7 +38,7 @@ class NullIOTest extends TestCase
         self::assertNull($io->askAndHideAnswer('foo'));
     }
 
-    public function testgetAuthentications(): void
+    public function testGetAuthentications(): void
     {
         $io = new NullIO();
 
@@ -58,7 +58,7 @@ class NullIOTest extends TestCase
     {
         $io = new NullIO();
 
-        self::assertEquals(false, $io->askConfirmation('bar', false));
+        self::assertFalse($io->askConfirmation('bar', false));
     }
 
     public function testAskAndValidate(): void


### PR DESCRIPTION
There are a few typo mistakes (camel case) in IO tests, so I fixed them.