### PR TITLE
GitHub Actions: use zizmor to harden existing workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels: []

--- a/.github/workflows/api-surface-comment.yml
+++ b/.github/workflows/api-surface-comment.yml
@@ -4,11 +4,9 @@ on:
   workflow_run:
     workflows: ["API Surface Check"]
     types:
-      - completed
+      - completed # zizmor: ignore[dangerous-triggers]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: api-surface-comment-${{ github.event.workflow_run.head_sha }}
@@ -16,8 +14,14 @@ concurrency:
 
 jobs:
   comment:
+    name: "API surface comment"
+
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write # required to create the comment on the pull request
 
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -60,7 +64,9 @@ jobs:
           persist-credentials: false
 
       - if: steps.pr.outputs.number && steps.preflight.outputs.should-run == 'true'
-        run: git fetch --no-tags origin "${{ steps.pr.outputs.base-ref }}:refs/remotes/origin/${{ steps.pr.outputs.base-ref }}"
+        run: git fetch --no-tags origin "${STEPS_PR_OUTPUTS_BASE_REF}:refs/remotes/origin/${STEPS_PR_OUTPUTS_BASE_REF}"
+        env:
+          STEPS_PR_OUTPUTS_BASE_REF: ${{ steps.pr.outputs.base-ref }}
 
       - if: steps.pr.outputs.number && steps.preflight.outputs.should-run == 'true'
         uses: composer/api-surface-check@1857f9bbc68072c4c6354f743bffcdb216b8964c # 0.1.1

--- a/.github/workflows/api-surface-comment.yml
+++ b/.github/workflows/api-surface-comment.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write # required to create the comment on the pull request
 
     steps:
-      - uses: composer/api-surface-check@main # zizmor: ignore[unpinned-uses]
+      - uses: composer/api-surface-check@f44cc54b3178fa161a0a7b4d4e76824f18eeb788 # 0.3.0
         with:
           install-dependencies: true
           # paths: src/**/*.php

--- a/.github/workflows/api-surface-comment.yml
+++ b/.github/workflows/api-surface-comment.yml
@@ -2,11 +2,9 @@ name: 'API Surface Comment'
 on:
   workflow_run:
     workflows: ['API Surface Check']
-    types: [completed]
+    types: [completed] # zizmor: ignore[dangerous-triggers]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 # Cancel an in-progress comment run when a force-push or workflow_run re-run
 # fires for the same PR. head_sha alone wouldn't catch force-pushes (each push
@@ -18,9 +16,16 @@ concurrency:
 
 jobs:
   comment:
+
+    name: "API surface comment"
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write # required to create the comment on the pull request
+
     steps:
-      - uses: composer/api-surface-check@main
+      - uses: composer/api-surface-check@main # zizmor: ignore[unpinned-uses]
         with:
           install-dependencies: true
           # paths: src/**/*.php

--- a/.github/workflows/api-surface-comment.yml
+++ b/.github/workflows/api-surface-comment.yml
@@ -15,13 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-<<<<<<< push-uzytlsvuulsz
-  comment:
-
-    name: "API surface comment"
-=======
   check-api-surface:
->>>>>>> main
+    name: "API surface comment"
+
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/autoloader.yml
+++ b/.github/workflows/autoloader.yml
@@ -1,6 +1,6 @@
 name: "Autoloader"
 
-on:
+on: # zizmor: ignore[concurrency-limits]
   push:
     paths-ignore:
       - 'doc/**'
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Install Composer dependencies"
         run: "composer config platform --unset && composer install"

--- a/.github/workflows/autoloader.yml
+++ b/.github/workflows/autoloader.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -19,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Install Composer dependencies"
         run: "composer config platform --unset && composer install"

--- a/.github/workflows/close-stale-support.yml
+++ b/.github/workflows/close-stale-support.yml
@@ -1,16 +1,19 @@
 name: Mark and close stale support issues
 
-on:
+on: # zizmor: ignore[concurrency-limits]
   schedule:
   - cron: '32 1 * * *'
 
+permissions: {}
+
 jobs:
   stale:
+    name: "Mark and close stale support issues"
 
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write # for actions/stale to label/close stale issues
+      pull-requests: write # for actions/stale to label/close stale pull requests
 
     steps:
     - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0

--- a/.github/workflows/close-stale-support.yml
+++ b/.github/workflows/close-stale-support.yml
@@ -4,13 +4,20 @@ on:
   schedule:
   - cron: '32 1 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   stale:
+    name: "Mark and close stale support issues"
 
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write # for actions/stale to label/close stale issues
+      pull-requests: write # for actions/stale to label/close stale pull requests
 
     steps:
     - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0

--- a/.github/workflows/conductor.yaml
+++ b/.github/workflows/conductor.yaml
@@ -1,22 +1,27 @@
 # See the Conductor setup guide at https://packagist.com/docs/conductor/getting-started
+name: Private Packagist Conductor
 
 on:
     repository_dispatch:
         types:
             - dependency_update
 
-name: Private Packagist Conductor
+concurrency:
+    group: ${{ github.workflow }}
 
