### PR TITLE
Scripts: add ENV variable to skip script execution for certain event names

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1293,6 +1293,10 @@ fully offline with `1`.
 If set to `1`, outputs information about events being dispatched, which can be
 useful for plugin authors to identify what is firing when exactly.
 
+### COMPOSER_SKIP_SCRIPTS
+
+Accepts a comma-seperated list of event names, e.g. `post-install-cmd` for which scripts execution should be skipped.
+
 ### COMPOSER_NO_AUDIT
 
 If set to `1`, it is the equivalent of passing the `--no-audit` option to `require`, `update`, `remove` or `create-project` command.

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -83,7 +83,9 @@ class EventDispatcher
         $this->io = $io;
         $this->process = $process ?? new ProcessExecutor($io);
         $this->eventStack = [];
-        $this->skipScripts = explode(',', (string) Platform::getEnv('COMPOSER_SKIP_SCRIPTS'));
+        $this->skipScripts = array_filter(array_map('trim', explode(',', (string) Platform::getEnv('COMPOSER_SKIP_SCRIPTS'))), function ($val) { 
+            return $val !== '';
+        });
     }
 
     /**

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -67,6 +67,8 @@ class EventDispatcher
     protected $runScripts = true;
     /** @var list<string> */
     private $eventStack;
+    /** @var list<string> */
+    private $skipScripts;
 
     /**
      * Constructor.
@@ -81,6 +83,7 @@ class EventDispatcher
         $this->io = $io;
         $this->process = $process ?? new ProcessExecutor($io);
         $this->eventStack = [];
+        $this->skipScripts = explode(',', (string) Platform::getEnv('COMPOSER_SKIP_SCRIPTS'));
     }
 
     /**
@@ -581,6 +584,10 @@ class EventDispatcher
         $scripts = $package->getScripts();
 
         if (empty($scripts[$event->getName()])) {
+            return [];
+        }
+
+        if (in_array($event->getName(), $this->skipScripts, true)) {
             return [];
         }
 

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -83,9 +83,12 @@ class EventDispatcher
         $this->io = $io;
         $this->process = $process ?? new ProcessExecutor($io);
         $this->eventStack = [];
-        $this->skipScripts = array_filter(array_map('trim', explode(',', (string) Platform::getEnv('COMPOSER_SKIP_SCRIPTS'))), function ($val) { 
-            return $val !== '';
-        });
+        $this->skipScripts = array_values(array_filter(
+            array_map('trim', explode(',', (string) Platform::getEnv('COMPOSER_SKIP_SCRIPTS'))), 
+            function ($val) { 
+                return $val !== '';
+            }
+        ));
     }
 
     /**


### PR DESCRIPTION
This allows running `COMPOSER_SKIP_SCRIPTS="post-install-cmd" && composer install` to for instance skip a configured `post-install-cmd`