### PR TITLE
Ensure installed.php & InstalledVersions are in opcache when preloading is used

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -1026,6 +1026,16 @@ PLATFORM_CHECK;
 
 CLASSLOADER_INIT;
 
+        $file .= <<<PRELOAD_INSTALLED_VERSIONS
+        // include InstalledVersions class & installed.php data to ensure it is in opcache when preloading
+        if (file_exists(__DIR__ . '/InstalledVersions.php') && !class_exists('Composer\\\\InstalledVersions', false)) {
+            include __DIR__ . '/InstalledVersions.php';
+            include __DIR__ . '/installed.php';
+        }
+
+
+PRELOAD_INSTALLED_VERSIONS;
+
         if ($useIncludePath) {
             $file .= <<<'INCLUDE_PATH'
         $includePaths = require __DIR__ . '/include_paths.php';

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_files_by_dependency.php
@@ -26,6 +26,12 @@ class ComposerAutoloaderInitFilesAutoloadOrder
         self::$loader = $loader = new \Composer\Autoload\ClassLoader(\dirname(__DIR__));
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoloadOrder', 'loadClassLoader'));
 
+        // include InstalledVersions class & installed.php data to ensure it is in opcache when preloading
+        if (file_exists(__DIR__ . '/InstalledVersions.php') && !class_exists('Composer\\InstalledVersions', false)) {
+            include __DIR__ . '/InstalledVersions.php';
+            include __DIR__ . '/installed.php';
+        }
+
         require __DIR__ . '/autoload_static.php';
         call_user_func(\Composer\Autoload\ComposerStaticInitFilesAutoloadOrder::getInitializer($loader));
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions.php
@@ -26,6 +26,12 @@ class ComposerAutoloaderInitFilesAutoload
         self::$loader = $loader = new \Composer\Autoload\ClassLoader(\dirname(__DIR__));
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
+        // include InstalledVersions class & installed.php data to ensure it is in opcache when preloading
+        if (file_exists(__DIR__ . '/InstalledVersions.php') && !class_exists('Composer\\InstalledVersions', false)) {
+            include __DIR__ . '/InstalledVersions.php';
+            include __DIR__ . '/installed.php';
+        }
+
         require __DIR__ . '/autoload_static.php';
         call_user_func(\Composer\Autoload\ComposerStaticInitFilesAutoload::getInitializer($loader));
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_include_paths.php
@@ -26,6 +26,12 @@ class ComposerAutoloaderInitFilesAutoload
         self::$loader = $loader = new \Composer\Autoload\ClassLoader(\dirname(__DIR__));
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
+        // include InstalledVersions class & installed.php data to ensure it is in opcache when preloading
+        if (file_exists(__DIR__ . '/InstalledVersions.php') && !class_exists('Composer\\InstalledVersions', false)) {
+            include __DIR__ . '/InstalledVersions.php';
+            include __DIR__ . '/installed.php';
+        }
+
         $includePaths = require __DIR__ . '/include_paths.php';
         $includePaths[] = get_include_path();
         set_include_path(implode(PATH_SEPARATOR, $includePaths));

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_functions_with_removed_include_paths_and_autolad_files.php
@@ -26,6 +26,12 @@ class ComposerAutoloaderInitFilesAutoload
         self::$loader = $loader = new \Composer\Autoload\ClassLoader(\dirname(__DIR__));
         spl_autoload_unregister(array('ComposerAutoloaderInitFilesAutoload', 'loadClassLoader'));
 
+        // include InstalledVersions class & installed.php data to ensure it is in opcache when preloading
+        if (file_exists(__DIR__ . '/InstalledVersions.php') && !class_exists('Composer\\InstalledVersions', false)) {
+            include __DIR__ . '/InstalledVersions.php';
+            include __DIR__ . '/installed.php';
+        }
+
         require __DIR__ . '/autoload_static.php';
         call_user_func(\Composer\Autoload\ComposerStaticInitFilesAutoload::getInitializer($loader));
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_include_path.php
@@ -26,6 +26,12 @@ class ComposerAutoloaderInitIncludePath
         self::$loader = $loader = new \Composer\Autoload\ClassLoader(\dirname(__DIR__));
         spl_autoload_unregister(array('ComposerAutoloaderInitIncludePath', 'loadClassLoader'));
 
+        // include InstalledVersions class & installed.php data to ensure it is in opcache when preloading
+        if (file_exists(__DIR__ . '/InstalledVersions.php') && !class_exists('Composer\\InstalledVersions', false)) {
+            include __DIR__ . '/InstalledVersions.php';
+            include __DIR__ . '/installed.php';
+        }
+
         require __DIR__ . '/autoload_static.php';
         call_user_func(\Composer\Autoload\ComposerStaticInitIncludePath::getInitializer($loader));
 

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_real_target_dir.php
@@ -26,6 +26,12 @@ class ComposerAutoloaderInitTargetDir
         self::$loader = $loader = new \Composer\Autoload\ClassLoader(\dirname(__DIR__));
         spl_autoload_unregister(array('ComposerAutoloaderInitTargetDir', 'loadClassLoader'));
 
+        // include InstalledVersions class & installed.php data to ensure it is in opcache when preloading
+        if (file_exists(__DIR__ . '/InstalledVersions.php') && !class_exists('Composer\\InstalledVersions', false)) {
+            include __DIR__ . '/InstalledVersions.php';
+            include __DIR__ . '/installed.php';
+        }
+
         require __DIR__ . '/autoload_static.php';
         call_user_func(\Composer\Autoload\ComposerStaticInitTargetDir::getInitializer($loader));
 


### PR DESCRIPTION
Fixes #11018 hopefully.

I am not sure about this patch tbh.. It'd be good to have feedback from people using preloading whether this looks like it is desired or not.

