### PR TITLE
FilterList: clean up auditor constants and --filtered reference in CLI docs

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1204,9 +1204,10 @@ php composer.phar audit
   flag will override the config value and the environment variable.
 * **--ignore-severity:** Ignore advisories of a certain severity level. Can be passed one or more
   time to ignore multiple severities.
-* **--filtered:** Behavior on filtered packages. Must be "ignore", "report",
-  or "fail".  See also [config.audit.filtered](06-config.md#filtered).  Passing this
-  flag will override the config value.
+* **--filtered:** Behavior on packages matched by `malware` and custom filter
+  lists. Must be "ignore", "report", or "fail". Overrides the per-list `audit`
+  setting (`config.policy.malware.audit` and every custom list's `audit`) for
+  the duration of this command.
 
 ## help
 

--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -22,6 +22,7 @@ use Composer\Package\BasePackage;
 use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;
 use Composer\Pcre\Preg;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\PolicyConfig;
 use Composer\Repository\RepositorySet;
 use Composer\Util\PackageInfo;
@@ -48,27 +49,12 @@ class Auditor
         self::FORMAT_SUMMARY,
     ];
 
-    public const ABANDONED_IGNORE = 'ignore';
-    public const ABANDONED_REPORT = 'report';
-    public const ABANDONED_FAIL = 'fail';
-
-    /** @internal */
-    public const ABANDONEDS = [
-        self::ABANDONED_IGNORE,
-        self::ABANDONED_REPORT,
-        self::ABANDONED_FAIL,
-    ];
-
-    public const FILTERED_IGNORE = 'ignore';
-    public const FILTERED_REPORT = 'report';
-    public const FILTERED_FAIL = 'fail';
-
-    /** @internal */
-    public const FILTERED = [
-        self::FILTERED_IGNORE,
-        self::FILTERED_REPORT,
-        self::FILTERED_FAIL,
-    ];
+    /** @deprecated Use ListPolicyConfig::AUDIT_IGNORE instead */
+    public const ABANDONED_IGNORE = ListPolicyConfig::AUDIT_IGNORE;
+    /** @deprecated Use ListPolicyConfig::AUDIT_REPORT instead */
+    public const ABANDONED_REPORT = ListPolicyConfig::AUDIT_REPORT;
+    /** @deprecated Use ListPolicyConfig::AUDIT_FAIL instead */
+    public const ABANDONED_FAIL = ListPolicyConfig::AUDIT_FAIL;
 
     /** Values to determine the audit result. */
     public const STATUS_OK = 0;
@@ -105,11 +91,11 @@ class Auditor
 
         $abandonedCount = 0;
         $affectedPackagesCount = count($advisories);
-        if ($policyConfig->abandoned->audit === self::ABANDONED_IGNORE) {
+        if ($policyConfig->abandoned->audit === ListPolicyConfig::AUDIT_IGNORE) {
             $abandonedPackages = [];
         } else {
             $abandonedPackages = $this->filterAbandonedPackages($packages, $policyConfig->abandoned->getFlatIgnoreForOperation('audit'));
-            if ($policyConfig->abandoned->audit === self::ABANDONED_FAIL) {
+            if ($policyConfig->abandoned->audit === ListPolicyConfig::AUDIT_FAIL) {
                 $abandonedCount = count($abandonedPackages);
             }
         }
@@ -121,7 +107,7 @@ class Auditor
         if ($filterListProviderSet !== null && count($activeAuditFilterLists) > 0) {
             $failingListNames = [];
             foreach ($activeAuditFilterLists as $name => $list) {
-                if ($list->audit === self::FILTERED_FAIL) {
+                if ($list->audit === ListPolicyConfig::AUDIT_FAIL) {
                     $failingListNames[$name] = true;
                 }
             }

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -14,6 +14,7 @@ namespace Composer\Command;
 
 use Composer\Composer;
 use Composer\FilterList\FilterListProvider\FilterListProviderSet;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\PolicyConfig;
 use Composer\Repository\RepositorySet;
 use Composer\Repository\RepositoryUtils;
@@ -35,10 +36,10 @@ class AuditCommand extends BaseCommand
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables auditing of require-dev packages.'),
                 new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format. Must be "table", "plain", "json", or "summary".', Auditor::FORMAT_TABLE, Auditor::FORMATS),
                 new InputOption('locked', null, InputOption::VALUE_NONE, 'Audit based on the lock file instead of the installed packages.'),
-                new InputOption('abandoned', null, InputOption::VALUE_REQUIRED, 'Behavior on abandoned packages. Must be "ignore", "report", or "fail".', null, Auditor::ABANDONEDS),
+                new InputOption('abandoned', null, InputOption::VALUE_REQUIRED, 'Behavior on abandoned packages. Must be "ignore", "report", or "fail".', null, ListPolicyConfig::AUDITS),
                 new InputOption('ignore-severity', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Ignore advisories of a certain severity level.', [], ['low', 'medium', 'high', 'critical']),
                 new InputOption('ignore-unreachable', null, InputOption::VALUE_NONE, 'Ignore repositories that are unreachable or return a non-200 status code.'),
-                new InputOption('filtered', null, InputOption::VALUE_REQUIRED, 'Behavior on filtered packages. Must be "ignore", "report", or "fail". Overrides the per-list audit setting for malware and every custom filter list.', null, Auditor::FILTERED),
+                new InputOption('filtered', null, InputOption::VALUE_REQUIRED, 'Behavior on filtered packages. Must be "ignore", "report", or "fail". Overrides the per-list audit setting for malware and every custom filter list.', null, ListPolicyConfig::AUDITS),
             ])
             ->setHelp(
                 <<<EOT
@@ -72,13 +73,13 @@ EOT
         }
 
         $abandoned = $input->getOption('abandoned');
-        if ($abandoned !== null && !in_array($abandoned, Auditor::ABANDONEDS, true)) {
-            throw new \InvalidArgumentException('--abandoned must be one of '.implode(', ', Auditor::ABANDONEDS).'.');
+        if ($abandoned !== null && !in_array($abandoned, ListPolicyConfig::AUDITS, true)) {
+            throw new \InvalidArgumentException('--abandoned must be one of '.implode(', ', ListPolicyConfig::AUDITS).'.');
         }
 
         $filtered = $input->getOption('filtered');
-        if ($filtered !== null && !in_array($filtered, Auditor::FILTERED, true)) {
-            throw new \InvalidArgumentException('--filtered must be one of '.implode(', ', Auditor::FILTERED).'.');
+        if ($filtered !== null && !in_array($filtered, ListPolicyConfig::AUDITS, true)) {
+            throw new \InvalidArgumentException('--filtered must be one of '.implode(', ', ListPolicyConfig::AUDITS).'.');
         }
 
         $policyConfig = $this->createPolicyConfig($composer->getConfig(), $input);

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -24,6 +24,7 @@ use Composer\Package\Locker;
 use Composer\Package\RootPackage;
 use Composer\Package\Version\VersionParser;
 use Composer\Pcre\Preg;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Repository\ComposerRepository;
 use Composer\Repository\FilesystemRepository;
 use Composer\Repository\PlatformRepository;
@@ -590,7 +591,7 @@ EOT
         }
         $repoSet->addRepository(new ComposerRepository(['type' => 'composer', 'url' => 'https://packagist.org'], new NullIO(), $config, $this->httpDownloader));
         $policyConfig = $this->createPolicyConfig($config, null);
-        $policyConfig = $policyConfig->withAudit(Auditor::ABANDONED_IGNORE, null);
+        $policyConfig = $policyConfig->withAudit(ListPolicyConfig::AUDIT_IGNORE, null);
 
         try {
             $io = new BufferIO();

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -17,6 +17,7 @@ use Composer\Config\ConfigSourceInterface;
 use Composer\Downloader\TransportException;
 use Composer\IO\IOInterface;
 use Composer\Pcre\Preg;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\PolicyConfig;
 use Composer\Util\Platform;
 use Composer\Util\ProcessExecutor;
@@ -39,7 +40,7 @@ class Config
         'allow-plugins' => [],
         'use-parent-dir' => 'prompt',
         'preferred-install' => 'dist',
-        'audit' => ['ignore' => [], 'abandoned' => Auditor::ABANDONED_FAIL],
+        'audit' => ['ignore' => [], 'abandoned' => ListPolicyConfig::AUDIT_FAIL],
         'policy' => true,
         'notify-on-install' => true,
         'github-protocols' => ['https', 'ssh', 'git'],
@@ -524,9 +525,9 @@ class Config
                 $result = $this->config[$key];
                 $abandonedEnv = $this->getComposerEnv('COMPOSER_AUDIT_ABANDONED');
                 if (false !== $abandonedEnv) {
-                    if (!in_array($abandonedEnv, $validChoices = Auditor::ABANDONEDS, true)) {
+                    if (!in_array($abandonedEnv, ListPolicyConfig::AUDITS, true)) {
                         throw new \RuntimeException(
-                            "Invalid value for COMPOSER_AUDIT_ABANDONED: {$abandonedEnv}. Expected one of ".implode(', ', Auditor::ABANDONEDS)."."
+                            "Invalid value for COMPOSER_AUDIT_ABANDONED: {$abandonedEnv}. Expected one of ".implode(', ', ListPolicyConfig::AUDITS)."."
                         );
                     }
                     $result['abandoned'] = $abandonedEnv;

--- a/src/Composer/Policy/ListPolicyConfig.php
+++ b/src/Composer/Policy/ListPolicyConfig.php
@@ -32,6 +32,13 @@ abstract class ListPolicyConfig
     public const AUDIT_REPORT = 'report';
     public const AUDIT_FAIL = 'fail';
 
+    /** @internal */
+    public const AUDITS = [
+        self::AUDIT_IGNORE,
+        self::AUDIT_REPORT,
+        self::AUDIT_FAIL,
+    ];
+
     /**
      * "update" = block during update/require only
      * "install" = block during install only

--- a/tests/Composer/Test/Advisory/AuditorTest.php
+++ b/tests/Composer/Test/Advisory/AuditorTest.php
@@ -23,6 +23,7 @@ use Composer\Package\Version\VersionParser;
 use Composer\Policy\AbandonedPolicyConfig;
 use Composer\Policy\AdvisoriesPolicyConfig;
 use Composer\Policy\CustomListPolicyConfig;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\IgnoreIdRule;
 use Composer\Policy\IgnorePackageRule;
 use Composer\Policy\IgnoreSeverityRule;
@@ -96,7 +97,7 @@ Reported at: 2022-05-25T13:21:00+00:00',
                     $abandonedNoReplacement,
                 ],
                 'warningOnly' => false,
-                'abandoned' => Auditor::ABANDONED_IGNORE,
+                'abandoned' => ListPolicyConfig::AUDIT_IGNORE,
             ],
             'expected' => Auditor::STATUS_OK,
             'output' => 'No security vulnerability advisories found.',
@@ -109,7 +110,7 @@ Reported at: 2022-05-25T13:21:00+00:00',
                     $abandonedNoReplacement,
                 ],
                 'warningOnly' => false,
-                'abandoned' => Auditor::ABANDONED_FAIL,
+                'abandoned' => ListPolicyConfig::AUDIT_FAIL,
                 'ignore-abandoned' => ['vendor/*' => null],
             ],
             'expected' => Auditor::STATUS_OK,
@@ -123,7 +124,7 @@ Reported at: 2022-05-25T13:21:00+00:00',
                     $abandonedNoReplacement,
                 ],
                 'warningOnly' => false,
-                'abandoned' => Auditor::ABANDONED_FAIL,
+                'abandoned' => ListPolicyConfig::AUDIT_FAIL,
                 'ignore-abandoned' => [$abandonedWithReplacement->getName() => null, $abandonedNoReplacement->getName() => null],
             ],
             'expected' => Auditor::STATUS_OK,
@@ -137,7 +138,7 @@ Reported at: 2022-05-25T13:21:00+00:00',
                     $abandonedNoReplacement,
                 ],
                 'warningOnly' => false,
-                'abandoned' => Auditor::ABANDONED_FAIL,
+                'abandoned' => ListPolicyConfig::AUDIT_FAIL,
                 'ignore-abandoned' => ['acme/test' => 'ignoring because yolo'],
             ],
             'expected' => Auditor::STATUS_ABANDONED,
@@ -154,7 +155,7 @@ vendor/abandoned2 is abandoned. No replacement was suggested.',
                     $abandonedNoReplacement,
                 ],
                 'warningOnly' => true,
-                'abandoned' => Auditor::ABANDONED_REPORT,
+                'abandoned' => ListPolicyConfig::AUDIT_REPORT,
             ],
             'expected' => Auditor::STATUS_OK,
             'output' => 'No security vulnerability advisories found.
@@ -170,7 +171,7 @@ vendor/abandoned2 is abandoned. No replacement was suggested.',
                     $abandonedNoReplacement,
                 ],
                 'warningOnly' => false,
-                'abandoned' => Auditor::ABANDONED_FAIL,
+                'abandoned' => ListPolicyConfig::AUDIT_FAIL,
                 'format' => Auditor::FORMAT_TABLE,
             ],
             'expected' => Auditor::STATUS_ABANDONED,
@@ -192,7 +193,7 @@ Found 2 abandoned packages:
                     $abandonedNoReplacement,
                 ],
                 'warningOnly' => false,
-                'abandoned' => Auditor::ABANDONED_FAIL,
+                'abandoned' => ListPolicyConfig::AUDIT_FAIL,
                 'format' => Auditor::FORMAT_TABLE,
             ],
             'expected' => Auditor::STATUS_VULNERABLE | Auditor::STATUS_ABANDONED,
@@ -233,7 +234,7 @@ Found 2 abandoned packages:
                     $abandonedNoReplacement,
                 ],
                 'warningOnly' => false,
-                'abandoned' => Auditor::ABANDONED_FAIL,
+                'abandoned' => ListPolicyConfig::AUDIT_FAIL,
                 'format' => Auditor::FORMAT_JSON,
             ],
             'expected' => Auditor::STATUS_ABANDONED,
@@ -258,7 +259,7 @@ Found 2 abandoned packages:
             $this->expectException(InvalidArgumentException::class);
         }
         $policyConfig = $this->createPolicyConfig(
-            $data['abandoned'] ?? Auditor::ABANDONED_IGNORE,
+            $data['abandoned'] ?? ListPolicyConfig::AUDIT_IGNORE,
             false,
             null,
             'test-list',
@@ -466,7 +467,7 @@ Found 2 abandoned packages:
     public function testAuditWithIgnore($packages, $ignoredIds, $exitCode, $expectedOutput): void
     {
         $policyConfig = $this->createPolicyConfig(
-            Auditor::ABANDONED_IGNORE,
+            ListPolicyConfig::AUDIT_IGNORE,
             false,
             null,
             'test-list',
@@ -577,7 +578,7 @@ Found 2 abandoned packages:
 
         // Test with ignoreUnreachable flag
         $io = new BufferIO();
-        $result = $auditor->audit($io, $repoSet, $this->createPolicyConfig(Auditor::ABANDONED_IGNORE, true), $packages, Auditor::FORMAT_PLAIN, false);
+        $result = $auditor->audit($io, $repoSet, $this->createPolicyConfig(ListPolicyConfig::AUDIT_IGNORE, true), $packages, Auditor::FORMAT_PLAIN, false);
 
         // Should find advisories from the reachable repositories
         self::assertSame(Auditor::STATUS_VULNERABLE, $result);
@@ -594,7 +595,7 @@ Found 2 abandoned packages:
 
         // Test with JSON format
         $io = new BufferIO();
-        $result = $auditor->audit($io, $repoSet, $this->createPolicyConfig(Auditor::ABANDONED_IGNORE, true), $packages, Auditor::FORMAT_JSON, false);
+        $result = $auditor->audit($io, $repoSet, $this->createPolicyConfig(ListPolicyConfig::AUDIT_IGNORE, true), $packages, Auditor::FORMAT_JSON, false);
         self::assertSame(Auditor::STATUS_VULNERABLE, $result);
 
         $json = json_decode($io->getOutput(), true);
@@ -626,7 +627,7 @@ Found 2 abandoned packages:
     public function testAuditWithIgnoreSeverity($packages, $ignoredSeverities, $exitCode, $expectedOutput): void
     {
         $policyConfig = $this->createPolicyConfig(
-            Auditor::ABANDONED_IGNORE,
+            ListPolicyConfig::AUDIT_IGNORE,
             false,
             null,
             'test-list',
@@ -666,28 +667,28 @@ Found 2 abandoned packages:
             'ID-test-1'
         );
 
-        yield 'FILTERED_IGNORE skips filter processing' => [
+        yield 'AUDIT_IGNORE skips filter processing' => [
             'packages' => [new Package('vendor/package', '9.0.0', '9.0.0')],
             'filterEntriesByList' => ['test-list' => [$matchingEntry]],
-            'filtered' => Auditor::FILTERED_IGNORE,
+            'filtered' => ListPolicyConfig::AUDIT_IGNORE,
             'format' => Auditor::FORMAT_PLAIN,
             'expected' => Auditor::STATUS_OK,
             'output' => 'No security vulnerability advisories found.',
         ];
 
-        yield 'FILTERED_FAIL with no matching entry returns STATUS_OK' => [
+        yield 'AUDIT_FAIL with no matching entry returns STATUS_OK' => [
             'packages' => [new Package('vendor/package', '9.0.0', '9.0.0')],
             'filterEntriesByList' => ['test-list' => [$nonMatchingEntry]],
-            'filtered' => Auditor::FILTERED_FAIL,
+            'filtered' => ListPolicyConfig::AUDIT_FAIL,
             'format' => Auditor::FORMAT_PLAIN,
             'expected' => Auditor::STATUS_OK,
             'output' => 'No security vulnerability advisories found.',
         ];
 
-        yield 'FILTERED_FAIL with matching entry returns STATUS_FILTERED (plain)' => [
+        yield 'AUDIT_FAIL with matching entry returns STATUS_FILTERED (plain)' => [
             'packages' => [new Package('vendor/package', '9.0.0', '9.0.0')],
             'filterEntriesByList' => ['test-list' => [$matchingEntry]],
-            'filtered' => Auditor::FILTERED_FAIL,
+            'filtered' => ListPolicyConfig::AUDIT_FAIL,
             'format' => Auditor::FORMAT_PLAIN,
             'expected' => Auditor::STATUS_FILTERED,
             'output' => 'No security vulnerability advisories found.
@@ -695,10 +696,10 @@ Found 1 package matching filters:
 vendor/package is on filter list "test-list". Reason: internal.',
         ];
 
-        yield 'FILTERED_FAIL with matching entry shows url and reason (plain)' => [
+        yield 'AUDIT_FAIL with matching entry shows url and reason (plain)' => [
             'packages' => [new Package('vendor/package', '9.0.0', '9.0.0')],
             'filterEntriesByList' => ['test-list' => [$matchingEntryWithDetails]],
-            'filtered' => Auditor::FILTERED_FAIL,
+            'filtered' => ListPolicyConfig::AUDIT_FAIL,
             'format' => Auditor::FORMAT_PLAIN,
             'expected' => Auditor::STATUS_FILTERED,
             'output' => 'No security vulnerability advisories found.
@@ -706,10 +707,10 @@ Found 1 package matching filters:
 vendor/package is on filter list "test-list". Reason: internal. URL: https://example.com/filtered.',
         ];
 
-        yield 'FILTERED_REPORT with matching entry returns STATUS_OK' => [
+        yield 'AUDIT_REPORT with matching entry returns STATUS_OK' => [
             'packages' => [new Package('vendor/package', '9.0.0', '9.0.0')],
             'filterEntriesByList' => ['test-list' => [$matchingEntry]],
-            'filtered' => Auditor::FILTERED_REPORT,
+            'filtered' => ListPolicyConfig::AUDIT_REPORT,
             'format' => Auditor::FORMAT_PLAIN,
             'expected' => Auditor::STATUS_OK,
             'output' => 'No security vulnerability advisories found.
@@ -717,17 +718,17 @@ vendor/package is on filter list "test-list". Reason: internal. URL: https://exa
 vendor/package is on filter list "test-list". Reason: internal.',
         ];
 
-        yield 'FILTERED_FAIL with matching entry shows summary line only (summary format)' => [
+        yield 'AUDIT_FAIL with matching entry shows summary line only (summary format)' => [
             'packages' => [new Package('vendor/package', '9.0.0', '9.0.0')],
             'filterEntriesByList' => ['test-list' => [$matchingEntry]],
-            'filtered' => Auditor::FILTERED_FAIL,
+            'filtered' => ListPolicyConfig::AUDIT_FAIL,
             'format' => Auditor::FORMAT_SUMMARY,
             'expected' => Auditor::STATUS_FILTERED,
             'output' => 'No security vulnerability advisories found.
 Found 1 package matching filters.',
         ];
 
-        yield 'FILTERED_FAIL with multiple matching packages shows plural form' => [
+        yield 'AUDIT_FAIL with multiple matching packages shows plural form' => [
             'packages' => [
                 new Package('vendor/package', '9.0.0.0', '9.0.0'),
                 new Package('vendor/other', '1.0.0.0', '10.0.0'),
@@ -738,7 +739,7 @@ Found 1 package matching filters.',
                     new FilterListEntry('vendor/other', new Constraint('>=', '1.0.0.0'), 'test-list', null, 'internal', 'ID-TEST'),
                 ],
             ],
-            'filtered' => Auditor::FILTERED_FAIL,
+            'filtered' => ListPolicyConfig::AUDIT_FAIL,
             'format' => Auditor::FORMAT_PLAIN,
             'expected' => Auditor::STATUS_FILTERED,
             'output' => 'No security vulnerability advisories found.
@@ -752,7 +753,7 @@ vendor/other is on filter list "test-list". Reason: internal.',
      * @dataProvider filteredProvider
      * @param array<Package> $packages
      * @param array<string, list<FilterListEntry>> $filterEntriesByList
-     * @param Auditor::FILTERED_* $filtered
+     * @param ListPolicyConfig::AUDIT_* $filtered
      * @param 'json'|'plain'|'summary'|'table' $format
      */
     public function testAuditWithFilter(array $packages, array $filterEntriesByList, string $filtered, string $format, int $expected, string $output): void
@@ -766,7 +767,7 @@ vendor/other is on filter list "test-list". Reason: internal.',
             ->method('getMatchingFilterLists')
             ->willReturn(['filter' => $filterEntriesByList, 'unreachableRepos' => []]);
 
-        $policyConfig = $this->createPolicyConfig(Auditor::ABANDONED_IGNORE, false, $filtered);
+        $policyConfig = $this->createPolicyConfig(ListPolicyConfig::AUDIT_IGNORE, false, $filtered);
 
         $auditor = new Auditor();
         $result = $auditor->audit(
@@ -803,7 +804,7 @@ vendor/other is on filter list "test-list". Reason: internal.',
             ->method('getMatchingFilterLists')
             ->willReturn(['filter' => ['test-list' => [$matchingEntry]], 'unreachableRepos' => []]);
 
-        $policyConfig = $this->createPolicyConfig(Auditor::ABANDONED_IGNORE, false, Auditor::FILTERED_FAIL);
+        $policyConfig = $this->createPolicyConfig(ListPolicyConfig::AUDIT_IGNORE, false, ListPolicyConfig::AUDIT_FAIL);
 
         $auditor = new Auditor();
         $result = $auditor->audit(
@@ -852,7 +853,7 @@ vendor/other is on filter list "test-list". Reason: internal.',
             ->method('getMatchingFilterLists')
             ->willReturn(['filter' => ['test-list' => [$matchingEntry]], 'unreachableRepos' => []]);
 
-        $policyConfig = $this->createPolicyConfig(Auditor::ABANDONED_IGNORE, false, Auditor::FILTERED_FAIL);
+        $policyConfig = $this->createPolicyConfig(ListPolicyConfig::AUDIT_IGNORE, false, ListPolicyConfig::AUDIT_FAIL);
 
         $auditor = new Auditor();
         // vendor1/package1 at 8.2.1 is vulnerable; vendor1/package2 at 9.0.0 matches the filter
@@ -878,13 +879,13 @@ vendor/other is on filter list "test-list". Reason: internal.',
 
     /**
      * @param Auditor::ABANDONED_* $abandoned
-     * @param Auditor::FILTERED_*|null $filteredAudit
+     * @param ListPolicyConfig::AUDIT_*|null $filteredAudit
      * @param array<string, string|null> $ignoreAdvisories Mixed flat map of advisory IDs and package names => reason.
      * @param list<string> $ignoreSeverities
      * @param array<string, string|null> $ignoreAbandoned Package name => reason; package name may be a wildcard pattern.
      */
     private function createPolicyConfig(
-        string $abandoned = Auditor::ABANDONED_IGNORE,
+        string $abandoned = ListPolicyConfig::AUDIT_IGNORE,
         bool $ignoreUnreachableAudit = false,
         ?string $filteredAudit = null,
         string $filteredListName = 'test-list',

--- a/tests/Composer/Test/Command/AuditCommandTest.php
+++ b/tests/Composer/Test/Command/AuditCommandTest.php
@@ -13,6 +13,7 @@
 namespace Composer\Test\Command;
 
 use Composer\Advisory\Auditor;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Test\TestCase;
 use UnexpectedValueException;
 
@@ -108,7 +109,7 @@ class AuditCommandTest extends TestCase
         $this->createComposerLockWithPackages($packages);
 
         $appTester = $this->getApplicationTester();
-        $exitCode = $appTester->run(['command' => 'audit', '--locked' => true, '--filtered' => Auditor::FILTERED_IGNORE]);
+        $exitCode = $appTester->run(['command' => 'audit', '--locked' => true, '--filtered' => ListPolicyConfig::AUDIT_IGNORE]);
 
         $display = $appTester->getDisplay(true);
         self::assertStringNotContainsString('matching filters', $display);
@@ -135,7 +136,7 @@ class AuditCommandTest extends TestCase
             ],
             'config' => [
                 'policy' => [
-                    'company-banned' => ['audit' => Auditor::FILTERED_REPORT],
+                    'company-banned' => ['audit' => ListPolicyConfig::AUDIT_REPORT],
                 ],
             ],
         ]);

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test;
 
 use Composer\Advisory\Auditor;
 use Composer\Config;
+use Composer\Policy\ListPolicyConfig;
 use Composer\Util\Platform;
 
 class ConfigTest extends TestCase
@@ -389,15 +390,15 @@ class ConfigTest extends TestCase
         $result = $config->get('audit');
         self::assertArrayHasKey('abandoned', $result);
         self::assertArrayHasKey('ignore', $result);
-        self::assertSame(Auditor::ABANDONED_FAIL, $result['abandoned']);
+        self::assertSame(ListPolicyConfig::AUDIT_FAIL, $result['abandoned']);
         self::assertSame([], $result['ignore']);
 
-        Platform::putEnv('COMPOSER_AUDIT_ABANDONED', Auditor::ABANDONED_IGNORE);
+        Platform::putEnv('COMPOSER_AUDIT_ABANDONED', ListPolicyConfig::AUDIT_IGNORE);
         $result = $config->get('audit');
         Platform::clearEnv('COMPOSER_AUDIT_ABANDONED');
         self::assertArrayHasKey('abandoned', $result);
         self::assertArrayHasKey('ignore', $result);
-        self::assertSame(Auditor::ABANDONED_IGNORE, $result['abandoned']);
+        self::assertSame(ListPolicyConfig::AUDIT_IGNORE, $result['abandoned']);
         self::assertSame([], $result['ignore']);
 
         $config->merge(['config' => ['audit' => ['ignore' => ['A', 'B']]]]);


### PR DESCRIPTION
Really no need to keep multiple constants around for the same value.