### PR TITLE
Fix `--global` flag path resolution for bin-dir config

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -183,6 +183,11 @@ EOT
         $io = $this->getIO();
         $this->config = Factory::createConfig($io);
 
+        // When using --global flag, set baseDir to home directory for correct absolute path resolution
+        if ($input->getOption('global')) {
+            $this->config->setBaseDir($this->config->get('home'));
+        }
+
         $configFile = $this->getComposerConfigFile($input, $this->config);
 
         // Create global composer.json if this was invoked using `composer global config`


### PR DESCRIPTION
 ## Summary

  Fixes incorrect path resolution when using composer global config to get bin-dir.

## How to Reproduce

  Current directory: `/Users/xx/Projects/dotfiles`
  Try to get global bin-dir `composer config -g bin-dir --absolute`

  Expected:  `~/.composer/vendor/bin`
  Actual: `/Users/xx/Projects/dotfiles/vendor/bin`

  ## Solution
  Set the config's baseDir to the home directory when --global flag is used, ensuring absolute paths are calculated correctly for global configuration.
