### PR TITLE
Validate licenses passed into init command

### DIFF
--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -21,6 +21,7 @@ use Composer\Pcre\Preg;
 use Composer\Repository\CompositeRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryFactory;
+use Composer\Spdx\SpdxLicenses;
 use Composer\Util\Filesystem;
 use Composer\Util\Silencer;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -398,6 +399,10 @@ EOT
             'License [<comment>'.$license.'</comment>]: ',
             $license
         );
+        $spdx = new SpdxLicenses();
+        if (!$spdx->validate($license)) {
+            throw new \InvalidArgumentException('Invalid license provided: '.$license.'. Only SPDX license identifiers (https://spdx.org/licenses/) or "proprietary" are accepted.');
+        }
         $input->setOption('license', $license);
 
         $io->writeError(['', 'Define your dependencies.', '']);

--- a/tests/Composer/Test/Command/InitCommandTest.php
+++ b/tests/Composer/Test/Command/InitCommandTest.php
@@ -711,7 +711,7 @@ class InitCommandTest extends TestCase
             'Mr. Test <test@example.org>',  // Author
             'stable',                       // Minimum stability
             'library',                      // Type
-            'Custom License',               // License
+            'AGPL-3.0-only',               // License
             'no',                           // Define dependencies
             'no',                           // Define dev dependencies
             'n',                            // Add PSR-4 autoload mapping
@@ -726,7 +726,7 @@ class InitCommandTest extends TestCase
             'name' => 'vendor/pkg',
             'description' => 'my desciption',
             'type' => 'library',
-            'license' => 'Custom License',
+            'license' => 'AGPL-3.0-only',
             'authors' => [['name' => 'Mr. Test', 'email' => 'test@example.org']],
             'minimum-stability' => 'stable',
             'require' => [],


### PR DESCRIPTION
Fixes #10838

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
