### PR TITLE
Add support for PIE list of download-url-methods

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -324,10 +324,28 @@
                     "default": null
                 },
                 "download-url-method": {
-                    "type": "string",
-                    "description": "If specified, this technique will be used to override the URL that PIE uses to download the asset. The default, if not specified, is composer-default.",
-                    "enum": ["composer-default", "pre-packaged-source"],
-                    "example": "composer-default"
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "description": "If specified, this technique will be used to override the URL that PIE uses to download the asset. The default, if not specified, is composer-default.",
+                            "deprecated": true,
+                            "enum": ["composer-default", "pre-packaged-source", "pre-packaged-binary"],
+                            "example": "composer-default",
+                            "default": "composer-default"
+                        },
+                        {
+                            "type": "array",
+                            "description": "Multiple techniques can be specified, in which case PIE will try each in turn until one succeeds. The first technique that succeeds will be used.",
+                            "items": {
+                                "type": "string",
+                                "description": "If specified, this technique will be used to override the URL that PIE uses to download the asset. The default, if not specified, is composer-default.",
+                                "enum": ["composer-default", "pre-packaged-source", "pre-packaged-binary"],
+                                "example": ["pre-packaged-binary", "composer-default"]
+                            },
+                            "minItems": 1,
+                            "default": ["composer-default"]
+                        }
+                    ]
                 },
                 "os-families": {
                     "type": "array",

--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -302,12 +302,27 @@ class ValidatingArrayLoader implements LoaderInterface
             }
 
             if (isset($phpExt['download-url-method'])) {
-                if (!is_string($phpExt['download-url-method'])) {
-                    $this->errors[] = 'php-ext.download-url-method : should be a string, '.get_debug_type($phpExt['download-url-method']).' given';
+                if (!is_array($phpExt['download-url-method']) && !is_string($phpExt['download-url-method'])) {
+                    $this->errors[] = 'php-ext.download-url-method : should be an array or a string, '.get_debug_type($phpExt['download-url-method']).' given';
                     unset($phpExt['download-url-method']);
-                } elseif (!in_array($phpExt['download-url-method'], ['composer-default', 'pre-packaged-source'], true)) {
-                    $this->errors[] = 'php-ext.download-url-method : invalid value ('.$phpExt['download-url-method'].'), must be one of composer-default, pre-packaged-source';
-                    unset($phpExt['download-url-method']);
+                } else {
+                    $validDownloadUrlMethods = ['composer-default', 'pre-packaged-source', 'pre-packaged-binary'];
+                    $definedDownloadUrlMethods = is_array($phpExt['download-url-method']) ? $phpExt['download-url-method'] : [$phpExt['download-url-method']];
+
+                    if ([] === $definedDownloadUrlMethods) {
+                        $this->errors[] = 'php-ext.download-url-method : must contain at least one element';
+                        unset($phpExt['download-url-method']);
+                    } else {
+                        foreach ($definedDownloadUrlMethods as $key => $downloadUrlMethod) {
+                            if (!is_string($downloadUrlMethod)) {
+                                $this->errors[] = 'php-ext.download-url-method.'.$key.' : should be a string, '.get_debug_type($downloadUrlMethod).' given';
+                                unset($phpExt['download-url-method']);
+                            } elseif (!in_array($downloadUrlMethod, $validDownloadUrlMethods, true)) {
+                                $this->errors[] = 'php-ext.download-url-method.'.$key.' : invalid value ('.$downloadUrlMethod.'), must be one of ' . implode(', ', $validDownloadUrlMethods);
+                                unset($phpExt['download-url-method']);
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/Composer/Package/PackageInterface.php
+++ b/src/Composer/Package/PackageInterface.php
@@ -23,7 +23,7 @@ use Composer\Repository\RepositoryInterface;
  *
  * @phpstan-type AutoloadRules    array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
  * @phpstan-type DevAutoloadRules array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>}
- * @phpstan-type PhpExtConfig     array{extension-name?: string, priority?: int, support-zts?: bool, support-nts?: bool, build-path?: string|null, download-url-method?: string, os-families?: non-empty-list<non-empty-string>, os-families-exclude?: non-empty-list<non-empty-string>, configure-options?: list<array{name: string, description?: string}>}
+ * @phpstan-type PhpExtConfig     array{extension-name?: string, priority?: int, support-zts?: bool, support-nts?: bool, build-path?: string|null, download-url-method?: string|list<string>, os-families?: non-empty-list<non-empty-string>, os-families-exclude?: non-empty-list<non-empty-string>, configure-options?: list<array{name: string, description?: string}>}
  */
 interface PackageInterface
 {

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -242,6 +242,24 @@ class ValidatingArrayLoaderTest extends TestCase
                     ],
                 ],
             ],
+            [ // valid php-ext with one download-url-method in a list
+                [
+                    'name' => 'foo/bar',
+                    'type' => 'php-ext',
+                    'php-ext' => [
+                        'download-url-method' => ['pre-packaged-binary'],
+                    ],
+                ],
+            ],
+            [ // valid php-ext with multiple download-url-methods
+                [
+                    'name' => 'foo/bar',
+                    'type' => 'php-ext',
+                    'php-ext' => [
+                        'download-url-method' => ['pre-packaged-binary', 'pre-packaged-source', 'composer-default'],
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -537,7 +555,7 @@ class ValidatingArrayLoaderTest extends TestCase
                         'download-url-method' => 123,
                     ],
                 ],
-                ['php-ext.download-url-method : should be a string, int given'],
+                ['php-ext.download-url-method : should be an array or a string, int given'],
             ],
             [
                 [
@@ -547,7 +565,54 @@ class ValidatingArrayLoaderTest extends TestCase
                         'download-url-method' => 'invalid-method',
                     ],
                 ],
-                ['php-ext.download-url-method : invalid value (invalid-method), must be one of composer-default, pre-packaged-source'],
+                ['php-ext.download-url-method.0 : invalid value (invalid-method), must be one of composer-default, pre-packaged-source, pre-packaged-binary'],
+            ],
+            [
+                [
+                    'name' => 'foo/bar',
+                    'type' => 'php-ext',
+                    'php-ext' => [
+                        'download-url-method' => [],
+                    ],
+                ],
+                ['php-ext.download-url-method : must contain at least one element'],
+            ],
+            [
+                [
+                    'name' => 'foo/bar',
+                    'type' => 'php-ext',
+                    'php-ext' => [
+                        'download-url-method' => [1, true, []],
+                    ],
+                ],
+                [
+                    'php-ext.download-url-method.0 : should be a string, int given',
+                    'php-ext.download-url-method.1 : should be a string, bool given',
+                    'php-ext.download-url-method.2 : should be a string, array given',
+                ],
+            ],
+            [
+                [
+                    'name' => 'foo/bar',
+                    'type' => 'php-ext',
+                    'php-ext' => [
+                        'download-url-method' => ['invalid-method', 'composer-default'],
+                    ],
+                ],
+                ['php-ext.download-url-method.0 : invalid value (invalid-method), must be one of composer-default, pre-packaged-source, pre-packaged-binary'],
+            ],
+            [
+                [
+                    'name' => 'foo/bar',
+                    'type' => 'php-ext',
+                    'php-ext' => [
+                        'download-url-method' => ['invalid-method', 'another-invalid-method'],
+                    ],
+                ],
+                [
+                    'php-ext.download-url-method.0 : invalid value (invalid-method), must be one of composer-default, pre-packaged-source, pre-packaged-binary',
+                    'php-ext.download-url-method.1 : invalid value (another-invalid-method), must be one of composer-default, pre-packaged-source, pre-packaged-binary',
+                ],
             ],
             [
                 [


### PR DESCRIPTION
New upcoming feature in PIE needs `php-ext.download-url-method` to support a list of strings. For backwards compatibility (and simplicity, really), a string is still supported