### PR TITLE
Preserve file mtimes in ZIP archives

### DIFF
--- a/src/Composer/Package/Archiver/ZipArchiver.php
+++ b/src/Composer/Package/Archiver/ZipArchiver.php
@@ -69,6 +69,16 @@ class ZipArchiver implements ArchiverInterface
                      */
                     $zip->setExternalAttributesName($relativePath, ZipArchive::OPSYS_UNIX, $perms << 16);
                 }
+
+                /**
+                 * setMtimeName() is only available with libzip 1.0.0 or above.
+                 */
+                if (method_exists($zip, 'setMtimeName')) {
+                    $mtime = filemtime($filepath);
+                    if (false !== $mtime) {
+                        $zip->setMtimeName($relativePath, $mtime);
+                    }
+                }
             }
             if ($zip->close()) {
                 if (!file_exists($target)) {

--- a/tests/Composer/Test/Package/Archiver/ZipArchiverTest.php
+++ b/tests/Composer/Test/Package/Archiver/ZipArchiverTest.php
@@ -67,6 +67,40 @@ class ZipArchiverTest extends ArchiverTestCase
         ]);
     }
 
+    public function testPreservesFileModificationTimes(): void
+    {
+        if (!class_exists('ZipArchive')) {
+            $this->markTestSkipped('Cannot run ZipArchiverTest, missing class "ZipArchive".');
+        }
+        if (!method_exists('ZipArchive', 'setMtimeName')) {
+            $this->markTestSkipped('Cannot run ZipArchiverTest, missing method "ZipArchive::setMtimeName".');
+        }
+
+        $this->setupDummyRepo([
+            'file.txt' => 'content',
+        ]);
+
+        $sourceFile = $this->testDir.'/file.txt';
+        $expectedMtime = 1700000000;
+        touch($sourceFile, $expectedMtime);
+
+        $package = $this->setupPackage();
+        $target = $this->filesToCleanup[] = sys_get_temp_dir().'/composer_archiver_test.zip';
+
+        $archiver = new ZipArchiver();
+        $archiver->archive($package->getSourceUrl(), $target, 'zip');
+
+        $zip = new ZipArchive();
+        $res = $zip->open($target);
+        static::assertTrue($res, 'Failed asserting that Zip file can be opened');
+
+        $fileStat = $zip->statName('file.txt');
+        static::assertIsArray($fileStat);
+        static::assertArrayHasKey('mtime', $fileStat);
+        static::assertSame($expectedMtime, $fileStat['mtime']);
+        $zip->close();
+    }
+
     /**
      * @param array<string, string|null> $files
      */


### PR DESCRIPTION
## Summary
- preserve source file modification times when Composer creates ZIP archives
- keep the change guarded by `ZipArchive::setMtimeName` so older environments still work
- add a regression test that verifies the archived mtime

Fixes #11342

## Validation
- git diff --check

## Notes
- local PHP is not installed in this environment, so I could not run the Composer PHPUnit suite here