### PR TITLE
Add missing documentation for schema properties

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -335,6 +335,37 @@ Example:
 
 Optional.
 
+### dist
+
+The distribution archive for the package.
+
+Properties:
+
+* **type:** The type of distribution archive (e.g. `zip`, `tar`, `phar`).
+* **url:** The URL to download the distribution archive.
+* **reference:** The specific commit, tag, or revision that this distribution represents.
+* **shasum:** The SHA-1 checksum of the distribution archive for verification.
+* **mirrors:** An array of alternative download URLs.
+
+Example:
+
+```json
+{
+    "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+        "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+        "shasum": "a1b8d00bb5bc3b0308e99a95e01bdbbefbe052b4",
+        "mirrors": [
+            "https://api.github.com/repos/alternative-one/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+            "https://api.github.com/repos/alternative-two/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6"
+        ]
+    }
+}
+```
+
+Optional.
+
 ### Package links
 
 All of the following take an object which maps package names to


### PR DESCRIPTION
There are [a couple of properties in `res/composer-schema.json`](https://github.com/composer/composer/blob/2.8.12/res/composer-schema.json#L1170-L1208) that are missing from the documentation at https://getcomposer.org/doc/04-schema.md. This PR adds them.

I have tried to match the structure and formatting of existing documentation. Obviously, let me know if you'd like changes.

Also, I noticed that a few other fields for which I could not find corresponding documentation--[`security-advisories`](https://github.com/composer/composer/blob/2.8.12/res/composer-repository-schema.json#L35-L51), [`metadata-changes-url`](https://github.com/composer/composer/blob/2.8.12/res/composer-repository-schema.json#L52-L55), [`warnings`](https://github.com/composer/composer/blob/2.8.12/res/composer-repository-schema.json#L72-L88), and [`infos`](https://github.com/composer/composer/blob/2.8.12/res/composer-repository-schema.json#L89-L105). I didn't attempt to add them in this PR because I wanted to get your input first. I'm happy to add them according to your direction, if you like.