### PR TITLE
feat: allow optional path repository

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -930,7 +930,8 @@
                 "options": {
                     "type": "object",
                     "properties": {
-                        "symlink": { "type": ["boolean", "null"] }
+                        "symlink": { "type": ["boolean", "null"] },
+                        "optional": { "type":  "boolean" }
                     },
                     "additionalProperties": true
                 }

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -105,7 +105,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
     /**
      * Initializes path repository.
      *
-     * @param array{url?: string, options?: array{symlink?: bool, reference?: string, relative?: bool, versions?: array<string, string>}} $repoConfig
+     * @param array{url?: string, options?: array{symlink?: bool, reference?: string, relative?: bool, versions?: array<string, string>, optional?: bool}} $repoConfig
      */
     public function __construct(array $repoConfig, IOInterface $io, Config $config, ?HttpDownloader $httpDownloader = null, ?EventDispatcher $dispatcher = null, ?ProcessExecutor $process = null)
     {
@@ -158,6 +158,10 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
                 if (is_dir($url)) {
                     return;
                 }
+            }
+
+            if (array_key_exists('optional', $this->options) && $this->options['optional'] === true) {
+                return;
             }
 
             throw new \RuntimeException('The `url` supplied for the path (' . $this->url . ') repository does not exist');

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -161,6 +161,13 @@ class PathRepositoryTest extends TestCase
         }
     }
 
+    public function testLoadPackageFromFileSystemWithIncorrectPathButOptional(): void
+    {
+        $repositoryUrl = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'missing']);
+        $repository = $this->createPathRepo(['url' => $repositoryUrl, 'options' => ['optional' => true]]);
+        self::assertEmpty($repository->getPackages());
+    }
+
     /**
      * @param array<mixed> $options
      */


### PR DESCRIPTION
allows a path repository to be optional non failing when the path is not there.

https://github.com/composer/composer/issues/12175