### PR TITLE
Improve reproducibility of autoloader files - add missing `sort`

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -1310,6 +1310,10 @@ INITIALIZER;
 
                     $autoloads[$namespace][] = $relativePath;
                 }
+
+                if (array_key_exists($namespace, $autoloads) && is_array($autoloads[$namespace])) {
+                    sort($autoloads[$namespace]);
+                }
             }
         }
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_main.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_main.php
@@ -7,5 +7,5 @@ $baseDir = dirname($vendorDir);
 
 return array(
     'Main' => array($baseDir . '/src'),
-    'Lala' => array($baseDir . '/src', $baseDir . '/lib'),
+    'Lala' => array($baseDir . '/lib', $baseDir . '/src'),
 );

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_psr4.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_psr4.php
@@ -7,5 +7,5 @@ $baseDir = dirname($vendorDir);
 
 return array(
     'Acme\\Fruit\\' => array($baseDir . '/src-fruit'),
-    'Acme\\Cake\\' => array($baseDir . '/src-cake', $baseDir . '/lib-cake'),
+    'Acme\\Cake\\' => array($baseDir . '/lib-cake', $baseDir . '/src-cake'),
 );

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_psr4_2.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_psr4_2.php
@@ -7,5 +7,5 @@ $baseDir = dirname(dirname($vendorDir));
 
 return array(
     'Acme\\Fruit\\' => array($baseDir . '/src-fruit'),
-    'Acme\\Cake\\' => array($baseDir . '/src-cake', $baseDir . '/lib-cake'),
+    'Acme\\Cake\\' => array($baseDir . '/lib-cake', $baseDir . '/src-cake'),
 );

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_psr4_3.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_psr4_3.php
@@ -7,5 +7,5 @@ $baseDir = $vendorDir;
 
 return array(
     'Acme\\Fruit\\' => array($vendorDir . '/src-fruit'),
-    'Acme\\Cake\\' => array($vendorDir . '/src-cake', $vendorDir . '/lib-cake'),
+    'Acme\\Cake\\' => array($vendorDir . '/lib-cake', $vendorDir . '/src-cake'),
 );


