### PR TITLE
Generate build provenance attestation during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     permissions:
       contents: write # for actions/create-release to create a release
+      id-token: write # for actions/attest-build-provenance to create a attestation certificate
+      attestations: write # for actions/attest-build-provenance to upload the attestation
     name: Upload Release Asset
     runs-on: ubuntu-latest
     steps:
@@ -40,6 +42,11 @@ jobs:
 
       - name: Build phar file
         run: "php -d phar.readonly=0 bin/compile"
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: '${{ github.workspace }}/composer.phar'
 
       - name: Create release
         id: create_release


### PR DESCRIPTION
This will simplify secure installation of composer in GitHub Actions to two calls to `gh` cli with no need to manually import any PGP signing keys:

    gh release --repo composer/composer download --pattern composer.phar
    gh attestation verify --repo composer/composer composer.phar

Given that the current PGP signing key is stored as a GitHub Action secret, this type of attestation is no less secure than the existing PGP signing.

-----------

see also php/pie#128 and php/pie#139 /cc @asgrim 

I verified functionality in my fork:

```
$ gh attestation verify --owner TimWolla composer.phar
Loaded digest sha256:cd4878b271526ebe5640c51e1843916549c2b97ecaf3340953df2e3926193024 for file://composer.phar
Loaded 1 attestation from GitHub API

The following policy criteria will be enforced:
- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
- Source Repository Owner URI must match:... https://github.com/TimWolla
- Predicate type must match:................ https://slsa.dev/provenance/v1
- Subject Alternative Name must match regex: (?i)^https://github.com/TimWolla/

✓ Verification succeeded!

sha256:cd4878b271526ebe5640c51e1843916549c2b97ecaf3340953df2e3926193024 was attested by:
REPO               PREDICATE_TYPE                  WORKFLOW                                                                 
TimWolla/composer  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/release-action-build-provenance-1
```