### PR TITLE
docs: Improve method description for configure() in ValidateCommand

### DIFF
--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -35,8 +35,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ValidateCommand extends BaseCommand
 {
     /**
-     * configure
-     */
+ * Configures the validate command with options and help text.
+ */
+protected function configure(): void
+
     protected function configure(): void
     {
         $this

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -34,10 +34,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ValidateCommand extends BaseCommand
 {
-    /**
+/**
  * Configures the validate command with options and help text.
  */
-protected function configure(): void
 
     protected function configure(): void
     {


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
Improved PHPDoc comment for configure() method to clarify its purpose.