### PR TITLE
FilterLists: adjust parsing of lists information in packages.json

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -337,8 +337,10 @@ describes what lists are available.
     "metadata-url": "/p2/%package%.json",
     "filter": {
         "metadata": true,
-        "lists": ["aikido-malware", "other-malware"],
-        "default-lists": ["aikido-malware"]
+        "lists": {
+            "malware": true,
+            "typosquatting": true
+        }
     }
 }
 ```
@@ -346,11 +348,8 @@ describes what lists are available.
 - **`metadata`** (required, boolean) — Set to `true` to indicate that per-package metadata files
   (served via `metadata-url`) contain filter list data. Composer will fetch the metadata for each
   relevant package and look for a `filter` key containing list entries.
-- **`lists`** (required, array of strings) — The names of all filter lists this repository provides.
-  Clients can use this to know which lists are available.
-- **`default-lists`** (required, array of strings) — The subset of lists that should be active by
-  default. When a user configures `"lists": ["defaults"]` (the default behaviour) in their
-  `repositories` entry for this repository, Composer expands `"defaults"` to these list names.
+- **`lists`** (required, object) — The names of all filter lists this repository provides, mapped to
+  `true` when the list is enabled. Clients can use this to know which lists are available.
 
 Per-package metadata files should include a `filter` key whose value is an object mapping list names
 to arrays of filter entries:
@@ -361,7 +360,7 @@ to arrays of filter entries:
         "vendor/package": [{ ... }]
     },
     "filter": {
-        "aikido-malware": [
+        "malware": [
             {
                 "constraint": ">=1.0.0,<1.2.0",
                 "url": "https://example.org/filters/123",

--- a/res/composer-repository-schema.json
+++ b/res/composer-repository-schema.json
@@ -59,10 +59,10 @@
                     "description": "Whether metadata files contain filter list data."
                 },
                 "lists": {
-                    "type": "array",
-                    "description": "Names of all filter lists provided by this repository.",
-                    "items": {
-                        "type": "string"
+                    "type": "object",
+                    "description": "Names of all filter lists provided by this repository, mapped to true. The boolean value is a presence marker only; the object shape exists for forward compatibility so future per-list metadata can be added without another wire-format break.",
+                    "additionalProperties": {
+                        "type": "boolean"
                     }
                 }
             }

--- a/src/Composer/FilterList/ComposerRepositoryFilterInformation.php
+++ b/src/Composer/FilterList/ComposerRepositoryFilterInformation.php
@@ -45,19 +45,26 @@ class ComposerRepositoryFilterInformation
      */
     public static function fromData(array $data): self
     {
-        $lists = isset($data['lists']) && is_array($data['lists']) ? array_values($data['lists']) : [];
-        $defaultLists = isset($data['default-lists']) && is_array($data['default-lists']) ? array_values($data['default-lists']) : [];
+        $lists = [];
+        if (isset($data['lists']) && is_array($data['lists'])) {
+            foreach ($data['lists'] as $name => $enabled) {
+                if (!is_string($name) || !(bool) $enabled) {
+                    continue;
+                }
+                $lists[] = $name;
+            }
+        }
 
         // Repos must not advertise built-in list names or names that collide with
         // future-reserved identifiers; drop them silently so they cannot shadow
         // Composer's own advisory/abandoned handling or claim a future reserved slot.
-        $lists = array_values(array_filter($lists, static function ($name): bool {
+        $lists = array_values(array_filter($lists, static function (string $name): bool {
             if (in_array($name, PolicyConfig::RESERVED_NAMES, true) || in_array($name, PolicyConfig::FUTURE_RESERVED_NAMES, true)) {
                 return false;
             }
 
             foreach (PolicyConfig::FUTURE_RESERVED_PREFIXES as $prefix) {
-                if (is_string($name) && str_starts_with($name, $prefix)) {
+                if (str_starts_with($name, $prefix)) {
                     return false;
                 }
             }

--- a/tests/Composer/Test/FilterList/ComposerRepositoryFilterInformationTest.php
+++ b/tests/Composer/Test/FilterList/ComposerRepositoryFilterInformationTest.php
@@ -21,17 +21,26 @@ class ComposerRepositoryFilterInformationTest extends TestCase
     {
         $info = ComposerRepositoryFilterInformation::fromData([
             'metadata' => true,
-            'lists' => ['company-policy', 'aikido'],
+            'lists' => ['company-policy' => true, 'aikido' => true],
         ]);
 
         self::assertTrue($info->metadata);
         self::assertSame(['company-policy', 'aikido'], $info->lists);
     }
 
+    public function testFromDataSkipsListsNotEnabled(): void
+    {
+        $info = ComposerRepositoryFilterInformation::fromData([
+            'lists' => ['company-policy' => true, 'aikido' => false],
+        ]);
+
+        self::assertSame(['company-policy'], $info->lists);
+    }
+
     public function testFromDataDropsReservedListNamesAdvertisedByRepository(): void
     {
         $info = ComposerRepositoryFilterInformation::fromData([
-            'lists' => ['advisories', 'company-policy', 'abandoned'],
+            'lists' => ['advisories' => true, 'company-policy' => true, 'abandoned' => true],
         ]);
 
         self::assertSame(['company-policy'], $info->lists);
@@ -40,7 +49,7 @@ class ComposerRepositoryFilterInformationTest extends TestCase
     public function testFromDataDropsListNamesWithReservedPrefixAdvertisedByRepository(): void
     {
         $info = ComposerRepositoryFilterInformation::fromData([
-            'lists' => ['ignore-foo', 'ignoremalware', 'company-policy'],
+            'lists' => ['ignore-foo' => true, 'ignoremalware' => true, 'company-policy' => true],
         ]);
 
         self::assertSame(['company-policy'], $info->lists);

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -523,8 +523,7 @@ class ComposerRepositoryTest extends TestCase
                         'metadata-url' => 'https://example.org/p2/%package%.json',
                         'filter' => [
                             'metadata' => true,
-                            'lists' => ['test'],
-                            'default-lists' => ['test'],
+                            'lists' => ['test' => true],
                         ],
                     ]),
                     'options' => ['http' => ['verify_peer' => false]],
@@ -590,7 +589,7 @@ class ComposerRepositoryTest extends TestCase
                         'metadata-url' => 'https://example.org/p2/%package%.json',
                         'filter' => [
                             'metadata' => true,
-                            'lists' => ['malware', 'typosquatting', 'deprecated'],
+                            'lists' => ['malware' => true, 'typosquatting' => true, 'deprecated' => true],
                         ],
                     ]),
                     'options' => ['http' => ['verify_peer' => false]],
@@ -632,7 +631,7 @@ class ComposerRepositoryTest extends TestCase
                         'metadata-url' => 'https://example.org/p2/%package%.json',
                         'filter' => [
                             'metadata' => true,
-                            'lists' => ['malware', 'typosquatting'],
+                            'lists' => ['malware' => true, 'typosquatting' => true],
                         ],
                     ]),
                     'options' => ['http' => ['verify_peer' => false]],


### PR DESCRIPTION
This now handles packages.json responses like
```
{
    "filter": {
        "metadata": true,
        "lists": {
            "malware": true
        }
    }
}
```

 See https://github.com/composer/packagist/pull/1721