### PR TITLE
FilterLists: COMPOSER_POLICY=1 should enable filtering if the config is disabled

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -547,8 +547,13 @@ class Config
                 // are applied in PolicyConfig::fromConfig against the parsed
                 // objects so the override layer is consistent and we never have
                 // to rewrite the raw array shape.
-                if (false === Platform::getBoolEnv('COMPOSER_POLICY')) {
+                $policyEnv = Platform::getBoolEnv('COMPOSER_POLICY');
+                if (false === $policyEnv) {
                     $policyConfig = false;
+                } elseif (true === $policyEnv && false === $policyConfig) {
+                    // Re-enable a config-disabled policy. Existing array configs
+                    // are left untouched — the env var only flips the kill switch.
+                    $policyConfig = true;
                 }
 
                 return $policyConfig;

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -427,11 +427,6 @@ class ConfigTest extends TestCase
 
         $this->assertTrue($result);
 
-        Platform::putEnv('COMPOSER_POLICY', '0');
-        $result = $config->get('policy');
-        $this->assertFalse($result);
-        Platform::clearEnv('COMPOSER_POLICY');
-
         $config->merge([
             'config' => [
                 'policy' => [
@@ -456,15 +451,30 @@ class ConfigTest extends TestCase
         self::assertIsArray($result);
         self::assertSame(['ignore' => ['acme/package'], 'ignore-severities' => ['low'], ], $result['advisories'] ?? []);
 
+        // COMPOSER_POLICY=1 is a no-op when policy is already enabled — the existing
+        // array config is preserved, not flattened back to the `true` shorthand.
         Platform::putEnv('COMPOSER_POLICY', '1');
-        self::assertNotTrue($config->get('policy'));
+        $resultWithEnvOn = $config->get('policy');
         Platform::clearEnv('COMPOSER_POLICY');
+        self::assertIsArray($resultWithEnvOn);
+        self::assertSame(['ignore' => ['acme/package'], 'ignore-severities' => ['low']], $resultWithEnvOn['advisories'] ?? []);
 
         $config->merge(['config' => ['policy' => true]]);
         self::assertIsArray($config->get('policy'));
 
         $config->merge(['config' => ['policy' => false]]);
         self::assertFalse($config->get('policy'));
+
+        // COMPOSER_POLICY=1 re-enables policy when the config has it disabled.
+        Platform::putEnv('COMPOSER_POLICY', '1');
+        self::assertTrue($config->get('policy'));
+        Platform::clearEnv('COMPOSER_POLICY');
+
+        // The disable path still wins — env var of 0 forces policy off regardless
+        // of any prior array config.
+        Platform::putEnv('COMPOSER_POLICY', '0');
+        self::assertFalse($config->get('policy'));
+        Platform::clearEnv('COMPOSER_POLICY');
 
         $config->merge(['config' => ['policy' => true]]);
         self::assertSame([], $config->get('policy'));


### PR DESCRIPTION
Follow up PR for https://github.com/composer/composer/pull/12804. So far we only handled COMPOSER_POLICY=0. This now also covers COMPOSER_POLICY=1.