### PR TITLE
Feature/composer auth file env

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1230,6 +1230,14 @@ github-oauth, bitbucket-oauth, ... objects as needed](articles/authentication-fo
 and following the
 [spec from the config](06-config.md).
 
+### COMPOSER_AUTH_FILE
+
+The `COMPOSER_AUTH_FILE` var allows you to set up authentication under an alternative file path.
+The contents of the variable should be an absolute path to a JSON formatted file containing
+[http-basic, github-oauth, bitbucket-oauth, ... objects as needed](articles/authentication-for-private-packages.md),
+and following the
+[spec from the config](06-config.md).
+
 ### COMPOSER_BIN_COMPAT
 
 Override the [`bin-compat`](06-config.md#bin-compat) config setting.

--- a/doc/articles/authentication-for-private-packages.md
+++ b/doc/articles/authentication-for-private-packages.md
@@ -47,7 +47,11 @@ command line or manually edit or create it.
 
 If you don't want to supply credentials for every project you work on, storing your credentials
 globally might be a better idea. These credentials are stored in a global `auth.json` in your
-Composer home directory.
+Composer home directory by default.
+
+Optionally, you may also set the `COMPOSER_AUTH_FILE` environment variable to specify a custom
+location for the global authentication file. This is useful in cases where you might be running
+Composer in a container runtime (e.g., Docker) and would like to mount the file as a secret.
 
 ### Command line global credential editing
 

--- a/phpstan/baseline-8.4.neon
+++ b/phpstan/baseline-8.4.neon
@@ -260,7 +260,7 @@ parameters:
 			count: 1
 			path: ../tests/Composer/Test/Util/RemoteFilesystemTest.php
 
-        -
-            message: "#^Call to function method_exists\\(\\) with Composer\\\\Console\\\\Application and 'setCatchErrors' will always evaluate to true\\.$#"
-            count: 1
-            path: ../tests/Composer/Test/ApplicationTest.php
+		-
+			message: "#^Call to function method_exists\\(\\) with Composer\\\\Console\\\\Application and 'setCatchErrors' will always evaluate to true\\.$#"
+			count: 1
+			path: ../tests/Composer/Test/ApplicationTest.php

--- a/phpstan/baseline-8.4.neon
+++ b/phpstan/baseline-8.4.neon
@@ -260,3 +260,7 @@ parameters:
 			count: 1
 			path: ../tests/Composer/Test/Util/RemoteFilesystemTest.php
 
+        -
+            message: "#^Call to function method_exists\\(\\) with Composer\\\\Console\\\\Application and 'setCatchErrors' will always evaluate to true\\.$#"
+            count: 1
+            path: ../tests/Composer/Test/ApplicationTest.php

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -207,12 +207,14 @@ class Factory
 
         // load global auth file
         $authFileEnv = Platform::getEnv('COMPOSER_AUTH_FILE');
-        $file = self::loadComposerAuthFile(
-            $authFileEnv ?: $config->get('home').'/auth.json',
-            $config,
-            $io,
-            $authFileEnv ? 'COMPOSER_AUTH_FILE' : null,
-        );
+        $path = $config->get('home').'/auth.json';
+        $source = null;
+
+        if($authFileEnv !== false && $authFileEnv !== '') {
+            $path = $authFileEnv;
+            $source = 'COMPOSER_AUTH_FILE';
+        }
+        $file = self::loadComposerAuthFile($path, $config, $io, $source);
         $config->setAuthConfigSource(new JsonConfigSource($file, true));
 
         self::loadComposerAuthEnv($config, $io);
@@ -331,7 +333,7 @@ class Factory
             $config->setConfigSource(new JsonConfigSource(new JsonFile(realpath($composerFile), null, $io)));
 
             $localAuthFile = self::loadComposerAuthFile(dirname(realpath($composerFile)) . '/auth.json', $config, $io);
-            if($localAuthFile !== false) {
+            if($localAuthFile->exists()) {
                 $config->setLocalAuthConfigSource(new JsonConfigSource($localAuthFile, true));
             }
         }
@@ -698,7 +700,7 @@ class Factory
         }
     }
 
