### PR TITLE
Added reproduction for #12107

### DIFF
--- a/tests/Composer/Test/Command/AboutCommandTest.php
+++ b/tests/Composer/Test/Command/AboutCommandTest.php
@@ -8,6 +8,9 @@ use Composer\Test\TestCase;
 class AboutCommandTest extends TestCase
 {
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testAbout(): void
     {
         $composerVersion = Composer::getVersion();
@@ -17,5 +20,7 @@ class AboutCommandTest extends TestCase
 
         self::assertStringContainsString("Composer is a dependency manager tracking local dependencies of your projects and libraries.", $appTester->getDisplay());
         self::assertStringContainsString("See https://getcomposer.org/ for more information.", $appTester->getDisplay());
+
+        self::assertSame(0, $appTester->run(['command' => 'about']));
     }
 }


### PR DESCRIPTION
Reproduction for #12107

This will fail CI with 

```
1) Composer\Test\Command\AboutCommandTest::testAbout
fopen(php://stdin): Failed to open stream: operation failed
```