### PR TITLE
Add Cache-Control headers when `--no-cache` is used

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -1473,9 +1473,21 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         while ($retries--) {
             try {
                 $options = $this->options;
+                
+                // Add Cache-Control: no-cache header when cache is disabled (--no-cache option)
+                if (!Cache::isUsable($this->cache->getRoot())) {
+                    if (!isset($options['http'])) {
+                        $options['http'] = [];
+                    }
+                    if (!isset($options['http']['header'])) {
+                        $options['http']['header'] = [];
+                    }
+                    $options['http']['header'][] = 'Cache-Control: no-cache';
+                }
+                
                 if ($this->eventDispatcher) {
                     $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata', ['repository' => $this]);
-                    $preFileDownloadEvent->setTransportOptions($this->options);
+                    $preFileDownloadEvent->setTransportOptions($options);
                     $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
                     $filename = $preFileDownloadEvent->getProcessedUrl();
                     $options = $preFileDownloadEvent->getTransportOptions();


### PR DESCRIPTION
### Add Cache-Control headers for `--no-cache` option to bypass CDN caching

When users specify `--no-cache`, Composer now sends `Cache-Control: no-cache` headers with repository metadata requests, directly bypassing all cache layers to fetch fresh data from origin servers.

This ensures that both local and CDN caches are completely skipped, providing a reliable solution for package version resolution issues caused by outdated cached data.

Specifically addresses scenarios where CDN synchronization delays or stale cache entries prevent immediate access to newly published package versions, allowing developers to force-fetch the latest repository state without any cache interference.

Fix https://github.com/composer/composer/issues/12339