### PR TITLE
Allow redirect responses to output warnings/infos

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -426,7 +426,7 @@ class CurlDownloader
                 }
                 fclose($job['bodyHandle']);
 
-                if ($response->getStatusCode() >= 400 && $response->getHeader('content-type') === 'application/json') {
+                if ($response->getStatusCode() >= 300 && $response->getHeader('content-type') === 'application/json') {
                     HttpDownloader::outputWarnings($this->io, $job['origin'], json_decode($response->getBody(), true));
                 }
 

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -304,7 +304,7 @@ class RemoteFilesystem
 
             if (!empty($http_response_header[0])) {
                 $statusCode = self::findStatusCode($http_response_header);
-                if ($statusCode >= 400 && Response::findHeaderValue($http_response_header, 'content-type') === 'application/json') {
+                if ($statusCode >= 300 && Response::findHeaderValue($http_response_header, 'content-type') === 'application/json') {
                     HttpDownloader::outputWarnings($this->io, $originUrl, json_decode($result, true));
                 }
 


### PR DESCRIPTION
Redirect responses can have a content too. This PR allows redirect responses to return warning(s)/info(s) which then appears as output during `composer install`