### PR TITLE
Fix deprecation notice on PHP 8.4

### DIFF
--- a/src/Composer/Downloader/TransportException.php
+++ b/src/Composer/Downloader/TransportException.php
@@ -26,7 +26,7 @@ class TransportException extends \RuntimeException
     /** @var array<mixed> */
     protected $responseInfo = [];
 
-    public function __construct(string $message = "", int $code = 400, \Throwable $previous = null)
+    public function __construct(string $message = "", int $code = 400, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }


### PR DESCRIPTION
PHP 8.4 requires nullable arguments to be explicitly declared as such.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
