### PR TITLE
Clarify version property pattern in schema.json

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -28,7 +28,7 @@
         "version": {
             "type": "string",
             "description": "Package version, see https://getcomposer.org/doc/04-schema.md#version for more info on valid schemes.",
-            "pattern": "^v?\\d+(\\.\\d+){0,3}|^dev-"
+            "pattern": "^v?\\d+(\\.\\d+){0,3}(-(dev|(patch|p|alpha|a|beta|b|RC)\\d*))?$|^dev-.*$"
         },
         "default-branch": {
             "type": ["boolean"],

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -38,6 +38,46 @@ class ComposerSchemaTest extends TestCase
         self::assertEquals($expectedError, $this->check($json));
     }
 
+    public function versionProvider(): array
+    {
+        return [
+            ['1.0.0', true],
+            ['1.0.2', true],
+            ['1.1.0', true],
+            ['1.0.0-dev', true],
+            ['1.0.0-alpha3', true],
+            ['1.0.0-beta232', true],
+            ['1.0.0-RC', true],
+            ['v2.0.4-p', true],
+            ['dev-master', true],
+            ['0.2.5.4', true],
+
+            ['invalid', false],
+            ['1.0b', false],
+            ['1.0.0-', false],
+        ];
+    }
+
+    /**
+     * @dataProvider versionProvider
+     */
+    public function testVersionPattern(string $version, bool $isValid): void
+    {
+        $json = '{"name": "vendor/package", "description": "description", "version": "' . $version . '"}';
+        if ($isValid) {
+            self::assertTrue($this->check($json));
+        } else {
+            self::assertEquals([
+                [
+                    'property' => 'version',
+                    'message' => 'Does not match the regex pattern ^v?\d+(\.\d+){0,3}(-(dev|(patch|p|alpha|a|beta|b|RC)\d*))?$|^dev-.*$',
+                    'constraint' => 'pattern',
+                    'pattern' => '^v?\d+(\.\d+){0,3}(-(dev|(patch|p|alpha|a|beta|b|RC)\d*))?$|^dev-.*$',
+                ],
+            ], $this->check($json));
+        }
+    }
+
     public function testOptionalAbandonedProperty(): void
     {
         $json = '{"name": "vendor/package", "description": "description", "abandoned": true}';


### PR DESCRIPTION
### Motivation
The primary reason for these changes is to attempt a workaround for an annoying bug in JetBrains' IDE.

### Background
I create private packages that are distributed via archives (using the `artifact` repository type). As a result, I need to specify the `version` of the packages directly in the `composer.json` file.

### What's wrong
PhpStorm considers the version `1.0.0-dev` as invalid, displaying the error: "String violates the pattern: '^v?\d+(\.\d+){0,3}|^dev-'".
In my opinion, the reason for this behavior is an incorrect implementation of the pattern matcher:

https://github.com/JetBrains/intellij-community/blob/33099feb7000ed4f798ba3f34fd28c08518c96cf/json/src/com/jetbrains/jsonSchema/impl/light/legacy/JsonSchemaObjectReadingUtils.java#L355-L386

1. It uses the `matches()` method (which attempts to match the entire region against the pattern) instead of `find()`.
2. It uses a suspicious `adaptSchemaPattern()` method, which "adapts" the original pattern and is incompatible with alternation (such as **`^v?\d+(\.\d+){0,3}|^dev-`**).

### Solution

1. According to the [Composer documentation](https://getcomposer.org/doc/04-schema.md#version), valid suffixes should be added to the pattern.
2. Following the [JSON Schema reference](https://json-schema.org/understanding-json-schema/reference/string#regexp), the regular expression is surrounded by `^...$`.