### PR TITLE
Optimize plugin autoloading by avoiding regenerating classmaps and co for every package

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -581,7 +581,11 @@ EOF;
      */
     public function parseAutoloads(array $packageMap, PackageInterface $rootPackage, $filteredDevPackages = false)
     {
-        $rootPackageMap = array_shift($packageMap);
+        if (isset($packageMap[0][0]) && $packageMap[0][0] instanceof RootPackageInterface) {
+            $rootPackageMap = array_shift($packageMap);
+        } else {
+            $rootPackageMap = null;
+        }
         if (is_array($filteredDevPackages)) {
             $packageMap = array_filter($packageMap, static function ($item) use ($filteredDevPackages): bool {
                 return !in_array($item[0]->getName(), $filteredDevPackages, true);
@@ -590,7 +594,9 @@ EOF;
             $packageMap = $this->filterPackageMap($packageMap, $rootPackage);
         }
         $sortedPackageMap = $this->sortPackageMap($packageMap);
-        $sortedPackageMap[] = $rootPackageMap;
+        if ($rootPackageMap !== null) {
+            $sortedPackageMap[] = $rootPackageMap;
+        }
         $reverseSortedMap = array_reverse($sortedPackageMap);
 
         // reverse-sorted means root first, then dependents, then their dependents, etc.


### PR DESCRIPTION

If they have been loaded once it should be enough

Fixes #12680

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
