### PR TITLE
Add option to block downloads based on URL before initializing

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -181,6 +181,14 @@ class CurlDownloader
             $this->config->prohibitUrlByConfig($url, $this->io, $options);
         }
 
+        if (
+            isset($options['prevent_url_access_callable']) &&
+            is_callable($options['prevent_url_access_callable']) &&
+            $options['prevent_url_access_callable']($url)
+        ) {
+            throw new TransportException('Access to "'.$url.'" is blocked.');
+        }
+
         $curlHandle = curl_init();
         $headerHandle = fopen('php://temp/maxmemory:32768', 'w+b');
         if (false === $headerHandle) {

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -250,6 +250,10 @@ class RemoteFilesystem
             throw new \RuntimeException("RemoteFilesystem doesn't support the 'prevent_ip_access_callable' config.");
         }
 
+        if (isset($options['prevent_url_access_callable'])) {
+            throw new \RuntimeException("RemoteFilesystem doesn't support the 'prevent_url_access_callable' config.");
+        }
+
         if (isset($options['gitlab-token'])) {
             $fileUrl .= (false === strpos($fileUrl, '?') ? '?' : '&') . 'access_token='.$options['gitlab-token'];
             unset($options['gitlab-token']);

--- a/tests/Composer/Test/Util/HttpDownloaderTest.php
+++ b/tests/Composer/Test/Util/HttpDownloaderTest.php
@@ -53,6 +53,25 @@ class HttpDownloaderTest extends TestCase
         }
     }
 
+    public function testPreventUrlAccessCallableBlocksDownload(): void
+    {
+        if (!extension_loaded('curl')) {
+            self::markTestSkipped('curl extension is required');
+        }
+
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $downloader = new HttpDownloader($io, $this->getConfigMock());
+
+        $this->expectException(\Composer\Downloader\TransportException::class);
+        $this->expectExceptionMessage('Access to "https://example.org/blocked" is blocked.');
+
+        $downloader->get('https://example.org/blocked', [
+            'prevent_url_access_callable' => static function (string $url): bool {
+                return true;
+            },
+        ]);
+    }
+
     public function testOutputWarnings(): void
     {
         $io = new BufferIO();


### PR DESCRIPTION
Adds a `prevent_url_access_callable` option to `HttpDownloader`. The callable is invoked synchronously at the start of `CurlDownloader::initDownload()` before `curl_init()`. If it returns true, the request is rejected with a `TransportException` and no connection is opened.

This complements the existing `prevent_ip_access_callable` (#11895), which can only fire after curl has resolved DNS and begun the TCP connection. At that point the request has already been started and is then aborted. The new option also works for redirects as they go through `restartJob()` → `initDownload()`, so each new URL is vetted before its own request begins.

`prevent_ip_access_callable` is intentionally left in place for potential BC reasons, but also because it can still protect from DNS rebinding after an initial lookup has been made which the new option wouldn't be able to cover alone.

`RemoteFilesystem` rejects the option, mirroring the existing IP-filter handling.