### PR TITLE
fix(AuthHelper:client-certificate): misplaced `username` and `password`

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -300,8 +300,8 @@ class AuthHelper
                     $headers[] = 'Authorization: Bearer ' . $auth['password'];
                     $authenticationDisplayMessage = 'Using Bitbucket OAuth token authentication';
                 }
-            } elseif ('client-certificate' === $auth['password']) {
-                $options['ssl'] = array_merge($options['ssl'] ?? [], json_decode((string) $auth['username'], true));
+            } elseif ('client-certificate' === $auth['username']) {
+                $options['ssl'] = array_merge($options['ssl'] ?? [], json_decode((string) $auth['password'], true));
                 $authenticationDisplayMessage = 'Using SSL client certificate';
             } else {
                 $authStr = base64_encode($auth['username'] . ':' . $auth['password']);

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -154,8 +154,8 @@ class AuthHelperTest extends TestCase
             'passphrase' => 'passphrase value',
         ];
         $auth = [
-            'username' => (string) json_encode($certificateConfiguration),
-            'password' => 'client-certificate',
+            'username' => 'client-certificate',
+            'password' => (string) json_encode($certificateConfiguration),
         ];
         $this->expectsAuthentication($origin, $auth);
         $options = $this->authHelper->addAuthenticationOptions($options, $origin, $url);


### PR DESCRIPTION
There is typo with applying transport options for Client-Certificate authorization option introduced at #12406.