### PR TITLE
fix: deprecation of curl_close in CurlDownloader.php

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -305,7 +305,9 @@ class CurlDownloader
         if (isset($this->jobs[$id], $this->jobs[$id]['curlHandle'])) {
             $job = $this->jobs[$id];
             curl_multi_remove_handle($this->multiHandle, $job['curlHandle']);
-            curl_close($job['curlHandle']);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($job['curlHandle']);
+            }
             if (is_resource($job['headerHandle'])) {
                 fclose($job['headerHandle']);
             }
@@ -351,7 +353,9 @@ class CurlDownloader
             $error = curl_error($curlHandle);
             $errno = curl_errno($curlHandle);
             curl_multi_remove_handle($this->multiHandle, $curlHandle);
-            curl_close($curlHandle);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($curlHandle);
+            }
 
             $headers = null;
             $statusCode = null;


### PR DESCRIPTION
The function `curl_close()` doesn't have any effect since PHP 8.0: https://www.php.net/manual/en/function.curl-close.php

The deprecation of the function is implemented in PHP 8.5.