### PR TITLE
FilterLists: add support for api-url to fetch filter list entries

### DIFF
--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -374,6 +374,44 @@ describes what lists are available.
   Composer revalidates the cached summary via `If-Modified-Since` on every install/update/audit, using the
   same on-disk repository cache as package metadata.
 
+- **`api-url`** (optional, string) — A URL (absolute or root-relative) that accepts a POST request
+  with the relevant package PURLs and configured list names, and replies with the matching filter
+  entries directly. When set, Composer uses `api-url` instead of `summary-url` and per-package
+  metadata for filter purposes; this is useful when the summary would be too large to serve in
+  full. If both `summary-url` and `api-url` are advertised, `api-url` takes precedence and
+  `summary-url` is ignored.
+
+  The endpoint receives a JSON body of the form:
+
+  ```json
+  {
+      "packages": ["pkg://composer/vendor/package", "pkg://composer/other/package"],
+      "lists": ["malware"]
+  }
+  ```
+
+  and must return JSON of the form:
+
+  ```json
+  {
+      "filter": {
+          "malware": [
+              {
+                  "package": "vendor/package",
+                  "constraint": ">=1.0.0,<1.2.0",
+                  "url": "https://example.org/filters/123",
+                  "reason": "Malware",
+                  "id": "PKFE-xxxx-xxxx-xxxx"
+              }
+          ]
+      }
+  }
+  ```
+
+  Each entry has the same shape as a per-package metadata filter entry, with the addition of the
+  `package` field (since one response covers many packages). The `api-url` POST is not cached
+  client-side because each request body is different.
+
 Per-package metadata files should include a `filter` key whose value is an object mapping list names
 to arrays of filter entries:
 

--- a/doc/05-repositories.md
+++ b/doc/05-repositories.md
@@ -379,7 +379,10 @@ describes what lists are available.
   entries directly. When set, Composer uses `api-url` instead of `summary-url` and per-package
   metadata for filter purposes; this is useful when the summary would be too large to serve in
   full. If both `summary-url` and `api-url` are advertised, `api-url` takes precedence and
-  `summary-url` is ignored.
+  `summary-url` is ignored. Implementors should be aware that large amounts (a few hundreds
+  would be normal) of package names can be submitted by Composer. You can decide to cap
+  that list and return only the first 1000 or whatever you decide but make sure to limit this
+  somehow.
 
   The endpoint receives a JSON body of the form:
 

--- a/res/composer-repository-schema.json
+++ b/res/composer-repository-schema.json
@@ -75,6 +75,10 @@
                 "summary-url": {
                     "type": "string",
                     "description": "Endpoint returning a compact mapping of list name to package name to version constraint, used to skip per-package metadata fetches for packages that cannot match any active list."
+                },
+                "api-url": {
+                    "type": "string",
+                    "description": "Endpoint that accepts a POST body with the relevant package PURLs and configured list names and returns the matching filter entries directly. Takes precedence over summary-url when both are advertised."
                 }
             }
         },

--- a/src/Composer/FilterList/ComposerRepositoryFilterInformation.php
+++ b/src/Composer/FilterList/ComposerRepositoryFilterInformation.php
@@ -37,18 +37,24 @@ class ComposerRepositoryFilterInformation
     public $summaryUrl;
 
     /**
+     * @var ?string
+     */
+    public $apiUrl;
+
+    /**
      * @param list<string> $lists
      */
-    private function __construct(bool $metadata, array $lists, ?string $summaryUrl)
+    private function __construct(bool $metadata, array $lists, ?string $summaryUrl, ?string $apiUrl)
     {
         $this->metadata = $metadata;
         $this->lists = $lists;
         $this->summaryUrl = $summaryUrl;
+        $this->apiUrl = $apiUrl;
     }
 
     /**
      * @param array<mixed> $data
-     * @param ?\Closure(string): string $canonicalizeUrl optional URL canonicalizer applied to summary-url
+     * @param ?\Closure(string): string $canonicalizeUrl optional URL canonicalizer applied to summary-url and api-url
      */
     public static function fromData(array $data, ?\Closure $canonicalizeUrl = null): self
     {
@@ -84,10 +90,16 @@ class ComposerRepositoryFilterInformation
             $summaryUrl = $canonicalizeUrl !== null ? $canonicalizeUrl($data['summary-url']) : $data['summary-url'];
         }
 
