### PR TITLE
Relay GitHub API error messages to the user on auth failures

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -81,7 +81,7 @@ class AuthHelper
      *                                retried, if storeAuth is true then on a successful retry the authentication should be persisted to auth.json
      * @phpstan-return array{retry: bool, storeAuth: 'prompt'|bool}
      */
-    public function promptAuthIfNeeded(string $url, string $origin, int $statusCode, ?string $reason = null, array $headers = [], int $retryCount = 0): array
+    public function promptAuthIfNeeded(string $url, string $origin, int $statusCode, ?string $reason = null, array $headers = [], int $retryCount = 0, ?string $responseBody = null): array
     {
         $storeAuth = false;
 
@@ -118,11 +118,24 @@ class AuthHelper
                     $rateLimit['reset']
                 )."\n";
             } else {
-                $message .= 'Could not fetch '.$url.', please ';
-                if ($this->io->hasAuthentication($origin)) {
-                    $message .= 'review your configured GitHub OAuth token or enter a new one to access private repos';
+                // Try to extract a more specific error message from GitHub's API response
+                $gitHubApiMessage = null;
+                if ($responseBody !== null) {
+                    $decoded = json_decode($responseBody, true);
+                    if (is_array($decoded) && isset($decoded['message']) && is_string($decoded['message'])) {
+                        $gitHubApiMessage = $decoded['message'];
+                    }
+                }
+
+                if ($gitHubApiMessage !== null) {
+                    $message .= 'Could not fetch '.$url.': '.$gitHubApiMessage;
                 } else {
-                    $message .= 'create a GitHub OAuth token to access private repos';
+                    $message .= 'Could not fetch '.$url.', please ';
+                    if ($this->io->hasAuthentication($origin)) {
+                        $message .= 'review your configured GitHub OAuth token or enter a new one to access private repos';
+                    } else {
+                        $message .= 'create a GitHub OAuth token to access private repos';
+                    }
                 }
             }
 

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -575,7 +575,7 @@ class CurlDownloader
     private function isAuthenticatedRetryNeeded(array $job, Response $response): array
     {
         if (in_array($response->getStatusCode(), [401, 403]) && $job['attributes']['retryAuthFailure']) {
-            $result = $this->authHelper->promptAuthIfNeeded($job['url'], $job['origin'], $response->getStatusCode(), $response->getStatusMessage(), $response->getHeaders(), $job['attributes']['retries']);
+            $result = $this->authHelper->promptAuthIfNeeded($job['url'], $job['origin'], $response->getStatusCode(), $response->getStatusMessage(), $response->getHeaders(), $job['attributes']['retries'], $response->getBody());
 
             if ($result['retry']) {
                 return $result;


### PR DESCRIPTION
## Summary

When a GitHub API request fails with 401/403, Composer now extracts and displays the actual error message from GitHub's JSON response body instead of showing a generic message about reviewing OAuth tokens or accessing private repos.

## Problem

As described in #12711, when GitHub returns specific error messages like:
- `organization forbids access via a personal access token (classic)`
- `organization forbids access via fine-grained personal access tokens if the token's lifetime is greater than 366 days`

Composer would only show a generic message suggesting to review your GitHub OAuth token or create one to access private repos. This made it very difficult to diagnose the actual issue.

## Solution

Added an optional `$responseBody` parameter to `AuthHelper::promptAuthIfNeeded()`. For GitHub domains, when a 401/403 response is received (and it's not a rate limit or SSO issue), the method now attempts to decode the JSON response body and extract the `message` field from GitHub's API response.

The extracted message is then displayed to the user, providing accurate information about why the request failed.

## Changes

- `src/Composer/Util/AuthHelper.php`: Added `$responseBody` parameter and GitHub API error message extraction logic
- `src/Composer/Util/Http/CurlDownloader.php`: Pass response body to `promptAuthIfNeeded()`

Fixes #12711