### PR TITLE
Fix fatal error with classes with double backslashes

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -573,7 +573,7 @@ class ClassLoader
          * @return void
          */
         self::$includeFile = \Closure::bind(static function($file) {
-            include $file;
+            include_once $file;
         }, null, null);
     }
 }

--- a/tests/Composer/Test/Autoload/ClassLoaderTest.php
+++ b/tests/Composer/Test/Autoload/ClassLoaderTest.php
@@ -82,4 +82,14 @@ class ClassLoaderTest extends TestCase
         self::assertSame($loader->getPrefixesPsr4(), $loader2->getPrefixesPsr4());
         self::assertSame($loader->getUseIncludePath(), $loader2->getUseIncludePath());
     }
+
+    public function testClassWithDoubleSlashes(): void
+    {
+        $loader = new ClassLoader();
+        $loader->add('Namespaced\\', __DIR__ . '/Fixtures');
+        $loader->loadClass('Namespaced\\\\FooDoubleSlashes');
+        $loader->loadClass('Namespaced\\\\FooDoubleSlashes');
+
+        self::expectNotToPerformAssertions();
+    }
 }

--- a/tests/Composer/Test/Autoload/Fixtures/Namespaced/FooDoubleSlashes.php
+++ b/tests/Composer/Test/Autoload/Fixtures/Namespaced/FooDoubleSlashes.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Namespaced;
+
+class FooDoubleSlashes
+{
+}


### PR DESCRIPTION
Hello, 

The following code
```php
require_once dirname(__DIR__).'/vendor/autoload.php';

var_dump(class_exists('App\\\\Kernel'));
var_dump(class_exists('App\\\\Kernel'));
```

Throws an `Fatal error: Cannot redeclare class App\Kernel`

After briefly looking into Composer's source code, I noticed that the `$file` variable is equal to `/vendor/composer/../../src//Kernel.php`.
The file is included, but the `App\\Kernel` class remains unknown.
When trying to load the class (with the second class_exists), the same file is encountered again, leading to its re-inclusion and the "cannot redeclare class" error.

We have several options to fix this:
1. `include_once` to ensure the file is never re-included
2. Add a verification around line `506` to see if `$file` contains double backslashes (`str_contains($file, '\\\\')`)
3. Throw an exception when loading a class containing double backslashes (`str_contains($class, '\\\\')`)

To me, the first option seems the best. Let me know if you think otherwise!