### PR TITLE
Improve stream wrapper support

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -1292,9 +1292,7 @@ INITIALIZER;
                         }
 
                         $resolvedPath = Platform::realpath($installPath . '/' . $updir);
-                        if (false === $resolvedPath) {
-                            continue;
-                        }
+
                         $autoloads[] = preg_quote(strtr($resolvedPath, '\\', '/')) . '/' . $path . '($|/)';
                         continue;
                     }

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -214,15 +214,15 @@ class AutoloadGenerator
         // Do not remove double realpath() calls.
         // Fixes failing Windows realpath() implementation.
         // See https://bugs.php.net/bug.php?id=72738
-        $basePath = $filesystem->normalizePath(realpath(realpath(Platform::getCwd())));
-        $vendorPath = $filesystem->normalizePath(realpath(realpath($config->get('vendor-dir'))));
+        $basePath = $filesystem->normalizePath(Platform::realpath(Platform::realpath(Platform::getCwd())));
+        $vendorPath = $filesystem->normalizePath(Platform::realpath(Platform::realpath($config->get('vendor-dir'))));
         $useGlobalIncludePath = $config->get('use-include-path');
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
         $targetDir = $vendorPath.'/'.$targetDir;
         $filesystem->ensureDirectoryExists($targetDir);
 
-        $vendorPathCode = $filesystem->findShortestPathCode(realpath($targetDir), $vendorPath, true);
-        $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, realpath($targetDir), true);
+        $vendorPathCode = $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true);
+        $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, Platform::realpath($targetDir), true);
 
         $appBaseDirCode = $filesystem->findShortestPathCode($vendorPath, $basePath, true);
         $appBaseDirCode = str_replace('__DIR__', '$vendorDir', $appBaseDirCode);
@@ -493,7 +493,7 @@ EOF;
         // if $dir does not exist, it should anyway not find anything there so no trouble
         if (file_exists($dir)) {
             // transform $dir in the same way that exclude-from-classmap patterns are transformed so we can match them against each other
-            $dirMatch = preg_quote(strtr(realpath($dir), '\\', '/'));
+            $dirMatch = preg_quote(strtr(Platform::realpath($dir), '\\', '/'));
             foreach ($excluded as $index => $pattern) {
                 // extract the constant string prefix of the pattern here, until we reach a non-escaped regex special character
                 $pattern = Preg::replace('{^(([^.+*?\[^\]$(){}=!<>|:\\\\#-]+|\\\\[.+*?\[^\]$(){}=!<>|:#-])*).*}', '$1', $pattern);
@@ -1165,10 +1165,10 @@ HEADER;
 
         $filesystem = new Filesystem();
 
-        $vendorPathCode = ' => ' . $filesystem->findShortestPathCode(realpath($targetDir), $vendorPath, true, true) . " . '/";
-        $vendorPharPathCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(realpath($targetDir), $vendorPath, true, true) . " . '/";
-        $appBaseDirCode = ' => ' . $filesystem->findShortestPathCode(realpath($targetDir), $basePath, true, true) . " . '/";
-        $appBaseDirPharCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(realpath($targetDir), $basePath, true, true) . " . '/";
+        $vendorPathCode = ' => ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true, true) . " . '/";
+        $vendorPharPathCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true, true) . " . '/";
+        $appBaseDirCode = ' => ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $basePath, true, true) . " . '/";
+        $appBaseDirPharCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $basePath, true, true) . " . '/";
 
         $absoluteVendorPathCode = ' => ' . substr(var_export(rtrim($vendorDir, '\\/') . '/', true), 0, -1);
         $absoluteVendorPharPathCode = ' => ' . substr(var_export(rtrim('phar://' . $vendorDir, '\\/') . '/', true), 0, -1);
@@ -1291,7 +1291,7 @@ INITIALIZER;
                             $installPath = strtr(Platform::getCwd(), '\\', '/');
                         }
 
-                        $resolvedPath = realpath($installPath . '/' . $updir);
+                        $resolvedPath = Platform::realpath($installPath . '/' . $updir);
                         if (false === $resolvedPath) {
                             continue;
                         }

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -217,9 +217,10 @@ class AutoloadGenerator
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
         $targetDir = $vendorPath.'/'.$targetDir;
         $filesystem->ensureDirectoryExists($targetDir);
+        $targetDir = Platform::realpath($vendorPath.'/'.$targetDir);
 
-        $vendorPathCode = $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true);
-        $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, Platform::realpath($targetDir), true);
+        $vendorPathCode = $filesystem->findShortestPathCode($targetDir, $vendorPath, true);
+        $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, $targetDir, true);
 
         $appBaseDirCode = $filesystem->findShortestPathCode($vendorPath, $basePath, true);
         $appBaseDirCode = str_replace('__DIR__', '$vendorDir', $appBaseDirCode);
@@ -1162,10 +1163,10 @@ HEADER;
 
         $filesystem = new Filesystem();
 
-        $vendorPathCode = ' => ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true, true) . " . '/";
-        $vendorPharPathCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true, true) . " . '/";
-        $appBaseDirCode = ' => ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $basePath, true, true) . " . '/";
-        $appBaseDirPharCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $basePath, true, true) . " . '/";
+        $vendorPathCode = ' => ' . $filesystem->findShortestPathCode($targetDir, $vendorPath, true, true) . " . '/";
+        $vendorPharPathCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode($targetDir, $vendorPath, true, true) . " . '/";
+        $appBaseDirCode = ' => ' . $filesystem->findShortestPathCode($targetDir, $basePath, true, true) . " . '/";
+        $appBaseDirPharCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode($targetDir, $basePath, true, true) . " . '/";
 
         $absoluteVendorPathCode = ' => ' . substr(var_export(rtrim($vendorDir, '\\/') . '/', true), 0, -1);
         $absoluteVendorPharPathCode = ' => ' . substr(var_export(rtrim('phar://' . $vendorDir, '\\/') . '/', true), 0, -1);

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -217,7 +217,7 @@ class AutoloadGenerator
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
         $targetDir = $vendorPath.'/'.$targetDir;
         $filesystem->ensureDirectoryExists($targetDir);
-        $targetDir = Platform::realpath($vendorPath.'/'.$targetDir);
+        $targetDir = Platform::realpath($targetDir);
 
         $vendorPathCode = $filesystem->findShortestPathCode($targetDir, $vendorPath, true);
         $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, $targetDir, true);

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -1288,7 +1288,11 @@ INITIALIZER;
                             $installPath = strtr(Platform::getCwd(), '\\', '/');
                         }
 
-                        $resolvedPath = Platform::realpath($installPath . '/' . $updir);
+                        try {
+                            $resolvedPath = Platform::realpath($installPath . '/' . $updir);
+                        } catch (\RuntimeException $e) {
+                            continue;
+                        }
 
                         $autoloads[] = preg_quote(strtr($resolvedPath, '\\', '/')) . '/' . $path . '($|/)';
                         continue;

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -211,11 +211,8 @@ class AutoloadGenerator
 
         $filesystem = new Filesystem();
         $filesystem->ensureDirectoryExists($config->get('vendor-dir'));
-        // Do not remove double realpath() calls.
-        // Fixes failing Windows realpath() implementation.
-        // See https://bugs.php.net/bug.php?id=72738
-        $basePath = $filesystem->normalizePath(Platform::realpath(Platform::realpath(Platform::getCwd())));
-        $vendorPath = $filesystem->normalizePath(Platform::realpath(Platform::realpath($config->get('vendor-dir'))));
+        $basePath = $filesystem->normalizePath(Platform::realpath(Platform::getCwd()));
+        $vendorPath = $filesystem->normalizePath(Platform::realpath($config->get('vendor-dir')));
         $useGlobalIncludePath = $config->get('use-include-path');
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
         $targetDir = $vendorPath.'/'.$targetDir;

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -217,10 +217,9 @@ class AutoloadGenerator
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
         $targetDir = $vendorPath.'/'.$targetDir;
         $filesystem->ensureDirectoryExists($targetDir);
-        $targetDir = Platform::realpath($targetDir);
 
-        $vendorPathCode = $filesystem->findShortestPathCode($targetDir, $vendorPath, true);
-        $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, $targetDir, true);
+        $vendorPathCode = $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true);
+        $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, Platform::realpath($targetDir), true);
 
         $appBaseDirCode = $filesystem->findShortestPathCode($vendorPath, $basePath, true);
         $appBaseDirCode = str_replace('__DIR__', '$vendorDir', $appBaseDirCode);

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -1307,7 +1307,11 @@ INITIALIZER;
                             $installPath = strtr(Platform::getCwd(), '\\', '/');
                         }
 
-                        $resolvedPath = Platform::realpath($installPath . '/' . $updir);
+                        try {
+                            $resolvedPath = Platform::realpath($installPath . '/' . $updir);
+                        } catch (\RuntimeException $e) {
+                            continue;
+                        }
 
                         $autoloads[] = preg_quote(strtr($resolvedPath, '\\', '/')) . '/' . $path . '($|/)';
                         continue;

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -214,15 +214,15 @@ class AutoloadGenerator
         // Do not remove double realpath() calls.
         // Fixes failing Windows realpath() implementation.
         // See https://bugs.php.net/bug.php?id=72738
-        $basePath = $filesystem->normalizePath(realpath(realpath(Platform::getCwd())));
-        $vendorPath = $filesystem->normalizePath(realpath(realpath($config->get('vendor-dir'))));
+        $basePath = $filesystem->normalizePath(Platform::realpath(Platform::realpath(Platform::getCwd())));
+        $vendorPath = $filesystem->normalizePath(Platform::realpath(Platform::realpath($config->get('vendor-dir'))));
         $useGlobalIncludePath = $config->get('use-include-path');
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
         $targetDir = $vendorPath.'/'.$targetDir;
         $filesystem->ensureDirectoryExists($targetDir);
 
-        $vendorPathCode = $filesystem->findShortestPathCode(realpath($targetDir), $vendorPath, true);
-        $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, realpath($targetDir), true);
+        $vendorPathCode = $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true);
+        $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, Platform::realpath($targetDir), true);
 
         $appBaseDirCode = $filesystem->findShortestPathCode($vendorPath, $basePath, true);
         $appBaseDirCode = str_replace('__DIR__', '$vendorDir', $appBaseDirCode);
@@ -493,10 +493,10 @@ EOF;
         // if $dir does not exist, it should anyway not find anything there so no trouble
         if (file_exists($dir)) {
             // transform $dir in the same way that exclude-from-classmap patterns are transformed so we can match them against each other
-            $dirMatch = preg_quote(strtr(realpath($dir), '\\', '/'));
+            $dirMatch = preg_quote(strtr(Platform::realpath($dir), '\\', '/'));
             // also match against the non-realpath version for symlinks
             $fs = new Filesystem();
-            $absDir = $fs->isAbsolutePath($dir) ? $dir : realpath(Platform::getCwd()).'/'.$dir;
+            $absDir = $fs->isAbsolutePath($dir) ? $dir : Platform::realpath(Platform::getCwd()).'/'.$dir;
             $dirMatchNormalized = preg_quote(strtr($fs->normalizePath($absDir), '\\', '/'));
             $isSymlink = $dirMatch !== $dirMatchNormalized;
 
@@ -1183,10 +1183,10 @@ HEADER;
 
         $filesystem = new Filesystem();
 
-        $vendorPathCode = ' => ' . $filesystem->findShortestPathCode(realpath($targetDir), $vendorPath, true, true) . " . '/";
-        $vendorPharPathCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(realpath($targetDir), $vendorPath, true, true) . " . '/";
-        $appBaseDirCode = ' => ' . $filesystem->findShortestPathCode(realpath($targetDir), $basePath, true, true) . " . '/";
-        $appBaseDirPharCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(realpath($targetDir), $basePath, true, true) . " . '/";
+        $vendorPathCode = ' => ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true, true) . " . '/";
+        $vendorPharPathCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true, true) . " . '/";
+        $appBaseDirCode = ' => ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $basePath, true, true) . " . '/";
+        $appBaseDirPharCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $basePath, true, true) . " . '/";
 
         $absoluteVendorPathCode = ' => ' . substr(var_export(rtrim($vendorDir, '\\/') . '/', true), 0, -1);
         $absoluteVendorPharPathCode = ' => ' . substr(var_export(rtrim('phar://' . $vendorDir, '\\/') . '/', true), 0, -1);
@@ -1310,7 +1310,7 @@ INITIALIZER;
                             $installPath = strtr(Platform::getCwd(), '\\', '/');
                         }
 
-                        $resolvedPath = realpath($installPath . '/' . $updir);
+                        $resolvedPath = Platform::realpath($installPath . '/' . $updir);
                         if (false === $resolvedPath) {
                             continue;
                         }

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -217,9 +217,10 @@ class AutoloadGenerator
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
         $targetDir = $vendorPath.'/'.$targetDir;
         $filesystem->ensureDirectoryExists($targetDir);
+        $targetDir = Platform::realpath($vendorPath.'/'.$targetDir);
 
-        $vendorPathCode = $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true);
-        $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, Platform::realpath($targetDir), true);
+        $vendorPathCode = $filesystem->findShortestPathCode($targetDir, $vendorPath, true);
+        $vendorPathToTargetDirCode = $filesystem->findShortestPathCode($vendorPath, $targetDir, true);
 
         $appBaseDirCode = $filesystem->findShortestPathCode($vendorPath, $basePath, true);
         $appBaseDirCode = str_replace('__DIR__', '$vendorDir', $appBaseDirCode);
@@ -1180,10 +1181,10 @@ HEADER;
 
         $filesystem = new Filesystem();
 
-        $vendorPathCode = ' => ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true, true) . " . '/";
-        $vendorPharPathCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $vendorPath, true, true) . " . '/";
-        $appBaseDirCode = ' => ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $basePath, true, true) . " . '/";
-        $appBaseDirPharCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode(Platform::realpath($targetDir), $basePath, true, true) . " . '/";
+        $vendorPathCode = ' => ' . $filesystem->findShortestPathCode($targetDir, $vendorPath, true, true) . " . '/";
+        $vendorPharPathCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode($targetDir, $vendorPath, true, true) . " . '/";
+        $appBaseDirCode = ' => ' . $filesystem->findShortestPathCode($targetDir, $basePath, true, true) . " . '/";
+        $appBaseDirPharCode = ' => \'phar://\' . ' . $filesystem->findShortestPathCode($targetDir, $basePath, true, true) . " . '/";
 
         $absoluteVendorPathCode = ' => ' . substr(var_export(rtrim($vendorDir, '\\/') . '/', true), 0, -1);
         $absoluteVendorPharPathCode = ' => ' . substr(var_export(rtrim('phar://' . $vendorDir, '\\/') . '/', true), 0, -1);

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -1311,9 +1311,7 @@ INITIALIZER;
                         }
 
                         $resolvedPath = Platform::realpath($installPath . '/' . $updir);
-                        if (false === $resolvedPath) {
-                            continue;
-                        }
+
                         $autoloads[] = preg_quote(strtr($resolvedPath, '\\', '/')) . '/' . $path . '($|/)';
                         continue;
                     }

--- a/src/Composer/Command/BaseConfigCommand.php
+++ b/src/Composer/Command/BaseConfigCommand.php
@@ -60,7 +60,7 @@ abstract class BaseConfigCommand extends BaseCommand
         if (
             ($configFile === 'composer.json' || $configFile === './composer.json')
             && !file_exists($configFile)
-            && realpath(Platform::getCwd()) === realpath($this->config->get('home'))
+            && Platform::realpath(Platform::getCwd()) === Platform::realpath($this->config->get('home'))
         ) {
             file_put_contents($configFile, "{\n}\n");
         }

--- a/src/Composer/Command/ClearCacheCommand.php
+++ b/src/Composer/Command/ClearCacheCommand.php
@@ -14,6 +14,7 @@ namespace Composer\Command;
 
 use Composer\Cache;
 use Composer\Factory;
+use Composer\Util\Platform;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -67,8 +68,9 @@ EOT
                 continue;
             }
 
