### PR TITLE
Added override-download-url-method directive for php-ext

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -323,6 +323,12 @@
                     "example": "my-extension-source",
                     "default": null
                 },
+                "override-download-url-method": {
+                    "type": "string",
+                    "description": "If specified, this technique will be used to override the URL that PIE uses to download the asset. The default, if not specified, is composer-default.",
+                    "enum": ["composer-default", "pre-packaged-source"],
+                    "example": "composer-default"
+                },
                 "os-families": {
                     "type": "array",
                     "minItems": 1,

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -23,7 +23,7 @@ use Composer\Repository\RepositoryInterface;
  *
  * @phpstan-type AutoloadRules    array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
  * @phpstan-type DevAutoloadRules array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>}
- * @phpstan-type PhpExtConfig     array{extension-name?: string, priority?: int, support-zts?: bool, support-nts?: bool, build-path?: string|null, os-families?: non-empty-list<non-empty-string>, os-families-exclude?: non-empty-list<non-empty-string>, configure-options?: list<array{name: string, description?: string}>}
+ * @phpstan-type PhpExtConfig     array{extension-name?: string, priority?: int, support-zts?: bool, support-nts?: bool, build-path?: string|null, override-download-url-method?: string, os-families?: non-empty-list<non-empty-string>, os-families-exclude?: non-empty-list<non-empty-string>, configure-options?: list<array{name: string, description?: string}>}
  */
 interface PackageInterface
 {


### PR DESCRIPTION
Adds a new directive `override-download-url-method` to let extensions change the behaviour of where PIE downloads the source code package from. Ref: php/pie#187