### PR TITLE
Reverting 86b4aa1 to fix path resolution for vendor/bin proxies

### DIFF
--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -251,14 +251,15 @@ if (PHP_VERSION_ID < 80000) {
         {
             private \$handle;
             private \$position;
+            private \$realpath;
 
             public function stream_open(\$path, \$mode, \$options, &\$opened_path)
             {
                 // get rid of phpvfscomposer:// prefix for __FILE__ & __DIR__ resolution
                 \$opened_path = substr(\$path, 17);
-                \$realpath = realpath(\$opened_path) ?: \$opened_path;
-                \$opened_path = $phpunitHack1\$realpath;
-                \$this->handle = fopen(\$realpath, \$mode);
+                \$this->realpath = realpath(\$opened_path) ?: \$opened_path;
+                \$opened_path = $phpunitHack1\$this->realpath;
+                \$this->handle = fopen(\$this->realpath, \$mode);
                 \$this->position = 0;
 
                 return (bool) \$this->handle;


### PR DESCRIPTION
The changes introduced in https://github.com/composer/composer/pull/12499 caused the path resolution to fail, giving the following error when trying to execute any of the vendor/bin files in composer 2.9.

<img width="1281" height="202" alt="image" src="https://github.com/user-attachments/assets/ef6ae513-42bd-49cf-a6ff-f31b4a26724d" />

The issue it that some lines further down, the class variable $realpath is actually used and now missing:
<img width="926" height="474" alt="image" src="https://github.com/user-attachments/assets/26f39924-435d-460a-b93e-c88c25f407d5" />

closes #12600