### PR TITLE
fix composer compile with custom gitconfig

### DIFF
--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -49,6 +49,10 @@ class Compiler
         }
 
         $process = new ProcessExecutor();
+        $process->setEnvironment([
+            'GIT_CONFIG_GLOBAL' => '/dev/null',
+            'GIT_CONFIG_SYSTEM' => '/dev/null',
+        ]);
 
         if (0 !== $process->execute(['git', 'log', '--pretty=%H', '-n1', 'HEAD'], $output, dirname(__DIR__, 2))) {
             throw new \RuntimeException('Can\'t run git log. You must ensure to run compile from composer git repository clone and that git binary is available.');

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -75,6 +75,9 @@ class ProcessExecutor
     /** @var array<string, string> */
     private static $executables = [];
 
+    /** @var array<string,string> */
+    private $environment = [];
+
     public function __construct(?IOInterface $io = null)
     {
         $this->io = $io;
@@ -122,6 +125,7 @@ class ProcessExecutor
      */
     private function runProcess($command, ?string $cwd, ?array $env, bool $tty, &$output = null): ?int
     {
+        $env = array_merge($this->environment, $env !== null ? $env : []);
         // On Windows, we don't rely on the OS to find the executable if possible to avoid lookups
         // in the current directory which could be untrusted. Instead we use the ExecutableFinder.
 
@@ -596,5 +600,13 @@ class ProcessExecutor
         }
 
         return self::$executables[$name] ?? $name;
+    }
+
+    /**
+     * @param array<string,string> $environment
+     * @return void
+     */
+    public function setEnvironment(array $environment): void {
+        $this->environment = $environment;
     }
 }


### PR DESCRIPTION
i happen to have a git configuration:

```
[log]
    showSignature = true
```

this breaks the command to obtain the datetime for the `composer compile` build, which uses `git log -n1 --pretty=%ci` and returning something like the following output

```shell
$  git log -n1 --pretty=%ci
Good "git" signature for easteregg@verfriemelt.org with RSA key SHA256:kwWUDttgZRoJgAE8i9tHFLqCkUWEnj+S5sct1Q9dHBs
2025-12-07 11:48:18 +0100
```

to avoid custom configuration to interfere with the build process, we should ignore that leveraging env vars to disable user-specific configuration: https://git-scm.com/docs/git-config#Documentation/git-config.txt-GITCONFIGGLOBAL

to achieve that, i added `ProcessExecutor::setEnvironment(array $environment): void;` to implement that. let me know if thats something you are intrested in, then i can flesh out the testing supporting that.
