### PR TITLE
Add forward compatibility layer for symfony/console >7.4

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -280,7 +280,8 @@ class Application extends BaseApplication
                     if ($this->has($command->getName())) {
                         $io->writeError('<warning>Plugin command '.$command->getName().' ('.get_class($command).') would override a Composer command and has been skipped</warning>');
                     } else {
-                        $this->add($command);
+                        // Compatibility layer for symfony/console <7.4
+                        method_exists($this, 'addCommand') ? $this->addCommand($command) : $this->add($command);
                     }
                 }
             } catch (NoSslException $e) {
@@ -380,7 +381,9 @@ class Application extends BaseApplication
 
                                 $aliases = $composer['scripts-aliases'][$script] ?? [];
 
-                                $this->add(new Command\ScriptAliasCommand($script, $description, $aliases));
+                                $scriptAlias = new Command\ScriptAliasCommand($script, $description, $aliases);
+                                // Compatibility layer for symfony/console <7.4
+                                method_exists($this, 'addCommand') ? $this->addCommand($scriptAlias) : $this->add($scriptAlias);
                             }
                         }
                     }

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -309,7 +309,12 @@ class EventDispatcher
                     }
                     $app->setAutoExit(false);
                     $cmd = new $className($event->getName());
-                    $app->add($cmd);
+                    if (method_exists($app, 'addCommand')) {
+                        $app->addCommand($cmd);
+                    } else {
+                        // Compatibility layer for symfony/console <7.4
+                        $app->add($cmd);
+                    }
                     $app->setDefaultCommand((string) $cmd->getName(), true);
                     try {
                         $args = implode(' ', array_map(static function ($arg) { return ProcessExecutor::escape($arg); }, $additionalArgs));

--- a/tests/Composer/Test/ApplicationTest.php
+++ b/tests/Composer/Test/ApplicationTest.php
@@ -63,7 +63,8 @@ class ApplicationTest extends TestCase
         }
 
         $application = new Application;
-        $application->add(new \Composer\Command\SelfUpdateCommand);
+        // Compatibility layer for symfony/console <7.4
+        method_exists($application, 'addCommand') ? $application->addCommand(new \Composer\Command\SelfUpdateCommand) : $application->add(new \Composer\Command\SelfUpdateCommand);
 
         if (!defined('COMPOSER_DEV_WARNING_TIME')) {
             define('COMPOSER_DEV_WARNING_TIME', time() - 1);
@@ -82,7 +83,8 @@ class ApplicationTest extends TestCase
     public function testProcessIsolationWorksMultipleTimes(): void
     {
         $application = new Application;
-        $application->add(new \Composer\Command\AboutCommand);
+        // Compatibility layer for symfony/console <7.4
+        method_exists($application, 'addCommand') ? $application->addCommand(new \Composer\Command\AboutCommand) : $application->add(new \Composer\Command\AboutCommand);
         self::assertSame(0, $application->doRun(new ArrayInput(['command' => 'about']), new BufferedOutput()));
         self::assertSame(0, $application->doRun(new ArrayInput(['command' => 'about']), new BufferedOutput()));
     }

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -372,7 +372,7 @@ class InstallerTest extends TestCase
 
             return $installer->run();
         });
-        $application->add($install);
+        method_exists($application, 'addCommand') ? $application->addCommand($install) : $application->add($install);
 
         $update = new Command('update');
         $update->addOption('ignore-platform-reqs', null, InputOption::VALUE_NONE);
@@ -420,7 +420,7 @@ class InstallerTest extends TestCase
 
             return $installer->run();
         });
-        $application->add($update);
+        method_exists($application, 'addCommand') ? $application->addCommand($update) : $application->add($update);
 
         if (!Preg::isMatch('{^(install|update)\b}', $run)) {
             throw new \UnexpectedValueException('The run command only supports install and update');


### PR DESCRIPTION
Following https://github.com/symfony/symfony/pull/60394. Please tell me if this should rather target main