### PR TITLE
Remove redundant boolean type casts

### DIFF
--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -53,7 +53,7 @@ class Cache
         $this->root = rtrim($cacheDir, '/\\') . '/';
         $this->allowlist = $allowlist;
         $this->filesystem = $filesystem ?: new Filesystem();
-        $this->readOnly = (bool) $readOnly;
+        $this->readOnly = $readOnly;
 
         if (!self::isUsable($cacheDir)) {
             $this->enabled = false;
@@ -65,7 +65,7 @@ class Cache
      */
     public function setReadOnly(bool $readOnly)
     {
-        $this->readOnly = (bool) $readOnly;
+        $this->readOnly = $readOnly;
     }
 
     /**

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -125,7 +125,7 @@ class Config
         $this->config = static::$defaultConfig;
 
         $this->repositories = static::$defaultRepositories;
-        $this->useEnvironment = (bool) $useEnvironment;
+        $this->useEnvironment = $useEnvironment;
         $this->baseDir = is_string($baseDir) && '' !== $baseDir ? $baseDir : null;
 
         foreach ($this->config as $configKey => $configValue) {

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -90,7 +90,7 @@ class EventDispatcher
      */
     public function setRunScripts(bool $runScripts = true): self
     {
-        $this->runScripts = (bool) $runScripts;
+        $this->runScripts = $runScripts;
 
         return $this;
     }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1173,7 +1173,7 @@ class Installer
      */
     public function setDryRun(bool $dryRun = true): self
     {
-        $this->dryRun = (bool) $dryRun;
+        $this->dryRun = $dryRun;
 
         return $this;
     }
@@ -1205,7 +1205,7 @@ class Installer
      */
     public function setPreferSource(bool $preferSource = true): self
     {
-        $this->preferSource = (bool) $preferSource;
+        $this->preferSource = $preferSource;
 
         return $this;
     }
@@ -1217,7 +1217,7 @@ class Installer
      */
     public function setPreferDist(bool $preferDist = true): self
     {
-        $this->preferDist = (bool) $preferDist;
+        $this->preferDist = $preferDist;
 
         return $this;
     }
@@ -1229,7 +1229,7 @@ class Installer
      */
     public function setOptimizeAutoloader(bool $optimizeAutoloader): self
     {
-        $this->optimizeAutoloader = (bool) $optimizeAutoloader;
+        $this->optimizeAutoloader = $optimizeAutoloader;
         if (!$this->optimizeAutoloader) {
             // Force classMapAuthoritative off when not optimizing the
             // autoloader
@@ -1247,7 +1247,7 @@ class Installer
      */
     public function setClassMapAuthoritative(bool $classMapAuthoritative): self
     {
-        $this->classMapAuthoritative = (bool) $classMapAuthoritative;
+        $this->classMapAuthoritative = $classMapAuthoritative;
         if ($this->classMapAuthoritative) {
             // Force optimizeAutoloader when classmap is authoritative
             $this->setOptimizeAutoloader(true);
@@ -1276,7 +1276,7 @@ class Installer
      */
     public function setUpdate(bool $update): self
     {
-        $this->update = (bool) $update;
+        $this->update = $update;
 
         return $this;
     }
@@ -1288,7 +1288,7 @@ class Installer
      */
     public function setInstall(bool $install): self
     {
-        $this->install = (bool) $install;
+        $this->install = $install;
 
         return $this;
     }
@@ -1300,7 +1300,7 @@ class Installer
      */
     public function setDevMode(bool $devMode = true): self
     {
-        $this->devMode = (bool) $devMode;
+        $this->devMode = $devMode;
 
         return $this;
     }
@@ -1314,7 +1314,7 @@ class Installer
      */
     public function setDumpAutoloader(bool $dumpAutoloader = true): self
     {
-        $this->dumpAutoloader = (bool) $dumpAutoloader;
+        $this->dumpAutoloader = $dumpAutoloader;
 
         return $this;
     }
@@ -1353,7 +1353,7 @@ class Installer
      */
     public function setVerbose(bool $verbose = true): self
     {
-        $this->verbose = (bool) $verbose;
+        $this->verbose = $verbose;
 
         return $this;
     }

--- a/src/Composer/Question/StrictConfirmationQuestion.php
+++ b/src/Composer/Question/StrictConfirmationQuestion.php
@@ -40,7 +40,7 @@ class StrictConfirmationQuestion extends Question
      */
     public function __construct(string $question, bool $default = true, string $trueAnswerRegex = '/^y(?:es)?$/i', string $falseAnswerRegex = '/^no?$/i')
     {
-        parent::__construct($question, (bool) $default);
+        parent::__construct($question, $default);
 
         $this->trueAnswerRegex = $trueAnswerRegex;
         $this->falseAnswerRegex = $falseAnswerRegex;


### PR DESCRIPTION
These parameters are declared as boolean and composer also uses `declare(strict_types=1);`. If we pass non-boolean values, it'll raise `TypeError`. So, we needn't to use type casts for them.