### PR TITLE
FilterLists: add warning in case security advisories or filter information cannot be fetched

### DIFF
--- a/src/Composer/DependencyResolver/FilterListPoolFilter.php
+++ b/src/Composer/DependencyResolver/FilterListPoolFilter.php
@@ -15,6 +15,7 @@ namespace Composer\DependencyResolver;
 use Composer\FilterList\FilterListAuditor;
 use Composer\FilterList\FilterListEntry;
 use Composer\FilterList\FilterListProvider\FilterListProviderSet;
+use Composer\IO\IOInterface;
 use Composer\Package\BasePackage;
 use Composer\Package\RootPackageInterface;
 use Composer\Policy\ListPolicyConfig;
@@ -40,6 +41,8 @@ class FilterListPoolFilter
     private $blockScope;
     /** @var array<RepositoryInterface> */
     private $repositories;
+    /** @var IOInterface */
+    private $io;
 
     /**
      * @param ListPolicyConfig::BLOCK_SCOPE_* $blockScope
@@ -50,13 +53,15 @@ class FilterListPoolFilter
         FilterListAuditor $filterListAuditor,
         HttpDownloader $httpDownloader,
         string $blockScope,
-        array $repositories
+        array $repositories,
+        IOInterface $io
     ) {
         $this->policyConfig = $policyConfig;
         $this->filterListAuditor = $filterListAuditor;
         $this->httpDownloader = $httpDownloader;
         $this->blockScope = $blockScope;
         $this->repositories = $repositories;
+        $this->io = $io;
     }
 
     public function filter(Pool $pool, Request $request): Pool
@@ -84,7 +89,12 @@ class FilterListPoolFilter
         }
 
         $providerSet = FilterListProviderSet::create($this->policyConfig, $this->repositories, $this->httpDownloader);
-        $unionMap = $this->fetchFilterListMap($pool, $providerSet, $unionListNames, $ignoreUnreachable);
+        $fetchResult = $this->fetchFilterListMap($pool, $providerSet, $unionListNames, $ignoreUnreachable);
+        $unionMap = $fetchResult['filter'];
+        if (count($fetchResult['unreachableRepos']) > 0) {
+            $this->warnUnreachable($fetchResult['unreachableRepos']);
+        }
+
         if (count($unionMap) === 0) {
             return $pool;
         }
@@ -134,7 +144,7 @@ class FilterListPoolFilter
 
     /**
      * @param list<string> $listNames
-     * @return array<string, array<string, list<FilterListEntry>>>
+     * @return array{filter: array<string, array<string, list<FilterListEntry>>>, unreachableRepos: array<string>}
      */
     private function fetchFilterListMap(Pool $pool, FilterListProviderSet $providerSet, array $listNames, bool $ignoreUnreachable): array
     {
@@ -152,7 +162,18 @@ class FilterListPoolFilter
             $providerSet,
             $listNames,
             $ignoreUnreachable
-        )['filter'];
+        );
+    }
+
+    /**
+     * @param array<string> $unreachableRepos
+     */
+    private function warnUnreachable(array $unreachableRepos): void
+    {
+        $this->io->writeError('<warning>Filter list data could not be fetched from some sources (ignored per policy.ignore-unreachable); matches may be incomplete:</warning>');
+        foreach ($unreachableRepos as $repo) {
+            $this->io->writeError('  - ' . $repo);
+        }
     }
 
     /**

--- a/src/Composer/DependencyResolver/SecurityAdvisoryPoolFilter.php
+++ b/src/Composer/DependencyResolver/SecurityAdvisoryPoolFilter.php
@@ -15,6 +15,7 @@ namespace Composer\DependencyResolver;
 use Composer\Advisory\Auditor;
 use Composer\Advisory\PartialSecurityAdvisory;
 use Composer\Advisory\SecurityAdvisory;
+use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackageInterface;
 use Composer\Policy\PolicyConfig;
@@ -32,13 +33,17 @@ class SecurityAdvisoryPoolFilter
     private $auditor;
     /** @var PolicyConfig */
     private $policyConfig;
