### PR TITLE
Fix failing Packagist updates / GitHubDriver::getFundingInfo(): add support for thanks.dev and polar.sh

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -257,35 +257,35 @@ class GitHubDriver extends VcsDriver
 
         foreach ($result as $key => $item) {
             switch ($item['type']) {
-                case 'tidelift':
-                    $result[$key]['url'] = 'https://tidelift.com/funding/github/' . $item['url'];
+                case 'community_bridge':
+                    $result[$key]['url'] = 'https://funding.communitybridge.org/projects/' . basename($item['url']);
                     break;
                 case 'github':
                     $result[$key]['url'] = 'https://github.com/' . basename($item['url']);
                     break;
-                case 'patreon':
-                    $result[$key]['url'] = 'https://www.patreon.com/' . basename($item['url']);
-                    break;
-                case 'otechie':
-                    $result[$key]['url'] = 'https://otechie.com/' . basename($item['url']);
-                    break;
-                case 'open_collective':
-                    $result[$key]['url'] = 'https://opencollective.com/' . basename($item['url']);
-                    break;
-                case 'liberapay':
-                    $result[$key]['url'] = 'https://liberapay.com/' . basename($item['url']);
+                case 'issuehunt':
+                    $result[$key]['url'] = 'https://issuehunt.io/r/' . $item['url'];
                     break;
                 case 'ko_fi':
                     $result[$key]['url'] = 'https://ko-fi.com/' . basename($item['url']);
                     break;
-                case 'issuehunt':
-                    $result[$key]['url'] = 'https://issuehunt.io/r/' . $item['url'];
+                case 'liberapay':
+                    $result[$key]['url'] = 'https://liberapay.com/' . basename($item['url']);
                     break;
-                case 'community_bridge':
-                    $result[$key]['url'] = 'https://funding.communitybridge.org/projects/' . basename($item['url']);
+                case 'open_collective':
+                    $result[$key]['url'] = 'https://opencollective.com/' . basename($item['url']);
+                    break;
+                case 'patreon':
+                    $result[$key]['url'] = 'https://www.patreon.com/' . basename($item['url']);
+                    break;
+                case 'tidelift':
+                    $result[$key]['url'] = 'https://tidelift.com/funding/github/' . $item['url'];
                     break;
                 case 'buy_me_a_coffee':
                     $result[$key]['url'] = 'https://www.buymeacoffee.com/' . basename($item['url']);
+                    break;
+                case 'otechie':
+                    $result[$key]['url'] = 'https://otechie.com/' . basename($item['url']);
                     break;
             }
         }

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -281,8 +281,14 @@ class GitHubDriver extends VcsDriver
                 case 'tidelift':
                     $result[$key]['url'] = 'https://tidelift.com/funding/github/' . $item['url'];
                     break;
+                case 'polar':
+                    $result[$key]['url'] = 'https://polar.sh/' . basename($item['url']);
+                    break;
                 case 'buy_me_a_coffee':
                     $result[$key]['url'] = 'https://www.buymeacoffee.com/' . basename($item['url']);
+                    break;
+                case 'thanks_dev':
+                    $result[$key]['url'] = 'https://thanks.dev/' . basename($item['url']);
                     break;
                 case 'otechie':
                     $result[$key]['url'] = 'https://otechie.com/' . basename($item['url']);


### PR DESCRIPTION
### GitHubDriver::getFundingInfo(): order the cases

This re-orders the cases in the `switch` to follow the same order as the GitHub documentation (largely alphabetic) for easier comparisons between the two lists.

Refs:
* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository

### GitHubDriver::getFundingInfo(): add support for thanks.dev and polar.sh

GitHub looks to have added a dedicated syntax for the thanks.dev funding platform when added to a `funding.yml` file.
However, it looks like Composer does not (yet) support this syntax as can be seen from failed Packagist updates of the dev branches of the [PHP_CodeSniffer](https://packagist.org/packages/squizlabs/php_codesniffer#dev-master) and [PHPCompatibility](https://packagist.org/packages/phpcompatibility/php-compatibility) packages.

![image](https://github.com/user-attachments/assets/e221de97-31bf-4471-bd16-124d830c0b62)


The polar.sh funding platform also appears to be newly supported by GH and missing from the list.

This PR fixes both.


Refs:
* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository


---

Note: while I'd love to add some tests for this, it looks like there are no tests covering this functionality at all yet and it would require some hacks to mock the various API calls to reach the code, while this is a relatively straight forward code change.

As it looks like (open) PR #12247 already adds a test method for this code, I'd like to suggest either of the following:
* Merge #12247 first (if ready) and then I could add a few additional test cases to the data provider.
* Or alternatively, I could cherrypick the test @andrewnicols created from their commit and add a data provider to safeguard the currently supported platforms.

Let me know what you'd prefer.

Also feel free to let me know if this should be pulled to an older branch. Happy to rebase.