### PR TITLE
Add `--only-dev` option to `show` and `outdated` commands

### DIFF
--- a/src/Composer/Command/OutdatedCommand.php
+++ b/src/Composer/Command/OutdatedCommand.php
@@ -44,6 +44,7 @@ class OutdatedCommand extends BaseCommand
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text', ['json', 'text']),
                 new InputOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore specified package(s). Can contain wildcards (*). Use it if you don\'t want to be informed about new versions of some packages.', null, $this->suggestInstalledPackage(false)),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),
+                new InputOption('only-dev', null, InputOption::VALUE_NONE, 'Restricts the list of packages to your require-dev packages.'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages). Use with the --outdated option'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages). Use with the --outdated option'),
             ])
@@ -109,6 +110,9 @@ EOT
         }
         if ($input->getOption('no-dev')) {
             $args['--no-dev'] = true;
+        }
+        if ($input->getOption('only-dev')) {
+            $args['--only-dev'] = true;
         }
         if ($input->getOption('sort-by-age')) {
             $args['--sort-by-age'] = true;

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -28,6 +28,7 @@ use Composer\Pcre\Preg;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Composer\Repository\InstalledArrayRepository;
+use Composer\Repository\LockArrayRepository;
 use Composer\Repository\ComposerRepository;
 use Composer\Repository\CompositeRepository;
 use Composer\Repository\FilterRepository;
@@ -101,6 +102,7 @@ class ShowCommand extends BaseCommand
                 new InputOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code when there are outdated packages'),
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format of the output: text or json', 'text', ['json', 'text']),
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables search in require-dev packages.'),
+                new InputOption('only-dev', null, InputOption::VALUE_NONE, 'Restricts the list of packages to your require-dev packages.'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages). Use with the --outdated option'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages). Use with the --outdated option'),
             ])
@@ -158,6 +160,12 @@ EOT
 
         if ($input->getOption('tree') && ($input->getOption('all') || $input->getOption('available'))) {
             $io->writeError('The --tree (-t) option is not usable in combination with --all or --available (-a)');
+
+            return 1;
+        }
+
+        if ($input->getOption('no-dev') && $input->getOption('only-dev')) {
+            $io->writeError('The --no-dev and --only-dev options cannot be combined.');
 
             return 1;
         }
@@ -240,9 +248,19 @@ EOT
                 throw new \UnexpectedValueException('A valid composer.json and composer.lock files is required to run this command with --locked');
             }
             $locker = $composer->getLocker();
-            $lockedRepo = $locker->getLockedRepository(!$input->getOption('no-dev'));
+            $lockedRepo = $locker->getLockedRepository(!$input->getOption('no-dev') || $input->getOption('only-dev'));
             if ($input->getOption('self')) {
                 $lockedRepo->addPackage(clone $composer->getPackage());
+            }
+            if ($input->getOption('only-dev')) {
+                $prodPackages = RepositoryUtils::filterRequiredPackages($lockedRepo->getPackages(), $composer->getPackage());
+                $devAndProdPackages = RepositoryUtils::filterRequiredPackages($lockedRepo->getPackages(), $composer->getPackage(), true);
+                $onlyDevPackages = array_values(array_filter($devAndProdPackages, static function (PackageInterface $package) use ($prodPackages) {
+                    return !in_array($package, $prodPackages, true);
+                }));
+                $lockedRepo = new LockArrayRepository(array_map(static function (PackageInterface $package) {
+                    return clone $package;
+                }, $onlyDevPackages));
             }
             $repos = $installedRepo = new InstalledRepository([$lockedRepo]);
         } else {
@@ -261,6 +279,16 @@ EOT
                 $repos = $installedRepo = new InstalledRepository([$rootRepo, new InstalledArrayRepository(array_map(static function ($pkg): PackageInterface {
                     return clone $pkg;
                 }, $packages))]);
+            } elseif ($input->getOption('only-dev')) {
+                $localPackages = $composer->getRepositoryManager()->getLocalRepository()->getPackages();
+                $prodPackages = RepositoryUtils::filterRequiredPackages($localPackages, $rootPkg, false);
+                $devAndProdPackages = RepositoryUtils::filterRequiredPackages($localPackages, $rootPkg, true);
+                $onlyDevPackages = array_values(array_filter($devAndProdPackages, static function (PackageInterface $package) use ($prodPackages) {
+                    return !in_array($package, $prodPackages, true);
+                }));
+                $repos = $installedRepo = new InstalledRepository([$rootRepo, new InstalledArrayRepository(array_map(static function (PackageInterface $package) {
+                    return clone $package;
+                }, $onlyDevPackages))]);
             } else {
                 $repos = $installedRepo = new InstalledRepository([$rootRepo, $composer->getRepositoryManager()->getLocalRepository()]);
             }

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -587,6 +587,9 @@ OUTPUT;
 
         $appTester->run(['command' => 'show', '--format' => 'test']);
         self::assertSame(1, $appTester->getStatusCode());
