### PR TITLE
Fix git rev-list usages to support older git versions

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -256,16 +256,6 @@ parameters:
 			path: ../src/Composer/Command/ConfigCommand.php
 
 		-
-			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
-			count: 1
-			path: ../src/Composer/Command/ConfigCommand.php
-
-		-
-			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
-			count: 1
-			path: ../src/Composer/Command/RepositoryCommand.php
-
-		-
 			message: "#^Only booleans are allowed in &&, Composer\\\\Package\\\\PackageInterface\\|false given on the right side\\.$#"
 			count: 1
 			path: ../src/Composer/Command/CreateProjectCommand.php
@@ -491,6 +481,11 @@ parameters:
 			path: ../src/Composer/Command/RemoveCommand.php
 
 		-
+			message: "#^Parameter \\#3 \\$referenceName of method Composer\\\\Config\\\\JsonConfigSource\\:\\:insertRepository\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: ../src/Composer/Command/RepositoryCommand.php
+
+		-
 			message: "#^Cannot call method getRepoName\\(\\) on Composer\\\\Repository\\\\RepositoryInterface\\|null\\.$#"
 			count: 2
 			path: ../src/Composer/Command/RequireCommand.php
@@ -574,12 +569,6 @@ parameters:
 			message: "#^Variable \\$match might not be defined\\.$#"
 			count: 2
 			path: ../src/Composer/Command/SelfUpdateCommand.php
-
-		# one of these parameters will be non-null
-		-
-			message: "#^Parameter \\#3 \\$referenceName of method Composer\\\\Config\\\\JsonConfigSource\\:\\:insertRepository\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/Command/RepositoryCommand.php
 
 		-
 			message: "#^Argument of an invalid type array\\<int, array\\<string, array\\|string\\>\\>\\|string supplied for foreach, only iterables are supported\\.$#"
@@ -1378,11 +1367,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a ternary operator condition, string\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/EventDispatcher/EventDispatcher.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, Composer\\\\Autoload\\\\ClassLoader\\|null given\\.$#"
 			count: 1
 			path: ../src/Composer/EventDispatcher/EventDispatcher.php
 
@@ -2660,16 +2644,6 @@ parameters:
 			path: ../src/Composer/Repository/Vcs/GitBitbucketDriver.php
 
 		-
-			message: "#^Cannot call method read\\(\\) on Composer\\\\Cache\\|null\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/GitBitbucketDriver.php
-
-		-
-			message: "#^Cannot call method write\\(\\) on Composer\\\\Cache\\|null\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/GitBitbucketDriver.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 4
 			path: ../src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -2726,16 +2700,6 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/GitHubDriver.php
-
-		-
-			message: "#^Cannot call method read\\(\\) on Composer\\\\Cache\\|null\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/GitHubDriver.php
-
-		-
-			message: "#^Cannot call method write\\(\\) on Composer\\\\Cache\\|null\\.$#"
 			count: 1
 			path: ../src/Composer/Repository/Vcs/GitHubDriver.php
 
@@ -2822,16 +2786,6 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 4
-			path: ../src/Composer/Repository/Vcs/GitLabDriver.php
-
-		-
-			message: "#^Cannot call method read\\(\\) on Composer\\\\Cache\\|null\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/GitLabDriver.php
-
-		-
-			message: "#^Cannot call method write\\(\\) on Composer\\\\Cache\\|null\\.$#"
-			count: 1
 			path: ../src/Composer/Repository/Vcs/GitLabDriver.php
 
 		-
@@ -2935,16 +2889,6 @@ parameters:
 			path: ../src/Composer/Repository/Vcs/PerforceDriver.php
 
 		-
-			message: "#^Cannot call method read\\(\\) on Composer\\\\Cache\\|null\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/SvnDriver.php
-
-		-
-			message: "#^Cannot call method write\\(\\) on Composer\\\\Cache\\|null\\.$#"
-			count: 2
-			path: ../src/Composer/Repository/Vcs/SvnDriver.php
-
-		-
 			message: "#^Method Composer\\\\Repository\\\\Vcs\\\\SvnDriver\\:\\:getRootIdentifier\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: ../src/Composer/Repository/Vcs/SvnDriver.php
@@ -2963,16 +2907,6 @@ parameters:
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: ../src/Composer/Repository/Vcs/SvnDriver.php
-
-		-
-			message: "#^Cannot call method read\\(\\) on Composer\\\\Cache\\|null\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/VcsDriver.php
-
-		-
-			message: "#^Cannot call method write\\(\\) on Composer\\\\Cache\\|null\\.$#"
-			count: 1
-			path: ../src/Composer/Repository/Vcs/VcsDriver.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
@@ -4306,6 +4240,11 @@ parameters:
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: ../tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
+
+		-
+			message: "#^Only booleans are allowed in and, null given on the right side\\.$#"
+			count: 2
+			path: ../tests/Composer/Test/Package/Version/VersionGuesserTest.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"

--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -133,7 +133,7 @@ class VersionGuesser
      */
     private function guessGitVersion(array $packageConfig, string $path): array
     {
-        GitUtil::cleanEnv();
+        GitUtil::cleanEnv($this->process);
         $commit = null;
         $version = null;
         $prettyVersion = null;
@@ -197,9 +197,9 @@ class VersionGuesser
         }
 
         if (null === $commit) {
-            $command = array_merge(['git', 'rev-list', '--no-commit-header', '--format=%H', '-n1', 'HEAD'], GitUtil::getNoShowSignatureFlags($this->process));
+            $command = GitUtil::buildRevListCommand($this->process, array_merge(['--format=%H', '-n1', 'HEAD'], GitUtil::getNoShowSignatureFlags($this->process)));
             if (0 === $this->process->execute($command, $output, $path)) {
-                $commit = trim($output) ?: null;
+                $commit = trim(GitUtil::parseRevListOutput($output, $this->process)) ?: null;
             }
         }
 

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -203,8 +203,9 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
             }
 
             $output = '';
