### PR TITLE
Make use of Phar::running() to get the current phar path

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -23,6 +23,7 @@ use Composer\SelfUpdate\Versions;
 use Composer\IO\IOInterface;
 use Composer\Downloader\FilesystemException;
 use Composer\Downloader\TransportException;
+use Phar;
 use Symfony\Component\Console\Input\InputInterface;
 use Composer\Console\Input\InputOption;
 use Composer\Console\Input\InputArgument;
@@ -116,9 +117,9 @@ EOT
         $cacheDir = $config->get('cache-dir');
         $rollbackDir = $config->get('data-dir');
         $home = $config->get('home');
-        $localFilename = realpath($_SERVER['argv'][0]);
-        if (false === $localFilename) {
-            $localFilename = $_SERVER['argv'][0];
+        $localFilename = Phar::running(false);
+        if ('' === $localFilename) {
+            throw new \RuntimeException('Could not determine the location of the composer.phar file as it appears you are not running this code from a phar archive.');
         }
 
         if ($input->getOption('update-keys')) {

--- a/src/Composer/Util/Tar.php
+++ b/src/Composer/Util/Tar.php
@@ -50,7 +50,7 @@ class Tar
         }
 
         $composerJsonPath = key($topLevelPaths).'/composer.json';
-        if ($topLevelPaths && isset($phar[$composerJsonPath])) {
+        if (\count($topLevelPaths) > 0 && isset($phar[$composerJsonPath])) {
             return $phar[$composerJsonPath]->getContent();
         }
 

--- a/tests/Composer/Test/AllFunctionalTest.php
+++ b/tests/Composer/Test/AllFunctionalTest.php
@@ -96,6 +96,7 @@ class AllFunctionalTest extends TestCase
 
         self::assertFileExists(self::$pharPath);
         copy(self::$pharPath, __DIR__.'/../../composer-test.phar');
+        chmod(__DIR__.'/../../composer-test.phar', 0777);
     }
 
     /**


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
