### PR TITLE
Fix relative:true not being respected in path repo installs

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -436,10 +436,11 @@ class Filesystem
      * Returns the shortest path from $from to $to
      *
      * @param  bool                      $directories if true, the source/target are considered to be directories
+     * @param  bool                      $preferRelative if true, relative paths will be preferred even if longer
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function findShortestPath(string $from, string $to, bool $directories = false)
+    public function findShortestPath(string $from, string $to, bool $directories = false, bool $preferRelative = false)
     {
         if (!$this->isAbsolutePath($from) || !$this->isAbsolutePath($to)) {
             throw new \InvalidArgumentException(sprintf('$from (%s) and $to (%s) must be absolute paths.', $from, $to));
@@ -471,7 +472,7 @@ class Filesystem
         $commonPathCode = str_repeat('../', $sourcePathDepth);
 
         // allow top level /foo & /bar dirs to be addressed relatively as this is common in Docker setups
-        if ('/' === $commonPath && $sourcePathDepth > 1) {
+        if (!$preferRelative && '/' === $commonPath && $sourcePathDepth > 1) {
             return $to;
         }
 
@@ -487,10 +488,11 @@ class Filesystem
      * Returns PHP code that, when executed in $from, will return the path to $to
      *
      * @param  bool                      $directories if true, the source/target are considered to be directories
+     * @param  bool                      $preferRelative if true, relative paths will be preferred even if longer
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function findShortestPathCode(string $from, string $to, bool $directories = false, bool $staticCode = false)
+    public function findShortestPathCode(string $from, string $to, bool $directories = false, bool $staticCode = false, bool $preferRelative = false)
     {
         if (!$this->isAbsolutePath($from) || !$this->isAbsolutePath($to)) {
             throw new \InvalidArgumentException(sprintf('$from (%s) and $to (%s) must be absolute paths.', $from, $to));
@@ -520,7 +522,7 @@ class Filesystem
         $sourcePathDepth = substr_count((string) substr($from, \strlen($commonPath)), '/') + (int) $directories;
 
         // allow top level /foo & /bar dirs to be addressed relatively as this is common in Docker setups
-        if ('/' === $commonPath && $sourcePathDepth > 1) {
+        if (!$preferRelative && '/' === $commonPath && $sourcePathDepth > 1) {
             return var_export($to, true);
         }
 

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -54,10 +54,10 @@ class FilesystemTest extends TestCase
     /**
      * @dataProvider providePathCouplesAsCode
      */
-    public function testFindShortestPathCode(string $a, string $b, bool $directory, string $expected, bool $static = false): void
+    public function testFindShortestPathCode(string $a, string $b, bool $directory, string $expected, bool $static = false, bool $preferRelative = false): void
     {
         $fs = new Filesystem;
-        self::assertEquals($expected, $fs->findShortestPathCode($a, $b, $directory, $static));
+        self::assertEquals($expected, $fs->findShortestPathCode($a, $b, $directory, $static, $preferRelative));
     }
 
     public static function providePathCouplesAsCode(): array
@@ -77,6 +77,7 @@ class FilesystemTest extends TestCase
             ['/foo/bar', '/foo/baz', true, "dirname(__DIR__).'/baz'"],
             ['/foo/bin/run', '/foo/vendor/acme/bin/run', true, "dirname(dirname(__DIR__)).'/vendor/acme/bin/run'"],
             ['/foo/bin/run', '/bar/bin/run', true, "'/bar/bin/run'"],
+            ['/app/vendor/foo/bar', '/lib', true, "dirname(dirname(dirname(dirname(__DIR__)))).'/lib'", false, true],
             ['/bin/run', '/bin/run', true, "__DIR__"],
             ['c:/bin/run', 'C:\\bin/run', true, "__DIR__"],
             ['c:/bin/run', 'c:/vendor/acme/bin/run', true, "dirname(dirname(__DIR__)).'/vendor/acme/bin/run'"],
@@ -113,10 +114,10 @@ class FilesystemTest extends TestCase
     /**
      * @dataProvider providePathCouples
      */
-    public function testFindShortestPath(string $a, string $b, string $expected, bool $directory = false): void
+    public function testFindShortestPath(string $a, string $b, string $expected, bool $directory = false, bool $preferRelative = false): void
     {
         $fs = new Filesystem;
-        self::assertEquals($expected, $fs->findShortestPath($a, $b, $directory));
+        self::assertEquals($expected, $fs->findShortestPath($a, $b, $directory, $preferRelative));
     }
 
     public static function providePathCouples(): array
@@ -152,6 +153,7 @@ class FilesystemTest extends TestCase
             ['C:/Temp', 'c:\Temp\..\..\test', "../test", true],
             ['C:/Temp/../..', 'c:\Temp\..\..\test', "./test", true],
             ['C:/Temp/../..', 'D:\Temp\..\..\test', "D:/test", true],
+            ['/app/vendor/foo/bar', '/lib', '../../../../lib', true, true],
             ['/tmp', '/tmp/../../test', '../test', true],
             ['/tmp', '/test', '../test', true],
             ['/foo/bar', '/foo/bar_vendor', '../bar_vendor', true],


### PR DESCRIPTION
Fixes #12074

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
