### PR TITLE
Ensure packages where the abandoned state changes get reinstalled to sync up the state in installed.json

### DIFF
--- a/src/Composer/DependencyResolver/Transaction.php
+++ b/src/Composer/DependencyResolver/Transaction.php
@@ -13,6 +13,7 @@
 namespace Composer\DependencyResolver;
 
 use Composer\Package\AliasPackage;
+use Composer\Package\CompletePackageInterface;
 use Composer\Package\Link;
 use Composer\Package\PackageInterface;
 use Composer\Repository\PlatformRepository;
@@ -163,7 +164,13 @@ class Transaction
                         // TODO different for lock?
                         if ($package->getVersion() !== $presentPackageMap[$package->getName()]->getVersion() ||
                             $package->getDistReference() !== $presentPackageMap[$package->getName()]->getDistReference() ||
-                            $package->getSourceReference() !== $presentPackageMap[$package->getName()]->getSourceReference()
+                            $package->getSourceReference() !== $presentPackageMap[$package->getName()]->getSourceReference() ||
+                            ($package instanceof CompletePackageInterface
+                                && $presentPackageMap[$package->getName()] instanceof CompletePackageInterface
+                                && ($package->isAbandoned() !== $presentPackageMap[$package->getName()]->isAbandoned()
+                                    || $package->getReplacementPackage() !== $presentPackageMap[$package->getName()]->getReplacementPackage()
+                                )
+                            )
                         ) {
                             $operations[] = new Operation\UpdateOperation($source, $package);
                         }

--- a/tests/Composer/Test/Fixtures/installer/install-forces-reinstall-if-abandon-changes.test
+++ b/tests/Composer/Test/Fixtures/installer/install-forces-reinstall-if-abandon-changes.test
@@ -1,17 +1,7 @@
 --TEST--
-Update updates the outdated state of packages
+Install triggers a reinstall of packages that have outdated information if their abandoned state changed
 --COMPOSER--
 {
-    "repositories": [
-        {
-            "type": "package",
-            "package": [
-                {
-                    "name": "a/a", "version": "1.0.0", "abandoned": "replacement"
-                }
-            ]
-        }
-    ],
     "require": {
         "a/a": "1.0.0"
     }
@@ -19,10 +9,10 @@ Update updates the outdated state of packages
 --INSTALLED--
 [
     {
-        "name": "a/a", "version": "1.0.0", "type": "library"
+        "name": "a/a", "version": "1.0.0", "type": "library", "abandoned": "old-replacement"
     }
 ]
---EXPECT-LOCK--
+--LOCK--
 {
     "packages": [
         {
@@ -47,6 +37,6 @@ Update updates the outdated state of packages
     }
 ]
 --RUN--
-update
+install
 --EXPECT--
 Upgrading a/a (1.0.0 => 1.0.0)


### PR DESCRIPTION

Fixes #12417

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
