### PR TITLE
docs: fix typo `seperated` → `separated` in 03-cli.md

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1382,7 +1382,7 @@ useful for plugin authors to identify what is firing when exactly.
 
 ### COMPOSER_SKIP_SCRIPTS
 
-Accepts a comma-seperated list of event names, e.g. `post-install-cmd` for which scripts execution should be skipped.
+Accepts a comma-separated list of event names, e.g. `post-install-cmd` for which scripts execution should be skipped.
 
 ### COMPOSER_NO_AUDIT
 


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `doc/03-cli.md` (line ~1385)
- Change: `seperated` → `separated`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
