### PR TITLE
Fix error handler to bypass some new php 8.5 warnings and avoid spamming output too much with deprecation notices

### DIFF
--- a/src/Composer/Util/ErrorHandler.php
+++ b/src/Composer/Util/ErrorHandler.php
@@ -24,6 +24,9 @@ class ErrorHandler
     /** @var ?IOInterface */
     private static $io;
 
+    /** @var int<0, 2> */
+    private static $hasShownDeprecationNotice = 0;
+
     /**
      * Error handler
      *
@@ -50,23 +53,26 @@ class ErrorHandler
         }
 
         if (!$isDeprecationNotice) {
+            // ignore some newly introduced warnings in new php versions until dependencies
+            // can be fixed as we do not want to abort execution for those
+            if (in_array($level, [E_WARNING, E_USER_WARNING], true) && str_contains($message, 'should either be used or intentionally ignored by casting it as (void)')) {
+                self::outputWarning('Ignored new PHP warning but it should be reported and fixed: '.$message.' in '.$file.':'.$line, true);
+                return true;
+            }
+
             throw new \ErrorException($message, 0, $level, $file, $line);
         }
 
         if (self::$io !== null) {
-            self::$io->writeError('<warning>Deprecation Notice: '.$message.' in '.$file.':'.$line.'</warning>');
-            if (self::$io->isVerbose()) {
-                self::$io->writeError('<warning>Stack trace:</warning>');
-                self::$io->writeError(array_filter(array_map(static function ($a): ?string {
-                    if (isset($a['line'], $a['file'])) {
-                        return '<warning> '.$a['file'].':'.$a['line'].'</warning>';
-                    }
-
-                    return null;
-                }, array_slice(debug_backtrace(), 2)), function (?string $line) {
-                    return $line !== null;
-                }));
+            if (self::$hasShownDeprecationNotice > 0 && !self::$io->isVerbose()) {
+                if (self::$hasShownDeprecationNotice === 1) {
+                    self::$io->writeError('<warning>More deprecation notices were hidden, run again with `-v` to show them.</warning>');
+                    self::$hasShownDeprecationNotice = 2;
+                }
+                return true;
             }
+            self::$hasShownDeprecationNotice = 1;
+            self::outputWarning('Deprecation Notice: '.$message.' in '.$file.':'.$line);
         }
 
         return true;
@@ -80,5 +86,34 @@ class ErrorHandler
         set_error_handler([__CLASS__, 'handle']);
         error_reporting(E_ALL);
         self::$io = $io;
+    }
+
+    private static function outputWarning(string $message, bool $outputEvenWithoutIO = false): void
+    {
+        if (self::$io !== null) {
+            self::$io->writeError('<warning>'.$message.'</warning>');
+            if (self::$io->isVerbose()) {
+                self::$io->writeError('<warning>Stack trace:</warning>');
+                self::$io->writeError(array_filter(array_map(static function ($a): ?string {
+                    if (isset($a['line'], $a['file'])) {
+                        return '<warning> '.$a['file'].':'.$a['line'].'</warning>';
+                    }
+
+                    return null;
+                }, array_slice(debug_backtrace(), 2)), function (?string $line) {
+                    return $line !== null;
+                }));
+            }
+
+            return;
+        }
+
+        if ($outputEvenWithoutIO) {
+            if (defined('STDERR') && is_resource(STDERR)) {
+                fwrite(STDERR, 'Warning: '.$message.PHP_EOL);
+            } else {
+                echo 'Warning: '.$message.PHP_EOL;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #12285

Workaround for symfony/symfony#60128 cc @sebastianbergmann this should work right?