-            if ('auto' === $reference && is_dir($path . DIRECTORY_SEPARATOR . '.git') && 0 === $this->process->execute(array_merge(['git', 'rev-list', '--no-commit-header', '-n1', '--format=%H', 'HEAD'], GitUtil::getNoShowSignatureFlags($this->process)), $output, $path)) {
-                $package['dist']['reference'] = trim($output);
+            $command = GitUtil::buildRevListCommand($this->process, array_merge(['-n1', '--format=%H', 'HEAD'], GitUtil::getNoShowSignatureFlags($this->process)));
+            if ('auto' === $reference && is_dir($path . DIRECTORY_SEPARATOR . '.git') && 0 === $this->process->execute($command, $output, $path)) {
+                $package['dist']['reference'] = trim(GitUtil::parseRevListOutput($output, $this->process));
             }
 
             if (!isset($package['version'])) {

--- a/tests/Composer/Test/Package/Version/VersionGuesserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionGuesserTest.php
@@ -27,6 +27,17 @@ class VersionGuesserTest extends TestCase
         if (!function_exists('proc_open')) {
             $this->markTestSkipped('proc_open() is not available');
         }
+
+        $reflProp = new \ReflectionProperty(GitUtil::class, 'version');
+        (\PHP_VERSION_ID < 80100) and $reflProp->setAccessible(true);
+        $reflProp->setValue(null, false);
+    }
+
+    public function tearDown(): void
+    {
+        $reflProp = new \ReflectionProperty(GitUtil::class, 'version');
+        (\PHP_VERSION_ID < 80100) and $reflProp->setAccessible(true);
+        $reflProp->setValue(null, false);
     }
 
     public function testHgGuessVersionReturnsData(): void
@@ -35,15 +46,14 @@ class VersionGuesserTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.33.0'],
             ['cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'], 'return' => 128],
             ['cmd' => ['git', 'describe', '--exact-match', '--tags'], 'return' => 128],
-            ['cmd' => array_merge(['git', 'rev-list', '--no-commit-header', '--format=%H', '-n1', 'HEAD'], GitUtil::getNoShowSignatureFlags($process)), 'return' => 128],
+            ['cmd' => ['git', 'rev-list', '--no-commit-header', '--format=%H', '-n1', 'HEAD', '--no-show-signature'], 'return' => 128],
             ['cmd' => ['hg', 'branch'], 'return' => 0, 'stdout' => $branch],
             ['cmd' => ['hg', 'branches'], 'return' => 0],
             ['cmd' => ['hg', 'bookmarks'], 'return' => 0],
         ], true);
-
-        GitUtil::getVersion(new ProcessExecutor);
 
         $config = new Config;
         $config->merge(['repositories' => ['packagist' => false]]);
@@ -63,6 +73,7 @@ class VersionGuesserTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* master $commitHash Commit message\n(no branch) $anotherCommitHash Commit message\n",
@@ -89,6 +100,7 @@ class VersionGuesserTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 // Assumption here is that arbitrary would be the default branch
@@ -113,6 +125,7 @@ class VersionGuesserTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "  arbitrary $commitHash Commit message\n* feature $anotherCommitHash Another message\n",
@@ -143,6 +156,7 @@ class VersionGuesserTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "  latest-testing $commitHash Commit message\n* feature $anotherCommitHash Another message\n",
@@ -173,6 +187,7 @@ class VersionGuesserTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* latest-testing $commitHash Commit message\n  current $anotherCommitHash Another message\n  master $anotherCommitHash Another message\n",
@@ -197,6 +212,7 @@ class VersionGuesserTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* (no branch) $commitHash Commit message\n",
@@ -219,6 +235,7 @@ class VersionGuesserTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* (HEAD detached at FETCH_HEAD) $commitHash Commit message\n",
@@ -241,6 +258,7 @@ class VersionGuesserTest extends TestCase
 
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* (HEAD detached at 03a15d220) $commitHash Commit message\n",
@@ -261,6 +279,7 @@ class VersionGuesserTest extends TestCase
     {
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* (HEAD detached at v2.0.5-alpha2) 433b98d4218c181bae01865901aac045585e8a1a Commit message\n",
@@ -284,6 +303,7 @@ class VersionGuesserTest extends TestCase
     {
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* (HEAD detached at 1.0.0) c006f0c12bbbf197b5c071ffb1c0e9812bb14a4d Commit message\n",
@@ -308,6 +328,7 @@ class VersionGuesserTest extends TestCase
     {
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* foo 03a15d220da53c52eddd5f32ffca64a7b3801bea Commit message\n",
@@ -327,6 +348,7 @@ class VersionGuesserTest extends TestCase
     {
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* 1.5 03a15d220da53c52eddd5f32ffca64a7b3801bea Commit message\n",
@@ -347,6 +369,7 @@ class VersionGuesserTest extends TestCase
     {
         $process = $this->getProcessExecutorMock();
         $process->expects([
+            ['cmd' => ['git', '--version'], 'return' => 0, 'stdout' => 'git version 2.52.0'],
             [
                 'cmd' => ['git', 'branch', '-a', '--no-color', '--no-abbrev', '-v'],
                 'stdout' => "* feature-branch 03a15d220da53c52eddd5f32ffca64a7b3801bea Commit message\n".


### PR DESCRIPTION
Fixes #12701

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
