### PR TITLE
Add note on installing runtime dependencies

### DIFF
--- a/doc/00-intro.md
+++ b/doc/00-intro.md
@@ -189,6 +189,9 @@ COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 COPY --from=composer/composer:2-bin /composer /usr/bin/composer
 ```
 
+**Note:** you need to manually install other runtime dependencies inside your image when using this method;
+see also https://github.com/composer/composer/blob/main/README.md#binary-dependencies.
+
 Read the [image description](https://hub.docker.com/r/composer/composer) for further usage information.
 
 **Note:** Docker specific issues should be filed [on the composer/docker repository](https://github.com/composer/docker/issues).


### PR DESCRIPTION
Added note about manually installing runtime dependencies.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->

As a follow-up to #12580 and the discussion at https://github.com/composer/composer/discussions/12278, this PR proposes to add some explicit note about runtime dependencies to the Docker usage documentation.