### PR TITLE
[bugfix] fix crash bumping version with composer update and disabled lockfile

### DIFF
--- a/src/Composer/Command/BumpCommand.php
+++ b/src/Composer/Command/BumpCommand.php
@@ -121,7 +121,10 @@ EOT
         unset($contents);
 
         $composer = $this->requireComposer();
-        if ($composer->getLocker()->isLocked()) {
+        $hasLockfileDisabled = !$composer->getConfig()->has('lock') || $composer->getConfig()->get('lock');
+        if (!$hasLockfileDisabled) {
+            $repo = $composer->getLocker()->getLockedRepository(true);
+        } elseif ($composer->getLocker()->isLocked()) {
             if (!$composer->getLocker()->isFresh()) {
                 $io->writeError('<error>The lock file is not up to date with the latest changes in composer.json. Run the appropriate `update` to fix that before you use the `bump` command.</error>');
 

--- a/tests/Composer/Test/Command/UpdateCommandTest.php
+++ b/tests/Composer/Test/Command/UpdateCommandTest.php
@@ -472,4 +472,40 @@ OUTPUT
         self::assertStringContainsString('Locking vulnerable/pkg (1.1.0)', $display);
         self::assertStringNotContainsString('Locking vulnerable/pkg (1.0.0)', $display);
     }
+
+    public function testBumpAfterUpdateWithoutLockfile(): void
+    {
+        $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'root/a', 'version' => '1.0.0'],
+                        ['name' => 'root/a', 'version' => '1.1.0'],
+                    ],
+                ],
+            ],
+            'require-dev' => [
+                'root/a' => '^1.0.0',
+            ],
+            'config' => [
+                'lock' => false
+            ]
+        ]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(array_merge(['command' => 'update', '--dry-run' => true,  '--no-audit' => true, '--bump-after-update' => 'dev']));
+
+        $expected = <<<OUTPUT
+Loading composer repositories with package information
+Updating dependencies
+Package operations: 1 install, 0 updates, 0 removals
+  - Installing root/a (1.1.0)
+Bumping dependencies
+./composer.json would be updated with:
+ - require-dev.root/a: ^1.1.0
+OUTPUT;
+
+        self::assertStringMatchesFormat(trim($expected), trim($appTester->getDisplay(true)));
+    }
 }


### PR DESCRIPTION
fixes a crash when using `--bump-after-update` on a project with disabled lockfile
```shell
$ cd $(mktemp -d) 
$ composer require symfony/dotenv "^6.0.0"
$ rm composer.lock
$ composer config lock false
$ composer update --bump-after-update
Loading composer repositories with package information
Updating dependencies
Nothing to install, update or remove
Generating autoload files
6 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
Bumping dependencies

In JsonFile.php line 398:

  "/dev/null" does not contain valid JSON
  Parse error on line 1:

  ^
  Expected one of: 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '['

```