### PR TITLE
Correct `exclude-files-from-classmap` typo

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -382,7 +382,7 @@ EOF;
             }
         }
         if (\count($ambiguousClasses) > 0) {
-            $this->io->writeError('<info>To resolve ambiguity in classes not under your control you can ignore them by path using <href='.OutputFormatter::escape('https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps').'>exclude-files-from-classmap</>');
+            $this->io->writeError('<info>To resolve ambiguity in classes not under your control you can ignore them by path using <href='.OutputFormatter::escape('https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps').'>exclude-from-classmap</>');
         }
 
         // output PSR violations which are not coming from the vendor dir


### PR DESCRIPTION
Correct a minor typo in `AutoloadGenereator.php` at line `385` : 

```diff
- $this->io->writeError('<info>To resolve ambiguity in classes not under your control you can ignore them by path using <href='...'>exclude-files-from-classmap</>');
+ $this->io->writeError('<info>To resolve ambiguity in classes not under your control you can ignore them by path using <href='...'>exclude-from-classmap</>');
```