### PR TITLE
Prevent script override warning

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -364,7 +364,7 @@ class Application extends BaseApplication
 
             // add non-standard scripts as own commands
             $file = Factory::getComposerFile();
-            if (is_file($file) && Filesystem::isReadable($file) && is_array($composer = json_decode(file_get_contents($file), true))) {
+            if (false !== $commandName && is_file($file) && Filesystem::isReadable($file) && is_array($composer = json_decode(file_get_contents($file), true))) {
                 if (isset($composer['scripts']) && is_array($composer['scripts'])) {
                     foreach ($composer['scripts'] as $script => $dummy) {
                         if (!defined('Composer\Script\ScriptEvents::'.str_replace('-', '_', strtoupper($script)))) {


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if  that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
The command name variable is equal to false when composer is run before the plugin commands are included and a new working directory is specified. This change prevents the following warning from displaying:

![image](https://github.com/user-attachments/assets/fb9ab013-d561-45c3-84e4-4947f0fd7161)

The warning does not display when running the command with long options.
```zsh
composer --working-dir=path/to/project outdated
```

The warning displays when using short options to specify another working directory
```zsh
composer -d path/to/project outdated
```

This happens because the first argument, `path/to/project`, is parsed as if it were a command when composer is run before the plugin commands are include.