### PR TITLE
feat: Detect containerd runtime and allow root execution

### DIFF
--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -217,7 +217,11 @@ class Platform
             } catch (\Throwable $e) {
                 break;
             }
-            if (is_string($data) && str_contains($data, '/var/lib/docker/')) {
+            if (!is_string($data)) {
+                continue;
+            }
+            // detect default mount points created by Docker/containerd
+            if (str_contains($data, '/var/lib/docker/') || str_contains($data, '/io.containerd.snapshotter')) {
                 return self::$isDocker = true;
             }
         }


### PR DESCRIPTION
Composer now permits running as root when the container runtime is [containerd](https://github.com/containerd/containerd), aligning with existing behavior for Docker and Podman.

This additional check is useful for modern Kubernetes environments where Docker isn't used for managing containers.

## Kubernetes pod running under containerd
```sh
sh-5.2# cat /proc/self/mountinfo
4029 2756 0:390 / / rw,relatime master:1322 - overlay overlay rw,lowerdir=/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591431/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591430/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591429/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591428/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591427/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591426/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591425/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591424/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591423/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591422/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591421/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591420/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591419/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591418/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591417/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591416/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591415/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591414/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591413/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591412/fs:/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591411/fs,upperdir=/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591432/fs,workdir=/var/lib/rancher/rke2/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1591432/work,uuid=on
4030 4029 0:392 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
4031 4029 0:393 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
4032 4031 0:394 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
4033 4031 0:383 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
4034 4029 0:387 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
4035 4034 0:25 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw
4036 4029 253:0 /kubelet/pods/c53c1e27-7851-464d-bf1c-89f6d01247bf/etc-hosts /etc/hosts rw,noatime - ext4 /dev/vda rw
4037 4031 253:0 /kubelet/pods/c53c1e27-7851-464d-bf1c-89f6d01247bf/containers/debug/4452dc47 /dev/termination-log rw,noatime - ext4 /dev/vda rw
4038 4029 253:0 /rancher/rke2/agent/containerd/io.containerd.grpc.v1.cri/sandboxes/2b0ba562178bdb34ff00f6e2eb4a750bc2a1c0b0880e98db079f53209b0716e4/hostname /etc/hostname rw,noatime - ext4 /dev/vda rw
4160 4029 253:0 /rancher/rke2/agent/containerd/io.containerd.grpc.v1.cri/sandboxes/2b0ba562178bdb34ff00f6e2eb4a750bc2a1c0b0880e98db079f53209b0716e4/resolv.conf /etc/resolv.conf rw,noatime - ext4 /dev/vda rw
4161 4031 0:373 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k
4162 4029 0:337 / /run/secrets/kubernetes.io/serviceaccount ro,relatime - tmpfs tmpfs rw,size=16402632k
2757 4031 0:394 /0 /dev/console rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
2758 4030 0:392 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
2759 4030 0:392 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw
2760 4030 0:392 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw
2761 4030 0:392 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw
2762 4030 0:392 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
2780 4030 0:395 / /proc/acpi ro,relatime - tmpfs tmpfs ro
2781 4030 0:393 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
2782 4030 0:393 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
2783 4030 0:393 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
2784 4034 0:396 / /sys/firmware ro,relatime - tmpfs tmpfs ro
```

## Plain Docker container
```sh
sh-5.2# cat /proc/self/mountinfo
2821 2616 0:556 / / rw,relatime - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/KME5PJX6JXOCPNCQFQLMGDZ3GN:/var/lib/docker/overlay2/l/W2XSSFDSVZFAYYA6LTSFB4NJX6:/var/lib/docker/overlay2/l/BGQTRY6N5MJNV2RA4NT3VW4HVL:/var/lib/docker/overlay2/l/5RYMDVDFHTQR5YCDNBC5MWMG43:/var/lib/docker/overlay2/l/RVEAUI3QQY6RD5LLUEMCR5J4AK:/var/lib/docker/overlay2/l/34MYMGVT2XX2HFVC5445I3T4GE:/var/lib/docker/overlay2/l/H4YV3UF3KO6UR6WSYYP66MFWJV:/var/lib/docker/overlay2/l/Q5IQ2A7UTJEVOKWUS2PAL3QSWT:/var/lib/docker/overlay2/l/KSZS7SLJ7QT63GHQYDYREAN254:/var/lib/docker/overlay2/l/PQYRIGCTWQXPWTAL2FOBZH7M2J:/var/lib/docker/overlay2/l/O7BUXBQY3KTTAFG6O5XJHHWEKE:/var/lib/docker/overlay2/l/KMWJXG63EII2VR7UYWWICQKQM6:/var/lib/docker/overlay2/l/AOZRONZVZDJ2VSOIW7N42NLZXJ:/var/lib/docker/overlay2/l/I7WOTPDU5X5EYZ2ZKKKJP7WJBI:/var/lib/docker/overlay2/l/K5GOJD6U372VB6JYN7FF6MJSFU:/var/lib/docker/overlay2/l/3SL2VM6754HTTKFVHDZFGSXSBG:/var/lib/docker/overlay2/l/RBEJW5HPLKHKVOHLHWDSLOVFJA:/var/lib/docker/overlay2/l/HT7N4UZET5HZCFEJU3JN2C2DIX:/var/lib/docker/overlay2/l/N3K2CBGRD6AW2KM7Y26Z3AQN47:/var/lib/docker/overlay2/l/BBP6CPB33LO2SYXTHW6YDAEKDN:/var/lib/docker/overlay2/l/FDMP7DPUXXDLJASDO7VAPMCD4D:/var/lib/docker/overlay2/l/EGGTK7XDL3K4WQZT2F77MH3WLD,upperdir=/var/lib/docker/overlay2/62cb7b629d8ccd360423fce0e4fd7c6a76e2f6ba39273bd3b488714298fd4c5e/diff,workdir=/var/lib/docker/overlay2/62cb7b629d8ccd360423fce0e4fd7c6a76e2f6ba39273bd3b488714298fd4c5e/work
2823 2821 0:560 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
2824 2821 0:591 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
2825 2824 0:592 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
2826 2821 0:593 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
2827 2826 0:31 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw,nsdelegate
2828 2824 0:558 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
2829 2824 0:594 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=4093952k
2830 2821 0:37 /docker/containers/9d80331390d88401a9b63240dd388322f2178ca6e729986687faaa558722d7dd/resolv.conf /etc/resolv.conf rw,noatime - btrfs /dev/vdb1 rw,nodatasum,nodatacow,ssd,discard,space_cache=v2,subvolid=5,subvol=/
2831 2821 0:37 /docker/containers/9d80331390d88401a9b63240dd388322f2178ca6e729986687faaa558722d7dd/hostname /etc/hostname rw,noatime - btrfs /dev/vdb1 rw,nodatasum,nodatacow,ssd,discard,space_cache=v2,subvolid=5,subvol=/
2832 2821 0:37 /docker/containers/9d80331390d88401a9b63240dd388322f2178ca6e729986687faaa558722d7dd/hosts /etc/hosts rw,noatime - btrfs /dev/vdb1 rw,nodatasum,nodatacow,ssd,discard,space_cache=v2,subvolid=5,subvol=/
2619 2824 0:592 /0 /dev/console rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
2620 2823 0:560 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
2621 2823 0:560 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw
2622 2823 0:560 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw
2623 2823 0:560 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw
2624 2823 0:560 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
2625 2823 0:591 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
2626 2823 0:591 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
2627 2826 0:595 / /sys/firmware ro,relatime - tmpfs tmpfs ro
``` 

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
