### PR TITLE
ProcessExecutor: mask GitHub fine grained access tokens similar to URL

### DIFF
--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -23,6 +23,8 @@ use Composer\Pcre\Preg;
  */
 class GitHub
 {
+    public const GITHUB_TOKEN_REGEX = '{^([a-f0-9]{12,}|gh[a-z]_[a-zA-Z0-9_]+|github_pat_[a-zA-Z0-9_]+)$}';
+
     /** @var IOInterface */
     protected $io;
     /** @var Config */

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -483,8 +483,8 @@ class ProcessExecutor
 
         $commandString = is_string($command) ? $command : implode(' ', array_map(self::class.'::escape', $command));
         $safeCommand = Preg::replaceCallback('{://(?P<user>[^:/\s]+):(?P<password>[^@\s/]+)@}i', static function ($m): string {
-            // if the username looks like a long (12char+) hex string, or a modern github token (e.g. ghp_xxx) we obfuscate that
-            if (Preg::isMatch('{^([a-f0-9]{12,}|gh[a-z]_[a-zA-Z0-9_]+)$}', $m['user'])) {
+            // if the username looks like a long (12char+) hex string, or a modern github token (e.g. ghp_xxx, github_pat_xxx) we obfuscate that
+            if (Preg::isMatch(GitHub::GITHUB_TOKEN_REGEX, $m['user'])) {
                 return '://***:***@';
             }
             if (Preg::isMatch('{^[a-f0-9]{12,}$}', $m['user'])) {

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -110,8 +110,8 @@ class Url
         $url = Preg::replace('{([&?]access_token=)[^&]+}', '$1***', $url);
 
         $url = Preg::replaceCallback('{^(?P<prefix>[a-z0-9]+://)?(?P<user>[^:/\s@]+):(?P<password>[^@\s/]+)@}i', static function ($m): string {
-            // if the username looks like a long (12char+) hex string, or a modern github token (e.g. ghp_xxx) we obfuscate that
-            if (Preg::isMatch('{^([a-f0-9]{12,}|gh[a-z]_[a-zA-Z0-9_]+|github_pat_[a-zA-Z0-9_]+)$}', $m['user'])) {
+            // if the username looks like a long (12char+) hex string, or a modern github token (e.g. ghp_xxx, github_pat_xxx) we obfuscate that
+            if (Preg::isMatch(GitHub::GITHUB_TOKEN_REGEX, $m['user'])) {
                 return $m['prefix'].'***:***@';
             }
 

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -83,6 +83,7 @@ class ProcessExecutorTest extends TestCase
             ['echo https://foo:bar@example.org/', 'echo https://foo:***@example.org/'],
             ['echo http://foo@example.org', 'echo http://foo@example.org'],
             ['echo http://abcdef1234567890234578:x-oauth-token@github.com/', 'echo http://***:***@github.com/'],
+            ['echo http://github_pat_1234567890abcdefghijkl_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVW:x-oauth-token@github.com/', 'echo http://***:***@github.com/'],
             ["svn ls --verbose --non-interactive  --username 'foo' --password 'bar'  'https://foo.example.org/svn/'", "svn ls --verbose --non-interactive  --username 'foo' --password '***'  'https://foo.example.org/svn/'"],
             ["svn ls --verbose --non-interactive  --username 'foo' --password 'bar \'bar'  'https://foo.example.org/svn/'", "svn ls --verbose --non-interactive  --username 'foo' --password '***'  'https://foo.example.org/svn/'"],
         ];


### PR DESCRIPTION
Similar to https://github.com/composer/composer/commit/90673e4f66fed79ec4d9ccf0247333b01dc3b444 wondering if the regex should be extracted into a const or similar to easier keep it in sync between the two components.