### PR TITLE
Always allow running self-update, but with warning

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -78,6 +78,20 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if (strpos(__FILE__, 'phar:') !== 0) {
+            if (str_contains(strtr(__DIR__, '\\', '/'), 'vendor/composer/composer')) {
+                $projDir = dirname(__DIR__, 6);
+                $output->writeln('<error>This instance of Composer does not have the self-update command.</error>');
+                $output->writeln('<comment>You are running Composer installed as a package in your current project ("'.$projDir.'").</comment>');
+                $output->writeln('<comment>To update Composer, download a composer.phar from https://getcomposer.org and then run `composer.phar update composer/composer` in your project.</comment>');
+            } else {
+                $output->writeln('<error>This instance of Composer does not have the self-update command.</error>');
+                $output->writeln('<comment>This could be due to a number of reasons, such as Composer being installed as a system package on your OS, or Composer being installed as a package in the current project.</comment>');
+            }
+
+            return 1;
+        }
+
         if ($_SERVER['argv'][0] === 'Standard input code') {
             return 1;
         }

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -603,7 +603,7 @@ class Application extends BaseApplication
      */
     protected function getDefaultCommands(): array
     {
-        $commands = array_merge(parent::getDefaultCommands(), [
+        return array_merge(parent::getDefaultCommands(), [
             new Command\AboutCommand(),
             new Command\ConfigCommand(),
             new Command\DependsCommand(),
@@ -634,13 +634,8 @@ class Application extends BaseApplication
             new Command\FundCommand(),
             new Command\ReinstallCommand(),
             new Command\BumpCommand(),
+            new Command\SelfUpdateCommand(),
         ]);
-
-        if (strpos(__FILE__, 'phar:') === 0 || '1' === Platform::getEnv('COMPOSER_TESTS_ARE_RUNNING')) {
-            $commands[] = new Command\SelfUpdateCommand();
-        }
-
-        return $commands;
     }
 
     /**

--- a/tests/Composer/Test/ApplicationTest.php
+++ b/tests/Composer/Test/ApplicationTest.php
@@ -72,7 +72,11 @@ class ApplicationTest extends TestCase
         $output = new BufferedOutput();
         $application->doRun(new ArrayInput(['command' => 'self-update']), $output);
 
-        self::assertSame('', $output->fetch());
+        self::assertSame(
+            'This instance of Composer does not have the self-update command.'.PHP_EOL.
+            'This could be due to a number of reasons, such as Composer being installed as a system package on your OS, or Composer being installed as a package in the current project.'.PHP_EOL,
+            $output->fetch()
+        );
     }
 
     /**


### PR DESCRIPTION
This will fail with a clear explanation why it is not available when not running from a phar

Fixes #12395

cc @joachim-n
