### PR TITLE
Avoid marking a plugin as loaded until it is actually loaded

### DIFF
--- a/src/Composer/Plugin/PluginManager.php
+++ b/src/Composer/Plugin/PluginManager.php
@@ -201,7 +201,6 @@ class PluginManager
         if (isset($this->registeredPlugins[$package->getName()])) {
             return;
         }
-        $this->registeredPlugins[$package->getName()] = [];
 
         $extra = $package->getExtra();
         if (empty($extra['class'])) {


### PR DESCRIPTION
Fixes https://github.com/composer/composer/issues/12433