### PR TITLE
Clarify validation message when lock file is outdated and not in version control

### DIFF
--- a/doc/articles/resolving-merge-conflicts.md
+++ b/doc/articles/resolving-merge-conflicts.md
@@ -113,7 +113,7 @@ If there are packages that are required but not installed, you should get output
 ./composer.json is valid but your composer.lock has some errors
 # Lock file errors
 - Required package "vendor/package-name" is not present in the lock file.
-This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
+This usually happens when composer files are incorrectly merged, the lock file is not in version control or the composer.json file is manually edited.
 Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
 and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require
 ```

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -96,7 +96,9 @@ EOT
         $checkLock = ($checkLock && $composer->getConfig()->get('lock')) || $input->getOption('check-lock');
         $locker = $composer->getLocker();
         if ($locker->isLocked() && !$locker->isFresh()) {
-            $lockErrors[] = '- The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update` or `composer update <package name>`.';
+            $lockErrors[] =  ($composer->getPackage()->getType() === 'library' && $locker->getJsonFile()->isInGit() === false)
+                ? '- The lock file is not up to date with the latest changes in composer.json. The lock file is not in git and this is a library so the lock file can probably be safely deleted.'
+                : '- The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update` or `composer update <package name>`.';
         }
 
         if ($locker->isLocked()) {

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -14,6 +14,7 @@ namespace Composer\Json;
 
 use Composer\Pcre\Preg;
 use Composer\Util\Filesystem;
+use Composer\Util\ProcessExecutor;
 use JsonSchema\Validator;
 use Seld\JsonLint\JsonParser;
 use Seld\JsonLint\ParsingException;
@@ -389,5 +390,20 @@ class JsonFile
             return $match[1];
         }
         return self::INDENT_DEFAULT;
+    }
+
+    /** @return ?bool, True if it exists, False if it doesn't, null when git is not installed or on other exit codes */
+    public function isInGit(): ?bool
+    {
+        $code = (new ProcessExecutor($this->io))->execute(['git', 'show', "HEAD~1:{$this->path}", '> /dev/null 2>&1'], $output);
+        if ($code === 0) {
+            return true;
+        }
+
+        if ($code === 128) {
+            return false;
+        }
+
+        return null;
     }
 }

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -392,7 +392,7 @@ class JsonFile
         return self::INDENT_DEFAULT;
     }
 
-    /** @return ?bool, True if it exists, False if it doesn't, null when git is not installed or on other exit codes */
+    /** @return ?bool True if it exists, False if it doesn't, null when git is not installed or on other exit codes */
     public function isInGit(): ?bool
     {
         $code = (new ProcessExecutor($this->io))->execute(['git', 'show', "HEAD~1:{$this->path}", '> /dev/null 2>&1'], $output);

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -620,7 +620,7 @@ class Locker
         }
 
         if ($missingRequirements) {
-            $missingRequirementInfo[] = 'This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.';
+            $missingRequirementInfo[] = 'This usually happens when composer files are incorrectly merged, the lock file is not in version control or the composer.json file is manually edited.';
             $missingRequirementInfo[] = 'Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md';
             $missingRequirementInfo[] = 'and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r';
         }

--- a/tests/Composer/Test/Command/ValidateCommandTest.php
+++ b/tests/Composer/Test/Command/ValidateCommandTest.php
@@ -58,7 +58,7 @@ class ValidateCommandTest extends TestCase
 ./composer.json is valid but your composer.lock has some errors
 # Lock file errors
 - Required package "root/req" is not present in the lock file.
-This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
+This usually happens when composer files are incorrectly merged, the lock file is not in version control or the composer.json file is manually edited.
 Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
 and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
 OUTPUT;

--- a/tests/Composer/Test/Fixtures/installer/install-from-incomplete-lock-with-ignore.test
+++ b/tests/Composer/Test/Fixtures/installer/install-from-incomplete-lock-with-ignore.test
@@ -38,7 +38,7 @@ install
 Installing dependencies from lock file (including require-dev)
 Verifying lock file contents can be installed on current platform.
 - Required package "newly-required/pkg" is not present in the lock file.
-This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
+This usually happens when composer files are incorrectly merged, the lock file is not in version control or the composer.json file is manually edited.
 Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
 and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
 Package operations: 1 install, 0 updates, 0 removals

--- a/tests/Composer/Test/Fixtures/installer/install-from-incomplete-lock.test
+++ b/tests/Composer/Test/Fixtures/installer/install-from-incomplete-lock.test
@@ -34,7 +34,7 @@ install
 Installing dependencies from lock file (including require-dev)
 Verifying lock file contents can be installed on current platform.
 - Required package "newly-required/pkg" is not present in the lock file.
-This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
+This usually happens when composer files are incorrectly merged, the lock file is not in version control or the composer.json file is manually edited.
 Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
 and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
 --EXPECT-EXIT-CODE--

--- a/tests/Composer/Test/Fixtures/installer/outdated-lock-file-fails-install.test
+++ b/tests/Composer/Test/Fixtures/installer/outdated-lock-file-fails-install.test
@@ -32,7 +32,7 @@ Verifying lock file contents can be installed on current platform.
 <warning>Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.</warning>
 - Required package "some/dep" is in the lock file as "dev-foo" but that does not satisfy your constraint "dev-main".
 - Required package "some/dep2" is not present in the lock file.
-This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
+This usually happens when composer files are incorrectly merged, the lock file is not in version control or the composer.json file is manually edited.
 Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
 and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
 

--- a/tests/Composer/Test/Fixtures/installer/root-requirements-do-not-affect-locked-versions.test
+++ b/tests/Composer/Test/Fixtures/installer/root-requirements-do-not-affect-locked-versions.test
@@ -62,7 +62,7 @@ Verifying lock file contents can be installed on current platform.
 - Required package "foo/bar" is in the lock file as "1.0.0" but that does not satisfy your constraint "2.0.0".
 - Required package "foo/provided-wrong-version" is in the lock file as "provided as ^3 by foo/self 1.2.2" but that does not satisfy your constraint "1.0.0".
 - Required package "foo/root-replaced-wrong-version" is in the lock file as "replaced as ^2 by __root__ 1.2.3" but that does not satisfy your constraint "1.0.0".
-This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
+This usually happens when composer files are incorrectly merged, the lock file is not in version control or the composer.json file is manually edited.
 Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
 and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
 --EXPECT-EXIT-CODE--


### PR DESCRIPTION
When developing on a library and without the composer.lock file committed to version control, the lock file might get outdated. 

I run into this scenario quite often as I have checkouts of a bunch of libraries on my laptop and desktop. When I update the composer.json on one machine and then run a composer install on the other this error appears.

Currently, in that case the following error message gets shown:
```
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
- Required (in require-dev) package ######## is in the lock file as ###### but that does not satisfy your constraint #####.
This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r

```

After the changes from this PR, the error message will be this for libraries where the composer.lock file is not in version control:
```
Warning: The lock file is not up to date with the latest changes in composer.json. The lock file is not in git and this is a library so the lock file can probably be safely deleted.
- Required (in require-dev) package ######## is in the lock file as ###### but that does not satisfy your constraint #####.
This usually happens when composer files are incorrectly merged, the lock file is not in version control or the composer.json file is manually edited.
Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
```