### PR TITLE
Streamline IO confirmation questions to use lowercase 'y'.

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -278,7 +278,7 @@ EOT
             && (
                 $input->getOption('remove-vcs')
                 || !$io->isInteractive()
-                || $io->askConfirmation('<info>Do you want to remove the existing VCS (.git, .svn..) history?</info> [<comment>Y,n</comment>]? ')
+                || $io->askConfirmation('<info>Do you want to remove the existing VCS (.git, .svn..) history?</info> [<comment>y,n</comment>]? ')
             )
         ) {
             $finder = new Finder();

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -544,7 +544,7 @@ EOT
 
             if (Preg::isMatch('{^dev-(?!main$|master$|trunk$|latest$)}', $requirements[$packageName])) {
                 $this->getIO()->warning('Version '.$requirements[$packageName].' looks like it may be a feature branch which is unlikely to keep working in the long run and may be in an unstable state');
-                if ($this->getIO()->isInteractive() && !$this->getIO()->askConfirmation('Are you sure you want to use this constraint (<comment>Y</comment>) or would you rather abort (<comment>n</comment>) the whole operation [<comment>Y,n</comment>]? ')) {
+                if ($this->getIO()->isInteractive() && !$this->getIO()->askConfirmation('Are you sure you want to use this constraint (<comment>y</comment>) or would you rather abort (<comment>n</comment>) the whole operation [<comment>y,n</comment>]? ')) {
                     $this->revertComposerFile();
 
                     return 1;

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -208,7 +208,7 @@ class Application extends BaseApplication
                         $io->writeError('<info>No composer.json in current directory, to use the one at '.$dir.' run interactively or set config.use-parent-dir to true</info>');
                         break;
                     }
-                    if ($useParentDirIfNoJsonAvailable === true || $io->askConfirmation('<info>No composer.json in current directory, do you want to use the one at '.$dir.'?</info> [<comment>Y,n</comment>]? ')) {
+                    if ($useParentDirIfNoJsonAvailable === true || $io->askConfirmation('<info>No composer.json in current directory, do you want to use the one at '.$dir.'?</info> [<comment>y,n</comment>]? ')) {
                         if ($useParentDirIfNoJsonAvailable === true) {
                             $io->writeError('<info>No composer.json in current directory, changing working directory to '.$dir.'</info>');
                         } else {

--- a/tests/Composer/Test/Command/RequireCommandTest.php
+++ b/tests/Composer/Test/Command/RequireCommandTest.php
@@ -78,7 +78,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing required/pkg (dev-foo-bar)
 Using version dev-foo-bar for required/pkg
 <warning>Version dev-foo-bar looks like it may be a feature branch which is unlikely to keep working in the long run and may be in an unstable state</warning>
-Are you sure you want to use this constraint (Y) or would you rather abort (n) the whole operation [Y,n]? '.'
+Are you sure you want to use this constraint (y) or would you rather abort (n) the whole operation [y,n]? '.'
 Installation failed, reverting ./composer.json to its original content.
 ', $appTester->getDisplay(true));
     }


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->

Not sure if this should be reported as a bug, I therefore opened this against `main`. Let me know if I should update.

I was mislead by some of the IO confirmation questions which were indicating an uppercase `Y` as valid answer. I checked, and the default regex used in `Composer\Question\StrictConfirmationQuestion` does in fact not allow an uppercase `Y`. I therefore propose to adjust the remaining questions which do not already indicate a lowercase `y`.

I searched for usages of `Composer\IO\ConsoleIO::askConfirmation()` and these were the remaining questions which did not already use `yes` or `y`.