### PR TITLE
Work around issue with msys/rmdir on windows

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -109,6 +109,12 @@ class Filesystem
         }
 
         if (Platform::isWindows()) {
+            // Work around bug on MSYS for safety if the path contains an equal sign, see https://github.com/composer/composer/issues/11568
+            // TODO remove if https://github.com/symfony/symfony/issues/62921 is fixed and we can upgrade to a version with the fix
+            if (str_contains($directory, '=')) {
+                return $this->removeDirectoryPhp($directory);
+            }
+
             $cmd = ['rmdir', '/S', '/Q', Platform::realpath($directory)];
         } else {
             $cmd = ['rm', '-rf', $directory];
@@ -144,6 +150,12 @@ class Filesystem
         }
 
         if (Platform::isWindows()) {
+            // Work around bug on MSYS for safety if the path contains an equal sign, see https://github.com/composer/composer/issues/11568
+            // TODO remove if https://github.com/symfony/symfony/issues/62921 is fixed and we can upgrade to a version with the fix
+            if (str_contains($directory, '=')) {
+                return \React\Promise\resolve($this->removeDirectoryPhp($directory));
+            }
+
             $cmd = ['rmdir', '/S', '/Q', Platform::realpath($directory)];
         } else {
             $cmd = ['rm', '-rf', $directory];


### PR DESCRIPTION
Fixes #11568

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