+
+        $appTester->run(['command' => 'show', '--no-dev' => true, '--only-dev' => true]);
+        self::assertSame(1, $appTester->getStatusCode());
     }
 
     public function testIgnoredOptionCombinations(): void
@@ -920,5 +923,77 @@ vendor/somepackage', trim($appTester->getDisplay(true))); // trim() is fine here
 ~ major release available - update possible
 vendor/apackage
 vendor/longpackagename', trim($appTester->getDisplay(true))); // trim() is fine here, but see CAUTION above
+    }
+
+    public function testShowOnlyDev(): void
+    {
+        $this->initTempComposer([
+            'repositories' => ['packages' => ['type' => 'package', 'package' => [
+                ['name' => 'vendor/prod', 'version' => '1.0.0'],
+                ['name' => 'vendor/shared', 'version' => '1.0.0'],
+                ['name' => 'vendor/dev', 'version' => '1.0.0'],
+            ]]],
+            'require' => ['vendor/prod' => '*', 'vendor/shared' => '*'],
+            'require-dev' => ['vendor/dev' => '*', 'vendor/shared' => '*'],
+        ]);
+
+        $prod = self::getPackage('vendor/prod', '1.0.0');
+        $shared = self::getPackage('vendor/shared', '1.0.0');
+        $dev = self::getPackage('vendor/dev', '1.0.0');
+
+        $this->createInstalledJson([$prod, $shared], [$dev]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'show', '--only-dev' => true]);
+        $output = trim($appTester->getDisplay(true));
+        self::assertSame('vendor/dev 1.0.0', $output);
+        self::assertStringNotContainsString('vendor/prod', $output);
+        self::assertStringNotContainsString('vendor/shared', $output);
+    }
+
+    public function testShowLockedOnlyDev(): void
+    {
+        $this->initTempComposer([
+            'require' => ['vendor/prod' => '*', 'vendor/shared' => '*'],
+            'require-dev' => ['vendor/dev' => '*', 'vendor/shared' => '*'],
+        ]);
+
+        $prod = self::getPackage('vendor/prod', '1.0.0');
+        $shared = self::getPackage('vendor/shared', '1.0.0');
+        $dev = self::getPackage('vendor/dev', '1.0.0');
+
+        $this->createComposerLock([$prod, $shared], [$dev]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'show', '--locked' => true, '--only-dev' => true]);
+        $output = trim($appTester->getDisplay(true));
+        self::assertSame('vendor/dev 1.0.0', $output);
+        self::assertStringNotContainsString('vendor/prod', $output);
+        self::assertStringNotContainsString('vendor/shared', $output);
+    }
+
+    public function testOutdatedOnlyDev(): void
+    {
+        $this->initTempComposer([
+            'repositories' => ['packages' => ['type' => 'package', 'package' => [
+                ['name' => 'vendor/prod', 'version' => '1.0.0'],
+                ['name' => 'vendor/prod', 'version' => '1.1.0'],
+                ['name' => 'vendor/dev', 'version' => '1.0.0'],
+                ['name' => 'vendor/dev', 'version' => '1.1.0'],
+            ]]],
+            'require' => ['vendor/prod' => '*'],
+            'require-dev' => ['vendor/dev' => '*'],
+        ]);
+
+        $this->createInstalledJson(
+            [self::getPackage('vendor/prod', '1.0.0')],
+            [self::getPackage('vendor/dev', '1.0.0')]
+        );
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'outdated', '--only-dev' => true]);
+        $output = trim($appTester->getDisplay(true));
+        self::assertStringContainsString('vendor/dev 1.0.0 <highlight>! 1.1.0</highlight>', $output);
+        self::assertStringNotContainsString('vendor/prod', $output);
     }
 }

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -996,4 +996,59 @@ vendor/longpackagename', trim($appTester->getDisplay(true))); // trim() is fine 
         self::assertStringContainsString('vendor/dev 1.0.0 <highlight>! 1.1.0</highlight>', $output);
         self::assertStringNotContainsString('vendor/prod', $output);
     }
