### PR TITLE
Fix addressability of branches containing # characters

### DIFF
--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -270,7 +270,7 @@ class Problem
                 new Constraint(Constraint::STR_OP_EQ, str_replace('#', '+', $newConstraint))
             ], false));
             if (\count($packages) > 0) {
-                return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but '.(self::hasMultipleNames($packages) ? 'these' : 'it').' had a # in the branch name which was replaced by +. Make sure to require it as "'.str_replace('#', '+', $constraint->getPrettyString()).'".'];
+                return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).'. The # character in branch names is replaced by a + character. Make sure to require it as "'.str_replace('#', '+', $constraint->getPrettyString()).'".'];
             }
         }
 

--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -341,7 +341,8 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
 
             // make sure branch packages have a dev flag
             if (strpos($parsedBranch, 'dev-') === 0 || VersionParser::DEFAULT_BRANCH_ALIAS === $parsedBranch) {
-                $version = 'dev-' . $branch;
+                $version = 'dev-' . str_replace('#', '+', $branch);
+                $parsedBranch = str_replace('#', '+', $parsedBranch);
             } else {
                 $prefix = strpos($branch, 'v') === 0 ? 'v' : '';
                 $version = $prefix . Preg::replace('{(\.9{7})+}', '.x', $parsedBranch);

--- a/tests/Composer/Test/Fixtures/installer/solver-problem-with-hash-in-branch.test
+++ b/tests/Composer/Test/Fixtures/installer/solver-problem-with-hash-in-branch.test
@@ -33,8 +33,8 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - Root composer.json requires package/found dev-foo#bar, found package/found[dev-foo+bar] but it had a # in the branch name which was replaced by +. Make sure to require it as "dev-foo+bar".
+    - Root composer.json requires package/found dev-foo#bar, found package/found[dev-foo+bar]. The # character in branch names is replaced by a + character. Make sure to require it as "dev-foo+bar".
   Problem 2
-    - Root composer.json requires package/found2 dev-foo#abcd09832478, found package/found2[dev-foo+abcd09832478] but it had a # in the branch name which was replaced by +. Make sure to require it as "dev-foo+abcd09832478".
+    - Root composer.json requires package/found2 dev-foo#abcd09832478, found package/found2[dev-foo+abcd09832478]. The # character in branch names is replaced by a + character. Make sure to require it as "dev-foo+abcd09832478".
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/solver-problem-with-hash-in-branch.test
+++ b/tests/Composer/Test/Fixtures/installer/solver-problem-with-hash-in-branch.test
@@ -1,0 +1,40 @@
+--TEST--
+Test the problem output suggests fixes for branch names where the # was replaced by +
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "package/found", "version": "dev-foo+bar" },
+                { "name": "package/found2", "version": "dev-foo+abcd09832478" },
+                { "name": "package/works", "version": "dev-foo+abcd09832478" },
+                { "name": "package/works2", "version": "dev-+123" }
+            ]
+        }
+    ],
+    "require": {
+        "package/found": "dev-foo#bar",
+        "package/found2": "dev-foo#abcd09832478",
+        "package/works": "dev-foo+abcd09832478",
+        "package/works2": "dev-+123"
+    }
+}
+
+--RUN--
+update
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires package/found dev-foo#bar, found package/found[dev-foo+bar] but it had a # in the branch name which was replaced by +. Make sure to require it as "dev-foo+bar".
+  Problem 2
+    - Root composer.json requires package/found2 dev-foo#abcd09832478, found package/found2[dev-foo+abcd09832478] but it had a # in the branch name which was replaced by +. Make sure to require it as "dev-foo+abcd09832478".
+
+--EXPECT--

--- a/tests/Composer/Test/Repository/VcsRepositoryTest.php
+++ b/tests/Composer/Test/Repository/VcsRepositoryTest.php
@@ -94,6 +94,9 @@ class VcsRepositoryTest extends TestCase
         $exec('git add foo');
         $exec('git commit -m change-a');
 
+        // add foo#bar branch which should result in dev-foo+bar
+        $exec('git branch foo#bar');
+
         // add version to composer.json
         $exec('git checkout master');
         $composer['version'] = '1.0.0';
@@ -154,6 +157,7 @@ class VcsRepositoryTest extends TestCase
             '1.1.x-dev' => true,
             'dev-feature-b' => true,
             'dev-feature/a-1.0-B' => true,
+            'dev-foo+bar' => true,
             'dev-master' => true,
             '9999999-dev' => true, // alias of dev-master
         ];


### PR DESCRIPTION
Fixes #12029

This makes sure that VCS branches containing `#` signs get it replaced by a `+`. That makes them addressable (right now they are not at all).

And also it adds proper error reporting suggesting a solution if someone requires `dev-foo#bar` meaning to require that branch and not `dev-foo` at ref `bar`.