### PR TITLE
add support for temporary constraint wildcards in UpdateCommand

### DIFF
--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -176,13 +176,12 @@ EOT
 
                     $temporaryConstraints[$rootRequirementPackageName] = $parsedConstraint;
                     if (!Intervals::haveIntersections($parsedConstraint, $rootRequirement->getConstraint())) {
-                        $io->writeError('<error>The temporary constraint "'.$constraint.'" for "'.$package.'" matching "'. $rootRequirementPackageName .'" must be a subset of the constraint in your composer.json ('.$rootRequirement->getPrettyConstraint().')</error>');
+                        $io->writeError('<error>The temporary constraint "'.$constraint.'" for "'.$package.'" matching "'.$rootRequirementPackageName.'" must be a subset of the constraint in your composer.json ('.$rootRequirement->getPrettyConstraint().')</error>');
 
                         return self::FAILURE;
                     }
                 }
             } else {
-                $parsedConstraint = $parser->parseConstraints($constraint);
                 $temporaryConstraints[$package] = $parsedConstraint;
                 if (isset($rootRequirements[$package]) && !Intervals::haveIntersections($parsedConstraint, $rootRequirements[$package]->getConstraint())) {
                     $io->writeError('<error>The temporary constraint "'.$constraint.'" for "'.$package.'" must be a subset of the constraint in your composer.json ('.$rootRequirements[$package]->getPrettyConstraint().')</error>');

--- a/tests/Composer/Test/Command/UpdateCommandTest.php
+++ b/tests/Composer/Test/Command/UpdateCommandTest.php
@@ -564,4 +564,70 @@ OUTPUT;
 
         self::assertStringMatchesFormat(trim($expected), trim($appTester->getDisplay(true)));
     }
+
+    public function testUpdateWithTemporaryConstraintWildcardFailsIntersection(): void
+    {
+        $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'root/a', 'version' => '1.0.0'],
+                        ['name' => 'root/a', 'version' => '2.0.0'],
+                        ['name' => 'root/ab', 'version' => '1.0.0'],
+                        ['name' => 'root/ab', 'version' => '2.0.0'],
+                    ],
+                ],
+            ],
+            'require' => [
+                'root/a' => '^1',
+                'root/ab' => '^1',
+            ],
+        ]);
+
+        $package = self::getPackage('root/a', '1.0.0');
+        $package2 = self::getPackage('root/ab', '1.0.0');
+        $this->createComposerLock([$package, $package2]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(array_merge(['command' => 'update', '--dry-run' => true, '--no-audit' => true, '--no-install' => true, '--with' => ['root/*:^2']]));
+
+        $expected = <<<OUTPUT
+The temporary constraint "^2" for "root/*" matching "root/a" must be a subset of the constraint in your composer.json (^1)
+OUTPUT;
+
+        self::assertStringMatchesFormat(trim($expected), trim($appTester->getDisplay(true)));
+    }
+
+    public function testUpdateWithTemporaryConstraintWildcardMatchingNothing(): void
+    {
+        $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'root/a', 'version' => '1.0.0'],
+                        ['name' => 'root/a', 'version' => '2.0.0'],
+                    ],
+                ],
+            ],
+            'require' => [
+                'root/a' => '^1 || ^2',
+            ],
+        ]);
+
+        $package = self::getPackage('root/a', '2.0.0');
+        $this->createComposerLock([$package]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(array_merge(['command' => 'update', '--dry-run' => true, '--no-audit' => true, '--no-install' => true, '--with' => ['other/*:^1']]));
+
+        $expected = <<<OUTPUT
+Loading composer repositories with package information
+Updating dependencies
+Nothing to modify in lock file
+OUTPUT;
+
+        self::assertStringMatchesFormat(trim($expected), trim($appTester->getDisplay(true)));
+    }
 }


### PR DESCRIPTION
This will allow multiple packages to selected for update using a temporary constraint. Useful for CI/CD type workloads testing multiple supported versions for a given package like this

```shell
$ composer update --with "phpunit/*:12.4.*"
```

Updates using wildcards will only affect root requirements!

see https://github.com/composer/composer/issues/11125

