### PR TITLE
FilterLists: improve fallback handling for config.audit.* keys

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -580,20 +580,22 @@ dependencies, ensuring they cannot be installed.
 The legacy `config.audit` keys are only read as a fallback when the corresponding
 [`config.policy`](#policy) block is **absent**. The fallback is all-or-nothing per built-in list:
 
-- If [`config.policy.advisories`](#advisories) is set (to any value, including `false`), every
-  `audit.*` key that maps to advisories — [`block-insecure`](#block-insecure),
-  [`ignore`](#ignore), [`ignore-severity`](#ignore-severity) — is **ignored entirely**.
-  Only `policy.advisories.*` is read. Mix-and-matching, e.g. setting `policy.advisories.block`
-  while expecting `audit.ignore-severity` to still apply, is not supported — migrate all
-  advisories-related settings together.
-- If [`config.policy.abandoned`](#abandoned) is set (to any value, including `false`), every
-  `audit.*` key that maps to abandoned — [`block-abandoned`](#block-abandoned),
-  [`abandoned`](#abandoned), [`ignore-abandoned`](#ignore-abandoned) — is **ignored
-  entirely**. Only `policy.abandoned.*` is read.
+- If [`config.policy.advisories`](#advisories) is set (to any value, including `false`),
+  every advisories-related `audit.*` key ([`audit.block-insecure`](#block-insecure), [`audit.ignore`](#ignore-3),
+  [`audit.ignore-severity`](#ignore-severity-1)) is **ignored entirely** — only
+  [`policy.advisories.block`](#block), [`policy.advisories.ignore`](#ignore), and
+  [`policy.advisories.ignore-severity`](#ignore-severity) are read. Mix-and-matching,
+  e.g. setting `policy.advisories.block` while expecting `audit.ignore-severity` to still
+  apply, is not supported — migrate all advisories-related settings together.
+- If [`config.policy.abandoned`](#abandoned) is set (to any value, including `false`),
+  every abandoned-related `audit.*` key ([`audit.block-abandoned`](#block-abandoned), [`audit.abandoned`](#abandoned-1),
+  [`audit.ignore-abandoned`](#ignore-abandoned)) is **ignored entirely** — only
+  [`policy.abandoned.block`](#block-1), [`policy.abandoned.audit`](#audit-1), and
+  [`policy.abandoned.ignore`](#ignore-1) are read.
 - The two built-in lists are independent: configuring `policy.advisories` while leaving the
   abandoned settings under `audit.*` is allowed and vice versa.
-- [`audit.ignore-unreachable`](#ignore-unreachable) is superseded by
-  [`policy.ignore-unreachable`](#ignore-unreachable) as soon as the latter is set.
+- Setting [`policy.ignore-unreachable`](#ignore-unreachable) supersedes the legacy
+  [`audit.ignore-unreachable`](#ignore-unreachable-1) key.
 
 ### ignore
 
@@ -695,7 +697,7 @@ config value and the environment variable.
 
 ### ignore-abandoned
 
-> **Deprecated.** Use [`config.policy.abandoned.ignore`](#ignore-2) instead.
+> **Deprecated.** Use [`config.policy.abandoned.ignore`](#ignore-1) instead.
 > Note: the new format uses `on-block`/`on-audit` booleans instead of `"apply": "audit|block|all"`.
 
 A list of abandoned package names that are ignored for audit reports and/or version blocking. Allows you to select packages that you want to keep

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -571,6 +571,26 @@ and short format versions are automatically reported at the end of update or req
 discards package versions identified as insecure or abandoned, depending on configuration, before resolving
 dependencies, ensuring they cannot be installed.
 
+### How `config.audit` interacts with `config.policy`
+
+The legacy `config.audit` keys are only read as a fallback when the corresponding
+[`config.policy`](#policy) block is **absent**. The fallback is all-or-nothing per built-in list:
+
+- If [`config.policy.advisories`](#advisories) is set (to any value, including `false`), every
+  `audit.*` key that maps to advisories — [`block-insecure`](#block-insecure),
+  [`ignore`](#ignore), [`ignore-severity`](#ignore-severity) — is **ignored entirely**.
+  Only `policy.advisories.*` is read. Mix-and-matching, e.g. setting `policy.advisories.block`
+  while expecting `audit.ignore-severity` to still apply, is not supported — migrate all
+  advisories-related settings together.
+- If [`config.policy.abandoned`](#abandoned) is set (to any value, including `false`), every
+  `audit.*` key that maps to abandoned — [`block-abandoned`](#block-abandoned),
+  [`abandoned`](#abandoned), [`ignore-abandoned`](#ignore-abandoned) — is **ignored
+  entirely**. Only `policy.abandoned.*` is read.
+- The two built-in lists are independent: configuring `policy.advisories` while leaving the
+  abandoned settings under `audit.*` is allowed and vice versa.
+- [`audit.ignore-unreachable`](#ignore-unreachable) is superseded by
+  [`policy.ignore-unreachable`](#ignore-unreachable) as soon as the latter is set.
+
 ### ignore
 
 > **Deprecated.** Use [`config.policy.advisories.ignore-id`](#ignore-id) for advisory IDs

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -162,6 +162,10 @@ Set to `false` to disable all policy enforcement:
 }
 ```
 
+> **Migrating from `config.audit`?** See
+> [How `config.audit` interacts with `config.policy`](#how-configaudit-interacts-with-configpolicy)
+> for how the legacy keys are still honored as a fallback while you migrate.
+
 ### advisories
 
 Configuration for packages affected by security advisories.

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -257,10 +257,12 @@
             }
         },
         "target-dir": {
+            "deprecated": true,
             "description": "DEPRECATED: Forces the package to be installed into the given subdirectory path. This is used for autoloading PSR-0 packages that do not contain their full path. Use forward slashes for cross-platform compatibility.",
             "type": "string"
         },
         "include-path": {
+            "deprecated": true,
             "type": ["array"],
             "description": "DEPRECATED: A list of directories which should get added to PHP's include path. This is only present to support legacy projects, and all new code should preferably use autoloading.",
             "items": {
@@ -327,7 +329,7 @@
                     "oneOf": [
                         {
                             "type": "string",
-                            "description": "If specified, this technique will be used to override the URL that PIE uses to download the asset. The default, if not specified, is composer-default.",
+                            "description": "DEPRECATED: use the array form instead. If specified, this technique will be used to override the URL that PIE uses to download the asset. The default, if not specified, is composer-default.",
                             "deprecated": true,
                             "enum": ["composer-default", "pre-packaged-source", "pre-packaged-binary"],
                             "example": "composer-default",
@@ -443,11 +445,11 @@
                 "audit": {
                     "type": "object",
                     "deprecated": true,
-                    "description": "Deprecated: use 'config.policy' instead. All 'audit.*' keys still work as a fallback, but the fallback is all-or-nothing per built-in list — once 'policy.advisories' is set every 'audit.*' advisories key is ignored, and once 'policy.abandoned' is set every 'audit.*' abandoned key is ignored.",
+                    "description": "DEPRECATED: use 'config.policy' instead. All 'audit.*' keys still work as a fallback for now. See https://getcomposer.org/doc/06-config.md#policy",
                     "properties": {
                         "ignore": {
                             "deprecated": true,
-                            "description": "Deprecated: use 'config.policy.advisories.ignore-id' for advisory IDs (CVE/GHSA/PKSA) and 'config.policy.advisories.ignore' for package names instead. The new format uses 'on-block' / 'on-audit' booleans instead of 'apply: audit|block|all'.",
+                            "description": "DEPRECATED: use 'config.policy.advisories.ignore-id' for advisory IDs (CVE/GHSA/PKSA) and 'config.policy.advisories.ignore' for package names instead. The new format uses 'on-block' / 'on-audit' booleans instead of 'apply: audit|block|all'.",
                             "anyOf": [
                                 {
                                     "type": "object",
@@ -492,11 +494,11 @@
                         "abandoned": {
                             "enum": ["ignore", "report", "fail"],
                             "deprecated": true,
-                            "description": "Deprecated: use 'config.policy.abandoned.audit' instead. Whether abandoned packages should be ignored, reported as problems or cause an audit failure. Applies only to audit reports, not to version blocking."
+                            "description": "DEPRECATED: use 'config.policy.abandoned.audit' instead. Whether abandoned packages should be ignored, reported as problems or cause an audit failure. Applies only to audit reports, not to version blocking."
                         },
                         "ignore-severity": {
                             "deprecated": true,
-                            "description": "Deprecated: use 'config.policy.advisories.ignore-severity' instead. The new format uses 'on-block' / 'on-audit' booleans instead of 'apply: audit|block|all'.",
+                            "description": "DEPRECATED: use 'config.policy.advisories.ignore-severity' instead. The new format uses 'on-block' / 'on-audit' booleans instead of 'apply: audit|block|all'.",
                             "anyOf": [
                                 {
                                     "type": "object",
@@ -537,23 +539,23 @@
                         "ignore-unreachable": {
                             "type": "boolean",
                             "deprecated": true,
-                            "description": "Deprecated: use 'config.policy.ignore-unreachable' instead. The new key accepts a boolean or an array of scopes ('audit', 'install', 'update') and is shared across all policy lists."
+                            "description": "DEPRECATED: use 'config.policy.ignore-unreachable' instead. The new key accepts a boolean or an array of scopes ('audit', 'install', 'update') and is shared across all policy lists."
                         },
                         "block-insecure": {
                             "type": "boolean",
                             "deprecated": true,
-                            "description": "Deprecated: use 'config.policy.advisories.block' instead. Whether insecure versions should be blocked during a composer update/require command or not.",
+                            "description": "DEPRECATED: use 'config.policy.advisories.block' instead. Whether insecure versions should be blocked during a composer update/require command or not.",
                             "default": true
                         },
                         "block-abandoned": {
                             "type": "boolean",
                             "deprecated": true,
-                            "description": "Deprecated: use 'config.policy.abandoned.block' instead. Whether abandoned packages should be blocked during a composer update/require command or not.",
+                            "description": "DEPRECATED: use 'config.policy.abandoned.block' instead. Whether abandoned packages should be blocked during a composer update/require command or not.",
                             "default": false
                         },
                         "ignore-abandoned": {
                             "deprecated": true,
-                            "description": "Deprecated: use 'config.policy.abandoned.ignore' instead. The new format uses 'on-block' / 'on-audit' booleans instead of 'apply: audit|block|all'.",
+                            "description": "DEPRECATED: use 'config.policy.abandoned.ignore' instead. The new format uses 'on-block' / 'on-audit' booleans instead of 'apply: audit|block|all'.",
                             "anyOf": [
                                 {
                                     "type": "object",
@@ -1462,6 +1464,7 @@
                     "type": "string"
                 },
                 "target-dir": {
+                    "deprecated": true,
                     "description": "DEPRECATED: Forces the package to be installed into the given subdirectory path. This is used for autoloading PSR-0 packages that do not contain their full path. Use forward slashes for cross-platform compatibility.",
                     "type": "string"
                 },
@@ -1552,6 +1555,7 @@
                     }
                 },
                 "include-path": {
+                    "deprecated": true,
                     "type": ["array"],
                     "description": "DEPRECATED: A list of directories which should get added to PHP's include path. This is only present to support legacy projects, and all new code should preferably use autoloading.",
                     "items": {

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -442,9 +442,12 @@
                 },
                 "audit": {
                     "type": "object",
-                    "description": "Security audit and version blocking configuration options",
+                    "deprecated": true,
+                    "description": "Deprecated: use 'config.policy' instead. All 'audit.*' keys still work as a fallback, but the fallback is all-or-nothing per built-in list — once 'policy.advisories' is set every 'audit.*' advisories key is ignored, and once 'policy.abandoned' is set every 'audit.*' abandoned key is ignored.",
                     "properties": {
                         "ignore": {
+                            "deprecated": true,
+                            "description": "Deprecated: use 'config.policy.advisories.ignore-id' for advisory IDs (CVE/GHSA/PKSA) and 'config.policy.advisories.ignore' for package names instead. The new format uses 'on-block' / 'on-audit' booleans instead of 'apply: audit|block|all'.",
                             "anyOf": [
                                 {
                                     "type": "object",
@@ -488,9 +491,12 @@
                         },
                         "abandoned": {
                             "enum": ["ignore", "report", "fail"],
-                            "description": "Whether abandoned packages should be ignored, reported as problems or cause an audit failure. Applies only to audit reports, not to version blocking."
+                            "deprecated": true,
+                            "description": "Deprecated: use 'config.policy.abandoned.audit' instead. Whether abandoned packages should be ignored, reported as problems or cause an audit failure. Applies only to audit reports, not to version blocking."
                         },
                         "ignore-severity": {
+                            "deprecated": true,
+                            "description": "Deprecated: use 'config.policy.advisories.ignore-severity' instead. The new format uses 'on-block' / 'on-audit' booleans instead of 'apply: audit|block|all'.",
                             "anyOf": [
                                 {
                                     "type": "object",
@@ -530,19 +536,24 @@
                         },
                         "ignore-unreachable": {
                             "type": "boolean",
-                            "description": "Whether repositories that are unreachable or return a non-200 status code should be ignored or not. Applies only to the composer audit command, does not affect audit report summaries in other commands or version blocking."
+                            "deprecated": true,
+                            "description": "Deprecated: use 'config.policy.ignore-unreachable' instead. The new key accepts a boolean or an array of scopes ('audit', 'install', 'update') and is shared across all policy lists."
                         },
                         "block-insecure": {
                             "type": "boolean",
-                            "description": "Whether insecure versions should be blocked during a composer update/require command or not.",
+                            "deprecated": true,
+                            "description": "Deprecated: use 'config.policy.advisories.block' instead. Whether insecure versions should be blocked during a composer update/require command or not.",
                             "default": true
                         },
                         "block-abandoned": {
                             "type": "boolean",
-                            "description": "Whether abandoned packages should be blocked during a composer update/require command or not. Applies only if blocking of insecure versions is enabled.",
+                            "deprecated": true,
+                            "description": "Deprecated: use 'config.policy.abandoned.block' instead. Whether abandoned packages should be blocked during a composer update/require command or not.",
                             "default": false
                         },
                         "ignore-abandoned": {
+                            "deprecated": true,
+                            "description": "Deprecated: use 'config.policy.abandoned.ignore' instead. The new format uses 'on-block' / 'on-audit' booleans instead of 'apply: audit|block|all'.",
                             "anyOf": [
                                 {
                                     "type": "object",

--- a/tests/Composer/Test/Policy/AbandonedPolicyConfigTest.php
+++ b/tests/Composer/Test/Policy/AbandonedPolicyConfigTest.php
@@ -114,6 +114,36 @@ class AbandonedPolicyConfigTest extends TestCase
         self::assertSame(['vendor/package2' => 'Block but do not report'], $abandoned->getFlatIgnoreForOperation('block'));
     }
 
+    public function testPolicyAbandonedSetIgnoresLegacyAuditAbandonedKeys(): void
+    {
+        $policyConfig = ['abandoned' => ['block' => true, 'audit' => 'report']];
+        $auditConfig = [
+            'block-abandoned' => false,
+            'abandoned' => 'ignore',
+            'ignore-abandoned' => ['acme/abandoned' => 'should be ignored'],
+        ];
+
+        $abandoned = AbandonedPolicyConfig::fromRawConfig($policyConfig, $auditConfig, new VersionParser());
+
+        self::assertTrue($abandoned->block);
+        self::assertSame(ListPolicyConfig::AUDIT_REPORT, $abandoned->audit);
+        self::assertSame([], $abandoned->ignore);
+    }
+
+    public function testPolicyAbandonedFalseIgnoresLegacyAuditAbandonedKeys(): void
+    {
+        $policyConfig = ['abandoned' => false];
+        $auditConfig = [
+            'block-abandoned' => true,
+            'abandoned' => 'fail',
+            'ignore-abandoned' => ['acme/abandoned' => 'should be ignored'],
+        ];
+
+        $abandoned = AbandonedPolicyConfig::fromRawConfig($policyConfig, $auditConfig, new VersionParser());
+
+        $this->assertEquals(AbandonedPolicyConfig::disabled(), $abandoned);
+    }
+
     public function testGetFlatIgnoreForOperationMergesMultiRuleReasons(): void
     {
         $config = new Config();

--- a/tests/Composer/Test/Policy/AdvisoriesPolicyConfigTest.php
+++ b/tests/Composer/Test/Policy/AdvisoriesPolicyConfigTest.php
@@ -299,6 +299,38 @@ class AdvisoriesPolicyConfigTest extends TestCase
         self::assertSame([], $updated->getIgnoreSeverityForOperation('block'));
     }
 
+    public function testPolicyAdvisoriesSetIgnoresLegacyAuditAdvisoriesKeys(): void
+    {
+        $policyConfig = ['advisories' => ['block' => false, 'audit' => 'report']];
+        $auditConfig = [
+            'block-insecure' => true,
+            'ignore' => ['CVE-2024-1234' => 'should be ignored'],
+            'ignore-severity' => ['low' => 'should be ignored'],
+        ];
+
+        $advisories = AdvisoriesPolicyConfig::fromRawConfig($policyConfig, $auditConfig, new VersionParser());
+
+        self::assertFalse($advisories->block);
+        self::assertSame(ListPolicyConfig::AUDIT_REPORT, $advisories->audit);
+        self::assertSame([], $advisories->ignore);
+        self::assertSame([], $advisories->ignoreId);
+        self::assertSame([], $advisories->ignoreSeverity);
+    }
+
+    public function testPolicyAdvisoriesFalseIgnoresLegacyAuditAdvisoriesKeys(): void
+    {
+        $policyConfig = ['advisories' => false];
+        $auditConfig = [
+            'block-insecure' => true,
+            'ignore' => ['CVE-2024-1234' => 'should be ignored'],
+            'ignore-severity' => ['low' => 'should be ignored'],
+        ];
+
+        $advisories = AdvisoriesPolicyConfig::fromRawConfig($policyConfig, $auditConfig, new VersionParser());
+
+        $this->assertEquals(AdvisoriesPolicyConfig::disabled(), $advisories);
+    }
+
     public function testWithIgnoreSeverityPreservesExistingRulesAndReasons(): void
     {
         $config = new Config();


### PR DESCRIPTION
This updates/adds:
* section in the docs that explains how we handle configs where both policy and audit is set
* tests to verify the behaviour
* JSON schema to deprecate audit properties