### PR TITLE
On Windows, don't rely on the OS to find executables

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "48a792895a2b7a6ee65dd5442c299d7b835b6137"
+                "reference": "3b1fc3f0be055baa7c6258b1467849c3e8204eb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/48a792895a2b7a6ee65dd5442c299d7b835b6137",
-                "reference": "48a792895a2b7a6ee65dd5442c299d7b835b6137",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/3b1fc3f0be055baa7c6258b1467849c3e8204eb2",
+                "reference": "3b1fc3f0be055baa7c6258b1467849c3e8204eb2",
                 "shasum": ""
             },
             "require": {
@@ -64,7 +64,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.2"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.3"
             },
             "funding": [
                 {
@@ -80,7 +80,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T07:49:53+00:00"
+            "time": "2024-11-04T10:15:26+00:00"
         },
         {
             "name": "composer/class-map-generator",
@@ -941,16 +941,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.44",
+            "version": "v5.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83"
+                "reference": "fb0d4760e7147d81ab4d9e2d57d56268261b4e4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5b5a0aa66e3296e303e22490f90f521551835a83",
-                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83",
+                "url": "https://api.github.com/repos/symfony/console/zipball/fb0d4760e7147d81ab4d9e2d57d56268261b4e4e",
+                "reference": "fb0d4760e7147d81ab4d9e2d57d56268261b4e4e",
                 "shasum": ""
             },
             "require": {
@@ -1020,7 +1020,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.44"
+                "source": "https://github.com/symfony/console/tree/v5.4.46"
             },
             "funding": [
                 {
@@ -1036,7 +1036,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T07:56:40+00:00"
+            "time": "2024-11-05T14:17:06+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1107,16 +1107,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.44",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc"
+                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/76c3818964e9d32be3862c9318ae3ba9aa280ddc",
-                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/57c8294ed37d4a055b77057827c67f9558c95c54",
+                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54",
                 "shasum": ""
             },
             "require": {
@@ -1154,7 +1154,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.44"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -1170,20 +1170,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-16T14:52:48+00:00"
+            "time": "2024-10-22T13:05:35+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.43",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ae25a9145a900764158d439653d5630191155ca0"
+                "reference": "63741784cd7b9967975eec610b256eed3ede022b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ae25a9145a900764158d439653d5630191155ca0",
-                "reference": "ae25a9145a900764158d439653d5630191155ca0",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/63741784cd7b9967975eec610b256eed3ede022b",
+                "reference": "63741784cd7b9967975eec610b256eed3ede022b",
                 "shasum": ""
             },
             "require": {
@@ -1217,7 +1217,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.43"
+                "source": "https://github.com/symfony/finder/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -1233,7 +1233,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-13T14:03:51+00:00"
+            "time": "2024-09-28T13:32:08+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1787,16 +1787,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.44",
+            "version": "v5.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "1b9fa82b5c62cd49da8c9e3952dd8531ada65096"
+                "reference": "01906871cb9b5e3cf872863b91aba4ec9767daf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/1b9fa82b5c62cd49da8c9e3952dd8531ada65096",
-                "reference": "1b9fa82b5c62cd49da8c9e3952dd8531ada65096",
+                "url": "https://api.github.com/repos/symfony/process/zipball/01906871cb9b5e3cf872863b91aba4ec9767daf4",
+                "reference": "01906871cb9b5e3cf872863b91aba4ec9767daf4",
                 "shasum": ""
             },
             "require": {
@@ -1829,7 +1829,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.44"
+                "source": "https://github.com/symfony/process/tree/v5.4.46"
             },
             "funding": [
                 {
@@ -1845,7 +1845,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-17T12:46:43+00:00"
+            "time": "2024-11-06T09:18:28+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -1932,16 +1932,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.44",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "832caa16b6d9aac6bf11747315225f5aba384c24"
+                "reference": "7f6807add88b1e2635f3c6de5e1ace631ed7cad2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/832caa16b6d9aac6bf11747315225f5aba384c24",
-                "reference": "832caa16b6d9aac6bf11747315225f5aba384c24",
+                "url": "https://api.github.com/repos/symfony/string/zipball/7f6807add88b1e2635f3c6de5e1ace631ed7cad2",
+                "reference": "7f6807add88b1e2635f3c6de5e1ace631ed7cad2",
                 "shasum": ""
             },
             "require": {
@@ -1998,7 +1998,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.44"
+                "source": "https://github.com/symfony/string/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -2014,22 +2014,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T07:56:40+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.5",
+            "version": "1.12.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17"
+                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17",
-                "reference": "7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
+                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
                 "shasum": ""
             },
             "require": {
@@ -2074,7 +2074,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-26T12:45:22+00:00"
+            "time": "2024-10-18T11:12:07+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -2226,16 +2226,16 @@
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "1.4.10",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "f7d5782044bedf93aeb3f38e09c91148ee90e5a1"
+                "reference": "270c2ee1478d1f8dc5121f539e890017bd64b04c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/f7d5782044bedf93aeb3f38e09c91148ee90e5a1",
-                "reference": "f7d5782044bedf93aeb3f38e09c91148ee90e5a1",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/270c2ee1478d1f8dc5121f539e890017bd64b04c",
+                "reference": "270c2ee1478d1f8dc5121f539e890017bd64b04c",
                 "shasum": ""
             },
             "require": {
@@ -2292,22 +2292,22 @@
             "description": "Symfony Framework extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-symfony/issues",
-                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.4.10"
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.4.11"
             },
-            "time": "2024-09-26T18:14:50+00:00"
+            "time": "2024-10-30T12:07:21+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v7.1.4",
+            "version": "v7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "e876eb90e32a8fc4c4911d458e09f88d65877d1c"
+                "reference": "c6b9d8f52d3e276bedb49612aa4a2a046171287f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/e876eb90e32a8fc4c4911d458e09f88d65877d1c",
-                "reference": "e876eb90e32a8fc4c4911d458e09f88d65877d1c",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/c6b9d8f52d3e276bedb49612aa4a2a046171287f",
+                "reference": "c6b9d8f52d3e276bedb49612aa4a2a046171287f",
                 "shasum": ""
             },
             "require": {
@@ -2360,7 +2360,7 @@
             "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v7.1.4"
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v7.1.6"
             },
             "funding": [
                 {
@@ -2376,7 +2376,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-13T14:28:19+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         }
     ],
     "aliases": [],

--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -301,11 +301,6 @@ parameters:
 			path: ../src/Composer/Command/CreateProjectCommand.php
 
 		-
-			message: "#^Parameter \\#3 \\$existingRepos of static method Composer\\\\Repository\\\\RepositoryFactory\\:\\:generateRepositoryName\\(\\) expects array\\<string, mixed\\>, array\\<int\\|string, mixed\\> given\\.$#"
-			count: 1
-			path: ../src/Composer/Command/CreateProjectCommand.php
-
-		-
 			message: "#^Variable method call on Composer\\\\Package\\\\RootPackageInterface\\.$#"
 			count: 1
 			path: ../src/Composer/Command/CreateProjectCommand.php
@@ -494,11 +489,6 @@ parameters:
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 2
 			path: ../src/Composer/Command/LicensesCommand.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\<int, Composer\\\\Package\\\\PackageInterface\\> given\\.$#"
-			count: 1
-			path: ../src/Composer/Command/ReinstallCommand.php
 
 		-
 			message: "#^Foreach overwrites \\$type with its key variable\\.$#"
@@ -956,11 +946,6 @@ parameters:
 			path: ../src/Composer/Config.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, string\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/Config.php
-
-		-
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: ../src/Composer/Config.php
@@ -1159,11 +1144,6 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between null and Composer\\\\Util\\\\Http\\\\Response\\|string will always evaluate to false\\.$#"
 			count: 1
 			path: ../src/Composer/Downloader/FileDownloader.php
-
-		-
-			message: "#^Parameter \\#3 \\$cwd of method Composer\\\\Util\\\\ProcessExecutor\\:\\:execute\\(\\) expects string\\|null, string\\|false given\\.$#"
-			count: 5
-			path: ../src/Composer/Downloader/FossilDownloader.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
@@ -1367,7 +1347,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, array\\<int, array\\<int, string\\>\\> given\\.$#"
-			count: 3
+			count: 2
 			path: ../src/Composer/Downloader/ZipDownloader.php
 
 		-
@@ -2331,11 +2311,6 @@ parameters:
 			path: ../src/Composer/Question/StrictConfirmationQuestion.php
 
 		-
-			message: "#^Method Composer\\\\Repository\\\\ArrayRepository\\:\\:getProviders\\(\\) should return array\\<string, array\\{name\\: string, description\\: string, type\\: string\\}\\> but returns array\\<string, array\\{name\\: string, description\\: string\\|null, type\\: string\\}\\>\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/ArrayRepository.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, Composer\\\\Semver\\\\Constraint\\\\ConstraintInterface\\|null given\\.$#"
 			count: 1
 			path: ../src/Composer/Repository/ArrayRepository.php
@@ -2381,7 +2356,7 @@ parameters:
 			path: ../src/Composer/Repository/ComposerRepository.php
 
 		-
-			message: "#^Method Composer\\\\Repository\\\\ComposerRepository\\:\\:getProviders\\(\\) should return array\\<string, array\\{name\\: string, description\\: string|null, type\\: string\\}\\> but returns array\\<int\\|string, array\\{name\\: mixed, description\\: mixed, type\\: mixed\\}\\>\\.$#"
+			message: "#^Method Composer\\\\Repository\\\\ComposerRepository\\:\\:getProviders\\(\\) should return array\\<string, array\\{name\\: string, description\\: string\\|null, type\\: string\\}\\> but returns array\\<int\\|string, array\\{name\\: mixed, description\\: mixed, type\\: mixed\\}\\>\\.$#"
 			count: 1
 			path: ../src/Composer/Repository/ComposerRepository.php
 
@@ -2496,7 +2471,7 @@ parameters:
 			path: ../src/Composer/Repository/CompositeRepository.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, array\\<int, array\\<string, array\\<string, string|null\\>\\>\\> given\\.$#"
+			message: "#^Only booleans are allowed in a ternary operator condition, array\\<int, array\\<string, array\\<string, string\\|null\\>\\>\\> given\\.$#"
 			count: 1
 			path: ../src/Composer/Repository/CompositeRepository.php
 
@@ -2714,7 +2689,7 @@ parameters:
 			path: ../src/Composer/Repository/RepositorySet.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, array\\<string, array\\<string, string|null\\>\\> given\\.$#"
+			message: "#^Only booleans are allowed in an if condition, array\\<string, array\\<string, string\\|null\\>\\> given\\.$#"
 			count: 1
 			path: ../src/Composer/Repository/RepositorySet.php
 
@@ -2722,21 +2697,6 @@ parameters:
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: ../src/Composer/Repository/RepositorySet.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, string given\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/FossilDriver.php
-
-		-
-			message: "#^Parameter \\#1 \\$file of method Composer\\\\Util\\\\Filesystem\\:\\:remove\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/FossilDriver.php
-
-		-
-			message: "#^Parameter \\#1 \\$filename of function is_file expects string, string\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/FossilDriver.php
 
 		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
@@ -3969,11 +3929,6 @@ parameters:
 			path: ../src/Composer/Util/Svn.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/Util/Svn.php
-
-		-
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: ../src/Composer/Util/Svn.php
@@ -4342,6 +4297,11 @@ parameters:
 			path: ../tests/Composer/Test/Mock/ProcessExecutorMock.php
 
 		-
+			message: "#^Property Composer\\\\Test\\\\Mock\\\\ProcessExecutorMock\\:\\:\\$expectations \\(array\\<array\\{cmd\\: list\\<string\\>\\|string, return\\: int, stdout\\: string, stderr\\: string, callback\\: \\(callable\\(\\)\\: mixed\\)\\|null\\}\\>\\|null\\) does not accept array\\<non\\-empty\\-array\\<'callback'\\|'cmd'\\|'return'\\|'stderr'\\|'stdout'\\|int\\<0, max\\>, non\\-empty\\-list\\<non\\-empty\\-list\\<string\\>\\|\\(callable\\(\\)\\: mixed\\)\\|int\\|string\\>\\|\\(callable\\(\\)\\: mixed\\)\\|int\\|string\\|null\\>\\>\\.$#"
+			count: 1
+			path: ../tests/Composer/Test/Mock/ProcessExecutorMock.php
+
+		-
 			message: "#^Composer\\\\Test\\\\Mock\\\\VersionGuesserMock\\:\\:__construct\\(\\) does not call parent constructor from Composer\\\\Package\\\\Version\\\\VersionGuesser\\.$#"
 			count: 1
 			path: ../tests/Composer/Test/Mock/VersionGuesserMock.php
@@ -4487,8 +4447,13 @@ parameters:
 			path: ../tests/Composer/Test/TestCase.php
 
 		-
+			message: "#^Cannot access an offset on array\\<int, array\\<string, array\\<int, string\\>\\|int\\|string\\>\\>\\|false\\.$#"
+			count: 2
+			path: ../tests/Composer/Test/Util/GitTest.php
+
+		-
 			message: "#^Cannot access an offset on array\\<int, array\\<string, int\\|string\\>\\>\\|false\\.$#"
-			count: 3
+			count: 1
 			path: ../tests/Composer/Test/Util/GitTest.php
 
 		-

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -302,7 +302,7 @@ EOT
             return '<comment>proc_open is not available, git cannot be used</comment>';
         }
 
-        $this->process->execute('git config color.ui', $output);
+        $this->process->execute(['git', 'config', 'color.ui'], $output);
         if (strtolower(trim($output)) === 'always') {
             return '<comment>Your git color.ui setting is set to always, this is known to create issues. Use "git config --global color.ui true" to set it correctly.</comment>';
         }

--- a/src/Composer/Command/HomeCommand.php
+++ b/src/Composer/Command/HomeCommand.php
@@ -122,22 +122,20 @@ EOT
      */
     private function openBrowser(string $url): void
     {
-        $url = ProcessExecutor::escape($url);
-
         $process = new ProcessExecutor($this->getIO());
         if (Platform::isWindows()) {
-            $process->execute('start "web" explorer ' . $url, $output);
+            $process->execute(['start', '"web"', 'explorer', $url], $output);
 
             return;
         }
 
-        $linux = $process->execute('which xdg-open', $output);
-        $osx = $process->execute('which open', $output);
+        $linux = $process->execute(['which', 'xdg-open'], $output);
+        $osx = $process->execute(['which', 'open'], $output);
 
         if (0 === $linux) {
-            $process->execute('xdg-open ' . $url, $output);
+            $process->execute(['xdg-open', $url], $output);
         } elseif (0 === $osx) {
-            $process->execute('open ' . $url, $output);
+            $process->execute(['open', $url], $output);
         } else {
             $this->getIO()->writeError('No suitable browser opening command found, open yourself: ' . $url);
         }

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -27,6 +27,7 @@ use Composer\Util\Silencer;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Composer\Console\Input\InputOption;
+use Composer\Util\ProcessExecutor;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -535,15 +536,11 @@ EOT
             return $this->gitConfig;
         }
 
-        $finder = new ExecutableFinder();
-        $gitBin = $finder->find('git');
+        $process = new ProcessExecutor($this->getIO());
 
-        $cmd = new Process([$gitBin, 'config', '-l']);
-        $cmd->run();
-
-        if ($cmd->isSuccessful()) {
+        if (0 === $process->execute(['git', 'config', '-l'], $output)) {
             $this->gitConfig = [];
-            Preg::matchAllStrictGroups('{^([^=]+)=(.*)$}m', $cmd->getOutput(), $matches);
+            Preg::matchAllStrictGroups('{^([^=]+)=(.*)$}m', $output, $matches);
             foreach ($matches[1] as $key => $match) {
                 $this->gitConfig[$match] = $matches[2][$key];
             }

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -15,6 +15,7 @@ namespace Composer;
 use Composer\Json\JsonFile;
 use Composer\CaBundle\CaBundle;
 use Composer\Pcre\Preg;
+use Composer\Util\ProcessExecutor;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 use Seld\PharUtils\Timestamps;
@@ -48,23 +49,22 @@ class Compiler
             unlink($pharFile);
         }
 
-        $process = new Process(['git', 'log', '--pretty=%H', '-n1', 'HEAD'], __DIR__);
-        if ($process->run() !== 0) {
+        $process = new ProcessExecutor();
+
+        if (0 !== $process->execute(['git', 'log', '--pretty=%H', '-n1', 'HEAD'], $output, __DIR__)) {
             throw new \RuntimeException('Can\'t run git log. You must ensure to run compile from composer git repository clone and that git binary is available.');
         }
-        $this->version = trim($process->getOutput());
+        $this->version = trim($output);
 
-        $process = new Process(['git', 'log', '-n1', '--pretty=%ci', 'HEAD'], __DIR__);
-        if ($process->run() !== 0) {
+        if (0 !== $process->execute(['git', 'log', '-n1', '--pretty=%ci', 'HEAD'], $output, __DIR__)) {
             throw new \RuntimeException('Can\'t run git log. You must ensure to run compile from composer git repository clone and that git binary is available.');
         }
 
-        $this->versionDate = new \DateTime(trim($process->getOutput()));
+        $this->versionDate = new \DateTime(trim($output));
         $this->versionDate->setTimezone(new \DateTimeZone('UTC'));
 
-        $process = new Process(['git', 'describe', '--tags', '--exact-match', 'HEAD'], __DIR__);
-        if ($process->run() === 0) {
-            $this->version = trim($process->getOutput());
+        if (0 !== $process->execute(['git', 'describe', '--tags', '--exact-match', 'HEAD'], $output, __DIR__)) {
+            $this->version = trim($output);
         } else {
             // get branch-alias defined in composer.json for dev-main (if any)
             $localConfig = __DIR__.'/../../composer.json';

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -63,7 +63,7 @@ class Compiler
         $this->versionDate = new \DateTime(trim($output));
         $this->versionDate->setTimezone(new \DateTimeZone('UTC'));
 
-        if (0 !== $process->execute(['git', 'describe', '--tags', '--exact-match', 'HEAD'], $output, __DIR__)) {
+        if (0 === $process->execute(['git', 'describe', '--tags', '--exact-match', 'HEAD'], $output, __DIR__)) {
             $this->version = trim($output);
         } else {
             // get branch-alias defined in composer.json for dev-main (if any)
@@ -73,6 +73,10 @@ class Compiler
             if (isset($localConfig['extra']['branch-alias']['dev-main'])) {
                 $this->branchAliasVersion = $localConfig['extra']['branch-alias']['dev-main'];
             }
+        }
+
+        if ('' === $this->version) {
+            throw new \UnexpectedValueException('Version detection failed');
         }
 
         $phar = new \Phar($pharFile, 0, 'composer.phar');

--- a/src/Composer/Downloader/FossilDownloader.php
+++ b/src/Composer/Downloader/FossilDownloader.php
@@ -109,7 +109,7 @@ class FossilDownloader extends VcsDownloader
     }
 
     /**
-     * @param list<string> $command
+     * @param non-empty-list<string> $command
      * @throws \RuntimeException
      */
     private function execute(array $command, ?string $cwd = null, ?string &$output = null): void

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -94,7 +94,6 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
         $path = $this->normalizePath($path);
         $cachePath = $this->config->get('cache-vcs-dir').'/'.Preg::replace('{[^a-z0-9.]}i', '-', Url::sanitize($url)).'/';
         $ref = $package->getSourceReference();
-        $flag = Platform::isWindows() ? ['/D'] : [];
 
         if (!empty($this->cachedPackages[$package->getId()][$ref])) {
             $msg = "Cloning ".$this->getShortHash($ref).' from cache';
@@ -107,7 +106,6 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
 
             $commands = [
                 array_merge(['git', 'clone', '--no-checkout', $cachePath, $path], $cloneFlags),
-                array_merge(['cd'], $flag, [$path]),
                 ['git', 'remote', 'set-url', 'origin', '--', '%sanitizedUrl%'],
                 ['git', 'remote', 'add', 'composer', '--', '%sanitizedUrl%'],
             ];
@@ -115,7 +113,6 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
             $msg = "Cloning ".$this->getShortHash($ref);
             $commands = [
                 array_merge(['git', 'clone', '--no-checkout', '--', '%url%', $path]),
-                array_merge(['cd'], $flag, [$path]),
                 ['git', 'remote', 'add', 'composer', '--', '%url%'],
                 ['git', 'fetch', 'composer'],
                 ['git', 'remote', 'set-url', 'origin', '--', '%sanitizedUrl%'],
@@ -181,7 +178,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
                 ['git', 'fetch', '--tags', 'composer'],
             ];
 
-            $this->gitUtil->runCommands($commands, $url, $path, true);
+            $this->gitUtil->runCommands($commands, $url, $path);
         }
 
         $command = ['git', 'remote', 'set-url', 'composer', '--', '%sanitizedUrl%'];

--- a/src/Composer/Downloader/GzipDownloader.php
+++ b/src/Composer/Downloader/GzipDownloader.php
@@ -31,7 +31,7 @@ class GzipDownloader extends ArchiveDownloader
 
         // Try to use gunzip on *nix
         if (!Platform::isWindows()) {
-            $command = 'gzip -cd -- ' . ProcessExecutor::escape($file) . ' > ' . ProcessExecutor::escape($targetFilepath);
+            $command = ['sh', '-c', 'gzip -cd -- "$0" > "$1"', $file, $targetFilepath];
 
             if (0 === $this->process->execute($command, $ignoredOutput)) {
                 return \React\Promise\resolve(null);
@@ -44,7 +44,7 @@ class GzipDownloader extends ArchiveDownloader
                 return \React\Promise\resolve(null);
             }
 
-            $processError = 'Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput();
+            $processError = 'Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput();
             throw new \RuntimeException($processError);
         }
 

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -47,7 +47,7 @@ class HgDownloader extends VcsDownloader
 
         $hgUtils->runCommand($cloneCommand, $url, $path);
 
-        $command = ['hg', 'up', '--', $package->getSourceReference()];
+        $command = ['hg', 'up', '--', (string) $package->getSourceReference()];
         if (0 !== $this->process->execute($command, $ignoredOutput, realpath($path))) {
             throw new \RuntimeException('Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput());
         }

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -41,16 +41,15 @@ class HgDownloader extends VcsDownloader
     {
         $hgUtils = new HgUtils($this->io, $this->config, $this->process);
 
-        $cloneCommand = static function (string $url) use ($path): string {
-            return sprintf('hg clone -- %s %s', ProcessExecutor::escape($url), ProcessExecutor::escape($path));
+        $cloneCommand = static function (string $url) use ($path): array {
+            return ['hg', 'clone', '--', $url, $path];
         };
 
         $hgUtils->runCommand($cloneCommand, $url, $path);
 
-        $ref = ProcessExecutor::escape($package->getSourceReference());
-        $command = sprintf('hg up -- %s', $ref);
+        $command = ['hg', 'up', '--', $package->getSourceReference()];
         if (0 !== $this->process->execute($command, $ignoredOutput, realpath($path))) {
-            throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
+            throw new \RuntimeException('Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput());
         }
 
         return \React\Promise\resolve(null);
@@ -70,10 +69,14 @@ class HgDownloader extends VcsDownloader
             throw new \RuntimeException('The .hg directory is missing from '.$path.', see https://getcomposer.org/commit-deps for more information');
         }
 
-        $command = static function ($url) use ($ref): string {
-            return sprintf('hg pull -- %s && hg up -- %s', ProcessExecutor::escape($url), ProcessExecutor::escape($ref));
+        $command = static function ($url): array {
+            return ['hg', 'pull', '--', $url];
         };
+        $hgUtils->runCommand($command, $url, $path);
 
+        $command = static function () use ($ref): array {
+            return ['hg', 'up', '--', $ref];
+        };
         $hgUtils->runCommand($command, $url, $path);
 
         return \React\Promise\resolve(null);
@@ -88,7 +91,7 @@ class HgDownloader extends VcsDownloader
             return null;
         }
 
-        $this->process->execute('hg st', $output, realpath($path));
+        $this->process->execute(['hg', 'st'], $output, realpath($path));
 
         $output = trim($output);
 
@@ -100,10 +103,10 @@ class HgDownloader extends VcsDownloader
      */
     protected function getCommitLogs(string $fromReference, string $toReference, string $path): string
     {
-        $command = sprintf('hg log -r %s:%s --style compact', ProcessExecutor::escape($fromReference), ProcessExecutor::escape($toReference));
+        $command = ['hg', 'log', '-r', $fromReference.':'.$toReference, '--style', 'compact'];
 
         if (0 !== $this->process->execute($command, $output, realpath($path))) {
-            throw new \RuntimeException('Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput());
+            throw new \RuntimeException('Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput());
         }
 
         return $output;

--- a/src/Composer/Downloader/RarDownloader.php
+++ b/src/Composer/Downloader/RarDownloader.php
@@ -34,13 +34,13 @@ class RarDownloader extends ArchiveDownloader
 
         // Try to use unrar on *nix
         if (!Platform::isWindows()) {
-            $command = 'unrar x -- ' . ProcessExecutor::escape($file) . ' ' . ProcessExecutor::escape($path) . ' >/dev/null && chmod -R u+w ' . ProcessExecutor::escape($path);
+            $command = ['sh', '-c', 'unrar x -- "$0" "$1" >/dev/null && chmod -R u+w "$1"', $file, $path];
 
             if (0 === $this->process->execute($command, $ignoredOutput)) {
                 return \React\Promise\resolve(null);
             }
 
-            $processError = 'Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput();
+            $processError = 'Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput();
         }
 
         if (!class_exists('RarArchive')) {

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -97,7 +97,7 @@ class SvnDownloader extends VcsDownloader
             return null;
         }
 
-        $this->process->execute('svn status --ignore-externals', $output, $path);
+        $this->process->execute(['svn', 'status', '--ignore-externals'], $output, $path);
 
         return Preg::isMatch('{^ *[^X ] +}m', $output) ? $output : null;
     }
@@ -194,10 +194,10 @@ class SvnDownloader extends VcsDownloader
     {
         if (Preg::isMatch('{@(\d+)$}', $fromReference) && Preg::isMatch('{@(\d+)$}', $toReference)) {
             // retrieve the svn base url from the checkout folder
-            $command = sprintf('svn info --non-interactive --xml -- %s', ProcessExecutor::escape($path));
+            $command = ['svn', 'info', '--non-interactive', '--xml', '--', $path];
             if (0 !== $this->process->execute($command, $output, $path)) {
                 throw new \RuntimeException(
-                    'Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput()
+                    'Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput()
                 );
             }
 
@@ -235,7 +235,7 @@ class SvnDownloader extends VcsDownloader
      */
     protected function discardChanges(string $path): PromiseInterface
     {
-        if (0 !== $this->process->execute('svn revert -R .', $output, $path)) {
+        if (0 !== $this->process->execute(['svn', 'revert', '-R', '.'], $output, $path)) {
             throw new \RuntimeException("Could not reset changes\n\n:".$this->process->getErrorOutput());
         }
 

--- a/src/Composer/Downloader/XzDownloader.php
+++ b/src/Composer/Downloader/XzDownloader.php
@@ -26,13 +26,13 @@ class XzDownloader extends ArchiveDownloader
 {
     protected function extract(PackageInterface $package, string $file, string $path): PromiseInterface
     {
-        $command = 'tar -xJf ' . ProcessExecutor::escape($file) . ' -C ' . ProcessExecutor::escape($path);
+        $command = ['tar', '-xJf', $file, '-C', $path];
 
         if (0 === $this->process->execute($command, $ignoredOutput)) {
             return \React\Promise\resolve(null);
         }
 
-        $processError = 'Failed to execute ' . $command . "\n\n" . $this->process->getErrorOutput();
+        $processError = 'Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput();
 
         throw new \RuntimeException($processError);
     }

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -46,16 +46,16 @@ class ZipDownloader extends ArchiveDownloader
             self::$unzipCommands = [];
             $finder = new ExecutableFinder;
             if (Platform::isWindows() && ($cmd = $finder->find('7z', null, ['C:\Program Files\7-Zip']))) {
-                self::$unzipCommands[] = ['7z', $cmd, 'x', '-bb0', '-y', '%file%', '-o', '%path%'];
+                self::$unzipCommands[] = ['7z', $cmd, 'x', '-bb0', '-y', '%file%', '-o%path%'];
             }
             if ($cmd = $finder->find('unzip')) {
                 self::$unzipCommands[] = ['unzip', $cmd, '-qq', '%file%', '-d', '%path%'];
             }
             if (!Platform::isWindows() && ($cmd = $finder->find('7z'))) { // 7z linux/macOS support is only used if unzip is not present
-                self::$unzipCommands[] = ['7z', $cmd, 'x', '-bb0', '-y', '%file%', '-o', '%path%'];
+                self::$unzipCommands[] = ['7z', $cmd, 'x', '-bb0', '-y', '%file%', '-o%path%'];
             }
             if (!Platform::isWindows() && ($cmd = $finder->find('7zz'))) { // 7zz linux/macOS support is only used if unzip is not present
-                self::$unzipCommands[] = ['7zz', $cmd, 'x', '-bb0', '-y', '%file%', '-o', '%path%'];
+                self::$unzipCommands[] = ['7zz', $cmd, 'x', '-bb0', '-y', '%file%', '-o%path%'];
             }
         }
 
@@ -130,7 +130,7 @@ class ZipDownloader extends ArchiveDownloader
             '%path%' => strtr($path, '/', DIRECTORY_SEPARATOR),
         ];
         $command = array_map(static function ($value) use ($map) {
-            return $map[$value] ?? $value;
+            return strtr($value, $map);
         }, $command);
 
         if (!$warned7ZipLinux && !Platform::isWindows() && in_array($executable, ['7z', '7zz'], true)) {

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -554,13 +554,14 @@ class Locker
                 case 'git':
                     GitUtil::cleanEnv();
 
-                    if (0 === $this->process->execute('git log -n1 --pretty=%ct '.ProcessExecutor::escape($sourceRef).GitUtil::getNoShowSignatureFlag($this->process), $output, $path) && Preg::isMatch('{^\s*\d+\s*$}', $output)) {
+                    $command = array_merge(['git', 'log', '-n1', '--pretty=%ct', $sourceRef], GitUtil::getNoShowSignatureFlags($this->process));
+                    if (0 === $this->process->execute($command, $output, $path) && Preg::isMatch('{^\s*\d+\s*$}', $output)) {
                         $datetime = new \DateTime('@'.trim($output), new \DateTimeZone('UTC'));
                     }
                     break;
 
                 case 'hg':
-                    if (0 === $this->process->execute('hg log --template "{date|hgdate}" -r '.ProcessExecutor::escape($sourceRef), $output, $path) && Preg::isMatch('{^\s*(\d+)\s*}', $output, $match)) {
+                    if (0 === $this->process->execute(['hg', 'log', '--template', '{date|hgdate}', '-r', $sourceRef], $output, $path) && Preg::isMatch('{^\s*(\d+)\s*}', $output, $match)) {
                         $datetime = new \DateTime('@'.$match[1], new \DateTimeZone('UTC'));
                     }
                     break;

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -554,14 +554,14 @@ class Locker
                 case 'git':
                     GitUtil::cleanEnv();
 
-                    $command = array_merge(['git', 'log', '-n1', '--pretty=%ct', $sourceRef], GitUtil::getNoShowSignatureFlags($this->process));
+                    $command = array_merge(['git', 'log', '-n1', '--pretty=%ct', (string) $sourceRef], GitUtil::getNoShowSignatureFlags($this->process));
                     if (0 === $this->process->execute($command, $output, $path) && Preg::isMatch('{^\s*\d+\s*$}', $output)) {
                         $datetime = new \DateTime('@'.trim($output), new \DateTimeZone('UTC'));
                     }
                     break;
 
                 case 'hg':
-                    if (0 === $this->process->execute(['hg', 'log', '--template', '{date|hgdate}', '-r', $sourceRef], $output, $path) && Preg::isMatch('{^\s*(\d+)\s*}', $output, $match)) {
+                    if (0 === $this->process->execute(['hg', 'log', '--template', '{date|hgdate}', '-r', (string) $sourceRef], $output, $path) && Preg::isMatch('{^\s*(\d+)\s*}', $output, $match)) {
                         $datetime = new \DateTime('@'.$match[1], new \DateTimeZone('UTC'));
                     }
                     break;

--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -190,7 +190,7 @@ class VersionGuesser
         }
 
         if (null === $commit) {
-            $command = 'git log --pretty="%H" -n1 HEAD'.GitUtil::getNoShowSignatureFlag($this->process);
+            $command = array_merge(['git', 'log', '--pretty=%H', '-n1', 'HEAD'], GitUtil::getNoShowSignatureFlags($this->process));
             if (0 === $this->process->execute($command, $output, $path)) {
                 $commit = trim($output) ?: null;
             }
@@ -209,7 +209,7 @@ class VersionGuesser
     private function versionFromGitTags(string $path): ?array
     {
         // try to fetch current version from git tags
-        if (0 === $this->process->execute('git describe --exact-match --tags', $output, $path)) {
+        if (0 === $this->process->execute(['git', 'describe', '--exact-match', '--tags'], $output, $path)) {
             try {
                 $version = $this->versionParser->normalize(trim($output));
 
@@ -229,7 +229,7 @@ class VersionGuesser
     private function guessHgVersion(array $packageConfig, string $path): ?array
     {
         // try to fetch current version from hg branch
-        if (0 === $this->process->execute('hg branch', $output, $path)) {
+        if (0 === $this->process->execute(['hg', 'branch'], $output, $path)) {
             $branch = trim($output);
             $version = $this->versionParser->normalizeBranch($branch);
             $isFeatureBranch = 0 === strpos($version, 'dev-');
@@ -367,14 +367,14 @@ class VersionGuesser
         $prettyVersion = null;
 
         // try to fetch current version from fossil
-        if (0 === $this->process->execute('fossil branch list', $output, $path)) {
+        if (0 === $this->process->execute(['fossil', 'branch', 'list'], $output, $path)) {
             $branch = trim($output);
             $version = $this->versionParser->normalizeBranch($branch);
             $prettyVersion = 'dev-' . $branch;
         }
 
         // try to fetch current version from fossil tags
-        if (0 === $this->process->execute('fossil tag list', $output, $path)) {
+        if (0 === $this->process->execute(['fossil', 'tag', 'list'], $output, $path)) {
             try {
                 $version = $this->versionParser->normalize(trim($output));
                 $prettyVersion = trim($output);
@@ -395,7 +395,7 @@ class VersionGuesser
         SvnUtil::cleanEnv();
 
         // try to fetch current version from svn
-        if (0 === $this->process->execute('svn info --xml', $output, $path)) {
+        if (0 === $this->process->execute(['svn', 'info', '--xml'], $output, $path)) {
             $trunkPath = isset($packageConfig['trunk-path']) ? preg_quote($packageConfig['trunk-path'], '#') : 'trunk';
             $branchesPath = isset($packageConfig['branches-path']) ? preg_quote($packageConfig['branches-path'], '#') : 'branches';
             $tagsPath = isset($packageConfig['tags-path']) ? preg_quote($packageConfig['tags-path'], '#') : 'tags';

--- a/src/Composer/Platform/HhvmDetector.php
+++ b/src/Composer/Platform/HhvmDetector.php
@@ -49,11 +49,7 @@ class HhvmDetector
             $hhvmPath = $this->executableFinder->find('hhvm');
             if ($hhvmPath !== null) {
                 $this->processExecutor = $this->processExecutor ?? new ProcessExecutor();
-                $exitCode = $this->processExecutor->execute(
-                    ProcessExecutor::escape($hhvmPath).
-                    ' --php -d hhvm.jit=0 -r "echo HHVM_VERSION;" 2>/dev/null',
-                    self::$hhvmVersion
-                );
+                $exitCode = $this->processExecutor->execute([$hhvmPath, '--php', '-d', 'hhvm.jit=0', '-r', 'echo HHVM_VERSION;'], self::$hhvmVersion);
                 if ($exitCode !== 0) {
                     self::$hhvmVersion = false;
                 }

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -194,8 +194,8 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             // carry over the root package version if this path repo is in the same git repository as root package
             if (!isset($package['version']) && ($rootVersion = Platform::getEnv('COMPOSER_ROOT_VERSION'))) {
                 if (
-                    0 === $this->process->execute('git rev-parse HEAD', $ref1, $path)
-                    && 0 === $this->process->execute('git rev-parse HEAD', $ref2)
+                    0 === $this->process->execute(['git', 'rev-parse', 'HEAD'], $ref1, $path)
+                    && 0 === $this->process->execute(['git', 'rev-parse', 'HEAD'], $ref2)
                     && $ref1 === $ref2
                 ) {
                     $package['version'] = $this->versionGuesser->getRootVersionFromEnv();
@@ -203,7 +203,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             }
 
             $output = '';
-            if ('auto' === $reference && is_dir($path . DIRECTORY_SEPARATOR . '.git') && 0 === $this->process->execute('git log -n1 --pretty=%H'.GitUtil::getNoShowSignatureFlag($this->process), $output, $path)) {
+            if ('auto' === $reference && is_dir($path . DIRECTORY_SEPARATOR . '.git') && 0 === $this->process->execute(array_merge(['git', 'log', '-n1', '--pretty=%H'], GitUtil::getNoShowSignatureFlags($this->process)), $output, $path)) {
                 $package['dist']['reference'] = trim($output);
             }
 

--- a/src/Composer/Repository/Vcs/FossilDriver.php
+++ b/src/Composer/Repository/Vcs/FossilDriver.php
@@ -81,6 +81,8 @@ class FossilDriver extends VcsDriver
      */
     protected function updateLocalRepo(): void
     {
+        assert($this->repoFile !== null);
+
         $fs = new Filesystem();
         $fs->ensureDirectoryExists($this->checkoutDir);
 
@@ -157,7 +159,7 @@ class FossilDriver extends VcsDriver
     {
         $this->process->execute(['fossil', 'cat', '-r', $identifier, '--', $file], $content, $this->checkoutDir);
 
-        if (!trim($content)) {
+        if ('' === trim($content)) {
             return null;
         }
 

--- a/src/Composer/Repository/Vcs/FossilDriver.php
+++ b/src/Composer/Repository/Vcs/FossilDriver.php
@@ -71,7 +71,7 @@ class FossilDriver extends VcsDriver
      */
     protected function checkFossil(): void
     {
-        if (0 !== $this->process->execute('fossil version', $ignoredOutput)) {
+        if (0 !== $this->process->execute(['fossil', 'version'], $ignoredOutput)) {
             throw new \RuntimeException("fossil was not found, check that it is installed and in your PATH env.\n\n" . $this->process->getErrorOutput());
         }
     }
@@ -89,8 +89,8 @@ class FossilDriver extends VcsDriver
         }
 
         // update the repo if it is a valid fossil repository
-        if (is_file($this->repoFile) && is_dir($this->checkoutDir) && 0 === $this->process->execute('fossil info', $output, $this->checkoutDir)) {
-            if (0 !== $this->process->execute('fossil pull', $output, $this->checkoutDir)) {
+        if (is_file($this->repoFile) && is_dir($this->checkoutDir) && 0 === $this->process->execute(['fossil', 'info'], $output, $this->checkoutDir)) {
+            if (0 !== $this->process->execute(['fossil', 'pull'], $output, $this->checkoutDir)) {
                 $this->io->writeError('<error>Failed to update '.$this->url.', package information from this repository may be outdated ('.$this->process->getErrorOutput().')</error>');
             }
         } else {
@@ -100,13 +100,13 @@ class FossilDriver extends VcsDriver
 
             $fs->ensureDirectoryExists($this->checkoutDir);
 
-            if (0 !== $this->process->execute(sprintf('fossil clone -- %s %s', ProcessExecutor::escape($this->url), ProcessExecutor::escape($this->repoFile)), $output)) {
+            if (0 !== $this->process->execute(['fossil', 'clone', '--', $this->url, $this->repoFile], $output)) {
                 $output = $this->process->getErrorOutput();
 
                 throw new \RuntimeException('Failed to clone '.$this->url.' to repository ' . $this->repoFile . "\n\n" .$output);
             }
 
-            if (0 !== $this->process->execute(sprintf('fossil open --nested -- %s', ProcessExecutor::escape($this->repoFile)), $output, $this->checkoutDir)) {
+            if (0 !== $this->process->execute(['fossil', 'open', '--nested', '--', $this->repoFile], $output, $this->checkoutDir)) {
                 $output = $this->process->getErrorOutput();
 
                 throw new \RuntimeException('Failed to open repository '.$this->repoFile.' in ' . $this->checkoutDir . "\n\n" .$output);
@@ -155,8 +155,7 @@ class FossilDriver extends VcsDriver
      */
     public function getFileContent(string $file, string $identifier): ?string
     {
-        $command = sprintf('fossil cat -r %s -- %s', ProcessExecutor::escape($identifier), ProcessExecutor::escape($file));
-        $this->process->execute($command, $content, $this->checkoutDir);
+        $this->process->execute(['fossil', 'cat', '-r', $identifier, '--', $file], $content, $this->checkoutDir);
 
         if (!trim($content)) {
             return null;
@@ -170,7 +169,7 @@ class FossilDriver extends VcsDriver
      */
     public function getChangeDate(string $identifier): ?\DateTimeImmutable
     {
-        $this->process->execute('fossil finfo -b -n 1 composer.json', $output, $this->checkoutDir);
+        $this->process->execute(['fossil', 'finfo', '-b', '-n', '1', 'composer.json'], $output, $this->checkoutDir);
         [, $date] = explode(' ', trim($output), 3);
 
         return new \DateTimeImmutable($date, new \DateTimeZone('UTC'));
@@ -184,7 +183,7 @@ class FossilDriver extends VcsDriver
         if (null === $this->tags) {
             $tags = [];
 
-            $this->process->execute('fossil tag list', $output, $this->checkoutDir);
+            $this->process->execute(['fossil', 'tag', 'list'], $output, $this->checkoutDir);
             foreach ($this->process->splitLines($output) as $tag) {
                 $tags[$tag] = $tag;
             }
@@ -203,7 +202,7 @@ class FossilDriver extends VcsDriver
         if (null === $this->branches) {
             $branches = [];
 
-            $this->process->execute('fossil branch list', $output, $this->checkoutDir);
+            $this->process->execute(['fossil', 'branch', 'list'], $output, $this->checkoutDir);
             foreach ($this->process->splitLines($output) as $branch) {
                 $branch = trim(Preg::replace('/^\*/', '', trim($branch)));
                 $branches[$branch] = $branch;
@@ -237,7 +236,7 @@ class FossilDriver extends VcsDriver
 
             $process = new ProcessExecutor($io);
             // check whether there is a fossil repo in that path
-            if ($process->execute('fossil info', $output, $url) === 0) {
+            if ($process->execute(['fossil', 'info'], $output, $url) === 0) {
                 return true;
             }
         }

--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -242,9 +242,7 @@ class GitDriver extends VcsDriver
         GitUtil::cleanEnv();
 
         try {
-            $gitUtil->runCommand(static function ($url): array {
-                return ['git', 'ls-remote', '--heads', '--', $url];
-            }, $url, sys_get_temp_dir());
+            $gitUtil->runCommands([['git', 'ls-remote', '--heads', '--', '%url%']], $url, sys_get_temp_dir());
         } catch (\RuntimeException $e) {
             return false;
         }

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -187,7 +187,7 @@ class SvnDriver extends VcsDriver
 
         try {
             $resource = $path.$file;
-            $output = $this->execute('svn cat', $this->baseUrl . $resource . $rev);
+            $output = $this->execute(['svn', 'cat'], $this->baseUrl . $resource . $rev);
             if ('' === trim($output)) {
                 return null;
             }
@@ -213,7 +213,7 @@ class SvnDriver extends VcsDriver
             $rev = '';
         }
 
-        $output = $this->execute('svn info', $this->baseUrl . $path . $rev);
+        $output = $this->execute(['svn', 'info'], $this->baseUrl . $path . $rev);
         foreach ($this->process->splitLines($output) as $line) {
             if ($line !== '' && Preg::isMatchStrictGroups('{^Last Changed Date: ([^(]+)}', $line, $match)) {
                 return new \DateTimeImmutable($match[1], new \DateTimeZone('UTC'));
@@ -232,7 +232,7 @@ class SvnDriver extends VcsDriver
             $tags = [];
 
             if ($this->tagsPath !== false) {
-                $output = $this->execute('svn ls --verbose', $this->baseUrl . '/' . $this->tagsPath);
+                $output = $this->execute(['svn', 'ls', '--verbose'], $this->baseUrl . '/' . $this->tagsPath);
                 if ($output !== '') {
                     $lastRev = 0;
                     foreach ($this->process->splitLines($output) as $line) {
@@ -271,7 +271,7 @@ class SvnDriver extends VcsDriver
                 $trunkParent = $this->baseUrl . '/' . $this->trunkPath;
             }
 
-            $output = $this->execute('svn ls --verbose', $trunkParent);
+            $output = $this->execute(['svn', 'ls', '--verbose'], $trunkParent);
             if ($output !== '') {
                 foreach ($this->process->splitLines($output) as $line) {
                     $line = trim($line);
@@ -290,7 +290,7 @@ class SvnDriver extends VcsDriver
             unset($output);
 
             if ($this->branchesPath !== false) {
-                $output = $this->execute('svn ls --verbose', $this->baseUrl . '/' . $this->branchesPath);
+                $output = $this->execute(['svn', 'ls', '--verbose'], $this->baseUrl . '/' . $this->branchesPath);
                 if ($output !== '') {
                     $lastRev = 0;
                     foreach ($this->process->splitLines(trim($output)) as $line) {
@@ -372,11 +372,11 @@ class SvnDriver extends VcsDriver
      * Execute an SVN command and try to fix up the process with credentials
      * if necessary.
      *
-     * @param  string            $command The svn command to run.
+     * @param  non-empty-list<string> $command The svn command to run.
      * @param  string            $url     The SVN URL.
      * @throws \RuntimeException
      */
-    protected function execute(string $command, string $url): string
+    protected function execute(array $command, string $url): string
     {
         if (null === $this->util) {
             $this->util = new SvnUtil($this->baseUrl, $this->io, $this->config, $this->process);

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -331,10 +331,7 @@ class SvnDriver extends VcsDriver
         }
 
         $process = new ProcessExecutor($io);
-        $exit = $process->execute(
-            "svn info --non-interactive -- ".ProcessExecutor::escape($url),
-            $ignoredOutput
-        );
+        $exit = $process->execute(['svn', 'info', '--non-interactive', '--', $url], $ignoredOutput);
 
         if ($exit === 0) {
             // This is definitely a Subversion repository.

--- a/src/Composer/Util/Bitbucket.php
+++ b/src/Composer/Util/Bitbucket.php
@@ -77,7 +77,7 @@ class Bitbucket
         }
 
         // if available use token from git config
-        if (0 === $this->process->execute('git config bitbucket.accesstoken', $output)) {
+        if (0 === $this->process->execute(['git', 'config', 'bitbucket.accesstoken'], $output)) {
             $this->io->setAuthentication($originUrl, 'x-token-auth', trim($output));
 
             return true;

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -109,7 +109,7 @@ class Filesystem
         }
 
         if (Platform::isWindows()) {
-            $cmd = ['rmdir', '/S', '/Q', realpath($directory)];
+            $cmd = ['rmdir', '/S', '/Q', Platform::realpath($directory)];
         } else {
             $cmd = ['rm', '-rf', $directory];
         }
@@ -144,7 +144,7 @@ class Filesystem
         }
 
         if (Platform::isWindows()) {
-            $cmd = ['rmdir', '/S', '/Q', realpath($directory)];
+            $cmd = ['rmdir', '/S', '/Q', Platform::realpath($directory)];
         } else {
             $cmd = ['rm', '-rf', $directory];
         }
@@ -839,7 +839,7 @@ class Filesystem
             @rmdir($junction);
         }
 
-        $cmd = ['mklink', '/J', str_replace('/', DIRECTORY_SEPARATOR, $junction), realpath($target)];
+        $cmd = ['mklink', '/J', str_replace('/', DIRECTORY_SEPARATOR, $junction), Platform::realpath($target)];
         if ($this->getProcess()->execute($cmd, $output) !== 0) {
             throw new IOException(sprintf('Failed to create junction to "%s" at "%s".', $target, $junction), 0, null, $target);
         }

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -109,9 +109,9 @@ class Filesystem
         }
 
         if (Platform::isWindows()) {
-            $cmd = sprintf('rmdir /S /Q %s', ProcessExecutor::escape(realpath($directory)));
+            $cmd = ['rmdir', '/S', '/Q', realpath($directory)];
         } else {
-            $cmd = sprintf('rm -rf %s', ProcessExecutor::escape($directory));
+            $cmd = ['rm', '-rf', $directory];
         }
 
         $result = $this->getProcess()->execute($cmd, $output) === 0;
@@ -144,9 +144,9 @@ class Filesystem
         }
 
         if (Platform::isWindows()) {
-            $cmd = sprintf('rmdir /S /Q %s', ProcessExecutor::escape(realpath($directory)));
+            $cmd = ['rmdir', '/S', '/Q', realpath($directory)];
         } else {
-            $cmd = sprintf('rm -rf %s', ProcessExecutor::escape($directory));
+            $cmd = ['rm', '-rf', $directory];
         }
 
         $promise = $this->getProcess()->executeAsync($cmd);
@@ -427,8 +427,7 @@ class Filesystem
 
         if (Platform::isWindows()) {
             // Try to copy & delete - this is a workaround for random "Access denied" errors.
-            $command = sprintf('xcopy %s %s /E /I /Q /Y', ProcessExecutor::escape($source), ProcessExecutor::escape($target));
-            $result = $this->getProcess()->execute($command, $output);
+            $result = $this->getProcess()->execute(['xcopy', $source, $target, '/E', '/I', '/Q', '/Y'], $output);
 
             // clear stat cache because external processes aren't tracked by the php stat cache
             clearstatcache();
@@ -441,8 +440,7 @@ class Filesystem
         } else {
             // We do not use PHP's "rename" function here since it does not support
             // the case where $source, and $target are located on different partitions.
-            $command = sprintf('mv %s %s', ProcessExecutor::escape($source), ProcessExecutor::escape($target));
-            $result = $this->getProcess()->execute($command, $output);
+            $result = $this->getProcess()->execute(['mv', $source, $target], $output);
 
             // clear stat cache because external processes aren't tracked by the php stat cache
             clearstatcache();
@@ -841,11 +839,7 @@ class Filesystem
             @rmdir($junction);
         }
 
-        $cmd = sprintf(
-            'mklink /J %s %s',
-            ProcessExecutor::escape(str_replace('/', DIRECTORY_SEPARATOR, $junction)),
-            ProcessExecutor::escape(realpath($target))
-        );
+        $cmd = ['mklink', '/J', str_replace('/', DIRECTORY_SEPARATOR, $junction), realpath($target)];
         if ($this->getProcess()->execute($cmd, $output) !== 0) {
             throw new IOException(sprintf('Failed to create junction to "%s" at "%s".', $target, $junction), 0, null, $target);
         }

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -435,13 +435,18 @@ class Git
      */
     public static function getNoShowSignatureFlags(ProcessExecutor $process): array
     {
-        return explode(' ', substr(static::getNoShowSignatureFlag($process), 1));
+        $flags = static::getNoShowSignatureFlag($process);
+        if ('' === $flags) {
+            return [];
+        }
+
+        return explode(' ', substr($flags, 1));
     }
 
     private function checkRefIsInMirror(string $dir, string $ref): bool
     {
         if (is_dir($dir) && 0 === $this->process->execute(['git', 'rev-parse', '--git-dir'], $output, $dir) && trim($output) === '.') {
-            $exitCode = $this->process->execute(['git rev-parse', '--quiet', '--verify', $ref.'^{commit}'], $ignoredOutput, $dir);
+            $exitCode = $this->process->execute(['git', 'rev-parse', '--quiet', '--verify', $ref.'^{commit}'], $ignoredOutput, $dir);
             if ($exitCode === 0) {
                 return true;
             }

--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -61,7 +61,7 @@ class GitHub
         }
 
         // if available use token from git config
-        if (0 === $this->process->execute('git config github.accesstoken', $output)) {
+        if (0 === $this->process->execute(['git', 'config', 'github.accesstoken'], $output)) {
             $this->io->setAuthentication($originUrl, trim($output), 'x-oauth-basic');
 
             return true;
@@ -86,7 +86,7 @@ class GitHub
         }
 
         $note = 'Composer';
-        if ($this->config->get('github-expose-hostname') === true && 0 === $this->process->execute('hostname', $output)) {
+        if ($this->config->get('github-expose-hostname') === true && 0 === $this->process->execute(['hostname'], $output)) {
             $note .= ' on ' . trim($output);
         }
         $note .= ' ' . date('Y-m-d Hi');

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -65,14 +65,14 @@ class GitLab
         }
 
         // if available use token from git config
-        if (0 === $this->process->execute('git config gitlab.accesstoken', $output)) {
+        if (0 === $this->process->execute(['git', 'config', 'gitlab.accesstoken'], $output)) {
             $this->io->setAuthentication($originUrl, trim($output), 'oauth2');
 
             return true;
         }
 
         // if available use deploy token from git config
-        if (0 === $this->process->execute('git config gitlab.deploytoken.user', $tokenUser) && 0 === $this->process->execute('git config gitlab.deploytoken.token', $tokenPassword)) {
+        if (0 === $this->process->execute(['git', 'config', 'gitlab.deploytoken.user'], $tokenUser) && 0 === $this->process->execute(['git', 'config', 'gitlab.deploytoken.token'], $tokenPassword)) {
             $this->io->setAuthentication($originUrl, trim($tokenUser), trim($tokenPassword));
 
             return true;

--- a/src/Composer/Util/Hg.php
+++ b/src/Composer/Util/Hg.php
@@ -111,7 +111,7 @@ class Hg
     {
         if (false === self::$version) {
             self::$version = null;
-            if (0 === $process->execute('hg --version', $output) && Preg::isMatch('/^.+? (\d+(?:\.\d+)+)(?:\+.*?)?\)?\r?\n/', $output, $matches)) {
+            if (0 === $process->execute(['hg', '--version'], $output) && Preg::isMatch('/^.+? (\d+(?:\.\d+)+)(?:\+.*?)?\)?\r?\n/', $output, $matches)) {
                 self::$version = $matches[1];
             }
         }

--- a/src/Composer/Util/Perforce.php
+++ b/src/Composer/Util/Perforce.php
@@ -82,7 +82,7 @@ class Perforce
 
     public static function checkServerExists(string $url, ProcessExecutor $processExecutor): bool
     {
-        return 0 === $processExecutor->execute([$this->getP4Executable(), '-p', $url, 'info', '-s'], $ignoredOutput);
+        return 0 === $processExecutor->execute(['p4', '-p', $url, 'info', '-s'], $ignoredOutput);
     }
 
     /**
@@ -622,7 +622,7 @@ class Perforce
         $this->filesystem = $fs;
     }
 
-    private function getP4Executable()
+    private function getP4Executable(): string
     {
         static $p4Executable;
 

--- a/src/Composer/Util/Perforce.php
+++ b/src/Composer/Util/Perforce.php
@@ -14,6 +14,7 @@ namespace Composer\Util;
 
 use Composer\IO\IOInterface;
 use Composer\Pcre\Preg;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
@@ -81,7 +82,7 @@ class Perforce
 
     public static function checkServerExists(string $url, ProcessExecutor $processExecutor): bool
     {
-        return 0 === $processExecutor->execute('p4 -p ' . ProcessExecutor::escape($url) . ' info -s', $ignoredOutput);
+        return 0 === $processExecutor->execute([$this->getP4Executable(), '-p', $url, 'info', '-s'], $ignoredOutput);
     }
 
     /**
@@ -248,7 +249,7 @@ class Perforce
         }
         $this->p4User = $this->io->ask('Enter P4 User:');
         if ($this->windowsFlag) {
-            $command = 'p4 set P4USER=' . $this->p4User;
+            $command = $this->getP4Executable().' set P4USER=' . $this->p4User;
         } else {
             $command = 'export P4USER=' . $this->p4User;
         }
@@ -261,7 +262,7 @@ class Perforce
     protected function getP4variable(string $name): ?string
     {
         if ($this->windowsFlag) {
-            $command = 'p4 set';
+            $command = $this->getP4Executable().' set';
             $this->executeCommand($command);
             $result = trim($this->commandResult);
             $resArray = explode(PHP_EOL, $result);
@@ -309,7 +310,7 @@ class Perforce
      */
     public function generateP4Command(string $command, bool $useClient = true): string
     {
-        $p4Command = 'p4 ';
+        $p4Command = $this->getP4Executable().' ';
         $p4Command .= '-u ' . $this->getUser() . ' ';
         if ($useClient) {
             $p4Command .= '-c ' . $this->getClient() . ' ';
@@ -619,5 +620,18 @@ class Perforce
     public function setFilesystem(Filesystem $fs): void
     {
         $this->filesystem = $fs;
+    }
+
+    private function getP4Executable()
+    {
+        static $p4Executable;
+
+        if ($p4Executable) {
+            return $p4Executable;
+        }
+
+        $finder = new ExecutableFinder();
+
+        return $p4Executable = $finder->find('p4') ?? 'p4';
     }
 }

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -308,7 +308,7 @@ class Platform
             if (defined('PHP_OS_FAMILY') && PHP_OS_FAMILY === 'Linux') {
                 $process = new ProcessExecutor();
                 try {
-                    if (0 === $process->execute('lsmod | grep vboxguest', $ignoredOutput)) {
+                    if (0 === $process->execute(['lsmod'], $output) && false !== strpos($output, 'vboxguest')) {
                         return self::$isVirtualBoxGuest = true;
                     }
                 } catch (\Exception $e) {

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -321,7 +321,7 @@ class Platform
             if (defined('PHP_OS_FAMILY') && PHP_OS_FAMILY === 'Linux') {
                 $process = new ProcessExecutor();
                 try {
-                    if (0 === $process->execute(['lsmod'], $output) && false !== strpos($output, 'vboxguest')) {
+                    if (0 === $process->execute(['lsmod'], $output) && str_contains($output, 'vboxguest')) {
                         return self::$isVirtualBoxGuest = true;
                     }
                 } catch (\Exception $e) {

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -55,6 +55,19 @@ class Platform
     }
 
     /**
+     * Infallible realpath version that falls back on the given $path if realpath is not working
+     */
+    public static function realpath(string $path): string
+    {
+        $realPath = realpath($path);
+        if ($realPath === false) {
+            return $path;
+        }
+
+        return $realPath;
+    }
+
+    /**
      * getenv() equivalent but reads from the runtime global variables first
      *
      * @param non-empty-string $name

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -34,6 +34,24 @@ class ProcessExecutor
     private const STATUS_FAILED = 4;
     private const STATUS_ABORTED = 5;
 
+    private const BUILTIN_CMD_COMMANDS = [
+        'call' => true,
+        'cd' => true,
+        'copy' => true,
+        'del' => true,
+        'echo' => true,
+        'mkdir' => true,
+        'md' => true,
+        'mklink' => true,
+        'move' => true,
+        'ren' => true,
+        'rename' => true,
+        'rmdir' => true,
+        'rd' => true,
+        'set' => true,
+        'time' => true,
+    ];
+
     private const GIT_CMDS_NEED_GIT_DIR = [
         ['show'],
         ['log'],
@@ -568,6 +586,10 @@ class ProcessExecutor
 
     private static function getExecutable(string $name): string
     {
+        if (isset(self::BUILTIN_CMD_COMMANDS[strtolower($name)])) {
+            return $name;
+        }
+
         if (!isset(self::$executables[$name])) {
             $path = (new ExecutableFinder())->find($name, $name);
             if ($path !== null) {

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -35,21 +35,11 @@ class ProcessExecutor
     private const STATUS_ABORTED = 5;
 
     private const BUILTIN_CMD_COMMANDS = [
-        'call' => true,
-        'cd' => true,
-        'copy' => true,
-        'del' => true,
-        'echo' => true,
-        'mkdir' => true,
-        'md' => true,
-        'mklink' => true,
-        'move' => true,
-        'ren' => true,
-        'rename' => true,
-        'rmdir' => true,
-        'rd' => true,
-        'set' => true,
-        'time' => true,
+        'assoc', 'break', 'call', 'cd', 'chdir', 'cls', 'color', 'copy', 'date',
+        'del', 'dir', 'echo', 'endlocal', 'erase', 'exit', 'for', 'ftype', 'goto',
+        'help', 'if', 'label', 'md', 'mkdir', 'mklink', 'move', 'path', 'pause',
+        'popd', 'prompt', 'pushd', 'rd', 'rem', 'ren', 'rename', 'rmdir', 'set',
+        'setlocal', 'shift', 'start', 'time', 'title', 'type', 'ver', 'vol',
     ];
 
     private const GIT_CMDS_NEED_GIT_DIR = [
@@ -584,9 +574,12 @@ class ProcessExecutor
         return false;
     }
 
+    /**
+     * Resolves executable paths on Windows
+     */
     private static function getExecutable(string $name): string
     {
-        if (isset(self::BUILTIN_CMD_COMMANDS[strtolower($name)])) {
+        if (\in_array(strtolower($name), self::BUILTIN_CMD_COMMANDS, true)) {
             return $name;
         }
 

--- a/src/Composer/Util/Svn.php
+++ b/src/Composer/Util/Svn.php
@@ -349,7 +349,7 @@ class Svn
     public function binaryVersion(): ?string
     {
         if (!self::$version) {
-            if (0 === $this->process->execute('svn --version', $output)) {
+            if (0 === $this->process->execute(['svn', '--version'], $output)) {
                 if (Preg::isMatch('{(\d+(?:\.\d+)+)}', $output, $match)) {
                     self::$version = $match[1];
                 }

--- a/tests/Composer/Test/AllFunctionalTest.php
+++ b/tests/Composer/Test/AllFunctionalTest.php
@@ -87,6 +87,7 @@ class AllFunctionalTest extends TestCase
         }
 
         $proc = new Process([PHP_BINARY, '-dphar.readonly=0', './bin/compile'], $target);
+        $proc->setTimeout(300);
         $exitcode = $proc->run();
 
         if ($exitcode !== 0 || trim($proc->getOutput()) !== '') {

--- a/tests/Composer/Test/Downloader/FossilDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FossilDownloaderTest.php
@@ -76,8 +76,8 @@ class FossilDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            ['fossil', 'clone', '--', 'http://fossil.kd2.org/kd2fw/', $this->workingDir, '.fossil'],
-            ['fossil', 'open', '--nested', '--', $this->workingDir, '.fossil'],
+            ['fossil', 'clone', '--', 'http://fossil.kd2.org/kd2fw/', $this->workingDir.'.fossil'],
+            ['fossil', 'open', '--nested', '--', $this->workingDir.'.fossil'],
             ['fossil', 'update', '--', 'trunk'],
         ], true);
 

--- a/tests/Composer/Test/Downloader/FossilDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FossilDownloaderTest.php
@@ -76,9 +76,9 @@ class FossilDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            self::getCmd('fossil clone -- \'http://fossil.kd2.org/kd2fw/\' \''.$this->workingDir.'.fossil\''),
-            self::getCmd('fossil open --nested -- \''.$this->workingDir.'.fossil\''),
-            self::getCmd('fossil update -- \'trunk\''),
+            ['fossil', 'clone', '--', 'http://fossil.kd2.org/kd2fw/', $this->workingDir, '.fossil'],
+            ['fossil', 'open', '--nested', '--', $this->workingDir, '.fossil'],
+            ['fossil', 'update', '--', 'trunk'],
         ], true);
 
         $downloader = $this->getDownloaderMock(null, null, $process);
@@ -123,8 +123,9 @@ class FossilDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            self::getCmd("fossil changes"),
-            self::getCmd("fossil pull && fossil up 'trunk'"),
+            ['fossil', 'changes'],
+            ['fossil', 'pull'],
+            ['fossil', 'up', 'trunk'],
         ], true);
 
         $downloader = $this->getDownloaderMock(null, null, $process);
@@ -143,7 +144,7 @@ class FossilDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            self::getCmd('fossil changes'),
+            ['fossil', 'changes'],
         ], true);
 
         $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -123,9 +123,14 @@ class GitDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->winCompat("git clone --no-checkout -- 'https://example.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://example.com/composer/composer' && git fetch composer && git remote set-url origin -- 'https://example.com/composer/composer' && git remote set-url composer -- 'https://example.com/composer/composer'"),
-            $this->winCompat("git branch -r"),
-            $this->winCompat("(git checkout 'master' -- || git checkout -B 'master' 'composer/master' --) && git reset --hard '1234567890123456789012345678901234567890' --"),
+            ['git', 'clone', '--no-checkout', '--', 'https://example.com/composer/composer', 'composerPath'],
+            ['git', 'remote', 'add', 'composer', '--', 'https://example.com/composer/composer'],
+            ['git', 'fetch', 'composer'],
+            ['git', 'remote', 'set-url', 'origin', '--', 'https://example.com/composer/composer'],
+            ['git', 'remote', 'set-url', 'composer', '--', 'https://example.com/composer/composer'],
+            ['git', 'branch', '-r'],
+            ['git', 'checkout', 'master', '--'],
+            ['git', 'reset', '--hard', '1234567890123456789012345678901234567890', '--'],
         ], true);
 
         $downloader = $this->getDownloaderMock(null, null, $process);
@@ -609,7 +614,7 @@ composer https://github.com/old/url (push)
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            'git show-ref --head -d',
+            ['git', 'show-ref', '--head', '-d'],
             $expectedGitResetCommand,
         ], true);
 

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -166,6 +166,7 @@ class GitDownloaderTest extends TestCase
         $filesystem = new \Composer\Util\Filesystem;
         $filesystem->removeDirectory($cachePath);
 
+        $expectedPath = Platform::isWindows() ? Platform::getCwd().'/composerPath' : 'composerPath';
         $process = $this->getProcessExecutorMock();
         $process->expects([
             [
@@ -176,7 +177,7 @@ class GitDownloaderTest extends TestCase
             ],
             ['cmd' => ['git', 'rev-parse', '--git-dir'], 'stdout' => '.'],
             ['git', 'rev-parse', '--quiet', '--verify', '1234567890123456789012345678901234567890^{commit}'],
-            ['git', 'clone', '--no-checkout', $cachePath, 'composerPath', '--dissociate', '--reference', $cachePath],
+            ['git', 'clone', '--no-checkout', $cachePath, $expectedPath, '--dissociate', '--reference', $cachePath],
             ['git', 'remote', 'set-url', 'origin', '--', 'https://example.com/composer/composer'],
             ['git', 'remote', 'add', 'composer', '--', 'https://example.com/composer/composer'],
             ['git', 'branch', '-r'],
@@ -317,7 +318,7 @@ class GitDownloaderTest extends TestCase
         ]);
 
         self::expectException('RuntimeException');
-        self::expectExceptionMessage('Failed to execute git clone --no-checkout -- https://example.com/composer/composer composerPath');
+        self::expectExceptionMessage('Failed to execute git clone --no-checkout -- https://example.com/composer/composer '.$expectedPath);
         $downloader = $this->getDownloaderMock(null, null, $process);
         $downloader->download($packageMock, 'composerPath');
         $downloader->prepare('install', $packageMock, 'composerPath');

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -122,8 +122,9 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue('dev-master'));
 
         $process = $this->getProcessExecutorMock();
+        $expectedPath = Platform::isWindows() ? Platform::getCwd().'/composerPath' : 'composerPath';
         $process->expects([
-            ['git', 'clone', '--no-checkout', '--', 'https://example.com/composer/composer', 'composerPath'],
+            ['git', 'clone', '--no-checkout', '--', 'https://example.com/composer/composer', $expectedPath],
             ['git', 'remote', 'add', 'composer', '--', 'https://example.com/composer/composer'],
             ['git', 'fetch', 'composer'],
             ['git', 'remote', 'set-url', 'origin', '--', 'https://example.com/composer/composer'],
@@ -209,10 +210,11 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue('1.0.0'));
 
         $process = $this->getProcessExecutorMock();
+        $expectedPath = Platform::isWindows() ? Platform::getCwd().'/composerPath' : 'composerPath';
         $process->expects([
-            ['cmd' => ['git', 'clone', '--no-checkout', '--', 'https://github.com/mirrors/composer', 'composerPath'], 'return' => 1, 'stderr' => 'Error1'],
+            ['cmd' => ['git', 'clone', '--no-checkout', '--', 'https://github.com/mirrors/composer', $expectedPath], 'return' => 1, 'stderr' => 'Error1'],
 
-            ['git', 'clone', '--no-checkout', '--', 'git@github.com:mirrors/composer', 'composerPath'],
+            ['git', 'clone', '--no-checkout', '--', 'git@github.com:mirrors/composer', $expectedPath],
             ['git', 'remote', 'add', 'composer', '--', 'git@github.com:mirrors/composer'],
             ['git', 'fetch', 'composer'],
             ['git', 'remote', 'set-url', 'origin', '--', 'git@github.com:mirrors/composer'],
@@ -265,8 +267,9 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue('1.0.0'));
 
         $process = $this->getProcessExecutorMock();
+        $expectedPath = Platform::isWindows() ? Platform::getCwd().'/composerPath' : 'composerPath';
         $process->expects([
-            ['git', 'clone', '--no-checkout', '--', $url, 'composerPath'],
+            ['git', 'clone', '--no-checkout', '--', $url, $expectedPath],
             ['git', 'remote', 'add', 'composer', '--', $url],
             ['git', 'fetch', 'composer'],
             ['git', 'remote', 'set-url', 'origin', '--', $url],
@@ -305,9 +308,10 @@ class GitDownloaderTest extends TestCase
             ->will($this->returnValue('1.0.0'));
 
         $process = $this->getProcessExecutorMock();
+        $expectedPath = Platform::isWindows() ? Platform::getCwd().'/composerPath' : 'composerPath';
         $process->expects([
             [
-                'cmd' => ['git', 'clone', '--no-checkout', '--', 'https://example.com/composer/composer', 'composerPath'],
+                'cmd' => ['git', 'clone', '--no-checkout', '--', 'https://example.com/composer/composer', $expectedPath],
                 'return' => 1,
             ],
         ]);

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -167,14 +167,21 @@ class GitDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            ['cmd' => $this->winCompat(sprintf("git clone --mirror -- 'https://example.com/composer/composer' '%s'", $cachePath)), 'callback' => static function () use ($cachePath): void {
-                @mkdir($cachePath, 0777, true);
-            }],
-            ['cmd' => 'git rev-parse --git-dir', 'stdout' => '.'],
-            $this->winCompat('git rev-parse --quiet --verify \'1234567890123456789012345678901234567890^{commit}\''),
-            $this->winCompat(sprintf("git clone --no-checkout '%1\$s' 'composerPath' --dissociate --reference '%1\$s' && cd 'composerPath' && git remote set-url origin -- 'https://example.com/composer/composer' && git remote add composer -- 'https://example.com/composer/composer'", $cachePath)),
-            'git branch -r',
-            $this->winCompat("(git checkout 'master' -- || git checkout -B 'master' 'composer/master' --) && git reset --hard '1234567890123456789012345678901234567890' --"),
+            [
+                'cmd' => ['git', 'clone', '--mirror', '--', 'https://example.com/composer/composer', $cachePath],
+                'callback' => static function () use ($cachePath): void {
+                    @mkdir($cachePath, 0777, true);
+                }
+            ],
+            ['cmd' => ['git', 'rev-parse', '--git-dir'], 'stdout' => '.'],
+            ['git', 'rev-parse', '--quiet', '--verify', '1234567890123456789012345678901234567890^{commit}'],
+            ['git', 'clone', '--no-checkout', $cachePath, 'composerPath', '--dissociate', '--reference', $cachePath],
+            ['git', 'remote', 'set-url', 'origin', '--', 'https://example.com/composer/composer'],
+            ['git', 'remote', 'add', 'composer', '--', 'https://example.com/composer/composer'],
+            ['git', 'branch', '-r'],
+            ['cmd' => ['git', 'checkout', 'master', '--'], 'return' => 1],
+            ['git', 'checkout', '-B', 'master', 'composer/master', '--'],
+            ['git', 'reset', '--hard', '1234567890123456789012345678901234567890', '--'],
         ], true);
 
         $downloader = $this->getDownloaderMock(null, $config, $process);
@@ -203,16 +210,19 @@ class GitDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            [
-                'cmd' => $this->winCompat("git clone --no-checkout -- 'https://github.com/mirrors/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://github.com/mirrors/composer' && git fetch composer && git remote set-url origin -- 'https://github.com/mirrors/composer' && git remote set-url composer -- 'https://github.com/mirrors/composer'"),
-                'return' => 1,
-                'stderr' => 'Error1',
-            ],
-            $this->winCompat("git clone --no-checkout -- 'git@github.com:mirrors/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'git@github.com:mirrors/composer' && git fetch composer && git remote set-url origin -- 'git@github.com:mirrors/composer' && git remote set-url composer -- 'git@github.com:mirrors/composer'"),
-            $this->winCompat("git remote set-url origin -- 'https://github.com/composer/composer'"),
-            $this->winCompat("git remote set-url --push origin -- 'git@github.com:composer/composer.git'"),
-            'git branch -r',
-            $this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"),
+            ['cmd' => ['git', 'clone', '--no-checkout', '--', 'https://github.com/mirrors/composer', 'composerPath'], 'return' => 1, 'stderr' => 'Error1'],
+
+            ['git', 'clone', '--no-checkout', '--', 'git@github.com:mirrors/composer', 'composerPath'],
+            ['git', 'remote', 'add', 'composer', '--', 'git@github.com:mirrors/composer'],
+            ['git', 'fetch', 'composer'],
+            ['git', 'remote', 'set-url', 'origin', '--', 'git@github.com:mirrors/composer'],
+            ['git', 'remote', 'set-url', 'composer', '--', 'git@github.com:mirrors/composer'],
+
+            ['git', 'remote', 'set-url', 'origin', '--', 'https://github.com/composer/composer'],
+            ['git', 'remote', 'set-url', '--push', 'origin', '--', 'git@github.com:composer/composer.git'],
+            ['git', 'branch', '-r'],
+            ['git', 'checkout', 'ref', '--'],
+            ['git', 'reset', '--hard', 'ref', '--'],
         ], true);
 
         $downloader = $this->getDownloaderMock(null, new Config(), $process);
@@ -256,10 +266,16 @@ class GitDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->winCompat("git clone --no-checkout -- '{$url}' 'composerPath' && cd 'composerPath' && git remote add composer -- '{$url}' && git fetch composer && git remote set-url origin -- '{$url}' && git remote set-url composer -- '{$url}'"),
-            $this->winCompat("git remote set-url --push origin -- '{$pushUrl}'"),
-            'git branch -r',
-            $this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"),
+            ['git', 'clone', '--no-checkout', '--', $url, 'composerPath'],
+            ['git', 'remote', 'add', 'composer', '--', $url],
+            ['git', 'fetch', 'composer'],
+            ['git', 'remote', 'set-url', 'origin', '--', $url],
+            ['git', 'remote', 'set-url', 'composer', '--', $url],
+
+            ['git', 'remote', 'set-url', '--push', 'origin', '--', $pushUrl],
+            ['git', 'branch', '-r'],
+            ['git', 'checkout', 'ref', '--'],
+            ['git', 'reset', '--hard', 'ref', '--'],
         ], true);
 
         $config = new Config();
@@ -291,26 +307,18 @@ class GitDownloaderTest extends TestCase
         $process = $this->getProcessExecutorMock();
         $process->expects([
             [
-                'cmd' => $this->winCompat("git clone --no-checkout -- 'https://example.com/composer/composer' 'composerPath' && cd 'composerPath' && git remote add composer -- 'https://example.com/composer/composer' && git fetch composer && git remote set-url origin -- 'https://example.com/composer/composer' && git remote set-url composer -- 'https://example.com/composer/composer'"),
+                'cmd' => ['git', 'clone', '--no-checkout', '--', 'https://example.com/composer/composer', 'composerPath'],
                 'return' => 1,
             ],
         ]);
 
-        // not using PHPUnit's expected exception because Prophecy exceptions extend from RuntimeException too so it is not safe
-        try {
-            $downloader = $this->getDownloaderMock(null, null, $process);
-            $downloader->download($packageMock, 'composerPath');
-            $downloader->prepare('install', $packageMock, 'composerPath');
-            $downloader->install($packageMock, 'composerPath');
-            $downloader->cleanup('install', $packageMock, 'composerPath');
-
-            $this->fail('This test should throw');
-        } catch (\RuntimeException $e) {
-            if ('RuntimeException' !== get_class($e)) {
-                throw $e;
-            }
-            self::assertEquals('RuntimeException', get_class($e));
-        }
+        self::expectException('RuntimeException');
+        self::expectExceptionMessage('Failed to execute git clone --no-checkout -- https://example.com/composer/composer composerPath');
+        $downloader = $this->getDownloaderMock(null, null, $process);
+        $downloader->download($packageMock, 'composerPath');
+        $downloader->prepare('install', $packageMock, 'composerPath');
+        $downloader->install($packageMock, 'composerPath');
+        $downloader->cleanup('install', $packageMock, 'composerPath');
     }
 
     public function testUpdateforPackageWithoutSourceReference(): void
@@ -332,8 +340,6 @@ class GitDownloaderTest extends TestCase
 
     public function testUpdate(): void
     {
-        $expectedGitUpdateCommand = $this->winCompat("(git remote set-url composer -- 'https://github.com/composer/composer' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)) && git remote set-url composer -- 'https://github.com/composer/composer'");
-
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
@@ -350,13 +356,23 @@ class GitDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->winCompat('git show-ref --head -d'),
-            $this->winCompat('git status --porcelain --untracked-files=no'),
-            $this->winCompat('git remote -v'),
-            $expectedGitUpdateCommand,
-            $this->winCompat('git branch -r'),
-            $this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"),
-            $this->winCompat('git remote -v'),
+            ['git', 'show-ref', '--head', '-d'],
+            ['git', 'status', '--porcelain', '--untracked-files=no'],
+            ['cmd' => ['git', 'rev-parse', '--quiet', '--verify', 'ref^{commit}'], 'return' => 1],
+
+            // fallback commands for the above failing
+            ['git', 'remote', '-v'],
+            ['git', 'remote', 'set-url', 'composer', '--', 'https://github.com/composer/composer'],
+            ['git', 'fetch', 'composer'],
+            ['git', 'fetch', '--tags', 'composer'],
+
+            ['git', 'remote', '-v'],
+            ['git', 'remote', 'set-url', 'composer', '--', 'https://github.com/composer/composer'],
+
+            ['git', 'branch', '-r'],
+            ['git', 'checkout', 'ref', '--'],
+            ['git', 'reset', '--hard', 'ref', '--'],
+            ['git', 'remote', '-v'],
         ], true);
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
@@ -369,8 +385,6 @@ class GitDownloaderTest extends TestCase
 
     public function testUpdateWithNewRepoUrl(): void
     {
-        $expectedGitUpdateCommand = $this->winCompat("(git remote set-url composer -- 'https://github.com/composer/composer' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)) && git remote set-url composer -- 'https://github.com/composer/composer'");
-
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
@@ -390,22 +404,26 @@ class GitDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->winCompat("git show-ref --head -d"),
-            $this->winCompat("git status --porcelain --untracked-files=no"),
-            $this->winCompat("git remote -v"),
-            $this->winCompat($expectedGitUpdateCommand),
-            'git branch -r',
-            $this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"),
+            ['git', 'show-ref', '--head', '-d'],
+            ['git', 'status', '--porcelain', '--untracked-files=no'],
+            ['cmd' => ['git', 'rev-parse', '--quiet', '--verify', 'ref^{commit}'], 'return' => 0],
+
+            ['git', 'remote', '-v'],
+            ['git', 'remote', 'set-url', 'composer', '--', 'https://github.com/composer/composer'],
+
+            ['git', 'branch', '-r'],
+            ['git', 'checkout', 'ref', '--'],
+            ['git', 'reset', '--hard', 'ref', '--'],
             [
-                'cmd' => $this->winCompat("git remote -v"),
+                'cmd' => ['git', 'remote', '-v'],
                 'stdout' => 'origin https://github.com/old/url (fetch)
 origin https://github.com/old/url (push)
 composer https://github.com/old/url (fetch)
 composer https://github.com/old/url (push)
 ',
             ],
-            $this->winCompat("git remote set-url origin -- 'https://github.com/composer/composer'"),
-            $this->winCompat("git remote set-url --push origin -- 'git@github.com:composer/composer.git'"),
+            ['git', 'remote', 'set-url', 'origin', '--', 'https://github.com/composer/composer'],
+            ['git', 'remote', 'set-url', '--push', 'origin', '--', 'git@github.com:composer/composer.git'],
         ], true);
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
@@ -421,9 +439,6 @@ composer https://github.com/old/url (push)
      */
     public function testUpdateThrowsRuntimeExceptionIfGitCommandFails(): void
     {
-        $expectedGitUpdateCommand = $this->winCompat("(git remote set-url composer -- 'https://github.com/composer/composer' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)) && git remote set-url composer -- 'https://github.com/composer/composer'");
-        $expectedGitUpdateCommand2 = $this->winCompat("(git remote set-url composer -- 'git@github.com:composer/composer' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)) && git remote set-url composer -- 'git@github.com:composer/composer'");
-
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
@@ -437,44 +452,38 @@ composer https://github.com/old/url (push)
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->winCompat('git show-ref --head -d'),
-            $this->winCompat('git status --porcelain --untracked-files=no'),
-            $this->winCompat('git remote -v'),
-            [
-                'cmd' => $expectedGitUpdateCommand,
-                'return' => 1,
-            ],
-            [
-                'cmd' => $expectedGitUpdateCommand2,
-                'return' => 1,
-            ],
-            $this->winCompat('git --version'),
+            ['git', 'show-ref', '--head', '-d'],
+            ['git', 'status', '--porcelain', '--untracked-files=no'],
+
+            // commit not yet in so we try to fetch
+            ['cmd' => ['git', 'rev-parse', '--quiet', '--verify', 'ref^{commit}'], 'return' => 1],
+
+            // fail first fetch
+            ['git', 'remote', '-v'],
+            ['git', 'remote', 'set-url', 'composer', '--', 'https://github.com/composer/composer'],
+            ['cmd' => ['git', 'fetch', 'composer'], 'return' => 1],
+
+            // fail second fetch
+            ['git', 'remote', 'set-url', 'composer', '--', 'git@github.com:composer/composer'],
+            ['cmd' => ['git', 'fetch', 'composer'], 'return' => 1],
+
+            ['git', '--version'],
         ], true);
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
 
-        // not using PHPUnit's expected exception because Prophecy exceptions extend from RuntimeException too so it is not safe
-        try {
-            $downloader = $this->getDownloaderMock(null, new Config(), $process);
-            $downloader->download($packageMock, $this->workingDir, $packageMock);
-            $downloader->prepare('update', $packageMock, $this->workingDir, $packageMock);
-            $downloader->update($packageMock, $packageMock, $this->workingDir);
-            $downloader->cleanup('update', $packageMock, $this->workingDir, $packageMock);
-
-            $this->fail('This test should throw');
-        } catch (\RuntimeException $e) {
-            if ('RuntimeException' !== get_class($e)) {
-                throw $e;
-            }
-            self::assertEquals('RuntimeException', get_class($e));
-        }
+        self::expectException('RuntimeException');
+        self::expectExceptionMessage('Failed to clone https://github.com/composer/composer via https, ssh protocols, aborting.');
+        self::expectExceptionMessageMatches('{git@github\.com:composer/composer}');
+        $downloader = $this->getDownloaderMock(null, new Config(), $process);
+        $downloader->download($packageMock, $this->workingDir, $packageMock);
+        $downloader->prepare('update', $packageMock, $this->workingDir, $packageMock);
+        $downloader->update($packageMock, $packageMock, $this->workingDir);
+        $downloader->cleanup('update', $packageMock, $this->workingDir, $packageMock);
     }
 
     public function testUpdateDoesntThrowsRuntimeExceptionIfGitCommandFailsAtFirstButIsAbleToRecover(): void
     {
-        $expectedFirstGitUpdateCommand = $this->winCompat("(git remote set-url composer -- '".(Platform::isWindows() ? 'C:\\' : '/')."' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)) && git remote set-url composer -- '".(Platform::isWindows() ? 'C:\\' : '/')."'");
-        $expectedSecondGitUpdateCommand = $this->winCompat("(git remote set-url composer -- 'https://github.com/composer/composer' && git rev-parse --quiet --verify 'ref^{commit}' || (git fetch composer && git fetch --tags composer)) && git remote set-url composer -- 'https://github.com/composer/composer'");
-
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $packageMock->expects($this->any())
             ->method('getSourceReference')
@@ -491,22 +500,33 @@ composer https://github.com/old/url (push)
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            $this->winCompat('git show-ref --head -d'),
-            $this->winCompat('git status --porcelain --untracked-files=no'),
-            $this->winCompat('git remote -v'),
-            [
-                'cmd' => $expectedFirstGitUpdateCommand,
-                'return' => 1,
-            ],
-            $this->winCompat('git --version'),
-            $this->winCompat('git remote -v'),
-            [
-                'cmd' => $expectedSecondGitUpdateCommand,
-                'return' => 0,
-            ],
-            $this->winCompat('git branch -r'),
-            $this->winCompat("git checkout 'ref' -- && git reset --hard 'ref' --"),
-            $this->winCompat('git remote -v'),
+            ['git', 'show-ref', '--head', '-d'],
+            ['git', 'status', '--porcelain', '--untracked-files=no'],
+
+            // commit not yet in so we try to fetch
+            ['cmd' => ['git', 'rev-parse', '--quiet', '--verify', 'ref^{commit}'], 'return' => 1],
+
+            // fail first source URL
+            ['git', 'remote', '-v'],
+            ['git', 'remote', 'set-url', 'composer', '--', Platform::isWindows() ? 'C:\\' : '/'],
+            ['cmd' => ['git', 'fetch', 'composer'], 'return' => 1],
+            ['git', '--version'],
+
+            // commit not yet in so we try to fetch
+            ['cmd' => ['git', 'rev-parse', '--quiet', '--verify', 'ref^{commit}'], 'return' => 1],
+
+            // pass second source URL
+            ['git', 'remote', '-v'],
+            ['git', 'remote', 'set-url', 'composer', '--', 'https://github.com/composer/composer'],
+            ['cmd' => ['git', 'fetch', 'composer'], 'return' => 0],
+            ['git', 'fetch', '--tags', 'composer'],
+            ['git', 'remote', '-v'],
+            ['git', 'remote', 'set-url', 'composer', '--', 'https://github.com/composer/composer'],
+
+            ['git', 'branch', '-r'],
+            ['git', 'checkout', 'ref', '--'],
+            ['git', 'reset', '--hard', 'ref', '--'],
+            ['git', 'remote', '-v'],
         ], true);
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
@@ -609,13 +629,11 @@ composer https://github.com/old/url (push)
 
     public function testRemove(): void
     {
-        $expectedGitResetCommand = $this->winCompat("git status --porcelain --untracked-files=no");
-
         $packageMock = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
         $process = $this->getProcessExecutorMock();
         $process->expects([
             ['git', 'show-ref', '--head', '-d'],
-            $expectedGitResetCommand,
+            ['git', 'status', '--porcelain', '--untracked-files=no'],
         ], true);
 
         $this->fs->ensureDirectoryExists($this->workingDir.'/.git');
@@ -637,17 +655,5 @@ composer https://github.com/old/url (push)
         $downloader = $this->getDownloaderMock();
 
         self::assertEquals('source', $downloader->getInstallationSource());
-    }
-
-    private function winCompat(string $cmd): string
-    {
-        if (Platform::isWindows()) {
-            $cmd = str_replace('cd ', 'cd /D ', $cmd);
-            $cmd = str_replace('composerPath', Platform::getCwd().'/composerPath', $cmd);
-
-            return self::getCmd($cmd);
-        }
-
-        return $cmd;
     }
 }

--- a/tests/Composer/Test/Downloader/HgDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/HgDownloaderTest.php
@@ -76,8 +76,8 @@ class HgDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            self::getCmd('hg clone -- \'https://mercurial.dev/l3l0/composer\' \''.$this->workingDir.'\''),
-            self::getCmd('hg up -- \'ref\''),
+            ['hg', 'clone', '--', 'https://mercurial.dev/l3l0/composer', $this->workingDir],
+            ['hg', 'up', '--', 'ref'],
         ], true);
 
         $downloader = $this->getDownloaderMock(null, null, $process);
@@ -117,8 +117,9 @@ class HgDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            self::getCmd('hg st'),
-            self::getCmd("hg pull -- 'https://github.com/l3l0/composer' && hg up -- 'ref'"),
+            ['hg', 'st'],
+            ['hg', 'pull', '--', 'https://github.com/l3l0/composer'],
+            ['hg', 'up', '--', 'ref'],
         ], true);
 
         $downloader = $this->getDownloaderMock(null, null, $process);
@@ -135,7 +136,7 @@ class HgDownloaderTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            self::getCmd('hg st'),
+            ['hg', 'st'],
         ], true);
 
         $filesystem = $this->getMockBuilder('Composer\Util\Filesystem')->getMock();

--- a/tests/Composer/Test/Mock/ProcessExecutorMock.php
+++ b/tests/Composer/Test/Mock/ProcessExecutorMock.php
@@ -57,16 +57,16 @@ class ProcessExecutorMock extends ProcessExecutor
     }
 
     /**
-     * @param array<string|array{cmd: string|list<string>, return?: int, stdout?: string, stderr?: string, callback?: callable}> $expectations
+     * @param array<string|non-empty-list<string>|array{cmd: string|non-empty-list<string>, return?: int, stdout?: string, stderr?: string, callback?: callable}> $expectations
      * @param bool                                                                                                               $strict         set to true if you want to provide *all* expected commands, and not just a subset you are interested in testing
      * @param array{return: int, stdout?: string, stderr?: string}                                                               $defaultHandler default command handler for undefined commands if not in strict mode
      */
     public function expects(array $expectations, bool $strict = false, array $defaultHandler = ['return' => 0, 'stdout' => '', 'stderr' => '']): void
     {
-        /** @var array{cmd: string|list<string>, return: int, stdout: string, stderr: string, callback: callable|null} $default */
+        /** @var array{cmd: string|non-empty-list<string>, return: int, stdout: string, stderr: string, callback: callable|null} $default */
         $default = ['cmd' => '', 'return' => 0, 'stdout' => '', 'stderr' => '', 'callback' => null];
         $this->expectations = array_map(static function ($expect) use ($default): array {
-            if (is_string($expect)) {
+            if (is_string($expect) || array_is_list($expect)) {
                 $command = $expect;
                 $expect = $default;
                 $expect['cmd'] = $command;

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -36,11 +36,11 @@ class VersionGuesserTest extends TestCase
         $process = $this->getProcessExecutorMock();
         $process->expects([
             ['cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'], 'return' => 128],
-            ['cmd' => 'git describe --exact-match --tags', 'return' => 128],
-            ['cmd' => 'git log --pretty="%H" -n1 HEAD'.GitUtil::getNoShowSignatureFlag($process), 'return' => 128],
-            ['cmd' => 'hg branch', 'return' => 0, 'stdout' => $branch],
-            ['cmd' => 'hg branches', 'return' => 0],
-            ['cmd' => 'hg bookmarks', 'return' => 0],
+            ['cmd' => ['git', 'describe', '--exact-match', '--tags'], 'return' => 128],
+            ['cmd' => array_merge(['git log', '--pretty=%H', '-n1', 'HEAD'], GitUtil::getNoShowSignatureFlags($process)), 'return' => 128],
+            ['cmd' => ['hg', 'branch'], 'return' => 0, 'stdout' => $branch],
+            ['cmd' => ['hg', 'branches'], 'return' => 0],
+            ['cmd' => ['hg', 'bookmarks'], 'return' => 0],
         ], true);
 
         GitUtil::getVersion(new ProcessExecutor);

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -37,7 +37,7 @@ class VersionGuesserTest extends TestCase
         $process->expects([
             ['cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'], 'return' => 128],
             ['cmd' => ['git', 'describe', '--exact-match', '--tags'], 'return' => 128],
-            ['cmd' => array_merge(['git log', '--pretty=%H', '-n1', 'HEAD'], GitUtil::getNoShowSignatureFlags($process)), 'return' => 128],
+            ['cmd' => array_merge(['git', 'log', '--pretty=%H', '-n1', 'HEAD'], GitUtil::getNoShowSignatureFlags($process)), 'return' => 128],
             ['cmd' => ['hg', 'branch'], 'return' => 0, 'stdout' => $branch],
             ['cmd' => ['hg', 'branches'], 'return' => 0],
             ['cmd' => ['hg', 'bookmarks'], 'return' => 0],
@@ -201,7 +201,7 @@ class VersionGuesserTest extends TestCase
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* (no branch) $commitHash Commit message\n",
             ],
-            'git describe --exact-match --tags',
+            ['git', 'describe', '--exact-match', '--tags'],
         ], true);
 
         $config = new Config;
@@ -223,7 +223,7 @@ class VersionGuesserTest extends TestCase
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* (HEAD detached at FETCH_HEAD) $commitHash Commit message\n",
             ],
-            'git describe --exact-match --tags',
+            ['git', 'describe', '--exact-match', '--tags'],
         ], true);
 
         $config = new Config;
@@ -245,7 +245,7 @@ class VersionGuesserTest extends TestCase
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* (HEAD detached at 03a15d220) $commitHash Commit message\n",
             ],
-            'git describe --exact-match --tags',
+            ['git', 'describe', '--exact-match', '--tags'],
         ], true);
 
         $config = new Config;
@@ -266,7 +266,7 @@ class VersionGuesserTest extends TestCase
                 'stdout' => "* (HEAD detached at v2.0.5-alpha2) 433b98d4218c181bae01865901aac045585e8a1a Commit message\n",
             ],
             [
-                'cmd' => 'git describe --exact-match --tags',
+                'cmd' => ['git', 'describe', '--exact-match', '--tags'],
                 'stdout' => "v2.0.5-alpha2",
             ],
         ], true);
@@ -289,7 +289,7 @@ class VersionGuesserTest extends TestCase
                 'stdout' => "* (HEAD detached at 1.0.0) c006f0c12bbbf197b5c071ffb1c0e9812bb14a4d Commit message\n",
             ],
             [
-                'cmd' => 'git describe --exact-match --tags',
+                'cmd' => ['git', 'describe', '--exact-match', '--tags'],
                 'stdout' => '1.0.0',
             ],
         ], true);

--- a/tests/Composer/Test/Repository/Vcs/GitDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitDriverTest.php
@@ -72,7 +72,7 @@ GIT;
 
         $process
             ->expects([[
-                'cmd' => 'git branch --no-color',
+                'cmd' => ['git', 'branch', '--no-color'],
                 'stdout' => $stdout,
             ]], true);
 
@@ -102,11 +102,17 @@ GIT;
 
         $process
             ->expects([[
-                'cmd' => 'git remote -v',
+                'cmd' => ['git', 'remote', '-v'],
                 'stdout' => '',
             ], [
-                'cmd' => Platform::isWindows() ? "git remote set-url origin -- https://example.org/acme.git && git remote show origin && git remote set-url origin -- https://example.org/acme.git" : "git remote set-url origin -- 'https://example.org/acme.git' && git remote show origin && git remote set-url origin -- 'https://example.org/acme.git'",
+                'cmd' => ['git', 'remote', 'set-url', 'origin', '--', 'https://example.org/acme.git'],
+                'stdout' => '',
+            ], [
+                'cmd' => ['git', 'remote', 'show', 'origin'],
                 'stdout' => $stdout,
+            ], [
+                'cmd' => ['git', 'remote', 'set-url', 'origin', '--', 'https://example.org/acme.git'],
+                'stdout' => '',
             ]]);
 
         self::assertSame('main', $driver->getRootIdentifier());
@@ -130,7 +136,7 @@ GIT;
 
         $process
             ->expects([[
-                'cmd' => 'git branch --no-color',
+                'cmd' => ['git', 'branch', '--no-color'],
                 'stdout' => $stdout,
             ]]);
 
@@ -155,7 +161,7 @@ GIT;
 
         $process
             ->expects([[
-                'cmd' => 'git branch --no-color --no-abbrev -v',
+                'cmd' => ['git', 'branch', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => $stdout,
             ]]);
 

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -303,18 +303,18 @@ class GitHubDriverTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
-            ['cmd' => 'git config github.accesstoken', 'return' => 1],
-            'git clone --mirror -- '.ProcessExecutor::escape($repoSshUrl).' '.ProcessExecutor::escape($this->config->get('cache-vcs-dir').'/git-github.com-composer-packagist.git/'),
+            ['cmd' => ['git', 'config', 'github.accesstoken'], 'return' => 1],
+            ['git', 'clone', '--mirror', '--', $repoSshUrl, $this->config->get('cache-vcs-dir').'/git-github.com-composer-packagist.git/'],
             [
-                'cmd' => 'git show-ref --tags --dereference',
+                'cmd' => ['git', 'show-ref', '--tags', '--dereference'],
                 'stdout' => $sha.' refs/tags/'.$identifier,
             ],
             [
-                'cmd' => 'git branch --no-color --no-abbrev -v',
+                'cmd' => ['git', 'branch', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => '  test_master     edf93f1fccaebd8764383dc12016d0a1a9672d89 Fix test & behavior',
             ],
             [
-                'cmd' => 'git branch --no-color',
+                'cmd' => ['git', 'branch', '--no-color'],
                 'stdout' => '* test_master',
             ],
         ], true);

--- a/tests/Composer/Test/Repository/Vcs/HgDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/HgDriverTest.php
@@ -85,10 +85,10 @@ HG_BOOKMARKS;
 
         $process
             ->expects([[
-                'cmd' => 'hg branches',
+                'cmd' => ['hg', 'branches'],
                 'stdout' => $stdout,
             ], [
-                'cmd' => 'hg bookmarks',
+                'cmd' => ['hg', 'bookmarks'],
                 'stdout' => $stdout1,
             ]]);
 

--- a/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
@@ -60,12 +60,7 @@ class SvnDriverTest extends TestCase
         $output .= " rejected Basic challenge (https://corp.svn.local/)";
 
         $process = $this->getProcessExecutorMock();
-        $authedCommand = sprintf(
-            'svn ls --verbose --non-interactive  --username %s --password %s  -- %s',
-            ProcessExecutor::escape('till'),
-            ProcessExecutor::escape('secret'),
-            ProcessExecutor::escape('https://till:secret@corp.svn.local/repo/trunk')
-        );
+        $authedCommand = ['svn', 'ls', '--verbose', '--non-interactive', '--username', 'till', '--password', 'secret', '--', 'https://till:secret@corp.svn.local/repo/trunk'];
         $process->expects([
             ['cmd' => $authedCommand, 'return' => 1, 'stderr' => $output],
             ['cmd' => $authedCommand, 'return' => 1, 'stderr' => $output],
@@ -73,7 +68,7 @@ class SvnDriverTest extends TestCase
             ['cmd' => $authedCommand, 'return' => 1, 'stderr' => $output],
             ['cmd' => $authedCommand, 'return' => 1, 'stderr' => $output],
             ['cmd' => $authedCommand, 'return' => 1, 'stderr' => $output],
-            ['cmd' => 'svn --version', 'return' => 0, 'stdout' => '1.2.3'],
+            ['cmd' => ['svn', '--version'], 'return' => 0, 'stdout' => '1.2.3'],
         ], true);
 
         $repoConfig = [

--- a/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
@@ -60,7 +60,7 @@ class SvnDriverTest extends TestCase
         $output .= " rejected Basic challenge (https://corp.svn.local/)";
 
         $process = $this->getProcessExecutorMock();
-        $authedCommand = 'svn ls --verbose --non-interactive  --username '.ProcessExecutor::escape('till').' --password '.ProcessExecutor::escape('secret').'  -- '.ProcessExecutor::escape('https://till:secret@corp.svn.local/repo/trunk');
+        $authedCommand = ['svn', 'ls', '--verbose', '--non-interactive', '--username', 'till', '--password', 'secret', '--', 'https://till:secret@corp.svn.local/repo/trunk'];
         $process->expects([
             ['cmd' => $authedCommand, 'return' => 1, 'stderr' => $output],
             ['cmd' => $authedCommand, 'return' => 1, 'stderr' => $output],

--- a/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
@@ -60,7 +60,7 @@ class SvnDriverTest extends TestCase
         $output .= " rejected Basic challenge (https://corp.svn.local/)";
 
         $process = $this->getProcessExecutorMock();
-        $authedCommand = ['svn', 'ls', '--verbose', '--non-interactive', '--username', 'till', '--password', 'secret', '--', 'https://till:secret@corp.svn.local/repo/trunk'];
+        $authedCommand = 'svn ls --verbose --non-interactive  --username '.ProcessExecutor::escape('till').' --password '.ProcessExecutor::escape('secret').'  -- '.ProcessExecutor::escape('https://till:secret@corp.svn.local/repo/trunk');
         $process->expects([
             ['cmd' => $authedCommand, 'return' => 1, 'stderr' => $output],
             ['cmd' => $authedCommand, 'return' => 1, 'stderr' => $output],

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -155,7 +155,7 @@ class GitTest extends TestCase
             // When we are testing what happens without auth saved, and URLs
             // with https, there will also be an attempt to find the token in
             // the git config for the folder and repo, locally.
-            $additional_calls = array_fill(0, $bitbucket_git_auth_calls, ['cmd' => 'git config bitbucket.accesstoken', 'return' => 1]);
+            $additional_calls = array_fill(0, $bitbucket_git_auth_calls, ['cmd' => ['git', 'config', 'bitbucket.accesstoken'], 'return' => 1]);
             foreach ($additional_calls as $call) {
                 $expectedCalls[] = $call;
             }
@@ -206,7 +206,7 @@ class GitTest extends TestCase
         if (count($initial_config) > 0) {
             $expectedCalls[] = ['cmd' => 'git command failing', 'return' => 1];
         } else {
-            $expectedCalls[] = ['cmd' => 'git config bitbucket.accesstoken', 'return' => 1];
+            $expectedCalls[] = ['cmd' => ['git', 'config', 'bitbucket.accesstoken'], 'return' => 1];
         }
         $expectedCalls[] = ['cmd' => 'git command ok', 'return' => 0];
         $this->process->expects($expectedCalls, true);

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -82,7 +82,7 @@ class GitTest extends TestCase
 
         $this->process->expects([
             ['cmd' => 'git command', 'return' => 1],
-            ['cmd' => 'git --version', 'return' => 0],
+            ['cmd' => ['git', '--version'], 'return' => 0],
         ], true);
 
         $this->git->runCommand($commandCallable, 'https://github.com/acme/repo', null, true);

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -57,6 +57,7 @@ class GitTest extends TestCase
 
         $this->process->expects(['git command'], true);
 
+        // @phpstan-ignore method.deprecated
         $this->git->runCommand($commandCallable, 'https://github.com/acme/repo', null, true);
     }
 
@@ -85,6 +86,7 @@ class GitTest extends TestCase
             ['cmd' => ['git', '--version'], 'return' => 0],
         ], true);
 
+        // @phpstan-ignore method.deprecated
         $this->git->runCommand($commandCallable, 'https://github.com/acme/repo', null, true);
     }
 
@@ -124,6 +126,7 @@ class GitTest extends TestCase
             ->with($this->equalTo('github.com'))
             ->willReturn(['username' => 'token', 'password' => $gitHubToken]);
 
+        // @phpstan-ignore method.deprecated
         $this->git->runCommand($commandCallable, $gitUrl, null, true);
     }
 
@@ -177,6 +180,7 @@ class GitTest extends TestCase
                 ->with($this->equalTo('bitbucket.org'))
                 ->willReturn(['username' => 'token', 'password' => $bitbucketToken]);
         }
+        // @phpstan-ignore method.deprecated
         $this->git->runCommand($commandCallable, $gitUrl, null, true);
     }
 
@@ -259,6 +263,7 @@ class GitTest extends TestCase
             ['url' => 'https://bitbucket.org/site/oauth2/access_token', 'status' => 200, 'body' => '{"expires_in": 600, "access_token": "my-access-token"}']
         ]);
         $this->git->setHttpDownloader($downloader_mock);
+        // @phpstan-ignore method.deprecated
         $this->git->runCommand($commandCallable, $gitUrl, null, true);
     }
 

--- a/tests/Composer/Test/Util/PerforceTest.php
+++ b/tests/Composer/Test/Util/PerforceTest.php
@@ -561,7 +561,9 @@ class PerforceTest extends TestCase
     public function testCheckServerExists(): void
     {
         $this->processExecutor->expects(
-            ['p4 -p '.ProcessExecutor::escape('perforce.does.exist:port').' info -s'],
+            [
+                ['p4', '-p', 'perforce.does.exist:port', 'info', '-s']
+            ],
             true
         );
 
@@ -578,7 +580,7 @@ class PerforceTest extends TestCase
     {
         $processExecutor = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
 
-        $expectedCommand = 'p4 -p '.ProcessExecutor::escape('perforce.does.exist:port').' info -s';
+        $expectedCommand = ['p4', '-p', 'perforce.does.exist:port', 'info', '-s'];
         $processExecutor->expects($this->once())
             ->method('execute')
             ->with($this->equalTo($expectedCommand), $this->equalTo(null))

--- a/tests/Composer/Test/Util/SvnTest.php
+++ b/tests/Composer/Test/Util/SvnTest.php
@@ -23,14 +23,14 @@ class SvnTest extends TestCase
      * Test the credential string.
      *
      * @param string $url    The SVN url.
-     * @param string $expect The expectation for the test.
+     * @param non-empty-list<string> $expect The expectation for the test.
      *
      * @dataProvider urlProvider
      */
-    public function testCredentials(string $url, string $expect): void
+    public function testCredentials(string $url, array $expect): void
     {
         $svn = new Svn($url, new NullIO, new Config());
-        $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialString');
+        $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialArgs');
         $reflMethod->setAccessible(true);
 
         self::assertEquals($expect, $reflMethod->invoke($svn));
@@ -39,9 +39,9 @@ class SvnTest extends TestCase
     public static function urlProvider(): array
     {
         return [
-            ['http://till:test@svn.example.org/', self::getCmd(" --username 'till' --password 'test' ")],
-            ['http://svn.apache.org/', ''],
-            ['svn://johndoe@example.org', self::getCmd(" --username 'johndoe' --password '' ")],
+            ['http://till:test@svn.example.org/', ['--username', 'till', '--password', 'test']],
+            ['http://svn.apache.org/', []],
+            ['svn://johndoe@example.org', ['--username', 'johndoe', '--password', '']],
         ];
     }
 
@@ -54,8 +54,8 @@ class SvnTest extends TestCase
         $reflMethod->setAccessible(true);
 
         self::assertEquals(
-            self::getCmd("svn ls --non-interactive  -- 'http://svn.example.org'"),
-            $reflMethod->invokeArgs($svn, ['svn ls', $url])
+            ['svn', 'ls', '--non-interactive', '--', 'http://svn.example.org'],
+            $reflMethod->invokeArgs($svn, [['svn', 'ls'], $url])
         );
     }
 
@@ -73,10 +73,10 @@ class SvnTest extends TestCase
         ]);
 
         $svn = new Svn($url, new NullIO, $config);
-        $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialString');
+        $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialArgs');
         $reflMethod->setAccessible(true);
 
-        self::assertEquals(self::getCmd(" --username 'foo' --password 'bar' "), $reflMethod->invoke($svn));
+        self::assertEquals(['--username', 'foo', '--password', 'bar'], $reflMethod->invoke($svn));
     }
 
     public function testCredentialsFromConfigWithCacheCredentialsTrue(): void
@@ -96,10 +96,10 @@ class SvnTest extends TestCase
 
         $svn = new Svn($url, new NullIO, $config);
         $svn->setCacheCredentials(true);
-        $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialString');
+        $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialArgs');
         $reflMethod->setAccessible(true);
 
-        self::assertEquals(self::getCmd(" --username 'foo' --password 'bar' "), $reflMethod->invoke($svn));
+        self::assertEquals(['--username', 'foo', '--password', 'bar'], $reflMethod->invoke($svn));
     }
 
     public function testCredentialsFromConfigWithCacheCredentialsFalse(): void
@@ -119,9 +119,9 @@ class SvnTest extends TestCase
 
         $svn = new Svn($url, new NullIO, $config);
         $svn->setCacheCredentials(false);
-        $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialString');
+        $reflMethod = new \ReflectionMethod('Composer\\Util\\Svn', 'getCredentialArgs');
         $reflMethod->setAccessible(true);
 
-        self::assertEquals(self::getCmd(" --no-auth-cache --username 'foo' --password 'bar' "), $reflMethod->invoke($svn));
+        self::assertEquals(['--no-auth-cache', '--username', 'foo', '--password', 'bar'], $reflMethod->invoke($svn));
     }
 }


### PR DESCRIPTION
Windows always looks up in the current directory when searching for a binary.
This is risky practice, so this PR tries to prevent this by using ExecutableFinder instead (which looks up using the PATH only).

While at it, I replaced all string command lines by array commands. This removed the need for explicit argument escaping.
Some remain, but most are removed.