### PR TITLE
doc: update link to CI to lead to the main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Composer helps you declare, manage, and install dependencies of PHP projects.
 
 See [https://getcomposer.org/](https://getcomposer.org/) for more information and documentation.
 
-[![Continuous Integration](https://github.com/composer/composer/workflows/Continuous%20Integration/badge.svg?branch=main)](https://github.com/composer/composer/actions)
+[![Continuous Integration](https://github.com/composer/composer/actions/workflows/continuous-integration.yml/badge.svg?branch=main)](https://github.com/composer/composer/actions/workflows/continuous-integration.yml?query=branch%3Amain)
 
 Installation / Usage
 --------------------


### PR DESCRIPTION
The image already specify the `main` branch. Adding it to the link means that it won't show the results of CIs from other branches, PRs, etc.