### PR TITLE
Improve performance of script handlers

### DIFF
--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -94,7 +94,7 @@ class EventDispatcherTest extends TestCase
         $composer->setAutoloadGenerator($generator);
 
         $package = $this->getMockBuilder('Composer\Package\RootPackageInterface')->getMock();
-        $package->method('getScripts')->will($this->returnValue(['scriptName' => ['scriptName']]));
+        $package->method('getScripts')->will($this->returnValue(['scriptName' => ['ClassName::testMethod']]));
         $composer->setPackage($package);
 
         $composer->setRepositoryManager($this->getRepositoryManagerMockForDevModePassingTest());
@@ -114,7 +114,7 @@ class EventDispatcherTest extends TestCase
             ->method('isDevMode')
             ->will($this->returnValue($devMode));
 
-        $dispatcher->hasEventListeners($event);
+        $dispatcher->dispatch('scriptName', $event);
     }
 
     public static function provideDevModes(): array


### PR DESCRIPTION
Only create autoloaders when needed, and avoid creating duplicate autoloaders.

In pathological cases like declaring a post-package-install script as `"Foo::bar"`, it would classmap-scan the whole project on every package being installed, causing 200ms of delay at every package. Trying this on a repo here this PR improves a fresh install time from 38 down to 9seconds, which is quite dramatic. I suppose other cases where large classmaps or listener-heavy plugins are present might also see significant speedups.

Targetting 2.9 though because it does carry some risk of regression in case I missed a corner.

Refs #8587

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
