### PR TITLE
fixes a regression introduced via 304107d breaking bumping versions containing a zero

### DIFF
--- a/src/Composer/Package/Version/VersionBumper.php
+++ b/src/Composer/Package/Version/VersionBumper.php
@@ -73,7 +73,7 @@ class VersionBumper
             return $prettyConstraint;
         }
 
-        $major = Preg::replace('{^([1-9]+|0\.\d+).*}', '$1', $version);
+        $major = Preg::replace('{^([1-9][0-9]*|0\.\d+).*}', '$1', $version);
         $versionWithoutSuffix = Preg::replace('{(?:\.(?:0|9999999))+(-dev)?$}', '', $version);
         $newPrettyConstraint = '^'.$versionWithoutSuffix;
 

--- a/tests/Composer/Test/Package/Version/VersionBumperTest.php
+++ b/tests/Composer/Test/Package/Version/VersionBumperTest.php
@@ -69,6 +69,7 @@ class VersionBumperTest extends TestCase
         yield 'upgrade patch-only-tilde, longer version' => ['~2.2.3', '2.2.6.2', '~2.2.6'];
         yield 'upgrade patch-only-tilde' => ['~2.2.3', '2.2.6', '~2.2.6'];
         yield 'upgrade patch-only-tilde, also .0s' => ['~2.0.0', '2.0.0', '~2.0.0'];
+        yield 'upgrade patch-only-tilde - with year based versions' => ['~2025.1.561', '2025.1.583', '~2025.1.583'];
         yield 'upgrade 4 bits tilde' => ['~2.2.3.1', '2.2.4', '~2.2.4.0'];
         yield 'upgrade 4 bits tilde/2' => ['~2.2.3.1', '2.2.4.0', '~2.2.4.0'];
         yield 'upgrade 4 bits tilde/3' => ['~2.2.3.1', '2.2.4.5', '~2.2.4.5'];


### PR DESCRIPTION
the preg match was not updated to support major versions containing a zero :) like ~2025.1.x this should do the trick now. checkout the testcase for a proper example
