### PR TITLE
Fix PSR-4 warnings when using exclude-from-classmap with symlinked directories

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -498,13 +498,20 @@ EOF;
             $fs = new Filesystem();
             $absDir = $fs->isAbsolutePath($dir) ? $dir : realpath(Platform::getCwd()).'/'.$dir;
             $dirMatchNormalized = preg_quote(strtr($fs->normalizePath($absDir), '\\', '/'));
+            $isSymlink = $dirMatch !== $dirMatchNormalized;
 
             foreach ($excluded as $index => $pattern) {
                 // extract the constant string prefix of the pattern here, until we reach a non-escaped regex special character
                 $pattern = Preg::replace('{^(([^.+*?\[^\]$(){}=!<>|:\\\\#-]+|\\\\[.+*?\[^\]$(){}=!<>|:#-])*).*}', '$1', $pattern);
                 // if the pattern is not a subset or superset of $dir, it is unrelated and we skip it
-                if (0 !== strpos($pattern, $dirMatch) && 0 !== strpos($dirMatch, $pattern) &&
-                    0 !== strpos($pattern, $dirMatchNormalized) && 0 !== strpos($dirMatchNormalized, $pattern)) {
+                if (
+                    (!str_starts_with($pattern, $dirMatch) && !str_starts_with($dirMatch, $pattern))
+                    && (
+                        // only check dirMatchNormalized if it is actually different from dirMatch otherwise there is no point
+                        !$isSymlink
+                        || (!str_starts_with($pattern, $dirMatchNormalized) && !str_starts_with($dirMatchNormalized, $pattern))
+                    )
+                ) {
                     unset($excluded[$index]);
                 }
             }


### PR DESCRIPTION
Fixes #12478 in 2.8

### Description

This PR fixes an issue where Composer generates incorrect PSR-4 compliance warnings when using `exclude-from-classmap` patterns with directories that are symlinks.

### The Problem

When a PSR-4 autoload path is a symlink (either relative or absolute) and the project uses `exclude-from-classmap` patterns (e.g., `**/vendor/`), Composer incorrectly reports that classes in the excluded directories don't comply with PSR-4 standards.

Example warning:
```
Class Doctrine\Instantiator\InstantiatorInterface located in ./tools/vendor/doctrine/instantiator/src/Doctrine/Instantiator/InstantiatorInterface.php does not comply with psr-4 autoloading standard (rule: MyTools\ => ./tools). Skipping.
```

### Root Cause

The issue occurs because:
1. The `buildExclusionRegex` method was only matching exclude patterns against the real path of directories
2. When scanning symlinked directories, the patterns needed to match against both the symlink path and the resolved path

### The Solution

The fix updates `buildExclusionRegex` to also check exclude patterns against the normalized (non-realpath) version of the directory being scanned. This ensures that exclude patterns work correctly whether the directory is accessed via its symlink path or its real path.

### Testing

Added a new test case `testAbsoluteSymlinkWithPsr4DoesNotGenerateWarnings` that:
1. Creates a PSR-4 autoload rule pointing to an absolute symlink
2. Uses `exclude-from-classmap` to exclude vendor directories
3. Verifies that no PSR-4 compliance warnings are generated

All existing tests continue to pass.

### Reproducing the Issue

Before this fix:
```bash
# Create a test directory with a symlink (relative or absolute)
mkdir actual-tools
ln -s actual-tools tools
# OR with absolute path:
# ln -s /tmp/tools-composer-test tools

# Add to composer.json:
{
    "autoload": {
        "psr-4": {
            "MyTools\\": "tools/"
        },
        "exclude-from-classmap": ["**/vendor/"]
    }
}

# Run composer dump-autoload -o
# Results in PSR-4 warnings for files in tools/vendor/
```

After this fix: No warnings are generated for excluded paths.


<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
