### PR TITLE
Reduce memory usage in PoolBuilder

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -38,6 +38,8 @@ use Composer\Semver\Intervals;
  */
 class PoolBuilder
 {
+    private const LOAD_BATCH_SIZE = 50;
+
     /**
      * @var int[]
      * @phpstan-var array<key-of<BasePackage::STABILITIES>, BasePackage::STABILITY_*>
@@ -420,7 +422,7 @@ class PoolBuilder
         }
 
         // Load packages in chunks of 50 to prevent memory usage build-up due to caches of all sorts
-        $packageBatches = array_chunk($this->packagesToLoad, 50, true);
+        $packageBatches = array_chunk($this->packagesToLoad, self::LOAD_BATCH_SIZE, true);
         $this->packagesToLoad = [];
 
         foreach ($repositories as $repoIndex => $repository) {
@@ -451,7 +453,7 @@ class PoolBuilder
                 }
             }
 
-            $packageBatches = array_chunk(array_merge(...$packageBatches), 50, true);
+            $packageBatches = array_chunk(array_merge(...$packageBatches), self::LOAD_BATCH_SIZE, true);
         }
     }
 


### PR DESCRIPTION
Not something you would notice when running a regular `composer update` or so because there are other - much more important - factors that influence memory usage. However, if you use e.g. the `ComposerRepository` pretty much isolated like I do in https://github.com/terminal42/composer-lock-validator, the fact that we're keeping all provider data in memory for all the packages provided is quite noticeable - the more packages, the more memory.
This is because the promises cause `$contents` to never be cleaned up by GC as it is used until the promise is finally resolved.

Loading packages in batches instead of all at once prevents such potential memory allocations quite nicely:

<img width="287" height="136" alt="Bildschirmfoto 2025-09-18 um 11 50 43" src="https://github.com/user-attachments/assets/5fd27e75-2389-42a6-8520-8b22ad53dcae" />

<img width="635" height="922" alt="Bildschirmfoto 2025-09-18 um 11 47 24" src="https://github.com/user-attachments/assets/588d6e2d-6a7d-4aa9-bb4c-c758bda1717a" />



So `json_decode()` still allocates `83 MB` in my case in total but because it does it in junks now, we reduce peak memory usage.
