### PR TITLE
Add update-with-minimal-changes config option

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -505,7 +505,7 @@ Defaults to `false`. Ignores error during `install` if there are any missing
 requirements - the lock file is not up to date with the latest changes in
 `composer.json`.
 
-## minimal-changes
+## update-with-minimal-changes
 
 Defaults to `false`. If set to true, Composer will only perform absolutely necessary
 changes to transitive dependencies during update.

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -748,6 +748,10 @@
                 "allow-missing-requirements": {
                     "type": ["boolean"],
                     "description": "Defaults to false. If set to true, Composer will allow install when lock file is not up to date with the latest changes in composer.json."
+                },
+                "update-with-minimal-changes": {
+                    "type": ["boolean"],
+                    "description": "Defaults to false. If set to true, Composer will only perform absolutely necessary changes to transitive dependencies during update."
                 }
             }
         },

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -467,7 +467,7 @@ EOT
             'classmap-authoritative' => [$booleanValidator, $booleanNormalizer],
             'apcu-autoloader' => [$booleanValidator, $booleanNormalizer],
             'prepend-autoloader' => [$booleanValidator, $booleanNormalizer],
-            'minimal-changes' => [$booleanValidator, $booleanNormalizer],
+            'update-with-minimal-changes' => [$booleanValidator, $booleanNormalizer],
             'disable-tls' => [$booleanValidator, $booleanNormalizer],
             'secure-http' => [$booleanValidator, $booleanNormalizer],
             'bump-after-update' => [

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -258,7 +258,7 @@ EOT
         $authoritative = $input->getOption('classmap-authoritative') || $composer->getConfig()->get('classmap-authoritative');
         $apcuPrefix = $input->getOption('apcu-autoloader-prefix');
         $apcu = $apcuPrefix !== null || $input->getOption('apcu-autoloader') || $composer->getConfig()->get('apcu-autoloader');
-        $minimalChanges = $input->getOption('minimal-changes') || $composer->getConfig()->get('minimal-changes');
+        $minimalChanges = $input->getOption('minimal-changes') || $composer->getConfig()->get('update-with-minimal-changes');
 
         $updateAllowTransitiveDependencies = Request::UPDATE_LISTED_WITH_TRANSITIVE_DEPS_NO_ROOT_REQUIRE;
         $flags = '';

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -442,7 +442,7 @@ EOT
         $authoritative = $input->getOption('classmap-authoritative') || $composer->getConfig()->get('classmap-authoritative');
         $apcuPrefix = $input->getOption('apcu-autoloader-prefix');
         $apcu = $apcuPrefix !== null || $input->getOption('apcu-autoloader') || $composer->getConfig()->get('apcu-autoloader');
-        $minimalChanges = $input->getOption('minimal-changes') || $composer->getConfig()->get('minimal-changes');
+        $minimalChanges = $input->getOption('minimal-changes') || $composer->getConfig()->get('update-with-minimal-changes');
 
         $updateAllowTransitiveDependencies = Request::UPDATE_ONLY_LISTED;
         $flags = '';

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -238,7 +238,7 @@ EOT
         $authoritative = $input->getOption('classmap-authoritative') || $config->get('classmap-authoritative');
         $apcuPrefix = $input->getOption('apcu-autoloader-prefix');
         $apcu = $apcuPrefix !== null || $input->getOption('apcu-autoloader') || $config->get('apcu-autoloader');
-        $minimalChanges = $input->getOption('minimal-changes') || $config->get('minimal-changes');
+        $minimalChanges = $input->getOption('minimal-changes') || $config->get('update-with-minimal-changes');
 
         $updateAllowTransitiveDependencies = Request::UPDATE_ONLY_LISTED;
         if ($input->getOption('with-all-dependencies')) {

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -61,7 +61,7 @@ class Config
         'classmap-authoritative' => false,
         'apcu-autoloader' => false,
         'prepend-autoloader' => true,
-        'minimal-changes' => false,
+        'update-with-minimal-changes' => false,
         'github-domains' => ['github.com'],
         'bitbucket-expose-hostname' => true,
         'disable-tls' => false,


### PR DESCRIPTION
Resolves #12355

Adds `update-with-minimal-changes` config option which can be set on both global and project level, allowing to minimize impact of `composer update`.

~~The test is exactly the same as `full-update-minimal-changes` - simply added config entry there.~~
