### PR TITLE
Do not output script being run when running via composer <script-name>

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -346,8 +346,12 @@ class EventDispatcher
 
                     if ($this->io->isVerbose()) {
                         $this->io->writeError(sprintf('> %s: %s', $event->getName(), $exec));
-                    } elseif ($event->getName() !== '__exec_command') {
+                    } elseif (
                         // do not output the command being run when using `composer exec` as it is fairly obvious the user is running it
+                        $event->getName() !== '__exec_command'
+                        // do not output the command being run when using `composer <script-name>` as it is also fairly obvious the user is running it
+                        && ($event->getFlags()['script-alias-input'] ?? null) === null
+                    ) {
                         $this->io->writeError(sprintf('> %s', $exec));
                     }
 

--- a/tests/Composer/Test/Command/GlobalCommandTest.php
+++ b/tests/Composer/Test/Command/GlobalCommandTest.php
@@ -23,10 +23,10 @@ class GlobalCommandTest extends TestCase
         Platform::clearEnv('COMPOSER_HOME');
         Platform::clearEnv('COMPOSER');
     }
-    
+
     public function testGlobal(): void
     {
-        $script = '@php -r \'echo getenv("COMPOSER") . PHP_EOL;\'';
+        $script = '@php -r "echo \'COMPOSER SCRIPT OUTPUT: \'.getenv(\'COMPOSER\') . PHP_EOL;"';
         $fakeComposer = 'TMP_COMPOSER.JSON';
         $composerHome = $this->initTempComposer(
             [
@@ -51,12 +51,11 @@ class GlobalCommandTest extends TestCase
 
         $display = $appTester->getDisplay(true);
 
-        self::assertStringContainsString(
-            'Changed current directory to ' . $composerHome,
+        self::assertSame(
+            'Changed current directory to ' . $composerHome . "\n".
+            "COMPOSER SCRIPT OUTPUT: \n",
             $display
         );
-        self::assertStringContainsString($script, $display);
-        self::assertStringNotContainsString($fakeComposer, $display, '$COMPOSER is not unset by global command');
     }
 
     public function testCannotCreateHome(): void


### PR DESCRIPTION
Fixes #12375

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
