### PR TITLE
Discard unsupported FUNDING.yml URL values

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -287,6 +287,19 @@ class GitHubDriver extends VcsDriver
                 case 'buy_me_a_coffee':
                     $result[$key]['url'] = 'https://www.buymeacoffee.com/' . basename($item['url']);
                     break;
+                case 'custom':
+                    $bits = parse_url($item['url']);
+                    if ($bits === false) {
+                        unset($result[$key]);
+                        break;
+                    }
+
+                    if (!array_key_exists('scheme', $bits) && !array_key_exists('host', $bits)) {
+                        $this->io->writeError('<warning>Funding URL '.$item['url'].' not in a supported format.</warning>');
+                        unset($result[$key]);
+                        break;
+                    }
+                    break;
             }
         }
 

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -301,6 +301,11 @@ class GitHubDriver extends VcsDriver
                     }
 
                     if (!array_key_exists('scheme', $bits) && !array_key_exists('host', $bits)) {
+                        if (Preg::isMatch('{^[a-z0-9-]++\.[a-z]{2,3}$}', $item['url'])) {
+                            $result[$key]['url'] = 'https://'.$item['url'];
+                            break;
+                        }
+
                         $this->io->writeError('<warning>Funding URL '.$item['url'].' not in a supported format.</warning>');
                         unset($result[$key]);
                         break;

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -288,11 +288,21 @@ class GitHubDriverTest extends TestCase
         return [
             [
                 'custom: example.com',
-                null,
+                [
+                    [
+                        'type' => 'custom',
+                        'url' => 'https://example.com',
+                    ],
+                ],
             ],
             [
                 'custom: [example.com]',
-                null,
+                [
+                    [
+                        'type' => 'custom',
+                        'url' => 'https://example.com',
+                    ],
+                ],
             ],
             [
                 'custom: "https://example.com"',
@@ -319,6 +329,10 @@ class GitHubDriverTest extends TestCase
                         'type' => 'custom',
                         'url' => 'https://example.com',
                     ],
+                    [
+                        'type' => 'custom',
+                        'url' => 'https://example.org',
+                    ],
                 ],
             ],
             [
@@ -327,6 +341,10 @@ class GitHubDriverTest extends TestCase
                     [
                         'type' => 'custom',
                         'url' => 'https://example.com',
+                    ],
+                    [
+                        'type' => 'custom',
+                        'url' => 'https://example.org',
                     ],
                 ],
             ],


### PR DESCRIPTION
This patch is intended as an interim solution for #12245 but some form of this should probably be present anyway even after that issue is sorted.

At the moment if a GitHub repo uses a FUNDING.yml in the format documented by GitHub then that entire branch will be skipped from import into Packagist beacuse some of the documented formats are not supported by Packagist/Composer.

As a worst case I would expect the unsupported data to be removed. This isn't critical data - it's optional metadata which is not even present in the composer.json file and which is correct per the GitHub documentation.

On our side I'm trying to get the GitHub FUNDING.yml updated but many of the branches this issue exists on are archived branches which we do not normally modify.

At the moment the Packagist management view shows the following warning:

> This package is in a broken state and will not update anymore. Some branches contain invalid data and until you fix them the entire package is frozen. Click "Update" below to see details.

This suggests that if _any_ of our branches contain 'invalid' data that the entire package will be rejected.