### PR TITLE
feat: Added --ignore-unreachable flag to audit command for private/unreachable repositories

### DIFF
--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -35,12 +35,15 @@ class AuditCommand extends BaseCommand
                 new InputOption('locked', null, InputOption::VALUE_NONE, 'Audit based on the lock file instead of the installed packages.'),
                 new InputOption('abandoned', null, InputOption::VALUE_REQUIRED, 'Behavior on abandoned packages. Must be "ignore", "report", or "fail".', null, Auditor::ABANDONEDS),
                 new InputOption('ignore-severity', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Ignore advisories of a certain severity level.', [], ['low', 'medium', 'high', 'critical']),
+                new InputOption('ignore-unreachable', null, InputOption::VALUE_NONE, 'Ignore repositories that are unreachable or return a non-200 status code.'),
             ])
             ->setHelp(
                 <<<EOT
 The <info>audit</info> command checks for security vulnerability advisories for installed packages.
 
 If you do not want to include dev dependencies in the audit you can omit them with --no-dev
+
+If you want to ignore repositories that are unreachable or return a non-200 status code, use --ignore-unreachable
 
 Read more at https://getcomposer.org/doc/03-cli.md#audit
 EOT
@@ -75,6 +78,7 @@ EOT
         $abandoned = $abandoned ?? $auditConfig['abandoned'] ?? Auditor::ABANDONED_FAIL;
 
         $ignoreSeverities = $input->getOption('ignore-severity') ?? [];
+        $ignoreUnreachable = $input->getOption('ignore-unreachable');
 
         return min(255, $auditor->audit(
             $this->getIO(),
@@ -84,7 +88,8 @@ EOT
             false,
             $auditConfig['ignore'] ?? [],
             $abandoned,
-            $ignoreSeverities
+            $ignoreSeverities,
+            $ignoreUnreachable
         ));
 
     }

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -290,7 +290,7 @@ class RepositorySet
             }
         }
 
-        $advisories = !empty($repoAdvisories) ? array_merge_recursive([], ...$repoAdvisories) : [];
+        $advisories = count($repoAdvisories) > 0 ? array_merge_recursive([], ...$repoAdvisories) : [];
         ksort($advisories);
 
         return $advisories;

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -227,23 +227,26 @@ class RepositorySet
 
     /**
      * @param string[] $packageNames
-     * @return ($allowPartialAdvisories is true ? array<string, array<PartialSecurityAdvisory|SecurityAdvisory>> : array<string, array<SecurityAdvisory>>)
+     * @return ($allowPartialAdvisories is true ? array{advisories: array<string, array<PartialSecurityAdvisory|SecurityAdvisory>>, unreachableRepos: array<string>} : array{advisories: array<string, array<SecurityAdvisory>>, unreachableRepos: array<string>})
      */
-    public function getSecurityAdvisories(array $packageNames, bool $allowPartialAdvisories = false): array
+    public function getSecurityAdvisories(array $packageNames, bool $allowPartialAdvisories, bool $ignoreUnreachable = false): array
     {
         $map = [];
         foreach ($packageNames as $name) {
             $map[$name] = new MatchAllConstraint();
         }
 
-        return $this->getSecurityAdvisoriesForConstraints($map, $allowPartialAdvisories);
+        $unreachableRepos = [];
+        $advisories = $this->getSecurityAdvisoriesForConstraints($map, $allowPartialAdvisories, $ignoreUnreachable, $unreachableRepos);
+
+        return ['advisories' => $advisories, 'unreachableRepos' => $unreachableRepos];
     }
 
     /**
      * @param PackageInterface[] $packages
-     * @return ($allowPartialAdvisories is true ? array<string, array<PartialSecurityAdvisory|SecurityAdvisory>> : array<string, array<SecurityAdvisory>>)
+     * @return ($allowPartialAdvisories is true ? array{advisories: array<string, array<PartialSecurityAdvisory|SecurityAdvisory>>, unreachableRepos: array<string>} : array{advisories: array<string, array<SecurityAdvisory>>, unreachableRepos: array<string>})
      */
