### PR TITLE
Indicate scope of --strict-psr option when dumping autoload

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -997,9 +997,9 @@ performance.
   `lib-*` and `ext-*`) and skip the [platform check](07-runtime.md#platform-check) for it.
   Multiple requirements can be ignored via wildcard.
 * **--strict-psr:** Return a failed exit code (1) if PSR-4 or PSR-0 mapping errors
-  are present. Requires --optimize to work.
+  are present in the current project (dependencies excluded). Requires `--optimize` to work.
 * **--strict-ambiguous:** Return a failed exit code (2) if the same class is found
-  in multiple files. Requires --optimize to work.
+  in multiple files. Requires `--optimize` to work.
 
 ## clear-cache / clearcache / cc
 


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->

Addresses #12239 
