### PR TITLE
 Add `InitCommand.php` Interactive tests 

### DIFF
--- a/tests/Composer/Test/Command/InitCommandTest.php
+++ b/tests/Composer/Test/Command/InitCommandTest.php
@@ -748,8 +748,9 @@ class InitCommandTest extends TestCase
         foreach (array_keys($default_inputs) as $key) {
             $flat_inputs = array_merge(
                 $flat_inputs,
-                $inputs[$key] ?? $default_inputs[$key],
+                $inputs[$key] ?? $default_inputs[$key]
             );
+        }
 
         return $flat_inputs;
     }

--- a/tests/Composer/Test/Command/InitCommandTest.php
+++ b/tests/Composer/Test/Command/InitCommandTest.php
@@ -697,7 +697,7 @@ class InitCommandTest extends TestCase
         self::assertEquals($expected, $file->read());
     }
 
-    public function testInteractiveRunDescription()
+    public function testInteractiveRunDescription(): void
     {
         $dir = $this->initTempComposer();
         unlink($dir . '/composer.json');
@@ -728,7 +728,11 @@ class InitCommandTest extends TestCase
         self::assertEquals($expected, $file->read());
     }
 
-    static public function generateInteractiveInputs(array $inputs)
+    /**
+     * @param array<string, array<string>> $inputs
+     * @return array<string>
+     */
+    static public function generateInteractiveInputs(array $inputs): array
     {
         $default_inputs = [
             'package_name' => ['pkg/dep'],

--- a/tests/Composer/Test/Command/InitCommandTest.php
+++ b/tests/Composer/Test/Command/InitCommandTest.php
@@ -696,4 +696,61 @@ class InitCommandTest extends TestCase
         $file = new JsonFile($dir . '/composer.json');
         self::assertEquals($expected, $file->read());
     }
+
+    public function testInteractiveRunDescription()
+    {
+        $dir = $this->initTempComposer();
+        unlink($dir . '/composer.json');
+        unlink($dir . '/auth.json');
+
+        $appTester = $this->getApplicationTester();
+
+        $inputs = self::generateInteractiveInputs([
+            'package_name' => ['vendor/my-package'],
+        ]);
+        $appTester->setInputs($inputs);
+
+        $appTester->run(['command' => 'init']);
+
+        self::assertSame(0, $appTester->getStatusCode());
+
+        $expected = [
+            "name" => "vendor/my-package",
+            "description" => "my desciption",
+            "type" => "library",
+            "license" => "Custom Liscence",
+            "authors" => [["name" => "Mr. Test", "email" => "test@example.org"]],
+            "minimum-stability" => "stable",
+            "require" => [],
+        ];
+
+        $file = new JsonFile($dir . '/composer.json');
+        self::assertEquals($expected, $file->read());
+    }
+
+    static public function generateInteractiveInputs(array $inputs)
+    {
+        $default_inputs = [
+            'package_name' => ['pkg/dep'],
+            'description' => ['my desciption'],
+            'author' => ['Mr. Test <test@example.org>'],
+            'minimum_stability' => ['stable'],
+            'type' => ['library'],
+            'liscene' => ['Custom Liscence'],
+            'define_dep' => ['no'],
+            'define_dev_dependencies' => ['no'],
+            // Add PSR-4 autoload mapping
+            'add_psr' => ['n'],
+            'confirm' => [''],
+        ];
+        $flat_inputs = [];
+
+        foreach (array_keys($default_inputs) as $key) {
+            $flat_inputs = array_merge(
+                $flat_inputs,
+                $inputs[$key] ?? $default_inputs[$key],
+            );
+
+        return $flat_inputs;
+    }
 }


### PR DESCRIPTION
This is to expand test coverage as explained in #10796.


### Why `generateInteractiveInput`

Since `$appTester->inputs` takes in all the inputs as an array, all inputs have
to be provided and all must be in correct order.  I thought it would be
appropriate to create a helper method that would do that.

- You don't have to provide all the data for each test case
  (`generateInteractiveInput` will pull the defaults for you).
- Less of the code would have to be changed in case the prompting process
  changes for `init` command, whether the prompts be reorderd or new prompts
  added.

------

You describe inputs by mapping the input name to an array of inputs.

```php
[
    'package_name' => ['vendor/my-package'],
    'minimum-stability' => 'stable',
]

[
    'package_name' => ['vendor', ''],
    'minimum-stability' => 'stable',
]
```

The reason I used array of inputs is to allow testing for cases where you'd have
to provide more than one input (think adding requirements or testing invalid
package name.