### PR DESCRIPTION
While updating PHPDocumentor in Nix ([#336145](https://github.com/NixOS/nixpkgs/pull/336145)), we encountered instability with the new version of the Composer builder introduced in [#308059](https://github.com/NixOS/nixpkgs/pull/308059). In the context of Nix, "unstable" means that the `vendor` directory produced by Composer was not consistently reproducible.

![image](https://github.com/user-attachments/assets/1435e50d-46a1-41ad-9e51-e520fe87f735)

To reproduce the issue locally:

```
$ git clone https://github.com/phpdocumentor/phpdocumentor
$ cd phpdocumentor
$ git checkout v3.6.0
$ rm -rf vendor0 vendor1
$ composer install
$ mv vendor vendor0
$ rm -rf ~/.cache/composer
$ composer install
$ mv vendor vendor1
$ diffoscope --exclude-directory-metadata recursive vendor0 vendor1
--- vendor0
+++ vendor1
│   --- vendor0/composer
├── +++ vendor1/composer
│ │   --- vendor0/composer/autoload_psr4.php
│ ├── +++ vendor1/composer/autoload_psr4.php
│ │ @@ -4,15 +4,15 @@
│ │  
│ │  $vendorDir = dirname(__DIR__);
│ │  $baseDir = dirname($vendorDir);
│ │  
│ │  return array(
│ │      'phpDocumentor\\Reflection\\' => array($vendorDir . '/phpdocumentor/reflection-common/src', $vendorDir . '/phpdocumentor/type-resolver/src', $vendorDir . '/phpdocumentor/reflection-docblock/src'),
│ │      'phpDocumentor\\JsonPath\\' => array($baseDir . '/incubator/json-path/tests/unit', $vendorDir . '/phpdocumentor/json-path/src'),
│ │ +    'phpDocumentor\\Guides\\' => array($vendorDir . '/phpdocumentor/guides/src', $vendorDir . '/phpdocumentor/guides-graphs/src', $vendorDir . '/phpdocumentor/guides-restructured-text/src', $vendorDir . '/phpdocumentor/guides-markdown/src'),
│ │ -    'phpDocumentor\\Guides\\' => array($vendorDir . '/phpdocumentor/guides-graphs/src', $vendorDir . '/phpdocumentor/guides/src', $vendorDir . '/phpdocumentor/guides-restructured-text/src', $vendorDir . '/phpdocumentor/guides-markdown/src'),
│ │      'phpDocumentor\\GraphViz\\PHPStan\\' => array($vendorDir . '/phpdocumentor/graphviz/src/phpDocumentor/PHPStan'),
│ │      'phpDocumentor\\GraphViz\\' => array($vendorDir . '/phpdocumentor/graphviz/src/phpDocumentor/GraphViz'),
│ │      'phpDocumentor\\' => array($baseDir . '/src/phpDocumentor', $baseDir . '/tests/unit/phpDocumentor', $baseDir . '/tests/integration/phpDocumentor', $baseDir . '/tests/functional/phpDocumentor', $vendorDir . '/phpdocumentor/reflection/src/phpDocumentor'),
│ │      'Webmozart\\Assert\\' => array($vendorDir . '/webmozart/assert/src'),
│ │      'Twig\\' => array($vendorDir . '/twig/twig/src'),
│ │      'Symfony\\Polyfill\\Php83\\' => array($vendorDir . '/symfony/polyfill-php83'),
│ │      'Symfony\\Polyfill\\Php80\\' => array($vendorDir . '/symfony/polyfill-php80'),
│ │   --- vendor0/composer/autoload_static.php
│ ├── +++ vendor1/composer/autoload_static.php
│ │ @@ -491,19 +491,19 @@
│ │  00001ea0: 292c 0a20 2020 2020 2020 2027 7068 7044  ),.        'phpD
│ │  00001eb0: 6f63 756d 656e 746f 725c 5c47 7569 6465  ocumentor\\Guide
│ │  00001ec0: 735c 5c27 203d 3e20 0a20 2020 2020 2020  s\\' => .       
│ │  00001ed0: 2061 7272 6179 2028 0a20 2020 2020 2020   array (.       
│ │  00001ee0: 2020 2020 2030 203d 3e20 5f5f 4449 525f       0 => __DIR_
│ │  00001ef0: 5f20 2e20 272f 2e2e 2720 2e20 272f 7068  _ . '/..' . '/ph
│ │  00001f00: 7064 6f63 756d 656e 746f 722f 6775 6964  pdocumentor/guid
│ │ +00001f10: 6573 2f73 7263 272c 0a20 2020 2020 2020  es/src',.       
│ │ +00001f20: 2020 2020 2031 203d 3e20 5f5f 4449 525f       1 => __DIR_
│ │ +00001f30: 5f20 2e20 272f 2e2e 2720 2e20 272f 7068  _ . '/..' . '/ph
│ │ +00001f40: 7064 6f63 756d 656e 746f 722f 6775 6964  pdocumentor/guid
│ │ +00001f50: 6573 2d67 7261 7068 732f 7372 6327 2c0a  es-graphs/src',.
│ │ -00001f10: 6573 2d67 7261 7068 732f 7372 6327 2c0a  es-graphs/src',.
│ │ -00001f20: 2020 2020 2020 2020 2020 2020 3120 3d3e              1 =>
│ │ -00001f30: 205f 5f44 4952 5f5f 202e 2027 2f2e 2e27   __DIR__ . '/..'
│ │ -00001f40: 202e 2027 2f70 6870 646f 6375 6d65 6e74   . '/phpdocument
│ │ -00001f50: 6f72 2f67 7569 6465 732f 7372 6327 2c0a  or/guides/src',.
│ │  00001f60: 2020 2020 2020 2020 2020 2020 3220 3d3e              2 =>
│ │  00001f70: 205f 5f44 4952 5f5f 202e 2027 2f2e 2e27   __DIR__ . '/..'
│ │  00001f80: 202e 2027 2f70 6870 646f 6375 6d65 6e74   . '/phpdocument
│ │  00001f90: 6f72 2f67 7569 6465 732d 7265 7374 7275  or/guides-restru
│ │  00001fa0: 6374 7572 6564 2d74 6578 742f 7372 6327  ctured-text/src'
│ │  00001fb0: 2c0a 2020 2020 2020 2020 2020 2020 3320  ,.            3 
│ │  00001fc0: 3d3e 205f 5f44 4952 5f5f 202e 2027 2f2e  => __DIR__ . '/.
```

~~Additionally, I've added a commit (`refactor: DRY`) to remove duplicated code and clarify the autoloader files generation process. Please let me know if you'd prefer to keep or revert this change.~~ I removed it, I was not satisfied with my implementation.