-    private static function loadComposerAuthFile(string $path, Config $config, ?IOInterface $io = null, ?string $source = null): JsonFile|false
+    private static function loadComposerAuthFile(string $path, Config $config, ?IOInterface $io = null, ?string $source = null): JsonFile
     {
         $file = new JsonFile($path, null, $io);
         if ($file->exists()) {
@@ -707,9 +709,8 @@ class Factory
             }
             self::validateJsonSchema($io, $file, JsonFile::AUTH_SCHEMA, $source);
             $config->merge(['config' => $file->read()], $file->getPath());
-            return $file;
         }
-        return false;
+        return $file;
     }
 
     private static function useXdg(): bool

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -206,14 +206,13 @@ class Factory
         }
 
         // load global auth file
-        $file = new JsonFile($config->get('home').'/auth.json');
-        if ($file->exists()) {
-            if ($io instanceof IOInterface) {
-                $io->writeError('Loading config file ' . $file->getPath(), true, IOInterface::DEBUG);
-            }
-            self::validateJsonSchema($io, $file, JsonFile::AUTH_SCHEMA);
-            $config->merge(['config' => $file->read()], $file->getPath());
-        }
+        $authFileEnv = Platform::getEnv('COMPOSER_AUTH_FILE');
+        $file = self::loadComposerAuthFile(
+            $authFileEnv ?: $config->get('home').'/auth.json',
+            $config,
+            $io,
+            $authFileEnv ? 'COMPOSER_AUTH_FILE' : null,
+        );
         $config->setAuthConfigSource(new JsonConfigSource($file, true));
 
         self::loadComposerAuthEnv($config, $io);
@@ -331,11 +330,8 @@ class Factory
             $io->writeError('Loading config file ' . $composerFile .' ('.realpath($composerFile).')', true, IOInterface::DEBUG);
             $config->setConfigSource(new JsonConfigSource(new JsonFile(realpath($composerFile), null, $io)));
 
-            $localAuthFile = new JsonFile(dirname(realpath($composerFile)) . '/auth.json', null, $io);
-            if ($localAuthFile->exists()) {
-                $io->writeError('Loading config file ' . $localAuthFile->getPath(), true, IOInterface::DEBUG);
-                self::validateJsonSchema($io, $localAuthFile, JsonFile::AUTH_SCHEMA);
-                $config->merge(['config' => $localAuthFile->read()], $localAuthFile->getPath());
+            $localAuthFile = self::loadComposerAuthFile(dirname(realpath($composerFile)) . '/auth.json', $config, $io);
+            if($localAuthFile !== false) {
                 $config->setLocalAuthConfigSource(new JsonConfigSource($localAuthFile, true));
             }
         }
@@ -700,6 +696,20 @@ class Factory
         if (null !== $authData) {
             $config->merge(['config' => $authData], 'COMPOSER_AUTH');
         }
+    }
+
+    private static function loadComposerAuthFile(string $path, Config $config, ?IOInterface $io = null, ?string $source = null): JsonFile|false
+    {
+        $file = new JsonFile($path, null, $io);
+        if ($file->exists()) {
+            if ($io instanceof IOInterface) {
+                $io->writeError('Loading config file ' . $file->getPath(), true, IOInterface::DEBUG);
+            }
+            self::validateJsonSchema($io, $file, JsonFile::AUTH_SCHEMA, $source);
+            $config->merge(['config' => $file->read()], $file->getPath());
+            return $file;
+        }
+        return false;
     }
 
     private static function useXdg(): bool


### PR DESCRIPTION
See: #9920

This is a small feature enhancement to cover for a use-case in which users might want to set an environment variable to alter the default path of the global `auth.json` configuration.

This is primarily useful in containerized environments in which an `auth.json` file might need to be mounted as a secret. Specifically in Docker containers, the `*_FILE` suffix is a common pattern for indicating the location of a particular piece of sensitive data as a file rather than directly as an environment variable or build arg (which can be viewed in plain text with tools like `docker inspect`).

When `COMPOSER_AUTH_FILE` is present and non-empty, the default path of `$config->get('home').'/auth.json'` is replaced with the value of this variable and the contents of the file in that location will be loaded and validated as normal.

I didn't see any relevant unit tests for the existing `COMPOSER_AUTH` or `createConfig` methods (outside of possibly the FactoryMock, which does not seem to be Environment-aware) so I'm not sure if that's something we would like to add into any tests to account for this new behavior.