### PR TITLE
Revert code

### DIFF
--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -218,7 +218,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
                     $package['version'] = $versionData['pretty_version'];
                 } else {
-                    $package['version'] = 'dev-main';
+                    $package['version'] = 'dev-master';
                 }
             }
 


### PR DESCRIPTION
(https://github.com/composer/composer/issues/12078)
There was a fix [here](https://github.com/composer/composer/pull/10372/commits/714d68c0e58aa91ef595743fd43313305958fe0b) to have aliases for branches and it is reverted [here](https://github.com/composer/composer/commit/2b99d069b22557cf87f3caacfb50251e3cf6c2ee) but we didn't change the default branch name 