### PR TITLE
Fix deprecated ParametersAcceptorSelector::selectSingle

### DIFF
--- a/src/Composer/PHPStan/ConfigReturnTypeExtension.php
+++ b/src/Composer/PHPStan/ConfigReturnTypeExtension.php
@@ -65,7 +65,11 @@ final class ConfigReturnTypeExtension implements DynamicMethodReturnTypeExtensio
     {
         $args = $methodCall->getArgs();
 
-        $defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+        $defaultReturn = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            $methodCall->getArgs(),
+            $methodReflection->getVariants()
+        )->getReturnType();
 
         if (count($args) < 1) {
             return $defaultReturn;

--- a/src/Composer/PHPStan/ConfigReturnTypeExtension.php
+++ b/src/Composer/PHPStan/ConfigReturnTypeExtension.php
@@ -61,18 +61,12 @@ final class ConfigReturnTypeExtension implements DynamicMethodReturnTypeExtensio
         return strtolower($methodReflection->getName()) === 'get';
     }
 
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
     {
         $args = $methodCall->getArgs();
 
-        $defaultReturn = ParametersAcceptorSelector::selectFromArgs(
-            $scope,
-            $methodCall->getArgs(),
-            $methodReflection->getVariants()
-        )->getReturnType();
-
         if (count($args) < 1) {
-            return $defaultReturn;
+            return null;
         }
 
         $keyType = $scope->getType($args[0]->value);
@@ -86,7 +80,7 @@ final class ConfigReturnTypeExtension implements DynamicMethodReturnTypeExtensio
             $types = [];
             foreach($strings as $string) {
                 if (!isset($this->properties[$string->getValue()])) {
-                    return $defaultReturn;
+                    return null;
                 }
                 $types[] = $this->properties[$string->getValue()];
             }
@@ -94,7 +88,7 @@ final class ConfigReturnTypeExtension implements DynamicMethodReturnTypeExtensio
             return TypeCombinator::union(...$types);
         }
 
-        return $defaultReturn;
+        return null;
     }
 
     /**


### PR DESCRIPTION
This fixes a deprecation warning being reported by PHPStan in the `ConfigReturnTypeExtension`, as part of the bleeding edge rules:

```
  Line   Composer/PHPStan/ConfigReturnTypeExtension.php
 ------ ------------------------------------------------------------------------------------------------------------------------------
  68     Call to deprecated method selectSingle() of class PHPStan\Reflection\ParametersAcceptorSelector:
         See https://github.com/phpstan/phpstan-src/blob/2.0.x/UPGRADING.md#removed-deprecated-parametersacceptorselectorselectsingle
```

After this fix PHPStan analysis passes again.