### PR TITLE
Fix regression from #12233 in InstalledVersions when reload is used

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,7 +10,6 @@
  * file that was distributed with this source code.
  */
 
-use Composer\InstalledVersions;
 use Composer\Util\Platform;
 
 error_reporting(E_ALL);
@@ -20,10 +19,7 @@ if (function_exists('date_default_timezone_set') && function_exists('date_defaul
 }
 
 require __DIR__.'/../src/bootstrap.php';
-
-if (!class_exists(InstalledVersions::class, false)) {
-    require __DIR__.'/../src/Composer/InstalledVersions.php';
-}
+require __DIR__.'/../vendor/composer/InstalledVersions.php';
 
 Platform::putEnv('COMPOSER_TESTS_ARE_RUNNING', '1');
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,9 @@ if (function_exists('date_default_timezone_set') && function_exists('date_defaul
 }
 
 require __DIR__.'/../src/bootstrap.php';
+// ensure we always use the latest InstalledVersions.php even if an older composer ran the install, but we need
+// to have it included from vendor dir and not from src/ otherwise some gated check in the code will not work
+copy(__DIR__.'/../src/Composer/InstalledVersions.php', __DIR__.'/../vendor/composer/InstalledVersions.php');
 require __DIR__.'/../vendor/composer/InstalledVersions.php';
 
 Platform::putEnv('COMPOSER_TESTS_ARE_RUNNING', '1');


### PR DESCRIPTION
Fixes #12235

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
