### PR TITLE
PHP 8.4 | Remove use of `E_STRICT`

### DIFF
--- a/src/Composer/Util/ErrorHandler.php
+++ b/src/Composer/Util/ErrorHandler.php
@@ -78,7 +78,7 @@ class ErrorHandler
     public static function register(?IOInterface $io = null): void
     {
         set_error_handler([__CLASS__, 'handle']);
-        error_reporting(E_ALL | E_STRICT);
+        error_reporting(E_ALL);
         self::$io = $io;
     }
 }

--- a/src/Composer/Util/Silencer.php
+++ b/src/Composer/Util/Silencer.php
@@ -33,7 +33,7 @@ class Silencer
     public static function suppress(?int $mask = null): int
     {
         if (!isset($mask)) {
-            $mask = E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE | E_DEPRECATED | E_USER_DEPRECATED | E_STRICT;
+            $mask = E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE | E_DEPRECATED | E_USER_DEPRECATED;
         }
         $old = error_reporting();
         self::$stack[] = $old;


### PR DESCRIPTION
The `E_STRICT` constant is deprecated as of PHP 8.4 and will be removed in PHP 9.0 (commit finally went in today).

The error level hasn't been in use since PHP 8.0 anyway and was only barely still used in PHP 7.x, so removing the exclusion from the `error_reporting()` setting in these script shouldn't really make any difference in practice.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant