### PR TITLE
FilterList: block malware packages during composer install

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -1036,7 +1036,7 @@ parameters:
 			path: ../src/Composer/DependencyResolver/Problem.php
 
 		-
-			message: "#^Method Composer\\\\DependencyResolver\\\\Rule\\:\\:getReason\\(\\) should return 2\\|3\\|6\\|7\\|10\\|12\\|13\\|14 but returns int\\<0, 255\\>\\.$#"
+			message: "#^Method Composer\\\\DependencyResolver\\\\Rule\\:\\:getReason\\(\\) should return 2\\|3\\|6\\|7\\|10\\|12\\|13\\|14\\|15 but returns int\\<0, 255\\>\\.$#"
 			count: 1
 			path: ../src/Composer/DependencyResolver/Rule.php
 
@@ -3960,7 +3960,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method solve\\(\\) on Composer\\\\DependencyResolver\\\\Solver\\|null\\.$#"
-			count: 8
+			count: 9
 			path: ../tests/Composer/Test/DependencyResolver/SolverTest.php
 
 		-

--- a/src/Composer/Advisory/AuditConfig.php
+++ b/src/Composer/Advisory/AuditConfig.php
@@ -327,7 +327,7 @@ class AuditConfig
         // and skip them inside Auditor::audit when malware is set to "ignore".
         // @todo handle this more accurate once we drop the audit config
         $filteredMode = Auditor::FILTERED_IGNORE;
