### PR TITLE
Update installer script URL to include openssl_free_key() deprecation fix

### DIFF
--- a/doc/faqs/how-to-install-composer-programmatically.md
+++ b/doc/faqs/how-to-install-composer-programmatically.md
@@ -35,7 +35,7 @@ give it uniqueness and authenticity as long as you can trust the GitHub servers.
 For example:
 
 ```shell
-wget https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer -O - -q | php -- --quiet
+wget https://raw.githubusercontent.com/composer/getcomposer.org/f3108f64b4e1c1ce6eb462b159956461592b3e3e/web/installer -O - -q | php -- --quiet
 ```
 
 You may replace the commit hash by whatever the last commit hash is on


### PR DESCRIPTION
If the installer script linked from [this page](https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md) is run using PHP 8, it generates the following deprecation notice.

```
Deprecated: Function openssl_free_key() is deprecated since 8.0, as OpenSSLAsymmetricKey objects are freed automatically in Standard input code on line 982
```

This issue was [addressed in the installer script](https://github.com/composer/getcomposer.org/pull/159), but the documentation was not updated to point to a version of it that includes the fix.