### PR TITLE
Fix deprecation warnings

### DIFF
--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -19,6 +19,7 @@ use Composer\Pcre\Preg;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Composer\IO\BufferIO;
 use Composer\Json\JsonFile;
@@ -360,11 +361,11 @@ class InstallerTest extends TestCase
         $install->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
         $install->addOption('no-dev', null, InputOption::VALUE_NONE);
         $install->addOption('dry-run', null, InputOption::VALUE_NONE);
-        $install->setCode(static function ($input, $output) use ($installer): int {
-            $ignorePlatformReqs = $input->getOption('ignore-platform-reqs') ?: ($input->getOption('ignore-platform-req') ?: false);
+        $install->setCode(static function (InputInterface $input, OutputInterface $output) use ($installer): int {
+            $ignorePlatformReqs = true === $input->getOption('ignore-platform-reqs') ?: ($input->getOption('ignore-platform-req') ?: false);
 
             $installer
-                ->setDevMode(!$input->getOption('no-dev'))
+                ->setDevMode(false === $input->getOption('no-dev'))
                 ->setDryRun($input->getOption('dry-run'))
                 ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList($ignorePlatformReqs))
                 ->setAudit(false);
@@ -386,27 +387,27 @@ class InstallerTest extends TestCase
         $update->addOption('prefer-stable', null, InputOption::VALUE_NONE);
         $update->addOption('prefer-lowest', null, InputOption::VALUE_NONE);
         $update->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL);
-        $update->setCode(static function ($input, $output) use ($installer): int {
+        $update->setCode(static function (InputInterface $input, OutputInterface $output) use ($installer): int {
             $packages = $input->getArgument('packages');
             $filteredPackages = array_filter($packages, static function ($package): bool {
                 return !in_array($package, ['lock', 'nothing', 'mirrors'], true);
             });
-            $updateMirrors = $input->getOption('lock') || count($filteredPackages) !== count($packages);
+            $updateMirrors = true === $input->getOption('lock') || count($filteredPackages) !== count($packages);
             $packages = $filteredPackages;
 
             $updateAllowTransitiveDependencies = Request::UPDATE_ONLY_LISTED;
-            if ($input->getOption('with-all-dependencies')) {
+            if (true === $input->getOption('with-all-dependencies')) {
                 $updateAllowTransitiveDependencies = Request::UPDATE_LISTED_WITH_TRANSITIVE_DEPS;
-            } elseif ($input->getOption('with-dependencies')) {
+            } elseif (true === $input->getOption('with-dependencies')) {
                 $updateAllowTransitiveDependencies = Request::UPDATE_LISTED_WITH_TRANSITIVE_DEPS_NO_ROOT_REQUIRE;
             }
 
-            $ignorePlatformReqs = $input->getOption('ignore-platform-reqs') ?: ($input->getOption('ignore-platform-req') ?: false);
+            $ignorePlatformReqs = true === $input->getOption('ignore-platform-reqs') ?: ($input->getOption('ignore-platform-req') ?: false);
 
             $installer
-                ->setDevMode(!$input->getOption('no-dev'))
+                ->setDevMode(false === $input->getOption('no-dev'))
                 ->setUpdate(true)
-                ->setInstall(!$input->getOption('no-install'))
+                ->setInstall(false === $input->getOption('no-install'))
                 ->setDryRun($input->getOption('dry-run'))
                 ->setUpdateMirrors($updateMirrors)
                 ->setUpdateAllowList($packages)

--- a/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
+++ b/tests/Composer/Test/Package/Archiver/ArchiveManagerTest.php
@@ -16,6 +16,7 @@ use Composer\IO\NullIO;
 use Composer\Factory;
 use Composer\Package\Archiver\ArchiveManager;
 use Composer\Package\CompletePackage;
+use Composer\Util\Filesystem;
 use Composer\Util\Loop;
 use Composer\Test\Mock\FactoryMock;
 use Composer\Util\Platform;


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