-    public function getMatchingSecurityAdvisories(array $packages, bool $allowPartialAdvisories = false): array
+    public function getMatchingSecurityAdvisories(array $packages, bool $allowPartialAdvisories = false, bool $ignoreUnreachable = false): array
     {
         $map = [];
         foreach ($packages as $package) {
@@ -258,25 +261,36 @@ class RepositorySet
             }
         }
 
-        return $this->getSecurityAdvisoriesForConstraints($map, $allowPartialAdvisories);
+        $unreachableRepos = [];
+        $advisories = $this->getSecurityAdvisoriesForConstraints($map, $allowPartialAdvisories, $ignoreUnreachable, $unreachableRepos);
+
+        return ['advisories' => $advisories, 'unreachableRepos' => $unreachableRepos];
     }
 
     /**
      * @param array<string, ConstraintInterface> $packageConstraintMap
+     * @param array<string> &$unreachableRepos Array to store messages about unreachable repositories
      * @return ($allowPartialAdvisories is true ? array<string, array<PartialSecurityAdvisory|SecurityAdvisory>> : array<string, array<SecurityAdvisory>>)
      */
-    private function getSecurityAdvisoriesForConstraints(array $packageConstraintMap, bool $allowPartialAdvisories): array
+    private function getSecurityAdvisoriesForConstraints(array $packageConstraintMap, bool $allowPartialAdvisories, bool $ignoreUnreachable = false, array &$unreachableRepos = []): array
     {
         $repoAdvisories = [];
         foreach ($this->repositories as $repository) {
-            if (!$repository instanceof AdvisoryProviderInterface || !$repository->hasSecurityAdvisories()) {
-                continue;
-            }
+            try {
+                if (!$repository instanceof AdvisoryProviderInterface || !$repository->hasSecurityAdvisories()) {
+                    continue;
+                }
 
-            $repoAdvisories[] = $repository->getSecurityAdvisories($packageConstraintMap, $allowPartialAdvisories)['advisories'];
+                $repoAdvisories[] = $repository->getSecurityAdvisories($packageConstraintMap, $allowPartialAdvisories)['advisories'];
+            } catch (\Composer\Downloader\TransportException $e) {
+                if (!$ignoreUnreachable) {
+                    throw $e;
+                }
+                $unreachableRepos[] = $e->getMessage();
+            }
         }
 
-        $advisories = array_merge_recursive([], ...$repoAdvisories);
+        $advisories = !empty($repoAdvisories) ? array_merge_recursive([], ...$repoAdvisories) : [];
         ksort($advisories);
 
         return $advisories;

--- a/tests/Composer/Test/Advisory/AuditorTest.php
+++ b/tests/Composer/Test/Advisory/AuditorTest.php
@@ -393,14 +393,52 @@ Found 2 abandoned packages:
             new Package('vendor1/package1', '3.0.0.0', '3.0.0'),
         ];
 
