### PR TITLE
Pre-load `GithubActionError` before phar swap in self-update

### DIFF
--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -100,6 +100,7 @@ EOT
         // to ensure we do not try to load them from the new phar, see https://github.com/composer/composer/issues/10252
         class_exists('Composer\Util\Platform');
         class_exists('Composer\Downloader\FilesystemException');
+        class_exists('Composer\Console\GithubActionError');
 
         $config = Factory::createConfig();
 


### PR DESCRIPTION
Fixes #12619

After `rename()` swaps the phar on disk, any class not yet autoloaded will be loaded from the new phar. `GithubActionError` is used in `Application::doRun()` catch block and may not be loaded before the swap, causing a fatal "class not found" error when an exception occurs during self-update on systems where the phar directory is writable.

Follows the same fix pattern as 6a7264fc2 which added Platform and FilesystemException pre-loading for issue #10252.

### Before
```
/usr/local/bin/composer self-update
Upgrading to version 2.9.5 (stable channel).

Fatal error: Uncaught Error: Class "Composer\Console\GithubActionError" not found in phar:///usr/local/bin/composer/src/Composer/Console/Application.php:464
Stack trace:
#0 phar:///usr/local/bin/composer/vendor/symfony/console/Application.php(171): Composer\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#1 phar:///usr/local/bin/composer/src/Composer/Console/Application.php(139): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 phar:///usr/local/bin/composer/bin/composer(112): Composer\Console\Application->run()
#3 /usr/local/bin/composer(29): require('phar:///usr/loc...')
#4 {main}
  thrown in phar:///usr/local/bin/composer/src/Composer/Console/Application.php on line 464
```

### After
```
/usr/local/bin/composer self-update
Upgrading to version 2.9.5 (stable channel).


In SelfUpdateCommand.php line 511:

  Filesystem exception:
  Composer update failed: "/usr/local/bin/composer" could not be written.
  rename(/Users/jerome/Library/Caches/composer/composer-temp3112775.phar,/usr/local/bin/composer): Permission denied


self-update [-r|--rollback] [--clean-backups] [--no-progress] [--update-keys] [--stable] [--preview] [--snapshot] [--1] [--2] [--2.2] [--set-channel-only] [--] [<version>]
```