### PR TITLE
Only allow name attribute for list representation of repositories

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -194,7 +194,7 @@
             "description": "A set of additional repositories where packages can be found.",
             "additionalProperties": {
                 "anyOf": [
-                    { "$ref": "#/definitions/repository" },
+                    { "$ref": "#/definitions/anonymous-repository" },
                     { "type": "boolean", "enum": [false] }
                 ]
             },
@@ -965,6 +965,12 @@
                 { "$ref": "#/definitions/artifact-repository" },
                 { "$ref": "#/definitions/pear-repository" },
                 { "$ref": "#/definitions/package-repository" }
+            ]
+        },
+        "anonymous-repository": {
+            "allOf": [
+                { "$ref": "#/definitions/repository" },
+                { "not": { "required": ["name"] } }
             ]
         },
         "composer-repository": {

--- a/tests/Composer/Test/Json/ComposerSchemaTest.php
+++ b/tests/Composer/Test/Json/ComposerSchemaTest.php
@@ -170,6 +170,51 @@ class ComposerSchemaTest extends TestCase
         self::assertTrue($this->check($json), 'stable');
     }
 
+    public function assertAmbiguousRepositoryNotPossible(): void
+    {
+        $json = '{
+    "repositories": {
+        "foo": {
+            "name": "bar",
+            "type": "path",
+            "url": "vendor/package"
+        }
+    }
+}';
+        self::assertFalse($this->check($json));
+
+        $json = '{
+    "repositories": {
+        "foo": {
+            "type": "path",
+            "url": "vendor/package"
+        }
+    }
+}';
+        self::assertTrue($this->check($json));
+
+        $json = '{
+    "repositories": [
+        {
+            "name": "foo",
+            "type": "path",
+            "url": "vendor/package"
+        }
+    ]
+}';
+        self::assertTrue($this->check($json));
+
+        $json = '{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "vendor/package"
+        }
+    ]
+}';
+        self::assertTrue($this->check($json));
+    }
+
     /**
      * @return mixed
      */


### PR DESCRIPTION
Follow up to #12388 . It ensures, that the new and unreleased property name can only be used for the list representation to prevent ambiguous configurations.

<img width="1623" height="1053" alt="grafik" src="https://github.com/user-attachments/assets/e978148e-8b6b-421c-877f-e2367ac34583" />

@Seldaek @dzuelke I do not know if I am thinking to simple about it, but when the schema does not even allow it, it cannot go wrong anywhere. Neither IDE nor composer would work with it. And as it is about a new property, that is not yet released, we can introduce new rules around it.