### PR TITLE
Fix require command skipping new stability-flags from the lock file, …

### DIFF
--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -561,10 +561,16 @@ EOT
                 }
                 $lockFile = Factory::getLockFile($this->json->getPath());
                 if (file_exists($lockFile)) {
+                    $stabilityFlags = RootPackageLoader::extractStabilityFlags($requirements, $composer->getPackage()->getMinimumStability(), []);
+
                     $lockMtime = filemtime($lockFile);
                     $lock = new JsonFile($lockFile);
                     $lockData = $lock->read();
                     $lockData['content-hash'] = Locker::getContentHash($contents);
+                    foreach ($stabilityFlags as $packageName => $flag) {
+                        $lockData['stability-flags'][$packageName] = $flag;
+                    }
+                    ksort($lockData['stability-flags']);
                     $lock->write($lockData);
                     if (is_int($lockMtime)) {
                         @touch($lockFile, $lockMtime);

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -373,6 +373,8 @@ class Locker
             'prefer-lowest' => $preferLowest,
         ];
 
+        ksort($lock['stability-flags']);
+
         $lock['packages'] = $this->lockPackages($packages);
         if (null !== $devPackages) {
             $lock['packages-dev'] = $this->lockPackages($devPackages);


### PR DESCRIPTION
Fixes #11698

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
