### PR TITLE
Fix update --lock / update mirrors not working when locked packages contain vulnerabilities

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1122,7 +1122,7 @@ class Installer
     {
         $auditConfig = $this->getAuditConfig();
 
-        if ($auditConfig->blockInsecure) {
+        if ($auditConfig->blockInsecure && !$this->updateMirrors) {
             return new SecurityAdvisoryPoolFilter(new Auditor(), $auditConfig);
         }
 


### PR DESCRIPTION
Fixes #12634

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
