### PR TITLE
Fix Bitbucket oauth failure

### DIFF
--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -228,7 +228,7 @@ class Git
                     $message = 'Enter your Bitbucket credentials to access private repos';
 
                     if (!$bitbucketUtil->authorizeOAuth($domain) && $this->io->isInteractive()) {
-                        $bitbucketUtil->authorizeOAuthInteractively($match[2], $message);
+                        $bitbucketUtil->authorizeOAuthInteractively($domain, $message);
                         $accessToken = $bitbucketUtil->getToken();
                         $this->io->setAuthentication($domain, 'x-token-auth', $accessToken);
                     }

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -228,7 +228,7 @@ class Git
                     $message = 'Enter your Bitbucket credentials to access private repos';
 
                     if (!$bitbucketUtil->authorizeOAuth($domain) && $this->io->isInteractive()) {
-                        $bitbucketUtil->authorizeOAuthInteractively($match[1], $message);
+                        $bitbucketUtil->authorizeOAuthInteractively($match[2], $message);
                         $accessToken = $bitbucketUtil->getToken();
                         $this->io->setAuthentication($domain, 'x-token-auth', $accessToken);
                     }


### PR DESCRIPTION
Change match index from 1 to 2 to account for recently changed regex expressions for Bitbucket URLs

Based on changes from PR [#12103](https://github.com/composer/composer/pull/12103). Bitbucket URL regex was changed, but following reference to $match for $bitbucketUtil->authorizeOAuthInteractively were not updated accordingly.