### PR TITLE
Add warning when --minimal-changes is used without package and a fresh lock file

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -531,6 +531,10 @@ class Installer
 
         if (!$lockTransaction->getOperations()) {
             $this->io->writeError('Nothing to modify in lock file');
+
+            if ($this->minimalUpdate && $this->updateAllowList === null && $this->locker->isFresh()) {
+                $this->io->writeError('<warning>Updates using --minimal-changes that do not change any requirement typically will not yield any dependency changes.</warning>');
+            }
         }
 
         $exitCode = $this->extractDevPackages($lockTransaction, $platformRepo, $aliases, $policy, $lockedRepository);


### PR DESCRIPTION

Refs #12349

cc @dkarlovi

Sample:

![image](https://github.com/user-attachments/assets/f8c02825-c6d8-4e5a-8271-8b5544a7920e)
