### PR TITLE
Consistency with json and command

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -797,7 +797,7 @@ You can disable the default Packagist.org repository by adding this to your
 {
     "repositories": [
         {
-            "packagist.org": false
+            "packagist": false
         }
     ]
 }


### PR DESCRIPTION
The suggested command `composer config -g repo.packagist false` results in `"packagist": false`. Whereas the shown JSON shows `packagist.org`.  Since Composer suggests to use the CLI as much as possible instead of manual edits, I assume that that is the desired format. Though both may work? I haven't tested it. It would make sense to have one format to specify this.