### PR TITLE
Support schemeless funding URLs

### DIFF
--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -646,6 +646,14 @@ class ValidatingArrayLoader implements LoaderInterface
         }
 
         $bits = parse_url($value);
+        if ($bits === false) {
+            return false;
+        }
+
+        if (array_key_exists('path', $bits) && !array_key_exists('scheme', $bits) && !array_key_exists('host', $bits)) {
+            return true;
+        }
+
         if (empty($bits['scheme']) || empty($bits['host'])) {
             return false;
         }

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -83,6 +83,14 @@ class ValidatingArrayLoaderTest extends TestCase
                         array(
                             'url' => 'https://example.org/fund',
                         ),
+                        array(
+                            'type' => 'custom',
+                            'url' => 'example.com',
+                        ),
+                        array(
+                            'type' => 'custom',
+                            'url' => 'example.com/fund#fundus',
+                        ),
                     ),
                     'require' => array(
                         'a/b' => '1.*',

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -192,7 +192,7 @@ class GitHubDriverTest extends TestCase
         $httpDownloader->expects($this->at(3))
             ->method('get')
             ->with($this->equalTo($url = 'https://api.github.com/repos/composer/packagist/contents/.github/FUNDING.yml'))
-            ->will($this->returnValue(new Response(array('url' => $url), 200, array(), '{"encoding": "base64", "content": "'.base64_encode("custom: https://example.com").'"}')));
+            ->will($this->returnValue(new Response(array('url' => $url), 200, array(), '{"encoding": "base64", "content": "'.base64_encode("custom: [\"https://example.com/funding\", octocat.com]").'"}')));
 
         $repoConfig = array(
             'url' => $repoUrl,


### PR DESCRIPTION
We encountered this issue when parsing the FUNDING.yml on our repo - https://github.com/moodle/moodle.

The [GitHub documentation][1] for FUNDING.yml specifically notes that if a custom URL is in the Array format, and includes `:` then it must be quoted.

From this we can infer that the custom URL does not have to contain a `:` at all.

The example for a Custom URL also gives an example of an unquoted URL without any `:` character:

```
custom: ["https://www.paypal.me/octocat", octocat.com]
```

However if a repository uses a URL in this format it is currently rejected because it does not specify a scheme. Furthermore the `parse_url` method treats the `octocat.com` example as a path and not a host. The same is true for URLs such as
`octocat.com/funding/example.html`.

This patch adds an additional allowance for the URL filter to capture the case where a URL has no scheme or host, but does have a path.

[1]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository#about-funding-files

Note: I've also got a branch for the `main` branch at https://github.com/andrewnicols/composer/tree/schemelessUrlMain