### PR TITLE
Add support for cache-busting

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -134,6 +134,8 @@ resolution.
   a `+` makes it only ignore the upper-bound of the requirements. For example, if a package
   requires `php: ^7`, then the option `--ignore-platform-req=php+` would allow installing on PHP 8,
   but installation on PHP 5.6 would still fail.
+* **--cache-bust:** append a URL parameter to bypass the Packagist cache.
+  Only use this when the cache malfunctioning!
 
 ## update / u / upgrade
 
@@ -238,6 +240,8 @@ php composer.phar update vendor/package:2.0.1 vendor/package2:3.0.*
 * **--interactive:** Interactive interface with autocompletion to select the packages to update.
 * **--root-reqs:** Restricts the update to your first degree dependencies.
 * **--bump-after-update:** Runs `bump` after performing the update. Set to `dev` or `no-dev` to only bump those dependencies.
+* **--cache-bust:** append a URL parameter to bypass the Packagist cache.
+  Only use this when the cache malfunctioning!
 
 Specifying one of the words `mirrors`, `lock`, or `nothing` as an argument has the same effect as specifying the option `--lock`, for example `composer update mirrors` is exactly the same as `composer update --lock`.
 

--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -244,6 +244,11 @@ abstract class BaseCommand extends Command
         if ($composer) {
             $preCommandRunEvent = new PreCommandRunEvent(PluginEvents::PRE_COMMAND_RUN, $input, $this->getName());
             $composer->getEventDispatcher()->dispatch($preCommandRunEvent->getName(), $preCommandRunEvent);
+
+            if ($input->hasParameterOption('--cache-bust')) {
+                $cacheBust = $input->getParameterOption('--cache-bust');
+                $composer->getConfig()->merge(['config' => ['cache-bust' => $cacheBust]], Config::SOURCE_COMMAND);
+            }
         }
 
         if (true === $input->hasParameterOption(['--no-ansi']) && $input->hasOption('no-progress')) {

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -59,6 +59,7 @@ class Config
         'sort-packages' => false,
         'optimize-autoloader' => false,
         'classmap-authoritative' => false,
+        'cache-bust' => false,
         'apcu-autoloader' => false,
         'prepend-autoloader' => true,
         'update-with-minimal-changes' => false,
@@ -331,6 +332,7 @@ class Config
                 return (($flags & self::RELATIVE_PATHS) === self::RELATIVE_PATHS) ? $val : $this->realpath($val);
 
             // booleans with env var support
+            case 'cache-bust':
             case 'cache-read-only':
             case 'htaccess-protect':
                 // convert foo-bar to COMPOSER_FOO_BAR and check if it exists since it overrides the local config

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -700,6 +700,7 @@ class Application extends BaseApplication
         $definition->addOption(new InputOption('--no-scripts', null, InputOption::VALUE_NONE, 'Skips the execution of all scripts defined in composer.json file.'));
         $definition->addOption(new InputOption('--working-dir', '-d', InputOption::VALUE_REQUIRED, 'If specified, use the given directory as working directory.'));
         $definition->addOption(new InputOption('--no-cache', null, InputOption::VALUE_NONE, 'Prevent use of the cache'));
+        $definition->addOption(new InputOption('--cache-bust', null, InputOption::VALUE_NONE, 'Add a cache-busting parameter to Packagist queries.'));
 
         return $definition;
     }

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -430,4 +430,27 @@ class ComposerRepositoryTest extends TestCase
             'advisories' => [],
         ], $repository->getSecurityAdvisories(['foo/bar' => new Constraint('=', '1.0.0.0')]));
     }
+
+    public function testCacheBust(): void
+    {
+        $repoConfig = [
+            'url' => 'http://example.org',
+        ];
+
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader->expects(
+            [
+                ['url' => 'http://example.org/packages.json?cachebust=1', 'body' => '{"packages": []}'],
+            ],
+            true
+        );
+
+        $config = FactoryMock::createConfig();
+        $config->merge(['config' => ['cache-bust' => '1']]);
+
+        $repository = new ComposerRepository($repoConfig, new NullIO, $config, $httpDownloader);
+        $repository->findPackage('foo/bar', new Constraint('=', '1.0.0.0'));
+
+        $httpDownloader->wait();
+    }
 }


### PR DESCRIPTION
See https://github.com/composer/packagist/issues/1606

Sometimes Packagist is too aggressive wit hits caching and we need to bypass it in a pinch. This adds a `--cache-bust` flag for this purpose.