### PR TITLE
Disable HTTP/3 when HTTP proxy is used

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -240,7 +240,7 @@ class CurlDownloader
         $proxy = ProxyManager::getInstance()->getProxyForRequest($url);
 
         if (0 === strpos($url, 'https://')) {
-            $willUseProxy = !empty($proxy->getStatus()) && !$proxy->isExcludedByNoProxy();
+            $willUseProxy = $proxy->getStatus() !== '' && !$proxy->isExcludedByNoProxy();
 
             if (!$willUseProxy && \defined('CURL_VERSION_HTTP3') && \defined('CURL_HTTP_VERSION_3') && (CURL_VERSION_HTTP3 & $features) !== 0) {
                 curl_setopt($curlHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3);


### PR DESCRIPTION
HTTP/3 is not supported over an HTTP proxy. This change adds a check to detect when a proxy will be used for a request and falls back to HTTP/2 instead of attempting to use HTTP/3, preventing connection errors.

<img width="1374" height="220" alt="image" src="https://github.com/user-attachments/assets/f4954162-9170-4ec7-afb8-d0e30700203f" />
