### PR TITLE
Trim trailing spaces in autoload files

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -1201,6 +1201,7 @@ HEADER;
                 ]
             );
             $value = ltrim(Preg::replace('/^ */m', '    $0$0', $value));
+            $value = Preg::replace('/ +$/m', '', $value);
 
             $file .= sprintf("    public static $%s = %s;\n\n", $prop, $value);
             if ('files' !== $prop) {

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_phar_static.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_phar_static.php
@@ -7,68 +7,68 @@ namespace Composer\Autoload;
 class ComposerStaticInitPhar
 {
     public static $prefixLengthsPsr4 = array (
-        'S' => 
+        'S' =>
         array (
             'Sit\\' => 4,
         ),
-        'Q' => 
+        'Q' =>
         array (
             'Qux\\' => 4,
         ),
-        'D' => 
+        'D' =>
         array (
             'Dolor\\' => 6,
         ),
-        'B' => 
+        'B' =>
         array (
             'Baz\\' => 4,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'Sit\\' => 
+        'Sit\\' =>
         array (
             0 => 'phar://' . __DIR__ . '/..' . '/a/a/dir/sit.phar/src',
         ),
-        'Qux\\' => 
+        'Qux\\' =>
         array (
             0 => 'phar://' . __DIR__ . '/../..' . '/dir/qux.phar/src',
         ),
-        'Dolor\\' => 
+        'Dolor\\' =>
         array (
             0 => 'phar://' . __DIR__ . '/..' . '/a/a/dolor.phar',
         ),
-        'Baz\\' => 
+        'Baz\\' =>
         array (
             0 => 'phar://' . __DIR__ . '/../..' . '/baz.phar',
         ),
     );
 
     public static $prefixesPsr0 = array (
-        'L' => 
+        'L' =>
         array (
-            'Lorem' => 
+            'Lorem' =>
             array (
                 0 => 'phar://' . __DIR__ . '/..' . '/a/a/lorem.phar',
             ),
         ),
-        'I' => 
+        'I' =>
         array (
-            'Ipsum' => 
+            'Ipsum' =>
             array (
                 0 => 'phar://' . __DIR__ . '/..' . '/a/a/dir/ipsum.phar/src',
             ),
         ),
-        'F' => 
+        'F' =>
         array (
-            'Foo' => 
+            'Foo' =>
             array (
                 0 => 'phar://' . __DIR__ . '/../..' . '/foo.phar',
             ),
         ),
-        'B' => 
+        'B' =>
         array (
-            'Bar' => 
+            'Bar' =>
             array (
                 0 => 'phar://' . __DIR__ . '/../..' . '/dir/bar.phar/src',
             ),

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_static_include_path.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_static_include_path.php
@@ -7,13 +7,13 @@ namespace Composer\Autoload;
 class ComposerStaticInitIncludePath
 {
     public static $prefixesPsr0 = array (
-        'M' => 
+        'M' =>
         array (
-            'Main\\Foo' => 
+            'Main\\Foo' =>
             array (
                 0 => __DIR__ . '/../..' . '/',
             ),
-            'Main\\Bar' => 
+            'Main\\Bar' =>
             array (
                 0 => __DIR__ . '/../..' . '/',
             ),

--- a/tests/Composer/Test/Autoload/Fixtures/autoload_static_target_dir.php
+++ b/tests/Composer/Test/Autoload/Fixtures/autoload_static_target_dir.php
@@ -12,13 +12,13 @@ class ComposerStaticInitTargetDir
     );
 
     public static $prefixesPsr0 = array (
-        'M' => 
+        'M' =>
         array (
-            'Main\\Foo' => 
+            'Main\\Foo' =>
             array (
                 0 => __DIR__ . '/../..' . '/',
             ),
-            'Main\\Bar' => 
+            'Main\\Bar' =>
             array (
                 0 => __DIR__ . '/../..' . '/',
             ),


### PR DESCRIPTION
PhpStorm trims trailing spaces (which I have specified in `.editorconfig`) when I do the Rename class refactoring.