### PR TITLE
Handle Planner role in GitLab

### DIFF
--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -463,7 +463,7 @@ class GitLabDriver extends VcsDriver
             if ($fetchingRepoData) {
                 $json = $response->decodeJson();
 
-                // Accessing the API with a token with Guest (10) access will return
+                // Accessing the API with a token with Guest (10) or Planner (15) access will return
                 // more data than unauthenticated access but no default_branch data
                 // accessing files via the API will then also fail
                 if (!isset($json['default_branch']) && isset($json['permissions'])) {
@@ -474,7 +474,7 @@ class GitLabDriver extends VcsDriver
                     // - value will be null if no access is set
                     // - value will be array with key access_level if set
                     foreach ($json['permissions'] as $permission) {
-                        if ($permission && $permission['access_level'] > 10) {
+                        if ($permission && $permission['access_level'] >= 20) {
                             $moreThanGuestAccess = true;
                         }
                     }

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -480,7 +480,7 @@ class GitLabDriver extends VcsDriver
                     }
 
                     if (!$moreThanGuestAccess) {
-                        $this->io->writeError('<warning>GitLab token with Guest only access detected</warning>');
+                        $this->io->writeError('<warning>GitLab token with Guest or Partner only access detected</warning>');
 
                         $this->attemptCloneFallback();
 

--- a/src/Composer/Repository/Vcs/GitLabDriver.php
+++ b/src/Composer/Repository/Vcs/GitLabDriver.php
@@ -480,7 +480,7 @@ class GitLabDriver extends VcsDriver
                     }
 
                     if (!$moreThanGuestAccess) {
-                        $this->io->writeError('<warning>GitLab token with Guest or Partner only access detected</warning>');
+                        $this->io->writeError('<warning>GitLab token with Guest or Planner only access detected</warning>');
 
                         $this->attemptCloneFallback();
 


### PR DESCRIPTION
GitLab's new Planner permission has access level 15, which prevents Composer from figuring out that the token does not have enough access to determine the main branch. 

See: https://docs.gitlab.com/api/access_requests/ 