### PR TITLE
GitHubDriverTest::testFundingFormat(): expand the tests + fix bug

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -288,7 +288,7 @@ class GitHubDriver extends VcsDriver
                     $result[$key]['url'] = 'https://www.buymeacoffee.com/' . basename($item['url']);
                     break;
                 case 'thanks_dev':
-                    $result[$key]['url'] = 'https://thanks.dev/' . basename($item['url']);
+                    $result[$key]['url'] = 'https://thanks.dev/' . $item['url'];
                     break;
                 case 'otechie':
                     $result[$key]['url'] = 'https://otechie.com/' . basename($item['url']);

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -285,8 +285,80 @@ class GitHubDriverTest extends TestCase
 
     public static function fundingUrlProvider(): array
     {
+        $allNamedPlatforms = <<<'FUNDING'
+community_bridge: project-name
+github: [userA, userB]
+issuehunt: userName
+ko_fi: userName
+liberapay: userName
+open_collective: userName
+patreon: userName
+tidelift: Platform/Package
+polar: userName
+buy_me_a_coffee: userName
+thanks_dev: u/gh/userName
+otechie: userName
+FUNDING;
+
         return [
-            [
+            'All named platforms' => [
+                $allNamedPlatforms,
+                [
+                    [
+                        'type' => 'community_bridge',
+                        'url' => 'https://funding.communitybridge.org/projects/project-name',
+                    ],
+                    [
+                        'type' => 'github',
+                        'url' => 'https://github.com/userA',
+                    ],
+                    [
+                        'type' => 'github',
+                        'url' => 'https://github.com/userB',
+                    ],
+                    [
+                        'type' => 'issuehunt',
+                        'url' => 'https://issuehunt.io/r/userName',
+                    ],
+                    [
+                        'type' => 'ko_fi',
+                        'url' => 'https://ko-fi.com/userName',
+                    ],
+                    [
+                        'type' => 'liberapay',
+                        'url' => 'https://liberapay.com/userName',
+                    ],
+                    [
+                        'type' => 'open_collective',
+                        'url' => 'https://opencollective.com/userName',
+                    ],
+                    [
+                        'type' => 'patreon',
+                        'url' => 'https://www.patreon.com/userName',
+                    ],
+                    [
+                        'type' => 'tidelift',
+                        'url' => 'https://tidelift.com/funding/github/Platform/Package',
+                    ],
+                    [
+                        'type' => 'polar',
+                        'url' => 'https://polar.sh/userName',
+                    ],
+                    [
+                        'type' => 'buy_me_a_coffee',
+                        'url' => 'https://www.buymeacoffee.com/userName',
+                    ],
+                    [
+                        'type' => 'thanks_dev',
+                        'url' => 'https://thanks.dev/u/gh/userName',
+                    ],
+                    [
+                        'type' => 'otechie',
+                        'url' => 'https://otechie.com/userName',
+                    ],
+                ],
+            ],
+            'Custom: single schemaless URL' => [
                 'custom: example.com',
                 [
                     [
@@ -295,7 +367,7 @@ class GitHubDriverTest extends TestCase
                     ],
                 ],
             ],
-            [
+            'Custom: single schemaless URL in array format' => [
                 'custom: [example.com]',
                 [
                     [
@@ -304,7 +376,7 @@ class GitHubDriverTest extends TestCase
                     ],
                 ],
             ],
-            [
+            'Custom: double-quoted single URL' => [
                 'custom: "https://example.com"',
                 [
                     [
@@ -313,7 +385,7 @@ class GitHubDriverTest extends TestCase
                     ],
                 ],
             ],
-            [
+            'Custom: double-quoted single URL in array format' => [
                 'custom: ["https://example.com"]',
                 [
                     [
@@ -322,7 +394,7 @@ class GitHubDriverTest extends TestCase
                     ],
                 ],
             ],
-            [
+            'Custom: array with quoted URL and schemaless unquoted URL' => [
                 'custom: ["https://example.com", example.org]',
                 [
                     [
@@ -335,7 +407,7 @@ class GitHubDriverTest extends TestCase
                     ],
                 ],
             ],
-            [
+            'Custom: array containing a non-simple scheme-less URL which will be discarded' => [
                 'custom: [example.net/funding, "https://example.com", example.org]',
                 [
                     [


### PR DESCRIPTION
Glad that I added some tests as this meant I found a bug in the PR I pulled previously (#12257).

The `thanks_dev` key expects a username in the format `u/gh/USERNAME`, but the call to `basename()` was stripping the `u/gh/` part off.

If the use of `basename()` is preferred here, the alternative would be to add `u/gh/` to the default URL prefix for thanks.dev. Let me know if you want me to change that.
