### PR TITLE
Change config command to allow empty name when adding new repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+  * Added support to `config repositories` command to add repositories without a name (#9918)
+
 ### [2.8.8] 2025-04-04
 
   * Fixed json schema issues with version validation (#12367)

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -862,10 +862,16 @@ In addition to modifying the config section, the `config` command also supports 
 changes to the repositories section by using it the following way:
 
 ```shell
-php composer.phar config repositories.foo vcs https://github.com/foo/bar
+php composer.phar config repositories vcs https://github.com/foo/bar
 ```
 
 If your repository requires more configuration options, you can instead pass its JSON representation :
+
+```shell
+php composer.phar config repositories '{"type": "vcs", "url": "http://svn.example.org/my-project/", "trunk-path": "master"}'
+```
+
+If you want to name the repository you can add a name to it:
 
 ```shell
 php composer.phar config repositories.foo '{"type": "vcs", "url": "http://svn.example.org/my-project/", "trunk-path": "master"}'

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -123,11 +123,16 @@ To edit the global config.json file:
 
 To add a repository:
 
+    <comment>%command.full_name% repositories vcs https://bar.com</comment>
+
+To add a repository by name:
+
     <comment>%command.full_name% repositories.foo vcs https://bar.com</comment>
 
 To remove a repository (repo is a short alias for repositories):
 
     <comment>%command.full_name% --unset repo.foo</comment>
+    <comment>%command.full_name% --unset repo.0</comment>
 
 To disable packagist:
 
@@ -731,8 +736,14 @@ EOT
         }
 
         // handle repositories
-        if (Preg::isMatchStrictGroups('/^repos?(?:itories)?\.(.+)/', $settingKey, $matches)) {
+        if (Preg::isMatchStrictGroups('/^repos?(?:itories)?($|\..+)/', $settingKey, $matches)) {
+            $matches[1] = ltrim($matches[1], '.');
+
             if ($input->getOption('unset')) {
+                if ($matches[1] === '') {
+                    throw new \RuntimeException('You must pass the index or name of the repository to remove. Example: php composer.phar config --unset repositories.foo');
+                }
+
                 $this->configSource->removeRepository($matches[1]);
 
                 return 0;

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -75,10 +75,18 @@ class JsonConfigSource implements ConfigSourceInterface
                 }
             }
 
-            if ($append) {
-                $config['repositories'][$repo] = $repoConfig;
+            if ($repo === '') {
+                if ($append) {
+                    $config['repositories'][] = $repoConfig;
+                } else {
+                    array_unshift($config['repositories'], $repoConfig);
+                }
             } else {
-                $config['repositories'] = [$repo => $repoConfig] + $config['repositories'];
+                if ($append) {
+                    $config['repositories'][$repo] = $repoConfig;
+                } else {
+                    $config['repositories'] = [$repo => $repoConfig] + $config['repositories'];
+                }
             }
         }, $name, $config, $append);
     }

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -159,7 +159,11 @@ class JsonManipulator
      */
     public function addRepository(string $name, $config, bool $append = true): bool
     {
-        return $this->addSubNode('repositories', $name, $config, $append);
+        if ($name === '') {
+            return $this->addListItem('repositories', $name, $config, $append);
+        } else {
+            return $this->addSubNode('repositories', $name, $config, $append);
+        }
     }
 
     public function removeRepository(string $name): bool
@@ -317,6 +321,110 @@ class JsonManipulator
 
                 // children present but empty
                 $children = '{' . $this->newline . $this->indent . $this->indent . JsonFile::encode($name).': '.$this->format($value, 1) . $whitespace . '}';
+            }
+        } else {
+            throw new \LogicException('Nothing matched above for: '.$children);
+        }
+
+        $this->contents = Preg::replaceCallback($nodeRegex, static function ($m) use ($children): string {
+            return $m['start'] . $children . $m['end'];
+        }, $this->contents);
+
+        return true;
+    }
+
+    /**
+     * @param mixed  $value
+     */
+    public function addListItem(string $mainNode, string $name, $value, bool $append = true): bool
+    {
+        $decoded = JsonFile::parseJson($this->contents);
+
+        $subName = null;
+        if (in_array($mainNode, ['config', 'extra', 'scripts']) && false !== strpos($name, '.')) {
+            [$name, $subName] = explode('.', $name, 2);
+        }
+
+        // no main node yet
+        if (!isset($decoded[$mainNode])) {
+            if ($subName !== null) {
+                $this->addMainKey($mainNode, [$name => [$subName => [$value]]]);
+            } else {
+                $this->addMainKey($mainNode, [$name => [$value]]);
+            }
+
+            return true;
+        }
+
+        // main node content not match-able
+        $nodeRegex = '{'.self::DEFINES.'^(?P<start> \s* \{ \s* (?: (?&string) \s* : (?&json) \s* , \s* )*?'.
+            preg_quote(JsonFile::encode($mainNode)).'\s*:\s*)(?P<content>(?&array))(?P<end>.*)}sx';
+
+        try {
+            if (!Preg::isMatch($nodeRegex, $this->contents, $match)) {
+                return false;
+            }
+        } catch (\RuntimeException $e) {
+            if ($e->getCode() === PREG_BACKTRACK_LIMIT_ERROR) {
+                return false;
+            }
+            throw $e;
+        }
+
+        assert(is_string($match['start']));
+        assert(is_string($match['content']));
+        assert(is_string($match['end']));
+
+        $children = $match['content'];
+        // invalid match due to un-regexable content, abort
+        if (!@json_decode($children)) {
+            return false;
+        }
+
+        // child exists
+        $childRegex = '{'.self::DEFINES.'(?P<start>"'.preg_quote($name).'"\s*:\s*)(?P<content>(?&json))(?P<end>,?)}x';
+        if (Preg::isMatch($childRegex, $children, $matches)) {
+            $children = Preg::replaceCallback($childRegex, function ($matches) use ($subName, $value): string {
+                if ($subName !== null && is_string($matches['content'])) {
+                    $curVal = json_decode($matches['content'], true);
+
+                    if (!is_array($curVal)) {
+                        $curVal = [];
+                    }
+
+                    $curVal[] = $value;
+
+                    $value = $curVal;
+                }
+
+                return $matches['start'] . $this->format($value, 1) . $matches['end'];
+            }, $children);
+        } elseif (Preg::isMatch('#^\[(?P<leadingspace>\s*?)(?P<content>\S+.*?)?(?P<trailingspace>\s*)\]$#s', $children, $match)) {
+            $whitespace = $match['trailingspace'];
+
+            if ($subName !== null) {
+                $value = [$subName => $value];
+            }
+
+            if (null !== $match['content']) {
+                // child missing but non empty children
+                if ($append) {
+                    $children = Preg::replace(
+                        '#'.$whitespace.']$#',
+                        addcslashes(',' . $this->newline . $this->indent . $this->indent . $this->format($value, 1) . $whitespace . ']', '\\$'),
+                        $children
+                    );
+                } else {
+                    $whitespace = $match['leadingspace'];
+                    $children = Preg::replace(
+                        '#^\['.$whitespace.'#',
+                        addcslashes('[' . $whitespace . $this->format($value, 1) . ',' . $this->newline . $this->indent . $this->indent, '\\$'),
+                        $children
+                    );
+                }
+            } else {
+                // children present but empty
+                $children = '[' . $this->newline . $this->indent . $this->indent . $this->format($value, 1) . $whitespace . ']';
             }
         } else {
             throw new \LogicException('Nothing matched above for: '.$children);

--- a/tests/Composer/Test/Command/ConfigCommandTest.php
+++ b/tests/Composer/Test/Command/ConfigCommandTest.php
@@ -25,7 +25,7 @@ class ConfigCommandTest extends TestCase
      */
     public function testConfigUpdates(array $before, array $command, array $expected): void
     {
-        $this->initTempComposer($before);
+        $this->initTempComposer($before, [], [], false);
 
         $appTester = $this->getApplicationTester();
         $appTester->run(array_merge(['command' => 'config'], $command));
@@ -116,6 +116,46 @@ class ConfigCommandTest extends TestCase
             ['autoload-dev' => ['psr-4' => ['test'], 'classmap' => ['test']]],
             ['setting-key' => 'autoload-dev.psr-4', '--unset' => true],
             ['autoload-dev' => ['classmap' => ['test']]],
+        ];
+        yield 'prepend repository by name (list to assoc)' => [
+            ['repositories' => [['type' => 'git', 'url' => 'example.tld']]],
+            ['setting-key' => 'repositories.foo', 'setting-value' => ['path', 'foo/bar']],
+            ['repositories' => ['foo' => ['type' => 'path', 'url' => 'foo/bar'], '0' => ['type' => 'git', 'url' => 'example.tld']]],
+        ];
+        yield 'append repository by name (list to assoc)' => [
+            ['repositories' => [['type' => 'git', 'url' => 'example.tld']]],
+            ['setting-key' => 'repositories.foo', 'setting-value' => ['path', 'foo/bar'], '--append' => true],
+            ['repositories' => ['0' => ['type' => 'git', 'url' => 'example.tld'], 'foo' => ['type' => 'path', 'url' => 'foo/bar']]],
+        ];
+        yield 'prepend repository (list)' => [
+            ['repositories' => [['type' => 'git', 'url' => 'example.tld']]],
+            ['setting-key' => 'repositories', 'setting-value' => ['path', 'foo/bar']],
+            ['repositories' => [['type' => 'path', 'url' => 'foo/bar'], ['type' => 'git', 'url' => 'example.tld']]],
+        ];
+        yield 'append repository (list)' => [
+            ['repositories' => [['type' => 'git', 'url' => 'example.tld']]],
+            ['setting-key' => 'repositories', 'setting-value' => ['path', 'foo/bar'], '--append' => true],
+            ['repositories' => [['type' => 'git', 'url' => 'example.tld'], ['type' => 'path', 'url' => 'foo/bar']]],
+        ];
+        yield 'prepend repository by name (assoc)' => [
+            ['repositories' => [['type' => 'git', 'url' => 'example.tld'], 'packagist.org' => false]],
+            ['setting-key' => 'repositories.foo', 'setting-value' => ['path', 'foo/bar']],
+            ['repositories' => ['foo' => ['type' => 'path', 'url' => 'foo/bar'], '0' => ['type' => 'git', 'url' => 'example.tld'], 'packagist.org' => false]],
+        ];
+        yield 'append repository by name (assoc)' => [
+            ['repositories' => [['type' => 'git', 'url' => 'example.tld'], 'packagist.org' => false]],
+            ['setting-key' => 'repositories.foo', 'setting-value' => ['path', 'foo/bar'], '--append' => true],
+            ['repositories' => ['0' => ['type' => 'git', 'url' => 'example.tld'], 'packagist.org' => false, 'foo' => ['type' => 'path', 'url' => 'foo/bar']]],
+        ];
+        yield 'prepend repository (assoc)' => [
+            ['repositories' => [['type' => 'git', 'url' => 'example.tld'], 'packagist.org' => false]],
+            ['setting-key' => 'repositories', 'setting-value' => ['path', 'foo/bar']],
+            ['repositories' => [['type' => 'path', 'url' => 'foo/bar'], ['type' => 'git', 'url' => 'example.tld'], 'packagist.org' => false]],
+        ];
+        yield 'append repository (assoc)' => [
+            ['repositories' => [['type' => 'git', 'url' => 'example.tld'], 'packagist.org' => false]],
+            ['setting-key' => 'repositories', 'setting-value' => ['path', 'foo/bar'], '--append' => true],
+            ['repositories' => [['type' => 'git', 'url' => 'example.tld'], 'packagist.org' => false, ['type' => 'path', 'url' => 'foo/bar']]],
         ];
     }
 

--- a/tests/Composer/Test/Config/Fixtures/config/config-with-exampletld-repository-as-list.json
+++ b/tests/Composer/Test/Config/Fixtures/config/config-with-exampletld-repository-as-list.json
@@ -1,0 +1,10 @@
+{
+    "name": "my-vend/my-app",
+    "license": "MIT",
+    "repositories": [
+        {
+            "type": "git",
+            "url": "example.tld"
+        }
+    ]
+}

--- a/tests/Composer/Test/Config/JsonConfigSourceTest.php
+++ b/tests/Composer/Test/Config/JsonConfigSourceTest.php
@@ -53,6 +53,16 @@ class JsonConfigSourceTest extends TestCase
         self::assertFileEquals(self::fixturePath('config/config-with-exampletld-repository.json'), $config);
     }
 
+    public function testAddRepositoryAsList(): void
+    {
+        $config = $this->workingDir.'/composer.json';
+        copy(self::fixturePath('composer-repositories.json'), $config);
+        $jsonConfigSource = new JsonConfigSource(new JsonFile($config));
+        $jsonConfigSource->addRepository('', ['type' => 'git', 'url' => 'example.tld']);
+
+        self::assertFileEquals(self::fixturePath('config/config-with-exampletld-repository-as-list.json'), $config);
+    }
+
     public function testAddRepositoryWithOptions(): void
     {
         $config = $this->workingDir.'/composer.json';

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -2021,6 +2021,235 @@ class JsonManipulatorTest extends TestCase
 ', $manipulator->getContents());
     }
 
+    /**
+     * @return iterable<string, array{0: string, 1: string, 2: string, 3: array, 4: bool}>
+     */
+    public static function addRepositoryProvider(): iterable
+    {
+        yield 'prepend repository (list)' => [
+            '{
+    "repositories": [
+        {
+            "type": "git",
+            "url": "example.tld"
+        }
+    ]
+}
+',
+            '{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "foo/bar"
+        },
+        {
+            "type": "git",
+            "url": "example.tld"
+        }
+    ]
+}
+',
+            '',
+            [
+                'type' => 'path',
+                'url' => 'foo/bar',
+            ],
+            false,
+        ];
+        yield 'append repository (list)' => [
+            '{
+    "repositories": [
+        {
+            "type": "git",
+            "url": "example.tld"
+        }
+    ]
+}
+',
+            '{
+    "repositories": [
+        {
+            "type": "git",
+            "url": "example.tld"
+        },
+        {
+            "type": "path",
+            "url": "foo/bar"
+        }
+    ]
+}
+',
+            '',
+            [
+                'type' => 'path',
+                'url' => 'foo/bar',
+            ],
+            true,
+        ];
+        yield 'prepend repository by name (assoc)' => [
+            '{
+    "repositories": {
+        "0": {
+            "type": "git",
+            "url": "example.tld"
+        },
+        "packagist.org": false
+    }
+}
+',
+            '{
+    "repositories": {
+        "foo": {
+            "type": "path",
+            "url": "foo/bar"
+        },
+        "0": {
+            "type": "git",
+            "url": "example.tld"
+        },
+        "packagist.org": false
+    }
+}
+',
+            'foo',
+            [
+                'type' => 'path',
+                'url' => 'foo/bar',
+            ],
+            false,
+        ];
+        yield 'append repository by name (assoc)' => [
+            '{
+    "repositories": {
+        "0": {
+            "type": "git",
+            "url": "example.tld"
+        },
+        "packagist.org": false
+    }
+}
+',
+            '{
+    "repositories": {
+        "0": {
+            "type": "git",
+            "url": "example.tld"
+        },
+        "packagist.org": false,
+        "foo": {
+            "type": "path",
+            "url": "foo/bar"
+        }
+    }
+}
+',
+            'foo',
+            [
+                'type' => 'path',
+                'url' => 'foo/bar',
+            ],
+            true,
+        ];
+    }
+
+    /**
+     * @dataProvider addRepositoryProvider
+     */
+    public function testAddRepository(string $from, string $to, string $name, array $config, bool $append): void
+    {
+        $manipulator = new JsonManipulator($from);
+
+        self::assertTrue($manipulator->addRepository($name, $config, $append));
+        self::assertEquals($to, $manipulator->getContents());
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string, 2: array, 3: bool}>
+     */
+    public static function addRepositoryProviderExpectingFallbackToHandle(): iterable
+    {
+        yield 'prepend repository by name (list to assoc)' => [
+            '{
+    "repositories": [
+        {
+            "type": "git",
+            "url": "example.tld"
+        }
+    ]
+}
+',
+            'foo',
+            [
+                'type' => 'path',
+                'url' => 'foo/bar',
+            ],
+            false,
+        ];
+        yield 'append repository by name (list to assoc)' => [
+            '{
+    "repositories": [
+        {
+            "type": "git",
+            "url": "example.tld"
+        }
+    ]
+}
+',
+            'foo',
+            [
+                'type' => 'path',
+                'url' => 'foo/bar',
+            ],
+            true,
+        ];
+        yield 'prepend repository (assoc)' => [
+            '{
+    "repositories": {
+        "0": {
+            "type": "git",
+            "url": "example.tld"
+        },
+        "packagist.org": false
+    }
+}
+',
+            '',
+            [
+                'type' => 'path',
+                'url' => 'foo/bar',
+            ],
+            false,
+        ];
+        yield 'append repository (assoc)' => [
+            '{
+    "repositories": {
+        "0": {
+            "type": "git",
+            "url": "example.tld"
+        },
+        "packagist.org": false
+    }
+}
+',
+            '',
+            [
+                'type' => 'path',
+                'url' => 'foo/bar',
+            ],
+            true,
+        ];
+    }
+
+    /**
+     * @dataProvider addRepositoryProviderExpectingFallbackToHandle
+     */
+    public function testAddRepositoryFailsOnAssocToListOrListToAssoc(string $from, string $name, array $config, bool $append): void
+    {
+        $manipulator = new JsonManipulator($from);
+
+        self::assertFalse($manipulator->addRepository($name, $config, $append));
+    }
+
     public function testAddRepositoryCanOverrideDeepRepos(): void
     {
         $manipulator = new JsonManipulator('{

--- a/tests/Composer/Test/TestCase.php
+++ b/tests/Composer/Test/TestCase.php
@@ -125,7 +125,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @param mixed[] $composerLock
      * @return string the newly created temp dir
      */
-    public function initTempComposer(array $composerJson = [], array $authJson = [], array $composerLock = []): string
+    public function initTempComposer(array $composerJson = [], array $authJson = [], array $composerLock = [], bool $setupRepositories = true): string
     {
         $dir = self::getUniqueTmpDirectory();
 
@@ -143,7 +143,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             $authJson = new \stdClass;
         }
 
-        if (is_array($composerJson) && isset($composerJson['repositories']) && !isset($composerJson['repositories']['packagist.org'])) {
+        if ($setupRepositories && is_array($composerJson) && isset($composerJson['repositories']) && !isset($composerJson['repositories']['packagist.org'])) {
             $composerJson['repositories']['packagist.org'] = false;
         }
 


### PR DESCRIPTION
When working with third-party package repositories I learned to just execute a command like

```shell
$ composer config repositories.shopware-packages '{"type": "composer", "url": "https://packages.shopware.com"}'
```

and have access to new packages. I once was confused, that everyone is writing repositories as lists and after that one has a diff like that

```diff
 {
-    "repositories": [
+    "repositories": {
-        {
+        "shopware-packages": {
+            "type": "composer",
+            "url": "https://packages.shopware.com"
+        },
+        "0": {
             "type": "path",
             "url": "custom/static-plugins/*"
         }
-    ]
+    }
 }
```

Back then I was not really questioning it. Just different styles of writing it. Now as of today I am aware of more PHP internals like arrays have three indices. Therefore I better understand warnings like these in the docs

> Using JSON object notation is also possible. However, JSON key/value pairs are to be considered unordered so consistent behaviour cannot be guaranteed.

Now coming back to this topic after some years I decided to tackle this and later noticed there is an open discussion in #9918 and the comments in https://stackoverflow.com/a/32814046 . I tried to follow up on the expected results of the discussions and have this pull request as a suggestion.

With this change you are now able to run 

```shell
$ composer config repositories composer https://packages.shopware.com
```

and get this diff instead

```diff
 {
     "repositories": [
+        {
+            "type": "composer",
+            "url": "https://packages.shopware.com"
+        },
         {
             "type": "path",
             "url": "custom/static-plugins/*"
         }
     ]
 }
```

I do not see this a breaking change as the command line would not allow the command to work like this. Therefore this likely can just be a feature.

---

I hope this pull request meets requirements you expect for pull requests. I tried to update everything one might need:

* documentation
* tests
* open issues
* a reason why the change is needed
* changelog entry
* atomic commits

If you need something else just have it part of the review.

---

Sidenote: at first I tried to implement the logic for the list item to subnode but noticed, that there are so many more logic branches and changes to the regex that it became less easy to read. I noticed that the regex solution must have a reason to exist so I rather not have it a breaking change and started to introduce a new method. I did not try to make a solution that can convert list to assoc and assoc to list. At this point I just expected the fallback logic to make things work right.