-            $cachePath = realpath($cachePath);
-            if (!$cachePath) {
+            try {
+                $cachePath = Platform::realpath($cachePath);
+            } catch (\RuntimeException $e) {
                 $io->writeError("<info>Cache directory does not exist ($key): $cachePath</info>");
 
                 continue;

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -189,7 +189,7 @@ EOT
         if (
             ($configFile === 'composer.json' || $configFile === './composer.json')
             && !file_exists($configFile)
-            && realpath(Platform::getCwd()) === realpath($this->config->get('home'))
+            && Platform::realpath(Platform::getCwd()) === Platform::realpath($this->config->get('home'))
         ) {
             file_put_contents($configFile, "{\n}\n");
         }

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -163,28 +163,6 @@ EOT
     {
         parent::initialize($input, $output);
 
-        if ($input->getOption('global') && null !== $input->getOption('file')) {
-            throw new \RuntimeException('--file and --global can not be combined');
-        }
-
-        $io = $this->getIO();
-        $this->config = Factory::createConfig($io);
-
-        $configFile = $this->getComposerConfigFile($input, $this->config);
-
-        // Create global composer.json if this was invoked using `composer global config`
-        if (
-            ($configFile === 'composer.json' || $configFile === './composer.json')
-            && !file_exists($configFile)
-            && Platform::realpath(Platform::getCwd()) === Platform::realpath($this->config->get('home'))
-        ) {
-            file_put_contents($configFile, "{\n}\n");
-        }
-
-        $this->configFile = new JsonFile($configFile, null, $io);
-        $this->configSource = new JsonConfigSource($this->configFile);
-
-
         $authConfigFile = $this->getAuthConfigFile($input, $this->config);
 
         $this->authConfigFile = new JsonFile($authConfigFile, null, $this->getIO());

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -163,6 +163,28 @@ EOT
     {
         parent::initialize($input, $output);
 
+        if ($input->getOption('global') && null !== $input->getOption('file')) {
+            throw new \RuntimeException('--file and --global can not be combined');
+        }
+
+        $io = $this->getIO();
+        $this->config = Factory::createConfig($io);
+
+        $configFile = $this->getComposerConfigFile($input, $this->config);
+
+        // Create global composer.json if this was invoked using `composer global config`
+        if (
+            ($configFile === 'composer.json' || $configFile === './composer.json')
+            && !file_exists($configFile)
+            && Platform::realpath(Platform::getCwd()) === Platform::realpath($this->config->get('home'))
+        ) {
+            file_put_contents($configFile, "{\n}\n");
+        }
+
+        $this->configFile = new JsonFile($configFile, null, $io);
+        $this->configSource = new JsonConfigSource($this->configFile);
+
+
         $authConfigFile = $this->getAuthConfigFile($input, $this->config);
 
         $this->authConfigFile = new JsonFile($authConfigFile, null, $this->getIO());

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -432,13 +432,15 @@ EOT
 
         // handler Ctrl+C aborts gracefully
         @mkdir($directory, 0777, true);
-        if (false !== ($realDir = realpath($directory))) {
+        try {
+            $realDir = Platform::realpath($directory);
             $signalHandler = SignalHandler::create([SignalHandler::SIGINT, SignalHandler::SIGTERM, SignalHandler::SIGHUP], function (string $signal, SignalHandler $handler) use ($realDir) {
                 $this->getIO()->writeError('Received '.$signal.', aborting', true, IOInterface::DEBUG);
                 $fs = new Filesystem();
                 $fs->removeDirectory($realDir);
                 $handler->exitWithLastSignal();
             });
+        } catch (\RuntimeException $exception) {
         }
 
         // avoid displaying 9999999-dev as version if default-branch was selected

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -457,13 +457,15 @@ EOT
 
         // handler Ctrl+C aborts gracefully
         @mkdir($directory, 0777, true);
-        if (false !== ($realDir = realpath($directory))) {
+        try {
+            $realDir = Platform::realpath($directory);
             $signalHandler = SignalHandler::create([SignalHandler::SIGINT, SignalHandler::SIGTERM, SignalHandler::SIGHUP], function (string $signal, SignalHandler $handler) use ($realDir) {
                 $this->getIO()->writeError('Received '.$signal.', aborting', true, IOInterface::DEBUG);
                 $fs = new Filesystem();
                 $fs->removeDirectory($realDir);
                 $handler->exitWithLastSignal();
             });
+        } catch (\RuntimeException $exception) {
         }
 
         // avoid displaying 9999999-dev as version if default-branch was selected

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -466,6 +466,7 @@ EOT
                 $handler->exitWithLastSignal();
             });
         } catch (\RuntimeException $exception) {
+            // If `mkdir` failed causing `Platform::realpath()` to throw, no `SignalHandler` was added, but none is needed since all it does is delete the directory.
         }
 
         // avoid displaying 9999999-dev as version if default-branch was selected

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -185,7 +185,7 @@ EOT
             try {
                 $ignoreFile = Platform::realpath('.gitignore');
             } catch (\RuntimeException $exception) {
-                $ignoreFile = Platform::realpath('.') . '/.gitignore';
+                $ignoreFile = Platform::getCwd() . '/.gitignore';
             }
 
             if (!$this->hasVendorIgnore($ignoreFile)) {

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -272,7 +272,7 @@ EOT
 
         $name = $input->getOption('name');
         if (null === $name) {
-            $cwd = Platform::realpath(".");
+            $cwd = Platform::getCwd();
             $name = basename($cwd);
             $name = $this->sanitizePackageNameComponent($name);
 

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -23,6 +23,7 @@ use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryFactory;
 use Composer\Spdx\SpdxLicenses;
 use Composer\Util\Filesystem;
+use Composer\Util\Platform;
 use Composer\Util\Silencer;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -181,10 +182,10 @@ EOT
         }
 
         if ($input->isInteractive() && is_dir('.git')) {
-            $ignoreFile = realpath('.gitignore');
-
-            if (false === $ignoreFile) {
-                $ignoreFile = realpath('.') . '/.gitignore';
+            try {
+                $ignoreFile = Platform::realpath('.gitignore');
+            } catch (\RuntimeException $exception) {
+                $ignoreFile = Platform::realpath('.') . '/.gitignore';
             }
 
             if (!$this->hasVendorIgnore($ignoreFile)) {
@@ -269,10 +270,9 @@ EOT
             '',
         ]);
 
-        $cwd = realpath(".");
-
         $name = $input->getOption('name');
         if (null === $name) {
+            $cwd = Platform::realpath(".");
             $name = basename($cwd);
             $name = $this->sanitizePackageNameComponent($name);
 

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -616,7 +616,7 @@ EOT
     private function getDefaultPackageName(): string
     {
         $git = $this->getGitConfig();
-        $cwd = Platform::getCwd();
+        $cwd = Platform::realpath('.');
         $name = basename($cwd);
         $name = $this->sanitizePackageNameComponent($name);
 

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -616,7 +616,7 @@ EOT
     private function getDefaultPackageName(): string
     {
         $git = $this->getGitConfig();
-        $cwd = Platform::realpath(".");
+        $cwd = Platform::getCwd();
         $name = basename($cwd);
         $name = $this->sanitizePackageNameComponent($name);
 

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -176,7 +176,7 @@ EOT
             try {
                 $ignoreFile = Platform::realpath('.gitignore');
             } catch (\RuntimeException $exception) {
-                $ignoreFile = Platform::getCwd() . '/.gitignore';
+                $ignoreFile = Platform::realpath('.') . '/.gitignore';
             }
 
             if (!$this->hasVendorIgnore($ignoreFile)) {

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -176,7 +176,7 @@ EOT
             try {
                 $ignoreFile = Platform::realpath('.gitignore');
             } catch (\RuntimeException $exception) {
-                $ignoreFile = Platform::realpath('.') . '/.gitignore';
+                $ignoreFile = Platform::getCwd() . '/.gitignore';
             }
 
             if (!$this->hasVendorIgnore($ignoreFile)) {

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -22,6 +22,7 @@ use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryFactory;
 use Composer\Spdx\SpdxLicenses;
 use Composer\Util\Filesystem;
+use Composer\Util\Platform;
 use Composer\Util\Silencer;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -172,10 +173,10 @@ EOT
         }
 
         if ($input->isInteractive() && is_dir('.git')) {
-            $ignoreFile = realpath('.gitignore');
-
-            if (false === $ignoreFile) {
-                $ignoreFile = realpath('.') . '/.gitignore';
+            try {
+                $ignoreFile = Platform::realpath('.gitignore');
+            } catch (\RuntimeException $exception) {
+                $ignoreFile = Platform::realpath('.') . '/.gitignore';
             }
 
             if (!$this->hasVendorIgnore($ignoreFile)) {
@@ -615,7 +616,7 @@ EOT
     private function getDefaultPackageName(): string
     {
         $git = $this->getGitConfig();
-        $cwd = realpath(".");
+        $cwd = Platform::realpath(".");
         $name = basename($cwd);
         $name = $this->sanitizePackageNameComponent($name);
 

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -1068,11 +1068,12 @@ EOT
 
         if (!PlatformRepository::isPlatformPackage($package->getName()) && $installedRepo->hasPackage($package)) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
+            $json['path'] = null;
             if (is_string($path)) {
-                $path = Platform::realpath($path);
-                $json['path'] = $path;
-            } else {
-                $json['path'] = null;
+                try {
+                    $json['path'] = Platform::realpath($path);
+                } catch (\RuntimeException $exception) {
+                }
             }
 
             if ($package->getReleaseDate() !== null) {

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -904,7 +904,11 @@ EOT
         if ($isInstalledPackage) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
             if (is_string($path)) {
-                $io->write('<info>path</info>     : ' . Platform::realpath($path));
+                try {
+                    $io->write('<info>path</info>     : ' . Platform::realpath($path));
+                } catch (\RuntimeException $exception) {
+                    $io->write('<info>path</info>     : ');
+                }
             } else {
                 $io->write('<info>path</info>     : null');
             }
@@ -1065,10 +1069,8 @@ EOT
         if (!PlatformRepository::isPlatformPackage($package->getName()) && $installedRepo->hasPackage($package)) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
             if (is_string($path)) {
-                $path = realpath($path);
-                if ($path !== false) {
-                    $json['path'] = $path;
-                }
+                $path = Platform::realpath($path);
+                $json['path'] = $path;
             } else {
                 $json['path'] = null;
             }

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -43,6 +43,7 @@ use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Semver\Semver;
 use Composer\Spdx\SpdxLicenses;
 use Composer\Util\PackageInfo;
+use Composer\Util\Platform;
 use DateTimeInterface;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Formatter\OutputFormatter;
@@ -359,7 +360,7 @@ EOT
                 $io->write($package->getName(), false);
                 $path = $composer->getInstallationManager()->getInstallPath($package);
                 if (is_string($path)) {
-                    $io->write(' ' . strtok(realpath($path), "\r\n"));
+                    $io->write(' ' . strtok(Platform::realpath($path), "\r\n"));
                 } else {
                     $io->write(' null');
                 }
@@ -581,7 +582,7 @@ EOT
                         if ($writePath) {
                             $path = $composer->getInstallationManager()->getInstallPath($package);
                             if (is_string($path)) {
-                                $packageViewData['path'] = strtok(realpath($path), "\r\n");
+                                $packageViewData['path'] = strtok(Platform::realpath($path), "\r\n");
                             } else {
                                 $packageViewData['path'] = null;
                             }
@@ -903,7 +904,7 @@ EOT
         if ($isInstalledPackage) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
             if (is_string($path)) {
-                $io->write('<info>path</info>     : ' . realpath($path));
+                $io->write('<info>path</info>     : ' . Platform::realpath($path));
             } else {
                 $io->write('<info>path</info>     : null');
             }

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -42,6 +42,7 @@ use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Semver\Semver;
 use Composer\Spdx\SpdxLicenses;
 use Composer\Util\PackageInfo;
+use Composer\Util\Platform;
 use DateTimeInterface;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Formatter\OutputFormatter;
@@ -355,7 +356,7 @@ EOT
                 $io->write($package->getName(), false);
                 $path = $composer->getInstallationManager()->getInstallPath($package);
                 if (is_string($path)) {
-                    $io->write(' ' . strtok(realpath($path), "\r\n"));
+                    $io->write(' ' . strtok(Platform::realpath($path), "\r\n"));
                 } else {
                     $io->write(' null');
                 }
@@ -577,7 +578,7 @@ EOT
                         if ($writePath) {
                             $path = $composer->getInstallationManager()->getInstallPath($package);
                             if (is_string($path)) {
-                                $packageViewData['path'] = strtok(realpath($path), "\r\n");
+                                $packageViewData['path'] = strtok(Platform::realpath($path), "\r\n");
                             } else {
                                 $packageViewData['path'] = null;
                             }
@@ -918,7 +919,7 @@ EOT
         if ($isInstalledPackage) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
             if (is_string($path)) {
-                $io->write('<info>path</info>     : ' . realpath($path));
+                $io->write('<info>path</info>     : ' . Platform::realpath($path));
             } else {
                 $io->write('<info>path</info>     : null');
             }

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -1081,11 +1081,12 @@ EOT
 
         if (!PlatformRepository::isPlatformPackage($package->getName()) && $installedRepo->hasPackage($package)) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
+            $json['path'] = null;
             if (is_string($path)) {
-                $path = Platform::realpath($path);
-                $json['path'] = $path;
-            } else {
-                $json['path'] = null;
+                try {
+                    $json['path'] = Platform::realpath($path);
+                } catch (\RuntimeException $exception) {
+                }
             }
 
             if ($package->getReleaseDate() !== null) {

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -919,7 +919,11 @@ EOT
         if ($isInstalledPackage) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
             if (is_string($path)) {
-                $io->write('<info>path</info>     : ' . Platform::realpath($path));
+                try {
+                    $io->write('<info>path</info>     : ' . Platform::realpath($path));
+                } catch (\RuntimeException $exception) {
+                    $io->write('<info>path</info>     : ');
+                }
             } else {
                 $io->write('<info>path</info>     : null');
             }
@@ -1078,10 +1082,8 @@ EOT
         if (!PlatformRepository::isPlatformPackage($package->getName()) && $installedRepo->hasPackage($package)) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
             if (is_string($path)) {
-                $path = realpath($path);
-                if ($path !== false) {
-                    $json['path'] = $path;
-                }
+                $path = Platform::realpath($path);
+                $json['path'] = $path;
             } else {
                 $json['path'] = null;
             }

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -919,11 +919,7 @@ EOT
         if ($isInstalledPackage) {
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
             if (is_string($path)) {
-                try {
-                    $io->write('<info>path</info>     : ' . Platform::realpath($path));
-                } catch (\RuntimeException $exception) {
-                    $io->write('<info>path</info>     : ');
-                }
+                $io->write('<info>path</info>     : ' . Platform::realpath($path));
             } else {
                 $io->write('<info>path</info>     : null');
             }
@@ -1083,10 +1079,7 @@ EOT
             $path = $this->requireComposer()->getInstallationManager()->getInstallPath($package);
             $json['path'] = null;
             if (is_string($path)) {
-                try {
-                    $json['path'] = Platform::realpath($path);
-                } catch (\RuntimeException $exception) {
-                }
+                $json['path'] = Platform::realpath($path);
             }
 
             if ($package->getReleaseDate() !== null) {

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -143,8 +143,9 @@ class Compiler
             __DIR__ . '/../../vendor/symfony/console/Resources/bin/hiddeninput.exe',
             __DIR__ . '/../../vendor/symfony/console/Resources/completion.bash',
         ] as $file) {
-            $extraFiles[$file] = Platform::realpath($file);
-            if (!file_exists($file)) {
+            try {
+                $extraFiles[$file] = Platform::realpath($file);
+            } catch (\RuntimeException $e) {
                 throw new \RuntimeException('Extra file listed is missing from the filesystem: '.$file);
             }
         }

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -15,6 +15,7 @@ namespace Composer;
 use Composer\Json\JsonFile;
 use Composer\CaBundle\CaBundle;
 use Composer\Pcre\Preg;
+use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
@@ -142,7 +143,7 @@ class Compiler
             __DIR__ . '/../../vendor/symfony/console/Resources/bin/hiddeninput.exe',
             __DIR__ . '/../../vendor/symfony/console/Resources/completion.bash',
         ] as $file) {
-            $extraFiles[$file] = realpath($file);
+            $extraFiles[$file] = Platform::realpath($file);
             if (!file_exists($file)) {
                 throw new \RuntimeException('Extra file listed is missing from the filesystem: '.$file);
             }

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -146,8 +146,9 @@ class Compiler
             __DIR__ . '/../../vendor/symfony/console/Resources/bin/hiddeninput.exe',
             __DIR__ . '/../../vendor/symfony/console/Resources/completion.bash',
         ] as $file) {
-            $extraFiles[$file] = Platform::realpath($file);
-            if (!file_exists($file)) {
+            try {
+                $extraFiles[$file] = Platform::realpath($file);
+            } catch (\RuntimeException $e) {
                 throw new \RuntimeException('Extra file listed is missing from the filesystem: '.$file);
             }
         }

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -16,6 +16,7 @@ use Composer\Json\JsonFile;
 use Composer\CaBundle\CaBundle;
 use Composer\Pcre\Preg;
 use Composer\Util\Git;
+use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Symfony\Component\Finder\Finder;
 use Seld\PharUtils\Timestamps;
@@ -145,7 +146,7 @@ class Compiler
             __DIR__ . '/../../vendor/symfony/console/Resources/bin/hiddeninput.exe',
             __DIR__ . '/../../vendor/symfony/console/Resources/completion.bash',
         ] as $file) {
-            $extraFiles[$file] = realpath($file);
+            $extraFiles[$file] = Platform::realpath($file);
             if (!file_exists($file)) {
                 throw new \RuntimeException('Extra file listed is missing from the filesystem: '.$file);
             }

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -199,7 +199,7 @@ class Application extends BaseApplication
             && $input->hasParameterOption('-h', true) === false
         ) {
             $dir = dirname(Platform::getCwd(true));
-            $home = realpath(Platform::getEnv('HOME') ?: Platform::getEnv('USERPROFILE') ?: '/');
+            $home = Platform::realpath(Platform::getEnv('HOME') ?: Platform::getEnv('USERPROFILE') ?: '/');
 
             // abort when we reach the home dir or top of the filesystem
             while (dirname($dir) !== $dir && $dir !== $home) {
@@ -288,7 +288,7 @@ class Application extends BaseApplication
             } catch (ParsingException $e) {
                 $details = $e->getDetails();
 
-                $file = realpath(Factory::getComposerFile());
+                $file = Platform::realpath(Factory::getComposerFile());
 
                 $line = null;
                 if ($details && isset($details['line'])) {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -204,7 +204,11 @@ class Application extends BaseApplication
             && $input->hasParameterOption('-h', true) === false
         ) {
             $dir = dirname(Platform::getCwd(true));
-            $home = Platform::realpath(Platform::getEnv('HOME') ?: Platform::getEnv('USERPROFILE') ?: '/');
+            try{
+                $home = Platform::realpath(Platform::getEnv('HOME') ?: Platform::getEnv('USERPROFILE') ?: '/');
+            }catch(\Throwable $e){
+                $home = Platform::realpath('/');
+            }
 
             // abort when we reach the home dir or top of the filesystem
             while (dirname($dir) !== $dir && $dir !== $home) {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -301,8 +301,8 @@ class Application extends BaseApplication
             } catch (ParsingException $e) {
                 $details = $e->getDetails();
 
-                $composerFile = Factory::getComposerFile();
                 try{
+                    $composerFile = Factory::getComposerFile();
                     $file = Platform::realpath($composerFile);
                 } catch(RuntimeException $realpathException) {
                     $file = $composerFile;

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -204,7 +204,7 @@ class Application extends BaseApplication
             && $input->hasParameterOption('-h', true) === false
         ) {
             $dir = dirname(Platform::getCwd(true));
-            $home = realpath(Platform::getEnv('HOME') ?: Platform::getEnv('USERPROFILE') ?: '/');
+            $home = Platform::realpath(Platform::getEnv('HOME') ?: Platform::getEnv('USERPROFILE') ?: '/');
 
             // abort when we reach the home dir or top of the filesystem
             while (dirname($dir) !== $dir && $dir !== $home) {
@@ -297,7 +297,7 @@ class Application extends BaseApplication
             } catch (ParsingException $e) {
                 $details = $e->getDetails();
 
-                $file = realpath(Factory::getComposerFile());
+                $file = Platform::realpath(Factory::getComposerFile());
 
                 $line = null;
                 if ($details && isset($details['line'])) {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -301,7 +301,12 @@ class Application extends BaseApplication
             } catch (ParsingException $e) {
                 $details = $e->getDetails();
 
-                $file = Platform::realpath(Factory::getComposerFile());
+                $composerFile = Factory::getComposerFile();
+                try{
+                    $file = Platform::realpath($composerFile);
+                } catch(RuntimeException $realpathException) {
+                    $file = $composerFile;
+                }
 
                 $line = null;
                 if ($details && isset($details['line'])) {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -206,7 +206,7 @@ class Application extends BaseApplication
             $dir = dirname(Platform::getCwd(true));
             try{
                 $home = Platform::realpath(Platform::getEnv('HOME') ?: Platform::getEnv('USERPROFILE') ?: '/');
-            }catch(\Throwable $e){
+            }catch(\TypeError|\RuntimeException $e){
                 $home = Platform::realpath('/');
             }
 

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -204,9 +204,9 @@ class Application extends BaseApplication
             && $input->hasParameterOption('-h', true) === false
         ) {
             $dir = dirname(Platform::getCwd(true));
-            try{
+            try {
                 $home = Platform::realpath(Platform::getEnv('HOME') ?: Platform::getEnv('USERPROFILE') ?: '/');
-            }catch(\TypeError|\RuntimeException $e){
+            } catch (\TypeError|RuntimeException $e) {
                 $home = Platform::realpath('/');
             }
 
@@ -301,10 +301,10 @@ class Application extends BaseApplication
             } catch (ParsingException $e) {
                 $details = $e->getDetails();
 
-                try{
+                try {
                     $composerFile = Factory::getComposerFile();
                     $file = Platform::realpath($composerFile);
-                } catch(RuntimeException $realpathException) {
+                } catch (RuntimeException $realpathException) {
                     $file = $composerFile;
                 }
 

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -74,7 +74,7 @@ abstract class ArchiveDownloader extends FileDownloader
         $this->addCleanupPath($package, $temporaryDir);
         // avoid cleaning up $path if installing in "." for eg create-project as we can not
         // delete the directory we are currently in on windows
-        if (!is_dir($path) || realpath($path) !== Platform::getCwd()) {
+        if (!is_dir($path) || Platform::realpath($path) !== Platform::getCwd()) {
             $this->addCleanupPath($package, $path);
         }
 
@@ -89,7 +89,7 @@ abstract class ArchiveDownloader extends FileDownloader
 
             // clean up
             $filesystem->removeDirectory($temporaryDir);
-            if (is_dir($path) && realpath($path) !== Platform::getCwd()) {
+            if (is_dir($path) && Platform::realpath($path) !== Platform::getCwd()) {
                 $filesystem->removeDirectory($path);
             }
             $this->removeCleanupPath($package, $temporaryDir);

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -93,10 +93,8 @@ abstract class ArchiveDownloader extends FileDownloader
                 $filesystem->removeDirectory($path);
             }
             $this->removeCleanupPath($package, $temporaryDir);
-            $realpath = realpath($path);
-            if ($realpath !== false) {
-                $this->removeCleanupPath($package, $realpath);
-            }
+            $realpath = Platform::realpath($path);
+            $this->removeCleanupPath($package, $realpath);
         };
 
         try {

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -93,8 +93,12 @@ abstract class ArchiveDownloader extends FileDownloader
                 $filesystem->removeDirectory($path);
             }
             $this->removeCleanupPath($package, $temporaryDir);
-            $realpath = Platform::realpath($path);
-            $this->removeCleanupPath($package, $realpath);
+            try{
+                $realpath = Platform::realpath($path);
+                $this->removeCleanupPath($package, $realpath);
+            } catch (\RuntimeException $e) {
+                // ignore error, and simply do not remove the cleanup path
+            }
         };
 
         try {

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -93,7 +93,7 @@ abstract class ArchiveDownloader extends FileDownloader
                 $filesystem->removeDirectory($path);
             }
             $this->removeCleanupPath($package, $temporaryDir);
-            try{
+            try {
                 $realpath = Platform::realpath($path);
                 $this->removeCleanupPath($package, $realpath);
             } catch (\RuntimeException $e) {

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -333,7 +333,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
         }
 
         foreach ($dirsToCleanUp as $dir) {
-            if (is_dir($dir) && $this->filesystem->isDirEmpty($dir) && realpath($dir) !== Platform::getCwd()) {
+            if (is_dir($dir) && $this->filesystem->isDirEmpty($dir) && Platform::realpath($dir) !== Platform::getCwd()) {
                 $this->filesystem->removeDirectoryPhp($dir);
             }
         }

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -607,7 +607,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
                 return $path;
             }
 
-            $path = rtrim(realpath($basePath) . '/' . implode('/', $removed), '/');
+            $path = rtrim(Platform::realpath($basePath) . '/' . implode('/', $removed), '/');
         }
 
         return $path;

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Downloader;
 
+use Composer\Util\Platform;
 use React\Promise\PromiseInterface;
 use Composer\Package\PackageInterface;
 use Composer\Util\ProcessExecutor;
@@ -48,7 +49,7 @@ class HgDownloader extends VcsDownloader
         $hgUtils->runCommand($cloneCommand, $url, $path);
 
         $command = ['hg', 'up', '--', (string) $package->getSourceReference()];
-        if (0 !== $this->process->execute($command, $ignoredOutput, realpath($path))) {
+        if (0 !== $this->process->execute($command, $ignoredOutput, Platform::realpath($path))) {
             throw new \RuntimeException('Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput());
         }
 
@@ -91,7 +92,7 @@ class HgDownloader extends VcsDownloader
             return null;
         }
 
-        $this->process->execute(['hg', 'st'], $output, realpath($path));
+        $this->process->execute(['hg', 'st'], $output, Platform::realpath($path));
 
         $output = trim($output);
 
@@ -105,7 +106,7 @@ class HgDownloader extends VcsDownloader
     {
         $command = ['hg', 'log', '-r', $fromReference.':'.$toReference, '--style', 'compact'];
 
-        if (0 !== $this->process->execute($command, $output, realpath($path))) {
+        if (0 !== $this->process->execute($command, $output, Platform::realpath($path))) {
             throw new \RuntimeException('Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput());
         }
 

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Downloader;
 
+use Composer\Util\Platform;
 use React\Promise\PromiseInterface;
 use Composer\Package\PackageInterface;
 use Composer\Util\Hg as HgUtils;
@@ -47,7 +48,7 @@ class HgDownloader extends VcsDownloader
         $hgUtils->runCommand($cloneCommand, $url, $path);
 
         $command = ['hg', 'up', '--', (string) $package->getSourceReference()];
-        if (0 !== $this->process->execute($command, $ignoredOutput, realpath($path))) {
+        if (0 !== $this->process->execute($command, $ignoredOutput, Platform::realpath($path))) {
             throw new \RuntimeException('Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput());
         }
 
@@ -90,7 +91,7 @@ class HgDownloader extends VcsDownloader
             return null;
         }
 
-        $this->process->execute(['hg', 'st'], $output, realpath($path));
+        $this->process->execute(['hg', 'st'], $output, Platform::realpath($path));
 
         $output = trim($output);
 
@@ -104,7 +105,7 @@ class HgDownloader extends VcsDownloader
     {
         $command = ['hg', 'log', '-r', $fromReference.':'.$toReference, '--style', 'compact'];
 
-        if (0 !== $this->process->execute($command, $output, realpath($path))) {
+        if (0 !== $this->process->execute($command, $output, Platform::realpath($path))) {
             throw new \RuntimeException('Failed to execute ' . implode(' ', $command) . "\n\n" . $this->process->getErrorOutput());
         }
 

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -88,9 +88,6 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             throw new \RuntimeException('The package '.$package->getPrettyName().' has no dist url configured, cannot install.');
         }
         $realUrl = Platform::realpath($url);
-        if (false === $realUrl) {
-            throw new \RuntimeException('Failed to realpath '.$url);
-        }
 
         if (Platform::realpath($path) === $realUrl) {
             if ($output) {

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -55,11 +55,11 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             ));
         }
 
-        if (realpath($path) === $realUrl) {
+        if (Platform::realpath($path) === $realUrl) {
             return \React\Promise\resolve(null);
         }
 
-        if (strpos(realpath($path) . DIRECTORY_SEPARATOR, $realUrl . DIRECTORY_SEPARATOR) === 0) {
+        if (strpos(Platform::realpath($path) . DIRECTORY_SEPARATOR, $realUrl . DIRECTORY_SEPARATOR) === 0) {
             // IMPORTANT NOTICE: If you wish to change this, don't. You are wasting your time and ours.
             //
             // Please see https://github.com/composer/composer/pull/5974 and https://github.com/composer/composer/pull/6174
@@ -67,7 +67,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             throw new \RuntimeException(sprintf(
                 'Package %s cannot install to "%s" inside its source at "%s"',
                 $package->getName(),
-                realpath($path),
+                Platform::realpath($path),
                 $realUrl
             ));
         }
@@ -90,7 +90,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             throw new \RuntimeException('Failed to realpath '.$url);
         }
 
-        if (realpath($path) === $realUrl) {
+        if (Platform::realpath($path) === $realUrl) {
             if ($output) {
                 $this->io->writeError("  - " . InstallOperation::format($package) . $this->getInstallOperationAppendix($package, $path));
             }
@@ -250,7 +250,7 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             throw new \RuntimeException('Failed to realpath '.$url);
         }
 
-        if (realpath($path) === $realUrl) {
+        if (Platform::realpath($path) === $realUrl) {
             return ': Source already present';
         }
 

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -79,6 +79,8 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
 
     /**
      * @inheritDoc
+     *
+     * @throws \RuntimeException When package dist url, or target path do not exist.
      */
     public function install(PackageInterface $package, string $path, bool $output = true): PromiseInterface
     {

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -56,7 +56,11 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
             ));
         }
 
-        $realPath = Platform::realpath($path);
+        try {
+            $realPath = Platform::realpath($path);
+        } catch (\RuntimeException $exception) {
+            $realPath = false;
+        }
         if ($realPath === $realUrl) {
             return \React\Promise\resolve(null);
         }

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -91,12 +91,16 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
         }
         $realUrl = Platform::realpath($url);
 
-        if (Platform::realpath($path) === $realUrl) {
-            if ($output) {
-                $this->io->writeError("  - " . InstallOperation::format($package) . $this->getInstallOperationAppendix($package, $path));
-            }
+        try {
+            if (Platform::realpath($path) === $realUrl) {
+                if ($output) {
+                    $this->io->writeError("  - " . InstallOperation::format($package) . $this->getInstallOperationAppendix($package, $path));
+                }
 
-            return \React\Promise\resolve(null);
+                return \React\Promise\resolve(null);
+            }
+        } catch (\RuntimeException $exception) {
+            // Most likely $path does not exist; it is about to be deleted anyway.
         }
 
         // Get the transport options with default values

--- a/src/Composer/Downloader/PathDownloader.php
+++ b/src/Composer/Downloader/PathDownloader.php
@@ -256,7 +256,12 @@ class PathDownloader extends FileDownloader implements VcsCapableDownloaderInter
         }
         $realUrl = Platform::realpath($url);
 
-        if (Platform::realpath($path) === $realUrl) {
+        try {
+            $realpath = Platform::realpath($path);
+        } catch (\RuntimeException $exception) {
+            $realpath = false;
+        }
+        if ($realpath === $realUrl) {
             return ': Source already present';
         }
 

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -17,6 +17,7 @@ use Composer\Package\Dumper\ArrayDumper;
 use Composer\Package\PackageInterface;
 use Composer\Package\Version\VersionGuesser;
 use Composer\Package\Version\VersionParser;
+use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
@@ -350,7 +351,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
                     $url = rawurldecode($url);
                 }
 
-                $urls[$index] = realpath($url);
+                $urls[$index] = Platform::realpath($url);
 
                 if ($isFileProtocol) {
                     $urls[$index] = $fileProtocol . $urls[$index];

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -351,7 +351,13 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
                     $url = rawurldecode($url);
                 }
 
-                $urls[$index] = Platform::realpath($url);
+                try {
+                    $urls[$index] = Platform::realpath($url);
+                } catch( \RuntimeException $e ) {
+                    unset($urls[$index]);
+                    continue;
+                }
+
 
                 if ($isFileProtocol) {
                     $urls[$index] = $fileProtocol . $urls[$index];

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -353,7 +353,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
 
                 try {
                     $urls[$index] = Platform::realpath($url);
-                } catch(\RuntimeException $e) {
+                } catch (\RuntimeException $e) {
                     unset($urls[$index]);
                     continue;
                 }

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -353,11 +353,10 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
 
                 try {
                     $urls[$index] = Platform::realpath($url);
-                } catch( \RuntimeException $e ) {
+                } catch(\RuntimeException $e) {
                     unset($urls[$index]);
                     continue;
                 }
-
 
                 if ($isFileProtocol) {
                     $urls[$index] = $fileProtocol . $urls[$index];

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -683,7 +683,7 @@ class EventDispatcher
         // add the bin dir to the PATH to make local binaries of deps usable in scripts
         $binDir = $this->composer->getConfig()->get('bin-dir');
         if (is_dir($binDir)) {
-            $binDir = realpath($binDir);
+            $binDir = Platform::realpath($binDir);
             $pathValue = (string) Platform::getEnv($pathEnv);
             if (!Preg::isMatch('{(^|'.PATH_SEPARATOR.')'.preg_quote($binDir).'($|'.PATH_SEPARATOR.')}', $pathValue)) {
                 Platform::putEnv($pathEnv, $binDir.PATH_SEPARATOR.$pathValue);

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -690,7 +690,7 @@ class EventDispatcher
         // add the bin dir to the PATH to make local binaries of deps usable in scripts
         $binDir = $this->composer->getConfig()->get('bin-dir');
         if (is_dir($binDir)) {
-            $binDir = realpath($binDir);
+            $binDir = Platform::realpath($binDir);
             $pathValue = (string) Platform::getEnv($pathEnv);
             if (!Preg::isMatch('{(^|'.PATH_SEPARATOR.')'.preg_quote($binDir).'($|'.PATH_SEPARATOR.')}', $pathValue)) {
                 Platform::putEnv($pathEnv, $binDir.PATH_SEPARATOR.$pathValue);

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -324,14 +324,14 @@ class Factory
 
         // Load config and override with local config/auth config
         $config = static::createConfig($io, $cwd);
-        $isGlobal = $localConfigSource !== Config::SOURCE_UNKNOWN && realpath($config->get('home')) === realpath(dirname($localConfigSource));
+        $isGlobal = $localConfigSource !== Config::SOURCE_UNKNOWN && Platform::realpath($config->get('home')) === Platform::realpath(dirname($localConfigSource));
         $config->merge($localConfig, $localConfigSource);
 
         if (isset($composerFile)) {
-            $io->writeError('Loading config file ' . $composerFile .' ('.realpath($composerFile).')', true, IOInterface::DEBUG);
-            $config->setConfigSource(new JsonConfigSource(new JsonFile(realpath($composerFile), null, $io)));
+            $io->writeError('Loading config file ' . $composerFile .' ('.Platform::realpath($composerFile).')', true, IOInterface::DEBUG);
+            $config->setConfigSource(new JsonConfigSource(new JsonFile(Platform::realpath($composerFile), null, $io)));
 
-            $localAuthFile = new JsonFile(dirname(realpath($composerFile)) . '/auth.json', null, $io);
+            $localAuthFile = new JsonFile(dirname(Platform::realpath($composerFile)) . '/auth.json', null, $io);
             if ($localAuthFile->exists()) {
                 $io->writeError('Loading config file ' . $localAuthFile->getPath(), true, IOInterface::DEBUG);
                 self::validateJsonSchema($io, $localAuthFile, JsonFile::AUTH_SCHEMA);

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -324,7 +324,11 @@ class Factory
 
         // Load config and override with local config/auth config
         $config = static::createConfig($io, $cwd);
-        $isGlobal = $localConfigSource !== Config::SOURCE_UNKNOWN && Platform::realpath($config->get('home')) === Platform::realpath(dirname($localConfigSource));
+        try{
+            $isGlobal = $localConfigSource !== Config::SOURCE_UNKNOWN && Platform::realpath($config->get('home')) === Platform::realpath(dirname($localConfigSource));
+        }catch(\RuntimeException|\TypeError $e){
+            $isGlobal = false;
+        }
         $config->merge($localConfig, $localConfigSource);
 
         if (isset($composerFile)) {

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -332,10 +332,11 @@ class Factory
         $config->merge($localConfig, $localConfigSource);
 
         if (isset($composerFile)) {
-            $io->writeError('Loading config file ' . $composerFile .' ('.Platform::realpath($composerFile).')', true, IOInterface::DEBUG);
-            $config->setConfigSource(new JsonConfigSource(new JsonFile(Platform::realpath($composerFile), null, $io)));
+            $composerFileRealpath = Platform::realpath($composerFile);
+            $io->writeError('Loading config file ' . $composerFile .' ('.$composerFileRealpath.')', true, IOInterface::DEBUG);
+            $config->setConfigSource(new JsonConfigSource(new JsonFile($composerFileRealpath, null, $io)));
 
-            $localAuthFile = new JsonFile(dirname(Platform::realpath($composerFile)) . '/auth.json', null, $io);
+            $localAuthFile = new JsonFile(dirname($composerFileRealpath) . '/auth.json', null, $io);
             if ($localAuthFile->exists()) {
                 $io->writeError('Loading config file ' . $localAuthFile->getPath(), true, IOInterface::DEBUG);
                 self::validateJsonSchema($io, $localAuthFile, JsonFile::AUTH_SCHEMA);

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -326,7 +326,7 @@ class Factory
         $config = static::createConfig($io, $cwd);
         try{
             $isGlobal = $localConfigSource !== Config::SOURCE_UNKNOWN && Platform::realpath($config->get('home')) === Platform::realpath(dirname($localConfigSource));
-        }catch(\RuntimeException|\TypeError $e){
+        }catch(\RuntimeException $e){
             $isGlobal = false;
         }
         $config->merge($localConfig, $localConfigSource);

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -324,9 +324,9 @@ class Factory
 
         // Load config and override with local config/auth config
         $config = static::createConfig($io, $cwd);
-        try{
+        try {
             $isGlobal = $localConfigSource !== Config::SOURCE_UNKNOWN && Platform::realpath($config->get('home')) === Platform::realpath(dirname($localConfigSource));
-        }catch(\RuntimeException $e){
+        } catch (\RuntimeException $e) {
             $isGlobal = false;
         }
         $config->merge($localConfig, $localConfigSource);

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -226,10 +226,7 @@ class BinaryInstaller
             // Don't expose autoload path when vendor dir was not set in custom installers
             if ($this->vendorDir !== null) {
                 // ensure comparisons work accurately if the CWD is a symlink, as $link is realpath'd already
-                $vendorDirReal = realpath($this->vendorDir);
-                if ($vendorDirReal === false) {
-                    $vendorDirReal = $this->vendorDir;
-                }
+                $vendorDirReal = Platform::realpath($this->vendorDir);
                 $globalsCode .= '$GLOBALS[\'_composer_autoload_path\'] = ' . $this->filesystem->findShortestPathCode($link, $vendorDirReal . '/autoload.php', false, true).";\n";
             }
             // Add workaround for PHPUnit process isolation

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -76,7 +76,7 @@ class BinaryInstaller
                 // $package, we can now safely turn it into a absolute path (as we
                 // already checked the binary's existence). The following helpers
                 // will require absolute paths to work properly.
-                $binPath = realpath($binPath);
+                $binPath = Platform::realpath($binPath);
             }
             $this->initializeBinDir();
             $link = $this->binDir.'/'.basename($bin);
@@ -87,7 +87,7 @@ class BinaryInstaller
                     }
                     continue;
                 }
-                if (realpath($link) === realpath($binPath)) {
+                if (Platform::realpath($link) === Platform::realpath($binPath)) {
                     // It is a linked binary from a previous installation, which can be replaced with a proxy file
                     $this->filesystem->unlink($link);
                 }
@@ -180,7 +180,7 @@ class BinaryInstaller
     protected function initializeBinDir(): void
     {
         $this->filesystem->ensureDirectoryExists($this->binDir);
-        $this->binDir = realpath($this->binDir);
+        $this->binDir = Platform::realpath($this->binDir);
     }
 
     protected function generateWindowsProxyCode(string $bin, string $link): string

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -223,10 +223,7 @@ class BinaryInstaller
             // Don't expose autoload path when vendor dir was not set in custom installers
             if ($this->vendorDir !== null) {
                 // ensure comparisons work accurately if the CWD is a symlink, as $link is realpath'd already
-                $vendorDirReal = realpath($this->vendorDir);
-                if ($vendorDirReal === false) {
-                    $vendorDirReal = $this->vendorDir;
-                }
+                $vendorDirReal = Platform::realpath($this->vendorDir);
                 $globalsCode .= '$GLOBALS[\'_composer_autoload_path\'] = ' . $this->filesystem->findShortestPathCode($link, $vendorDirReal . '/autoload.php', false, true).";\n";
             }
             // Add workaround for PHPUnit process isolation

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -73,7 +73,7 @@ class BinaryInstaller
                 // $package, we can now safely turn it into a absolute path (as we
                 // already checked the binary's existence). The following helpers
                 // will require absolute paths to work properly.
-                $binPath = realpath($binPath);
+                $binPath = Platform::realpath($binPath);
             }
             $this->initializeBinDir();
             $link = $this->binDir.'/'.basename($bin);
@@ -84,7 +84,7 @@ class BinaryInstaller
                     }
                     continue;
                 }
-                if (realpath($link) === realpath($binPath)) {
+                if (Platform::realpath($link) === Platform::realpath($binPath)) {
                     // It is a linked binary from a previous installation, which can be replaced with a proxy file
                     $this->filesystem->unlink($link);
                 }
@@ -177,7 +177,7 @@ class BinaryInstaller
     protected function initializeBinDir(): void
     {
         $this->filesystem->ensureDirectoryExists($this->binDir);
-        $this->binDir = realpath($this->binDir);
+        $this->binDir = Platform::realpath($this->binDir);
     }
 
     protected function generateWindowsProxyCode(string $bin, string $link): string

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -333,7 +333,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
     protected function initializeVendorDir()
     {
         $this->filesystem->ensureDirectoryExists($this->vendorDir);
-        $this->vendorDir = realpath($this->vendorDir);
+        $this->vendorDir = Platform::realpath($this->vendorDir);
     }
 
     protected function getDownloadManager(): DownloadManager

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -23,6 +23,7 @@ use Composer\Util\Silencer;
 use Composer\Util\Platform;
 use React\Promise\PromiseInterface;
 use Composer\Downloader\DownloadManager;
+use RuntimeException;
 
 /**
  * Package installation manager.
@@ -93,7 +94,9 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
         }
 
         if (is_link($installPath)) {
-            if (realpath($installPath) === false) {
+            try {
+                Platform::realpath($installPath);
+            } catch (RuntimeException $exception) {
                 return false;
             }
 

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -330,7 +330,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
     protected function initializeVendorDir()
     {
         $this->filesystem->ensureDirectoryExists($this->vendorDir);
-        $this->vendorDir = realpath($this->vendorDir);
+        $this->vendorDir = Platform::realpath($this->vendorDir);
     }
 
     protected function getDownloadManager(): DownloadManager

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -23,6 +23,7 @@ use Composer\Util\Silencer;
 use Composer\Util\Platform;
 use React\Promise\PromiseInterface;
 use Composer\Downloader\DownloadManager;
+use RuntimeException;
 
 /**
  * Package installation manager.
@@ -90,7 +91,9 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
         }
 
         if (is_link($installPath)) {
-            if (realpath($installPath) === false) {
+            try {
+                Platform::realpath($installPath);
+            } catch (RuntimeException $exception) {
                 return false;
             }
 

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -106,10 +106,11 @@ class JsonFile
                 }
                 if ($this->io && $this->io->isDebug()) {
                     $realpathInfo = '';
-                    $realpath = realpath($this->path);
-                    if (false !== $realpath && $realpath !== $this->path) {
+                    $realpath = Platform::realpath($this->path);
+                    if ($realpath !== $this->path) {
                         $realpathInfo = ' (' . $realpath . ')';
                     }
+
                     $this->io->writeError('Reading ' . $this->path . $realpathInfo);
                 }
                 $json = file_get_contents($this->path);

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -14,6 +14,7 @@ namespace Composer\Json;
 
 use Composer\Pcre\Preg;
 use Composer\Util\Filesystem;
+use Composer\Util\Platform;
 use JsonSchema\Validator;
 use Seld\JsonLint\JsonParser;
 use Seld\JsonLint\ParsingException;
@@ -148,7 +149,7 @@ class JsonFile
         if (!is_dir($dir)) {
             if (file_exists($dir)) {
                 throw new \UnexpectedValueException(
-                    realpath($dir).' exists and is not a directory.'
+                    Platform::realpath($dir).' exists and is not a directory.'
                 );
             }
             if (!@mkdir($dir, 0777, true)) {

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -105,10 +105,11 @@ class JsonFile
                 }
                 if ($this->io && $this->io->isDebug()) {
                     $realpathInfo = '';
-                    $realpath = realpath($this->path);
-                    if (false !== $realpath && $realpath !== $this->path) {
+                    $realpath = Platform::realpath($this->path);
+                    if ($realpath !== $this->path) {
                         $realpathInfo = ' (' . $realpath . ')';
                     }
+
                     $this->io->writeError('Reading ' . $this->path . $realpathInfo);
                 }
                 $json = file_get_contents($this->path);

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -107,7 +107,7 @@ class JsonFile
                     $realpathInfo = '';
                     $realpath = Platform::realpath($this->path);
                     $filesystem = new Filesystem();
-                    if ($filesystem->normalizePath($realpath) !== $filesystem->($this->path)) {
+                    if ($filesystem->normalizePath($realpath) !== $filesystem->normalizePath($this->path)) {
                         $realpathInfo = ' (' . $realpath . ')';
                     }
 

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -106,7 +106,8 @@ class JsonFile
                 if ($this->io && $this->io->isDebug()) {
                     $realpathInfo = '';
                     $realpath = Platform::realpath($this->path);
-                    if ($realpath !== $this->path) {
+                    $filesystem = new Filesystem();
+                    if ($filesystem->normalizePath($realpath) !== $filesystem->($this->path)) {
                         $realpathInfo = ' (' . $realpath . ')';
                     }
 

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -14,6 +14,7 @@ namespace Composer\Json;
 
 use Composer\Pcre\Preg;
 use Composer\Util\Filesystem;
+use Composer\Util\Platform;
 use JsonSchema\Validator;
 use Seld\JsonLint\JsonParser;
 use Seld\JsonLint\ParsingException;
@@ -147,7 +148,7 @@ class JsonFile
         if (!is_dir($dir)) {
             if (file_exists($dir)) {
                 throw new \UnexpectedValueException(
-                    realpath($dir).' exists and is not a directory.'
+                    Platform::realpath($dir).' exists and is not a directory.'
                 );
             }
             if (!@mkdir($dir, 0777, true)) {

--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -14,6 +14,7 @@ namespace Composer\Package\Archiver;
 
 use Composer\Pcre\Preg;
 use Composer\Util\Filesystem;
+use Composer\Util\Platform;
 use FilesystemIterator;
 use FilterIterator;
 use Iterator;
@@ -47,8 +48,9 @@ class ArchivableFilesFinder extends FilterIterator
     {
         $fs = new Filesystem();
 
-        $sourcesRealPath = realpath($sources);
-        if ($sourcesRealPath === false) {
+        try {
+            $sourcesRealPath = Platform::realpath($sources);
+        } catch (\RuntimeException $exception) {
             throw new \RuntimeException('Could not realpath() the source directory "'.$sources.'"');
         }
         $sources = $fs->normalizePath($sourcesRealPath);

--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -48,11 +48,7 @@ class ArchivableFilesFinder extends FilterIterator
     {
         $fs = new Filesystem();
 
-        try {
-            $sourcesRealPath = Platform::realpath($sources);
-        } catch (\RuntimeException $exception) {
-            throw new \RuntimeException('Could not realpath() the source directory "'.$sources.'"');
-        }
+        $sourcesRealPath = Platform::realpath($sources);
         $sources = $fs->normalizePath($sourcesRealPath);
 
         if ($ignoreFilters) {

--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -17,6 +17,7 @@ use Composer\Package\RootPackageInterface;
 use Composer\Pcre\Preg;
 use Composer\Util\Filesystem;
 use Composer\Util\Loop;
+use Composer\Util\Platform;
 use Composer\Util\SyncHelper;
 use Composer\Json\JsonFile;
 use Composer\Package\CompletePackageInterface;
@@ -208,7 +209,7 @@ class ArchiveManager
 
         // Archive filename
         $filesystem->ensureDirectoryExists($targetDir);
-        $target = realpath($targetDir).'/'.$packageName.'.'.$format;
+        $target = Platform::realpath($targetDir).'/'.$packageName.'.'.$format;
         $filesystem->ensureDirectoryExists(dirname($target));
 
         if (!$this->overwriteFiles && file_exists($target)) {

--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -17,6 +17,7 @@ use Composer\Package\RootPackageInterface;
 use Composer\Pcre\Preg;
 use Composer\Util\Filesystem;
 use Composer\Util\Loop;
+use Composer\Util\Platform;
 use Composer\Util\SyncHelper;
 use Composer\Json\JsonFile;
 use Composer\Package\CompletePackageInterface;
@@ -207,7 +208,7 @@ class ArchiveManager
 
         // Archive filename
         $filesystem->ensureDirectoryExists($targetDir);
-        $target = realpath($targetDir).'/'.$packageName.'.'.$format;
+        $target = Platform::realpath($targetDir).'/'.$packageName.'.'.$format;
         $filesystem->ensureDirectoryExists(dirname($target));
 
         if (!$this->overwriteFiles && file_exists($target)) {

--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -168,7 +168,7 @@ class ArchiveManager
         $filesystem = new Filesystem();
 
         if ($package instanceof RootPackageInterface) {
-            $sourcePath = realpath('.');
+            $sourcePath = Platform::realpath('.');
         } else {
             // Directory used to download the sources
             $sourcePath = sys_get_temp_dir().'/composer_archive'.bin2hex(random_bytes(5));

--- a/src/Composer/Package/Archiver/PharArchiver.php
+++ b/src/Composer/Package/Archiver/PharArchiver.php
@@ -12,6 +12,8 @@
 
 namespace Composer\Package\Archiver;
 
+use Composer\Util\Platform;
+
 /**
  * @author Till Klampaeckel <till@php.net>
  * @author Nils Adermann <naderman@naderman.de>
@@ -38,7 +40,7 @@ class PharArchiver implements ArchiverInterface
      */
     public function archive(string $sources, string $target, string $format, array $excludes = [], bool $ignoreFilters = false): string
     {
-        $sources = realpath($sources);
+        $sources = Platform::realpath($sources);
 
         // Phar would otherwise load the file which we don't want
         if (file_exists($target)) {

--- a/src/Composer/Package/Archiver/PharArchiver.php
+++ b/src/Composer/Package/Archiver/PharArchiver.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Package\Archiver;
 
+use Composer\Util\Platform;
 use PharData;
 
 /**
@@ -40,7 +41,7 @@ class PharArchiver implements ArchiverInterface
      */
     public function archive(string $sources, string $target, string $format, array $excludes = [], bool $ignoreFilters = false): string
     {
-        $sources = realpath($sources);
+        $sources = Platform::realpath($sources);
 
         // Phar would otherwise load the file which we don't want
         if (file_exists($target)) {

--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -32,11 +32,12 @@ class ZipArchiver implements ArchiverInterface
     public function archive(string $sources, string $target, string $format, array $excludes = [], bool $ignoreFilters = false): string
     {
         $fs = new Filesystem();
-        $sourcesRealpath = realpath($sources);
-        if (false !== $sourcesRealpath) {
-            $sources = $sourcesRealpath;
+
+        try {
+            $sources = Platform::realpath($sources);
+        } catch (\Exception $exception) {
         }
-        unset($sourcesRealpath);
+
         $sources = $fs->normalizePath($sources);
 
         $zip = new ZipArchive();

--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -14,6 +14,7 @@ namespace Composer\Package\Archiver;
 
 use Composer\Util\Filesystem;
 use Composer\Util\Platform;
+use RuntimeException;
 use ZipArchive;
 
 /**
@@ -35,7 +36,7 @@ class ZipArchiver implements ArchiverInterface
 
         try {
             $sources = Platform::realpath($sources);
-        } catch (\Exception $exception) {
+        } catch (RuntimeException $exception) {
         }
 
         $sources = $fs->normalizePath($sources);

--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -98,7 +98,7 @@ class ZipArchiver implements ArchiverInterface
             $sources,
             $zip->getStatusString()
         );
-        throw new \RuntimeException($message);
+        throw new RuntimeException($message);
     }
 
     /**

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -19,6 +19,7 @@ use Composer\Repository\InstalledRepository;
 use Composer\Repository\LockArrayRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RootPackageRepository;
+use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Composer\Package\Dumper\ArrayDumper;
 use Composer\Package\Loader\ArrayLoader;
@@ -544,11 +545,15 @@ class Locker
         if ($path === null) {
             return null;
         }
-        $path = realpath($path);
+        try {
+            $path = Platform::realpath($path);
+        } catch (\RuntimeException $exception) {
+            return null;
+        }
         $sourceType = $package->getSourceType();
         $datetime = null;
 
-        if ($path && in_array($sourceType, ['git', 'hg'])) {
+        if (in_array($sourceType, ['git', 'hg'])) {
             $sourceRef = $package->getSourceReference() ?: $package->getDistReference();
             switch ($sourceType) {
                 case 'git':

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -34,6 +34,7 @@ use Composer\Plugin\PostFileDownloadEvent;
 use Composer\Semver\CompilingMatcher;
 use Composer\Util\HttpDownloader;
 use Composer\Util\Loop;
+use Composer\Util\Platform;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PreFileDownloadEvent;
 use Composer\EventDispatcher\EventDispatcher;
@@ -162,11 +163,10 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     {
         parent::__construct();
         if (!Preg::isMatch('{^[\w.]+\??://}', $repoConfig['url'])) {
-            if (($localFilePath = realpath($repoConfig['url'])) !== false) {
-                // it is a local path, add file scheme
-                $repoConfig['url'] = 'file://'.$localFilePath;
-            } else {
-                // otherwise, assume http as the default protocol
+            try {
+                $repoConfig['url'] = 'file://'.Platform::realpath($repoConfig['url']);
+            } catch (\RuntimeException $e) {
+                // not a local path, assume http as the default protocol
                 $repoConfig['url'] = 'http://'.$repoConfig['url'];
             }
         }

--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -129,7 +129,7 @@ class FilesystemRepository extends WritableArrayRepository
         $repoDir = dirname($this->file->getPath());
         $this->filesystem->ensureDirectoryExists($repoDir);
 
-        $repoDir = $this->filesystem->normalizePath(realpath($repoDir));
+        $repoDir = $this->filesystem->normalizePath(Platform::realpath($repoDir));
         $installPaths = [];
 
         foreach ($this->getCanonicalPackages() as $package) {
@@ -375,7 +375,7 @@ REGEX;
         }
 
         if ($package instanceof RootPackageInterface) {
-            $to = $this->filesystem->normalizePath(realpath(Platform::getCwd()));
+            $to = $this->filesystem->normalizePath(Platform::realpath(Platform::getCwd()));
             $installPath = $this->filesystem->findShortestPath($repoDir, $to, true);
         } else {
             $installPath = $installPaths[$package->getName()];

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -164,7 +164,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
         }
 
         foreach ($urlMatches as $url) {
-            $path = realpath($url) . DIRECTORY_SEPARATOR;
+            $path = Platform::realpath($url) . DIRECTORY_SEPARATOR;
             $composerFilePath = $path.'composer.json';
 
             if (!file_exists($composerFilePath)) {

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -164,12 +164,12 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
         }
 
         foreach ($urlMatches as $url) {
-            $path = Platform::realpath($url) . DIRECTORY_SEPARATOR;
-            $composerFilePath = $path.'composer.json';
-
-            if (!file_exists($composerFilePath)) {
+            try {
+                $path = Platform::realpath($url) . DIRECTORY_SEPARATOR;
+            } catch (\RuntimeException $exception) {
                 continue;
             }
+            $composerFilePath = $path.'composer.json';
 
             $json = file_get_contents($composerFilePath);
             $package = JsonFile::parseJson($json, $composerFilePath);

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -165,11 +165,11 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
         foreach ($urlMatches as $url) {
             try {
-                $path = Platform::realpath($url) . DIRECTORY_SEPARATOR;
+                $composerFilePath = $url.DIRECTORY_SEPARATOR.'composer.json';
+                $path = Platform::realpath($composerFilePath);
             } catch (\RuntimeException $exception) {
                 continue;
             }
-            $composerFilePath = $path.'composer.json';
 
             $json = file_get_contents($composerFilePath);
             $package = JsonFile::parseJson($json, $composerFilePath);

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -165,11 +165,11 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
         foreach ($urlMatches as $url) {
             try {
-                $composerFilePath = $url.DIRECTORY_SEPARATOR.'composer.json';
-                $path = Platform::realpath($composerFilePath);
+                $composerFilePath = Platform::realpath($url.DIRECTORY_SEPARATOR.'composer.json');
             } catch (\RuntimeException $exception) {
                 continue;
             }
+            $path = dirname($composerFilePath) . DIRECTORY_SEPARATOR;
 
             $json = file_get_contents($composerFilePath);
             $package = JsonFile::parseJson($json, $composerFilePath);

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -173,7 +173,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             if (!file_exists($composerFilePath)) {
                 continue;
             }
-    
+
             $json = file_get_contents($composerFilePath);
             $package = JsonFile::parseJson($json, $composerFilePath);
             $package['dist'] = [

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -165,12 +165,15 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
 
         foreach ($urlMatches as $url) {
             try {
-                $composerFilePath = Platform::realpath($url.DIRECTORY_SEPARATOR.'composer.json');
+                $path = Platform::realpath($url) . DIRECTORY_SEPARATOR;
             } catch (\RuntimeException $exception) {
                 continue;
             }
-            $path = dirname($composerFilePath) . DIRECTORY_SEPARATOR;
-
+            $composerFilePath = $path.'composer.json';
+            if (!file_exists($composerFilePath)) {
+                continue;
+            }
+    
             $json = file_get_contents($composerFilePath);
             $package = JsonFile::parseJson($json, $composerFilePath);
             $package['dist'] = [

--- a/src/Composer/Repository/RepositoryFactory.php
+++ b/src/Composer/Repository/RepositoryFactory.php
@@ -17,7 +17,9 @@ use Composer\IO\IOInterface;
 use Composer\Config;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\Pcre\Preg;
+use Composer\Util\Filesystem;
 use Composer\Util\HttpDownloader;
+use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\Url;
 use Composer\Json\JsonFile;
@@ -38,7 +40,14 @@ class RepositoryFactory
             $json = new JsonFile($repository, Factory::createHttpDownloader($io, $config));
             $data = $json->read();
             if (!empty($data['packages']) || !empty($data['includes']) || !empty($data['provider-includes'])) {
-                $repoConfig = ['type' => 'composer', 'url' => 'file://' . strtr(realpath($repository), '\\', '/')];
+                $repository = Platform::realpath((new Filesystem())->normalizePath($repository));
+                if (!Filesystem::isStreamWrapperPath($repository) && !str_starts_with($repository, 'file://')) {
+                    $repository = 'file://' . $repository;
+                }
+                $repoConfig = [
+                    'type' => 'composer',
+                    'url' => $repository,
+                ];
             } elseif ($allowFilesystem) {
                 $repoConfig = ['type' => 'filesystem', 'json' => $json];
             } else {

--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -13,6 +13,7 @@
 namespace Composer\Repository\Vcs;
 
 use Composer\Pcre\Preg;
+use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\Filesystem;
 use Composer\Util\Url;
@@ -46,7 +47,7 @@ class GitDriver extends VcsDriver
                 throw new \RuntimeException('Failed to read package information from '.$this->url.' as the path does not exist');
             }
             $this->repoDir = $this->url;
-            $cacheUrl = realpath($this->url);
+            $cacheUrl = Platform::realpath($this->url);
         } else {
             if (!Cache::isUsable($this->config->get('cache-vcs-dir'))) {
                 throw new \RuntimeException('GitDriver requires a usable cache directory, and it looks like you set it to be disabled');

--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -13,6 +13,7 @@
 namespace Composer\Repository\Vcs;
 
 use Composer\Pcre\Preg;
+use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\Filesystem;
 use Composer\Util\Url;
@@ -46,7 +47,7 @@ class GitDriver extends VcsDriver
                 throw new \RuntimeException('Failed to read package information from '.Url::sanitize($this->url).' as the path does not exist');
             }
             $this->repoDir = $this->url;
-            $cacheUrl = realpath($this->url);
+            $cacheUrl = Platform::realpath($this->url);
         } else {
             if (!Cache::isUsable($this->config->get('cache-vcs-dir'))) {
                 throw new \RuntimeException('GitDriver requires a usable cache directory, and it looks like you set it to be disabled');

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -361,7 +361,7 @@ class SvnDriver extends VcsDriver
     protected static function normalizeUrl(string $url): string
     {
         $fs = new Filesystem();
-        if ($fs->isAbsolutePath($url)) {
+        if ($fs->isAbsolutePath($url) && !Filesystem::isStreamWrapperPath($url)) {
             return 'file://' . strtr($url, '\\', '/');
         }
 

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -663,10 +663,19 @@ class Filesystem
         return $path;
     }
 
+    /**
+     * Is the file addressed with a streamwrapper:// prefix?
+     *
+     * `file://` is excluded – its paths can be relative, distinct from other stream wrappers which are always absolute.
+     *
+     * @see https://www.php.net/manual/en/intro.stream.php
+     *
+     * @param string $path Path to check
+     */
     public static function isStreamWrapperPath(string $path): bool
     {
-        if(!isset(self::$streamWrappersRegex)) {
             self::$streamWrappersRegex = sprintf( '{^(?:%s)://}', implode( '|', array_map( 'preg_quote', stream_get_wrappers() ) ) );
+            self::$streamWrappersRegex = sprintf('{^(?:%s)://}', implode('|', array_map('preg_quote', stream_get_wrappers())));
         }
 
         $path = Preg::replace('{^file://}i', '', $path);

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -30,14 +30,13 @@ class Filesystem
     private $processExecutor;
 
     /**
-     * @var non-empty-string
+     * @var ?non-empty-string
      */
-    private $streamWrappersRegex;
+    private static $streamWrappersRegex = null;
 
     public function __construct(?ProcessExecutor $executor = null)
     {
         $this->processExecutor = $executor;
-        $this->streamWrappersRegex = sprintf('{^(?:%s)://}', implode('|', array_map('preg_quote', stream_get_wrappers())));
     }
 
     /**
@@ -575,7 +574,7 @@ class Filesystem
         return strpos($path, '/') === 0
                || substr($path, 1, 1) === ':'
                || strpos($path, '\\\\') === 0
-               || Preg::isMatch($this->streamWrappersRegex, $path);
+               || self::isStreamWrapperPath($path);
     }
 
     /**
@@ -662,6 +661,15 @@ class Filesystem
         }
 
         return $path;
+    }
+
+    public static function isStreamWrapperPath(string $path): bool
+    {
+        if(!isset(self::$streamWrappersRegex)) {
+            self::$streamWrappersRegex = sprintf( '{^(?:%s)://}', implode( '|', array_map( 'preg_quote', stream_get_wrappers() ) ) );
+        }
+
+        return Preg::isMatch(self::$streamWrappersRegex, $path);
     }
 
     /**

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -669,6 +669,8 @@ class Filesystem
             self::$streamWrappersRegex = sprintf( '{^(?:%s)://}', implode( '|', array_map( 'preg_quote', stream_get_wrappers() ) ) );
         }
 
+        $path = Preg::replace('{^file://}i', '', $path);
+
         return Preg::isMatch(self::$streamWrappersRegex, $path);
     }
 

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -570,6 +570,8 @@ class Filesystem
      */
     public function isAbsolutePath(string $path)
     {
+        $path = str_replace('file://', '', $path);
+
         return strpos($path, '/') === 0
                || substr($path, 1, 1) === ':'
                || strpos($path, '\\\\') === 0

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -570,7 +570,7 @@ class Filesystem
      */
     public function isAbsolutePath(string $path)
     {
-        $path = str_replace('file://', '', $path);
+        $path = Preg::replace('{^file://}i', '', $path);
 
         return strpos($path, '/') === 0
                || substr($path, 1, 1) === ':'

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -29,9 +29,15 @@ class Filesystem
     /** @var ?ProcessExecutor */
     private $processExecutor;
 
+    /**
+     * @var non-empty-string
+     */
+    private $streamWrappersRegex;
+
     public function __construct(?ProcessExecutor $executor = null)
     {
         $this->processExecutor = $executor;
+        $this->streamWrappersRegex = sprintf('{^(?:%s)://}', implode('|', array_map('preg_quote', stream_get_wrappers())));
     }
 
     /**
@@ -564,7 +570,10 @@ class Filesystem
      */
     public function isAbsolutePath(string $path)
     {
-        return strpos($path, '/') === 0 || substr($path, 1, 1) === ':' || strpos($path, '\\\\') === 0;
+        return strpos($path, '/') === 0
+               || substr($path, 1, 1) === ':'
+               || strpos($path, '\\\\') === 0
+               || Preg::isMatch($this->streamWrappersRegex, $path);
     }
 
     /**

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -674,7 +674,7 @@ class Filesystem
      */
     public static function isStreamWrapperPath(string $path): bool
     {
-            self::$streamWrappersRegex = sprintf( '{^(?:%s)://}', implode( '|', array_map( 'preg_quote', stream_get_wrappers() ) ) );
+        if (!isset(self::$streamWrappersRegex)) {
             self::$streamWrappersRegex = sprintf('{^(?:%s)://}', implode('|', array_map('preg_quote', stream_get_wrappers())));
         }
 

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -572,7 +572,7 @@ class Filesystem
      */
     public function isAbsolutePath(string $path)
     {
-        $path = str_replace('file://', '', $path);
+        $path = Preg::replace('{^file://}i', '', $path);
 
         return strpos($path, '/') === 0
                || substr($path, 1, 1) === ':'

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -29,11 +29,6 @@ class Filesystem
     /** @var ?ProcessExecutor */
     private $processExecutor;
 
-    /**
-     * @var ?non-empty-string
-     */
-    private static $streamWrappersRegex = null;
-
     public function __construct(?ProcessExecutor $executor = null)
     {
         $this->processExecutor = $executor;
@@ -676,13 +671,15 @@ class Filesystem
      */
     public static function isStreamWrapperPath(string $path): bool
     {
-        if (!isset(self::$streamWrappersRegex)) {
-            self::$streamWrappersRegex = sprintf('{^(?:%s)://}', implode('|', array_map('preg_quote', stream_get_wrappers())));
+        $wrappers = array_map('preg_quote', stream_get_wrappers());
+        if (count($wrappers) === 0) {
+            return false;
         }
+        $streamWrappersRegex = sprintf('{^(?:%s)://}', implode('|', $wrappers));
 
         $path = Preg::replace('{^file://}i', '', $path);
 
-        return Preg::isMatch(self::$streamWrappersRegex, $path);
+        return Preg::isMatch($streamWrappersRegex, $path);
     }
 
     /**

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -665,10 +665,19 @@ class Filesystem
         return $path;
     }
 
+    /**
+     * Is the file addressed with a streamwrapper:// prefix?
+     *
+     * `file://` is excluded – its paths can be relative, distinct from other stream wrappers which are always absolute.
+     *
+     * @see https://www.php.net/manual/en/intro.stream.php
+     *
+     * @param string $path Path to check
+     */
     public static function isStreamWrapperPath(string $path): bool
     {
-        if(!isset(self::$streamWrappersRegex)) {
             self::$streamWrappersRegex = sprintf( '{^(?:%s)://}', implode( '|', array_map( 'preg_quote', stream_get_wrappers() ) ) );
+            self::$streamWrappersRegex = sprintf('{^(?:%s)://}', implode('|', array_map('preg_quote', stream_get_wrappers())));
         }
 
         $path = Preg::replace('{^file://}i', '', $path);

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -29,9 +29,15 @@ class Filesystem
     /** @var ?ProcessExecutor */
     private $processExecutor;
 
+    /**
+     * @var non-empty-string
+     */
+    private $streamWrappersRegex;
+
     public function __construct(?ProcessExecutor $executor = null)
     {
         $this->processExecutor = $executor;
+        $this->streamWrappersRegex = sprintf('{^(?:%s)://}', implode('|', array_map('preg_quote', stream_get_wrappers())));
     }
 
     /**
@@ -566,7 +572,10 @@ class Filesystem
      */
     public function isAbsolutePath(string $path)
     {
-        return strpos($path, '/') === 0 || substr($path, 1, 1) === ':' || strpos($path, '\\\\') === 0;
+        return strpos($path, '/') === 0
+               || substr($path, 1, 1) === ':'
+               || strpos($path, '\\\\') === 0
+               || Preg::isMatch($this->streamWrappersRegex, $path);
     }
 
     /**

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -572,6 +572,8 @@ class Filesystem
      */
     public function isAbsolutePath(string $path)
     {
+        $path = str_replace('file://', '', $path);
+
         return strpos($path, '/') === 0
                || substr($path, 1, 1) === ':'
                || strpos($path, '\\\\') === 0

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -676,7 +676,7 @@ class Filesystem
      */
     public static function isStreamWrapperPath(string $path): bool
     {
-            self::$streamWrappersRegex = sprintf( '{^(?:%s)://}', implode( '|', array_map( 'preg_quote', stream_get_wrappers() ) ) );
+        if (!isset(self::$streamWrappersRegex)) {
             self::$streamWrappersRegex = sprintf('{^(?:%s)://}', implode('|', array_map('preg_quote', stream_get_wrappers())));
         }
 

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -671,6 +671,8 @@ class Filesystem
             self::$streamWrappersRegex = sprintf( '{^(?:%s)://}', implode( '|', array_map( 'preg_quote', stream_get_wrappers() ) ) );
         }
 
+        $path = Preg::replace('{^file://}i', '', $path);
+
         return Preg::isMatch(self::$streamWrappersRegex, $path);
     }
 

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -30,14 +30,13 @@ class Filesystem
     private $processExecutor;
 
     /**
-     * @var non-empty-string
+     * @var ?non-empty-string
      */
-    private $streamWrappersRegex;
+    private static $streamWrappersRegex = null;
 
     public function __construct(?ProcessExecutor $executor = null)
     {
         $this->processExecutor = $executor;
-        $this->streamWrappersRegex = sprintf('{^(?:%s)://}', implode('|', array_map('preg_quote', stream_get_wrappers())));
     }
 
     /**
@@ -577,7 +576,7 @@ class Filesystem
         return strpos($path, '/') === 0
                || substr($path, 1, 1) === ':'
                || strpos($path, '\\\\') === 0
-               || Preg::isMatch($this->streamWrappersRegex, $path);
+               || self::isStreamWrapperPath($path);
     }
 
     /**
@@ -664,6 +663,15 @@ class Filesystem
         }
 
         return $path;
+    }
+
+    public static function isStreamWrapperPath(string $path): bool
+    {
+        if(!isset(self::$streamWrappersRegex)) {
+            self::$streamWrappersRegex = sprintf( '{^(?:%s)://}', implode( '|', array_map( 'preg_quote', stream_get_wrappers() ) ) );
+        }
+
+        return Preg::isMatch(self::$streamWrappersRegex, $path);
     }
 
     /**

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -59,12 +59,18 @@ class Platform
      *
      * NB: Do not remove recursive `realpath()` calls. Fixes failing Windows `realpath()` implementation.
      * @see https://bugs.php.net/bug.php?id=72738
+     *
+     * @throws \RuntimeException If the path does not exist. Distinct from `\realpath()` returning `false` in that case.
      */
     public static function realpath(string $path): string
     {
+        if(Filesystem::isStreamWrapperPath($path)) {
+            return $path;
+        }
+
         $realPath = realpath($path);
         if ($realPath === false) {
-            return $path;
+            throw new \RuntimeException('Path does not exist: ' . $path);
         }
         if ($realPath !== $path) {
             return Platform::realpath($realPath);

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -64,7 +64,9 @@ class Platform
      */
     public static function realpath(string $path): string
     {
-        if(Filesystem::isStreamWrapperPath($path)) {
+        $path = Preg::replace('{^file://}i', '', $path);
+
+        if (Filesystem::isStreamWrapperPath($path)) {
             return $path;
         }
 

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -56,12 +56,18 @@ class Platform
 
     /**
      * Infallible realpath version that falls back on the given $path if realpath is not working
+     *
+     * NB: Do not remove recursive `realpath()` calls. Fixes failing Windows `realpath()` implementation.
+     * @see https://bugs.php.net/bug.php?id=72738
      */
     public static function realpath(string $path): string
     {
         $realPath = realpath($path);
         if ($realPath === false) {
             return $path;
+        }
+        if ($realPath !== $path) {
+            return Platform::realpath($realPath);
         }
 
         return $realPath;

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -55,7 +55,7 @@ class Platform
     }
 
     /**
-     * Infallible realpath version that falls back on the given $path if realpath is not working
+     * Realpath function that assumes stream wrapper paths are valid and throws when realpath fails.
      *
      * NB: Do not remove recursive `realpath()` calls. Fixes failing Windows `realpath()` implementation.
      * @see https://bugs.php.net/bug.php?id=72738

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -60,7 +60,7 @@ class Platform
      * NB: Do not remove recursive `realpath()` calls. Fixes failing Windows `realpath()` implementation.
      * @see https://bugs.php.net/bug.php?id=72738
      *
-     * @throws \RuntimeException If the path does not exist. Distinct from `\realpath()` returning `false` in that case.
+     * @throws \RuntimeException If the path does not exist or is not accessible. Distinct from `\realpath()` returning `false` in that case.
      */
     public static function realpath(string $path): string
     {

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -74,7 +74,7 @@ class Platform
         if ($realPath === false) {
             throw new \RuntimeException('Path does not exist: ' . $path);
         }
-        if ($realPath !== $path) {
+        if ($realPath !== $path && Platform::isWindows()) {
             return Platform::realpath($realPath);
         }
 

--- a/tests/Composer/Test/Command/ClearCacheCommandTest.php
+++ b/tests/Composer/Test/Command/ClearCacheCommandTest.php
@@ -58,4 +58,26 @@ class ClearCacheCommandTest extends TestCase
 
         self::assertStringContainsString('Cache is not enabled', $output);
     }
+
+    /**
+     * @covers \Composer\Command\ClearCacheCommand::execute
+     */
+    public function testClearCacheCommandDirectoryDoesNotExist(): void
+    {
+        $testTempDirPath = $this->initTempComposer();
+
+        // Create the expected cache directories, except the `/vcs` directory.
+        mkdir($testTempDirPath . '/composer-home/cache', 0777, true);
+        mkdir($testTempDirPath . '/composer-home/cache/repo');
+        mkdir($testTempDirPath . '/composer-home/cache/files');
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'clear-cache']);
+
+        $appTester->assertCommandIsSuccessful();
+
+        $output = $appTester->getDisplay(true);
+
+        self::assertStringContainsString('Cache directory does not exist', $output);
+    }
 }

--- a/tests/Composer/Test/Command/ConfigCommandTest.php
+++ b/tests/Composer/Test/Command/ConfigCommandTest.php
@@ -184,4 +184,31 @@ class ConfigCommandTest extends TestCase
         $appTester = $this->getApplicationTester();
         $appTester->run(['command' => 'config', '--file' => 'alt.composer.json', '--global' => true]);
     }
+
+    /**
+     * @covers \Composer\Command\ConfigCommand::initialize
+     */
+    public function testCreatesComposerJsonIfNotExists(): void
+    {
+        $testTempDirPath = $this->initTempComposer();
+
+        $composerDirPath = $testTempDirPath . '/composer-home';
+
+        mkdir($composerDirPath);
+
+        $composerFilePath = $composerDirPath . '/composer.json';
+
+        assert(!file_exists($composerFilePath));
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run([
+            'command' => 'global',
+            'command-name' => 'config',
+            '--no-interaction',
+        ]);
+
+        $appTester->assertCommandIsSuccessful();
+
+        self::assertFileExists($composerFilePath);
+    }
 }

--- a/tests/Composer/Test/Command/ConfigCommandTest.php
+++ b/tests/Composer/Test/Command/ConfigCommandTest.php
@@ -600,4 +600,31 @@ class ConfigCommandTest extends TestCase
         $appTester = $this->getApplicationTester();
         $appTester->run(['command' => 'config', 'setting-key' => $settingKey, 'setting-value' => [$settingValue]]);
     }
+
+    /**
+     * @covers \Composer\Command\ConfigCommand::initialize
+     */
+    public function testCreatesComposerJsonIfNotExists(): void
+    {
+        $testTempDirPath = $this->initTempComposer();
+
+        $composerDirPath = $testTempDirPath . '/composer-home';
+
+        mkdir($composerDirPath);
+
+        $composerFilePath = $composerDirPath . '/composer.json';
+
+        assert(!file_exists($composerFilePath));
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run([
+            'command' => 'global',
+            'command-name' => 'config',
+            '--no-interaction',
+        ]);
+
+        $appTester->assertCommandIsSuccessful();
+
+        self::assertFileExists($composerFilePath);
+    }
 }

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -626,7 +626,9 @@ OUTPUT;
 
     public function testSelf(): void
     {
-        $this->initTempComposer(['name' => 'vendor/package', 'version' => '1.2.3', 'time' => date('Y-m-d')]);
+        $tmpDir = $this->initTempComposer(['name' => 'vendor/package', 'version' => '1.2.3', 'time' => date('Y-m-d')]);
+        $packageDir = $tmpDir.'/vendor/vendor/package';
+        mkdir($packageDir, 0777, true);
 
         $appTester = $this->getApplicationTester();
         $appTester->run(['command' => 'show', '--self' => true]);
@@ -640,7 +642,7 @@ OUTPUT;
             'homepage' => '',
             'source' => '[]  ',
             'dist' => '[]  ',
-            'path' => '',
+            'path' => $packageDir,
             'names' => 'vendor/package',
         ];
         $expectedString = implode(

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -17,6 +17,7 @@ use Composer\Pcre\Preg;
 use Composer\Pcre\Regex;
 use Composer\Repository\PlatformRepository;
 use Composer\Test\TestCase;
+use Composer\Util\Filesystem;
 use DateTimeImmutable;
 use InvalidArgumentException;
 
@@ -627,7 +628,7 @@ OUTPUT;
     public function testSelf(): void
     {
         $tmpDir = $this->initTempComposer(['name' => 'vendor/package', 'version' => '1.2.3', 'time' => date('Y-m-d')]);
-        $packageDir = $tmpDir.'/vendor/vendor/package';
+        $packageDir = (new Filesystem())->normalizePath($tmpDir.'/vendor/vendor/package');
         mkdir($packageDir, 0777, true);
 
         $appTester = $this->getApplicationTester();

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -17,7 +17,6 @@ use Composer\Pcre\Preg;
 use Composer\Pcre\Regex;
 use Composer\Repository\PlatformRepository;
 use Composer\Test\TestCase;
-use Composer\Util\Filesystem;
 use DateTimeImmutable;
 use InvalidArgumentException;
 
@@ -628,7 +627,7 @@ OUTPUT;
     public function testSelf(): void
     {
         $tmpDir = $this->initTempComposer(['name' => 'vendor/package', 'version' => '1.2.3', 'time' => date('Y-m-d')]);
-        $packageDir = (new Filesystem())->normalizePath($tmpDir.'/vendor/vendor/package');
+        $packageDir = str_replace('/', DIRECTORY_SEPARATOR, $tmpDir.'/vendor/vendor/package');
         mkdir($packageDir, 0777, true);
 
         $appTester = $this->getApplicationTester();

--- a/tests/Composer/Test/Installer/LibraryInstallerTest.php
+++ b/tests/Composer/Test/Installer/LibraryInstallerTest.php
@@ -135,6 +135,16 @@ class LibraryInstallerTest extends TestCase
         self::ensureDirectoryExistsAndClear($this->vendorDir.'/'.$package->getPrettyName());
         self::assertTrue($library->isInstalled($repository, $package));
 
+        // package in symlinked directory is also seen as installed
+        $this->fs->removeDirectory($this->vendorDir.'/'.$package->getPrettyName());
+        self::ensureDirectoryExistsAndClear($this->vendorDir.'/test/pkg-link-target');
+        symlink($this->vendorDir.'/test/pkg-link-target', $this->vendorDir.'/'.$package->getPrettyName());
+        self::assertTrue($library->isInstalled($repository, $package));
+
+        // package in broken symlinked directory is not installed
+        $this->fs->rmdir($this->vendorDir.'/test/pkg-link-target');
+        self::assertFalse($library->isInstalled($repository, $package));
+
         $repository->removePackage($package);
         self::assertFalse($library->isInstalled($repository, $package));
     }

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -466,4 +466,33 @@ class JsonFileTest extends TestCase
 
         $filesystem->unlink(__DIR__.'/Fixtures/tabs3.json');
     }
+
+    /**
+     * @covers \Composer\Json\JsonFile::write
+     */
+    public function testThrowsWhenWriteConflict(): void
+    {
+        @mkdir(__DIR__.'/Fixtures/subdirfile/');
+        copy(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/subdirfile/tabs.json');
+
+        $jsonFile = new JsonFile(__DIR__.'/Fixtures/subdirfile/tabs.json');
+        $jsonFile->read();
+
+        $filesystem = new Filesystem();
+        $filesystem->unlink(__DIR__.'/Fixtures/subdirfile/tabs.json');
+        $filesystem->removeDirectory(__DIR__.'/Fixtures/subdirfile');
+
+        copy(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/subdirfile');
+
+        $exceptionMessage = '';
+        try {
+            $jsonFile->write(['foo' => 'bar']);
+        } catch (\UnexpectedValueException $e) {
+            $exceptionMessage = $e->getMessage();
+        }
+
+        self::assertStringEndsWith(__DIR__ . '/Fixtures/subdirfile exists and is not a directory.', $exceptionMessage);
+
+        $filesystem->unlink(__DIR__.'/Fixtures/subdirfile');
+    }
 }

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\Json;
 
+use Composer\Util\Filesystem;
 use Seld\JsonLint\ParsingException;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonValidationException;
@@ -410,5 +411,59 @@ class JsonFileTest extends TestCase
         } else {
             self::assertEquals($json, $file->encode($data, $options));
         }
+    }
+
+    /**
+     * @covers \Composer\Json\JsonFile::read
+     */
+    public function testPrintsMessageWhenReading(): void
+    {
+        $io = $this->getIOMock();
+        $io->expects([['text' => 'Reading ' . __DIR__ . '/Fixtures/tabs.json']], true);
+
+        $jsonFile = new JsonFile(__DIR__.'/Fixtures/tabs.json', null, $io);
+        $jsonFile->read();
+    }
+
+    /**
+     * @covers \Composer\Json\JsonFile::read
+     */
+    public function testPrintsMessageWhenReadingSymlink(): void
+    {
+        $io = $this->getIOMock();
+        $io->expects([['text' => 'Reading ' . __DIR__ . '/Fixtures/tabs2.json (' . __DIR__ . '/Fixtures/tabs.json)']], true);
+
+        $filesystem = new Filesystem();
+        $filesystem->relativeSymlink(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/tabs2.json');
+
+        $jsonFile = new JsonFile(__DIR__.'/Fixtures/tabs2.json', null, $io);
+        $jsonFile->read();
+
+        $filesystem->unlink(__DIR__.'/Fixtures/tabs2.json');
+    }
+
+    /**
+     * @covers \Composer\Json\JsonFile::read
+     */
+    public function testThrowsWhenReadingBrokenSymlink(): void
+    {
+        copy(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/tabs2.json');
+
+        $filesystem = new Filesystem();
+        $filesystem->relativeSymlink(__DIR__.'/Fixtures/tabs2.json', __DIR__.'/Fixtures/tabs3.json');
+
+        $filesystem->unlink(__DIR__.'/Fixtures/tabs2.json');
+
+        $exceptionMessage = '';
+        try {
+            $jsonFile = new JsonFile(__DIR__.'/Fixtures/tabs3.json');
+            $jsonFile->read();
+        } catch (\RuntimeException $e) {
+            $exceptionMessage = $e->getMessage();
+        }
+
+        self::assertStringEndsWith('The file "' . __DIR__ . '/Fixtures/tabs3.json" is not readable.', $exceptionMessage);
+
+        $filesystem->unlink(__DIR__.'/Fixtures/tabs3.json');
     }
 }

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -548,4 +548,33 @@ class JsonFileTest extends TestCase
 
         $filesystem->unlink(__DIR__.'/Fixtures/tabs3.json');
     }
+
+    /**
+     * @covers \Composer\Json\JsonFile::write
+     */
+    public function testThrowsWhenWriteConflict(): void
+    {
+        @mkdir(__DIR__.'/Fixtures/subdirfile/');
+        copy(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/subdirfile/tabs.json');
+
+        $jsonFile = new JsonFile(__DIR__.'/Fixtures/subdirfile/tabs.json');
+        $jsonFile->read();
+
+        $filesystem = new Filesystem();
+        $filesystem->unlink(__DIR__.'/Fixtures/subdirfile/tabs.json');
+        $filesystem->removeDirectory(__DIR__.'/Fixtures/subdirfile');
+
+        copy(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/subdirfile');
+
+        $exceptionMessage = '';
+        try {
+            $jsonFile->write(['foo' => 'bar']);
+        } catch (\UnexpectedValueException $e) {
+            $exceptionMessage = $e->getMessage();
+        }
+
+        self::assertStringEndsWith(__DIR__ . '/Fixtures/subdirfile exists and is not a directory.', $exceptionMessage);
+
+        $filesystem->unlink(__DIR__.'/Fixtures/subdirfile');
+    }
 }

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -513,7 +513,7 @@ class JsonFileTest extends TestCase
     public function testPrintsMessageWhenReadingSymlink(): void
     {
         $io = $this->getIOMock();
-        $io->expects([['text' => 'Reading ' . __DIR__ . '/Fixtures/tabs2.json (' . __DIR__ . '/Fixtures/tabs.json)']], true);
+        $io->expects([['text' => 'Reading ' . __DIR__ . '/Fixtures/tabs2.json (' . __DIR__ . str_replace('/', DIRECTORY_SEPARATOR, '/Fixtures/tabs.json)')]], true);
 
         $filesystem = new Filesystem();
         $filesystem->relativeSymlink(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/tabs2.json');

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\Json;
 
 use Composer\Util\Filesystem;
+use Composer\Util\Platform;
 use Seld\JsonLint\ParsingException;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonValidationException;
@@ -531,6 +532,10 @@ class JsonFileTest extends TestCase
      */
     public function testThrowsWhenReadingBrokenSymlink(): void
     {
+        if (Platform::isWindows()) {
+            $this->markTestSkipped('Does not run on windows');
+        }
+
         copy(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/tabs2.json');
 
         $filesystem = new Filesystem();

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -546,7 +546,8 @@ class JsonFileTest extends TestCase
                 $exceptionMessage = $e->getMessage();
             }
 
-            self::assertStringEndsWith('The file "' . __DIR__ . '/Fixtures/tabs3.json" is not readable.', $exceptionMessage);
+            $expectedPath = __DIR__ . str_replace('/', DIRECTORY_SEPARATOR, '/Fixtures/tabs3.json');
+            self::assertStringEndsWith('The file "' . $expectedPath . '" is not readable.', $exceptionMessage);
         } finally {
             $filesystem->unlink(__DIR__.'/Fixtures/tabs3.json');
         }
@@ -577,7 +578,8 @@ class JsonFileTest extends TestCase
                 $exceptionMessage = $e->getMessage();
             }
 
-            self::assertStringEndsWith(__DIR__ . '/Fixtures/subdirfile exists and is not a directory.', $exceptionMessage);
+            $expectedPath = __DIR__ . str_replace('/', DIRECTORY_SEPARATOR, '/Fixtures/subdirfile');
+            self::assertStringEndsWith($expectedPath . ' exists and is not a directory.', $exceptionMessage);
         } finally {
             $filesystem->unlink(__DIR__.'/Fixtures/subdirfile');
         }

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\Json;
 
+use Composer\Util\Filesystem;
 use Seld\JsonLint\ParsingException;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonValidationException;
@@ -492,5 +493,59 @@ class JsonFileTest extends TestCase
         } else {
             self::assertEquals($json, $file->encode($data, $options));
         }
+    }
+
+    /**
+     * @covers \Composer\Json\JsonFile::read
+     */
+    public function testPrintsMessageWhenReading(): void
+    {
+        $io = $this->getIOMock();
+        $io->expects([['text' => 'Reading ' . __DIR__ . '/Fixtures/tabs.json']], true);
+
+        $jsonFile = new JsonFile(__DIR__.'/Fixtures/tabs.json', null, $io);
+        $jsonFile->read();
+    }
+
+    /**
+     * @covers \Composer\Json\JsonFile::read
+     */
+    public function testPrintsMessageWhenReadingSymlink(): void
+    {
+        $io = $this->getIOMock();
+        $io->expects([['text' => 'Reading ' . __DIR__ . '/Fixtures/tabs2.json (' . __DIR__ . '/Fixtures/tabs.json)']], true);
+
+        $filesystem = new Filesystem();
+        $filesystem->relativeSymlink(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/tabs2.json');
+
+        $jsonFile = new JsonFile(__DIR__.'/Fixtures/tabs2.json', null, $io);
+        $jsonFile->read();
+
+        $filesystem->unlink(__DIR__.'/Fixtures/tabs2.json');
+    }
+
+    /**
+     * @covers \Composer\Json\JsonFile::read
+     */
+    public function testThrowsWhenReadingBrokenSymlink(): void
+    {
+        copy(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/tabs2.json');
+
+        $filesystem = new Filesystem();
+        $filesystem->relativeSymlink(__DIR__.'/Fixtures/tabs2.json', __DIR__.'/Fixtures/tabs3.json');
+
+        $filesystem->unlink(__DIR__.'/Fixtures/tabs2.json');
+
+        $exceptionMessage = '';
+        try {
+            $jsonFile = new JsonFile(__DIR__.'/Fixtures/tabs3.json');
+            $jsonFile->read();
+        } catch (\RuntimeException $e) {
+            $exceptionMessage = $e->getMessage();
+        }
+
+        self::assertStringEndsWith('The file "' . __DIR__ . '/Fixtures/tabs3.json" is not readable.', $exceptionMessage);
+
+        $filesystem->unlink(__DIR__.'/Fixtures/tabs3.json');
     }
 }

--- a/tests/Composer/Test/Json/JsonFileTest.php
+++ b/tests/Composer/Test/Json/JsonFileTest.php
@@ -518,10 +518,12 @@ class JsonFileTest extends TestCase
         $filesystem = new Filesystem();
         $filesystem->relativeSymlink(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/tabs2.json');
 
-        $jsonFile = new JsonFile(__DIR__.'/Fixtures/tabs2.json', null, $io);
-        $jsonFile->read();
-
-        $filesystem->unlink(__DIR__.'/Fixtures/tabs2.json');
+        try {
+            $jsonFile = new JsonFile(__DIR__.'/Fixtures/tabs2.json', null, $io);
+            $jsonFile->read();
+        } finally {
+            $filesystem->unlink(__DIR__.'/Fixtures/tabs2.json');
+        }
     }
 
     /**
@@ -533,20 +535,21 @@ class JsonFileTest extends TestCase
 
         $filesystem = new Filesystem();
         $filesystem->relativeSymlink(__DIR__.'/Fixtures/tabs2.json', __DIR__.'/Fixtures/tabs3.json');
-
         $filesystem->unlink(__DIR__.'/Fixtures/tabs2.json');
 
-        $exceptionMessage = '';
         try {
-            $jsonFile = new JsonFile(__DIR__.'/Fixtures/tabs3.json');
-            $jsonFile->read();
-        } catch (\RuntimeException $e) {
-            $exceptionMessage = $e->getMessage();
+            $exceptionMessage = '';
+            try {
+                $jsonFile = new JsonFile(__DIR__.'/Fixtures/tabs3.json');
+                $jsonFile->read();
+            } catch (\RuntimeException $e) {
+                $exceptionMessage = $e->getMessage();
+            }
+
+            self::assertStringEndsWith('The file "' . __DIR__ . '/Fixtures/tabs3.json" is not readable.', $exceptionMessage);
+        } finally {
+            $filesystem->unlink(__DIR__.'/Fixtures/tabs3.json');
         }
-
-        self::assertStringEndsWith('The file "' . __DIR__ . '/Fixtures/tabs3.json" is not readable.', $exceptionMessage);
-
-        $filesystem->unlink(__DIR__.'/Fixtures/tabs3.json');
     }
 
     /**
@@ -566,15 +569,17 @@ class JsonFileTest extends TestCase
 
         copy(__DIR__.'/Fixtures/tabs.json', __DIR__.'/Fixtures/subdirfile');
 
-        $exceptionMessage = '';
         try {
-            $jsonFile->write(['foo' => 'bar']);
-        } catch (\UnexpectedValueException $e) {
-            $exceptionMessage = $e->getMessage();
+            $exceptionMessage = '';
+            try {
+                $jsonFile->write(['foo' => 'bar']);
+            } catch (\UnexpectedValueException $e) {
+                $exceptionMessage = $e->getMessage();
+            }
+
+            self::assertStringEndsWith(__DIR__ . '/Fixtures/subdirfile exists and is not a directory.', $exceptionMessage);
+        } finally {
+            $filesystem->unlink(__DIR__.'/Fixtures/subdirfile');
         }
-
-        self::assertStringEndsWith(__DIR__ . '/Fixtures/subdirfile exists and is not a directory.', $exceptionMessage);
-
-        $filesystem->unlink(__DIR__.'/Fixtures/subdirfile');
     }
 }

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -18,6 +18,7 @@ use Composer\Package\Locker;
 use Composer\Plugin\PluginInterface;
 use Composer\IO\NullIO;
 use Composer\Test\TestCase;
+use Composer\Util\Git;
 
 class LockerTest extends TestCase
 {
@@ -288,32 +289,33 @@ class LockerTest extends TestCase
                 ->willReturn('git');
 
         if ($isValidPath) {
-            $processExecutor->expects($this->exactly(2))
-                            ->method('execute')
-                            ->willReturnOnConsecutiveCalls(
-                                $this->returnCallback(function (array $command, ?string &$output1) {
-                                    // Using `::withConsecutive()` to assert the parameters was failing.
-                                    $this->assertEquals([ 'git', '--version' ], $command);
+            $processExecutor->expects($this->atLeast(1))
+                ->method('execute')
+                ->willReturnCallback(
+                    /**
+                     * {@see Locker::getPackageTime()} builds its command by first calling
+                     * {@see Git::getVersion()} via {@see Git::getNoShowSignatureFlags()}. On the first call
+                     * we want to return the "Git version", then we want the `ProcessExecutor` to return the
+                     * time of the package's last Git commit.
+                     *
+                     * But... {@see Git::getVersion()} stores its result in static {@see Git::$version} so depending on
+                     * the tests' order, using `::willReturnOnConsecutiveCalls()` in tests is not accurate.
+                     */
+                    static function ($command, &$output, ?string $path) {
+                        switch (true) {
+                            case ($command === [ 'git', '--version' ]):
+                                $output = '2.49.0';
+                                break;
+                            case ($command === ['git', 'log', '-n1', '--pretty=%ct', 'git']):
+                                $output = (string) time();
+                                break;
+                            default:
+                                throw new \Exception('Unexpected command to ProcessExecutor in test LockerTest::testGetPackageTime()');
+                        }
 
-                                    $output1 = '2.49.0';
-
-                                    return 0;
-                                }),
-                                $this->returnCallback(function ($command, &$output2, ?string $path) {
-                                    $this->assertEquals([
-                                        'git',
-                                        'log',
-                                        '-n1',
-                                        '--pretty=%ct',
-                                        'git',
-                                    ], $command);
-                                    $this->assertEquals(__DIR__, $path);
-
-                                    $output2 = (string) time();
-
-                                    return 0;
-                                })
-                            );
+                        return 0;
+                    }
+                );
         } else {
             $processExecutor->expects($this->never())
                              ->method('execute');
@@ -344,6 +346,7 @@ class LockerTest extends TestCase
 
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject&\Composer\Json\JsonFile
+     * @return \PHPUnit\Framework\MockObject\MockObject&JsonFile
      */
     private function createJsonFileMock()
     {

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -309,7 +309,8 @@ class LockerTest extends TestCase
                             case ($command === [ 'git', '--version' ]):
                                 $output = '2.49.0';
                                 break;
-                            case ($command === ['git', 'log', '-n1', '--pretty=%ct', 'git']):
+                            case (in_array('--format=%ct', $command, true)):
+                                // `ct` = committer timestamp.
                                 $output = (string) time();
                                 break;
                             default:

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -18,6 +18,7 @@ use Composer\Package\Locker;
 use Composer\Plugin\PluginInterface;
 use Composer\IO\NullIO;
 use Composer\Test\TestCase;
+use Composer\Util\Git;
 
 class LockerTest extends TestCase
 {
@@ -288,32 +289,33 @@ class LockerTest extends TestCase
                 ->willReturn('git');
 
         if ($isValidPath) {
-            $processExecutor->expects($this->exactly(2))
-                            ->method('execute')
-                            ->willReturnOnConsecutiveCalls(
-                                $this->returnCallback(function (array $command, ?string &$output1) {
-                                    // Using `::withConsecutive()` to assert the parameters was failing.
-                                    $this->assertEquals([ 'git', '--version' ], $command);
+            $processExecutor->expects($this->atLeast(1))
+                ->method('execute')
+                ->willReturnCallback(
+                    /**
+                     * {@see Locker::getPackageTime()} builds its command by first calling
+                     * {@see Git::getVersion()} via {@see Git::getNoShowSignatureFlags()}. On the first call
+                     * we want to return the "Git version", then we want the `ProcessExecutor` to return the
+                     * time of the package's last Git commit.
+                     *
+                     * But... {@see Git::getVersion()} stores its result in static {@see Git::$version} so depending on
+                     * the tests' order, using `::willReturnOnConsecutiveCalls()` in tests is not accurate.
+                     */
+                    static function ($command, &$output, ?string $path) {
+                        switch (true) {
+                            case ($command === [ 'git', '--version' ]):
+                                $output = '2.49.0';
+                                break;
+                            case ($command === ['git', 'log', '-n1', '--pretty=%ct', 'git']):
+                                $output = (string) time();
+                                break;
+                            default:
+                                throw new \Exception('Unexpected command to ProcessExecutor in test LockerTest::testGetPackageTime()');
+                        }
 
-                                    $output1 = '2.49.0';
-
-                                    return 0;
-                                }),
-                                $this->returnCallback(function ($command, &$output2, ?string $path) {
-                                    $this->assertEquals([
-                                        'git',
-                                        'log',
-                                        '-n1',
-                                        '--pretty=%ct',
-                                        'git',
-                                    ], $command);
-                                    $this->assertEquals(__DIR__, $path);
-
-                                    $output2 = (string) time();
-
-                                    return 0;
-                                })
-                            );
+                        return 0;
+                    }
+                );
         } else {
             $processExecutor->expects($this->never())
                              ->method('execute');

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -313,7 +313,7 @@ class LockerTest extends TestCase
                                 $output = (string) time();
                                 break;
                             default:
-                                throw new \Exception('Unexpected command to ProcessExecutor in test LockerTest::testGetPackageTime()');
+                                throw new \Exception('Unexpected command to ProcessExecutor in test LockerTest::testGetPackageTime(): [\'' . implode("', '", $command) . '\']');
                         }
 
                         return 0;

--- a/tests/Composer/Test/Package/LockerTest.php
+++ b/tests/Composer/Test/Package/LockerTest.php
@@ -225,6 +225,9 @@ class LockerTest extends TestCase
         self::assertFalse($locker->isFresh());
     }
 
+    /**
+     * @return array<string, array{path:string, isValidPath:bool}>
+     */
     public static function provideGetPackageTimePath(): array
     {
         return [

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test\Repository;
 
 use Composer\Repository\PathRepository;
 use Composer\Test\TestCase;
+use Composer\Util\Filesystem;
 use Composer\Util\HttpDownloader;
 use Composer\Util\Loop;
 use Composer\Util\Platform;
@@ -173,5 +174,51 @@ class PathRepositoryTest extends TestCase
         $loop = new Loop(new HttpDownloader($io, $config), $proc);
 
         return new PathRepository($options, $io, $config, null, null, $proc);
+    }
+
+    /**
+     * Ensure `realpath()` is invoked and its result is valid in loading the repository.
+     *
+     * @covers \Composer\Repository\PathRepository::initialize()
+     */
+    public function testLoadPackageFromFileSystemThroughSymlink(): void
+    {
+        $repositoryUrl = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'with-version']);
+        $symlinkUrl = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'link-target-with-version']);
+
+        $filesystem = new Filesystem();
+        $filesystem->relativeSymlink($repositoryUrl, $symlinkUrl);
+
+        $repository = $this->createPathRepo(['url' => $symlinkUrl]);
+
+        self::assertSame(1, $repository->count());
+        self::assertTrue($repository->hasPackage(self::getPackage('test/path-versioned', '0.0.2')));
+
+        $filesystem->remove($symlinkUrl);
+    }
+
+    /**
+     * @covers \Composer\Repository\PathRepository::initialize()
+     */
+    public function testLoadPackageFromFileSystemWithGitVersion(): void
+    {
+        $fixtureSource = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'without-version']);
+        $repositoryUrl = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'with-git-version']);
+        $repository = $this->createPathRepo(['url' => $repositoryUrl]);
+
+        $filesystem = new Filesystem();
+        $filesystem->copy($fixtureSource, $repositoryUrl);
+
+        $process = new ProcessExecutor();
+        $command = 'git init; git add .; git commit -am "Initial commit"; git tag -a v1.4 -m "my version 1.4"; git checkout v1.4';
+        $process->execute($command, $output, $repositoryUrl);
+
+        $packages = $repository->getPackages();
+        $packageVersion = $packages[0]->getPrettyVersion();
+
+        self::assertEquals('v1.4', $packageVersion);
+
+        // Cleanup.
+        $filesystem->remove($repositoryUrl);
     }
 }

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -183,6 +183,10 @@ class PathRepositoryTest extends TestCase
      */
     public function testLoadPackageFromFileSystemThroughSymlink(): void
     {
+        if (Platform::isWindows()) {
+            $this->markTestSkipped('Does not run on windows');
+        }
+
         $repositoryTargetUrl = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'with-version']);
         $symlinkLocationUrl = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'link-location-with-version']);
 

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -213,8 +213,12 @@ class PathRepositoryTest extends TestCase
         $filesystem->copy($fixtureSource, $repositoryUrl);
 
         $process = new ProcessExecutor();
-        $command = 'git init; git add .; git commit -am "Initial commit"; git tag -a v1.4 -m "my version 1.4"; git checkout v1.4';
-        $process->execute($command, $output, $repositoryUrl);
+
+        self::assertSame(0, $process->execute('git init', $output, $repositoryUrl), $output);
+        self::assertSame(0, $process->execute('git add .', $output, $repositoryUrl), $output);
+        self::assertSame(0, $process->execute('git commit -m "Initial commit"', $output, $repositoryUrl), $output);
+        self::assertSame(0, $process->execute('git tag -a v1.4 -m "my version 1.4"', $output, $repositoryUrl), $output);
+        self::assertSame(0, $process->execute('git checkout v1.4', $output, $repositoryUrl), $output);
 
         $packages = $repository->getPackages();
         $packageVersion = $packages[0]->getPrettyVersion();

--- a/tests/Composer/Test/Repository/PathRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PathRepositoryTest.php
@@ -183,18 +183,21 @@ class PathRepositoryTest extends TestCase
      */
     public function testLoadPackageFromFileSystemThroughSymlink(): void
     {
-        $repositoryUrl = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'with-version']);
-        $symlinkUrl = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'link-target-with-version']);
+        $repositoryTargetUrl = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'with-version']);
+        $symlinkLocationUrl = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', 'path', 'link-location-with-version']);
 
         $filesystem = new Filesystem();
-        $filesystem->relativeSymlink($repositoryUrl, $symlinkUrl);
 
-        $repository = $this->createPathRepo(['url' => $symlinkUrl]);
+        $filesystem->relativeSymlink($repositoryTargetUrl, $symlinkLocationUrl);
 
-        self::assertSame(1, $repository->count());
-        self::assertTrue($repository->hasPackage(self::getPackage('test/path-versioned', '0.0.2')));
+        try {
+            $repository = $this->createPathRepo(['url' => $symlinkLocationUrl]);
 
-        $filesystem->remove($symlinkUrl);
+            self::assertSame(1, $repository->count());
+            self::assertTrue($repository->hasPackage(self::getPackage('test/path-versioned', '0.0.2')));
+        } finally {
+            $filesystem->remove($symlinkLocationUrl);
+        }
     }
 
     /**

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -399,4 +399,32 @@ class FilesystemTest extends TestCase
         self::assertDirectoryDoesNotExist($this->workingDir . '/foo/bar', 'Still a directory: ' . $this->workingDir . '/foo/bar');
         self::assertDirectoryDoesNotExist($this->workingDir . '/foo', 'Still a directory: ' . $this->workingDir . '/foo');
     }
+
+    /**
+     * A Unix path is absolute if it starts with a forward-slash.
+     * A Windows path is absolute if it starts with a drive letter followed by a colon and a back-slash.
+     * A network path is always absolute and starts with two backslashes.
+     * A stream path is always absolute and starts with a scheme followed by "://".
+     */
+    public static function isAbsolutePathDataProvider(): array
+    {
+        return [
+            'unixPath' => ['/foo/bar', true],
+            'smbPath' => ['\\\\smb\\folder\\file.txt', true],
+            'windowsPath' => ['C:\\foo\\bar', true],
+            'streamPath' => ['file://path/to/whatever', true],
+            'relativeSubPath' => ['foo/bar', false],
+            'relativeSubPath2' => ['./foo/bar', false],
+            'relativeParentPath' => ['../foo/bar', false],
+        ];
+    }
+
+    /**
+     * @covers \Composer\Util\Filesystem::isAbsolutePath
+     * @dataProvider isAbsolutePathDataProvider
+     */
+    public function testIsAbsolutePath(string $path, bool $expected): void
+    {
+        self::assertEquals($expected, (new Filesystem())->isAbsolutePath($path));
+    }
 }

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -412,7 +412,9 @@ class FilesystemTest extends TestCase
             'unixPath' => ['/foo/bar', true],
             'smbPath' => ['\\\\smb\\folder\\file.txt', true],
             'windowsPath' => ['C:\\foo\\bar', true],
-            'streamPath' => ['file://path/to/whatever', true],
+            'streamPath' => ['customstreamwrapper://path/to/whatever', true],
+            'fileStreamAbsolutePath' => ['file:///path/to/whatever', true],
+            'fileStreamRelativePath' => ['file://path/to/whatever', false],
             'relativeSubPath' => ['foo/bar', false],
             'relativeSubPath2' => ['./foo/bar', false],
             'relativeParentPath' => ['../foo/bar', false],
@@ -425,6 +427,10 @@ class FilesystemTest extends TestCase
      */
     public function testIsAbsolutePath(string $path, bool $expected): void
     {
+        if (str_starts_with($path, 'customstreamwrapper://') && !in_array('customstreamwrapper', stream_get_wrappers(), true)) {
+            stream_wrapper_register('customstreamwrapper', __CLASS__);
+        }
+
         self::assertEquals($expected, (new Filesystem())->isAbsolutePath($path));
     }
 }

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -429,4 +429,31 @@ class FilesystemTest extends TestCase
     {
         self::assertEquals($expected, (new Filesystem())->isAbsolutePath($path));
     }
+
+    /**
+     * Same dataset as {@see FilesystemTest::isAbsolutePathDataProvider} but with different expected results.
+     */
+    public static function isStreamWrapperPathProvider(): array
+    {
+        return [
+            'unixPath' => ['/foo/bar', false],
+            'smbPath' => ['\\\\smb\\folder\\file.txt', false],
+            'windowsPath' => ['C:\\foo\\bar', false],
+            'streamPath' => ['composertestsstreamwrapper://path/to/whatever', true],
+            'fileStreamAbsolutePath' => ['file:///path/to/whatever', false],
+            'fileStreamRelativePath' => ['file://path/to/whatever', false],
+            'relativeSubPath' => ['foo/bar', false],
+            'relativeSubPath2' => ['./foo/bar', false],
+            'relativeParentPath' => ['../foo/bar', false],
+        ];
+    }
+
+    /**
+     * @covers \Composer\Util\Filesystem::isStreamWrapperPath
+     * @dataProvider isStreamWrapperPathProvider
+     */
+    public function testIsStreamWrapperPath(string $path, bool $expected): void
+    {
+        self::assertEquals($expected, Filesystem::isStreamWrapperPath($path));
+    }
 }

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -476,10 +476,10 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * The purpose of this method is to determine if a cache should be used. With stream wrappers, we can't tell
-     * if the path is local or not. Currently, we return false, meaning that a cache typically will be used. But
-     * it could be argued that caching is the business of whoever is implementing the stream wrapper, and we should
-     * treat it like a local path.
+     * The purpose of this method is generally to determine if a cache should be used. With stream wrappers, we can't
+     * tell if the path is local or not. Currently, we return false, meaning that a cache typically will be used. While
+     * it could be argued that caching is the business of whoever is implementing the stream wrapper, some such as
+     * http:// and git:// are clearly remote paths, so we should return false for `::isLocalPath()` on stream wrappers.
      *
      * @covers \Composer\Util\Filesystem::isLocalPath
      * @dataProvider isLocalPathProvider

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -412,7 +412,7 @@ class FilesystemTest extends TestCase
             'unixPath' => ['/foo/bar', true],
             'smbPath' => ['\\\\smb\\folder\\file.txt', true],
             'windowsPath' => ['C:\\foo\\bar', true],
-            'streamPath' => ['customstreamwrapper://path/to/whatever', true],
+            'streamPath' => ['composertestsstreamwrapper://path/to/whatever', true],
             'fileStreamAbsolutePath' => ['file:///path/to/whatever', true],
             'fileStreamRelativePath' => ['file://path/to/whatever', false],
             'relativeSubPath' => ['foo/bar', false],
@@ -427,10 +427,6 @@ class FilesystemTest extends TestCase
      */
     public function testIsAbsolutePath(string $path, bool $expected): void
     {
-        if (str_starts_with($path, 'customstreamwrapper://') && !in_array('customstreamwrapper', stream_get_wrappers(), true)) {
-            stream_wrapper_register('customstreamwrapper', __CLASS__);
-        }
-
         self::assertEquals($expected, (new Filesystem())->isAbsolutePath($path));
     }
 }

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -456,4 +456,36 @@ class FilesystemTest extends TestCase
     {
         self::assertEquals($expected, Filesystem::isStreamWrapperPath($path));
     }
+
+    /**
+     * Similar dataset as {@see FilesystemTest::isAbsolutePathDataProvider} but with different expected results.
+     */
+    public static function isLocalPathProvider(): array
+    {
+        return [
+            'unixPath' => ['/foo/bar', true],
+            'smbPath' => ['\\\\smb\\folder\\file.txt', false],
+            'windowsPath' => ['C:\\foo\\bar', true],
+            'streamPath' => ['composertestsstreamwrapper://path/to/whatever', false],
+            'fileStreamAbsolutePath' => ['file:///path/to/whatever', true],
+            'fileStreamRelativePath' => ['file://path/to/whatever', true],
+            'relativeSubPath' => ['foo/bar', true],
+            'relativeSubPath2' => ['./foo/bar', true],
+            'relativeParentPath' => ['../foo/bar', true],
+        ];
+    }
+
+    /**
+     * The purpose of this method is to determine if a cache should be used. With stream wrappers, we can't tell
+     * if the path is local or not. Currently, we return false, meaning that a cache typically will be used. But
+     * it could be argued that caching is the business of whoever is implementing the stream wrapper, and we should
+     * treat it like a local path.
+     *
+     * @covers \Composer\Util\Filesystem::isLocalPath
+     * @dataProvider isLocalPathProvider
+     */
+    public function testIsLocalPath(string $path, bool $expected): void
+    {
+        self::assertEquals($expected, Filesystem::isLocalPath($path));
+    }
 }

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -407,11 +407,13 @@ class FilesystemTest extends TestCase
      */
     public function testCreatesSymlink(): void
     {
+        if (Platform::isWindows()) {
+            $this->markTestSkipped('Does not run on windows');
+        }
 
         $fs = new Filesystem();
 
         $symlinkTarget = __DIR__ . '/Fixtures/Tar';
-
         $symlinkLocation = __DIR__ . '/Fixtures/Zip/tar-symlink';
 
         try {

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -403,6 +403,28 @@ class FilesystemTest extends TestCase
     }
 
     /**
+     * @covers Filesystem::relativeSymlink
+     */
+    public function testCreatesSymlink(): void
+    {
+
+        $fs = new Filesystem();
+
+        $symlinkTarget = __DIR__ . '/Fixtures/Tar';
+
+        $symlinkLocation = __DIR__ . '/Fixtures/Zip/tar-symlink';
+
+        try {
+            $result = $fs->relativeSymlink($symlinkTarget, $symlinkLocation);
+
+            $this->assertTrue($result);
+            $this->assertFileExists($symlinkLocation . '/empty.tar.gz');
+        } finally {
+            $fs->unlink($symlinkLocation);
+        }
+    }
+
+    /**
      * A Unix path is absolute if it starts with a forward-slash.
      * A Windows path is absolute if it starts with a drive letter followed by a colon and a back-slash.
      * A network path is always absolute and starts with two backslashes.

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -437,6 +437,7 @@ class FilesystemTest extends TestCase
     /**
      * Same dataset as {@see FilesystemTest::isAbsolutePathDataProvider} but with different expected results.
      *
+     * @used-by self::testIsStreamWrapperPath
      * @return array<string, array{0:string,1:bool}>
      */
     public static function isStreamWrapperPathProvider(): array

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -38,6 +38,7 @@ class FilesystemTest extends TestCase
         $this->fs = new Filesystem;
         $this->workingDir = self::getUniqueTmpDirectory();
         $this->testFile = self::getUniqueTmpDirectory() . '/composer_test_file';
+        stream_wrapper_register('composertestsstreamwrapper', \stdclass::class);
     }
 
     protected function tearDown(): void
@@ -49,6 +50,7 @@ class FilesystemTest extends TestCase
         if (is_file($this->testFile)) {
             $this->fs->removeDirectory(dirname($this->testFile));
         }
+        stream_wrapper_unregister('composertestsstreamwrapper');
     }
 
     /**

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -38,7 +38,7 @@ class FilesystemTest extends TestCase
         $this->fs = new Filesystem;
         $this->workingDir = self::getUniqueTmpDirectory();
         $this->testFile = self::getUniqueTmpDirectory() . '/composer_test_file';
-        stream_wrapper_register('composertestsstreamwrapper', \stdclass::class);
+        stream_wrapper_register('composertestsstreamwrapper', \stdClass::class);
     }
 
     protected function tearDown(): void

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -407,6 +407,8 @@ class FilesystemTest extends TestCase
      * A Windows path is absolute if it starts with a drive letter followed by a colon and a back-slash.
      * A network path is always absolute and starts with two backslashes.
      * A stream path is always absolute and starts with a scheme followed by "://".
+     *
+     * @return array<string, array{0:string,1:bool}>
      */
     public static function isAbsolutePathDataProvider(): array
     {
@@ -434,6 +436,8 @@ class FilesystemTest extends TestCase
 
     /**
      * Same dataset as {@see FilesystemTest::isAbsolutePathDataProvider} but with different expected results.
+     *
+     * @return array<string, array{0:string,1:bool}>
      */
     public static function isStreamWrapperPathProvider(): array
     {
@@ -461,6 +465,8 @@ class FilesystemTest extends TestCase
 
     /**
      * Similar dataset as {@see FilesystemTest::isAbsolutePathDataProvider} but with different expected results.
+     *
+     * @return array<string, array{0:string,1:bool}>
      */
     public static function isLocalPathProvider(): array
     {

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test\Util;
 
 use Composer\Util\Platform;
 use Composer\Test\TestCase;
+use RuntimeException;
 
 /**
  * PlatformTest
@@ -35,5 +36,12 @@ class PlatformTest extends TestCase
         // Compare 2 common tests for Windows to the built-in Windows test
         self::assertEquals(('\\' === DIRECTORY_SEPARATOR), Platform::isWindows());
         self::assertEquals(defined('PHP_WINDOWS_VERSION_MAJOR'), Platform::isWindows());
+    }
+
+    public function testRealPathException(): void
+    {
+        // Test that `::realpath()` throws an exception on a non-existing path
+        $this->expectException(RuntimeException::class);
+        Platform::realpath('/path/does/not/exist');
     }
 }

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -38,6 +38,13 @@ class PlatformTest extends TestCase
         self::assertEquals(defined('PHP_WINDOWS_VERSION_MAJOR'), Platform::isWindows());
     }
 
+    public function testRealPathFileStreamStripsScheme(): void
+    {
+        $file = __FILE__;
+        $streamPath = 'file://' . $file;
+        self::assertEquals($file, Platform::realpath($streamPath));
+    }
+
     public function testRealPathException(): void
     {
         // Test that `::realpath()` throws an exception on a non-existing path

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -108,6 +108,13 @@ class PlatformTest extends TestCase
         Platform::getBoolEnv('COMPOSER_TEST_BOOL_ENV');
     }
 
+    public function testRealPathFileStreamStripsScheme(): void
+    {
+        $file = __FILE__;
+        $streamPath = 'file://' . $file;
+        self::assertEquals($file, Platform::realpath($streamPath));
+    }
+
     public function testRealPathException(): void
     {
         // Test that `::realpath()` throws an exception on a non-existing path

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test\Util;
 
 use Composer\Util\Platform;
 use Composer\Test\TestCase;
+use RuntimeException;
 
 /**
  * PlatformTest
@@ -105,5 +106,12 @@ class PlatformTest extends TestCase
         self::expectExceptionMessage('Invalid value for COMPOSER_TEST_BOOL_ENV');
 
         Platform::getBoolEnv('COMPOSER_TEST_BOOL_ENV');
+    }
+
+    public function testRealPathException(): void
+    {
+        // Test that `::realpath()` throws an exception on a non-existing path
+        $this->expectException(RuntimeException::class);
+        Platform::realpath('/path/does/not/exist');
     }
 }

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -23,9 +23,15 @@ use RuntimeException;
  */
 class PlatformTest extends TestCase
 {
+    public function setUp(): void
+    {
+        stream_wrapper_register('composertestsstreamwrapper', \stdClass::class);
+    }
+
     protected function tearDown(): void
     {
         Platform::clearEnv('COMPOSER_TEST_BOOL_ENV');
+        stream_wrapper_unregister('composertestsstreamwrapper');
         parent::tearDown();
     }
 
@@ -113,6 +119,12 @@ class PlatformTest extends TestCase
         $file = __FILE__;
         $streamPath = 'file://' . $file;
         self::assertEquals($file, Platform::realpath($streamPath));
+    }
+
+    public function testRealPathStreamWrapperPath(): void
+    {
+        $streamPath = 'composertestsstreamwrapper://any/path.true';
+        self::assertEquals($streamPath, Platform::realpath($streamPath));
     }
 
     public function testRealPathException(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,3 +35,12 @@ Platform::putEnv('NO_COLOR', '1');
 Platform::clearEnv('COMPOSER');
 Platform::clearEnv('COMPOSER_VENDOR_DIR');
 Platform::clearEnv('COMPOSER_BIN_DIR');
+
+/**
+ * The stream wrapper checks use a static property to store the stream wrapper names. If it is accessed before
+ * the stream wrapper is registered, and a later test relies on that stream wrapper, the static property will be
+ * outdated and the test will fail.
+ *
+ * @see \Composer\Util\Filesystem::isStreamWrapperPath()
+ */
+stream_wrapper_register('composertestsstreamwrapper', stdclass::class);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,7 +37,7 @@ Platform::clearEnv('COMPOSER_VENDOR_DIR');
 Platform::clearEnv('COMPOSER_BIN_DIR');
 
 /**
- * The stream wrapper checks use a static property to store the stream wrapper names. If it is accessed before
+ * Tests involving stream wrapper checks use a static property to store the stream wrapper names. If it is accessed before
  * the stream wrapper is registered, and a later test relies on that stream wrapper, the static property will be
  * outdated and the test will fail.
  *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,12 +35,3 @@ Platform::putEnv('NO_COLOR', '1');
 Platform::clearEnv('COMPOSER');
 Platform::clearEnv('COMPOSER_VENDOR_DIR');
 Platform::clearEnv('COMPOSER_BIN_DIR');
-
-/**
- * Tests involving stream wrapper checks use a static property to store the stream wrapper names. If it is accessed before
- * the stream wrapper is registered, and a later test relies on that stream wrapper, the static property will be
- * outdated and the test will fail.
- *
- * @see \Composer\Util\Filesystem::isStreamWrapperPath()
- */
-stream_wrapper_register('composertestsstreamwrapper', stdclass::class);


### PR DESCRIPTION
`realpath()` always returns `false` for stream wrappers. This PR changes:
*  `Factory` and `AutoloadGenerator` to use the existing [`Composer\Util\Platform::realpath()`](https://github.com/composer/composer/blob/2a7c71266b2545a3bed9f4860734081963f6e688/src/Composer/Util/Platform.php#L57-L68) function instead of PHP's `realpath()`
* `Filesystem::isAbsolutePath()` to return `true` for stream wrappers' paths

See:

* https://github.com/composer/composer/pull/12180 –– added `Platform::realpath()`, released [2.8.3](https://github.com/composer/composer/releases/tag/2.8.3), Nov 2024
* https://github.com/composer/class-map-generator/pull/18 – similar change
* https://github.com/php/php-src/issues/12118 – root issue

PhpStan CI check fails for `SuggestedPackagesReporter.php` which is not related to this PR.

_Edit:_ 

There are an additional ~58 uses of regular `realpath()` in the code (`grep -rn src -e "[^t:]realpath(" | grep -v '//'  | grep -v "\s*\*" | wc -l`), across 30 files (`grep -rl src -e "[^t:]realpath(" | wc -l`). An okay find & replace regex for PhpStorm is `(^((?!//|\*).)*(?<!function |get|::|>))(realpath\()`, `$1Platform::$3` but it has some false positives, particularly `BinaryInstaller`'s `$globalsCode` string, and the files may need `use Composer\Util\Platform;` added.

And in `AutoloadGenerator`:

https://github.com/composer/composer/blob/85ff84d6c5260ba21740a7c5c9a111890805d6e7/src/Composer/Autoload/AutoloadGenerator.php#L214-L217

Maybe the double-realpath call should be moved into `Platform::realpath()` and the `Platform::getCwd()` should always return its `realpath()`?