+    /** @var IOInterface */
+    private $io;
 
     public function __construct(
         Auditor $auditor,
-        PolicyConfig $policyConfig
+        PolicyConfig $policyConfig,
+        IOInterface $io
     ) {
         $this->auditor = $auditor;
         $this->policyConfig = $policyConfig;
+        $this->io = $io;
     }
 
     /**
@@ -71,6 +76,13 @@ class SecurityAdvisoryPoolFilter
         $allAdvisories = $repoSet->getMatchingSecurityAdvisories($packagesForAdvisories, true, $ignoreUnreachableUpdate);
         if ($this->auditor->needsCompleteAdvisoryLoad($allAdvisories['advisories'], $ignoreListForBlocking)) {
             $allAdvisories = $repoSet->getMatchingSecurityAdvisories($packagesForAdvisories, false, $ignoreUnreachableUpdate);
+        }
+
+        if ($ignoreUnreachableUpdate && count($allAdvisories['unreachableRepos']) > 0) {
+            $this->io->writeError('<warning>Security advisory data could not be fetched from some repositories (ignored per policy.ignore-unreachable); matches may be incomplete:</warning>');
+            foreach ($allAdvisories['unreachableRepos'] as $repo) {
+                $this->io->writeError('  - ' . $repo);
+            }
         }
 
         $advisoryMap = $this->auditor->processAdvisories($allAdvisories['advisories'], $ignoreListForBlocking, $advisories->getIgnoreSeverityForOperation('block'))['advisories'];

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1160,7 +1160,7 @@ class Installer
         $policyConfig = $this->getPolicyConfig();
 
         if ($policyConfig->enabled && $policyConfig->advisories->shouldBlock('update') && !$this->updateMirrors) {
-            return new SecurityAdvisoryPoolFilter(new Auditor(), $policyConfig);
+            return new SecurityAdvisoryPoolFilter(new Auditor(), $policyConfig, $this->io);
         }
 
         return null;
@@ -1191,7 +1191,7 @@ class Installer
             return null;
         }
 
-        return new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->repositoryManager->getHttpDownloader(), $blockScope, $this->repositoryManager->getRepositories());
+        return new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->repositoryManager->getHttpDownloader(), $blockScope, $this->repositoryManager->getRepositories(), $this->io);
     }
 
     /**

--- a/tests/Composer/Test/DependencyResolver/FilterListPoolFilterTest.php
+++ b/tests/Composer/Test/DependencyResolver/FilterListPoolFilterTest.php
@@ -16,7 +16,10 @@ use Composer\Config;
 use Composer\DependencyResolver\FilterListPoolFilter;
 use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
+use Composer\Downloader\TransportException;
 use Composer\FilterList\FilterListAuditor;
+use Composer\IO\BufferIO;
+use Composer\IO\NullIO;
 use Composer\Package\Package;
 use Composer\Policy\ListPolicyConfig;
 use Composer\Policy\PolicyConfig;
@@ -45,7 +48,7 @@ class FilterListPoolFilterTest extends TestCase
         $policyConfig = PolicyConfig::fromConfig($config);
 
         $repository = $this->generatePackageRepository('1.0');
-        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository], new NullIO());
 
         $pool = new Pool([
             new Package('acme/package', '1.0.0.0', '1.0'),
@@ -70,7 +73,7 @@ class FilterListPoolFilterTest extends TestCase
 
         $policyConfig = PolicyConfig::fromConfig($config);
         $repository = $this->generatePackageRepository('*');
-        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository], new NullIO());
 
         $pool = new Pool([
             $expectedPackage1 = new Package('acme/package', '1.0.0.0', '1.0'),
@@ -105,7 +108,7 @@ class FilterListPoolFilterTest extends TestCase
 
         $policyConfig = PolicyConfig::fromConfig($config);
         $repository = $this->generatePackageRepository('>=1.0');
-        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository], new NullIO());
 
         $pool = new Pool([
             $expectedPackage = new Package('acme/package', '1.0.0.0', '1.0'),
@@ -140,7 +143,7 @@ class FilterListPoolFilterTest extends TestCase
 
         $policyConfig = PolicyConfig::fromConfig($config);
         $repository = $this->generatePackageRepository('0.0.1');
-        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository], new NullIO());
 
         $pool = new Pool([
             new Package('acme/package', '3.0.0.0', '3.0'),
@@ -179,14 +182,14 @@ class FilterListPoolFilterTest extends TestCase
         $request->fixLockedPackage($package);
 
         // Install scope: locked package IS checked, gets filter-list-removed.
-        $installFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_INSTALL, [$repository]);
+        $installFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_INSTALL, [$repository], new NullIO());
         $installPool = $installFilter->filter(new Pool([$package]), $request);
         self::assertSame([], $installPool->getPackages(), 'install-scope filter must include locked packages');
         self::assertTrue($installPool->isFilterListRemovedPackageVersion('acme/locked', new Constraint('==', '1.0.0.0')));
 
         // Update scope: locked packages are checked against install-scope filter lists too,
         // so a malware-flagged locked package is still removed from the pool.
-        $updateFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+        $updateFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository], new NullIO());
         $updatePool = $updateFilter->filter(new Pool([$package]), $request);
         self::assertSame([], $updatePool->getPackages(), 'update-scope filter must apply install-scope rules to locked packages');
         self::assertTrue($updatePool->isFilterListRemovedPackageVersion('acme/locked', new Constraint('==', '1.0.0.0')));
@@ -223,7 +226,7 @@ class FilterListPoolFilterTest extends TestCase
         $request = new Request($lockedRepo);
         $request->requireName('acme/mirrored', new Constraint('==', '1.0.0.0'));
 
-        $updateFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+        $updateFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository], new NullIO());
         $updatePool = $updateFilter->filter(new Pool([$poolPackage]), $request);
         self::assertSame([], $updatePool->getPackages(), 'packages from the locked repo must be checked against install-scope filter lists');
         self::assertTrue($updatePool->isFilterListRemovedPackageVersion('acme/mirrored', new Constraint('==', '1.0.0.0')));
@@ -255,10 +258,77 @@ class FilterListPoolFilterTest extends TestCase
         $package = new Package('acme/free', '1.0.0.0', '1.0');
         $request = new Request();
 
-        $updateFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository]);
+        $updateFilter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$repository], new NullIO());
         $updatePool = $updateFilter->filter(new Pool([$package]), $request);
         self::assertSame([$package], $updatePool->getPackages(), 'install-only lists must not block non-locked packages during update scope');
         self::assertCount(0, $updatePool->getAllFilterListRemovedPackageVersions());
+    }
+
+    public function testWarnsWhenUnreachableSourcesAreIgnored(): void
+    {
+        $unreachable = new class([
+            'package' => [],
+            'filter' => [
+                'test-list' => [
+                    ['package' => 'acme/package', 'constraint' => '*', 'reason' => 'malware'],
+                ],
+            ],
+        ]) extends PackageRepository {
+            public function getFilter(array $packageConstraintMap): array
+            {
+                throw new TransportException('The "https://example.org/filter.json" file could not be downloaded: HTTP/1.1 500 Internal Server Error', 500);
+            }
+
+            public function getRepoName(): string
+            {
+                return 'unreachable filter list repo';
+            }
+        };
+
+        // ignore-unreachable defaults to ["update", "install"], so the transport error is swallowed.
+        $config = new Config();
+        $config->merge(['config' => ['policy' => ['test-list' => true]]]);
+        $policyConfig = PolicyConfig::fromConfig($config);
+
+        $io = new BufferIO();
+        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$unreachable], $io);
+        $filter->filter(new Pool([new Package('acme/package', '1.0.0.0', '1.0')]), new Request());
+
+        $output = $io->getOutput();
+        self::assertStringContainsString('Filter list data could not be fetched from some sources', $output);
+        self::assertStringContainsString('HTTP/1.1 500 Internal Server Error', $output);
+    }
+
+    public function testRethrowsTransportErrorWhenUnreachableIsNotIgnored(): void
+    {
+        $unreachable = new class([
+            'package' => [],
+            'filter' => [
+                'test-list' => [
+                    ['package' => 'acme/package', 'constraint' => '*', 'reason' => 'malware'],
+                ],
+            ],
+        ]) extends PackageRepository {
+            public function getFilter(array $packageConstraintMap): array
+            {
+                throw new TransportException('boom', 500);
+            }
+
+            public function getRepoName(): string
+            {
+                return 'unreachable filter list repo';
+            }
+        };
+
+        // ignore-unreachable: false — transport errors bubble up; no warning needed.
+        $config = new Config();
+        $config->merge(['config' => ['policy' => ['test-list' => true, 'ignore-unreachable' => false]]]);
+        $policyConfig = PolicyConfig::fromConfig($config);
+
+        $filter = new FilterListPoolFilter($policyConfig, new FilterListAuditor(), $this->httpDownloaderMock, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [$unreachable], new BufferIO());
+
+        $this->expectException(TransportException::class);
+        $filter->filter(new Pool([new Package('acme/package', '1.0.0.0', '1.0')]), new Request());
     }
 
     private function generatePackageRepository(string $constraint): PackageRepository

--- a/tests/Composer/Test/DependencyResolver/SecurityAdvisoryPoolFilterTest.php
+++ b/tests/Composer/Test/DependencyResolver/SecurityAdvisoryPoolFilterTest.php
@@ -16,6 +16,9 @@ use Composer\Advisory\Auditor;
 use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
 use Composer\DependencyResolver\SecurityAdvisoryPoolFilter;
+use Composer\Downloader\TransportException;
+use Composer\IO\BufferIO;
+use Composer\IO\NullIO;
 use Composer\Package\CompletePackage;
 use Composer\Package\Package;
 use Composer\Policy\AbandonedPolicyConfig;
@@ -55,7 +58,7 @@ class SecurityAdvisoryPoolFilterTest extends TestCase
 
     public function testFilterPackagesByAdvisories(): void
     {
-        $filter = new SecurityAdvisoryPoolFilter(new Auditor(), self::policyConfig());
+        $filter = new SecurityAdvisoryPoolFilter(new Auditor(), self::policyConfig(), new NullIO());
 
         $repository = new PackageRepository([
             'package' => [],
@@ -99,7 +102,7 @@ class SecurityAdvisoryPoolFilterTest extends TestCase
             [],
             IgnoreUnreachable::default()
         );
-        $filter = new SecurityAdvisoryPoolFilter(new Auditor(), $policyConfig);
+        $filter = new SecurityAdvisoryPoolFilter(new Auditor(), $policyConfig, new NullIO());
 
         $repository = new PackageRepository([
             'package' => [],
@@ -120,7 +123,7 @@ class SecurityAdvisoryPoolFilterTest extends TestCase
 
     public function testDontFilterPackagesWithBlockInsecureDisabled(): void
     {
-        $filter = new SecurityAdvisoryPoolFilter(new Auditor(), self::policyConfig(false));
+        $filter = new SecurityAdvisoryPoolFilter(new Auditor(), self::policyConfig(false), new NullIO());
 
         $repository = new PackageRepository([
             'package' => [],
@@ -148,7 +151,7 @@ class SecurityAdvisoryPoolFilterTest extends TestCase
             [],
             [$packageNameIgnoreAbandoned => [new IgnorePackageRule($packageNameIgnoreAbandoned, new MatchAllConstraint())]]
         );
-        $filter = new SecurityAdvisoryPoolFilter(new Auditor(), $policyConfig);
+        $filter = new SecurityAdvisoryPoolFilter(new Auditor(), $policyConfig, new NullIO());
 
         $abandonedPackage = new CompletePackage('acme/package', '1.0.0.0', '1.0');
         $abandonedPackage->setAbandoned(true);
@@ -166,6 +169,81 @@ class SecurityAdvisoryPoolFilterTest extends TestCase
         $this->assertSame([$expectedPackage, $ignoreAbandonedPackage], $filteredPool->getPackages());
         $this->assertCount(1, $filteredPool->getAllAbandonedRemovedPackageVersions());
         $this->assertCount(0, $filteredPool->getAllSecurityRemovedPackageVersions());
+    }
+
+    public function testWarnsWhenUnreachableRepositoriesAreIgnored(): void
+    {
+        $unreachable = new class([
+            'package' => [],
+            'security-advisories' => [
+                'acme/package' => [
+                    [
+                        'advisoryId' => 'PKSA-test',
+                        'packageName' => 'acme/package',
+                        'remoteId' => 'r',
+                        'title' => 'Security Advisory',
+                        'link' => null,
+                        'cve' => 'CVE-2024-9999',
+                        'affectedVersions' => '>=1.0.0,<2.0.0',
+                        'source' => 'Tests',
+                        'reportedAt' => '2024-04-31 12:37:47',
+                        'composerRepository' => 'Unreachable Repo',
+                        'severity' => 'high',
+                        'sources' => [['name' => 'Test', 'remoteId' => 'r']],
+                    ],
+                ],
+            ],
+        ]) extends PackageRepository {
+            public function getSecurityAdvisories(array $packageConstraintMap, bool $allowPartialAdvisories = false): array
+            {
+                throw new TransportException('The "https://example.org/security.json" file could not be downloaded: HTTP/1.1 502 Bad Gateway', 502);
+            }
+
+            public function getRepoName(): string
+            {
+                return 'unreachable advisory repo';
+            }
+        };
+
+        // ignore-unreachable defaults to ["update", "install"], so the transport error is swallowed.
+        $filter = new SecurityAdvisoryPoolFilter(new Auditor(), self::policyConfig(), $io = new BufferIO());
+        $filter->filter(new Pool([new Package('acme/package', '1.0.0.0', '1.0')]), [$unreachable], new Request());
+
+        $output = $io->getOutput();
+        self::assertStringContainsString('Security advisory data could not be fetched from some repositories', $output);
+        self::assertStringContainsString('HTTP/1.1 502 Bad Gateway', $output);
+    }
+
+    public function testRethrowsTransportErrorWhenUnreachableIsNotIgnored(): void
+    {
+        $unreachable = new class([
+            'package' => [],
+            'security-advisories' => ['acme/package' => []],
+        ]) extends PackageRepository {
+            public function getSecurityAdvisories(array $packageConstraintMap, bool $allowPartialAdvisories = false): array
+            {
+                throw new TransportException('boom', 500);
+            }
+
+            public function getRepoName(): string
+            {
+                return 'unreachable advisory repo';
+            }
+        };
+
+        $policyConfig = new PolicyConfig(
+            true,
+            new AdvisoriesPolicyConfig(true, ListPolicyConfig::AUDIT_FAIL, [], [], []),
+            MalwarePolicyConfig::disabled(),
+            new AbandonedPolicyConfig(true, ListPolicyConfig::AUDIT_FAIL, []),
+            [],
+            IgnoreUnreachable::none()
+        );
+
+        $filter = new SecurityAdvisoryPoolFilter(new Auditor(), $policyConfig, new BufferIO());
+
+        $this->expectException(TransportException::class);
+        $filter->filter(new Pool([new Package('acme/package', '1.0.0.0', '1.0')]), [$unreachable], new Request());
     }
 
     /**


### PR DESCRIPTION
This will generate an output like below in case one or more repository/source cannot be accessed.

```
composer install
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Filter list data could not be fetched from some sources (ignored per policy.ignore-unreachable); matches may be incomplete:
  - The "https://repo.packagist.com/filter/lists/summary.json" file could not be downloaded: HTTP/1.1 502 Bad
  Gateway
Nothing to install, update or remove
Generating autoload files
```