### PR TITLE
Allow custom scripts to be defined directly by its `Command`'s props/methods

### DIFF
--- a/src/Composer/Command/RunScriptCommand.php
+++ b/src/Composer/Command/RunScriptCommand.php
@@ -16,6 +16,7 @@ use Composer\Script\Event as ScriptEvent;
 use Composer\Script\ScriptEvents;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\Platform;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Composer\Console\Input\InputOption;
 use Composer\Console\Input\InputArgument;
@@ -173,7 +174,7 @@ EOT
             $description = '';
             try {
                 $cmd = $this->getApplication()->find($name);
-                if ($cmd instanceof ScriptAliasCommand) {
+                if ($cmd instanceof Command) {
                     $description = $cmd->getDescription();
                 }
             } catch (\Symfony\Component\Console\Exception\CommandNotFoundException $e) {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -20,6 +20,7 @@ use Composer\Util\Silencer;
 use LogicException;
 use RuntimeException;
 use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -380,6 +381,15 @@ class Application extends BaseApplication
 
                                 $aliases = $composer['scripts-aliases'][$script] ?? [];
 
+                                //if the command points to a valid Command class, import its details directly
+                                if (is_string($dummy) && class_exists($dummy)) {
+                                    $cmd = new $dummy;
+                                    if ($cmd instanceof SymfonyCommand) {
+                                        $this->add($cmd);
+                                        continue;
+                                    }
+                                }
+
                                 $this->add(new Command\ScriptAliasCommand($script, $description, $aliases));
                             }
                         }
@@ -599,7 +609,7 @@ class Application extends BaseApplication
 
     /**
      * Initializes all the composer commands.
-     * @return \Symfony\Component\Console\Command\Command[]
+     * @return SymfonyCommand[]
      */
     protected function getDefaultCommands(): array
     {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -385,6 +385,12 @@ class Application extends BaseApplication
                                 if (is_string($dummy) && class_exists($dummy)) {
                                     $cmd = new $dummy;
                                     if ($cmd instanceof SymfonyCommand) {
+                                        if ($cmd->getName() === '' || $cmd->getName() === null) {
+                                            $cmd->setName($script);
+                                        }
+                                        if ($cmd->getDescription() === '') {
+                                            $cmd->setDescription($description);
+                                        }
                                         $this->add($cmd);
                                         continue;
                                     }

--- a/tests/Composer/Test/Command/RunScriptCommandTest.php
+++ b/tests/Composer/Test/Command/RunScriptCommandTest.php
@@ -16,6 +16,7 @@ use Composer\Composer;
 use Composer\Config;
 use Composer\Script\Event as ScriptEvent;
 use Composer\Test\TestCase;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
 
 class RunScriptCommandTest extends TestCase
 {
@@ -135,12 +136,16 @@ class RunScriptCommandTest extends TestCase
         self::assertSame($expectedAliases, $actualAliases, 'The custom aliases for the test command should be printed');
     }
 
-    public function testExecutionOfCustomSymfonyCommand(): void
+    public function testExecutionOfSimpleSymfonyCommand(): void
     {
+        $description = 'Sample description for test command';
         $this->initTempComposer([
             'scripts' => [
                 'test-direct' => 'Test\\MyCommand',
                 'test-ref' => ['@test-direct --inneropt innerarg'],
+            ],
+            'scripts-descriptions' => [
+                'test-direct' => $description
             ],
             'autoload' => [
                 'psr-4' => [
@@ -205,6 +210,83 @@ inneropt: set
 outeropt: set
 ', $appTester->getDisplay(true));
         self::assertSame(2, $appTester->getStatusCode());
+
+        //check if the description from composer.json is correctly shown
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'run-script', '--list' => true]);
+        $appTester->assertCommandIsSuccessful();
+        $output = $appTester->getDisplay();
+        self::assertStringContainsString($description, $output, 'The contents of scripts-description for the test script should be printed');
+    }
+
+    public function testExecutionOfSymfonyCommandWithConfiguration(): void
+    {
+        $wrongName = 'dummy';
+        $cmdName = 'custom-cmd-123';
+        $cmdDesc = 'This is a Symfony command with custom configuration';
+
+        $this->initTempComposer([
+            'scripts' => [
+                $wrongName => 'Test\\MyCommandWithDefinitions',
+            ],
+            'scripts-descriptions' => [
+                $wrongName => 'dummy description',
+                $cmdName => 'this should be ignored',
+            ],
+            'autoload' => [
+                'psr-4' => [
+                    'Test\\' => '',
+                ],
+            ],
+        ]);
+
+        file_put_contents('MyCommandWithDefinitions.php', <<<TEST
+<?php
+
+namespace Test;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\Command;
+
+class MyCommandWithDefinitions extends Command
+{
+    protected static \$defaultName = "$cmdName"; //same as calling setName()
+    protected static \$defaultDescription = "$cmdDesc"; //same as calling setDescription()
+
+    protected function configure(): void
+    {
+        \$this->setDefinition([new InputArgument('req-arg', InputArgument::REQUIRED, 'Required arg.')]);
+    }
+
+    public function execute(InputInterface \$input, OutputInterface \$output): int
+    {
+        \$output->writeln(\$input->getArgument('req-arg'));
+        return Command::SUCCESS;
+    }
+}
+
+TEST
+);
+
+        //makes sure the command executes with the name defined inside its `configure()`...
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => $cmdName, 'req-arg' => 'lala']);
+        self::assertSame("lala\n", $appTester->getDisplay(true));
+
+        //...not in composer.scripts...
+        $this->expectException(CommandNotFoundException::class);
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => $wrongName, 'req-arg' => 'lala']);
+
+        //...and also uses its own description, instead of the one in composer.scripts-descriptions
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'run-script', '--list' => true]);
+        $appTester->assertCommandIsSuccessful();
+        $output = $appTester->getDisplay();
+        self::assertStringContainsString($cmdDesc, $output, 'The custom description for the test script should be printed');
+        self::assertStringNotContainsString($wrongName, $output, 'The dummy script shouldn\'t show');
     }
 
     /** @return bool[][] **/


### PR DESCRIPTION
> Builds on top of #11151; originally mentioned at https://github.com/composer/composer/issues/11134#issuecomment-2816499996

Long story short, this allows `Command` subclasses to have complete definitions inside them, instead of splitting the command and description between `composer.json` and the class contents.

I included this because, otherwise, someone may try to use `setName()` or `setDescription()` and get confused - while `setHelp()` can still only be defined inside the class.
It's also useful when defining a family of script classes, for writing dynamic descriptions, or pairing the description with the long help contents.

-----------

I'm just not sure about the change in `Command\RunScriptCommand` - was there a specific reason for it to filter only for `ScriptAliasCommand`, or could it be simply because there were no other subclasses of `Command` at that time?

Also: I guess we should now rename `$dummy` at `Console\Application`? In fact, when the `name` is defined inside the Command, the dummy value ends up being the array key :joy: