### PR TITLE
Suppress require-dev hint when requiring things globally

### DIFF
--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -231,7 +231,7 @@ EOT
 
         $requirements = $this->formatRequirements($requirements);
 
-        if (!$input->getOption('dev') && $io->isInteractive()) {
+        if (!$input->getOption('dev') && $io->isInteractive() && !$composer->isGlobal()) {
             $devPackages = [];
             $devTags = ['dev', 'testing', 'static analysis'];
             $currentRequiresByKey = $this->getPackagesByRequireKey();

--- a/src/Composer/PartialComposer.php
+++ b/src/Composer/PartialComposer.php
@@ -24,6 +24,11 @@ use Composer\EventDispatcher\EventDispatcher;
 class PartialComposer
 {
     /**
+     * @var bool
+     */
+    private $global = false;
+
+    /**
      * @var RootPackageInterface
      */
     private $package;
@@ -111,5 +116,15 @@ class PartialComposer
     public function getEventDispatcher(): EventDispatcher
     {
         return $this->eventDispatcher;
+    }
+
+    public function isGlobal(): bool
+    {
+        return $this->global;
+    }
+
+    public function setGlobal(): void
+    {
+        $this->global = true;
     }
 }


### PR DESCRIPTION
fixes #12253

Additionally this keeps track whether a Composer instance is the global one or not, which is a nice side effect/cleanup