### PR TITLE
Add build-path to php-ext config options for PIE

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -317,6 +317,12 @@
                     "example": false,
                     "default": true
                 },
+                "build-path": {
+                    "type": ["string", "null"],
+                    "description": "If specified, this is the subdirectory that will be used to build the extension instead of the root of the project.",
+                    "example": "my-extension-source",
+                    "default": null
+                },
                 "configure-options": {
                     "type": "array",
                     "description": "These configure options make up the flags that can be passed to ./configure when installing the extension.",

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -99,7 +99,10 @@ class Package extends BasePackage
     protected $isDefaultBranch = false;
     /** @var mixed[] */
     protected $transportOptions = [];
-    /** @var PhpExtConfig */
+    /**
+     * @var array|null
+     * @phpstan-var PhpExtConfig|null
+     */
     protected $phpExt = null;
 
     /**
@@ -596,7 +599,9 @@ class Package extends BasePackage
     /**
      * Sets the settings for php extension packages
      *
-     * @param PhpExtConfig $phpExt
+     * @param array|null $phpExt
+     *
+     * @phpstan-param PhpExtConfig|null $phpExt
      */
     public function setPhpExt(?array $phpExt): void
     {

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -23,6 +23,7 @@ use Composer\Util\ComposerMirror;
  *
  * @phpstan-import-type AutoloadRules from PackageInterface
  * @phpstan-import-type DevAutoloadRules from PackageInterface
+ * @phpstan-import-type PhpExtConfig from PackageInterface
  */
 class Package extends BasePackage
 {
@@ -98,7 +99,7 @@ class Package extends BasePackage
     protected $isDefaultBranch = false;
     /** @var mixed[] */
     protected $transportOptions = [];
-    /** @var array{priority?: int, configure-options?: list<array{name: string, description?: string}>}|null */
+    /** @var PhpExtConfig */
     protected $phpExt = null;
 
     /**
@@ -593,9 +594,9 @@ class Package extends BasePackage
     }
 
     /**
-     * Sets the list of paths added to PHP's include path.
+     * Sets the settings for php extension packages
      *
-     * @param array{extension-name?: string, priority?: int, support-zts?: bool, support-nts?: bool, configure-options?: list<array{name: string, description?: string}>}|null $phpExt List of directories.
+     * @param PhpExtConfig $phpExt
      */
     public function setPhpExt(?array $phpExt): void
     {

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -23,6 +23,7 @@ use Composer\Repository\RepositoryInterface;
  *
  * @phpstan-type AutoloadRules    array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
  * @phpstan-type DevAutoloadRules array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>}
+ * @phpstan-type PhpExtConfig     array{extension-name?: string, priority?: int, support-zts?: bool, support-nts?: bool, build-path?: string|null, configure-options?: list<array{name: string, description?: string}>}|null
  */
 interface PackageInterface
 {
@@ -326,7 +327,7 @@ interface PackageInterface
     /**
      * Returns the settings for php extension packages
      *
-     * @return array{extension-name?: string, priority?: int, support-zts?: bool, support-nts?: bool, configure-options?: list<array{name: string, description?: string}>}|null
+     * @return PhpExtConfig
      */
     public function getPhpExt(): ?array;
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -23,7 +23,7 @@ use Composer\Repository\RepositoryInterface;
  *
  * @phpstan-type AutoloadRules    array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
  * @phpstan-type DevAutoloadRules array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>}
- * @phpstan-type PhpExtConfig     array{extension-name?: string, priority?: int, support-zts?: bool, support-nts?: bool, build-path?: string|null, configure-options?: list<array{name: string, description?: string}>}|null
+ * @phpstan-type PhpExtConfig     array{extension-name?: string, priority?: int, support-zts?: bool, support-nts?: bool, build-path?: string|null, configure-options?: list<array{name: string, description?: string}>}
  */
 interface PackageInterface
 {
@@ -327,7 +327,9 @@ interface PackageInterface
     /**
      * Returns the settings for php extension packages
      *
-     * @return PhpExtConfig
+     * @return array|null
+     *
+     * @phpstan-return PhpExtConfig|null
      */
     public function getPhpExt(): ?array;
 


### PR DESCRIPTION
Adds `build-path` option for :pie: PIE - refs ThePHPF/pie-design#28

Also made the definition for the `php-ext` shape re-usable to avoid copy/pasta errors in future