-permissions:
-    contents: write
+permissions: {}
 
 jobs:
     conductor:
         name: Private Packagist Conductor
         runs-on: "ubuntu-latest"
+        permissions:
+            contents: write # for conductor-github-action to push dependency update branches
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: true
 
             # Install PHP. You can also replace this step by
             # reusing an existing workflow that sets up PHP.
@@ -31,4 +36,4 @@ jobs:
 
             # See the Conductor GitHub Action at https://github.com/packagist/conductor-github-action
             - name: "Running Conductor"
-              uses: packagist/conductor-github-action@v1
+              uses: packagist/conductor-github-action@e19c62f9d97caff6166604942962597e412e01d8 # 1.6.0

--- a/.github/workflows/conductor.yaml
+++ b/.github/workflows/conductor.yaml
@@ -1,22 +1,25 @@
 # See the Conductor setup guide at https://packagist.com/docs/conductor/getting-started
 
-on:
+on: # zizmor: ignore[concurrency-limits]
     repository_dispatch:
         types:
             - dependency_update
 
 name: Private Packagist Conductor
 
-permissions:
-    contents: write
+permissions: {}
 
 jobs:
     conductor:
         name: Private Packagist Conductor
         runs-on: "ubuntu-latest"
+        permissions:
+            contents: write # for conductor-github-action to push dependency update branches
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
 
             # Install PHP. You can also replace this step by
             # reusing an existing workflow that sets up PHP.
@@ -31,4 +34,4 @@ jobs:
 
             # See the Conductor GitHub Action at https://github.com/packagist/conductor-github-action
             - name: "Running Conductor"
-              uses: packagist/conductor-github-action@v1
+              uses: packagist/conductor-github-action@e19c62f9d97caff6166604942962597e412e01d8 # 1.6.0

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,6 @@
 name: "Continuous Integration"
 
-on:
+on: # zizmor: ignore[concurrency-limits]
   push:
     paths-ignore:
       - 'doc/**'
@@ -68,6 +68,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -97,14 +99,14 @@ jobs:
 
       - name: "Update dependencies from composer.json using composer binary provided by system"
         if: "contains(matrix.dependencies, 'highest') || contains(matrix.dependencies, 'lowest')"
-        run: "composer update ${{ env.COMPOSER_UPDATE_FLAGS }} ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer update $COMPOSER_UPDATE_FLAGS $COMPOSER_FLAGS'
 
       - name: "Install dependencies from composer.lock using composer binary provided by system"
         if: "matrix.dependencies == 'locked'"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Run install again using composer binary from source"
-        run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer install $COMPOSER_FLAGS'
 
       - name: "Make source binary the one used by default (Linux / macOS)"
         if: "!contains(matrix.os, 'windows')"
@@ -139,6 +141,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -149,7 +153,7 @@ jobs:
           tools: composer
 
       - name: "Install dependencies"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Validate composer.json"
         run: "bin/composer validate --strict"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
   COMPOSER_UPDATE_FLAGS: ""
@@ -68,6 +72,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -97,14 +103,14 @@ jobs:
 
       - name: "Update dependencies from composer.json using composer binary provided by system"
         if: "contains(matrix.dependencies, 'highest') || contains(matrix.dependencies, 'lowest')"
-        run: "composer update ${{ env.COMPOSER_UPDATE_FLAGS }} ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer update $COMPOSER_UPDATE_FLAGS $COMPOSER_FLAGS'
 
       - name: "Install dependencies from composer.lock using composer binary provided by system"
         if: "matrix.dependencies == 'locked'"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Run install again using composer binary from source"
-        run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer install $COMPOSER_FLAGS'
 
       - name: "Make source binary the one used by default (Linux / macOS)"
         if: "!contains(matrix.os, 'windows')"
@@ -139,6 +145,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -149,7 +157,7 @@ jobs:
           tools: composer
 
       - name: "Install dependencies"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Validate composer.json"
         run: "bin/composer validate --strict"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -25,6 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: "PHP Lint"
 
-on:
+on: # zizmor: ignore[concurrency-limits]
   push:
     paths-ignore:
       - 'doc/**'
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:

--- a/.github/workflows/php32bit.yml
+++ b/.github/workflows/php32bit.yml
@@ -7,6 +7,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
   COMPOSER_UPDATE_FLAGS: ""
@@ -23,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -33,10 +39,10 @@ jobs:
           tools: composer
 
       - name: "Install dependencies from composer.lock using composer binary provided by system"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Run install again using composer binary from source"
-        run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer install $COMPOSER_FLAGS'
 
       - name: "Make source binary the one used by default"
         run: |

--- a/.github/workflows/php32bit.yml
+++ b/.github/workflows/php32bit.yml
@@ -1,6 +1,6 @@
 name: "Continuous Integration (32bit)"
 
-on:
+on: # zizmor: ignore[concurrency-limits]
   push:
     branches:
       - main
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -33,10 +35,10 @@ jobs:
           tools: composer
 
       - name: "Install dependencies from composer.lock using composer binary provided by system"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Run install again using composer binary from source"