-        // Create a mock RepositorySet that throws a TransportException
+        $errorMessage = 'The "https://example.org/packages.json" file could not be downloaded: HTTP/1.1 404 Not Found';
+
+        // Create a mock RepositorySet that simulates multiple repositories with the middle one being unreachable
         $repoSet = $this->getMockBuilder(RepositorySet::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getMatchingSecurityAdvisories'])
             ->getMock();
 
         $repoSet->method('getMatchingSecurityAdvisories')
-            ->willThrowException(new \Composer\Downloader\TransportException('The "https://example.org/packages.json" file could not be downloaded: HTTP/1.1 404 Not Found', 404));
+            ->willReturnCallback(function ($packages, $allowPartialAdvisories, $ignoreUnreachable) use ($errorMessage) {
+                if (!$ignoreUnreachable) {
+                    throw new \Composer\Downloader\TransportException($errorMessage, 404);
+                }
+
+                // Simulate multiple repositories with the middle one being unreachable
+                // First and third repositories have advisories, middle one is unreachable
+                return [
+                    'advisories' => [
+                        'vendor1/package1' => [
+                            new SecurityAdvisory(
+                                'vendor1/package1',
+                                'CVE-2023-12345',
+                                new \Composer\Semver\Constraint\Constraint('=', '3.0.0.0'),
+                                'First repo advisory',
+                                [['name' => 'test', 'remoteId' => '1']],
+                                new \DateTimeImmutable('2023-01-01', new \DateTimeZone('UTC')),
+                                'CVE-2023-12345',
+                                'https://example.com/advisory/1',
+                                'medium'
+                            ),
+                            new SecurityAdvisory(
+                                'vendor1/package1',
+                                'CVE-2023-67890',
+                                new \Composer\Semver\Constraint\Constraint('=', '3.0.0.0'),
+                                'Third repo advisory',
+                                [['name' => 'test', 'remoteId' => '3']],
+                                new \DateTimeImmutable('2023-01-01', new \DateTimeZone('UTC')),
+                                'CVE-2023-67890',
+                                'https://example.com/advisory/3',
+                                'high'
+                            )
+                        ]
+                    ],
+                    'unreachableRepos' => [$errorMessage]
+                ];
+            });
 
         $auditor = new Auditor();
 
@@ -415,21 +453,42 @@ Found 2 abandoned packages:
         // Test with ignoreUnreachable flag
         $io = new BufferIO();
         $result = $auditor->audit($io, $repoSet, $packages, Auditor::FORMAT_PLAIN, false, [], Auditor::ABANDONED_IGNORE, [], true);
-        self::assertSame(Auditor::STATUS_OK, $result);
+
+        // Should find advisories from the reachable repositories
+        self::assertSame(Auditor::STATUS_VULNERABLE, $result);
 
         $output = $io->getOutput();
         self::assertStringContainsString('The following repositories were unreachable:', $output);
         self::assertStringContainsString('HTTP/1.1 404 Not Found', $output);
 
+        // Verify that advisories from reachable repositories were found
+        self::assertStringContainsString('First repo advisory', $output);
+        self::assertStringContainsString('Third repo advisory', $output);
+        self::assertStringContainsString('CVE-2023-12345', $output);
+        self::assertStringContainsString('CVE-2023-67890', $output);
+
         // Test with JSON format
         $io = new BufferIO();
         $result = $auditor->audit($io, $repoSet, $packages, Auditor::FORMAT_JSON, false, [], Auditor::ABANDONED_IGNORE, [], true);
-        self::assertSame(Auditor::STATUS_OK, $result);
+        self::assertSame(Auditor::STATUS_VULNERABLE, $result);
 
         $json = json_decode($io->getOutput(), true);
         self::assertArrayHasKey('unreachable-repositories', $json);
         self::assertCount(1, $json['unreachable-repositories']);
         self::assertStringContainsString('HTTP/1.1 404 Not Found', $json['unreachable-repositories'][0]);
+
+        // Verify that advisories from reachable repositories were included in JSON output
+        self::assertArrayHasKey('advisories', $json);
+        self::assertArrayHasKey('vendor1/package1', $json['advisories']);
+        self::assertCount(2, $json['advisories']['vendor1/package1']);
+
+        // Check first advisory
+        self::assertSame('CVE-2023-12345', $json['advisories']['vendor1/package1'][0]['cve']);
+        self::assertSame('First repo advisory', $json['advisories']['vendor1/package1'][0]['title']);
+
+        // Check second advisory
+        self::assertSame('CVE-2023-67890', $json['advisories']['vendor1/package1'][1]['cve']);
+        self::assertSame('Third repo advisory', $json['advisories']['vendor1/package1'][1]['title']);
     }
 
     /**

--- a/tests/Composer/Test/Advisory/AuditorTest.php
+++ b/tests/Composer/Test/Advisory/AuditorTest.php
@@ -418,7 +418,6 @@ Found 2 abandoned packages:
         self::assertSame(Auditor::STATUS_OK, $result);
 
         $output = $io->getOutput();
-        self::assertStringContainsString('Some repositories were unreachable', $output);
         self::assertStringContainsString('The following repositories were unreachable:', $output);
         self::assertStringContainsString('HTTP/1.1 404 Not Found', $output);
 


### PR DESCRIPTION
As discussed in https://github.com/composer/composer/issues/12467 this adds the option `--ignore-unreachable` which will let the audit command run even if repositories are unreachable. They will be listed as unreachable in the report. 

No change has been made to the overall error handling.
