### PR TITLE
fix(github): do not try to validate GitHub token

### DIFF
--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -137,11 +137,6 @@ abstract class BaseIO implements IOInterface
                 $config->merge(['config' => ['github-domains' => array_merge($config->get('github-domains'), [$domain])]], 'implicit-due-to-auth');
             }
 
-            // allowed chars for GH tokens are from https://github.blog/changelog/2021-03-04-authentication-token-format-updates/
-            // plus dots which were at some point used for GH app integration tokens
-            if (!Preg::isMatch('{^[.A-Za-z0-9_]+$}', $token)) {
-                throw new \UnexpectedValueException('Your github oauth token for '.$domain.' contains invalid characters: "'.$token.'"');
-            }
             $this->checkAndSetAuthentication($domain, $token, 'x-oauth-basic');
         }
 


### PR DESCRIPTION
* resolves https://github.com/composer/composer/issues/12849

According to GitHub the token format can change and thus no validation of the format is recommended. The even discourage using RegEx or similar.

So instead of trying to validate it simply try it.

Ref: https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/#how-to-prepare-for-this-change