+        $apiUrl = null;
+        if (isset($data['api-url']) && is_string($data['api-url']) && $data['api-url'] !== '') {
+            $apiUrl = $canonicalizeUrl !== null ? $canonicalizeUrl($data['api-url']) : $data['api-url'];
+        }
+
         return new self(
             (bool) ($data['metadata'] ?? false),
             $lists,
-            $summaryUrl
+            $summaryUrl,
+            $apiUrl
         );
     }
 }

--- a/src/Composer/FilterList/FilterListApiClient.php
+++ b/src/Composer/FilterList/FilterListApiClient.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\FilterList;
+
+use Composer\Util\Http\Response;
+use Composer\Util\HttpDownloader;
+
+/**
+ * @internal
+ * @final
+ * @readonly
+ */
+class FilterListApiClient
+{
+    /** @var HttpDownloader */
+    private $httpDownloader;
+
+    public function __construct(HttpDownloader $httpDownloader)
+    {
+        $this->httpDownloader = $httpDownloader;
+    }
+
+    /**
+     * POST a list of PURLs (and optionally configured list names) to a remote filter list endpoint.
+     *
+     * @param array<string, \Composer\Semver\Constraint\ConstraintInterface> $packageConstraintMap
+     * @param list<string> $configuredLists
+     */
+    public function postPurls(string $url, array $packageConstraintMap, array $configuredLists): Response
+    {
+        $purls = array_map(static function (string $packageName): string {
+            return 'pkg://composer/' . $packageName;
+        }, array_keys($packageConstraintMap));
+
+        $body = [
+            'packages' => $purls,
+            'lists' => $configuredLists,
+        ];
+
+        $options = [];
+        $options['http']['method'] = 'POST';
+        $options['http']['header'][] = 'Content-type: application/json';
+        $options['http']['timeout'] = 10;
+        $options['http']['content'] = json_encode($body);
+
+        return $this->httpDownloader->get($url, $options);
+    }
+}

--- a/src/Composer/FilterList/FilterListEntryBuilder.php
+++ b/src/Composer/FilterList/FilterListEntryBuilder.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\FilterList;
+
+use Composer\Package\Version\VersionParser;
+use Composer\Semver\Constraint\ConstraintInterface;
+
+/**
+ * Builds FilterListEntry objects from raw JSON dicts grouped by list name and drops entries
+ * that do not match the supplied package constraint map.
+ *
+ * @internal
+ * @final
+ */
+class FilterListEntryBuilder
+{
+    /** @var VersionParser */
+    private $versionParser;
+
+    public function __construct(?VersionParser $versionParser = null)
+    {
+        $this->versionParser = $versionParser ?? new VersionParser();
+    }
+
+    /**
+     * @param array<mixed> $rawByList list name => raw entry dicts
+     * @param array<string, ConstraintInterface> $packageConstraintMap
+     * @param string|null $defaultPackage when the raw entries omit a "package" field (e.g. per-package
+     *                                    metadata files where the package is implicit from the URL),
+     *                                    use this as the package name.
+     * @return array<string, list<FilterListEntry>>
+     */
+    public function build(array $rawByList, array $packageConstraintMap, ?string $defaultPackage = null): array
+    {
+        $result = [];
+        foreach ($rawByList as $listName => $entries) {
+            if (!is_string($listName) || !is_array($entries)) {
+                continue;
+            }
+            foreach ($entries as $data) {
+                if (!is_array($data)) {
+                    continue;
+                }
+
+                if (!isset($data['constraint'])) {
+                    continue;
+                }
+
+                if (!isset($data['package'])) {
+                    if ($defaultPackage === null) {
+                        continue;
+                    }
+
+                    $data['package'] = $defaultPackage;
+                }
+
+                $entry = FilterListEntry::create($listName, $data, $this->versionParser);
+
+                if (!isset($packageConstraintMap[$entry->packageName])) {
+                    continue;
+                }
+
+                if (!$entry->constraint->matches($packageConstraintMap[$entry->packageName])) {
+                    continue;
+                }
+
+                $result[$listName][] = $entry;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Composer/FilterList/FilterListProvider/UrlSourceFilterListProvider.php
+++ b/src/Composer/FilterList/FilterListProvider/UrlSourceFilterListProvider.php
@@ -12,9 +12,9 @@
 
 namespace Composer\FilterList\FilterListProvider;
 
-use Composer\FilterList\FilterListEntry;
+use Composer\FilterList\FilterListApiClient;
+use Composer\FilterList\FilterListEntryBuilder;
 use Composer\FilterList\Source\UrlSource;
-use Composer\Package\Version\VersionParser;
 use Composer\Repository\FilterListProviderInterface;
 use Composer\Util\HttpDownloader;
 
@@ -25,8 +25,10 @@ use Composer\Util\HttpDownloader;
  */
 class UrlSourceFilterListProvider implements FilterListProviderInterface
 {
-    /** @var HttpDownloader */
-    private $httpDownloader;
+    /** @var FilterListApiClient */
+    private $apiClient;
+    /** @var FilterListEntryBuilder */
+    private $entryBuilder;
     /** @var UrlSource */
     private $source;
 
@@ -34,7 +36,8 @@ class UrlSourceFilterListProvider implements FilterListProviderInterface
         HttpDownloader $httpDownloader,
         UrlSource $source
     ) {
-        $this->httpDownloader = $httpDownloader;
+        $this->apiClient = new FilterListApiClient($httpDownloader);
+        $this->entryBuilder = new FilterListEntryBuilder();
         $this->source = $source;
     }
 
@@ -48,34 +51,15 @@ class UrlSourceFilterListProvider implements FilterListProviderInterface
      */
     public function getFilter(array $packageConstraintMap, array $configuredLists): array
     {
-        $purls = array_map(static function (string $packageName) {
-            return 'pkg://composer/' . $packageName;
-        }, array_keys($packageConstraintMap));
+        $response = $this->apiClient->postPurls($this->source->url, $packageConstraintMap, [$this->source->listName]);
 
-        $options = [];
-        $options['http']['method'] = 'POST';
-        $options['http']['header'][] = 'Content-type: application/json';
-        $options['http']['timeout'] = 10;
-        $options['http']['content'] = json_encode(['packages' => $purls]);
+        $decoded = $response->decodeJson();
+        $entries = isset($decoded['filter']) && is_array($decoded['filter']) ? $decoded['filter'] : [];
 
-        $response = $this->httpDownloader->get($this->source->url, $options);
+        // The remote returns a flat list of entries; this provider is bound to a single list name.
+        $rawByList = [$this->source->listName => $entries];
 
-        $map = [];
-        $parser = new VersionParser();
-        foreach ($response->decodeJson()['filter'] as $data) {
-            $entry = FilterListEntry::create($this->source->listName, $data, $parser);
-            if (!isset($packageConstraintMap[$entry->packageName])) {
-                continue;
-            }
-
-            if (!$entry->constraint->matches($packageConstraintMap[$entry->packageName])) {
-                continue;
-            }
-
-            $map[$this->source->listName][] = $entry;
-        }
-
-        return ['filter' => $map];
+        return ['filter' => $this->entryBuilder->build($rawByList, $packageConstraintMap)];
     }
 
     public function getFilterLists(): array

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -15,7 +15,8 @@ namespace Composer\Repository;
 use Composer\Advisory\PartialSecurityAdvisory;
 use Composer\Advisory\SecurityAdvisory;
 use Composer\FilterList\ComposerRepositoryFilterInformation;
-use Composer\FilterList\FilterListEntry;
+use Composer\FilterList\FilterListApiClient;
+use Composer\FilterList\FilterListEntryBuilder;
 use Composer\Package\BasePackage;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\PackageInterface;
@@ -142,6 +143,16 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      * @var VersionParser
      */
     private $versionParser;
+
+    /**
+     * @var ?FilterListApiClient
+     */
+    private $filterApiClient = null;
+
+    /**
+     * @var ?FilterListEntryBuilder
+     */
+    private $filterEntryBuilder = null;
 
     /**
      * @param array<string, mixed> $repoConfig
@@ -810,6 +821,23 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
         }
 
+        // api-url returns the matched filter entries directly: skip the summary + per-package
+        // metadata path entirely. As with summary-url below, fall through to the cached metadata
+        // path if package metadata was already pulled in this run.
+        if ($this->filterConfig !== null && $this->filterConfig->apiUrl !== null && $this->freshMetadataUrls === []) {
+            $response = $this->getFilterApiClient()->postPurls(
+                $this->filterConfig->apiUrl,
+                $packageConstraintMap,
+                $configuredLists
+            );
+            $decoded = $response->decodeJson();
+            if (!isset($decoded['filter']) || !is_array($decoded['filter'])) {
+                throw new TransportException('Filter api-url '.$this->filterConfig->apiUrl.' returned an unexpected response for '.$this->getRepoName(), 0);
+            }
+
+            return ['filter' => $this->getFilterEntryBuilder()->build($decoded['filter'], $packageConstraintMap)];
+        }
+
         // skip the summary fetch if we already pulled package metadata in this run; per-package
         // calls below will short-circuit on the cache, so the summary would be wasted work.
         if ($this->filterConfig !== null && $this->filterConfig->summaryUrl !== null && $this->freshMetadataUrls === []) {
@@ -836,7 +864,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             $packageConstraintMap = array_intersect_key($packageConstraintMap, $candidates);
         }
 
-        $parser = new VersionParser();
+        $entryBuilder = $this->getFilterEntryBuilder();
         $filter = [];
         $promises = [];
         foreach ($packageConstraintMap as $name => $constraint) {
@@ -848,16 +876,16 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
 
             $promises[] = $this->startCachedAsyncDownload($name, $name)
-                ->then(static function (array $spec) use (&$filter, $name, $parser): void {
+                ->then(static function (array $spec) use (&$filter, $name, $entryBuilder, $packageConstraintMap): void {
                     [$response] = $spec;
 
-                    if (isset($response['filter']) && is_array($response['filter'])) {
-                        foreach ($response['filter'] as $listName => $listEntries) {
-                            foreach ($listEntries as $data) {
-                                $data['package'] = $name;
-                                $filter[$listName][] = FilterListEntry::create($listName, $data, $parser);
+                    if (!isset($response['filter']) || !is_array($response['filter'])) {
+                        return;
+                    }
 
-                            }
+                    foreach ($entryBuilder->build($response['filter'], $packageConstraintMap, $name) as $listName => $entries) {
+                        foreach ($entries as $entry) {
+                            $filter[$listName][] = $entry;
                         }
                     }
                 });
@@ -866,6 +894,24 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         $this->loop->wait($promises);
 
         return ['filter' => $filter];
+    }
+
+    private function getFilterApiClient(): FilterListApiClient
+    {
+        if ($this->filterApiClient === null) {
+            $this->filterApiClient = new FilterListApiClient($this->httpDownloader);
+        }
+
+        return $this->filterApiClient;
+    }
+
+    private function getFilterEntryBuilder(): FilterListEntryBuilder
+    {
+        if ($this->filterEntryBuilder === null) {
+            $this->filterEntryBuilder = new FilterListEntryBuilder($this->versionParser);
+        }
+
+        return $this->filterEntryBuilder;
     }
 
     /**

--- a/tests/Composer/Test/FilterList/ComposerRepositoryFilterInformationTest.php
+++ b/tests/Composer/Test/FilterList/ComposerRepositoryFilterInformationTest.php
@@ -111,4 +111,23 @@ class ComposerRepositoryFilterInformationTest extends TestCase
 
         self::assertNull($info->summaryUrl);
     }
+
+    public function testFromDataDefaultsApiUrlToNull(): void
+    {
+        $info = ComposerRepositoryFilterInformation::fromData(['lists' => ['malware' => ['enabled' => true]]]);
+
+        self::assertNull($info->apiUrl);
+    }
+
+    public function testFromDataAppliesCanonicalizerToApiUrl(): void
+    {
+        $info = ComposerRepositoryFilterInformation::fromData(
+            ['lists' => ['malware' => ['enabled' => true]], 'api-url' => '/api/filter'],
+            static function (string $url): string {
+                return 'https://example.org' . $url;
+            }
+        );
+
+        self::assertSame('https://example.org/api/filter', $info->apiUrl);
+    }
 }

--- a/tests/Composer/Test/FilterList/FilterListApiClientTest.php
+++ b/tests/Composer/Test/FilterList/FilterListApiClientTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\FilterList;
+
+use Composer\FilterList\FilterListApiClient;
+use Composer\Json\JsonFile;
+use Composer\Semver\Constraint\Constraint;
+use Composer\Test\TestCase;
+
+class FilterListApiClientTest extends TestCase
+{
+    public function testPostPurlsSendsPackagesAndListsAsBody(): void
+    {
+        $expectedApiRequestBody = json_encode([
+            'packages' => ['pkg://composer/vendor/foo', 'pkg://composer/vendor/bar'],
+            'lists' => ['malware', 'typosquatting'],
+        ]);
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader->expects(
+            [
+                [
+                    'url' => 'https://example.org/api/filter',
+                    'options' => [
+                        'http' => [
+                            'method' => 'POST',
+                            'header' => ['Content-type: application/json'],
+                            'timeout' => 10,
+                            'content' => $expectedApiRequestBody,
+                        ],
+                    ],
+                    'body' => JsonFile::encode(['filter' => []]),
+                ],
+            ],
+            true
+        );
+
+        $client = new FilterListApiClient($httpDownloader);
+        $response = $client->postPurls(
+            'https://example.org/api/filter',
+            [
+                'vendor/foo' => new Constraint('=', '1.0.0.0'),
+                'vendor/bar' => new Constraint('=', '2.0.0.0'),
+            ],
+            ['malware', 'typosquatting']
+        );
+
+        self::assertSame(['filter' => []], $response->decodeJson());
+    }
+}

--- a/tests/Composer/Test/FilterList/FilterListEntryBuilderTest.php
+++ b/tests/Composer/Test/FilterList/FilterListEntryBuilderTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\FilterList;
+
+use Composer\FilterList\FilterListEntryBuilder;
+use Composer\Semver\Constraint\Constraint;
+use Composer\Test\TestCase;
+
+class FilterListEntryBuilderTest extends TestCase
+{
+    public function testBuildFiltersByConstraintMatch(): void
+    {
+        $builder = new FilterListEntryBuilder();
+
+        $rawByList = [
+            'malware' => [
+                ['package' => 'vendor/foo', 'constraint' => '^1.0', 'url' => 'https://example.org/foo', 'reason' => 'bad', 'id' => 'A'],
+                ['package' => 'vendor/foo', 'constraint' => '^9.0', 'url' => null, 'reason' => 'ignored', 'id' => 'B'],
+                ['package' => 'vendor/unknown', 'constraint' => '*', 'url' => null, 'reason' => 'ignored', 'id' => 'C'],
+            ],
+        ];
+
+        $result = $builder->build($rawByList, [
+            'vendor/foo' => new Constraint('=', '1.2.3.0'),
+        ]);
+
+        self::assertArrayHasKey('malware', $result);
+        self::assertCount(1, $result['malware']);
+        self::assertSame('vendor/foo', $result['malware'][0]->packageName);
+        self::assertSame('A', $result['malware'][0]->id);
+    }
+
+    public function testBuildFillsInDefaultPackageWhenMissing(): void
+    {
+        $builder = new FilterListEntryBuilder();
+
+        // Per-package metadata files omit the "package" field — the builder uses defaultPackage.
+        $rawByList = [
+            'malware' => [
+                ['constraint' => '^1.0', 'url' => 'https://example.org/foo', 'reason' => 'bad', 'id' => 'PKFE-001'],
+            ],
+        ];
+
+        $result = $builder->build(
+            $rawByList,
+            ['vendor/foo' => new Constraint('=', '1.2.3.0')],
+            'vendor/foo'
+        );
+
+        self::assertCount(1, $result['malware']);
+        self::assertSame('vendor/foo', $result['malware'][0]->packageName);
+    }
+
+    public function testBuildPrefersExplicitPackageOverDefault(): void
+    {
+        $builder = new FilterListEntryBuilder();
+
+        $rawByList = [
+            'malware' => [
+                ['package' => 'vendor/foo', 'constraint' => '*', 'id' => 'X'],
+            ],
+        ];
+
+        // defaultPackage points at a different package; the explicit package field must win.
+        $result = $builder->build(
+            $rawByList,
+            ['vendor/foo' => new Constraint('=', '1.0.0.0')],
+            'vendor/bar'
+        );
+
+        self::assertSame('vendor/foo', $result['malware'][0]->packageName);
+    }
+
+    public function testBuildIgnoresMalformedListShapes(): void
+    {
+        $builder = new FilterListEntryBuilder();
+
+        $rawByList = [
+            'malware' => 'not-an-array',
+            5 => [['package' => 'vendor/foo', 'constraint' => '*']],
+            'typosquatting' => [
+                'not-an-entry',
+                ['package' => 'vendor/foo', 'constraint' => '*'],
+            ],
+        ];
+
+        $result = $builder->build($rawByList, [
+            'vendor/foo' => new Constraint('=', '1.0.0.0'),
+        ]);
+
+        self::assertSame(['typosquatting'], array_keys($result));
+        self::assertCount(1, $result['typosquatting']);
+    }
+
+    public function testBuildReturnsEmptyForEmptyInput(): void
+    {
+        $builder = new FilterListEntryBuilder();
+
+        self::assertSame([], $builder->build([], ['vendor/foo' => new Constraint('=', '1.0.0.0')]));
+    }
+}

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -135,7 +135,10 @@ class ComposerRepositoryTest extends TestCase
 
         foreach ($properties as $property => $value) {
             $ref = new \ReflectionProperty($repo, $property);
-            (\PHP_VERSION_ID < 80100) and $ref->setAccessible(true);
+            if (\PHP_VERSION_ID < 80100) {
+                $ref->setAccessible(true);
+            }
+
             $ref->setValue($repo, $value);
         }
 
@@ -948,6 +951,137 @@ class ComposerRepositoryTest extends TestCase
 
         $this->assertCount(1, $secondFilter['malware']);
         $this->assertSame('evil/pkg', $secondFilter['malware'][0]->packageName);
+    }
+
+    public function testGetFilterUsesApiUrlInsteadOfSummary(): void
+    {
+        $expectedApiRequestBody = json_encode([
+            'packages' => ['pkg://composer/evil/pkg', 'pkg://composer/safe/pkg'],
+            'lists' => ['malware'],
+        ]);
+
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader->expects(
+            [
+                [
+                    'url' => 'https://example.org/packages.json',
+                    'body' => JsonFile::encode([
+                        'metadata-url' => 'https://example.org/p2/%package%.json',
+                        'filter' => [
+                            'metadata' => true,
+                            'lists' => ['malware' => ['enabled' => true]],
+                            'api-url' => '/api/filter',
+                        ],
+                    ]),
+                    'options' => ['http' => ['verify_peer' => false]],
+                ],
+                [
+                    'url' => 'https://example.org/api/filter',
+                    'options' => [
+                        'http' => [
+                            'method' => 'POST',
+                            'header' => ['Content-type: application/json'],
+                            'timeout' => 10,
+                            'content' => $expectedApiRequestBody,
+                        ],
+                    ],
+                    'body' => JsonFile::encode([
+                        'filter' => [
+                            'malware' => [[
+                                'package' => 'evil/pkg',
+                                'constraint' => '*',
+                                'url' => 'https://example.org/evil/pkg/filters.json',
+                                'reason' => 'Confirmed malware',
+                                'id' => 'ID-api',
+                            ]],
+                        ],
+                    ]),
+                ],
+            ],
+            true
+        );
+
+        $repository = new ComposerRepository(
+            ['url' => 'https://example.org/packages.json', 'options' => ['http' => ['verify_peer' => false]]],
+            new NullIO(),
+            FactoryMock::createConfig(),
+            $httpDownloader
+        );
+
+        ['filter' => $filter] = $repository->getFilter(
+            [
+                'evil/pkg' => new Constraint('=', '1.0.0.0'),
+                'safe/pkg' => new Constraint('=', '1.0.0.0'),
+            ],
+            ['malware']
+        );
+
+        $this->assertArrayHasKey('malware', $filter);
+        $this->assertCount(1, $filter['malware']);
+        $this->assertSame('evil/pkg', $filter['malware'][0]->packageName);
+        $this->assertSame('ID-api', $filter['malware'][0]->id);
+    }
+
+    public function testGetFilterSkipsApiUrlWhenMetadataAlreadyFetched(): void
+    {
+        // When per-package metadata has already been fetched in this run, api-url must be
+        // skipped: the existing per-package metadata loop will short-circuit on the cache and
+        // surface the filter entries from there. We simulate that prior fetch by seeding
+        // freshMetadataUrls via reflection.
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader->expects(
+            [
+                [
+                    'url' => 'https://example.org/packages.json',
+                    'body' => JsonFile::encode([
+                        'metadata-url' => 'https://example.org/p2/%package%.json',
+                        'filter' => [
+                            'metadata' => true,
+                            'lists' => ['malware' => ['enabled' => true]],
+                            'api-url' => '/api/filter',
+                        ],
+                    ]),
+                    'options' => ['http' => ['verify_peer' => false]],
+                ],
+                [
+                    'url' => 'https://example.org/p2/evil/pkg.json',
+                    'body' => JsonFile::encode([
+                        'filter' => [
+                            'malware' => [[
+                                'constraint' => '*',
+                                'url' => 'https://example.org/evil/pkg/filters.json',
+                                'reason' => 'From metadata',
+                                'id' => 'ID-meta',
+                            ]],
+                        ],
+                    ]),
+                    'options' => ['http' => ['verify_peer' => false]],
+                ],
+            ],
+            true
+        );
+
+        $repository = new ComposerRepository(
+            ['url' => 'https://example.org/packages.json', 'options' => ['http' => ['verify_peer' => false]]],
+            new NullIO(),
+            FactoryMock::createConfig(),
+            $httpDownloader
+        );
+
+        // Pretend a previous metadata fetch has already happened in this run.
+        $reflFresh = new \ReflectionProperty($repository, 'freshMetadataUrls');
+        (\PHP_VERSION_ID < 80100) and $reflFresh->setAccessible(true);
+        $reflFresh->setValue($repository, ['https://example.org/p2/some-other/pkg.json' => true]);
+
+        ['filter' => $filter] = $repository->getFilter(
+            ['evil/pkg' => new Constraint('=', '1.0.0.0')],
+            ['malware']
+        );
+
+        // api-url POST is not in the expectations list — strict mode would fail if it was hit.
+        // The filter entry comes from the per-package metadata file, not from api-url.
+        $this->assertCount(1, $filter['malware']);
+        $this->assertSame('ID-meta', $filter['malware'][0]->id);
     }
 
     /**


### PR DESCRIPTION
In case the summary-url file is getting too big, we want to offer an alternative. Composer repositories can implement an api-url which accepts a list of PURLs and lists as a POST request and should then return a list of matching filter entries.