### PR TITLE
Don't run bump after update with `--lock`

### DIFF
--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -280,7 +280,7 @@ EOT
 
         $result = $install->run();
 
-        if ($result === 0) {
+        if ($result === 0 && !$input->getOption('lock')) {
             $bumpAfterUpdate = $input->getOption('bump-after-update');
             if (false === $bumpAfterUpdate) {
                 $bumpAfterUpdate = $composer->getConfig()->get('bump-after-update');

--- a/tests/Composer/Test/Command/UpdateCommandTest.php
+++ b/tests/Composer/Test/Command/UpdateCommandTest.php
@@ -151,6 +151,19 @@ OUTPUT
             , true
         ];
 
+        yield 'update & bump with lock' => [
+            $rootDepAndTransitiveDep,
+            ['--bump-after-update' => true, '--lock' => true],
+            <<<OUTPUT
+Loading composer repositories with package information
+Updating dependencies
+Nothing to modify in lock file
+Installing dependencies from lock file (including require-dev)
+Nothing to install, update or remove
+OUTPUT
+            , true
+        ];
+
         yield 'update & bump dev only' => [
             $rootDepAndTransitiveDep,
             ['--bump-after-update' => 'dev'],


### PR DESCRIPTION
I don't think it makes sense to run the `bump` command when `--lock` is used, since that option should only update the hash in the lock file.