### PR TITLE
Fix handling of COMPOSER_ROOT_VERSION to normalize according to expectations

### DIFF
--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -88,7 +88,7 @@ class RootPackageLoader extends ArrayLoader
 
             // override with env var if available
             if (Platform::getEnv('COMPOSER_ROOT_VERSION')) {
-                $config['version'] = Platform::getEnv('COMPOSER_ROOT_VERSION');
+                $config['version'] = $this->versionGuesser->getRootVersionFromEnv();
             } else {
                 $versionData = $this->versionGuesser->guessVersion($config, $cwd ?? Platform::getCwd(true));
                 if ($versionData) {

--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -420,4 +420,17 @@ class VersionGuesser
 
         return null;
     }
+
+    public function getRootVersionFromEnv(): string
+    {
+        $version = Platform::getEnv('COMPOSER_ROOT_VERSION');
+        if (!is_string($version) || $version === '') {
+            throw new \RuntimeException('COMPOSER_ROOT_VERSION not set or empty');
+        }
+        if (Preg::isMatch('{^(\d+(?:\.\d+)*)-dev$}i', $version, $match)) {
+            $version = $match[1].'.x-dev';
+        }
+
+        return $version;
+    }
 }

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -198,7 +198,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
                     && 0 === $this->process->execute('git rev-parse HEAD', $ref2)
                     && $ref1 === $ref2
                 ) {
-                    $package['version'] = $rootVersion;
+                    $package['version'] = $this->versionGuesser->getRootVersionFromEnv();
                 }
             }
 

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -17,6 +17,7 @@ use Composer\Package\Version\VersionGuesser;
 use Composer\Semver\VersionParser;
 use Composer\Test\TestCase;
 use Composer\Util\Git as GitUtil;
+use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 
 class VersionGuesserTest extends TestCase
@@ -364,5 +365,30 @@ class VersionGuesserTest extends TestCase
         self::assertIsArray($versionData);
         self::assertEquals("1.5.x-dev", $versionData['pretty_version']);
         self::assertEquals("1.5.9999999.9999999-dev", $versionData['version']);
+    }
+
+    /**
+     * @dataProvider rootEnvVersionsProvider
+     */
+    public function testGetRootVersionFromEnv(string $env, string $expectedVersion): void
+    {
+        Platform::putEnv('COMPOSER_ROOT_VERSION', $env);
+        $guesser = new VersionGuesser(new Config, $this->getProcessExecutorMock(), new VersionParser());
+        self::assertSame($expectedVersion, $guesser->getRootVersionFromEnv());
+        Platform::clearEnv('COMPOSER_ROOT_VERSION');
+    }
+
+    /**
+     * @return array<array{string, string}>
+     */
+    public function rootEnvVersionsProvider(): array
+    {
+        return [
+            ['1.0-dev', '1.0.x-dev'],
+            ['1.0.x-dev', '1.0.x-dev'],
+            ['1-dev', '1.x-dev'],
+            ['1.x-dev', '1.x-dev'],
+            ['1.0.0', '1.0.0'],
+        ];
     }
 }


### PR DESCRIPTION
fixes #12101

This will turn COMPOSER_ROOT_VERSION=1.0-dev into 1.0.x-dev which is kinda what people mean, and this can sometimes have a material impact on resolution.