### PR TITLE
FilterList: assert that malware blocking still applies during partial updates

### DIFF
--- a/src/Composer/DependencyResolver/FilterListPoolFilter.php
+++ b/src/Composer/DependencyResolver/FilterListPoolFilter.php
@@ -15,6 +15,7 @@ namespace Composer\DependencyResolver;
 use Composer\FilterList\FilterListAuditor;
 use Composer\FilterList\FilterListEntry;
 use Composer\FilterList\FilterListProvider\FilterListProviderSet;
+use Composer\Package\BasePackage;
 use Composer\Package\RootPackageInterface;
 use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\PolicyConfig;
@@ -60,18 +61,63 @@ class FilterListPoolFilter
 
     public function filter(Pool $pool, Request $request): Pool
     {
-        $providerSet = FilterListProviderSet::create($this->policyConfig, $this->repositories, $this->httpDownloader);
+        // During UPDATE scope, packages that are locked are about to be installed
+        // and must also be checked against install-scope filter lists (e.g. malware).
+        $checkLockedAgainstInstall = $this->blockScope === ListPolicyConfig::BLOCK_SCOPE_UPDATE;
 
-        $filterListMap = $this->collectFilterLists($pool, $providerSet, $request);
+        $configuredScopeListNames = $this->policyConfig->getActiveBlockFilterListNames($this->blockScope);
+        $installScopeListNames = $checkLockedAgainstInstall
+            ? $this->policyConfig->getActiveBlockFilterListNames(ListPolicyConfig::BLOCK_SCOPE_INSTALL)
+            : [];
 
-        if (count($filterListMap) === 0) {
+        $unionListNames = array_values(array_unique(array_merge($configuredScopeListNames, $installScopeListNames)));
+        if (count($unionListNames) === 0) {
             return $pool;
         }
+
+        // One fetch per provider for the union of both scopes' active lists.
+        // Conservative ignoreUnreachable: only suppress transport errors when
+        // both scopes opt in — otherwise the stricter scope wins.
+        $ignoreUnreachable = $this->policyConfig->ignoreUnreachable->forBlockScope($this->blockScope);
+        if ($checkLockedAgainstInstall) {
+            $ignoreUnreachable = $ignoreUnreachable && $this->policyConfig->ignoreUnreachable->forBlockScope(ListPolicyConfig::BLOCK_SCOPE_INSTALL);
+        }
+
+        $providerSet = FilterListProviderSet::create($this->policyConfig, $this->repositories, $this->httpDownloader);
+        $unionMap = $this->fetchFilterListMap($pool, $providerSet, $unionListNames, $ignoreUnreachable);
+        if (count($unionMap) === 0) {
+            return $pool;
+        }
+
+        $configuredScopeMap = self::filterMapByListNames($unionMap, $configuredScopeListNames);
+        $installScopeMap = $checkLockedAgainstInstall ? self::filterMapByListNames($unionMap, $installScopeListNames) : [];
+
+        $lockedNameVersionMap = $checkLockedAgainstInstall ? $this->buildLockedNameVersionMap($request) : [];
 
         $packages = [];
         $filterListRemovedVersions = [];
         foreach ($pool->getPackages() as $package) {
-            $matchingEntries = $this->filterListAuditor->getMatchingBlockEntries($package, $filterListMap, $this->policyConfig, $this->blockScope);
+            if (!self::isFilterable($package)) {
+                $packages[] = $package;
+                continue;
+            }
+
+            if ($checkLockedAgainstInstall && $this->isLockedEquivalent($package, $request, $lockedNameVersionMap)) {
+                $matchingEntries = $this->filterListAuditor->getMatchingBlockEntries(
+                    $package,
+                    $installScopeMap,
+                    $this->policyConfig,
+                    ListPolicyConfig::BLOCK_SCOPE_INSTALL
+                );
+            } else {
+                $matchingEntries = $this->filterListAuditor->getMatchingBlockEntries(
+                    $package,
+                    $configuredScopeMap,
+                    $this->policyConfig,
+                    $this->blockScope
+                );
+            }
+
             if (count($matchingEntries) > 0) {
                 foreach ($package->getNames(false) as $packageName) {
                     $filterListRemovedVersions[$packageName][$package->getVersion()] = $matchingEntries;
@@ -87,28 +133,98 @@ class FilterListPoolFilter
     }
 
     /**
+     * @param list<string> $listNames
      * @return array<string, array<string, list<FilterListEntry>>>
      */
-    private function collectFilterLists(Pool $pool, FilterListProviderSet $providerSet, Request $request): array
+    private function fetchFilterListMap(Pool $pool, FilterListProviderSet $providerSet, array $listNames, bool $ignoreUnreachable): array
     {
         $packagesForFilter = [];
         foreach ($pool->getPackages() as $package) {
-            if ($package instanceof RootPackageInterface || PlatformRepository::isPlatformPackage($package->getName())) {
+            if (!self::isFilterable($package)) {
                 continue;
             }
-            // Locked packages can't change during an update (partial updates keep them fixed),
-            // but install-scope blocking deliberately checks them so malware in the lock file is caught.
-            if ($this->blockScope === ListPolicyConfig::BLOCK_SCOPE_UPDATE && $request->isLockedPackage($package)) {
-                continue;
-            }
+
             $packagesForFilter[] = $package;
         }
 
         return $this->filterListAuditor->collectFilterLists(
             $packagesForFilter,
             $providerSet,
-            $this->policyConfig->getActiveBlockFilterListNames($this->blockScope),
-            $this->policyConfig->ignoreUnreachable->forBlockScope($this->blockScope)
+            $listNames,
+            $ignoreUnreachable
         )['filter'];
+    }
+
+    /**
+     * Restrict a packageName => listName => entries map to the given list names.
+     *
+     * Used to split a single union-fetched filter map into per-scope maps that
+     * `FilterListAuditor::matchingEntries()` can safely consume. The auditor's
+     * non-ignored-package code path does not re-filter entries by active list,
+     * so each map MUST only contain entries from lists active for its scope.
+     *
+     * @param array<string, array<string, list<FilterListEntry>>> $map
+     * @param list<string> $listNames
+     * @return array<string, array<string, list<FilterListEntry>>>
+     */
+    private static function filterMapByListNames(array $map, array $listNames): array
+    {
+        if (count($listNames) === 0) {
+            return [];
+        }
+
+        $allowed = array_flip($listNames);
+        $filtered = [];
+        foreach ($map as $packageName => $entriesByList) {
+            foreach ($entriesByList as $listName => $entries) {
+                if (isset($allowed[$listName])) {
+                    $filtered[$packageName][$listName] = $entries;
+                }
+            }
+        }
+
+        return $filtered;
+    }
+
+    private static function isFilterable(BasePackage $package): bool
+    {
+        return !($package instanceof RootPackageInterface) && !PlatformRepository::isPlatformPackage($package->getName());
+    }
+
+    /**
+     * Build a name => normalized-version-set lookup of the locked repository.
+     *
+     * Identity-based detection (`isLockedPackage`) only fires for packages the
+     * solver explicitly locked via `Request::lockPackage()` — that covers
+     * partial updates with an allow list, but NOT `update mirrors`, which
+     * pins packages via `requireName(==version)` and loads fresh package
+     * instances from configured repos. Matching by name + normalized version
+     * recognises those pool packages as locked-equivalent too.
+     *
+     * @return array<string, array<string, true>>
+     */
+    private function buildLockedNameVersionMap(Request $request): array
+    {
+        $map = [];
+        $lockedRepository = $request->getLockedRepository();
+        if ($lockedRepository !== null) {
+            foreach ($lockedRepository->getPackages() as $lockedPackage) {
+                $map[$lockedPackage->getName()][$lockedPackage->getVersion()] = true;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string, array<string, true>> $lockedNameVersionMap
+     */
+    private function isLockedEquivalent(BasePackage $package, Request $request, array $lockedNameVersionMap): bool
+    {
+        if ($request->isLockedPackage($package)) {
+            return true;
+        }
+
+        return isset($lockedNameVersionMap[$package->getName()][$package->getVersion()]);
     }
 }

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1174,11 +1174,21 @@ class Installer
     {
         $policyConfig = $this->getPolicyConfig();
 
-        if (!$policyConfig->enabled || $this->updateMirrors) {
+        if (!$policyConfig->enabled) {
             return null;
         }
 
-        if ($blockScope === ListPolicyConfig::BLOCK_SCOPE_INSTALL && \count($policyConfig->getActiveBlockFilterLists($blockScope)) === 0) {
+        $hasUpdateLists = \count($policyConfig->getActiveBlockFilterLists(ListPolicyConfig::BLOCK_SCOPE_UPDATE)) > 0;
+        $hasInstallLists = \count($policyConfig->getActiveBlockFilterLists(ListPolicyConfig::BLOCK_SCOPE_INSTALL)) > 0;
+
+        if ($blockScope === ListPolicyConfig::BLOCK_SCOPE_INSTALL && !$hasInstallLists) {
+            return null;
+        }
+
+        // For UPDATE scope we may also need install-scope lists for locked
+        // packages (so a malware-flagged dependency in the lock file is still
+        // blocked during a partial update / `update mirrors`).
+        if ($blockScope === ListPolicyConfig::BLOCK_SCOPE_UPDATE && !$hasUpdateLists && !$hasInstallLists) {
             return null;
         }
 

--- a/tests/Composer/Test/DependencyResolver/FilterListPoolFilterTest.php
+++ b/tests/Composer/Test/DependencyResolver/FilterListPoolFilterTest.php
@@ -20,6 +20,7 @@ use Composer\FilterList\FilterListAuditor;
 use Composer\Package\Package;
 use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\PolicyConfig;
+use Composer\Repository\LockArrayRepository;
 use Composer\Repository\PackageRepository;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Test\Mock\HttpDownloaderMock;
@@ -183,10 +184,80 @@ class FilterListPoolFilterTest extends TestCase
         self::assertSame([], $installPool->getPackages(), 'install-scope filter must include locked packages');
         self::assertTrue($installPool->isFilterListRemovedPackageVersion('acme/locked', new Constraint('==', '1.0.0.0')));
 
-        // Update scope: locked package is early-skipped, never reaches the filter.
+        // Update scope: locked packages are checked against install-scope filter lists too,
+        // so a malware-flagged locked package is still removed from the pool.
         $updateFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
         $updatePool = $updateFilter->filter(new Pool([$package]), $request);
-        self::assertSame([$package], $updatePool->getPackages(), 'update-scope filter must skip locked packages');
+        self::assertSame([], $updatePool->getPackages(), 'update-scope filter must apply install-scope rules to locked packages');
+        self::assertTrue($updatePool->isFilterListRemovedPackageVersion('acme/locked', new Constraint('==', '1.0.0.0')));
+    }
+
+    public function testUpdateScopeAppliesInstallScopeToPackagesInLockedRepository(): void
+    {
+        $repository = new PackageRepository([
+            'package' => [],
+            'filter' => [
+                'malware' => [
+                    [
+                        'package' => 'acme/mirrored',
+                        'constraint' => '*',
+                        'reason' => 'malware',
+                        'url' => 'https://example.org/malware/acme/mirrored',
+                    ],
+                ],
+            ],
+        ]);
+
+        // block-scope: install means the malware list is NOT in getActiveBlockFilterListNames(UPDATE)
+        $config = new Config();
+        $config->merge(['config' => ['policy' => ['malware' => ['block' => true, 'block-scope' => ListPolicyConfig::BLOCK_SCOPE_INSTALL]]]]);
+        $policyConfig = PolicyConfig::fromConfig($config);
+
+        // PoolBuilder loads fresh package instances from configured repos for `update mirrors`
+        // Use distinct instances to mirror that in this unit test — the locked
+        // package and the pool package have the same name+version but are not the same object.
+        $lockedPackage = new Package('acme/mirrored', '1.0.0.0', '1.0');
+        $poolPackage = new Package('acme/mirrored', '1.0.0.0', '1.0');
+        $lockedRepo = new LockArrayRepository();
+        $lockedRepo->addPackage($lockedPackage);
+        $request = new Request($lockedRepo);
+        $request->requireName('acme/mirrored', new Constraint('==', '1.0.0.0'));
+
+        $updateFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+        $updatePool = $updateFilter->filter(new Pool([$poolPackage]), $request);
+        self::assertSame([], $updatePool->getPackages(), 'packages from the locked repo must be checked against install-scope filter lists');
+        self::assertTrue($updatePool->isFilterListRemovedPackageVersion('acme/mirrored', new Constraint('==', '1.0.0.0')));
+    }
+
+    public function testUpdateScopeIgnoresInstallOnlyListsForNonLockedPackages(): void
+    {
+        $repository = new PackageRepository([
+            'package' => [],
+            'filter' => [
+                'malware' => [
+                    [
+                        'package' => 'acme/free',
+                        'constraint' => '*',
+                        'reason' => 'malware',
+                        'url' => 'https://example.org/malware/acme/free',
+                    ],
+                ],
+            ],
+        ]);
+
+        // block-scope: install — only locked-equivalent packages should be
+        // filtered. A package that is not in the locked repository must pass
+        // through the UPDATE-scope filter unmodified.
+        $config = new Config();
+        $config->merge(['config' => ['policy' => ['malware' => ['block' => true, 'block-scope' => ListPolicyConfig::BLOCK_SCOPE_INSTALL]]]]);
+        $policyConfig = PolicyConfig::fromConfig($config);
+
+        $package = new Package('acme/free', '1.0.0.0', '1.0');
+        $request = new Request();
+
+        $updateFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+        $updatePool = $updateFilter->filter(new Pool([$package]), $request);
+        self::assertSame([$package], $updatePool->getPackages(), 'install-only lists must not block non-locked packages during update scope');
         self::assertCount(0, $updatePool->getAllFilterListRemovedPackageVersions());
     }
 

--- a/tests/Composer/Test/Fixtures/installer/partial-update-policy-malware-block-locked-package.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-policy-malware-block-locked-package.test
@@ -106,6 +106,8 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - Root composer.json requires acme/library == 1.0.0.0 (exact version match), found acme/library[1.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - Root composer.json requires acme/library 1.0 (exact version match: 1.0, 1.0.0 or 1.0.0.0), found acme/library[1.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+  Problem 2
+    - Package acme/library 1.0 (in the lock file) was not loaded, because it was flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/partial-update-policy-malware-block-locked-package.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-policy-malware-block-locked-package.test
@@ -1,0 +1,111 @@
+--TEST--
+Partial update must apply install-scope filter lists to locked packages so a locked dependency that has been newly flagged as malware (and is not part of the partial update allow list) is still blocked from being installed
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0",
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/library.zip",
+                        "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+                    }
+                },
+                {
+                    "name": "acme/other",
+                    "version": "1.0.0",
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/other-1.0.0.zip",
+                        "reference": "1111111111111111111111111111111111111111"
+                    }
+                },
+                {
+                    "name": "acme/other",
+                    "version": "1.1.0",
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/other-1.1.0.zip",
+                        "reference": "2222222222222222222222222222222222222222"
+                    }
+                }
+            ],
+            "filter": {
+                "malware": [
+                    {
+                        "package": "acme/library",
+                        "constraint": "*",
+                        "url": "https://example.org/malware/acme/library",
+                        "reason": "malware",
+                        "id": "ID-test",
+                        "source": "Source"
+                    }
+                ]
+            }
+        }
+    ],
+    "config": {
+        "policy": {
+            "malware": {
+                "block": true
+            }
+        }
+    },
+    "require": {
+        "acme/library": "1.0",
+        "acme/other": "^1.0"
+    }
+}
+--RUN--
+update acme/other
+
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "acme/library",
+            "version": "1.0",
+            "dist": {
+                "type": "zip",
+                "url": "http://www.example.com/library.zip",
+                "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+            },
+            "type": "library"
+        },
+        {
+            "name": "acme/other",
+            "version": "1.0.0",
+            "dist": {
+                "type": "zip",
+                "url": "http://www.example.com/other-1.0.0.zip",
+                "reference": "1111111111111111111111111111111111111111"
+            },
+            "type": "library"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {}
+}
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires acme/library == 1.0.0.0 (exact version match), found acme/library[1.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/update-mirrors-policy-malware-block-locked-package.test
+++ b/tests/Composer/Test/Fixtures/installer/update-mirrors-policy-malware-block-locked-package.test
@@ -1,0 +1,80 @@
+--TEST--
+update mirrors must still apply install-scope filter lists to locked packages so a malware-flagged package in the lock file is not silently installed
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0",
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/dist.zip",
+                        "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+                    }
+                }
+            ],
+            "filter": {
+                "malware": [
+                    {
+                        "package": "acme/library",
+                        "constraint": "*",
+                        "url": "https://example.org/malware/acme/library",
+                        "reason": "malware",
+                        "id": "ID-test",
+                        "source": "Source"
+                    }
+                ]
+            }
+        }
+    ],
+    "config": {
+        "policy": {
+            "malware": {
+                "block": true
+            }
+        }
+    },
+    "require": {
+        "acme/library": "1.0"
+    }
+}
+--RUN--
+update mirrors
+
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "acme/library",
+            "version": "1.0",
+            "dist": {
+                "type": "zip",
+                "url": "http://www.example.com/dist.zip",
+                "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+            },
+            "type": "library"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {}
+}
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires acme/library == 1.0.0.0 (exact version match), found acme/library[1.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/update-mirrors-policy-malware-block-scope-install-locked-package.test
+++ b/tests/Composer/Test/Fixtures/installer/update-mirrors-policy-malware-block-scope-install-locked-package.test
@@ -1,0 +1,81 @@
+--TEST--
+update mirrors must apply install-scope filter lists to lock-pinned packages even when the malware list is configured with block-scope: install (so the update solver step would otherwise not consult that list at all)
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "acme/library",
+                    "version": "1.0",
+                    "dist": {
+                        "type": "zip",
+                        "url": "http://www.example.com/dist.zip",
+                        "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+                    }
+                }
+            ],
+            "filter": {
+                "malware": [
+                    {
+                        "package": "acme/library",
+                        "constraint": "*",
+                        "url": "https://example.org/malware/acme/library",
+                        "reason": "malware",
+                        "id": "ID-test",
+                        "source": "Source"
+                    }
+                ]
+            }
+        }
+    ],
+    "config": {
+        "policy": {
+            "malware": {
+                "block": true,
+                "block-scope": "install"
+            }
+        }
+    },
+    "require": {
+        "acme/library": "1.0"
+    }
+}
+--RUN--
+update mirrors
+
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "acme/library",
+            "version": "1.0",
+            "dist": {
+                "type": "zip",
+                "url": "http://www.example.com/dist.zip",
+                "reference": "459720ff3b74ee0c0d159277c6f2f5df89d8a4f6"
+            },
+            "type": "library"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {}
+}
+
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires acme/library == 1.0.0.0 (exact version match), found acme/library[1.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+
+--EXPECT--


### PR DESCRIPTION
Follow up PR to https://github.com/composer/composer/pull/12826

During a partial update the solver isn't run again during the install step. Therefore the pool filter needs to apply install blocking during the update step already.