### PR TITLE
Handle dump-autoload where vendor folder is not installed or not complete

### DIFF
--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -69,13 +69,9 @@ EOT
         $config = $composer->getConfig();
 
         $missingDependencies = false;
-        foreach ($localRepo->getPackages() as $package) {
-            if ($package instanceof AliasPackage) {
-                continue;
-            }
-
-            $installPath = $installationManager->getInstallPath($package);
-            if ($installPath !== null && (file_exists($installPath) === false || is_dir($installPath) === false)) {
+        foreach ($localRepo->getCanonicalPackages() as $localPkg) {
+            $installPath = $installationManager->getInstallPath($localPkg);
+            if ($installPath !== null && file_exists($installPath) === false) {
                 $missingDependencies = true;
                 $this->getIO()->write('<warning>Not all dependencies are installed. Make sure to run a "composer install" to install missing dependencies</warning>');
 


### PR DESCRIPTION
Currently, there is no error when the vendor folder is not complete or when there are no dependencies installed at all when running `composer dump-autoload`. This PR fixes that, and this results in an exit code 1 when one or more dependencies are not installed.