### PR TITLE
Adding explicit message to `why-not` if package is already installed

### DIFF
--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -126,6 +126,8 @@ abstract class BaseDependencyCommand extends BaseCommand
                 $extraNotice = ' (version provided by config.platform)';
             }
             $this->getIO()->writeError('<info>Package "'.$needle.' '.$textConstraint.'" found in version "'.$matchedPackage->getPrettyVersion().'"'.$extraNotice.'.</info>');
+        } elseif ($inverted) {
+            $this->getIO()->write('<comment>Package "'.$needle.'" '.$matchedPackage->getPrettyVersion().' is already installed! To find out why, run `composer why '.$needle.'`</comment>');
         }
 
         // Include replaced packages for inverted lookups as they are then the actual starting point to consider

--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -128,6 +128,7 @@ abstract class BaseDependencyCommand extends BaseCommand
             $this->getIO()->writeError('<info>Package "'.$needle.' '.$textConstraint.'" found in version "'.$matchedPackage->getPrettyVersion().'"'.$extraNotice.'.</info>');
         } elseif ($inverted) {
             $this->getIO()->write('<comment>Package "'.$needle.'" '.$matchedPackage->getPrettyVersion().' is already installed! To find out why, run `composer why '.$needle.'`</comment>');
+            return 0;
         }
 
         // Include replaced packages for inverted lookups as they are then the actual starting point to consider

--- a/tests/Composer/Test/Command/BaseDependencyCommandTest.php
+++ b/tests/Composer/Test/Command/BaseDependencyCommandTest.php
@@ -464,11 +464,10 @@ OUTPUT
             0
         ];
 
-        yield 'there is no installed package depending on the package in versions not matching a specific version' => [
+        yield 'Package is already installed!' => [
             ['package' => 'vendor1/package1', 'version' => '^1.3'],
             <<<OUTPUT
-There is no installed package depending on "vendor1/package1" in versions not matching ^1.3
-Not finding what you were looking for? Try calling `composer require "vendor1/package1:^1.3" --dry-run` to get another view on the problem.
+Package "vendor1/package1" 1.3.0 is already installed! To find out why, run `composer why vendor1/package1`
 OUTPUT
 ,
             0


### PR DESCRIPTION
Closes #12227

I just did what you told me in https://github.com/composer/composer/issues/12227#issuecomment-2531797705 - don't really have an overview ;-)

`return` is still missing, right? Should I just copy this from further down?:
```php
$return = $inverted ? 1 : 0;
```
Or move it upwards?



