### PR TITLE
Remove requirement that a full Composer instance be passed to EventDispatcher

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -710,7 +710,9 @@ class EventDispatcher
      */
     private function makeAutoloader(Event $event, $callable): void
     {
-        assert($this->composer instanceof Composer, new \LogicException('This should only be reached with a fully loaded Composer'));
+        if (!$this->composer instanceof Composer) {
+            return;
+        }
 
         if (is_array($callable)) {
             if (is_string($callable[0])) {

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -12,22 +12,16 @@
 
 namespace Composer\Test\Downloader;
 
-use Composer\Autoload\AutoloadGenerator;
 use Composer\Downloader\FileDownloader;
 use Composer\EventDispatcher\EventDispatcher;
-use Composer\IO\NullIO;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PreFileDownloadEvent;
-use Composer\Repository\InstalledArrayRepository;
-use Composer\Repository\RepositoryManager;
-use Composer\Test\Mock\HttpDownloaderMock;
-use Composer\Test\Mock\InstallationManagerMock;
 use Composer\Test\TestCase;
 use Composer\Util\Filesystem;
 use Composer\Util\Http\Response;
 use Composer\Util\Loop;
 use Composer\Config;
-use Composer\Composer;
+use Composer\PartialComposer;
 
 class FileDownloaderTest extends TestCase
 {
@@ -156,12 +150,9 @@ class FileDownloaderTest extends TestCase
             'bin-dir' => $path.'/vendor/bin',
         ]);
 
-        $composer = new Composer;
+        $composer = new PartialComposer;
         $composer->setPackage($rootPackage);
         $composer->setConfig($config);
-        $composer->setRepositoryManager($rm = new RepositoryManager(new NullIO(), $config, new HttpDownloaderMock()));
-        $rm->setLocalRepository(new InstalledArrayRepository([]));
-        $composer->setInstallationManager(new InstallationManagerMock());
 
         $expectedUrl = 'foobar';
         $expectedCacheKey = 'dummy/pkg/'.hash('sha1', $expectedUrl).'.';
@@ -174,7 +165,6 @@ class FileDownloaderTest extends TestCase
         $dispatcher->addListener(PluginEvents::PRE_FILE_DOWNLOAD, static function (PreFileDownloadEvent $event) use ($expectedUrl): void {
             $event->setProcessedUrl($expectedUrl);
         });
-        $composer->setAutoloadGenerator(new AutoloadGenerator($dispatcher));
 
         $cacheMock = $this->getMockBuilder('Composer\Cache')
             ->disableOriginalConstructor()
@@ -243,12 +233,9 @@ class FileDownloaderTest extends TestCase
             'bin-dir' => $path.'/vendor/bin',
         ]);
 
-        $composer = new Composer;
+        $composer = new PartialComposer;
         $composer->setPackage($rootPackage);
         $composer->setConfig($config);
-        $composer->setRepositoryManager($rm = new RepositoryManager(new NullIO(), $config, new HttpDownloaderMock()));
-        $rm->setLocalRepository(new InstalledArrayRepository([]));
-        $composer->setInstallationManager(new InstallationManagerMock());
 
         $expectedUrl = 'url';
         $customCacheKey = 'xyzzy';
@@ -262,7 +249,6 @@ class FileDownloaderTest extends TestCase
         $dispatcher->addListener(PluginEvents::PRE_FILE_DOWNLOAD, static function (PreFileDownloadEvent $event) use ($customCacheKey): void {
             $event->setCustomCacheKey($customCacheKey);
         });
-        $composer->setAutoloadGenerator(new AutoloadGenerator($dispatcher));
 
         $cacheMock = $this->getMockBuilder('Composer\Cache')
             ->disableOriginalConstructor()


### PR DESCRIPTION


<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