+
+    /**
+     * If vendor/dev is listed in require-dev but is also a transitive dependency of a
+     * require package, it must NOT appear in --only-dev output because it is needed in
+     * production.
+     */
+    public function testShowOnlyDevHidesTransitiveProdDeps(): void
+    {
+        $this->initTempComposer([
+            'repositories' => ['packages' => ['type' => 'package', 'package' => [
+                ['name' => 'vendor/prod', 'version' => '1.0.0'],
+                ['name' => 'vendor/dev', 'version' => '1.0.0'],
+            ]]],
+            'require' => ['vendor/prod' => '*'],
+            'require-dev' => ['vendor/dev' => '*'],
+        ]);
+
+        $prod = self::getPackage('vendor/prod', '1.0.0');
+        $prod->setRequires(['vendor/dev' => new Link('vendor/prod', 'vendor/dev', self::getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE, '1.0.0')]);
+        $dev = self::getPackage('vendor/dev', '1.0.0');
+
+        // vendor/dev is a dev package at the root level, but vendor/prod (a prod package)
+        // also requires it transitively — so it must be excluded from --only-dev output.
+        $this->createInstalledJson([$prod], [$dev]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'show', '--only-dev' => true]);
+        $output = trim($appTester->getDisplay(true));
+        self::assertStringNotContainsString('vendor/dev', $output);
+        self::assertStringNotContainsString('vendor/prod', $output);
+    }
+
+    /**
+     * Same transitive-prod-dep scenario but with --locked.
+     */
+    public function testShowLockedOnlyDevHidesTransitiveProdDeps(): void
+    {
+        $this->initTempComposer([
+            'require' => ['vendor/prod' => '*'],
+            'require-dev' => ['vendor/dev' => '*'],
+        ]);
+
+        $prod = self::getPackage('vendor/prod', '1.0.0');
+        $prod->setRequires(['vendor/dev' => new Link('vendor/prod', 'vendor/dev', self::getVersionConstraint('=', '1.0.0'), Link::TYPE_REQUIRE, '1.0.0')]);
+        $dev = self::getPackage('vendor/dev', '1.0.0');
+
+        $this->createComposerLock([$prod], [$dev]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'show', '--locked' => true, '--only-dev' => true]);
+        $output = trim($appTester->getDisplay(true));
+        self::assertSame('', $output);
+        self::assertStringNotContainsString('vendor/dev', $output);
+        self::assertStringNotContainsString('vendor/prod', $output);
+    }
 }


### PR DESCRIPTION
Fixes #12747  
 

- Added new `--only-dev` option, working with `show` and `outdated` commands, showing only `require-dev` packages in output
- Made sure `--no-dev` and `--only-dev` cannot be combined
- Add test cases in `ShowCommandTest` with the new behaviour (Covers `show` and `outdated` commands)