### PR TITLE
chore: Increase minimum version of composer/pcre

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/finder": "^5.4.35 || ^6.3.12 || ^7.0.3",
         "symfony/process": "^5.4.35 || ^6.3.12 || ^7.0.3",
         "react/promise": "^2.11 || ^3.2",
-        "composer/pcre": "^2.2 || ^3.2",
+        "composer/pcre": "^2.3 || ^3.3",
         "symfony/polyfill-php73": "^1.24",
         "symfony/polyfill-php80": "^1.24",
         "symfony/polyfill-php81": "^1.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b5da780ac109171fdf731568b39e01e",
+    "content-hash": "a39a6a32ea5cc4245a1ad2609e19859f",
     "packages": [
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
Hey there :wave: 

If I execute `composer update --prefer-lowest` in our project, I have a problem while checking the code with PHPStan. It will install `composer/pcre` in version `2.2.0` and the `%featureToggles.narrowPregMatches%` config in `extension.neon` causes the problem. This file was changed with `2.3.0` and updating to at least this version fixes the problem on our end. 
As we are not directly depending on the `composer/pcre` package, I made the change here.

Thanks for having a look at this and I am looking for feedback 🙂 👍

Best regards
