### PR TITLE
Add missing semicolon to code example in documentation

### DIFF
--- a/doc/articles/scripts.md
+++ b/doc/articles/scripts.md
@@ -273,7 +273,7 @@ class MyCommand extends Command
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('arbitrary-flag')) {
-            $output->writeln('The flag was used')
+            $output->writeln('The flag was used');
         }
 
         return 0;


### PR DESCRIPTION
Adds missing semicolon to a code example, which cannot be executed otherwise.