### PR TITLE
Add `composer audit --ignore-severity` option

### DIFF
--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -59,6 +59,7 @@ class Auditor
      * @param bool $warningOnly If true, outputs a warning. If false, outputs an error.
      * @param string[] $ignoreList List of advisory IDs, remote IDs or CVE IDs that reported but not listed as vulnerabilities.
      * @param self::ABANDONED_* $abandoned
+     * @param array<string> $ignoredSeverities List of ignored severity levels
      *
      * @return int Amount of packages with vulnerabilities found
      * @throws InvalidArgumentException If no packages are passed in

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -34,6 +34,7 @@ class AuditCommand extends BaseCommand
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format. Must be "table", "plain", "json", or "summary".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
                 new InputOption('locked', null, InputOption::VALUE_NONE, 'Audit based on the lock file instead of the installed packages.'),
                 new InputOption('abandoned', null, InputOption::VALUE_REQUIRED, 'Behavior on abandoned packages. Must be "ignore", "report", or "fail".', null, Auditor::ABANDONEDS),
+                new InputOption('ignore-severity', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Ignore advisories of a certain severity level.', []),
             ])
             ->setHelp(
                 <<<EOT
@@ -73,6 +74,8 @@ EOT
 
         $abandoned = $abandoned ?? $auditConfig['abandoned'] ?? Auditor::ABANDONED_FAIL;
 
+        $ignoreSeverities = $input->getOption('ignore-severity') ?? [];
+
         return min(255, $auditor->audit(
             $this->getIO(),
             $repoSet,
@@ -80,8 +83,10 @@ EOT
             $this->getAuditFormat($input, 'format'),
             false,
             $auditConfig['ignore'] ?? [],
-            $abandoned
+            $abandoned,
+            $ignoreSeverities
         ));
+
     }
 
     /**


### PR DESCRIPTION
This PR adds an `--ignore-severity` option to `composer audit`, allowing the user to ignore specified severity levels.

The `--ignore-severity` option can be passed multiple times, to ignore multiple levels (e.g. `composer audit --ignore-severity=low --ignore-severity=medium`). Ignored packages are still reported as ignored, similar to when using the ignore list.

The PR also includes minor code style fixes to the modified files, from `php-cs-fixer` using the provided config.

-----

Example output screenshot:

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/9538707d-452c-4c25-85a6-1b3e2d585caa">