### PR TITLE
Update authentication-for-private-packages.md

### DIFF
--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -155,7 +155,7 @@ If the username e.g. is an email address it needs to be passed as `name%40exampl
 ### Command line inline http-basic
 
 ```shell
-php composer.phar config [--global] repositories composer.unique-name https://username:password@repo.example.org
+php composer.phar config [--global] repositories.unique-name composer https://username:password@repo.example.org
 ```
 
 ### Manual inline http-basic


### PR DESCRIPTION
Fix Command line inline http-basic command.

Command was:
` composer config repositories composer.unique-name https://username:password@repo.example.org`

When I tried the command with Composer 2.7.6, I received the following error message:

> Setting repositories does not exist or is not supported by this command


![image](https://github.com/user-attachments/assets/c934f0e6-d1da-4570-a6d8-4c65f9581eb4)

The following command works
`composer config repositories.unique-name composer https://username:password@repo.example.org`


<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
