### PR TITLE
Improve return type annotation for `Application::getComposer()`

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -581,7 +581,7 @@ class Application extends BaseApplication
     /**
      * @throws JsonValidationException
      * @throws \InvalidArgumentException
-     * @return ?Composer If $required is true then the return value is guaranteed
+     * @return ($required is true ? Composer : Composer|null) If $required is true then the return value is guaranteed
      */
     public function getComposer(bool $required = true, ?bool $disablePlugins = null, ?bool $disableScripts = null): ?Composer
     {

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -581,7 +581,8 @@ class Application extends BaseApplication
     /**
      * @throws JsonValidationException
      * @throws \InvalidArgumentException
-     * @return ($required is true ? Composer : Composer|null) If $required is true then the return value is guaranteed
+     * @return ?Composer If $required is true then the return value is guaranteed
+     * @phpstan-return ($required is true ? Composer : Composer|null)
      */
     public function getComposer(bool $required = true, ?bool $disablePlugins = null, ?bool $disableScripts = null): ?Composer
     {


### PR DESCRIPTION
We can utilize PHPStan's conditional return types [^1] here in order to improve usage with static code analyzers.

[^1]: https://phpstan.org/writing-php-code/phpdoc-types#conditional-return-types