### PR TITLE
GitLab: adjust links to profile/user-settings for personal access token and application

### DIFF
--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -264,7 +264,7 @@ php composer.phar config [--global] --editor --auth
 > **Note:** For the gitlab authentication to work on private gitlab instances, the
 > [`gitlab-domains`](../06-config.md#gitlab-domains) section should also contain the URL.
 
-To create a new access token, go to your [access tokens section on GitLab](https://gitlab.com/-/profile/personal_access_tokens)
+To create a new access token, go to your [access tokens section on GitLab](https://gitlab.com/-/user_settings/personal_access_tokens)
 (or the equivalent URL on your private instance) and create a new token. See also [the GitLab access token documentation](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#creating-a-personal-access-token) for more information.
 
 When creating a gitlab token manually, make sure it has either the `read_api` or `api` scope.

--- a/src/Composer/Util/GitLab.php
+++ b/src/Composer/Util/GitLab.php
@@ -126,8 +126,8 @@ class GitLab
         }
 
         $localAuthConfig = $this->config->getLocalAuthConfigSource();
-        $personalAccessTokenLink = $scheme.'://'.$originUrl.'/-/profile/personal_access_tokens';
-        $revokeLink = $scheme.'://'.$originUrl.'/-/profile/applications';
+        $personalAccessTokenLink = $scheme.'://'.$originUrl.'/-/user_settings/personal_access_tokens';
+        $revokeLink = $scheme.'://'.$originUrl.'/-/user_settings/applications';
         $this->io->writeError(sprintf('A token will be created and stored in "%s", your password will never be stored', ($localAuthConfig !== null ? $localAuthConfig->getName() . ' OR ' : '') . $this->config->getAuthConfigSource()->getName()));
         $this->io->writeError('To revoke access to this token you can visit:');
         $this->io->writeError($revokeLink);
@@ -312,7 +312,7 @@ class GitLab
 
         $token = $this->httpDownloader->get($scheme.'://'.$originUrl.'/oauth/token', $options)->decodeJson();
         $this->io->writeError('GitLab token successfully refreshed', true, IOInterface::VERY_VERBOSE);
-        $this->io->writeError('To revoke access to this token you can visit '.$scheme.'://'.$originUrl.'/-/profile/applications', true, IOInterface::VERY_VERBOSE);
+        $this->io->writeError('To revoke access to this token you can visit '.$scheme.'://'.$originUrl.'/-/user_settings/applications', true, IOInterface::VERY_VERBOSE);
 
         return $token;
     }


### PR DESCRIPTION
GitLab changed their URL schema and have of their profile pages are now user-settings page. The personal access token one doesn't have a redirect in place, the application one still does.


<img width="780" alt="Screenshot 2024-11-20 at 17 14 48" src="https://github.com/user-attachments/assets/0c734fc3-200f-477a-8cdc-9bbfb5c1e50b">
