### PR TITLE
Improve error message on zip bomb

### DIFF
--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -229,7 +229,7 @@ class ZipDownloader extends ArchiveDownloader
                         }
                         $totalSize += $stat['size'];
                         if ($stat['size'] > $stat['comp_size'] * 200) {
-                            throw new \RuntimeException('Invalid zip file for "'.$package->getName().'" with compression ratio >99% (possible zip bomb)');
+                            throw new \RuntimeException('Invalid zip file "'.$stat['name'].'" for "'.$package->getName().'" with compression ratio >99% (possible zip bomb)');
                         }
                     }
                     if ($archiveSize !== false && $totalSize > $archiveSize * 100 && $totalSize > 50*1024*1024) {


### PR DESCRIPTION
improvement for diagnosing issues like https://github.com/composer/composer/issues/12369

----

After installing composer from source and patching up the ZipDownloader as instructed, I managed to track down the issue to https://github.com/cebe/markdown which is a dependency of [Yii2](https://github.com/yiisoft/yii2/blob/master/composer.json#L77C10-L77C23), more specifically caused by [this file](https://github.com/cebe/markdown/blob/master/tests/markdown-data/dos.html) which would be best if it could be ignored since its a test file.

Since the library in question has last been released in 2018, I'm not holding my hopes up that it will be fixed, so we will be looking at alternatives. 

In any case, this proposed error message would have made it 1000x easier to figure out what went wrong and why.

----
Edit: reported issues on PHPStan and PHP 8.3 seems unrelated?