### PR TITLE
Fix bug when plugin defines multiple PluginInterface classes

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -51,9 +51,9 @@ class PluginManager
     protected $disablePlugins = false;
 
     /** @var array<PluginInterface> */
-    protected $plugins = array();
-    /** @var array<string, PluginInterface|InstallerInterface> */
-    protected $registeredPlugins = array();
+    protected $plugins = [];
+    /** @var array<string, array<PluginInterface|InstallerInterface>> */
+    protected $registeredPlugins = [];
 
     /**
      * @var array<non-empty-string, bool>|null
@@ -210,6 +210,7 @@ class PluginManager
         if (isset($this->registeredPlugins[$package->getName()])) {
             return;
         }
+        $this->registeredPlugins[$package->getName()] = [];
 
         $extra = $package->getExtra();
         if (empty($extra['class'])) {
@@ -295,14 +296,14 @@ class PluginManager
                 $this->io->writeError('<warning>Loading "'.$package->getName() . '" '.($isGlobalPlugin ? '(installed globally) ' : '').'which is a legacy composer-installer built for Composer 1.x, it is likely to cause issues as you are running Composer 2.x.</warning>');
                 $installer = new $class($this->io, $this->composer);
                 $this->composer->getInstallationManager()->addInstaller($installer);
-                $this->registeredPlugins[$package->getName()] = $installer;
+                $this->registeredPlugins[$package->getName()][] = $installer;
             } elseif (class_exists($class)) {
                 if (!is_a($class, 'Composer\Plugin\PluginInterface', true)) {
                     throw new \RuntimeException('Could not activate plugin "'.$package->getName().'" as "'.$class.'" does not implement Composer\Plugin\PluginInterface');
                 }
                 $plugin = new $class();
                 $this->addPlugin($plugin, $isGlobalPlugin, $package);
-                $this->registeredPlugins[$package->getName()] = $plugin;
+                $this->registeredPlugins[$package->getName()][] = $plugin;
             } elseif ($failOnMissingClasses) {
                 throw new \UnexpectedValueException('Plugin '.$package->getName().' could not be initialized, class not found: '.$class);
             }
@@ -327,13 +328,15 @@ class PluginManager
             return;
         }
 
-        $plugin = $this->registeredPlugins[$package->getName()];
-        unset($this->registeredPlugins[$package->getName()]);
-        if ($plugin instanceof InstallerInterface) {
-            $this->composer->getInstallationManager()->removeInstaller($plugin);
-        } else {
-            $this->removePlugin($plugin);
+        $plugins = $this->registeredPlugins[$package->getName()];
+        foreach ($plugins as $plugin) {
+            if ($plugin instanceof InstallerInterface) {
+                $this->composer->getInstallationManager()->removeInstaller($plugin);
+            } else {
+                $this->removePlugin($plugin);
+            }
         }
+        unset($this->registeredPlugins[$package->getName()]);
     }
 
     /**
@@ -354,14 +357,16 @@ class PluginManager
             return;
         }
 
-        $plugin = $this->registeredPlugins[$package->getName()];
-        if ($plugin instanceof InstallerInterface) {
-            $this->deactivatePackage($package);
-        } else {
-            unset($this->registeredPlugins[$package->getName()]);
-            $this->removePlugin($plugin);
-            $this->uninstallPlugin($plugin);
+        $plugins = $this->registeredPlugins[$package->getName()];
+        foreach ($plugins as $plugin) {
+            if ($plugin instanceof InstallerInterface) {
+                $this->composer->getInstallationManager()->removeInstaller($plugin);
+            } else {
+                $this->removePlugin($plugin);
+                $this->uninstallPlugin($plugin);
+            }
         }
+        unset($this->registeredPlugins[$package->getName()]);
     }
 
     /**


### PR DESCRIPTION
I have a composer plugin that defines multiple `PluginInterface` classes in `composer.json` as mentioned in the [docs](https://getcomposer.org/doc/articles/plugins.md#plugin-package).

However, there is a bug when upgrading between versions of the plugin when there are multiple classes defined.

For example, assume this is the `composer.json` in version 1.0.0.

```json
{
    "name": "my/plugin",
    "version": "1.0.0",
    "autoload": {
        "psr-4": {
            "MyNamespace\\": "src/"
        }
    },
    "extra": {
        "class": [
            "MyNamespace\\FirstPlugin",
            "MyNamespace\\SecondPlugin",
            "MyNamespace\\ThirdPlugin"
        ]
    }
}
```

And then in 2.0.0, we consolidate the functionality into one single class:

```json
{
    "name": "my/plugin",
    "version": "2.0.0",
    "autoload": {
        "psr-4": {
            "MyNamespace\\": "src/"
        }
    },
    "extra": {
        "class": [
            "MyNamespace\\ConsolidatedPlugin"
        ]
    }
}
```


When we run `composer update`, the 1.0.0 package is activated before it's removed, but only a reference to `ThirdPlugin` will be kept in `$this->registeredPlugins[$package->getName()]`, and so only `ThirdPlugin` is deactivated.

Thus `FirstPlugin` and `SecondPlugin` are still called, which will cause an error if those classes aren't self-contained and depend on functionality removed in 2.0.0.

Hopefully the explanation is clear, but I can create a reproduction demo tomorrow if you'd like. I also haven't run unit tests or phpstan yet, but will wait for the workflows.