### PR TITLE
When resolving with prefer-lowest and prefer-stable, consider "dev" as more stable than alpha/beta/RC

### DIFF
--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -53,6 +53,14 @@ class DefaultPolicy implements PolicyInterface
     public function versionCompare(PackageInterface $a, PackageInterface $b, string $operator): bool
     {
         if ($this->preferStable && ($stabA = $a->getStability()) !== ($stabB = $b->getStability())) {
+            if ($this->preferLowest && 'stable' !== $stabA && 'stable' !== $stabB) {
+                 // When prefer-lowest is set and no stable version has been released,
+                // "dev" should be considered more stable than "alpha", "beta" or "RC":
+                // this allows testing lowest versions with potential fixes applied
+                $stabA = 'dev' === $stabA ? 'stable' : $stabA;
+                $stabB = 'dev' === $stabB ? 'stable' : $stabB;
+            }
+
             return BasePackage::STABILITIES[$stabA] < BasePackage::STABILITIES[$stabB];
         }
 


### PR DESCRIPTION
This is a behavior that [we had](https://github.com/symfony/flex/blob/f356aa35f3cf3d2f46c31d344c1098eb2d260426/src/Flex.php#L193-L198) in symfony/flex but that [has been broken](https://github.com/composer/composer/commit/685add70ec84d18075a202686288304db0d6d265) about one year ago.

When resolving dependencies with `--prefer-lowest` and `--prefer-stable`, the `dev` version should be considered as more stable than any other non-stable release. The reason is that the `dev` version is the one that's receiving fixes before the next `stable`.

An example today is this job: https://github.com/symfony/symfony/actions/runs/18909610115/job/53976430689?pr=62204
We released `7.4-beta1` and framework-bundle needs a fix that is in http-kernel `7.4-dev`. We can fix the job by bumping the require from `^7.4` to `^7.4-beta2`, but that's a hack: once the stable version will be released, we'll have to revert that change back to `^7.4`.

Quality of life improvement as maintainers + just something that makes sense.

Thanks for considering! 🙏 