### PR TITLE
FilterList: fix ignoreUnreachable is not honoured if a ComposerRepository is unreachable during FilterListProviderSet::__construct

### DIFF
--- a/src/Composer/FilterList/FilterListProvider/FilterListProviderSet.php
+++ b/src/Composer/FilterList/FilterListProvider/FilterListProviderSet.php
@@ -12,6 +12,7 @@
 
 namespace Composer\FilterList\FilterListProvider;
 
+use Composer\Downloader\TransportException;
 use Composer\FilterList\FilterListEntry;
 use Composer\FilterList\Source\UrlSource;
 use Composer\Package\AliasPackage;
@@ -33,6 +34,8 @@ class FilterListProviderSet
 {
     /** @var list<FilterListProviderInterface> */
     private $providers;
+    /** @var list<TransportException> */
+    private $unreachableRepoExceptions;
 
     /**
      * @param list<RepositoryInterface> $repositories
@@ -41,13 +44,20 @@ class FilterListProviderSet
     public function __construct(array $repositories, array $sources)
     {
         $providers = $sources;
+        $unreachableRepoExceptions = [];
         foreach ($repositories as $repository) {
-            if ($repository instanceof FilterListProviderInterface && $repository->hasFilter()) {
-                $providers[] = $repository;
+            try {
+                if ($repository instanceof FilterListProviderInterface && $repository->hasFilter()) {
+                    $providers[] = $repository;
+                }
+            } catch (\Composer\Downloader\TransportException $e) {
+                $unreachableRepoExceptions[] = $e;
             }
+
         }
 
         $this->providers = $providers;
+        $this->unreachableRepoExceptions = $unreachableRepoExceptions;
     }
 
     /**
@@ -105,6 +115,14 @@ class FilterListProviderSet
      */
     private function getFilterListEntriesForConstraints(array $packageConstraintMap, array $configuredLists, bool $ignoreUnreachable = false, array &$unreachableRepos = []): array
     {
+        foreach ($this->unreachableRepoExceptions as $e) {
+            if (!$ignoreUnreachable) {
+                throw $e;
+            }
+
+            $unreachableRepos[] = $e->getMessage();
+        }
+
         $filters = [];
         foreach ($this->providers as $provider) {
             $providerLists = $provider->getFilterLists();

--- a/tests/Composer/Test/FilterList/FilterListProvider/FilterListProviderSetTest.php
+++ b/tests/Composer/Test/FilterList/FilterListProvider/FilterListProviderSetTest.php
@@ -12,8 +12,11 @@
 
 namespace Composer\Test\FilterList\FilterListProvider;
 
+use Composer\Downloader\TransportException;
 use Composer\FilterList\FilterListProvider\FilterListProviderSet;
 use Composer\Package\Package;
+use Composer\Repository\ArrayRepository;
+use Composer\Repository\FilterListProviderInterface;
 use Composer\Repository\PackageRepository;
 use Composer\Test\TestCase;
 
@@ -52,5 +55,66 @@ class FilterListProviderSetTest extends TestCase
         $this->assertArrayNotHasKey('typosquatting', $result['filter']);
         $this->assertCount(1, $result['filter']['malware']);
         $this->assertSame('malware', $result['filter']['malware'][0]->reason);
+    }
+
+    public function testUnreachableRepositoryDuringConstructionIsReportedWhenIgnored(): void
+    {
+        $repository = $this->createUnreachableFilterListProvider('repo.example.com could not be reached');
+
+        $set = new FilterListProviderSet([$repository], []);
+
+        $result = $set->getMatchingFilterLists(
+            [new Package('acme/package', '1.0.0.0', '1.0')],
+            ['malware'],
+            true
+        );
+
+        $this->assertSame([], $result['filter']);
+        $this->assertSame(['repo.example.com could not be reached'], $result['unreachableRepos']);
+    }
+
+    public function testUnreachableRepositoryDuringConstructionIsThrownWhenNotIgnored(): void
+    {
+        $repository = $this->createUnreachableFilterListProvider('repo.example.com could not be reached');
+
+        $set = new FilterListProviderSet([$repository], []);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('repo.example.com could not be reached');
+
+        $set->getMatchingFilterLists(
+            [new Package('acme/package', '1.0.0.0', '1.0')],
+            ['malware'],
+            false
+        );
+    }
+
+    private function createUnreachableFilterListProvider(string $message): ArrayRepository
+    {
+        return new class($message) extends ArrayRepository implements FilterListProviderInterface {
+            /** @var string */
+            private $message;
+
+            public function __construct(string $message)
+            {
+                parent::__construct();
+                $this->message = $message;
+            }
+
+            public function hasFilter(): bool
+            {
+                throw new TransportException($this->message);
+            }
+
+            public function getFilter(array $packageConstraintMap, array $configuredLists): array
+            {
+                return ['filter' => []];
+            }
+
+            public function getFilterLists(): array
+            {
+                return [];
+            }
+        };
     }
 }


### PR DESCRIPTION
`ComposerRepository::hasFilter` will try to access the packages.json which will throw a TransportException if there is an error