### PR TITLE
Add Symfony 8 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -91,9 +91,9 @@ jobs:
         if: "contains(matrix.dependencies, 'highest') || contains(matrix.dependencies, 'lowest')"
         run: "composer config platform --unset"
 
-      - name: "Allow alpha releases for latest-deps builds to catch problems earlier"
+      - name: "Allow dev releases for latest-deps builds to catch problems earlier"
         if: "contains(matrix.dependencies, 'highest')"
-        run: "composer config minimum-stability alpha"
+        run: "composer config minimum-stability dev"
 
       - name: "Update dependencies from composer.json using composer binary provided by system"
         if: "contains(matrix.dependencies, 'highest') || contains(matrix.dependencies, 'lowest')"

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "seld/jsonlint": "^1.4",
         "seld/phar-utils": "^1.2",
-        "symfony/console": "^5.4.35 || ^6.3.12 || ^7.0.3",
-        "symfony/filesystem": "^5.4.35 || ^6.3.12 || ^7.0.3",
-        "symfony/finder": "^5.4.35 || ^6.3.12 || ^7.0.3",
-        "symfony/process": "^5.4.35 || ^6.3.12 || ^7.0.3",
+        "symfony/console": "^5.4.35 || ^6.3.12 || ^7.0.3 || ^8.0",
+        "symfony/filesystem": "^5.4.35 || ^6.3.12 || ^7.0.3 || ^8.0",
+        "symfony/finder": "^5.4.35 || ^6.3.12 || ^7.0.3 || ^8.0",
+        "symfony/process": "^5.4.35 || ^6.3.12 || ^7.0.3 || ^8.0",
         "react/promise": "^2.11 || ^3.3",
         "composer/pcre": "^2.3 || ^3.3",
         "symfony/polyfill-php73": "^1.24",
@@ -45,7 +45,7 @@
         "seld/signal-handler": "^2.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^6.4.3 || ^7.0.1",
+        "symfony/phpunit-bridge": "^6.4.3 || ^7.0.1 || ^8.0",
         "phpstan/phpstan": "^1.11.8",
         "phpstan/phpstan-phpunit": "^1.4.0",
         "phpstan/phpstan-deprecation-rules": "^1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af29dfa9c75342657314dbb349268bef",
+    "content-hash": "f2380adc7651e34a1ae8009338bc7637",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -218,7 +218,7 @@ abstract class BaseCommand extends Command
      *
      * @return void
      */
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         // initialize a plugin-enabled Composer instance, either local or global
         $disablePlugins = $input->hasParameterOption('--no-plugins');

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -27,7 +27,7 @@ class DumpAutoloadCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('dump-autoload')

--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -25,7 +25,7 @@ class ExecCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('exec')

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -50,7 +50,7 @@ class InitCommand extends BaseCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('init')
@@ -217,7 +217,7 @@ EOT
      *
      * @return void
      */
-    protected function interact(InputInterface $input, OutputInterface $output)
+    protected function interact(InputInterface $input, OutputInterface $output): void
     {
         $git = $this->getGitConfig();
         $io = $this->getIO();

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -35,7 +35,7 @@ class InstallCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('install')

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -39,7 +39,7 @@ class RemoveCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('remove')

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -74,7 +74,7 @@ class RequireCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('require')

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -76,7 +76,7 @@ class ShowCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('show')

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -50,7 +50,7 @@ class UpdateCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('update')

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v8/Installer/CommandProvider.php
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v8/Installer/CommandProvider.php
@@ -30,7 +30,7 @@ class CommandProvider implements CommandProviderCapability
 
 class Command extends BaseCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('custom-plugin-command');
     }


### PR DESCRIPTION
Allows installing with Symfony 8 components (dev) and updates commands accordingly.

Breaking change:
`BaseCommand::initialize()` added return type: `void`
