### PR TITLE
chore: remove redundant words in doc/03-cli.md

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1275,7 +1275,7 @@ in performance gains.
 
 ### COMPOSER_MAX_PARALLEL_PROCESSES
 
-Set to an an integer to configure how many processes can be executed in parallel.
+Set to an integer to configure how many processes can be executed in parallel.
 This defaults to 10 and must be between 1 and 50.
 
 ### COMPOSER_IPRESOLVE


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->


remove redundant words in doc/03-cli.md