### PR TITLE
Expose logic for using alternative domain in AuthHelper

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -273,8 +273,6 @@ class AuthHelper
         $authOrigin = self::findAuthOrigin($this->io, $origin);
         if ($authOrigin !== null) {
             $origin = $authOrigin;
-        }
-        if ($this->io->hasAuthentication($origin)) {
             $authenticationDisplayMessage = null;
             $auth = $this->io->getAuthentication($origin);
             if ($auth['password'] === 'bearer') {

--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -270,6 +270,10 @@ class AuthHelper
             $options['http']['header'] = [];
         }
         $headers = &$options['http']['header'];
+        $authOrigin = self::findAuthOrigin($this->io, $origin);
+        if ($authOrigin !== null) {
+            $origin = $authOrigin;
+        }
         if ($this->io->hasAuthentication($origin)) {
             $authenticationDisplayMessage = null;
             $auth = $this->io->getAuthentication($origin);
@@ -326,11 +330,23 @@ class AuthHelper
                 $this->io->writeError($authenticationDisplayMessage, true, IOInterface::DEBUG);
                 $this->displayedOriginAuthentications[$origin] = $authenticationDisplayMessage;
             }
-        } elseif (in_array($origin, ['api.bitbucket.org', 'api.github.com'], true)) {
-            return $this->addAuthenticationOptions($options, str_replace('api.', '', $origin), $url);
         }
 
         return $options;
+    }
+
+    public static function findAuthOrigin(IOInterface $io, string $origin ): ?string
+    {
+        if ($io->hasAuthentication($origin)) {
+            return $origin;
+        }
+        if (in_array($origin, ['api.bitbucket.org', 'api.github.com'], true)) {
+            $canonical = str_replace('api.', '', $origin);
+            if ($io->hasAuthentication($canonical)) {
+                return $canonical;
+            }
+        }
+        return null;
     }
 
     /**

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -710,4 +710,71 @@ class AuthHelperTest extends TestCase
             ->with($origin)
             ->willReturn($auth);
     }
+
+    /**
+     * @dataProvider findAuthOriginProvider
+     */
+    public function testFindAuthOrigin(string $origin, bool $originResult, string $originToPass, bool $originToPassResult, ?string $expectedResult = null): void
+    {
+        $this->io->method('hasAuthentication')
+            ->willReturnCallback(function ($originInTheCall) use ($origin, $originResult, $originToPass, $originToPassResult) {
+               if ($origin === $originInTheCall) {
+                   return $originResult;
+               }
+               if ($originToPass === $originInTheCall) {
+                   return $originToPassResult;
+               }
+               return false;
+            });
+        $authOrigin = AuthHelper::findAuthOrigin($this->io, $originToPass);
+        self::assertSame($expectedResult, $authOrigin);
+    }
+
+    public static function findAuthOriginProvider() : array
+    {
+        return [
+            [
+                'github.com',
+                true,
+                'github.com',
+                true,
+                'github.com',
+            ],
+            [
+                'github.com',
+                true,
+                'api.github.com',
+                false,
+                'github.com'
+            ],
+            [
+                'bitbucket.org',
+                true,
+                'bitbucket.org',
+                false,
+                'bitbucket.org'
+            ],
+            [
+                'bitbucket.org',
+                true,
+                'api.bitbucket.org',
+                false,
+                'bitbucket.org',
+            ],
+            [
+                'bitbucket.org',
+                false,
+                'bitbucket.org',
+                false,
+                null,
+            ],
+            [
+                'gitlab.com',
+                true,
+                'api.gitlab.com',
+                false,
+                null,
+            ]
+        ];
+    }
 }


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
This PR moves the two lines of logic that ends up placing auth on an alternate domain.

The reason for this, is if you wanted to retroactively determine if `IO` contains authentication that would end up being used by composer, you would have to duplicate the logic. Something like

```
if (!$this->io->hasAuthentication($urlHost) && in_array($urlHost, ['api.github.com', 'api.bitbucket.org'], true)) {
    $urlHost = str_replace('api.', '', $urlHost);
}
```

which is short and sweet, but just a copy paste from a moment in time. If this logic was ever changed, one would not notice and would have to manually track this duplication. Which is why I instead added a static helper, so you can pass your `IO` object and get the same result as composer would have.