-        foreach ($policyConfig->getActiveFilterLists('audit', null) as $listConfig) {
+        foreach ($policyConfig->getActiveAuditFilterLists() as $listConfig) {
             if ($listConfig->audit === ListPolicyConfig::AUDIT_FAIL) {
                 $filteredMode = Auditor::FILTERED_FAIL;
                 break;

--- a/src/Composer/Advisory/AuditConfig.php
+++ b/src/Composer/Advisory/AuditConfig.php
@@ -327,7 +327,7 @@ class AuditConfig
         // and skip them inside Auditor::audit when malware is set to "ignore".
         // @todo handle this more accurate once we drop the audit config
         $filteredMode = Auditor::FILTERED_IGNORE;
-        foreach ($policyConfig->getActiveFilterLists('audit') as $listConfig) {
+        foreach ($policyConfig->getActiveFilterLists('audit', null) as $listConfig) {
             if ($listConfig->audit === ListPolicyConfig::AUDIT_FAIL) {
                 $filteredMode = Auditor::FILTERED_FAIL;
                 break;

--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -119,10 +119,10 @@ class Auditor
         $filteredPackages = [];
         $filteredCount = 0;
         if ($policyConfig !== null && $filterListProviderSet !== null && $filtered !== self::FILTERED_IGNORE) {
-            $filterResult = $filterAuditor->collectFilterLists($packages, $filterListProviderSet, $policyConfig->getActiveFilterListNames('audit'), $ignoreUnreachable || $policyConfig->ignoreUnreachable->audit);
+            $filterResult = $filterAuditor->collectFilterLists($packages, $filterListProviderSet, $policyConfig->getActiveFilterListNames('audit', null), $ignoreUnreachable || $policyConfig->ignoreUnreachable->audit);
             $unreachableRepos = array_merge($unreachableRepos, $filterResult['unreachableRepos']);
             foreach ($packages as $package) {
-                $matchingEntries = $filterAuditor->getMatchingEntries($package, $filterResult['filter'], $policyConfig, 'audit');
+                $matchingEntries = $filterAuditor->getMatchingEntries($package, $filterResult['filter'], $policyConfig, 'audit', null);
                 if (count($matchingEntries) > 0) {
                     $filteredPackages[$package->getName()] = $matchingEntries;
                 }

--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -119,10 +119,10 @@ class Auditor
         $filteredPackages = [];
         $filteredCount = 0;
         if ($policyConfig !== null && $filterListProviderSet !== null && $filtered !== self::FILTERED_IGNORE) {
-            $filterResult = $filterAuditor->collectFilterLists($packages, $filterListProviderSet, $policyConfig->getActiveFilterListNames('audit', null), $ignoreUnreachable || $policyConfig->ignoreUnreachable->audit);
+            $filterResult = $filterAuditor->collectFilterLists($packages, $filterListProviderSet, $policyConfig->getActiveAuditFilterListNames(), $ignoreUnreachable || $policyConfig->ignoreUnreachable->audit);
             $unreachableRepos = array_merge($unreachableRepos, $filterResult['unreachableRepos']);
             foreach ($packages as $package) {
-                $matchingEntries = $filterAuditor->getMatchingEntries($package, $filterResult['filter'], $policyConfig, 'audit', null);
+                $matchingEntries = $filterAuditor->getMatchingAuditEntries($package, $filterResult['filter'], $policyConfig);
                 if (count($matchingEntries) > 0) {
                     $filteredPackages[$package->getName()] = $matchingEntries;
                 }

--- a/src/Composer/DependencyResolver/FilterListPoolFilter.php
+++ b/src/Composer/DependencyResolver/FilterListPoolFilter.php
@@ -16,6 +16,7 @@ use Composer\FilterList\FilterListAuditor;
 use Composer\FilterList\FilterListEntry;
 use Composer\FilterList\FilterListProvider\FilterListProviderSet;
 use Composer\Package\RootPackageInterface;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\PolicyConfig;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryInterface;
@@ -34,23 +35,32 @@ class FilterListPoolFilter
     private $filterListAuditor;
     /** @var HttpDownloader */
     private $httpDownloader;
+    /** @var ListPolicyConfig::BLOCK_SCOPE_* */
+    private $blockScope;
+    /** @var array<RepositoryInterface> */
+    private $repositories;
 
+    /**
+     * @param ListPolicyConfig::BLOCK_SCOPE_* $blockScope
+     * @param array<RepositoryInterface> $repositories Repositories consulted for filter list discovery
+     */
     public function __construct(
         PolicyConfig $policyConfig,
         FilterListAuditor $filterListAuditor,
-        HttpDownloader $httpDownloader
+        HttpDownloader $httpDownloader,
+        string $blockScope,
+        array $repositories
     ) {
         $this->policyConfig = $policyConfig;
         $this->filterListAuditor = $filterListAuditor;
         $this->httpDownloader = $httpDownloader;
+        $this->blockScope = $blockScope;
+        $this->repositories = $repositories;
     }
 
-    /**
-     * @param array<RepositoryInterface> $repositories
-     */
-    public function filter(Pool $pool, array $repositories, Request $request): Pool
+    public function filter(Pool $pool, Request $request): Pool
     {
-        $providerSet = FilterListProviderSet::create($this->policyConfig, $repositories, $this->httpDownloader);
+        $providerSet = FilterListProviderSet::create($this->policyConfig, $this->repositories, $this->httpDownloader);
 
         $filterListMap = $this->collectFilterLists($pool, $providerSet, $request);
 
@@ -61,7 +71,7 @@ class FilterListPoolFilter
         $packages = [];
         $filterListRemovedVersions = [];
         foreach ($pool->getPackages() as $package) {
-            $matchingEntries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $this->policyConfig, 'block');
+            $matchingEntries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $this->policyConfig, 'block', $this->blockScope);
             if (count($matchingEntries) > 0) {
                 foreach ($package->getNames(false) as $packageName) {
                     $filterListRemovedVersions[$packageName][$package->getVersion()] = $matchingEntries;
@@ -83,11 +93,22 @@ class FilterListPoolFilter
     {
         $packagesForFilter = [];
         foreach ($pool->getPackages() as $package) {
-            if (!$package instanceof RootPackageInterface && !PlatformRepository::isPlatformPackage($package->getName()) && !$request->isLockedPackage($package)) {
-                $packagesForFilter[] = $package;
+            if ($package instanceof RootPackageInterface || PlatformRepository::isPlatformPackage($package->getName())) {
+                continue;
             }
+            // Locked packages can't change during an update (partial updates keep them fixed),
+            // but install-scope blocking deliberately checks them so malware in the lock file is caught.
+            if ($this->blockScope === ListPolicyConfig::BLOCK_SCOPE_UPDATE && $request->isLockedPackage($package)) {
+                continue;
+            }
+            $packagesForFilter[] = $package;
         }
 
-        return $this->filterListAuditor->collectFilterLists($packagesForFilter, $providerSet, $this->policyConfig->getActiveFilterListNames('block'), $this->policyConfig->ignoreUnreachable->update)['filter'];
+        return $this->filterListAuditor->collectFilterLists(
+            $packagesForFilter,
+            $providerSet,
+            $this->policyConfig->getActiveFilterListNames('block', $this->blockScope),
+            $this->policyConfig->ignoreUnreachable->forBlockScope($this->blockScope)
+        )['filter'];
     }
 }

--- a/src/Composer/DependencyResolver/FilterListPoolFilter.php
+++ b/src/Composer/DependencyResolver/FilterListPoolFilter.php
@@ -71,7 +71,7 @@ class FilterListPoolFilter
         $packages = [];
         $filterListRemovedVersions = [];
         foreach ($pool->getPackages() as $package) {
-            $matchingEntries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $this->policyConfig, 'block', $this->blockScope);
+            $matchingEntries = $this->filterListAuditor->getMatchingBlockEntries($package, $filterListMap, $this->policyConfig, $this->blockScope);
             if (count($matchingEntries) > 0) {
                 foreach ($package->getNames(false) as $packageName) {
                     $filterListRemovedVersions[$packageName][$package->getVersion()] = $matchingEntries;
@@ -107,7 +107,7 @@ class FilterListPoolFilter
         return $this->filterListAuditor->collectFilterLists(
             $packagesForFilter,
             $providerSet,
-            $this->policyConfig->getActiveFilterListNames('block', $this->blockScope),
+            $this->policyConfig->getActiveBlockFilterListNames($this->blockScope),
             $this->policyConfig->ignoreUnreachable->forBlockScope($this->blockScope)
         )['filter'];
     }

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -357,7 +357,7 @@ class PoolBuilder
         // filter vulnerable packages before optimizing the pool otherwise we may end up with inconsistent state where the optimizer took away versions
         // that were not vulnerable and now suddenly the vulnerable ones are removed and we are missing some versions to make it solvable
         $pool = $this->runSecurityAdvisoryFilter($pool, $repositories, $request);
-        $pool = $this->runFilterListFilter($pool, $repositories, $request);
+        $pool = $this->runFilterListFilter($pool, $request);
         $pool = $this->runOptimizer($request, $pool);
 
         Intervals::clear();
@@ -819,10 +819,7 @@ class PoolBuilder
         return $pool;
     }
 
-    /**
-     * @param RepositoryInterface[] $repositories
-     */
-    private function runFilterListFilter(Pool $pool, array $repositories, Request $request): Pool
+    private function runFilterListFilter(Pool $pool, Request $request): Pool
     {
         if (null === $this->filterListPoolFilter) {
             return $pool;
@@ -833,7 +830,7 @@ class PoolBuilder
         $before = microtime(true);
         $total = \count($pool->getPackages());
 
-        $pool = $this->filterListPoolFilter->filter($pool, $repositories, $request);
+        $pool = $this->filterListPoolFilter->filter($pool, $request);
 
         $filtered = $total - \count($pool->getPackages());
 

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -86,17 +86,21 @@ class Problem
             reset($reasons);
             $rule = current($reasons);
 
-            if ($rule->getReason() !== Rule::RULE_ROOT_REQUIRE) {
-                throw new \LogicException("Single reason problems must contain a root require rule.");
-            }
+            if ($rule->getReason() === Rule::RULE_ROOT_REQUIRE) {
+                $reasonData = $rule->getReasonData();
+                $packageName = $reasonData['packageName'];
+                $constraint = $reasonData['constraint'];
 
-            $reasonData = $rule->getReasonData();
-            $packageName = $reasonData['packageName'];
-            $constraint = $reasonData['constraint'];
-
-            $packages = $pool->whatProvides($packageName, $constraint);
-            if (\count($packages) === 0) {
-                return "\n    ".implode(self::getMissingPackageReason($repositorySet, $request, $pool, $isVerbose, $packageName, $constraint));
+                $packages = $pool->whatProvides($packageName, $constraint);
+                if (\count($packages) === 0) {
+                    return "\n    ".implode(self::getMissingPackageReason($repositorySet, $request, $pool, $isVerbose, $packageName, $constraint));
+                }
+            } elseif ($rule->getReason() === Rule::RULE_FIXED_FILTER_LIST_REMOVED) {
+                // Solver::checkForFilterListRemovedFixedPackages emits these
+                // for fixed packages that the policy filter list dropped from
+                // the pool (typically malware blocked at install time).
+                $package = $rule->getReasonData()['package'];
+                return "\n    ".implode(self::getMissingFixedPackageReason($pool, $package));
             }
         }
 
@@ -119,6 +123,7 @@ class Problem
             case Rule::RULE_ROOT_REQUIRE:
                 return $rule->getReasonData()['packageName'];
             case Rule::RULE_FIXED:
+            case Rule::RULE_FIXED_FILTER_LIST_REMOVED:
                 return (string) $rule->getReasonData()['package'];
             case Rule::RULE_PACKAGE_CONFLICT:
             case Rule::RULE_PACKAGE_REQUIRES:
@@ -139,6 +144,7 @@ class Problem
     {
         switch ($rule->getReason()) {
             case Rule::RULE_FIXED:
+            case Rule::RULE_FIXED_FILTER_LIST_REMOVED:
                 return 3;
             case Rule::RULE_ROOT_REQUIRE:
                 return 2;
@@ -377,14 +383,6 @@ class Problem
                 }
             }
 
-            $nonLockedPackages = array_filter($packages, static function ($p): bool {
-                return !$p->getRepository() instanceof LockArrayRepository;
-            });
-
-            if (0 === \count($nonLockedPackages)) {
-                return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' in the lock file but not in remote repositories, make sure you avoid updating this package to keep the one from the lock file.'];
-            }
-
             if ($pool->isAbandonedRemovedPackageVersion($packageName, $constraint)) {
                 return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but these were not loaded, because they are abandoned and you configured "policy.abandoned.block" to true.'];
             }
@@ -427,6 +425,14 @@ class Problem
                 }, array_keys($filters)));
 
                 return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but these were not loaded, because they were ' . implode(', ', $filters). '. To ignore filters for this package, add the package to the ' . $ignorePaths . ' config. To turn the feature off entirely, you can set ' . $offPaths . ' to false.'];
+            }
+
+            $nonLockedPackages = array_filter($packages, static function ($p): bool {
+                return !$p->getRepository() instanceof LockArrayRepository;
+            });
+
+            if (0 === \count($nonLockedPackages)) {
+                return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' in the lock file but not in remote repositories, make sure you avoid updating this package to keep the one from the lock file.'];
             }
 
             return ["- Root composer.json requires $packageName".self::constraintToText($constraint) . ', ', 'found '.self::getPackageList($packages, $isVerbose, $pool, $constraint).' but these were not loaded, likely because '.(self::hasMultipleNames($packages) ? 'they conflict' : 'it conflicts').' with another require.'];
@@ -485,6 +491,37 @@ class Problem
         }
 
         return ["- Root composer.json requires $packageName, it ", "could not be found in any version, there may be a typo in the package name."];
+    }
+
+    /**
+     * Build the user-facing explanation for a fixed package the pool dropped.
+     *
+     * Used for problems emitted by Solver::checkForFilterListRemovedFixedPackages,
+     * where the package may have been a root require, a transitive locked dep,
+     * or an explicitly pinned package — we don't try to distinguish, so the
+     * wording stays neutral ("Package X 1.0 in the lock file ...").
+     *
+     * @return array{0: string, 1: string} [prefix, suffix] tuple matching getMissingPackageReason()
+     */
+    public static function getMissingFixedPackageReason(Pool $pool, BasePackage $package): array
+    {
+        $packageName = $package->getName();
+        $constraint = new Constraint(Constraint::STR_OP_EQ, $package->getVersion());
+        $prefix = "- Package $packageName ".$package->getPrettyVersion().' (in the lock file) ';
+
+        if ($pool->isFilterListRemovedPackageVersion($packageName, $constraint)) {
+            $filters = $pool->getFilterListEntryForPackageVersion($packageName, $constraint);
+            $ignorePaths = implode(' and ', array_map(static function (string $listName): string {
+                return '"policy.' . $listName . '.ignore"';
+            }, array_keys($filters)));
+            $offPaths = implode(' and ', array_map(static function (string $listName): string {
+                return '"policy.' . $listName . '.block"';
+            }, array_keys($filters)));
+
+            return [$prefix, 'was not loaded, because it was ' . implode(', ', $filters). '. To ignore filters for this package, add the package to the ' . $ignorePaths . ' config. To turn the feature off entirely, you can set ' . $offPaths . ' to false.'];
+        }
+
+        throw new \RuntimeException("Filter list removed fixed package must have version removed from pool.");
     }
 
     /**

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -95,12 +95,12 @@ class Problem
                 if (\count($packages) === 0) {
                     return "\n    ".implode(self::getMissingPackageReason($repositorySet, $request, $pool, $isVerbose, $packageName, $constraint));
                 }
-            } elseif ($rule->getReason() === Rule::RULE_FIXED_FILTER_LIST_REMOVED) {
-                // Solver::checkForFilterListRemovedFixedPackages emits these
-                // for fixed packages that the policy filter list dropped from
+            } elseif ($rule->getReason() === Rule::RULE_LOCKED_FILTER_LIST_REMOVED) {
+                // Solver::checkForFilterListRemovedLockedPackages emits these
+                // for locked packages that the policy filter list dropped from
                 // the pool (typically malware blocked at install time).
                 $package = $rule->getReasonData()['package'];
-                return "\n    ".implode(self::getMissingFixedPackageReason($pool, $package));
+                return "\n    ".implode(self::getMissingLockedPackageReason($pool, $package));
             }
         }
 
@@ -123,7 +123,7 @@ class Problem
             case Rule::RULE_ROOT_REQUIRE:
                 return $rule->getReasonData()['packageName'];
             case Rule::RULE_FIXED:
-            case Rule::RULE_FIXED_FILTER_LIST_REMOVED:
+            case Rule::RULE_LOCKED_FILTER_LIST_REMOVED:
                 return (string) $rule->getReasonData()['package'];
             case Rule::RULE_PACKAGE_CONFLICT:
             case Rule::RULE_PACKAGE_REQUIRES:
@@ -144,7 +144,7 @@ class Problem
     {
         switch ($rule->getReason()) {
             case Rule::RULE_FIXED:
-            case Rule::RULE_FIXED_FILTER_LIST_REMOVED:
+            case Rule::RULE_LOCKED_FILTER_LIST_REMOVED:
                 return 3;
             case Rule::RULE_ROOT_REQUIRE:
                 return 2;
@@ -494,9 +494,9 @@ class Problem
     }
 
     /**
-     * Build the user-facing explanation for a fixed package the pool dropped.
+     * Build the user-facing explanation for a locked package the pool dropped.
      *
-     * Used for problems emitted by Solver::checkForFilterListRemovedFixedPackages.
+     * Used for problems emitted by Solver::checkForFilterListRemovedLockedPackages.
      * Root and platform packages are filtered out before they can land in the
      * filter-list-removed map, so any package that reaches this method came
      * from the locked repository (composer install, or partial composer update
@@ -504,7 +504,7 @@ class Problem
      *
      * @return array{0: string, 1: string} [prefix, suffix] tuple matching getMissingPackageReason()
      */
-    public static function getMissingFixedPackageReason(Pool $pool, BasePackage $package): array
+    public static function getMissingLockedPackageReason(Pool $pool, BasePackage $package): array
     {
         $packageName = $package->getName();
         $constraint = new Constraint(Constraint::STR_OP_EQ, $package->getVersion());
@@ -522,7 +522,7 @@ class Problem
             return [$prefix, 'was not loaded, because it was ' . implode(', ', $filters). '. To ignore filters for this package, add the package to the ' . $ignorePaths . ' config. To turn the feature off entirely, you can set ' . $offPaths . ' to false.'];
         }
 
-        throw new \LogicException("Filter list removed fixed package must have version removed from pool.");
+        throw new \LogicException("Filter list removed locked package must have version removed from pool.");
     }
 
     /**

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -496,10 +496,11 @@ class Problem
     /**
      * Build the user-facing explanation for a fixed package the pool dropped.
      *
-     * Used for problems emitted by Solver::checkForFilterListRemovedFixedPackages,
-     * where the package may have been a root require, a transitive locked dep,
-     * or an explicitly pinned package — we don't try to distinguish, so the
-     * wording stays neutral ("Package X 1.0 in the lock file ...").
+     * Used for problems emitted by Solver::checkForFilterListRemovedFixedPackages.
+     * Root and platform packages are filtered out before they can land in the
+     * filter-list-removed map, so any package that reaches this method came
+     * from the locked repository (composer install, or partial composer update
+     * with kept locked deps) — hence the "(in the lock file)" hint in the prefix.
      *
      * @return array{0: string, 1: string} [prefix, suffix] tuple matching getMissingPackageReason()
      */
@@ -521,7 +522,7 @@ class Problem
             return [$prefix, 'was not loaded, because it was ' . implode(', ', $filters). '. To ignore filters for this package, add the package to the ' . $ignorePaths . ' config. To turn the feature off entirely, you can set ' . $offPaths . ' to false.'];
         }
 
-        throw new \RuntimeException("Filter list removed fixed package must have version removed from pool.");
+        throw new \LogicException("Filter list removed fixed package must have version removed from pool.");
     }
 
     /**

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -173,7 +173,7 @@ class Request
      */
     public function getLockedPackages(): array
     {
-        return $this->lockedPackages;
+        return array_merge($this->lockedPackages, $this->fixedLockedPackages);
     }
 
     public function isLockedPackage(PackageInterface $package): bool

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -37,6 +37,7 @@ abstract class Rule
     public const RULE_LEARNED = 12; // int (rule id)
     public const RULE_PACKAGE_ALIAS = 13; // BasePackage
     public const RULE_PACKAGE_INVERSE_ALIAS = 14; // BasePackage
+    public const RULE_FIXED_FILTER_LIST_REMOVED = 15; // array{package: BasePackage}
 
     // bitfield defs
     private const BITFIELD_TYPE = 0;
@@ -104,6 +105,7 @@ abstract class Rule
             case self::RULE_ROOT_REQUIRE:
                 return $this->getReasonData()['packageName'];
             case self::RULE_FIXED:
+            case self::RULE_FIXED_FILTER_LIST_REMOVED:
                 return $this->getReasonData()['package']->getName();
             case self::RULE_PACKAGE_REQUIRES:
                 return $this->getReasonData()->getTarget();
@@ -264,6 +266,10 @@ abstract class Rule
                 }
 
                 return $package->getPrettyName().' is present at version '.$package->getPrettyVersion() . ' and cannot be modified by Composer';
+
+            case self::RULE_FIXED_FILTER_LIST_REMOVED:
+                $package = $this->deduplicateDefaultBranchAlias($this->getReasonData()['package']);
+                return $package->getPrettyName().' '.$package->getPrettyVersion().' was removed by a policy filter list (e.g. malware) and cannot be installed.';
 
             case self::RULE_PACKAGE_CONFLICT:
                 $package1 = $this->deduplicateDefaultBranchAlias($pool->literalToPackage($literals[0]));

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -37,7 +37,7 @@ abstract class Rule
     public const RULE_LEARNED = 12; // int (rule id)
     public const RULE_PACKAGE_ALIAS = 13; // BasePackage
     public const RULE_PACKAGE_INVERSE_ALIAS = 14; // BasePackage
-    public const RULE_FIXED_FILTER_LIST_REMOVED = 15; // array{package: BasePackage}
+    public const RULE_LOCKED_FILTER_LIST_REMOVED = 15; // array{package: BasePackage}
 
     // bitfield defs
     private const BITFIELD_TYPE = 0;
@@ -105,7 +105,7 @@ abstract class Rule
             case self::RULE_ROOT_REQUIRE:
                 return $this->getReasonData()['packageName'];
             case self::RULE_FIXED:
-            case self::RULE_FIXED_FILTER_LIST_REMOVED:
+            case self::RULE_LOCKED_FILTER_LIST_REMOVED:
                 return $this->getReasonData()['package']->getName();
             case self::RULE_PACKAGE_REQUIRES:
                 return $this->getReasonData()->getTarget();
@@ -267,7 +267,7 @@ abstract class Rule
 
                 return $package->getPrettyName().' is present at version '.$package->getPrettyVersion() . ' and cannot be modified by Composer';
 
-            case self::RULE_FIXED_FILTER_LIST_REMOVED:
+            case self::RULE_LOCKED_FILTER_LIST_REMOVED:
                 $package = $this->deduplicateDefaultBranchAlias($this->getReasonData()['package']);
                 return $package->getPrettyName().' '.$package->getPrettyVersion().' was removed by a policy filter list (e.g. malware) and cannot be installed.';
 

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -251,8 +251,8 @@ class RuleSetGenerator
     protected function addRulesForRequest(Request $request, PlatformRequirementFilterInterface $platformRequirementFilter): void
     {
         foreach ($request->getFixedPackages() as $package) {
-            // Fixed package was dropped from this pool by a policy filter list
-            // (e.g. malware). Solver::checkForFilterListRemovedFixedPackages
+            // Locked package was dropped from this pool by a policy filter list
+            // (e.g. malware). Solver::checkForFilterListRemovedLockedPackages
             // surfaces a SolverProblemsException for it; here we simply skip
             // adding rules for the now-missing pool member.
             //
@@ -261,7 +261,7 @@ class RuleSetGenerator
             // stale positive id from any prior Pool it was part of (Pool only
             // re-assigns ids for packages it actually contains, so removed
             // entries keep their previous id).
-            if ($this->pool->isFilterListRemovedPackageVersion($package->getName(), new Constraint(Constraint::STR_OP_EQ, $package->getVersion()))) {
+            if ($request->isLockedPackage($package) && $this->pool->isFilterListRemovedPackageVersion($package->getName(), new Constraint(Constraint::STR_OP_EQ, $package->getVersion()))) {
                 continue;
             }
 

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -261,7 +261,7 @@ class RuleSetGenerator
             // stale positive id from any prior Pool it was part of (Pool only
             // re-assigns ids for packages it actually contains, so removed
             // entries keep their previous id).
-            if ($this->pool->isFilterListRemovedPackageVersion($package->getName(), new Constraint('==', $package->getVersion()))) {
+            if ($this->pool->isFilterListRemovedPackageVersion($package->getName(), new Constraint(Constraint::STR_OP_EQ, $package->getVersion()))) {
                 continue;
             }
 

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -17,6 +17,7 @@ use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterInterface;
 use Composer\Package\BasePackage;
 use Composer\Package\AliasPackage;
+use Composer\Semver\Constraint\Constraint;
 
 /**
  * @author Nils Adermann <naderman@naderman.de>
@@ -250,6 +251,14 @@ class RuleSetGenerator
     protected function addRulesForRequest(Request $request, PlatformRequirementFilterInterface $platformRequirementFilter): void
     {
         foreach ($request->getFixedPackages() as $package) {
+            // fixed package was removed from the pool by a policy filter list (e.g. malware);
+            // Solver::checkForFilterListRemovedFixedPackages surfaces a SolverProblemsException for it.
+            // Note: $package->id can still be a stale positive value from an earlier pool; check the
+            // filter-list-removed map directly instead of relying on id === -1.
+            if ($this->pool->isFilterListRemovedPackageVersion($package->getName(), new Constraint('==', $package->getVersion()))) {
+                continue;
+            }
+
             if ($package->id === -1) {
                 // fixed package was not added to the pool as it did not pass the stability requirements, this is fine
                 if ($this->pool->isUnacceptableFixedOrLockedPackage($package)) {

--- a/src/Composer/DependencyResolver/RuleSetGenerator.php
+++ b/src/Composer/DependencyResolver/RuleSetGenerator.php
@@ -251,10 +251,16 @@ class RuleSetGenerator
     protected function addRulesForRequest(Request $request, PlatformRequirementFilterInterface $platformRequirementFilter): void
     {
         foreach ($request->getFixedPackages() as $package) {
-            // fixed package was removed from the pool by a policy filter list (e.g. malware);
-            // Solver::checkForFilterListRemovedFixedPackages surfaces a SolverProblemsException for it.
-            // Note: $package->id can still be a stale positive value from an earlier pool; check the
-            // filter-list-removed map directly instead of relying on id === -1.
+            // Fixed package was dropped from this pool by a policy filter list
+            // (e.g. malware). Solver::checkForFilterListRemovedFixedPackages
+            // surfaces a SolverProblemsException for it; here we simply skip
+            // adding rules for the now-missing pool member.
+            //
+            // We must dispatch on the filter-list-removed map directly rather
+            // than `$package->id === -1` because the package object retains a
+            // stale positive id from any prior Pool it was part of (Pool only
+            // re-assigns ids for packages it actually contains, so removed
+            // entries keep their previous id).
             if ($this->pool->isFilterListRemovedPackageVersion($package->getName(), new Constraint('==', $package->getVersion()))) {
                 continue;
             }

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -17,6 +17,7 @@ use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterInterface;
 use Composer\IO\IOInterface;
 use Composer\Package\BasePackage;
+use Composer\Semver\Constraint\Constraint;
 
 /**
  * @author Nils Adermann <naderman@naderman.de>
@@ -172,6 +173,29 @@ class Solver
         }
     }
 
+    protected function checkForFilterListRemovedFixedPackages(Request $request): void
+    {
+        foreach ($request->getFixedPackages() as $package) {
+            $constraint = new Constraint(Constraint::STR_OP_EQ, $package->getVersion());
+            if (!$this->pool->isFilterListRemovedPackageVersion($package->getName(), $constraint)) {
+                continue;
+            }
+
+            // RULE_FIXED_FILTER_LIST_REMOVED is dedicated to this case: a fixed
+            // package (root require, transitive locked dep, or explicitly pinned)
+            // dropped from the pool by a policy filter list. We can't tell those
+            // apart from inside Solver, so emit a Problem keyed on the package
+            // itself and let Problem::getMissingFixedPackageReason render neutral
+            // wording. A dedicated rule type keeps RULE_FIXED's existing
+            // semantics ("present at version X, cannot be modified") untouched.
+            $problem = new Problem();
+            $problem->addRule(new GenericRule([], Rule::RULE_FIXED_FILTER_LIST_REMOVED, [
+                'package' => $package,
+            ]));
+            $this->problems[] = $problem;
+        }
+    }
+
     public function solve(Request $request, ?PlatformRequirementFilterInterface $platformRequirementFilter = null): LockTransaction
     {
         $platformRequirementFilter = $platformRequirementFilter ?? PlatformRequirementFilterFactory::ignoreNothing();
@@ -183,6 +207,7 @@ class Solver
         $this->rules = $ruleSetGenerator->getRulesFor($request, $platformRequirementFilter);
         unset($ruleSetGenerator);
         $this->checkForRootRequireProblems($request, $platformRequirementFilter);
+        $this->checkForFilterListRemovedFixedPackages($request);
         $this->decisions = new Decisions($this->pool);
         $this->watchGraph = new RuleWatchGraph;
 

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -210,6 +210,9 @@ class Solver
         $this->rules = $ruleSetGenerator->getRulesFor($request, $platformRequirementFilter);
         unset($ruleSetGenerator);
         $this->checkForRootRequireProblems($request, $platformRequirementFilter);
+        // Must run after RuleSetGenerator: the generator silently skips fixed
+        // packages whose pool entry was filter-list-removed, so this check is
+        // what actually surfaces the resulting SolverProblem to the user.
         $this->checkForFilterListRemovedFixedPackages($request);
         $this->decisions = new Decisions($this->pool);
         $this->watchGraph = new RuleWatchGraph;

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -173,6 +173,16 @@ class Solver
         }
     }
 
+    /**
+     * Surface a SolverProblemsException for fixed packages the pool dropped
+     * via a policy filter list (typically the malware list at install time).
+     *
+     * Each emitted Problem carries a single GenericRule of type
+     * RULE_FIXED_FILTER_LIST_REMOVED; Problem::getMissingFixedPackageReason
+     * renders neutral wording ("Package X 1.0 (in the lock file) was not
+     * loaded, because it was flagged as malware ..."). RuleSetGeneratorTest
+     * and ProblemTest lock the wiring in.
+     */
     protected function checkForFilterListRemovedFixedPackages(Request $request): void
     {
         foreach ($request->getFixedPackages() as $package) {
@@ -181,13 +191,6 @@ class Solver
                 continue;
             }
 
-            // RULE_FIXED_FILTER_LIST_REMOVED is dedicated to this case: a fixed
-            // package (root require, transitive locked dep, or explicitly pinned)
-            // dropped from the pool by a policy filter list. We can't tell those
-            // apart from inside Solver, so emit a Problem keyed on the package
-            // itself and let Problem::getMissingFixedPackageReason render neutral
-            // wording. A dedicated rule type keeps RULE_FIXED's existing
-            // semantics ("present at version X, cannot be modified") untouched.
             $problem = new Problem();
             $problem->addRule(new GenericRule([], Rule::RULE_FIXED_FILTER_LIST_REMOVED, [
                 'package' => $package,

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -174,25 +174,25 @@ class Solver
     }
 
     /**
-     * Surface a SolverProblemsException for fixed packages the pool dropped
+     * Surface a SolverProblemsException for locked packages the pool dropped
      * via a policy filter list (typically the malware list at install time).
      *
      * Each emitted Problem carries a single GenericRule of type
-     * RULE_FIXED_FILTER_LIST_REMOVED; Problem::getMissingFixedPackageReason
+     * RULE_LOCKED_FILTER_LIST_REMOVED; Problem::getMissingLockedPackageReason
      * renders neutral wording ("Package X 1.0 (in the lock file) was not
      * loaded, because it was flagged as malware ..."). RuleSetGeneratorTest
      * and ProblemTest lock the wiring in.
      */
-    protected function checkForFilterListRemovedFixedPackages(Request $request): void
+    protected function checkForFilterListRemovedLockedPackages(Request $request): void
     {
-        foreach ($request->getFixedPackages() as $package) {
+        foreach ($request->getLockedPackages() as $package) {
             $constraint = new Constraint(Constraint::STR_OP_EQ, $package->getVersion());
             if (!$this->pool->isFilterListRemovedPackageVersion($package->getName(), $constraint)) {
                 continue;
             }
 
             $problem = new Problem();
-            $problem->addRule(new GenericRule([], Rule::RULE_FIXED_FILTER_LIST_REMOVED, [
+            $problem->addRule(new GenericRule([], Rule::RULE_LOCKED_FILTER_LIST_REMOVED, [
                 'package' => $package,
             ]));
             $this->problems[] = $problem;
@@ -210,10 +210,10 @@ class Solver
         $this->rules = $ruleSetGenerator->getRulesFor($request, $platformRequirementFilter);
         unset($ruleSetGenerator);
         $this->checkForRootRequireProblems($request, $platformRequirementFilter);
-        // Must run after RuleSetGenerator: the generator silently skips fixed
+        // Must run after RuleSetGenerator: the generator silently skips locked
         // packages whose pool entry was filter-list-removed, so this check is
         // what actually surfaces the resulting SolverProblem to the user.
-        $this->checkForFilterListRemovedFixedPackages($request);
+        $this->checkForFilterListRemovedLockedPackages($request);
         $this->decisions = new Decisions($this->pool);
         $this->watchGraph = new RuleWatchGraph;
 

--- a/src/Composer/FilterList/FilterListAuditor.php
+++ b/src/Composer/FilterList/FilterListAuditor.php
@@ -19,7 +19,6 @@ use Composer\Package\RootPackageInterface;
 use Composer\Pcre\Preg;
 use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\MalwarePolicyConfig;
-use Composer\Policy\MalwarePolicyConfig;
 use Composer\Policy\PolicyConfig;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\Constraint\ConstraintInterface;

--- a/src/Composer/FilterList/FilterListAuditor.php
+++ b/src/Composer/FilterList/FilterListAuditor.php
@@ -19,6 +19,7 @@ use Composer\Package\RootPackageInterface;
 use Composer\Pcre\Preg;
 use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\MalwarePolicyConfig;
+use Composer\Policy\MalwarePolicyConfig;
 use Composer\Policy\PolicyConfig;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\Constraint\ConstraintInterface;
@@ -55,17 +56,35 @@ class FilterListAuditor
 
     /**
      * @param array<string, array<string, list<FilterListEntry>>> $filterListMap
-     * @param 'block'|'audit' $operation
-     * @param ListPolicyConfig::BLOCK_SCOPE_*|null $blockScope
      * @return list<FilterListEntry>
      */
-    public function getMatchingEntries(PackageInterface $package, array $filterListMap, PolicyConfig $policyConfig, string $operation, ?string $blockScope): array
+    public function getMatchingAuditEntries(PackageInterface $package, array $filterListMap, PolicyConfig $policyConfig): array
+    {
+        return $this->matchingEntries($package, $filterListMap, $policyConfig->getActiveAuditFilterLists(), 'audit');
+    }
+
+    /**
+     * @param array<string, array<string, list<FilterListEntry>>> $filterListMap
+     * @param ListPolicyConfig::BLOCK_SCOPE_* $blockScope
+     * @return list<FilterListEntry>
+     */
+    public function getMatchingBlockEntries(PackageInterface $package, array $filterListMap, PolicyConfig $policyConfig, string $blockScope): array
+    {
+        return $this->matchingEntries($package, $filterListMap, $policyConfig->getActiveBlockFilterLists($blockScope), 'block');
+    }
+
+    /**
+     * @param array<string, array<string, list<FilterListEntry>>> $filterListMap
+     * @param array<string, ListPolicyConfig> $activeListConfigs
+     * @param 'block'|'audit' $operation
+     * @return list<FilterListEntry>
+     */
+    private function matchingEntries(PackageInterface $package, array $filterListMap, array $activeListConfigs, string $operation): array
     {
         if ($package instanceof RootPackageInterface || count($filterListMap) === 0) {
             return [];
         }
 
-        $activeListConfigs = $policyConfig->getActiveFilterLists($operation, $blockScope);
         if (isset($activeListConfigs[MalwarePolicyConfig::NAME]) && $activeListConfigs[MalwarePolicyConfig::NAME] instanceof MalwarePolicyConfig) {
             $filterListMap = $this->applyMalwareIgnoreSource($filterListMap, $activeListConfigs[MalwarePolicyConfig::NAME], $operation);
         }

--- a/src/Composer/FilterList/FilterListAuditor.php
+++ b/src/Composer/FilterList/FilterListAuditor.php
@@ -56,15 +56,16 @@ class FilterListAuditor
     /**
      * @param array<string, array<string, list<FilterListEntry>>> $filterListMap
      * @param 'block'|'audit' $operation
+     * @param ListPolicyConfig::BLOCK_SCOPE_*|null $blockScope
      * @return list<FilterListEntry>
      */
-    public function getMatchingEntries(PackageInterface $package, array $filterListMap, PolicyConfig $policyConfig, string $operation): array
+    public function getMatchingEntries(PackageInterface $package, array $filterListMap, PolicyConfig $policyConfig, string $operation, ?string $blockScope): array
     {
         if ($package instanceof RootPackageInterface || count($filterListMap) === 0) {
             return [];
         }
 
-        $activeListConfigs = $policyConfig->getActiveFilterLists($operation);
+        $activeListConfigs = $policyConfig->getActiveFilterLists($operation, $blockScope);
         if (isset($activeListConfigs[MalwarePolicyConfig::NAME]) && $activeListConfigs[MalwarePolicyConfig::NAME] instanceof MalwarePolicyConfig) {
             $filterListMap = $this->applyMalwareIgnoreSource($filterListMap, $activeListConfigs[MalwarePolicyConfig::NAME], $operation);
         }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -38,6 +38,7 @@ use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterInterface
 use Composer\FilterList\FilterListAuditor;
 use Composer\FilterList\FilterListProvider\FilterListProviderSet;
 use Composer\Installer\InstallationManager;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\PolicyConfig;
 use Composer\Installer\InstallerEvents;
 use Composer\Installer\SuggestedPackagesReporter;
@@ -529,7 +530,7 @@ class Installer
             $request->setUpdateAllowList($this->updateAllowList, $this->updateAllowTransitiveDependencies);
         }
 
-        $pool = $repositorySet->createPool($request, $this->io, $this->eventDispatcher, $this->createPoolOptimizer($policy), $this->ignoredTypes, $this->allowedTypes, $this->createSecurityAuditPoolFilter(), $this->createFilterListPoolFilter());
+        $pool = $repositorySet->createPool($request, $this->io, $this->eventDispatcher, $this->createPoolOptimizer($policy), $this->ignoredTypes, $this->allowedTypes, $this->createSecurityAuditPoolFilter(), $this->createFilterListPoolFilter(ListPolicyConfig::BLOCK_SCOPE_UPDATE));
 
         $this->io->writeError('<info>Updating dependencies</info>');
 
@@ -803,7 +804,7 @@ class Installer
             }
             unset($rootRequires, $link);
 
-            $pool = $repositorySet->createPool($request, $this->io, $this->eventDispatcher, null, $this->ignoredTypes, $this->allowedTypes, null);
+            $pool = $repositorySet->createPool($request, $this->io, $this->eventDispatcher, null, $this->ignoredTypes, $this->allowedTypes, null, $this->createFilterListPoolFilter(ListPolicyConfig::BLOCK_SCOPE_INSTALL));
 
             // solve dependencies
             $solver = new Solver($policy, $pool, $this->io);
@@ -1166,7 +1167,10 @@ class Installer
         return null;
     }
 
-    private function createFilterListPoolFilter(): ?FilterListPoolFilter
+    /**
+     * @param ListPolicyConfig::BLOCK_SCOPE_UPDATE|ListPolicyConfig::BLOCK_SCOPE_INSTALL $blockScope
+     */
+    private function createFilterListPoolFilter(string $blockScope): ?FilterListPoolFilter
     {
         $policyConfig = $this->getPolicyConfig();
 
@@ -1174,7 +1178,11 @@ class Installer
             return null;
         }
 
-        return new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->repositoryManager->getHttpDownloader());
+        if ($blockScope === ListPolicyConfig::BLOCK_SCOPE_INSTALL && !$policyConfig->malware->shouldBlock($blockScope)) {
+            return null;
+        }
+
+        return new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->repositoryManager->getHttpDownloader(), $blockScope, $this->repositoryManager->getRepositories());
     }
 
     /**

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1178,7 +1178,7 @@ class Installer
             return null;
         }
 
-        if ($blockScope === ListPolicyConfig::BLOCK_SCOPE_INSTALL && !$policyConfig->malware->shouldBlock($blockScope)) {
+        if ($blockScope === ListPolicyConfig::BLOCK_SCOPE_INSTALL && \count($policyConfig->getActiveBlockFilterLists($blockScope)) === 0) {
             return null;
         }
 

--- a/src/Composer/PHPStan/RuleReasonDataReturnTypeExtension.php
+++ b/src/Composer/PHPStan/RuleReasonDataReturnTypeExtension.php
@@ -50,6 +50,7 @@ final class RuleReasonDataReturnTypeExtension implements DynamicMethodReturnType
         $types = [
             Rule::RULE_ROOT_REQUIRE => new ConstantArrayType([new ConstantStringType('packageName'), new ConstantStringType('constraint')], [new StringType, new ObjectType(ConstraintInterface::class)]),
             Rule::RULE_FIXED => new ConstantArrayType([new ConstantStringType('package')], [new ObjectType(BasePackage::class)]),
+            Rule::RULE_FIXED_FILTER_LIST_REMOVED => new ConstantArrayType([new ConstantStringType('package')], [new ObjectType(BasePackage::class)]),
             Rule::RULE_PACKAGE_CONFLICT => new ObjectType(Link::class),
             Rule::RULE_PACKAGE_REQUIRES => new ObjectType(Link::class),
             Rule::RULE_PACKAGE_SAME_NAME => TypeCombinator::intersect(new StringType, new AccessoryNonEmptyStringType()),
@@ -58,10 +59,21 @@ final class RuleReasonDataReturnTypeExtension implements DynamicMethodReturnType
             Rule::RULE_PACKAGE_INVERSE_ALIAS => new ObjectType(BasePackage::class),
         ];
 
+        // Collect every reasonData type whose reason constant is a possible
+        // value of the call-site's getReason(). Single-case `case RULE_FIXED:`
+        // narrows reasonType to one constant and yields a single match;
+        // fall-through `case RULE_FIXED: case RULE_FIXED_FILTER_LIST_REMOVED:`
+        // yields a union of constants and we return the union of their
+        // reasonData types so offset access can still narrow correctly.
+        $matched = [];
         foreach ($types as $const => $type) {
-            if ((new ConstantIntegerType($const))->isSuperTypeOf($reasonType)->yes()) {
-                return $type;
+            if ($reasonType->isSuperTypeOf(new ConstantIntegerType($const))->yes()) {
+                $matched[] = $type;
             }
+        }
+
+        if (\count($matched) > 0) {
+            return \count($matched) === 1 ? $matched[0] : TypeCombinator::union(...$matched);
         }
 
         return TypeCombinator::union(...$types);

--- a/src/Composer/PHPStan/RuleReasonDataReturnTypeExtension.php
+++ b/src/Composer/PHPStan/RuleReasonDataReturnTypeExtension.php
@@ -50,7 +50,7 @@ final class RuleReasonDataReturnTypeExtension implements DynamicMethodReturnType
         $types = [
             Rule::RULE_ROOT_REQUIRE => new ConstantArrayType([new ConstantStringType('packageName'), new ConstantStringType('constraint')], [new StringType, new ObjectType(ConstraintInterface::class)]),
             Rule::RULE_FIXED => new ConstantArrayType([new ConstantStringType('package')], [new ObjectType(BasePackage::class)]),
-            Rule::RULE_FIXED_FILTER_LIST_REMOVED => new ConstantArrayType([new ConstantStringType('package')], [new ObjectType(BasePackage::class)]),
+            Rule::RULE_LOCKED_FILTER_LIST_REMOVED => new ConstantArrayType([new ConstantStringType('package')], [new ObjectType(BasePackage::class)]),
             Rule::RULE_PACKAGE_CONFLICT => new ObjectType(Link::class),
             Rule::RULE_PACKAGE_REQUIRES => new ObjectType(Link::class),
             Rule::RULE_PACKAGE_SAME_NAME => TypeCombinator::intersect(new StringType, new AccessoryNonEmptyStringType()),
@@ -62,7 +62,7 @@ final class RuleReasonDataReturnTypeExtension implements DynamicMethodReturnType
         // Collect every reasonData type whose reason constant is a possible
         // value of the call-site's getReason(). Single-case `case RULE_FIXED:`
         // narrows reasonType to one constant and yields a single match;
-        // fall-through `case RULE_FIXED: case RULE_FIXED_FILTER_LIST_REMOVED:`
+        // fall-through `case RULE_FIXED: case RULE_LOCKED_FILTER_LIST_REMOVED:`
         // yields a union of constants and we return the union of their
         // reasonData types so offset access can still narrow correctly.
         $matched = [];

--- a/src/Composer/Policy/IgnoreUnreachable.php
+++ b/src/Composer/Policy/IgnoreUnreachable.php
@@ -37,6 +37,16 @@ class IgnoreUnreachable
         $this->update = $update;
     }
 
+    /**
+     * @param ListPolicyConfig::BLOCK_SCOPE_* $blockScope
+     */
+    public function forBlockScope(string $blockScope): bool
+    {
+        return $blockScope === ListPolicyConfig::BLOCK_SCOPE_INSTALL
+            ? $this->install
+            : $this->update;
+    }
+
     public static function default(): self
     {
         return new self(false, true, true);

--- a/src/Composer/Policy/ListPolicyConfig.php
+++ b/src/Composer/Policy/ListPolicyConfig.php
@@ -72,14 +72,30 @@ abstract class ListPolicyConfig
         $this->ignore = $ignore;
     }
 
+    protected function supportsInstallBlockScope(): bool
+    {
+        return false;
+    }
+
     /**
      * Whether blocking applies to a given command context.
+     *
+     * Lists that do not opt into install-time blocking via supportsInstallScope()
+     * are never active for BLOCK_SCOPE_INSTALL — even if `block` is true.
      *
      * @param self::BLOCK_SCOPE_* $blockScope
      */
     public function shouldBlock(string $blockScope): bool
     {
-        return $this->block;
+        if (!$this->block) {
+            return false;
+        }
+
+        if ($blockScope === self::BLOCK_SCOPE_INSTALL && !$this->supportsInstallBlockScope()) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Composer/Policy/ListPolicyConfig.php
+++ b/src/Composer/Policy/ListPolicyConfig.php
@@ -44,7 +44,12 @@ abstract class ListPolicyConfig
     /** @var string List name */
     public $name;
 
-    /** @var bool Whether this list blocks matching versions during update/require */
+    /**
+     * Whether this list blocks matching versions during update/require — and during install for
+     * lists that opt into install-time blocking via supportsInstallBlockScope().
+     *
+     * @var bool
+     */
     public $block;
 
     /** @var self::AUDIT_* How composer audit treats matches from this list */
@@ -80,7 +85,7 @@ abstract class ListPolicyConfig
     /**
      * Whether blocking applies to a given command context.
      *
-     * Lists that do not opt into install-time blocking via supportsInstallScope()
+     * Lists that do not opt into install-time blocking via supportsInstallBlockScope()
      * are never active for BLOCK_SCOPE_INSTALL — even if `block` is true.
      *
      * @param self::BLOCK_SCOPE_* $blockScope

--- a/src/Composer/Policy/MalwarePolicyConfig.php
+++ b/src/Composer/Policy/MalwarePolicyConfig.php
@@ -34,6 +34,16 @@ class MalwarePolicyConfig extends ListPolicyConfig
     public $ignoreSource;
 
     /**
+     * Malware is the one built-in list with install-time pool filtering wired up,
+     * so it opts into BLOCK_SCOPE_INSTALL via the base-class hook. The per-list
+     * `block-scope` config field narrows the decision further inside shouldBlock().
+     */
+    protected function supportsInstallBlockScope(): bool
+    {
+        return true;
+    }
+
+    /**
      * @param array<string, list<IgnorePackageRule>> $ignore
      * @param list<string> $ignoreSource
      * @param self::AUDIT_* $audit
@@ -62,6 +72,8 @@ class MalwarePolicyConfig extends ListPolicyConfig
      */
     public function shouldBlock(string $blockScope): bool
     {
+        // Defer the "is this list enabled at all + supports this scope?" question
+        // to the base class; only the per-list `block-scope` narrowing is malware-specific.
         if (!parent::shouldBlock($blockScope)) {
             return false;
         }

--- a/src/Composer/Policy/PolicyConfig.php
+++ b/src/Composer/Policy/PolicyConfig.php
@@ -242,22 +242,15 @@ class PolicyConfig
     }
 
     /**
-     * @param 'audit'|'block' $operation
-     * @param ListPolicyConfig::BLOCK_SCOPE_*|null $blockScope
+     * Filter lists active for `composer audit` reporting.
+     *
      * @return array<string, ListPolicyConfig>
      */
-    public function getActiveFilterLists(string $operation, ?string $blockScope): array
+    public function getActiveAuditFilterLists(): array
     {
-        $allLists = $this->getAllLists();
-        unset($allLists['abandoned'], $allLists['advisories']);
-
         $lists = [];
-        foreach ($allLists as $name => $list) {
-            if ($operation === 'audit' && $list->audit !== ListPolicyConfig::AUDIT_IGNORE) {
-                $lists[$name] = $list;
-            }
-
-            if ($operation === 'block' && $blockScope !== null && $list->shouldBlock($blockScope)) {
+        foreach ($this->filterableLists() as $name => $list) {
+            if ($list->audit !== ListPolicyConfig::AUDIT_IGNORE) {
                 $lists[$name] = $list;
             }
         }
@@ -266,13 +259,52 @@ class PolicyConfig
     }
 
     /**
-     * @param 'audit'|'block' $operation
-     * @param ListPolicyConfig::BLOCK_SCOPE_*|null $blockScope
+     * Filter lists active for blocking during the given block scope (update/install).
+     *
+     * @param ListPolicyConfig::BLOCK_SCOPE_* $blockScope
+     * @return array<string, ListPolicyConfig>
+     */
+    public function getActiveBlockFilterLists(string $blockScope): array
+    {
+        $lists = [];
+        foreach ($this->filterableLists() as $name => $list) {
+            if ($list->shouldBlock($blockScope)) {
+                $lists[$name] = $list;
+            }
+        }
+
+        return $lists;
+    }
+
+    /**
      * @return list<string>
      */
-    public function getActiveFilterListNames(string $operation, ?string $blockScope): array
+    public function getActiveAuditFilterListNames(): array
     {
-        return array_keys($this->getActiveFilterLists($operation, $blockScope));
+        return array_keys($this->getActiveAuditFilterLists());
+    }
+
+    /**
+     * @param ListPolicyConfig::BLOCK_SCOPE_* $blockScope
+     * @return list<string>
+     */
+    public function getActiveBlockFilterListNames(string $blockScope): array
+    {
+        return array_keys($this->getActiveBlockFilterLists($blockScope));
+    }
+
+    /**
+     * Lists eligible for filter-list filtering (i.e. all lists except `advisories`
+     * and `abandoned`, which are surfaced via dedicated code paths).
+     *
+     * @return array<string, ListPolicyConfig>
+     */
+    private function filterableLists(): array
+    {
+        $allLists = $this->getAllLists();
+        unset($allLists['abandoned'], $allLists['advisories']);
+
+        return $allLists;
     }
 
     /**

--- a/src/Composer/Policy/PolicyConfig.php
+++ b/src/Composer/Policy/PolicyConfig.php
@@ -243,9 +243,10 @@ class PolicyConfig
 
     /**
      * @param 'audit'|'block' $operation
+     * @param ListPolicyConfig::BLOCK_SCOPE_*|null $blockScope
      * @return array<string, ListPolicyConfig>
      */
-    public function getActiveFilterLists(string $operation): array
+    public function getActiveFilterLists(string $operation, ?string $blockScope): array
     {
         $allLists = $this->getAllLists();
         unset($allLists['abandoned'], $allLists['advisories']);
@@ -256,7 +257,7 @@ class PolicyConfig
                 $lists[$name] = $list;
             }
 
-            if ($operation === 'block' && $list->block) {
+            if ($operation === 'block' && $blockScope !== null && $list->shouldBlock($blockScope)) {
                 $lists[$name] = $list;
             }
         }
@@ -266,11 +267,12 @@ class PolicyConfig
 
     /**
      * @param 'audit'|'block' $operation
+     * @param ListPolicyConfig::BLOCK_SCOPE_*|null $blockScope
      * @return list<string>
      */
-    public function getActiveFilterListNames(string $operation): array
+    public function getActiveFilterListNames(string $operation, ?string $blockScope): array
     {
-        return array_keys($this->getActiveFilterLists($operation));
+        return array_keys($this->getActiveFilterLists($operation, $blockScope));
     }
 
     /**

--- a/tests/Composer/Test/DependencyResolver/FilterListPoolFilterTest.php
+++ b/tests/Composer/Test/DependencyResolver/FilterListPoolFilterTest.php
@@ -18,6 +18,7 @@ use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
 use Composer\FilterList\FilterListAuditor;
 use Composer\Package\Package;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\PolicyConfig;
 use Composer\Repository\PackageRepository;
 use Composer\Semver\Constraint\Constraint;
@@ -42,15 +43,15 @@ class FilterListPoolFilterTest extends TestCase
         $config->merge(['config' => ['policy' => ['test-list' => true]]]);
         $policyConfig = PolicyConfig::fromConfig($config);
 
-        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock);
-
         $repository = $this->generatePackageRepository('1.0');
+        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+
         $pool = new Pool([
             new Package('acme/package', '1.0.0.0', '1.0'),
             $expectedPackage1 = new Package('acme/package', '2.0.0.0', '2.0'),
             $expectedPackage2 = new Package('acme/other', '1.0.0.0', '1.0'),
         ]);
-        $filteredPool = $filter->filter($pool, [$repository], new Request());
+        $filteredPool = $filter->filter($pool, new Request());
 
         $this->assertSame([$expectedPackage1, $expectedPackage2], $filteredPool->getPackages());
         $this->assertTrue($filteredPool->isFilterListRemovedPackageVersion('acme/package', new Constraint('==', '1.0.0.0')));
@@ -67,14 +68,14 @@ class FilterListPoolFilterTest extends TestCase
         $config->merge(['config' => ['policy' => ['test-list' => $filterConfig]]]);
 
         $policyConfig = PolicyConfig::fromConfig($config);
-        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock);
-
         $repository = $this->generatePackageRepository('*');
+        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+
         $pool = new Pool([
             $expectedPackage1 = new Package('acme/package', '1.0.0.0', '1.0'),
             $expectedPackage2 = new Package('acme/package', '1.1.0.0', '1.1'),
         ]);
-        $filteredPool = $filter->filter($pool, [$repository], new Request());
+        $filteredPool = $filter->filter($pool, new Request());
 
         $this->assertSame([$expectedPackage1, $expectedPackage2], $filteredPool->getPackages());
         $this->assertCount(0, $filteredPool->getAllFilterListRemovedPackageVersions());
@@ -102,14 +103,14 @@ class FilterListPoolFilterTest extends TestCase
         ]);
 
         $policyConfig = PolicyConfig::fromConfig($config);
-        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock);
-
         $repository = $this->generatePackageRepository('>=1.0');
+        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+
         $pool = new Pool([
             $expectedPackage = new Package('acme/package', '1.0.0.0', '1.0'),
             new Package('acme/package', '1.1.0.0', '1.1'),
         ]);
-        $filteredPool = $filter->filter($pool, [$repository], new Request());
+        $filteredPool = $filter->filter($pool, new Request());
 
         $this->assertSame([$expectedPackage], $filteredPool->getPackages());
         $this->assertCount(1, $filteredPool->getAllFilterListRemovedPackageVersions());
@@ -137,19 +138,56 @@ class FilterListPoolFilterTest extends TestCase
         ]]]);
 
         $policyConfig = PolicyConfig::fromConfig($config);
-        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock);
-
         $repository = $this->generatePackageRepository('0.0.1');
+        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+
         $pool = new Pool([
             new Package('acme/package', '3.0.0.0', '3.0'),
             $expectedPackage1 = new Package('acme/package', '2.0.0.0', '2.0'),
             $expectedPackage2 = new Package('acme/other', '1.0.0.0', '1.0'),
         ]);
-        $filteredPool = $filter->filter($pool, [$repository], new Request());
+        $filteredPool = $filter->filter($pool, new Request());
 
         $this->assertSame([$expectedPackage1, $expectedPackage2], $filteredPool->getPackages());
         $this->assertTrue($filteredPool->isFilterListRemovedPackageVersion('acme/package', new Constraint('==', '3.0.0.0')));
         $this->assertCount(1, $filteredPool->getAllFilterListRemovedPackageVersions());
+    }
+
+    public function testInstallScopeFiltersLockedPackagesAgainstMalwareList(): void
+    {
+        $repository = new PackageRepository([
+            'package' => [],
+            'filter' => [
+                'malware' => [
+                    [
+                        'package' => 'acme/locked',
+                        'constraint' => '*',
+                        'reason' => 'malware',
+                        'url' => 'https://example.org/malware/acme/locked',
+                    ],
+                ],
+            ],
+        ]);
+
+        $config = new Config();
+        $config->merge(['config' => ['policy' => ['malware' => true]]]);
+        $policyConfig = PolicyConfig::fromConfig($config);
+
+        $package = new Package('acme/locked', '1.0.0.0', '1.0');
+        $request = new Request();
+        $request->fixLockedPackage($package);
+
+        // Install scope: locked package IS checked, gets filter-list-removed.
+        $installFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_INSTALL, [$repository]);
+        $installPool = $installFilter->filter(new Pool([$package]), $request);
+        self::assertSame([], $installPool->getPackages(), 'install-scope filter must include locked packages');
+        self::assertTrue($installPool->isFilterListRemovedPackageVersion('acme/locked', new Constraint('==', '1.0.0.0')));
+
+        // Update scope: locked package is early-skipped, never reaches the filter.
+        $updateFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+        $updatePool = $updateFilter->filter(new Pool([$package]), $request);
+        self::assertSame([$package], $updatePool->getPackages(), 'update-scope filter must skip locked packages');
+        self::assertCount(0, $updatePool->getAllFilterListRemovedPackageVersions());
     }
 
     private function generatePackageRepository(string $constraint): PackageRepository

--- a/tests/Composer/Test/DependencyResolver/ProblemTest.php
+++ b/tests/Composer/Test/DependencyResolver/ProblemTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\DependencyResolver;
+
+use Composer\DependencyResolver\GenericRule;
+use Composer\DependencyResolver\Pool;
+use Composer\DependencyResolver\Problem;
+use Composer\DependencyResolver\Rule;
+use Composer\FilterList\FilterListEntry;
+use Composer\Semver\Constraint\MatchAllConstraint;
+use Composer\Test\TestCase;
+
+class ProblemTest extends TestCase
+{
+    public function testGetMissingFixedPackageReasonForFilterListRemovedPackage(): void
+    {
+        $package = self::getPackage('vendor/malware', '1.0.0');
+        $entry = new FilterListEntry(
+            'vendor/malware',
+            new MatchAllConstraint(),
+            'malware',
+            'https://example.org/malware/vendor-malware',
+            'looks suspicious',
+            'PKG-1'
+        );
+        $pool = new Pool([], [], [], [], [], [], [
+            'vendor/malware' => ['1.0.0.0' => [$entry]],
+        ]);
+
+        [$prefix, $suffix] = Problem::getMissingFixedPackageReason($pool, $package);
+
+        self::assertSame('- Package vendor/malware 1.0.0 (in the lock file) ', $prefix);
+
+        self::assertStringContainsString('flagged as malware', $suffix);
+        self::assertStringContainsString('https://example.org/malware/vendor-malware', $suffix);
+        self::assertStringContainsString('reason: looks suspicious', $suffix);
+        self::assertStringContainsString('"policy.malware.ignore"', $suffix);
+        self::assertStringContainsString('"policy.malware.block"', $suffix);
+    }
+}

--- a/tests/Composer/Test/DependencyResolver/ProblemTest.php
+++ b/tests/Composer/Test/DependencyResolver/ProblemTest.php
@@ -22,7 +22,7 @@ use Composer\Test\TestCase;
 
 class ProblemTest extends TestCase
 {
-    public function testGetMissingFixedPackageReasonForFilterListRemovedPackage(): void
+    public function testGetMissingLockedPackageReasonForFilterListRemovedPackage(): void
     {
         $package = self::getPackage('vendor/malware', '1.0.0');
         $entry = new FilterListEntry(
@@ -37,7 +37,7 @@ class ProblemTest extends TestCase
             'vendor/malware' => ['1.0.0.0' => [$entry]],
         ]);
 
-        [$prefix, $suffix] = Problem::getMissingFixedPackageReason($pool, $package);
+        [$prefix, $suffix] = Problem::getMissingLockedPackageReason($pool, $package);
 
         self::assertSame('- Package vendor/malware 1.0.0 (in the lock file) ', $prefix);
 

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -108,4 +108,27 @@ class RuleTest extends TestCase
 
         self::assertEquals('baz 1.1 relates to foo * -> satisfiable by foo[2.1].', $rule->getPrettyString($repositorySetMock, $requestMock, $pool, false));
     }
+
+    public function testGetRequiredPackageForFixedFilterListRemovedRule(): void
+    {
+        $package = self::getPackage('vendor/malware', '1.0');
+        $rule = new GenericRule([], Rule::RULE_FIXED_FILTER_LIST_REMOVED, ['package' => $package]);
+
+        self::assertSame('vendor/malware', $rule->getRequiredPackage());
+    }
+
+    public function testPrettyStringForFixedFilterListRemovedRule(): void
+    {
+        $package = self::getPackage('vendor/malware', '1.0');
+        $pool = new Pool([$package]);
+        $repositorySetMock = $this->getMockBuilder('Composer\Repository\RepositorySet')->disableOriginalConstructor()->getMock();
+        $requestMock = $this->getMockBuilder('Composer\DependencyResolver\Request')->disableOriginalConstructor()->getMock();
+
+        $rule = new GenericRule([], Rule::RULE_FIXED_FILTER_LIST_REMOVED, ['package' => $package]);
+
+        self::assertEquals(
+            'vendor/malware 1.0 was removed by a policy filter list (e.g. malware) and cannot be installed.',
+            $rule->getPrettyString($repositorySetMock, $requestMock, $pool, false)
+        );
+    }
 }

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -109,22 +109,22 @@ class RuleTest extends TestCase
         self::assertEquals('baz 1.1 relates to foo * -> satisfiable by foo[2.1].', $rule->getPrettyString($repositorySetMock, $requestMock, $pool, false));
     }
 
-    public function testGetRequiredPackageForFixedFilterListRemovedRule(): void
+    public function testGetRequiredPackageForLockedFilterListRemovedRule(): void
     {
         $package = self::getPackage('vendor/malware', '1.0');
-        $rule = new GenericRule([], Rule::RULE_FIXED_FILTER_LIST_REMOVED, ['package' => $package]);
+        $rule = new GenericRule([], Rule::RULE_LOCKED_FILTER_LIST_REMOVED, ['package' => $package]);
 
         self::assertSame('vendor/malware', $rule->getRequiredPackage());
     }
 
-    public function testPrettyStringForFixedFilterListRemovedRule(): void
+    public function testPrettyStringForLockedFilterListRemovedRule(): void
     {
         $package = self::getPackage('vendor/malware', '1.0');
         $pool = new Pool([$package]);
         $repositorySetMock = $this->getMockBuilder('Composer\Repository\RepositorySet')->disableOriginalConstructor()->getMock();
         $requestMock = $this->getMockBuilder('Composer\DependencyResolver\Request')->disableOriginalConstructor()->getMock();
 
-        $rule = new GenericRule([], Rule::RULE_FIXED_FILTER_LIST_REMOVED, ['package' => $package]);
+        $rule = new GenericRule([], Rule::RULE_LOCKED_FILTER_LIST_REMOVED, ['package' => $package]);
 
         self::assertEquals(
             'vendor/malware 1.0 was removed by a policy filter list (e.g. malware) and cannot be installed.',

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -12,6 +12,8 @@
 
 namespace Composer\Test\DependencyResolver;
 
+use Composer\DependencyResolver\Rule;
+use Composer\FilterList\FilterListEntry;
 use Composer\IO\NullIO;
 use Composer\Repository\ArrayRepository;
 use Composer\Repository\LockArrayRepository;
@@ -1038,6 +1040,41 @@ class SolverTest extends TestCase
         // verify that the code path leading to a negative literal resulting in a positive learned literal is actually
         // executed
         self::assertTrue($this->solver->testFlagLearnedPositiveLiteral);
+    }
+
+    public function testSolveSurfacesFilterListRemovedFixedPackagesAsProblems(): void
+    {
+        $package = self::getPackage('vendor/malware', '1.0.0');
+        $pool = new Pool([], [], [], [], [], [], [
+            'vendor/malware' => ['1.0.0.0' => [
+                new FilterListEntry(
+                    'vendor/malware',
+                    new MatchAllConstraint(),
+                    'malware'
+                ),
+            ]],
+        ]);
+
+        $request = new Request($this->repoLocked);
+        $request->fixPackage($package);
+        $request->lockPackage($package);
+
+        $solver = new Solver($this->policy, $pool, new NullIO());
+
+        try {
+            $solver->solve($request);
+            self::fail('Expected SolverProblemsException for filter-list-removed package');
+        } catch (SolverProblemsException $e) {
+            $problems = $e->getProblems();
+            self::assertCount(1, $problems);
+            $reasons = $problems[0]->getReasons();
+            self::assertNotEmpty($reasons);
+            $firstSection = reset($reasons);
+            self::assertNotEmpty($firstSection);
+            $rule = reset($firstSection);
+            self::assertSame(Rule::RULE_FIXED_FILTER_LIST_REMOVED, $rule->getReason());
+            self::assertSame($package, $rule->getReasonData()['package']);
+        }
     }
 
     protected function reposComplete(): void

--- a/tests/Composer/Test/DependencyResolver/SolverTest.php
+++ b/tests/Composer/Test/DependencyResolver/SolverTest.php
@@ -1042,7 +1042,7 @@ class SolverTest extends TestCase
         self::assertTrue($this->solver->testFlagLearnedPositiveLiteral);
     }
 
-    public function testSolveSurfacesFilterListRemovedFixedPackagesAsProblems(): void
+    public function testSolveSurfacesFilterListRemovedLockedPackagesAsProblems(): void
     {
         $package = self::getPackage('vendor/malware', '1.0.0');
         $pool = new Pool([], [], [], [], [], [], [
@@ -1072,7 +1072,7 @@ class SolverTest extends TestCase
             $firstSection = reset($reasons);
             self::assertNotEmpty($firstSection);
             $rule = reset($firstSection);
-            self::assertSame(Rule::RULE_FIXED_FILTER_LIST_REMOVED, $rule->getReason());
+            self::assertSame(Rule::RULE_LOCKED_FILTER_LIST_REMOVED, $rule->getReason());
             self::assertSame($package, $rule->getReasonData()['package']);
         }
     }

--- a/tests/Composer/Test/FilterList/FilterListAuditorTest.php
+++ b/tests/Composer/Test/FilterList/FilterListAuditorTest.php
@@ -74,7 +74,7 @@ class FilterListAuditorTest extends TestCase
         ]]]);
         $policyConfig = PolicyConfig::fromConfig($config);
 
-        $entries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $policyConfig, 'block', ListPolicyConfig::BLOCK_SCOPE_UPDATE);
+        $entries = $this->filterListAuditor->getMatchingBlockEntries($package, $filterListMap, $policyConfig, ListPolicyConfig::BLOCK_SCOPE_UPDATE);
         $this->assertCount($expectedCount, $entries);
     }
 
@@ -160,7 +160,7 @@ class FilterListAuditorTest extends TestCase
         ]]]);
         $policyConfig = PolicyConfig::fromConfig($config);
 
-        $entries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $policyConfig, 'block',  ListPolicyConfig::BLOCK_SCOPE_UPDATE);
+        $entries = $this->filterListAuditor->getMatchingBlockEntries($package, $filterListMap, $policyConfig, ListPolicyConfig::BLOCK_SCOPE_UPDATE);
         $this->assertSame([], $entries);
     }
 }

--- a/tests/Composer/Test/FilterList/FilterListAuditorTest.php
+++ b/tests/Composer/Test/FilterList/FilterListAuditorTest.php
@@ -113,7 +113,15 @@ class FilterListAuditorTest extends TestCase
         ]]]);
         $policyConfig = PolicyConfig::fromConfig($config);
 
-        $entries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $policyConfig, $operation);
+        switch ($operation) {
+            case 'audit':
+                $entries = $this->filterListAuditor->getMatchingAuditEntries($package, $filterListMap, $policyConfig);
+                break;
+            case 'block':
+                $entries = $this->filterListAuditor->getMatchingBlockEntries($package, $filterListMap, $policyConfig, ListPolicyConfig::BLOCK_SCOPE_UPDATE);
+                break;
+        }
+
         $this->assertCount($expectedCount, $entries);
     }
 
@@ -137,7 +145,7 @@ class FilterListAuditorTest extends TestCase
         ]]]);
         $policyConfig = PolicyConfig::fromConfig($config);
 
-        $entries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $policyConfig, 'block');
+        $entries = $this->filterListAuditor->getMatchingBlockEntries($package, $filterListMap, $policyConfig, ListPolicyConfig::BLOCK_SCOPE_UPDATE);
 
         self::assertCount(1, $entries);
         self::assertSame('trusted', $entries[0]->source);

--- a/tests/Composer/Test/FilterList/FilterListAuditorTest.php
+++ b/tests/Composer/Test/FilterList/FilterListAuditorTest.php
@@ -16,6 +16,7 @@ use Composer\Config;
 use Composer\FilterList\FilterListAuditor;
 use Composer\FilterList\FilterListEntry;
 use Composer\Package\CompletePackage;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\PolicyConfig;
 use Composer\Test\TestCase;
 
@@ -73,7 +74,7 @@ class FilterListAuditorTest extends TestCase
         ]]]);
         $policyConfig = PolicyConfig::fromConfig($config);
 
-        $entries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $policyConfig, 'block');
+        $entries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $policyConfig, 'block', ListPolicyConfig::BLOCK_SCOPE_UPDATE);
         $this->assertCount($expectedCount, $entries);
     }
 
@@ -159,7 +160,7 @@ class FilterListAuditorTest extends TestCase
         ]]]);
         $policyConfig = PolicyConfig::fromConfig($config);
 
-        $entries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $policyConfig, 'block');
+        $entries = $this->filterListAuditor->getMatchingEntries($package, $filterListMap, $policyConfig, 'block',  ListPolicyConfig::BLOCK_SCOPE_UPDATE);
         $this->assertSame([], $entries);
     }
 }

--- a/tests/Composer/Test/Fixtures/installer/install-policy-custom-list-block-noop-on-install.test
+++ b/tests/Composer/Test/Fixtures/installer/install-policy-custom-list-block-noop-on-install.test
@@ -1,0 +1,69 @@
+--TEST--
+Install proceeds when a non-malware list has block:true (custom lists do not opt into install-time blocking)
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0",
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/dist.zip",
+                        "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+                    }
+                }
+            ],
+            "filter": {
+                "test-list": [
+                    {
+                        "package": "acme/library",
+                        "constraint": "*",
+                        "url": "https://example.org/test-list/acme/library",
+                        "reason": "internal block",
+                        "id": "ID-test"
+                    }
+                ]
+            }
+        }
+    ],
+    "config": {
+        "policy": {
+            "test-list": {
+                "block": true
+            }
+        }
+    },
+    "require": {
+        "acme/library": "1.0"
+    }
+}
+--RUN--
+install
+
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "acme/library",
+            "version": "1.0",
+            "dist": {
+                "type": "zip",
+                "url": "http://www.example.com/dist.zip",
+                "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+            },
+            "type": "library"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {}
+}
+
+--EXPECT--
+Installing acme/library (1.0)

--- a/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-direct-dependency.test
+++ b/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-direct-dependency.test
@@ -1,0 +1,80 @@
+--TEST--
+Install of direct dependency blocked because of malware blocking
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0",
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/dist.zip",
+                        "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+                    }
+                }
+            ],
+            "filter": {
+                "malware": [
+                    {
+                        "package": "acme/library",
+                        "constraint": "*",
+                        "url": "https://example.org/malware/acme/library",
+                        "reason": "malware",
+                        "id": "ID-test",
+                        "source": "Source"
+                    }
+                ]
+            }
+        }
+    ],
+    "config": {
+        "policy": {
+            "malware": {
+                "block": true,
+                "block-scope": "all"
+            }
+        }
+    },
+    "require": {
+        "acme/library": "1.0"
+    }
+}
+--RUN--
+install
+
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "acme/library",
+            "version": "1.0",
+            "dist": {
+                "type": "zip",
+                "url": "http://www.example.com/dist.zip",
+                "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+            },
+            "type": "library"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {}
+}
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Installing dependencies from lock file (including require-dev)
+Verifying lock file contents can be installed on current platform.
+Your lock file does not contain a compatible set of packages. Please run composer update.
+
+  Problem 1
+    - Package acme/library 1.0 (in the lock file) was not loaded, because it was flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-scope-install.test
+++ b/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-scope-install.test
@@ -1,0 +1,80 @@
+--TEST--
+Install blocked when malware policy uses explicit block-scope: install
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0",
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/dist.zip",
+                        "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+                    }
+                }
+            ],
+            "filter": {
+                "malware": [
+                    {
+                        "package": "acme/library",
+                        "constraint": "*",
+                        "url": "https://example.org/malware/acme/library",
+                        "reason": "malware",
+                        "id": "ID-test",
+                        "source": "Source"
+                    }
+                ]
+            }
+        }
+    ],
+    "config": {
+        "policy": {
+            "malware": {
+                "block": true,
+                "block-scope": "install"
+            }
+        }
+    },
+    "require": {
+        "acme/library": "1.0"
+    }
+}
+--RUN--
+install
+
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "acme/library",
+            "version": "1.0",
+            "dist": {
+                "type": "zip",
+                "url": "http://www.example.com/dist.zip",
+                "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+            },
+            "type": "library"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {}
+}
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Installing dependencies from lock file (including require-dev)
+Verifying lock file contents can be installed on current platform.
+Your lock file does not contain a compatible set of packages. Please run composer update.
+
+  Problem 1
+    - Package acme/library 1.0 (in the lock file) was not loaded, because it was flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-scope-update-noop-on-install.test
+++ b/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-scope-update-noop-on-install.test
@@ -1,0 +1,71 @@
+--TEST--
+Install proceeds when malware policy uses block-scope: update (no-op on install)
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0",
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/dist.zip",
+                        "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+                    }
+                }
+            ],
+            "filter": {
+                "malware": [
+                    {
+                        "package": "acme/library",
+                        "constraint": "*",
+                        "url": "https://example.org/malware/acme/library",
+                        "reason": "malware",
+                        "id": "ID-test",
+                        "source": "Source"
+                    }
+                ]
+            }
+        }
+    ],
+    "config": {
+        "policy": {
+            "malware": {
+                "block": true,
+                "block-scope": "update"
+            }
+        }
+    },
+    "require": {
+        "acme/library": "1.0"
+    }
+}
+--RUN--
+install
+
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "acme/library",
+            "version": "1.0",
+            "dist": {
+                "type": "zip",
+                "url": "http://www.example.com/dist.zip",
+                "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+            },
+            "type": "library"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {}
+}
+
+--EXPECT--
+Installing acme/library (1.0)

--- a/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-transitive-dependency.test
+++ b/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-transitive-dependency.test
@@ -1,0 +1,109 @@
+--TEST--
+Install of transitive dependency blocked because of malware blocking
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0",
+                    "require": {
+                        "acme/dependency": "1.0"
+                    },
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/dist.zip",
+                        "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+                    }
+                },
+                {
+                    "name": "acme/dependency",
+                    "version": "1.0",
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/dist.zip",
+                        "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+                    }
+                }
+            ],
+            "filter": {
+                "malware": [
+                    {
+                        "package": "acme/dependency",
+                        "constraint": "*",
+                        "url": "https://example.org/malware/acme/dependency",
+                        "reason": "malware",
+                        "id": "ID-test",
+                        "source": "Source"
+                    }
+                ]
+            }
+        }
+    ],
+    "config": {
+        "policy": {
+            "malware": {
+                "block": true,
+                "block-scope": "all"
+            }
+        }
+    },
+    "require": {
+        "acme/library": "1.0"
+    }
+}
+--RUN--
+install
+
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "acme/library",
+            "version": "1.0",
+            "require": {
+                "acme/dependency": "1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "http://www.example.com/dist.zip",
+                "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+            },
+            "type": "library"
+        },
+        {
+            "name": "acme/dependency",
+            "version": "1.0",
+            "dist": {
+                "type": "zip",
+                "url": "http://www.example.com/dist.zip",
+                "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+            },
+            "type": "library"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {}
+}
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Installing dependencies from lock file (including require-dev)
+Verifying lock file contents can be installed on current platform.
+Your lock file does not contain a compatible set of packages. Please run composer update.
+
+  Problem 1
+    - Package acme/dependency 1.0 (in the lock file) was not loaded, because it was flagged as malware (see https://example.org/malware/acme/dependency) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+  Problem 2
+    - acme/library is locked to version 1.0 and an update of this package was not requested.
+    - acme/library 1.0 requires acme/dependency 1.0 -> found acme/dependency[1.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/dependency) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+
+--EXPECT--

--- a/tests/Composer/Test/Policy/AdvisoriesPolicyConfigTest.php
+++ b/tests/Composer/Test/Policy/AdvisoriesPolicyConfigTest.php
@@ -80,6 +80,22 @@ class AdvisoriesPolicyConfigTest extends TestCase
         );
     }
 
+    public function testShouldBlockNeverAppliesToInstallScope(): void
+    {
+        $advisories = new AdvisoriesPolicyConfig(true, ListPolicyConfig::AUDIT_FAIL, [], [], []);
+
+        self::assertTrue($advisories->shouldBlock(ListPolicyConfig::BLOCK_SCOPE_UPDATE));
+        self::assertFalse($advisories->shouldBlock(ListPolicyConfig::BLOCK_SCOPE_INSTALL));
+    }
+
+    public function testShouldBlockReturnsFalseWhenBlockIsOff(): void
+    {
+        $advisories = new AdvisoriesPolicyConfig(false, ListPolicyConfig::AUDIT_FAIL, [], [], []);
+
+        self::assertFalse($advisories->shouldBlock(ListPolicyConfig::BLOCK_SCOPE_UPDATE));
+        self::assertFalse($advisories->shouldBlock(ListPolicyConfig::BLOCK_SCOPE_INSTALL));
+    }
+
     public function testFromAuditConfig(): void
     {
         $auditConfig = [

--- a/tests/Composer/Test/Policy/CustomListPolicyConfigTest.php
+++ b/tests/Composer/Test/Policy/CustomListPolicyConfigTest.php
@@ -43,6 +43,14 @@ class CustomListPolicyConfigTest extends TestCase
         );
     }
 
+    public function testShouldBlockNeverAppliesToInstallScope(): void
+    {
+        $custom = new CustomListPolicyConfig('company-policy', true, ListPolicyConfig::AUDIT_FAIL, [], []);
+
+        self::assertTrue($custom->shouldBlock(ListPolicyConfig::BLOCK_SCOPE_UPDATE));
+        self::assertFalse($custom->shouldBlock(ListPolicyConfig::BLOCK_SCOPE_INSTALL));
+    }
+
     public function testFromRawConfig(): void
     {
         $rawListConfig = [

--- a/tests/Composer/Test/Policy/IgnoreUnreachableTest.php
+++ b/tests/Composer/Test/Policy/IgnoreUnreachableTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\Policy;
 
 use Composer\Policy\IgnoreUnreachable;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Test\TestCase;
 
 class IgnoreUnreachableTest extends TestCase
@@ -26,5 +27,18 @@ class IgnoreUnreachableTest extends TestCase
         self::assertTrue($ignoreUnreachable->audit);
         self::assertFalse($ignoreUnreachable->install);
         self::assertFalse($ignoreUnreachable->update);
+    }
+
+    public function testForBlockScope(): void
+    {
+        $ignoreUnreachable = new IgnoreUnreachable(false, true, false);
+
+        self::assertTrue($ignoreUnreachable->forBlockScope(ListPolicyConfig::BLOCK_SCOPE_INSTALL));
+        self::assertFalse($ignoreUnreachable->forBlockScope(ListPolicyConfig::BLOCK_SCOPE_UPDATE));
+
+        $ignoreUnreachable = new IgnoreUnreachable(false, false, true);
+
+        self::assertFalse($ignoreUnreachable->forBlockScope(ListPolicyConfig::BLOCK_SCOPE_INSTALL));
+        self::assertTrue($ignoreUnreachable->forBlockScope(ListPolicyConfig::BLOCK_SCOPE_UPDATE));
     }
 }

--- a/tests/Composer/Test/Policy/MalwarePolicyConfigTest.php
+++ b/tests/Composer/Test/Policy/MalwarePolicyConfigTest.php
@@ -65,4 +65,38 @@ class MalwarePolicyConfigTest extends TestCase
             MalwarePolicyConfig::fromRawConfig($rawConfig, new VersionParser())
         );
     }
+
+    public function testShouldBlockReturnsFalseWhenBlockIsOff(): void
+    {
+        $malware = new MalwarePolicyConfig(false, ListPolicyConfig::AUDIT_FAIL, MalwarePolicyConfig::BLOCK_SCOPE_ALL, [], []);
+
+        self::assertFalse($malware->shouldBlock(ListPolicyConfig::BLOCK_SCOPE_UPDATE));
+        self::assertFalse($malware->shouldBlock(ListPolicyConfig::BLOCK_SCOPE_INSTALL));
+    }
+
+    /**
+     * @return iterable<string, array{0: ListPolicyConfig::BLOCK_SCOPE_*, 1: ListPolicyConfig::BLOCK_SCOPE_*, 2: bool}>
+     */
+    public static function shouldBlockMatrixProvider(): iterable
+    {
+        // [configured block-scope, query scope, expected]
+        yield 'all + update' => [ListPolicyConfig::BLOCK_SCOPE_ALL, ListPolicyConfig::BLOCK_SCOPE_UPDATE, true];
+        yield 'all + install' => [ListPolicyConfig::BLOCK_SCOPE_ALL, ListPolicyConfig::BLOCK_SCOPE_INSTALL, true];
+        yield 'update + update' => [ListPolicyConfig::BLOCK_SCOPE_UPDATE, ListPolicyConfig::BLOCK_SCOPE_UPDATE, true];
+        yield 'update + install' => [ListPolicyConfig::BLOCK_SCOPE_UPDATE, ListPolicyConfig::BLOCK_SCOPE_INSTALL, false];
+        yield 'install + update' => [ListPolicyConfig::BLOCK_SCOPE_INSTALL, ListPolicyConfig::BLOCK_SCOPE_UPDATE, false];
+        yield 'install + install' => [ListPolicyConfig::BLOCK_SCOPE_INSTALL, ListPolicyConfig::BLOCK_SCOPE_INSTALL, true];
+    }
+
+    /**
+     * @dataProvider shouldBlockMatrixProvider
+     * @param ListPolicyConfig::BLOCK_SCOPE_* $configuredScope
+     * @param ListPolicyConfig::BLOCK_SCOPE_* $queryScope
+     */
+    public function testShouldBlockHonoursConfiguredBlockScope(string $configuredScope, string $queryScope, bool $expected): void
+    {
+        $malware = new MalwarePolicyConfig(true, ListPolicyConfig::AUDIT_FAIL, $configuredScope, [], []);
+
+        self::assertSame($expected, $malware->shouldBlock($queryScope));
+    }
 }


### PR DESCRIPTION
Follow up PR for https://github.com/composer/composer/pull/12804 to add block malware packages during `composer install`