### PR TITLE
Add "require command with conflicting keys" test

### DIFF
--- a/tests/Composer/Test/Command/RequireCommandTest.php
+++ b/tests/Composer/Test/Command/RequireCommandTest.php
@@ -300,12 +300,14 @@ OUTPUT
         }
 
         $appTester = $this->getApplicationTester();
+        if ($isInteractive)
+            $appTester->setInputs(['yes']);
         $appTester->run([
             'command' => 'require',
             '--no-audit' => true,
             '--dev' => $isDev,
             '--no-install' => true,
-            '--no-interaction' => true,
+            '--no-interaction' => !$isInteractive,
             'packages' => ['required/pkg']
         ]);
 
@@ -330,6 +332,18 @@ OUTPUT
         yield [
             false,
             false,
+            '<warning>required/pkg is currently present in the require-dev key and you ran the command without the --dev flag, which will move it to the require key.</warning>'
+        ];
+
+        yield [
+            true,
+            true,
+            '<warning>required/pkg is currently present in the require key and you ran the command with the --dev flag, which will move it to the require-dev key.</warning>'
+        ];
+
+        yield [
+            false,
+            true,
             '<warning>required/pkg is currently present in the require-dev key and you ran the command without the --dev flag, which will move it to the require key.</warning>'
         ];
     }

--- a/tests/Composer/Test/Command/RequireCommandTest.php
+++ b/tests/Composer/Test/Command/RequireCommandTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\Command;
 
+use Composer\Json\JsonFile;
 use Composer\Test\TestCase;
 use InvalidArgumentException;
 
@@ -261,6 +262,75 @@ Lock file operations: 1 install, 0 updates, 0 removals
   - Locking required/pkg (1.1.0)
 Using version 1.1.0 for required/pkg
 OUTPUT
+        ];
+    }
+
+    /**
+     * @dataProvider provideInconsistentRequireKeys
+     * @param bool $isDev
+     * @param bool $isInteractive
+     * @param string $expectedWarning
+     */
+    public function testInconsistentRequireKeys(bool $isDev, bool $isInteractive, string $expectedWarning): void
+    {
+        $currentKey = $isDev ? "require" : "require-dev";
+        $otherKey = $isDev ? "require-dev" : "require";
+
+        $dir = $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'required/pkg', 'version' => '1.0.0'],
+                    ],
+                ],
+            ],
+            $currentKey => [
+                "required/pkg" => "^1.0",
+            ],
+        ]);
+
+        $package = self::getPackage('required/pkg');
+        if ($isDev) {
+            $this->createComposerLock([], [$package]);
+            $this->createInstalledJson([], [$package]);
+        } else {
+            $this->createComposerLock([$package], []);
+            $this->createInstalledJson([$package], []);
+        }
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run([
+            'command' => 'require',
+            '--no-audit' => true,
+            '--dev' => $isDev,
+            '--no-install' => true,
+            '--no-interaction' => true,
+            'packages' => ['required/pkg']
+        ]);
+
+        self::assertStringContainsString(
+            $expectedWarning,
+            $appTester->getDisplay(true),
+        );
+
+        $composer_content = (new JsonFile($dir . '/composer.json'))->read();
+        self::assertArrayHasKey($otherKey, $composer_content);
+        self::assertArrayNotHasKey($currentKey, $composer_content);
+    }
+
+    public function provideInconsistentRequireKeys(): \Generator
+    {
+        yield [
+            true,
+            false,
+            '<warning>required/pkg is currently present in the require key and you ran the command with the --dev flag, which will move it to the require-dev key.</warning>'
+        ];
+
+        yield [
+            false,
+            false,
+            '<warning>required/pkg is currently present in the require-dev key and you ran the command without the --dev flag, which will move it to the require key.</warning>'
         ];
     }
 }

--- a/tests/Composer/Test/Command/RequireCommandTest.php
+++ b/tests/Composer/Test/Command/RequireCommandTest.php
@@ -300,16 +300,20 @@ OUTPUT
         }
 
         $appTester = $this->getApplicationTester();
-        if ($isInteractive)
-            $appTester->setInputs(['yes']);
-        $appTester->run([
+        $command = [
             'command' => 'require',
             '--no-audit' => true,
             '--dev' => $isDev,
             '--no-install' => true,
-            '--no-interaction' => !$isInteractive,
             'packages' => ['required/pkg']
-        ]);
+        ];
+
+        if ($isInteractive)
+            $appTester->setInputs(['yes']);
+        else
+            $command['--no-interaction'] = true;
+
+        $appTester->run($command);
 
         self::assertStringContainsString(
             $expectedWarning,

--- a/tests/Composer/Test/Command/RequireCommandTest.php
+++ b/tests/Composer/Test/Command/RequireCommandTest.php
@@ -317,7 +317,7 @@ OUTPUT
 
         self::assertStringContainsString(
             $expectedWarning,
-            $appTester->getDisplay(true),
+            $appTester->getDisplay(true)
         );
 
         $composer_content = (new JsonFile($dir . '/composer.json'))->read();


### PR DESCRIPTION
re: #10796

Added four cases for conflicting keys

- with package in require or in require-dev
- with interactive or non interactive

For the interactive mode I'm testing for 'yes' input only.  I can test for 'no' too, but I didn't find an obvious way to do it without making the code too unreadable.

For the way I wrote the command part, I had to structure the code in that weird way to get it to work.  See commit message of d6479b8a for more.