### PR TITLE
Add `source-fallback` config option to disable/enable fallback on download failure

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -104,6 +104,9 @@ resolution.
   To get the legacy behavior where Composer use `source` automatically for dev
   versions of packages, use `--prefer-install=auto`. See also [config.preferred-install](06-config.md#preferred-install).
   Passing this flag will override the config value.
+* **--source-fallback / --no-source-fallback:** Override the [config.source-fallback](06-config.md#source-fallback)
+  setting. When disabled, Composer will not fall back to an alternative download source
+  (e.g., from dist to source or vice versa) if the preferred one fails. Also see [COMPOSER_SOURCE_FALLBACK](#composer-source-fallback).
 * **--dry-run:** If you want to run through an installation without actually
   installing a package, you can use `--dry-run`. This will simulate the
   installation and show you what would happen.
@@ -192,6 +195,9 @@ php composer.phar update vendor/package:2.0.1 vendor/package2:3.0.*
   To get the legacy behavior where Composer use `source` automatically for dev
   versions of packages, use `--prefer-install=auto`. See also [config.preferred-install](06-config.md#preferred-install).
   Passing this flag will override the config value.
+* **--source-fallback / --no-source-fallback:** Override the [config.source-fallback](06-config.md#source-fallback)
+  setting. When disabled, Composer will not fall back to an alternative download source
+  (e.g., from dist to source or vice versa) if the preferred one fails. Also see [COMPOSER_SOURCE_FALLBACK](#composer-source-fallback).
 * **--dry-run:** Simulate the command without actually doing anything.
 * **--dev:** Install packages listed in `require-dev` (this is the default behavior).
 * **--no-dev:** Skip installing packages listed in `require-dev`. The autoloader generation skips the `autoload-dev` rules. Also see [COMPOSER_NO_DEV](#composer-no-dev).
@@ -285,6 +291,9 @@ If you do not want to install the new dependencies immediately you can call it w
   To get the legacy behavior where Composer use `source` automatically for dev
   versions of packages, use `--prefer-install=auto`. See also [config.preferred-install](06-config.md#preferred-install).
   Passing this flag will override the config value.
+* **--source-fallback / --no-source-fallback:** Override the [config.source-fallback](06-config.md#source-fallback)
+  setting. When disabled, Composer will not fall back to an alternative download source
+  (e.g., from dist to source or vice versa) if the preferred one fails. Also see [COMPOSER_SOURCE_FALLBACK](#composer-source-fallback).
 * **--no-progress:** Removes the progress display that can mess with some
   terminals or scripts which don't handle backspace characters.
 * **--no-update:** Disables the automatic update of the dependencies (implies --no-install).
@@ -413,6 +422,9 @@ php composer.phar reinstall "acme/*"
   To get the legacy behavior where Composer use `source` automatically for dev
   versions of packages, use `--prefer-install=auto`. See also [config.preferred-install](06-config.md#preferred-install).
   Passing this flag will override the config value.
+* **--source-fallback / --no-source-fallback:** Override the [config.source-fallback](06-config.md#source-fallback)
+  setting. When disabled, Composer will not fall back to an alternative download source
+  (e.g., from dist to source or vice versa) if the preferred one fails. Also see [COMPOSER_SOURCE_FALLBACK](#composer-source-fallback).
 * **--no-autoloader:** Skips autoloader generation.
 * **--no-progress:** Removes the progress display that can mess with some
   terminals or scripts which don't handle backspace characters.
@@ -975,6 +987,9 @@ By default the command checks for the packages on packagist.org.
   To get the legacy behavior where Composer use `source` automatically for dev
   versions of packages, use `--prefer-install=auto`. See also [config.preferred-install](06-config.md#preferred-install).
   Passing this flag will override the config value.
+* **--source-fallback / --no-source-fallback:** Override the [config.source-fallback](06-config.md#source-fallback)
+  setting. When disabled, Composer will not fall back to an alternative download source
+  (e.g., from dist to source or vice versa) if the preferred one fails. Also see [COMPOSER_SOURCE_FALLBACK](#composer-source-fallback).
 * **--repository:** Provide a custom repository to search for the package,
   which will be used instead of packagist. Can be either an HTTP URL pointing
   to a `composer` repository, a path to a local `packages.json` file, or a
@@ -1389,6 +1404,12 @@ If set to `1`, when resolving dependencies with both `--prefer-stable` and
 alpha/beta/RC versions in cases where no stable release exists. This is useful
 to test lowest versions while still preferring branches that may contain
 critical fixes over prerelease versions.
+
+### COMPOSER_SOURCE_FALLBACK
+
+If set to `0`, Composer will not fall back to an alternative download source when the
+preferred one fails. Equivalent to passing `--no-source-fallback`. See also
+[config.source-fallback](06-config.md#source-fallback).
 
 ### COMPOSER_MINIMAL_CHANGES
 

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -113,6 +113,38 @@ optionally be an object with package name patterns for keys for more granular in
 > configuration in global and package configurations the string notation
 > is translated to a `*` package pattern.
 
+## source-fallback
+
+Defaults to `true`. When set to `true`, Composer will automatically fall back
+to an alternative installation source (e.g., from dist to source or vice versa)
+when a download fails. Set to `false` to disable this behavior and fail immediately
+if the preferred source is unavailable.
+
+```json
+{
+    "config": {
+        "source-fallback": false
+    }
+}
+```
+
+This can also be specified on the command line:
+
+```bash
+composer install --no-source-fallback
+composer update --source-fallback
+```
+
+Or via the `COMPOSER_SOURCE_FALLBACK` environment variable:
+
+```bash
+COMPOSER_SOURCE_FALLBACK=0 composer install
+```
+
+> **Note:** When this option is disabled and a download fails, Composer will
+> immediately throw an error instead of trying alternative sources. Make sure
+> your preferred installation source (`preferred-install`) is correctly configured.
+
 ## audit
 
 Security audit and version blocking configuration options. Audit reports can be generated with `composer audit`

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -572,6 +572,10 @@
                     "type": "boolean",
                     "description": "Composer allows repositories to define a notification URL, so that they get notified whenever a package from that repository is installed. This option allows you to disable that behaviour, defaults to true."
                 },
+                "source-fallback": {
+                    "type": "boolean",
+                    "description": "If true (default), Composer will fall back to a different installation source (e.g., from dist to source or vice versa) when a download fails. Set to false to disable this behavior."
+                },
                 "github-protocols": {
                     "type": "array",
                     "description": "A list of protocols to use for github.com clones, in priority order, defaults to [\"https\", \"ssh\", \"git\"].",

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -425,6 +425,7 @@ EOT
             'update-with-minimal-changes' => [$booleanValidator, $booleanNormalizer],
             'disable-tls' => [$booleanValidator, $booleanNormalizer],
             'secure-http' => [$booleanValidator, $booleanNormalizer],
+            'source-fallback' => [$booleanValidator, $booleanNormalizer],
             'bump-after-update' => [
                 static function ($val): bool {
                     return in_array($val, ['dev', 'no-dev', 'true', 'false', '1', '0'], true);

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -95,6 +95,7 @@ class CreateProjectCommand extends BaseCommand
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
                 new InputOption('ask', null, InputOption::VALUE_NONE, 'Whether to ask for project directory.'),
+                new InputOption('source-fallback', null, InputOption::VALUE_NEGATABLE, 'Whether to fall back to alternative sources (dist/source) on download failure.'),
             ])
             ->setHelp(
                 <<<EOT
@@ -242,6 +243,7 @@ EOT
             $installer = Installer::create($io, $composer);
             $installer->setPreferSource($preferSource)
                 ->setPreferDist($preferDist)
+                ->setSourceFallback($input->getOption('source-fallback') ?? $config->get('source-fallback'))
                 ->setDevMode($installDevPackages)
                 ->setPlatformRequirementFilter($platformRequirementFilter)
                 ->setSuggestedPackagesReporter($this->suggestedPackagesReporter)
@@ -457,7 +459,8 @@ EOT
 
         $dm = $composer->getDownloadManager();
         $dm->setPreferSource($preferSource)
-            ->setPreferDist($preferDist);
+            ->setPreferDist($preferDist)
+            ->setSourceFallback($input->getOption('source-fallback') ?? $config->get('source-fallback'));
 
         $projectInstaller = new ProjectInstaller($directory, $dm, $fs);
         $im = $composer->getInstallationManager();

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -60,6 +60,7 @@ class InstallCommand extends BaseCommand
                 new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
+                new InputOption('source-fallback', null, InputOption::VALUE_NEGATABLE, 'Whether to fall back to alternative sources (dist/source) on download failure.'),
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Should not be provided, use composer require instead to add a given package to composer.json.'),
             ])
             ->setHelp(
@@ -127,6 +128,7 @@ EOT
             ->setVerbose($input->getOption('verbose'))
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
+            ->setSourceFallback($input->getOption('source-fallback') ?? $config->get('source-fallback'))
             ->setDevMode(!$input->getOption('no-dev'))
             ->setDumpAutoloader(!$input->getOption('no-autoloader'))
             ->setOptimizeAutoloader($optimize)

--- a/src/Composer/Command/ReinstallCommand.php
+++ b/src/Composer/Command/ReinstallCommand.php
@@ -52,6 +52,7 @@ class ReinstallCommand extends BaseCommand
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
                 new InputOption('type', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter packages to reinstall by type(s)', null, $this->suggestInstalledPackageTypes(false)),
+                new InputOption('source-fallback', null, InputOption::VALUE_NEGATABLE, 'Whether to fall back to alternative sources (dist/source) on download failure.'),
                 new InputArgument('packages', InputArgument::IS_ARRAY, 'List of package names to reinstall, can include a wildcard (*) to match any substring.', null, $this->suggestInstalledPackage(false)),
             ])
             ->setHelp(
@@ -160,6 +161,7 @@ EOT
 
         $downloadManager->setPreferSource($preferSource);
         $downloadManager->setPreferDist($preferDist);
+        $downloadManager->setSourceFallback($input->getOption('source-fallback') ?? $config->get('source-fallback'));
 
         $devMode = $localRepo->getDevMode() !== null ? $localRepo->getDevMode() : true;
 

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -105,6 +105,7 @@ class RequireCommand extends BaseCommand
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
                 new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
                 new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
+                new InputOption('source-fallback', null, InputOption::VALUE_NEGATABLE, 'Whether to fall back to alternative sources (dist/source) on download failure.'),
             ])
             ->setHelp(
                 <<<EOT
@@ -471,6 +472,7 @@ EOT
             ->setVerbose($input->getOption('verbose'))
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
+            ->setSourceFallback($input->getOption('source-fallback') ?? $composer->getConfig()->get('source-fallback'))
             ->setDevMode($updateDevMode)
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -68,6 +68,7 @@ class UpdateCommand extends BaseCommand
                 new InputOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation'),
                 new InputOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
+                new InputOption('source-fallback', null, InputOption::VALUE_NEGATABLE, 'Whether to fall back to alternative sources (dist/source) on download failure.'),
                 new InputOption('with-dependencies', 'w', InputOption::VALUE_NONE, 'Update also dependencies of packages in the argument list, except those which are root requirements (can also be set via the COMPOSER_WITH_DEPENDENCIES=1 env var).'),
                 new InputOption('with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Update also dependencies of packages in the argument list, including those which are root requirements (can also be set via the COMPOSER_WITH_ALL_DEPENDENCIES=1 env var).'),
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
@@ -253,6 +254,7 @@ EOT
             ->setVerbose($input->getOption('verbose'))
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
+            ->setSourceFallback($input->getOption('source-fallback') ?? $config->get('source-fallback'))
             ->setDevMode(!$input->getOption('no-dev'))
             ->setDumpAutoloader(!$input->getOption('no-autoloader'))
             ->setOptimizeAutoloader($optimize)

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -91,6 +91,7 @@ class Config
         'client-certificate' => [],
         'forgejo-domains' => ['codeberg.org'],
         'forgejo-token' => [],
+        'source-fallback' => true,
     ];
 
     /** @var array<string, mixed> */
@@ -338,6 +339,7 @@ class Config
             // booleans with env var support
             case 'cache-read-only':
             case 'htaccess-protect':
+            case 'source-fallback':
                 // convert foo-bar to COMPOSER_FOO_BAR and check if it exists since it overrides the local config
                 $env = 'COMPOSER_' . strtoupper(strtr($key, '-', '_'));
 

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -217,7 +217,7 @@ class DownloadManager
                                 ' from ' . $source . ': '.
                                 $e->getMessage().'</warning>'
                             );
-                            $io->writeError('    <warning>Source fallback is disabled via config. Not trying alternative sources.</warning>');
+                            $io->writeError('    <warning>Source fallback is disabled. Not trying alternative sources.</warning>');
                         }
                         throw $e;
                     }

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -529,6 +529,10 @@ class Factory
             $dm->setPreferences($preferred);
         }
 
+        if (!$config->get('source-fallback')) {
+            $dm->setSourceFallback(false);
+        }
+
         $dm->setDownloader('git', new Downloader\GitDownloader($io, $config, $process, $fs));
         $dm->setDownloader('svn', new Downloader\SvnDownloader($io, $config, $process, $fs));
         $dm->setDownloader('fossil', new Downloader\FossilDownloader($io, $config, $process, $fs));

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -141,6 +141,8 @@ class Installer
     /** @var bool */
     protected $preferDist = false;
     /** @var bool */
+    protected $sourceFallback = true;
+    /** @var bool */
     protected $optimizeAutoloader = false;
     /** @var bool */
     protected $classMapAuthoritative = false;
@@ -294,6 +296,7 @@ class Installer
 
         $this->downloadManager->setPreferSource($this->preferSource);
         $this->downloadManager->setPreferDist($this->preferDist);
+        $this->downloadManager->setSourceFallback($this->sourceFallback);
 
         $localRepo = $this->repositoryManager->getLocalRepository();
 
@@ -1237,6 +1240,16 @@ class Installer
     public function setPreferDist(bool $preferDist = true): self
     {
         $this->preferDist = $preferDist;
+
+        return $this;
+    }
+
+    /**
+     * Allow fallback to alternative sources when download fails.
+     */
+    public function setSourceFallback(bool $sourceFallback): self
+    {
+        $this->sourceFallback = $sourceFallback;
 
         return $this;
     }

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -468,4 +468,37 @@ class ConfigTest extends TestCase
         $config->merge(['config' => ['allow-plugins' => true]]);
         self::assertEquals(true, $config->get('allow-plugins'));
     }
+
+    public function testSourceFallbackDefaultsToTrue(): void
+    {
+        $config = new Config(false);
+        self::assertTrue($config->get('source-fallback'));
+    }
+
+    public function testSourceFallbackCanBeDisabled(): void
+    {
+        $config = new Config(false);
+        $config->merge(['config' => ['source-fallback' => false]]);
+        self::assertFalse($config->get('source-fallback'));
+    }
+
+    public function testSourceFallbackCanBeSetFromString(): void
+    {
+        $config = new Config(false);
+        $config->merge(['config' => ['source-fallback' => 'false']]);
+        self::assertFalse($config->get('source-fallback'));
+
+        $config->merge(['config' => ['source-fallback' => 'true']]);
+        self::assertTrue($config->get('source-fallback'));
+    }
+
+    public function testSourceFallbackEnvOverride(): void
+    {
+        Platform::putEnv('COMPOSER_SOURCE_FALLBACK', '0');
+        $config = new Config(true);
+        $result = $config->get('source-fallback');
+        Platform::clearEnv('COMPOSER_SOURCE_FALLBACK');
+
+        self::assertFalse($result);
+    }
 }


### PR DESCRIPTION
  ### Background

By default, Composer silently falls back to cloning from source when dist downloads fail. While convenient, this behavior can be problematic in production/CI environments where:

  - Unpredictable build artifacts: Source installations include `.git` directories and other VCS files, causing deployments to fail or behave unexpectedly
  - Silent failures: Users have no way to detect when fallback occurs, making issues hard to diagnose

  ### Usage

  #### Config file:
```json
  {
      "config": {
          "source-fallback": false
      }
  }
```

  #### Command line:
  `composer install --no-source-fallback`
  `composer update --source-fallback`

  #### Environment variable:
  `COMPOSER_SOURCE_FALLBACK=0 composer install`

  ### Behavior

  - true (default): Current behavior - fallback to alternative source on failure
  - false: Fail immediately if preferred source is unavailable

  When disabled and a download fails, Composer will display a clear error message explaining that fallback is disabled, rather than silently trying alternatives.

  ### Changes

  - Added source-fallback config option (defaults to true)
  - Added --[no-]source-fallback flag to install, update, require, reinstall, and create-project commands
  - Added environment variable support (COMPOSER_SOURCE_FALLBACK)
  - Added tests for config and download manager behavior

  Fixes #4591

