### PR TITLE
ZipArchiver: treat backslashes in folder names on Unix

### DIFF
--- a/tests/Composer/Test/Package/Archiver/ZipArchiverTest.php
+++ b/tests/Composer/Test/Package/Archiver/ZipArchiverTest.php
@@ -37,6 +37,17 @@ class ZipArchiverTest extends ArchiverTestCase
         ];
     }
 
+    public function testFolderWithBackslashes(): void
+    {
+        if (Platform::isWindows()) {
+            $this->markTestSkipped('Folder names cannot contain backslashes on Windows.');
+        }
+
+        $this->testZipArchive([
+            'folder\with\backslashes/README.md' => '# doc',
+        ]);
+    }
+
     /**
      * @param array<string, string> $files
      */


### PR DESCRIPTION

Problem: On Linux there can be directories that contain backslashes in the name.
Repository with a folder with backslashes in it: https://github.com/psc-acme/repo19   
(you cannot test this on windows)

The showed the errors:
```
Warning: fileperms(): stat failed for /tmp/composer_archive558c5d2d06/folder/with/backslashes/README.md 
Warning: ZipArchive::addFile(): No such file or directory
```
when using the ZipArchiver to create a dist file from such a git repository.

Since all backslashes were forwarded the file wasnt found anymore.  
The test reproduces that.  

