### PR TITLE
Sanitize invalid unicode sequences into question marks to avoid preg errors

### DIFF
--- a/tests/Composer/Test/IO/ConsoleIOTest.php
+++ b/tests/Composer/Test/IO/ConsoleIOTest.php
@@ -494,6 +494,37 @@ class ConsoleIOTest extends TestCase
                 'allowNewlines' => true,
                 'expected' => "Warning: File not found\nRetrying...",
             ],
+            // Malformed UTF-8 handling
+            'malformed UTF-8 single byte' => [
+                'input' => "Hello\xFFWorld",
+                'allowNewlines' => true,
+                'expected' => "Hello?World",
+            ],
+            'malformed UTF-8 multiple bytes' => [
+                'input' => "Test\xC3\x28Data",
+                'allowNewlines' => true,
+                'expected' => "Test?(Data",
+            ],
+            'malformed UTF-8 with ANSI escape' => [
+                'input' => "Line\xFF\x1B[31mColor\xFE",
+                'allowNewlines' => true,
+                'expected' => "Line?Color?",
+            ],
+            'malformed UTF-8 in array' => [
+                'input' => ["Item\xFF", "Data\xC3\x28"],
+                'allowNewlines' => true,
+                'expected' => ["Item?", "Data?("],
+            ],
+            'valid UTF-8 unchanged' => [
+                'input' => "Hello 世界 Test",
+                'allowNewlines' => true,
+                'expected' => "Hello 世界 Test",
+            ],
+            'mixed valid and invalid UTF-8' => [
+                'input' => "Hello\xFF世界\xFETest",
+                'allowNewlines' => true,
+                'expected' => "Hello?世界?Test",
+            ],
         ];
     }
 }


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
