### PR TITLE
Fixes binary proxy to support spaces in source path

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+"<?php dec"lare(strict_types=1);
 
 /*
  * This file is part of Composer.
@@ -375,7 +375,7 @@ if [ -z "\$selfArg" ]; then
     selfArg="\$0"
 fi
 
-self=\$(realpath \$selfArg 2> /dev/null)
+self=\$(realpath "\$selfArg" 2> /dev/null)
 if [ -z "\$self" ]; then
     self="\$selfArg"
 fi

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -1,4 +1,4 @@
-"<?php dec"lare(strict_types=1);
+<?php declare(strict_types=1);
 
 /*
  * This file is part of Composer.


### PR DESCRIPTION
I ran across an issue while using [Drush](https://www.drush.org/13.x/) and calling a command that starts a subprocess (such as `updatedb`) and found that the binary proxy does not handle spaces in the source path.

In my environment, I have my Composer/Drupal install at a patch which has a space in the name (i.e. `/home/jenkins/workspace/Job Name`). I attempted to call `vendor/bin/drush updatedb` and got an error similar to:

```
The command "'/home/jenkins/workspace/Job Name/vendor/bin/drush' updatedb:status --no-cache-clear --strict=0 --uri=default" failed.                                                                                                        
                                                                                                                                       
  Exit Code: 127(Command not found)                                                                                                    
                                                                                                                                       
  Working directory:                                                                                                                   
                                                                                                                                       
  Output:                                                                                                                              
  ================                                                                                                                                                                                                                                           
                                                                                                                                       
                                                                                                                                       
  Error Output:                                                                                                                        
  ================                                                                                                                     
  /home/jenkins/workspace/Job Name/vendor/bin/drush: line 17: cd: ../drush/drush: No such file or directory                                                                                                                                  
  /home/jenkins/workspace/Job Name/vendor/bin/drush: line 41: /drush: No such file or directory
```

The `drush` command started correctly, but when it attempted to start a subprocess (`'/home/jenkins/workspace/Job Name/vendor/bin/drush' updatedb:status --no-cache-clear --strict=0 --uri=default`), it could not find drush.

I found the root cause to be in the binary proxy where it calls `realpath`:
```
selfArg="/home/jenkins/workspace/Job Name/vendor/bin/drush"
self=$(realpath $selfArg 2> /dev/null)
```

`self` was becoming `/home/jenkins/workspace/Job`.