### PR TITLE
feat: add COMPOSER_MAX_PARALLEL_PROCESSES 

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1274,7 +1274,7 @@ in performance gains.
 ### COMPOSER_MAX_PARALLEL_PROCESSES
 
 Set to an an integer to configure how many processes can be executed in parallel.
-This defaults to 10 and must be between 1 an 50.
+This defaults to 10 and must be between 1 and 50.
 
 ### COMPOSER_IPRESOLVE
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1271,6 +1271,11 @@ defaults to 12 and must be between 1 and 50. If your proxy has issues with
 concurrency maybe you want to lower this. Increasing it should generally not result
 in performance gains.
 
+### COMPOSER_MAX_PARALLEL_PROCESSES
+
+Set to an an integer to configure how many processes can be executed in parallel.
+This defaults to 10 and must be between 1 an 50.
+
 ### COMPOSER_IPRESOLVE
 
 Set to `4` or `6` to force IPv4 or IPv6 DNS resolution. This only works when the

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -78,9 +78,7 @@ class ProcessExecutor
     public function __construct(?IOInterface $io = null)
     {
         $this->io = $io;
-        if (is_numeric($maxJobs = Platform::getEnv('COMPOSER_MAX_PARALLEL_PROCESSES'))) {
-            $this->maxJobs = max(1, min(50, (int) $maxJobs));
-        }
+        $this->resetMaxJobs();
     }
 
     /**

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -78,6 +78,9 @@ class ProcessExecutor
     public function __construct(?IOInterface $io = null)
     {
         $this->io = $io;
+        if (is_numeric($maxJobs = Platform::getEnv('COMPOSER_MAX_PARALLEL_PROCESSES'))) {
+            $this->maxJobs = max(1, min(50, (int) $maxJobs));
+        }
     }
 
     /**
@@ -350,7 +353,11 @@ class ProcessExecutor
 
     public function resetMaxJobs(): void
     {
-        $this->maxJobs = 10;
+        if (is_numeric($maxJobs = Platform::getEnv('COMPOSER_MAX_PARALLEL_PROCESSES'))) {
+            $this->maxJobs = max(1, min(50, (int) $maxJobs));
+        } else {
+            $this->maxJobs = 10;
+        }
     }
 
     /**


### PR DESCRIPTION
This PR introduces the environment variable COMPOSER_MAX_PARALLEL_PROCESSES to increase or decrease the number parallel processes initiated by the ProcessExecutor.

In our case we want to decrease the number as 10 simultaneous unzip processes puts a severe strain on our server. (Especially when there are multiple composer installs being performed at the same time.