### PR TITLE
FilterLists: introduce a summary-url ComposerRepositories can implement to skip fetching all metadata files for all packages

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -340,7 +340,8 @@ describes what lists are available.
         "lists": {
             "malware": { "enabled": true },
             "typosquatting": { "enabled": true }
-        }
+        },
+        "summary-url": "/p2/filter-summary.json"
     }
 }
 ```
@@ -352,6 +353,26 @@ describes what lists are available.
   an object describing the list. The object currently carries an `enabled` flag (set to `true` when
   the list is available) and is structured this way so future per-list metadata can be added without
   breaking the wire format.
+- **`summary-url`** (optional, string) — A URL (absolute or root-relative) returning a compact
+  mapping of list name → package name → version constraint. When configured, Composer fetches this
+  endpoint during `composer install`, `composer update` and `composer audit` and uses it to skip per-package metadata
+  fetches for packages that cannot match any active list.
+
+  The summary endpoint must return JSON of the form:
+
+  ```json
+  {
+      "filter": {
+          "malware": {
+              "vendor/package": ">=1.0.0,<1.2.0",
+              "other/package": "*"
+          }
+      }
+  }
+  ```
+
+  Composer revalidates the cached summary via `If-Modified-Since` on every install/update/audit, using the
+  same on-disk repository cache as package metadata.
 
 Per-package metadata files should include a `filter` key whose value is an object mapping list names
 to arrays of filter entries:

--- a/res/composer-repository-schema.json
+++ b/res/composer-repository-schema.json
@@ -71,6 +71,10 @@
                             }
                         }
                     }
+                },
+                "summary-url": {
+                    "type": "string",
+                    "description": "Endpoint returning a compact mapping of list name to package name to version constraint, used to skip per-package metadata fetches for packages that cannot match any active list."
                 }
             }
         },

--- a/src/Composer/FilterList/ComposerRepositoryFilterInformation.php
+++ b/src/Composer/FilterList/ComposerRepositoryFilterInformation.php
@@ -32,18 +32,25 @@ class ComposerRepositoryFilterInformation
     public $lists;
 
     /**
+     * @var ?string
+     */
+    public $summaryUrl;
+
+    /**
      * @param list<string> $lists
      */
-    private function __construct(bool $metadata, array $lists)
+    private function __construct(bool $metadata, array $lists, ?string $summaryUrl)
     {
         $this->metadata = $metadata;
         $this->lists = $lists;
+        $this->summaryUrl = $summaryUrl;
     }
 
     /**
      * @param array<mixed> $data
+     * @param ?\Closure(string): string $canonicalizeUrl optional URL canonicalizer applied to summary-url
      */
-    public static function fromData(array $data): self
+    public static function fromData(array $data, ?\Closure $canonicalizeUrl = null): self
     {
         $lists = [];
         if (isset($data['lists']) && is_array($data['lists'])) {
@@ -72,9 +79,15 @@ class ComposerRepositoryFilterInformation
             return true;
         }));
 
+        $summaryUrl = null;
+        if (isset($data['summary-url']) && is_string($data['summary-url']) && $data['summary-url'] !== '') {
+            $summaryUrl = $canonicalizeUrl !== null ? $canonicalizeUrl($data['summary-url']) : $data['summary-url'];
+        }
+
         return new self(
             (bool) ($data['metadata'] ?? false),
-            $lists
+            $lists,
+            $summaryUrl
         );
     }
 }

--- a/src/Composer/FilterList/FilterListProvider/FilterListProviderSet.php
+++ b/src/Composer/FilterList/FilterListProvider/FilterListProviderSet.php
@@ -99,7 +99,7 @@ class FilterListProviderSet
 
     /**
      * @param array<string, ConstraintInterface> $packageConstraintMap
-     * @param array<string> $configuredLists
+     * @param list<string> $configuredLists
      * @param array<string> &$unreachableRepos Array to store messages about unreachable repositories
      * @return array<string, list<FilterListEntry>>
      */
@@ -108,12 +108,13 @@ class FilterListProviderSet
         $filters = [];
         foreach ($this->providers as $provider) {
             $providerLists = $provider->getFilterLists();
-            if ([] === array_intersect($configuredLists, $providerLists)) {
+            $relevantLists = array_values(array_intersect($configuredLists, $providerLists));
+            if ([] === $relevantLists) {
                 continue;
             }
 
             try {
-                $result = $provider->getFilter($packageConstraintMap);
+                $result = $provider->getFilter($packageConstraintMap, $relevantLists);
                 $repoFilter = $result['filter'];
 
                 foreach ($repoFilter as $listName => $entries) {

--- a/src/Composer/FilterList/FilterListProvider/UrlSourceFilterListProvider.php
+++ b/src/Composer/FilterList/FilterListProvider/UrlSourceFilterListProvider.php
@@ -46,7 +46,7 @@ class UrlSourceFilterListProvider implements FilterListProviderInterface
     /**
      * @inheritDoc
      */
-    public function getFilter(array $packageConstraintMap): array
+    public function getFilter(array $packageConstraintMap, array $configuredLists): array
     {
         $purls = array_map(static function (string $packageName) {
             return 'pkg://composer/' . $packageName;

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -14,8 +14,8 @@ namespace Composer\Repository;
 
 use Composer\Advisory\PartialSecurityAdvisory;
 use Composer\Advisory\SecurityAdvisory;
-use Composer\FilterList\FilterListEntry;
 use Composer\FilterList\ComposerRepositoryFilterInformation;
+use Composer\FilterList\FilterListEntry;
 use Composer\Package\BasePackage;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\PackageInterface;
@@ -797,7 +797,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     /**
      * @inheritDoc
      */
-    public function getFilter(array $packageConstraintMap): array
+    public function getFilter(array $packageConstraintMap, array $configuredLists): array
     {
         $this->loadRootServerFile(600);
 
@@ -808,6 +808,30 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     unset($packageConstraintMap[$name]);
                 }
             }
+        }
+
+        if ($this->filterConfig !== null && $this->filterConfig->summaryUrl !== null) {
+            $summary = $this->loadFilterSummary();
+
+            $candidates = [];
+            foreach ($configuredLists as $listName) {
+                if (!isset($summary[$listName])) {
+                    continue;
+                }
+
+                foreach ($summary[$listName] as $packageName => $summaryConstraint) {
+                    if (!isset($packageConstraintMap[$packageName])) {
+                        continue;
+                    }
+
+                    if (!$packageConstraintMap[$packageName] instanceof MatchAllConstraint && !$this->versionParser->parseConstraints($summaryConstraint)->matches($packageConstraintMap[$packageName])) {
+                        continue;
+                    }
+
+                    $candidates[$packageName] = true;
+                }
+            }
+            $packageConstraintMap = array_intersect_key($packageConstraintMap, $candidates);
         }
 
         $parser = new VersionParser();
@@ -840,6 +864,59 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         $this->loop->wait($promises);
 
         return ['filter' => $filter];
+    }
+
+    /**
+     * @return array<string, array<string, string>> List name → package name → constraint
+     */
+    private function loadFilterSummary(): array
+    {
+        if ($this->filterConfig === null || $this->filterConfig->summaryUrl === null) {
+            return [];
+        }
+
+        $cacheKey = 'filter-summary.json';
+        $contents = null;
+        $lastModified = null;
+        $cached = $this->cache->read($cacheKey);
+        if ($cached !== false) {
+            $cached = json_decode($cached, true);
+            if (is_array($cached)) {
+                $contents = $cached;
+                $lastModified = $cached['last-modified'] ?? null;
+            }
+        }
+
+        $data = null;
+        $promise = $this->asyncFetchFile($this->filterConfig->summaryUrl, $cacheKey, $lastModified)
+            ->then(static function ($response) use (&$data, $contents): void {
+                if (true === $response) {
+                    $data = $contents;
+                } else {
+                    $data = $response;
+                }
+            });
+        $this->loop->wait([$promise]);
+
+        if (!is_array($data) || !isset($data['filter']) || !is_array($data['filter'])) {
+            throw new TransportException('Filter summary URL '.$this->filterConfig->summaryUrl.' returned 404 for '.$this->getRepoName(), 404);
+        }
+
+        $summary = [];
+        foreach ($data['filter'] as $listName => $packages) {
+            if (!is_string($listName) || !is_array($packages)) {
+                throw new \UnexpectedValueException('Invalid filter summary received from '.$this->getRepoName().': list "'.(is_string($listName) ? $listName : '').'" must map to an object of package => constraint');
+            }
+
+            foreach ($packages as $packageName => $constraintString) {
+                if (!is_string($packageName) || !is_string($constraintString)) {
+                    throw new \UnexpectedValueException('Invalid filter summary received from '.$this->getRepoName().': list "'.$listName.'" entries must be strings');
+                }
+                $summary[$listName][strtolower($packageName)] = $constraintString;
+            }
+        }
+
+        return $summary;
     }
 
     public function getFilterLists(): array
@@ -1406,7 +1483,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
 
             if (isset($data['filter']) && is_array($data['filter'])) {
-                $this->filterConfig = ComposerRepositoryFilterInformation::fromData($data['filter']);
+                $this->filterConfig = ComposerRepositoryFilterInformation::fromData($data['filter'], \Closure::fromCallable([$this, 'canonicalizeUrl']));
             }
         }
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -810,7 +810,9 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
         }
 
-        if ($this->filterConfig !== null && $this->filterConfig->summaryUrl !== null) {
+        // skip the summary fetch if we already pulled package metadata in this run; per-package
+        // calls below will short-circuit on the cache, so the summary would be wasted work.
+        if ($this->filterConfig !== null && $this->filterConfig->summaryUrl !== null && $this->freshMetadataUrls === []) {
             $summary = $this->loadFilterSummary();
 
             $candidates = [];

--- a/src/Composer/Repository/FilterListProviderInterface.php
+++ b/src/Composer/Repository/FilterListProviderInterface.php
@@ -26,9 +26,11 @@ interface FilterListProviderInterface
 
     /**
      * @param array<string, ConstraintInterface> $packageConstraintMap
+     * @param list<string> $configuredLists List names the caller is interested in. Providers may use
+     *                                      this to skip work for lists outside this set.
      * @return array{filter: array<string, list<FilterListEntry>>}
      */
-    public function getFilter(array $packageConstraintMap): array;
+    public function getFilter(array $packageConstraintMap, array $configuredLists): array;
 
     /**
      * @return list<string>

--- a/src/Composer/Repository/FilterRepository.php
+++ b/src/Composer/Repository/FilterRepository.php
@@ -231,7 +231,7 @@ class FilterRepository implements RepositoryInterface, AdvisoryProviderInterface
     /**
      * @inheritDoc
      */
-    public function getFilter(array $packageConstraintMap): array
+    public function getFilter(array $packageConstraintMap, array $configuredLists): array
     {
         if (!$this->repo instanceof FilterListProviderInterface) {
             return ['filter' => []];
@@ -243,7 +243,7 @@ class FilterRepository implements RepositoryInterface, AdvisoryProviderInterface
             }
         }
 
-        return $this->repo->getFilter($packageConstraintMap);
+        return $this->repo->getFilter($packageConstraintMap, $configuredLists);
     }
 
     public function getFilterLists(): array

--- a/src/Composer/Repository/PackageRepository.php
+++ b/src/Composer/Repository/PackageRepository.php
@@ -114,7 +114,7 @@ class PackageRepository extends ArrayRepository implements AdvisoryProviderInter
         return count($this->filter) > 0;
     }
 
-    public function getFilter(array $packageConstraintMap): array
+    public function getFilter(array $packageConstraintMap, array $configuredLists): array
     {
         $parser = new VersionParser();
 

--- a/tests/Composer/Test/DependencyResolver/FilterListPoolFilterTest.php
+++ b/tests/Composer/Test/DependencyResolver/FilterListPoolFilterTest.php
@@ -274,7 +274,7 @@ class FilterListPoolFilterTest extends TestCase
                 ],
             ],
         ]) extends PackageRepository {
-            public function getFilter(array $packageConstraintMap): array
+            public function getFilter(array $packageConstraintMap, array $configuredLists): array
             {
                 throw new TransportException('The "https://example.org/filter.json" file could not be downloaded: HTTP/1.1 500 Internal Server Error', 500);
             }
@@ -309,7 +309,7 @@ class FilterListPoolFilterTest extends TestCase
                 ],
             ],
         ]) extends PackageRepository {
-            public function getFilter(array $packageConstraintMap): array
+            public function getFilter(array $packageConstraintMap, array $configuredLists): array
             {
                 throw new TransportException('boom', 500);
             }

--- a/tests/Composer/Test/FilterList/ComposerRepositoryFilterInformationTest.php
+++ b/tests/Composer/Test/FilterList/ComposerRepositoryFilterInformationTest.php
@@ -83,7 +83,7 @@ class ComposerRepositoryFilterInformationTest extends TestCase
 
     public function testFromDataDefaultsSummaryUrlToNull(): void
     {
-        $info = ComposerRepositoryFilterInformation::fromData(['lists' => ['malware' => true]]);
+        $info = ComposerRepositoryFilterInformation::fromData(['lists' => ['malware' => ['enabled' => true]]]);
 
         self::assertNull($info->summaryUrl);
     }
@@ -91,7 +91,7 @@ class ComposerRepositoryFilterInformationTest extends TestCase
     public function testFromDataAppliesCanonicalizerToSummaryUrl(): void
     {
         $info = ComposerRepositoryFilterInformation::fromData(
-            ['lists' => ['malware' => true], 'summary-url' => '/p2/filter-summary.json'],
+            ['lists' => ['malware' => ['enabled' => true]], 'summary-url' => '/p2/filter-summary.json'],
             static function (string $url): string {
                 return 'https://example.org' . $url;
             }
@@ -103,7 +103,7 @@ class ComposerRepositoryFilterInformationTest extends TestCase
     public function testFromDataIgnoresNonStringSummaryUrl(): void
     {
         $info = ComposerRepositoryFilterInformation::fromData(
-            ['lists' => ['malware' => true], 'summary-url' => ['oops']],
+            ['lists' => ['malware' => ['enabled' => true]], 'summary-url' => ['oops']],
             static function (string $url): string {
                 return $url;
             }

--- a/tests/Composer/Test/FilterList/ComposerRepositoryFilterInformationTest.php
+++ b/tests/Composer/Test/FilterList/ComposerRepositoryFilterInformationTest.php
@@ -80,4 +80,35 @@ class ComposerRepositoryFilterInformationTest extends TestCase
 
         self::assertSame(['company-policy'], $info->lists);
     }
+
+    public function testFromDataDefaultsSummaryUrlToNull(): void
+    {
+        $info = ComposerRepositoryFilterInformation::fromData(['lists' => ['malware']]);
+
+        self::assertNull($info->summaryUrl);
+    }
+
+    public function testFromDataAppliesCanonicalizerToSummaryUrl(): void
+    {
+        $info = ComposerRepositoryFilterInformation::fromData(
+            ['lists' => ['malware'], 'summary-url' => '/p2/filter-summary.json'],
+            static function (string $url): string {
+                return 'https://example.org' . $url;
+            }
+        );
+
+        self::assertSame('https://example.org/p2/filter-summary.json', $info->summaryUrl);
+    }
+
+    public function testFromDataIgnoresNonStringSummaryUrl(): void
+    {
+        $info = ComposerRepositoryFilterInformation::fromData(
+            ['lists' => ['malware'], 'summary-url' => ['oops']],
+            static function (string $url): string {
+                return $url;
+            }
+        );
+
+        self::assertNull($info->summaryUrl);
+    }
 }

--- a/tests/Composer/Test/FilterList/ComposerRepositoryFilterInformationTest.php
+++ b/tests/Composer/Test/FilterList/ComposerRepositoryFilterInformationTest.php
@@ -83,7 +83,7 @@ class ComposerRepositoryFilterInformationTest extends TestCase
 
     public function testFromDataDefaultsSummaryUrlToNull(): void
     {
-        $info = ComposerRepositoryFilterInformation::fromData(['lists' => ['malware']]);
+        $info = ComposerRepositoryFilterInformation::fromData(['lists' => ['malware' => true]]);
 
         self::assertNull($info->summaryUrl);
     }
@@ -91,7 +91,7 @@ class ComposerRepositoryFilterInformationTest extends TestCase
     public function testFromDataAppliesCanonicalizerToSummaryUrl(): void
     {
         $info = ComposerRepositoryFilterInformation::fromData(
-            ['lists' => ['malware'], 'summary-url' => '/p2/filter-summary.json'],
+            ['lists' => ['malware' => true], 'summary-url' => '/p2/filter-summary.json'],
             static function (string $url): string {
                 return 'https://example.org' . $url;
             }
@@ -103,7 +103,7 @@ class ComposerRepositoryFilterInformationTest extends TestCase
     public function testFromDataIgnoresNonStringSummaryUrl(): void
     {
         $info = ComposerRepositoryFilterInformation::fromData(
-            ['lists' => ['malware'], 'summary-url' => ['oops']],
+            ['lists' => ['malware' => true], 'summary-url' => ['oops']],
             static function (string $url): string {
                 return $url;
             }

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -553,7 +553,7 @@ class ComposerRepositoryTest extends TestCase
             $httpDownloader
         );
 
-        ['filter' => $filter] = $repository->getFilter(['acme/package' => new Constraint('=', '1.0.0.0')]);
+        ['filter' => $filter] = $repository->getFilter(['acme/package' => new Constraint('=', '1.0.0.0')], ['test']);
 
         $constraint = new MatchAllConstraint();
         $constraint->setPrettyString('*');
@@ -663,6 +663,220 @@ class ComposerRepositoryTest extends TestCase
 
         $this->assertTrue($repository->hasFilter());
         $this->assertSame(['malware'], $repository->getFilterLists());
+    }
+
+    public function testGetFilterSkipsMetadataFetchesForPackagesNotInSummary(): void
+    {
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader->expects(
+            [
+                [
+                    'url' => 'https://example.org/packages.json',
+                    'body' => JsonFile::encode([
+                        'metadata-url' => 'https://example.org/p2/%package%.json',
+                        'filter' => [
+                            'metadata' => true,
+                            'lists' => ['malware' => true],
+                            'summary-url' => '/lists/all/summary.json',
+                        ],
+                    ]),
+                    'options' => ['http' => ['verify_peer' => false]],
+                ],
+                [
+                    'url' => 'https://example.org/lists/all/summary.json',
+                    'body' => JsonFile::encode([
+                        'filter' => [
+                            'malware' => ['evil/pkg' => '^1.0'],
+                        ],
+                    ]),
+                    'options' => ['http' => ['verify_peer' => false]],
+                ],
+                [
+                    'url' => 'https://example.org/p2/evil/pkg.json',
+                    'body' => JsonFile::encode([
+                        'filter' => [
+                            'malware' => [[
+                                'constraint' => '*',
+                                'url' => 'https://example.org/evil/pkg/filters.json',
+                                'reason' => 'Confirmed malware',
+                                'id' => 'ID-test',
+                            ]],
+                        ],
+                    ]),
+                    'options' => ['http' => ['verify_peer' => false]],
+                ],
+            ],
+            true
+        );
+
+        $repository = new ComposerRepository(
+            ['url' => 'https://example.org/packages.json', 'options' => ['http' => ['verify_peer' => false]]],
+            new NullIO(),
+            FactoryMock::createConfig(),
+            $httpDownloader
+        );
+
+        ['filter' => $filter] = $repository->getFilter(
+            [
+                'evil/pkg' => new Constraint('=', '1.0.0.0'),
+                'safe/pkg' => new Constraint('=', '1.0.0.0'),
+            ],
+            ['malware']
+        );
+
+        $this->assertArrayHasKey('malware', $filter);
+        $this->assertCount(1, $filter['malware']);
+        $this->assertSame('evil/pkg', $filter['malware'][0]->packageName);
+    }
+
+    public function testGetFilterSkipsSummaryListsNotInConfiguredLists(): void
+    {
+        $httpDownloader = $this->getHttpDownloaderMock();
+        // typosquatting list is in the summary but not in configuredLists; no metadata fetch should happen.
+        $httpDownloader->expects(
+            [
+                [
+                    'url' => 'https://example.org/packages.json',
+                    'body' => JsonFile::encode([
+                        'metadata-url' => 'https://example.org/p2/%package%.json',
+                        'filter' => [
+                            'metadata' => true,
+                            'lists' => ['malware', 'typosquatting'],
+                            'summary-url' => '/lists/all/summary.json',
+                        ],
+                    ]),
+                    'options' => ['http' => ['verify_peer' => false]],
+                ],
+                [
+                    'url' => 'https://example.org/lists/all/summary.json',
+                    'body' => JsonFile::encode([
+                        'filter' => [
+                            'typosquatting' => ['lookalike/pkg' => '*'],
+                        ],
+                    ]),
+                    'options' => ['http' => ['verify_peer' => false]],
+                ],
+            ],
+            true
+        );
+
+        $repository = new ComposerRepository(
+            ['url' => 'https://example.org/packages.json', 'options' => ['http' => ['verify_peer' => false]]],
+            new NullIO(),
+            FactoryMock::createConfig(),
+            $httpDownloader
+        );
+
+        ['filter' => $filter] = $repository->getFilter(
+            ['lookalike/pkg' => new Constraint('=', '1.0.0.0')],
+            ['malware']
+        );
+
+        $this->assertSame([], $filter);
+    }
+
+    public function testGetFilterSkipsPackagesWithNonIntersectingSummaryConstraint(): void
+    {
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader->expects(
+            [
+                [
+                    'url' => 'https://example.org/packages.json',
+                    'body' => JsonFile::encode([
+                        'metadata-url' => 'https://example.org/p2/%package%.json',
+                        'filter' => [
+                            'metadata' => true,
+                            'lists' => ['malware'],
+                            'summary-url' => '/lists/all/summary.json',
+                        ],
+                    ]),
+                    'options' => ['http' => ['verify_peer' => false]],
+                ],
+                [
+                    'url' => 'https://example.org/lists/all/summary.json',
+                    'body' => JsonFile::encode([
+                        'filter' => [
+                            'malware' => ['evil/pkg' => '^1.0'],
+                        ],
+                    ]),
+                    'options' => ['http' => ['verify_peer' => false]],
+                ],
+            ],
+            true
+        );
+
+        $repository = new ComposerRepository(
+            ['url' => 'https://example.org/packages.json', 'options' => ['http' => ['verify_peer' => false]]],
+            new NullIO(),
+            FactoryMock::createConfig(),
+            $httpDownloader
+        );
+
+        // Requested constraint =2.5.0 does not intersect summary constraint ^1.0; no metadata fetch.
+        ['filter' => $filter] = $repository->getFilter(
+            ['evil/pkg' => new Constraint('=', '2.5.0.0')],
+            ['malware']
+        );
+
+        $this->assertSame([], $filter);
+    }
+
+    public function testGetFilterReusesCachedSummaryOn304(): void
+    {
+        $config = FactoryMock::createConfig();
+        $repoArgs = ['url' => 'https://example.org/packages.json', 'options' => ['http' => ['verify_peer' => false]]];
+
+        $packagesJsonBody = JsonFile::encode([
+            'metadata-url' => 'https://example.org/p2/%package%.json',
+            'filter' => [
+                'metadata' => true,
+                'lists' => ['malware'],
+                'summary-url' => '/lists/all/summary.json',
+            ],
+        ]);
+        $summaryBody = JsonFile::encode([
+            'filter' => ['malware' => ['evil/pkg' => '*']],
+        ]);
+        $metadataBody = JsonFile::encode([
+            'filter' => [
+                'malware' => [[
+                    'constraint' => '*',
+                    'url' => 'https://example.org/evil/pkg/filters.json',
+                    'reason' => 'Confirmed malware',
+                    'id' => 'ID-test',
+                ]],
+            ],
+        ]);
+
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader->expects(
+            [
+                // First call: fresh fetches, populating the on-disk cache.
+                ['url' => 'https://example.org/packages.json', 'body' => $packagesJsonBody, 'headers' => ['Last-Modified: Tue, 01 Jan 2030 00:00:00 GMT']],
+                ['url' => 'https://example.org/lists/all/summary.json', 'body' => $summaryBody, 'headers' => ['Last-Modified: Tue, 01 Jan 2030 00:00:00 GMT']],
+                ['url' => 'https://example.org/p2/evil/pkg.json', 'body' => $metadataBody, 'headers' => ['Last-Modified: Tue, 01 Jan 2030 00:00:00 GMT']],
+                // Second call: cache age on packages.json keeps it cache-fresh; summary + metadata revalidate via 304.
+                ['url' => 'https://example.org/lists/all/summary.json', 'status' => 304, 'body' => ''],
+                ['url' => 'https://example.org/p2/evil/pkg.json', 'status' => 304, 'body' => ''],
+            ],
+            true
+        );
+
+        $firstRepo = new ComposerRepository($repoArgs, new NullIO(), $config, $httpDownloader);
+        ['filter' => $firstFilter] = $firstRepo->getFilter(
+            ['evil/pkg' => new Constraint('=', '1.0.0.0')],
+            ['malware']
+        );
+        $this->assertCount(1, $firstFilter['malware']);
+
+        $secondRepo = new ComposerRepository($repoArgs, new NullIO(), $config, $httpDownloader);
+        ['filter' => $secondFilter] = $secondRepo->getFilter(
+            ['evil/pkg' => new Constraint('=', '1.0.0.0')],
+            ['malware']
+        );
+
+        $this->assertCount(1, $secondFilter['malware']);
+        $this->assertSame('evil/pkg', $secondFilter['malware'][0]->packageName);
     }
 
     /**

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -741,7 +741,7 @@ class ComposerRepositoryTest extends TestCase
                         'metadata-url' => 'https://example.org/p2/%package%.json',
                         'filter' => [
                             'metadata' => true,
-                            'lists' => ['malware', 'typosquatting'],
+                            'lists' => ['malware' => true, 'typosquatting' => true],
                             'summary-url' => '/lists/all/summary.json',
                         ],
                     ]),
@@ -786,7 +786,7 @@ class ComposerRepositoryTest extends TestCase
                         'metadata-url' => 'https://example.org/p2/%package%.json',
                         'filter' => [
                             'metadata' => true,
-                            'lists' => ['malware'],
+                            'lists' => ['malware' => true],
                             'summary-url' => '/lists/all/summary.json',
                         ],
                     ]),
@@ -821,6 +821,74 @@ class ComposerRepositoryTest extends TestCase
         $this->assertSame([], $filter);
     }
 
+    public function testGetFilterSkipsSummaryWhenMetadataAlreadyFetched(): void
+    {
+        $httpDownloader = $this->getHttpDownloaderMock();
+        // Only one fetch of each URL is expected: the second getFilter() call must skip the
+        // summary entirely (freshMetadataUrls is non-empty) and short-circuit the metadata fetch.
+        $httpDownloader->expects(
+            [
+                [
+                    'url' => 'https://example.org/packages.json',
+                    'body' => JsonFile::encode([
+                        'metadata-url' => 'https://example.org/p2/%package%.json',
+                        'filter' => [
+                            'metadata' => true,
+                            'lists' => ['malware' => true],
+                            'summary-url' => '/lists/all/summary.json',
+                        ],
+                    ]),
+                    'headers' => ['Last-Modified: Tue, 01 Jan 2099 00:00:00 GMT'],
+                ],
+                [
+                    'url' => 'https://example.org/lists/all/summary.json',
+                    'body' => JsonFile::encode([
+                        'filter' => [
+                            'malware' => ['evil/pkg' => '*'],
+                        ],
+                    ]),
+                    'headers' => ['Last-Modified: Tue, 01 Jan 2099 00:00:00 GMT'],
+                ],
+                [
+                    'url' => 'https://example.org/p2/evil/pkg.json',
+                    'body' => JsonFile::encode([
+                        'filter' => [
+                            'malware' => [[
+                                'constraint' => '*',
+                                'url' => 'https://example.org/evil/pkg/filters.json',
+                                'reason' => 'Confirmed malware',
+                                'id' => 'ID-test',
+                            ]],
+                        ],
+                    ]),
+                    'headers' => ['Last-Modified: Tue, 01 Jan 2030 00:00:00 GMT'],
+                ],
+            ],
+            true
+        );
+
+        $repository = new ComposerRepository(
+            ['url' => 'https://example.org/packages.json', 'options' => ['http' => ['verify_peer' => false]]],
+            new NullIO(),
+            FactoryMock::createConfig(),
+            $httpDownloader
+        );
+
+        ['filter' => $firstFilter] = $repository->getFilter(
+            ['evil/pkg' => new Constraint('=', '1.0.0.0')],
+            ['malware']
+        );
+        $this->assertCount(1, $firstFilter['malware']);
+
+        // Second call on the same instance: freshMetadataUrls is populated, so no further HTTP requests should be issued.
+        ['filter' => $secondFilter] = $repository->getFilter(
+            ['evil/pkg' => new Constraint('=', '1.0.0.0')],
+            ['malware']
+        );
+        $this->assertCount(1, $secondFilter['malware']);
+        $this->assertSame('evil/pkg', $secondFilter['malware'][0]->packageName);
+    }
+
     public function testGetFilterReusesCachedSummaryOn304(): void
     {
         $config = FactoryMock::createConfig();
@@ -830,7 +898,7 @@ class ComposerRepositoryTest extends TestCase
             'metadata-url' => 'https://example.org/p2/%package%.json',
             'filter' => [
                 'metadata' => true,
-                'lists' => ['malware'],
+                'lists' => ['malware' => true],
                 'summary-url' => '/lists/all/summary.json',
             ],
         ]);

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -676,7 +676,7 @@ class ComposerRepositoryTest extends TestCase
                         'metadata-url' => 'https://example.org/p2/%package%.json',
                         'filter' => [
                             'metadata' => true,
-                            'lists' => ['malware' => true],
+                            'lists' => ['malware' => ['enabled' => true]],
                             'summary-url' => '/lists/all/summary.json',
                         ],
                     ]),
@@ -741,7 +741,10 @@ class ComposerRepositoryTest extends TestCase
                         'metadata-url' => 'https://example.org/p2/%package%.json',
                         'filter' => [
                             'metadata' => true,
-                            'lists' => ['malware' => true, 'typosquatting' => true],
+                            'lists' => [
+                                'malware' => ['enabled' => true],
+                                'typosquatting' => ['enabled' => true],
+                            ],
                             'summary-url' => '/lists/all/summary.json',
                         ],
                     ]),
@@ -786,7 +789,7 @@ class ComposerRepositoryTest extends TestCase
                         'metadata-url' => 'https://example.org/p2/%package%.json',
                         'filter' => [
                             'metadata' => true,
-                            'lists' => ['malware' => true],
+                            'lists' => ['malware' => ['enabled' => true]],
                             'summary-url' => '/lists/all/summary.json',
                         ],
                     ]),
@@ -834,7 +837,7 @@ class ComposerRepositoryTest extends TestCase
                         'metadata-url' => 'https://example.org/p2/%package%.json',
                         'filter' => [
                             'metadata' => true,
-                            'lists' => ['malware' => true],
+                            'lists' => ['malware' => ['enabled' => true]],
                             'summary-url' => '/lists/all/summary.json',
                         ],
                     ]),
@@ -898,7 +901,7 @@ class ComposerRepositoryTest extends TestCase
             'metadata-url' => 'https://example.org/p2/%package%.json',
             'filter' => [
                 'metadata' => true,
-                'lists' => ['malware' => true],
+                'lists' => ['malware' => ['enabled' => true]],
                 'summary-url' => '/lists/all/summary.json',
             ],
         ]);

--- a/tests/Composer/Test/Repository/FilterRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilterRepositoryTest.php
@@ -89,7 +89,7 @@ class FilterRepositoryTest extends TestCase
         $repo = new FilterRepository($this->arrayRepo, ['only' => ['foo/*']]);
 
         self::assertFalse($repo->hasFilter());
-        self::assertSame(['filter' => []], $repo->getFilter(['foo/aaa' => new MatchAllConstraint()]));
+        self::assertSame(['filter' => []], $repo->getFilter(['foo/aaa' => new MatchAllConstraint()], []));
         self::assertSame([], $repo->getFilterLists());
     }
 


### PR DESCRIPTION
Follow up PR for https://github.com/composer/composer/pull/12804. Addresses the issue where before during a `composer install` run, Composer would try to fetch metadata information for all packages from packagist.org. This now first fetches a summary-url and only fetches the metadata for packages appearing in the summary URL. At the same time this skips the summary-url if we have already fetched metadata e.g. during a `composer update`.

This needs a corresponding PR on the packagist.org side but otherwise this PR is ready.