-        run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer install $COMPOSER_FLAGS'
 
       - name: "Make source binary the one used by default"
         run: |

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,6 +1,6 @@
 name: "PHPStan"
 
-on:
+on: # zizmor: ignore[concurrency-limits]
   push:
     paths-ignore:
       - 'doc/**'
@@ -33,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -54,11 +56,11 @@ jobs:
 
       - name: "Install highest dependencies"
         if: "matrix.experimental == true"
-        run: "composer config platform --unset && composer update ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer config platform --unset && composer update $COMPOSER_FLAGS'
 
       - name: "Install locked dependencies"
         if: "matrix.experimental == false"
-        run: "composer config platform --unset && composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer config platform --unset && composer install $COMPOSER_FLAGS'
 
       - name: "Initialize PHPUnit sources"
         run: "vendor/bin/simple-phpunit --filter NO_TEST_JUST_AUTOLOAD_THANKS"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --prefer-dist"
   SYMFONY_PHPUNIT_VERSION: ""
@@ -33,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -54,11 +60,11 @@ jobs:
 
       - name: "Install highest dependencies"
         if: "matrix.experimental == true"
-        run: "composer config platform --unset && composer update ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer config platform --unset && composer update $COMPOSER_FLAGS'
 
       - name: "Install locked dependencies"
         if: "matrix.experimental == false"
-        run: "composer config platform --unset && composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer config platform --unset && composer install $COMPOSER_FLAGS'
 
       - name: "Initialize PHPUnit sources"
         run: "vendor/bin/simple-phpunit --filter NO_TEST_JUST_AUTOLOAD_THANKS"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,11 @@
 name: "Release"
 
-on:
+on: # zizmor: ignore[concurrency-limits]
   push:
     tags:
       - "*"
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --no-suggest --prefer-dist"
@@ -21,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -30,10 +31,10 @@ jobs:
           php-version: "8.4"
 
       - name: "Install dependencies from composer.lock using composer binary provided by system"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Run install again using composer binary from source"
-        run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer install $COMPOSER_FLAGS'
 
       - name: "Validate composer.json"
         run: "bin/composer validate"
@@ -60,24 +61,30 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes TODO --draft --verify-tag
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release create "$REF_NAME" --title "$REF_NAME" --notes TODO --draft --verify-tag
 
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.ref_name }}" composer.phar composer.phar.asc --clobber
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release upload "$REF_NAME" composer.phar composer.phar.asc --clobber
 
       # This step requires a secret token with `pull` access to composer/docker. The default
       # secrets.GITHUB_TOKEN is scoped to this repository only which is not sufficient.
       - name: "Open issue @ Docker repository"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
         with:
           github-token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           script: |
             // create new issue on Docker repository
             github.rest.issues.create({
-              owner: "${{ github.repository_owner }}",
+              owner: process.env.REPO_OWNER,
               repo: "docker",
-              title: `New Composer tag: ${{ github.ref_name }}`,
-              body: `https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}`,
+              title: `New Composer tag: ${process.env.REF_NAME}`,
+              body: `https://github.com/${process.env.REPOSITORY}/releases/tag/${process.env.REF_NAME}`,
             });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@ on:
     tags:
       - "*"
 
-permissions:
-  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+permissions: {}
 
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --no-suggest --prefer-dist"
@@ -21,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -30,10 +34,10 @@ jobs:
           php-version: "8.4"
 
       - name: "Install dependencies from composer.lock using composer binary provided by system"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Run install again using composer binary from source"
-        run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer install $COMPOSER_FLAGS'
 
       - name: "Validate composer.json"
         run: "bin/composer validate"
@@ -60,24 +64,30 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes TODO --draft --verify-tag
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release create "$REF_NAME" --title "$REF_NAME" --notes TODO --draft --verify-tag
 
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.ref_name }}" composer.phar composer.phar.asc --clobber
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release upload "$REF_NAME" composer.phar composer.phar.asc --clobber
 
       # This step requires a secret token with `pull` access to composer/docker. The default
       # secrets.GITHUB_TOKEN is scoped to this repository only which is not sufficient.
       - name: "Open issue @ Docker repository"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
         with:
           github-token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           script: |
             // create new issue on Docker repository
             github.rest.issues.create({
-              owner: "${{ github.repository_owner }}",
+              owner: process.env.REPO_OWNER,
               repo: "docker",
-              title: `New Composer tag: ${{ github.ref_name }}`,
-              body: `https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}`,
+              title: `New Composer tag: ${process.env.REF_NAME}`,
+              body: `https://github.com/${process.env.REPOSITORY}/releases/tag/${process.env.REF_NAME}`,
             });

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on: # zizmor: ignore[concurrency-limits]
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'


### PR DESCRIPTION
This introduces [zizmor](https://github.com/zizmorcore/zizmor) a static analyzer for GitHub Actions to harden existing GitHub Action workflows and adds a new workflow to analyze any future changes to those workflows.

I didn't introduce any new concurrency limitations. Happy to add that if wanted but don't think this is necessary.