### PR TITLE
CurlDownloader - Add support for HTTP/3

### DIFF
--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -614,12 +614,20 @@ EOT
 
             $version = curl_version();
             $hasZstd = isset($version['features']) && defined('CURL_VERSION_ZSTD') && 0 !== ($version['features'] & CURL_VERSION_ZSTD);
+            $httpVersions = '1.0, 1.1';
+            if (isset($version['features']) && \defined('CURL_VERSION_HTTP2') && \defined('CURL_HTTP_VERSION_2_0') && (CURL_VERSION_HTTP2 & $version['features']) !== 0) {
+                $httpVersions .= ', 2';
+            }
+            if (isset($version['features']) && \defined('CURL_VERSION_HTTP3') && ($version['features'] & CURL_VERSION_HTTP3) !== 0) {
+                $httpVersions .= ', 3';
+            }
 
             return '<comment>'.$version['version'].'</comment> '.
                 'libz <comment>'.($version['libz_version'] ?? 'missing').'</comment> '.
                 'brotli <comment>'.($version['brotli_version'] ?? 'missing').'</comment> '.
                 'zstd <comment>'.($hasZstd ? 'supported' : 'missing').'</comment> '.
-                'ssl <comment>'.($version['ssl_version'] ?? 'missing').'</comment>';
+                'ssl <comment>'.($version['ssl_version'] ?? 'missing').'</comment> '.
+                'HTTP <comment>'.$httpVersions.'</comment>';
         }
 
         return '<error>missing, using php streams fallback, which reduces performance</error>';

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -237,8 +237,14 @@ class CurlDownloader
 
         $version = curl_version();
         $features = $version['features'];
-        if (0 === strpos($url, 'https://') && \defined('CURL_VERSION_HTTP2') && \defined('CURL_HTTP_VERSION_2_0') && (CURL_VERSION_HTTP2 & $features) !== 0) {
-            curl_setopt($curlHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+
+        if (0 === strpos($url, 'https://')) {
+            if (\defined('CURL_VERSION_HTTP3') && \defined('CURL_HTTP_VERSION_3') && (CURL_VERSION_HTTP3 & $features) !== 0) {
+                curl_setopt($curlHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3);
+            }
+            elseif (\defined('CURL_VERSION_HTTP2') && \defined('CURL_HTTP_VERSION_2_0') && (CURL_VERSION_HTTP2 & $features) !== 0) {
+                curl_setopt($curlHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+            }
         }
 
         // curl 8.7.0 - 8.7.1 has a bug whereas automatic accept-encoding header results in an error when reading the response


### PR DESCRIPTION
PHP 8.4 should be able to support HTTP/3 if the Curl extension is compiled with an OpenSSL branch with HTTP/3 support.

GitHub, GitLab, and packagist.org do not seem to support HTTP/3 yet, but we can still safely enable HTTP/3 if it's available to future-proof it.

This also updates the `diagnose` command to show the HTTP versions supported.

![image](https://github.com/user-attachments/assets/9685f21a-ac00-410a-97ce-3eb12f776a5f)
 