### PR TITLE
2.8 | Update reactphp/promise for PHP 8.5 compatibility (high priority)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/filesystem": "^5.4.35 || ^6.3.12 || ^7.0.3",
         "symfony/finder": "^5.4.35 || ^6.3.12 || ^7.0.3",
         "symfony/process": "^5.4.35 || ^6.3.12 || ^7.0.3",
-        "react/promise": "^2.11 || ^3.2",
+        "react/promise": "^2.11 || ^3.3",
         "composer/pcre": "^2.2 || ^3.2",
         "symfony/polyfill-php73": "^1.24",
         "symfony/polyfill-php80": "^1.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "346c859c80684f1cd23f57dc04f917b4",
+    "content-hash": "69dd3051579ad394c3b8a8608cb9877e",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -778,23 +778,23 @@
         },
         {
             "name": "react/promise",
-            "version": "v3.2.0",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "8a164643313c71354582dc850b42b33fa12a4b63"
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/8a164643313c71354582dc850b42b33fa12a4b63",
-                "reference": "8a164643313c71354582dc850b42b33fa12a4b63",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "1.10.39 || 1.4.10",
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
                 "phpunit/phpunit": "^9.6 || ^7.5"
             },
             "type": "library",
@@ -839,7 +839,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v3.2.0"
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -847,7 +847,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-05-24T10:39:05+00:00"
+            "time": "2025-08-19T18:57:03+00:00"
         },
         {
             "name": "seld/jsonlint",


### PR DESCRIPTION
At this moment, nearly every single `composer install` on PHP 8.5 is failing on a deprecation notice coming from the `react/promise` package.

To mitigate this, the ReactPHP team has just released a new version and I'd like to suggest for Composer to update to that version and release a new version of Composer itself to unblock early adopters from testing with PHP 8.5.

Note: other than fixing the deprecation notice, the `3.3.0` release does not contain any user-facing changes.

Ref:
* https://github.com/reactphp/promise/pull/264
* https://github.com/reactphp/promise/releases/tag/v3.3.0
* https://github.com/reactphp/promise/compare/v3.2.0...v3.3.0