### PR TITLE
fix: RootPackageLoader.php constructor creates unusable fallback instance of VersionGuesser

### DIFF
--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -60,10 +60,10 @@ class RootPackageLoader extends ArrayLoader
 
         $this->manager = $manager;
         $this->config = $config;
-        if (!$versionGuesser) {
-          $processExecutor = new ProcessExecutor($io);
-          $processExecutor->enableAsync();
-          $versionGuesser = new VersionGuesser($config, $processExecutor, $this->versionParser);
+        if (null === $versionGuesser) {
+            $processExecutor = new ProcessExecutor($io);
+            $processExecutor->enableAsync();
+            $versionGuesser = new VersionGuesser($config, $processExecutor, $this->versionParser);
         }
         $this->versionGuesser = $versionGuesser;
         $this->io = $io;

--- a/src/Composer/Package/Loader/RootPackageLoader.php
+++ b/src/Composer/Package/Loader/RootPackageLoader.php
@@ -60,7 +60,12 @@ class RootPackageLoader extends ArrayLoader
 
         $this->manager = $manager;
         $this->config = $config;
-        $this->versionGuesser = $versionGuesser ?: new VersionGuesser($config, new ProcessExecutor($io), $this->versionParser, $io);
+        if (!$versionGuesser) {
+          $processExecutor = new ProcessExecutor($io);
+          $processExecutor->enableAsync();
+          $versionGuesser = new VersionGuesser($config, $processExecutor, $this->versionParser);
+        }
+        $this->versionGuesser = $versionGuesser;
         $this->io = $io;
     }
 


### PR DESCRIPTION
Following commit enabled async execution https://github.com/composer/composer/commit/b0665981c2e80578b6692da8604edcda7b2093ab in the VersionGuesser:

```php
$promises[] = $this->process->executeAsync($cmdLine, $path)->then(function (Process $process) use (&$length, &$version, &$prettyVersion, $candidateVersion, &$promises): void {
```

However, the VersionGuesser fallback instance created in [RootPackageLoader constructor](https://github.com/composer/composer/blob/e58aad45b51c6b29b9f47800a182d7e86e654201/src/Composer/Package/Loader/RootPackageLoader.php#L63) still passes a ProcessExecutor instance _wihtout_ async enabled:

```php
$this->versionGuesser = $versionGuesser ?: new VersionGuesser($config, new ProcessExecutor($io), $this->versionParser, $io);
```

I suppose the most backwards compatible way to fix this is to adjust the constructor to actually enable async execution in the passed in ProcessExecutor instance similar to what the [RootPackageLoaderTest.php](https://github.com/composer/composer/blob/e58aad45b51c6b29b9f47800a182d7e86e654201/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php#L41).
