### PR TITLE
FilterList: apply only/exclude when fetching filters

### DIFF
--- a/src/Composer/Repository/FilterRepository.php
+++ b/src/Composer/Repository/FilterRepository.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Repository;
 
+use Composer\FilterList\FilterListProviderConfig;
 use Composer\Package\PackageInterface;
 use Composer\Package\BasePackage;
 use Composer\Pcre\Preg;
@@ -21,7 +22,7 @@ use Composer\Pcre\Preg;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class FilterRepository implements RepositoryInterface, AdvisoryProviderInterface
+class FilterRepository implements RepositoryInterface, AdvisoryProviderInterface, FilterListProviderInterface
 {
     /** @var ?string */
     private $only = null;
@@ -213,6 +214,36 @@ class FilterRepository implements RepositoryInterface, AdvisoryProviderInterface
         }
 
         return $this->repo->getSecurityAdvisories($packageConstraintMap, $allowPartialAdvisories);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasFilter(): bool
+    {
+        if (!$this->repo instanceof FilterListProviderInterface) {
+            return false;
+        }
+
+        return $this->repo->hasFilter();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFilter(array $packageConstraintMap): array
+    {
+        if (!$this->repo instanceof FilterListProviderInterface) {
+            return ['filter' => [], 'config' => FilterListProviderConfig::fromConfig(false, [])];
+        }
+
+        foreach ($packageConstraintMap as $name => $constraint) {
+            if (!$this->isAllowed($name)) {
+                unset($packageConstraintMap[$name]);
+            }
+        }
+
+        return $this->repo->getFilter($packageConstraintMap);
     }
 
     private function isAllowed(string $name): bool

--- a/src/Composer/Repository/PackageRepository.php
+++ b/src/Composer/Repository/PackageRepository.php
@@ -124,7 +124,10 @@ class PackageRepository extends ArrayRepository implements AdvisoryProviderInter
         foreach ($this->filter as $listName => $listEntries) {
             $lists[] = $listName;
             foreach ($listEntries as $data) {
-                $filter[$listName][] = FilterListEntry::create($listName, $data, $parser);
+                $filterEntry = FilterListEntry::create($listName, $data, $parser);
+                if (isset($packageConstraintMap[$filterEntry->packageName])) {
+                    $filter[$listName][] = $filterEntry;
+                }
             }
         }
 

--- a/tests/Composer/Test/Fixtures/installer/update-filter-entry-not-matching-only-exclude.test
+++ b/tests/Composer/Test/Fixtures/installer/update-filter-entry-not-matching-only-exclude.test
@@ -1,0 +1,70 @@
+--TEST--
+Filter list entry matching not matching only/exclude preventing a successful update.
+--COMPOSER--
+{
+    "name": "acme/project",
+    "version": "1.0.0",
+    "require": {
+        "acme/library": "1.0.0",
+        "acme/other": "1.0.0"
+    },
+    "config": {
+        "filter": true
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0.0",
+                    "type": "metapackage"
+                }
+            ],
+            "only": ["acme/library"],
+            "filter": {
+                "test-list": [
+                    {
+                        "package": "acme/other",
+                        "constraint": "*",
+                        "url": "https://example.org/malware/acme/other",
+                        "reason": "malware",
+                        "id": "ID-other"
+                    },
+                    {
+                        "package": "acme/library",
+                        "constraint": "*",
+                        "url": "https://example.org/malware/acme/library",
+                        "reason": "malware",
+                        "id": "ID-library"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/other",
+                    "version": "1.0.0",
+                    "source": { "reference": "some.branch", "type": "git", "url": "" }
+                }
+            ]
+        }
+    ]
+}
+--RUN--
+update -v
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires acme/library 1.0.0 (exact version match: 1.0.0 or 1.0.0.0), found acme/library[1.0.0] but these were not loaded, because they were filtered by test-list (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "filter.unfiltered-packages" config. To turn the feature off entirely, you can set "filter" to false.
+
+--EXPECT--

--- a/tests/Composer/Test/Repository/FilterRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilterRepositoryTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\Repository;
 
+use Composer\FilterList\FilterListProviderConfig;
 use Composer\Test\TestCase;
 use Composer\Repository\FilterRepository;
 use Composer\Repository\ArrayRepository;
@@ -81,6 +82,14 @@ class FilterRepositoryTest extends TestCase
 
         self::assertFalse($repo->hasSecurityAdvisories());
         self::assertSame(['namesFound' => [], 'advisories' => []], $repo->getSecurityAdvisories(['foo/aaa' => new MatchAllConstraint()], true));
+    }
+
+    public function testFiltersDisabledInChild(): void
+    {
+        $repo = new FilterRepository($this->arrayRepo, ['only' => ['foo/*']]);
+
+        self::assertFalse($repo->hasFilter());
+        self::assertEquals(['filter' => [], 'config' => FilterListProviderConfig::fromConfig(false, [])], $repo->getFilter(['foo/aaa' => new MatchAllConstraint()]));
     }
 
     public function testCanonicalDefaultTrue(): void


### PR DESCRIPTION
This fixes an issue where filter lists weren't loaded for repositories where only/exclude/canonical where defined because the FilterRepository didn't implement the FilterListProviderInterface.