### PR TITLE
Suppress E_DEPRECATED for PHP 8.4 compatibility

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -18,7 +18,9 @@ use Composer\XdebugHandler\XdebugHandler;
 use Composer\Util\Platform;
 use Composer\Util\ErrorHandler;
 
-error_reporting(-1);
+// no E_DEPRECATED for this LTS series, or we get countless deprecation notices related to E_STRICT and explicit nullable types for PHP 8.4+
+// also see ErrorHandler::register()
+error_reporting(E_ALL & ~E_DEPRECATED);
 
 // Restart without Xdebug
 $xdebug = new XdebugHandler('Composer');

--- a/src/Composer/Util/ErrorHandler.php
+++ b/src/Composer/Util/ErrorHandler.php
@@ -89,7 +89,9 @@ class ErrorHandler
     public static function register(IOInterface $io = null)
     {
         set_error_handler(array(__CLASS__, 'handle'));
-        error_reporting(E_ALL | E_STRICT);
+        // no E_DEPRECATED for this LTS series, or we get countless deprecation notices related to E_STRICT and explicit nullable types for PHP 8.4+
+        // also see bin/composer
+        error_reporting(E_ALL & ~E_DEPRECATED | E_STRICT);
         self::$io = $io;
     }
 }


### PR DESCRIPTION
The `E_STRICT` constant is deprecated in PHP 8.4, and explicit nullable types are also advised with a deprecation notice.

As there are circumstances where people still have to run the 2.2 LTS with newer versions of PHP, we're now suppressing `E_DEPRECATED` (especially because some of the deprecation warnings may end up on stdout due to `display_errors` getting set to `1` in `bin/composer`).

Also see #12214

Targeting 2.2 as discussed in https://github.com/composer/composer/issues/12214#issuecomment-2504292057