### PR TITLE
Fix handling of platform packages in why-not command and partial updates

### DIFF
--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -13,6 +13,7 @@
 namespace Composer\Command;
 
 use Composer\Package\Link;
+use Composer\Package\Package;
 use Composer\Package\PackageInterface;
 use Composer\Package\CompletePackageInterface;
 use Composer\Package\RootPackage;
@@ -24,6 +25,8 @@ use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryFactory;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
+use Composer\Semver\Constraint\Bound;
+use Composer\Util\Platform;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Composer\Package\Version\VersionParser;
@@ -102,13 +105,27 @@ abstract class BaseDependencyCommand extends BaseCommand
 
         // If the version we ask for is not installed then we need to locate it in remote repos and add it.
         // This is needed for why-not to resolve conflicts from an uninstalled version against installed packages.
-        if (!$installedRepo->findPackage($needle, $textConstraint)) {
+        $matchedPackage = $installedRepo->findPackage($needle, $textConstraint);
+        if (!$matchedPackage) {
             $defaultRepos = new CompositeRepository(RepositoryFactory::defaultRepos($this->getIO(), $composer->getConfig(), $composer->getRepositoryManager()));
             if ($match = $defaultRepos->findPackage($needle, $textConstraint)) {
                 $installedRepo->addRepository(new InstalledArrayRepository([clone $match]));
+            } elseif (PlatformRepository::isPlatformPackage($needle)) {
+                $parser = new VersionParser();
+                $constraint = $parser->parseConstraints($textConstraint);
+                if ($constraint->getLowerBound() !== Bound::zero()) {
+                    $tempPlatformPkg = new Package($needle, $constraint->getLowerBound()->getVersion(), $constraint->getLowerBound()->getVersion());
+                    $installedRepo->addRepository(new InstalledArrayRepository([$tempPlatformPkg]));
+                }
             } else {
                 $this->getIO()->writeError('<error>Package "'.$needle.'" could not be found with constraint "'.$textConstraint.'", results below will most likely be incomplete.</error>');
             }
+        } elseif (PlatformRepository::isPlatformPackage($needle)) {
+            $extraNotice = '';
+            if (($matchedPackage->getExtra()['config.platform'] ?? false) === true) {
+                $extraNotice = ' (version provided by config.platform)';
+            }
+            $this->getIO()->writeError('<info>Package "'.$needle.' '.$textConstraint.'" found in version "'.$matchedPackage->getPrettyVersion().'"'.$extraNotice.'.</info>');
         }
 
         // Include replaced packages for inverted lookups as they are then the actual starting point to consider
@@ -154,7 +171,7 @@ abstract class BaseDependencyCommand extends BaseCommand
             $this->printTable($output, $results);
         }
 
-        if ($inverted && $input->hasArgument(self::ARGUMENT_CONSTRAINT)) {
+        if ($inverted && $input->hasArgument(self::ARGUMENT_CONSTRAINT) && !PlatformRepository::isPlatformPackage($needle)) {
             $composerCommand = 'update';
 
             foreach ($composer->getPackage()->getRequires() as $rootRequirement) {

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -616,6 +616,8 @@ class PoolBuilder
     private function warnAboutNonMatchingUpdateAllowList(Request $request): void
     {
         foreach ($this->updateAllowList as $pattern) {
+            $matchedPlatformPackage = false;
+
             $patternRegexp = BasePackage::packageNameToRegexp($pattern);
             // update pattern matches a locked package? => all good
             foreach ($request->getLockedRepository()->getPackages() as $package) {
@@ -626,10 +628,16 @@ class PoolBuilder
             // update pattern matches a root require? => all good, probably a new package
             foreach ($request->getRequires() as $packageName => $constraint) {
                 if (Preg::isMatch($patternRegexp, $packageName)) {
+                    if (PlatformRepository::isPlatformPackage($packageName)) {
+                        $matchedPlatformPackage = true;
+                        continue;
+                    }
                     continue 2;
                 }
             }
-            if (strpos($pattern, '*') !== false) {
+            if ($matchedPlatformPackage) {
+                $this->io->writeError('<warning>Pattern "' . $pattern . '" listed for update matches platform packages, but these cannot be updated by Composer.</warning>');
+            } elseif (strpos($pattern, '*') !== false) {
                 $this->io->writeError('<warning>Pattern "' . $pattern . '" listed for update does not match any locked packages.</warning>');
             } else {
                 $this->io->writeError('<warning>Package "' . $pattern . '" listed for update is not locked.</warning>');


### PR DESCRIPTION
Fixes #12104

This actually lets one check for platform packages upgrades which is great:

```
$ composer why-not php 9.0
composer/composer                 2.7.x-dev requires php (^7.2.5 || ^8.0)
composer/ca-bundle                1.5.1     requires php (^7.2 || ^8.0)
composer/class-map-generator      1.3.4     requires php (^7.2 || ^8.0)
composer/metadata-minifier        1.0.0     requires php (^5.3.2 || ^7.0 || ^8.0)
composer/pcre                     2.3.1     requires php (^7.2 || ^8.0)
composer/semver                   3.4.2     requires php (^5.3.2 || ^7.0 || ^8.0)
composer/spdx-licenses            1.5.8     requires php (^5.3.2 || ^7.0 || ^8.0)
composer/xdebug-handler           3.0.5     requires php (^7.2.5 || ^8.0)
phpstan/phpstan                   1.12.1    requires php (^7.2|^8.0)
phpstan/phpstan-deprecation-rules 1.2.0     requires php (^7.2 || ^8.0)
phpstan/phpstan-phpunit           1.4.0     requires php (^7.2 || ^8.0)
phpstan/phpstan-strict-rules      1.6.0     requires php (^7.2 || ^8.0)
phpstan/phpstan-symfony           1.4.8     requires php (^7.2 || ^8.0)
seld/jsonlint                     1.11.0    requires php (^5.3 || ^7.0 || ^8.0)
```

```
$ composer why-not php ^8
There is no installed package depending on "php" in versions not matching ^8
```

```
$ composer why-not php ^7
Package "php ^7" found in version "7.2.5" (version provided by config.platform).
There is no installed package depending on "php" in versions not matching ^7
```