### PR TITLE
Bitbucket: add support for API tokens

### DIFF
--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -239,6 +239,13 @@ class Git
                 // password in there.
                 if ($this->io->hasAuthentication($domain)) {
                     $auth = $this->io->getAuthentication($domain);
+
+                    // Bitbucket API tokens use the email address as the username for HTTP API calls and
+                    // either the Bitbucket username or 'x-bitbucket-api-token-auth' as the username for git operations.
+                    if (strpos((string) $auth['password'], 'ATAT') === 0) {
+                        $auth['username'] = 'x-bitbucket-api-token-auth';
+                    }
+
                     $authUrl = 'https://' . rawurlencode($auth['username']) . ':' . rawurlencode($auth['password']) . '@' . $domain . '/' . $repo_with_git_part;
 
                     if (0 === $runCommands($authUrl)) {

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -286,6 +286,7 @@ class GitTest extends TestCase
             ['git@bitbucket.org:acme/repo.git', null, 'git@bitbucket.org:acme/repo.git', 0],
             ['https://bitbucket.org/acme/repo', null, 'git@bitbucket.org:acme/repo.git', 1, 1],
             ['https://bitbucket.org/acme/repo.git', null, 'git@bitbucket.org:acme/repo.git', 1, 1],
+            ['https://bitbucket.org/acme/repo.git', 'ATAT_BITBUCKET_API_TOKEN', 'https://x-bitbucket-api-token-auth:ATAT_BITBUCKET_API_TOKEN@bitbucket.org/acme/repo.git', 1],
         ];
     }
 


### PR DESCRIPTION
Resolves: https://github.com/composer/composer/issues/12482

To verify:
Create an API token with `read:repository:bitbucket` scope at https://id.atlassian.com/manage-profile/security/api-tokens

Configure the token:
```
composer config --auth http-basic.bitbucket.org your-bitbucket-email@example.org ATAT_YOUR_BITBUCKET_API_TOKEN
```
Have a composer.json file and try with both `git` and `bitbucket` repository types
```
{
"require": {
"acme/private": "dev-main"
},
"repositories": {
"bitbucket": {
"type": "git",
"url": "https://bitbucket.org/acme/private"
}
}
}
```

Run `composer update` like:
```
Running 2.8.999-dev+source (@release_date@) with PHP 8.4.11 on Darwin / 24.6.0
Composer is operating slower than normal because you have Xdebug enabled. See https://getcomposer.org/xdebug
Reading ./composer.json (/tmp/bitbucket/composer.json)
Loading config file ./composer.json (/tmp/bitbucket/composer.json)
Loading config file /tmp/bitbucket/auth.json
Reading /tmp/bitbucket/auth.json
Checked CA file /opt/homebrew/etc/ca-certificates/cert.pem: valid
Executing command (/tmp/bitbucket): 'git' 'branch' '-a' '--no-color' '--no-abbrev' '-v'
Failed to initialize global composer: Composer could not find the config file: /tmp/cache/composer.json

Reading ./composer.lock (/tmp/bitbucket/composer.lock)
Loading composer repositories with package information
Executing command (CWD): 'git' 'clone' '--mirror' '--' 'https://bitbucket.org/acme/private' '/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/'
Executing command (CWD): 'git' 'clone' '--mirror' '--' 'https://x-bitbucket-api-token-auth:***@bitbucket.org/acme/private.git' '/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'show-ref' '--tags' '--dereference'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'branch' '--no-color' '--no-abbrev' '-v'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'remote' '-v'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'remote' 'set-url' 'origin' '--' 'https://bitbucket.org/acme/private'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'remote' 'show' 'origin'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'remote' 'set-url' 'origin' '--' 'https://x-bitbucket-api-token-auth:***@bitbucket.org/acme/private.git'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'remote' 'show' 'origin'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'remote' 'set-url' 'origin' '--' 'https://bitbucket.org/acme/private.git'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'show' 't/composer:composer.json'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' '-c' 'log.showSignature=false' 'log' '-1' '--format=%at' 't/composer'
Reading composer.json of acme/private (t/composer)
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'show' 'bacc76a802e9ba0aea23af2f8c611ae1f8256411:composer.json'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' '-c' 'log.showSignature=false' 'log' '-1' '--format=%at' 'bacc76a802e9ba0aea23af2f8c611ae1f8256411'
Writing /tmp/cache/cache/repo/https---bitbucket.org-acme-private/bacc76a802e9ba0aea23af2f8c611ae1f8256411 into cache
Importing branch t/composer (dev-main)
Built pool.
Running pool optimizer.
Updating dependencies
Generating rules
Resolving dependencies through SAT
Looking at all rules.

Dependency resolution completed in 0.000 seconds
Analyzed 104 packages to resolve dependencies
Analyzed 105 rules to resolve dependencies
Nothing to modify in lock file
Writing lock file
Installing dependencies from lock file (including require-dev)
Reading ./composer.lock (/tmp/bitbucket/composer.lock)
Package operations: 1 install, 0 updates, 0 removals
Installs: acme/private:dev-main bacc76a
- Syncing acme/private (dev-main bacc76a) into cache
Cloning to cache at /tmp/cache/cache/vcs/https---bitbucket.org-acme-private/
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'rev-parse' '--git-dir'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'rev-parse' '--quiet' '--verify' 'bacc76a802e9ba0aea23af2f8c611ae1f8256411^{commit}'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'branch'
Executing command (/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/): 'git' 'tag'
- Installing acme/private (dev-main bacc76a): Cloning bacc76a802e9ba0aea23af2f8c611ae1f8256411 from cache
Executing command (CWD): 'git' 'clone' '--no-checkout' '/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/' '/tmp/bitbucket/vendor/acme/private' '--dissociate' '--reference' '/tmp/cache/cache/vcs/https---bitbucket.org-acme-private/'
Executing command (/tmp/bitbucket/vendor/acme/private): 'git' 'remote' 'set-url' 'origin' '--' 'https://bitbucket.org/acme/private'
Executing command (/tmp/bitbucket/vendor/acme/private): 'git' 'remote' 'add' 'composer' '--' 'https://bitbucket.org/acme/private'
Executing command (/tmp/bitbucket/vendor/acme/private): 'git' 'branch' '-r'
Executing command (/tmp/bitbucket/vendor/acme/private): 'git' 'checkout' 't/composer' '--'
Executing command (/tmp/bitbucket/vendor/acme/private): 'git' 'reset' '--hard' 'bacc76a802e9ba0aea23af2f8c611ae1f8256411' '--'
- Marking acme/private (9999999-dev bacc76a) as installed, alias of acme/private (dev-main bacc76a)
Generating autoload files
Downloading https://repo.packagist.org/packages.json
[200] https://repo.packagist.org/packages.json
Writing /tmp/cache/cache/repo/https---repo.packagist.org/packages.json into cache
Downloading https://repo.packagist.org/p2/acme/private.json
[404] https://repo.packagist.org/p2/acme/private.json
Downloading https://packagist.org/api/security-advisories/
[200] https://packagist.org/api/security-advisories/
No security vulnerability advisories found.
```