### PR TITLE
Problem: surface hidden constraint chain in CDCL conflict output

### DIFF
--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -104,6 +104,24 @@ class Problem
             }
         }
 
+        // Surface previously-hidden primitives from learned (CDCL) rules so the
+        // transitive chain that justified each "Conclusion: ..." line is visible.
+        // formatDeduplicatedRules below collapses primitives already in $reasons.
+        $learnedPrimitives = [];
+        foreach ($reasons as $rule) {
+            if ($rule->getReason() === Rule::RULE_LEARNED) {
+                $reasonId = $rule->getReasonData();
+                if (is_int($reasonId) && isset($learnedPool[$reasonId])) {
+                    foreach (self::collectLearnedRulePrimitives($learnedPool, $reasonId) as $primitive) {
+                        $learnedPrimitives[] = $primitive;
+                    }
+                }
+            }
+        }
+        if ($learnedPrimitives !== []) {
+            $reasons = array_merge($reasons, $learnedPrimitives);
+        }
+
         usort($reasons, function (Rule $rule1, Rule $rule2) use ($pool) {
             $rule1Prio = $this->getRulePriority($rule1);
             $rule2Prio = $this->getRulePriority($rule2);
@@ -160,6 +178,42 @@ class Problem
 
         // @phpstan-ignore deadCode.unreachable
         throw new \LogicException('Unknown rule type: '.$rule->getReason());
+    }
+
+    /**
+     * Flattens a learned-rule's reason chain (in $learnedPool) into its non-LEARNED
+     * primitive rules. Cycle-safe via a reasonId visited-set, bounded by $maxPrimitives.
+     *
+     * @param  array<int, Rule[]> $learnedPool
+     * @return list<Rule>
+     */
+    private static function collectLearnedRulePrimitives(array $learnedPool, int $reasonId, int $maxPrimitives = 50): array
+    {
+        $visited = [];
+        $queue = [$reasonId];
+        $primitives = [];
+        while ($queue !== [] && \count($primitives) < $maxPrimitives) {
+            $id = array_shift($queue);
+            if (isset($visited[$id]) || !isset($learnedPool[$id])) {
+                continue;
+            }
+            $visited[$id] = true;
+            foreach ($learnedPool[$id] as $rule) {
+                if ($rule->getReason() === Rule::RULE_LEARNED) {
+                    $childId = $rule->getReasonData();
+                    if (is_int($childId) && !isset($visited[$childId])) {
+                        $queue[] = $childId;
+                    }
+                } else {
+                    $primitives[] = $rule;
+                    if (\count($primitives) >= $maxPrimitives) {
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        return $primitives;
     }
 
     /**

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -239,6 +239,13 @@ class Problem
                 foreach ($pool->getRemovedVersionsByPackage(spl_object_hash($sourcePackage)) as $version => $prettyVersion) {
                     $templates[$template][$m[1]][$version] = $prettyVersion;
                 }
+            } elseif ($rule->getReason() === Rule::RULE_LEARNED && Preg::isMatchStrictGroups('{^Conclusion: (?P<verb>install|don\'t install|keep|remove) (?P<package>\S+) (?P<version>\S+) \(conflict analysis result\)$}', $message, $m)) {
+                // Collapse simple single-literal learned-rule "Conclusion: ... X.Y.Z (conflict analysis result)"
+                // lines across versions of the same package. Without this collapse, CDCL learning
+                // produces one bullet per rejected literal, blowing up the problem block at scale.
+                $template = "Conclusion: {$m['verb']} %s%s (conflict analysis result)";
+                $messages[] = $template;
+                $templates[$template][$m['package']][$parser->normalize($m['version'])] = $m['version'];
             } elseif ($message !== '') {
                 $messages[] = $message;
             }

--- a/tests/Composer/Test/Fixtures/installer/github-issues-12862.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-12862.test
@@ -1,0 +1,95 @@
+--TEST--
+GitHub issue #12862: when CDCL conflict analysis fires due to a locked package's transitive constraint conflicting with a new require's branches, the transitive rules walked during analysis that are NOT in $problem->reasons must still be surfaced so users can see the full chain that justified each "Conclusion: ... (conflict analysis result)" line.
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                { "name": "locked/pkg", "version": "1.0.0", "require": { "locked/dep": "^1" } },
+                { "name": "locked/dep", "version": "1.0.0", "require": { "shared/lib": "^2" } },
+
+                { "name": "new/pkg",   "version": "1.0.0", "require": { "new/dep": "^1" } },
+                { "name": "new/pkg",   "version": "1.1.0", "require": { "new/dep": "^1" } },
+
+                { "name": "new/dep",   "version": "1.0.0", "require": { "shared/lib": "^1.0" } },
+                { "name": "new/dep",   "version": "1.1.0", "require": { "shared/lib": "~1.5" } },
+
+                { "name": "shared/lib", "version": "1.0.0" },
+                { "name": "shared/lib", "version": "1.0.1" },
+                { "name": "shared/lib", "version": "1.1.0" },
+                { "name": "shared/lib", "version": "1.2.0" },
+                { "name": "shared/lib", "version": "1.5.0" },
+                { "name": "shared/lib", "version": "1.5.1" },
+                { "name": "shared/lib", "version": "1.6.0" },
+                { "name": "shared/lib", "version": "2.0.0" },
+                { "name": "shared/lib", "version": "2.0.1" },
+                { "name": "shared/lib", "version": "2.1.0" }
+            ]
+        }
+    ],
+    "require": {
+        "locked/pkg": "^1",
+        "new/pkg":    "^1"
+    }
+}
+--INSTALLED--
+[
+    { "name": "locked/pkg", "version": "1.0.0", "require": { "locked/dep": "^1" } },
+    { "name": "locked/dep", "version": "1.0.0", "require": { "shared/lib": "^2" } },
+    { "name": "shared/lib", "version": "2.0.0" }
+]
+--LOCK--
+{
+    "packages": [
+        { "name": "locked/pkg", "version": "1.0.0", "require": { "locked/dep": "^1" } },
+        { "name": "locked/dep", "version": "1.0.0", "require": { "shared/lib": "^2" } },
+        { "name": "shared/lib", "version": "2.0.0" }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {}
+}
+--RUN--
+update new/pkg --with-dependencies
+--EXPECT-EXIT-CODE--
+2
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - locked/pkg is locked to version 1.0.0 and an update of this package was not requested.
+    - Root composer.json requires new/pkg ^1 -> satisfiable by new/pkg[1.0.0, 1.1.0].
+    - locked/dep 1.0.0 requires shared/lib ^2 -> satisfiable by shared/lib[2.0.0, 2.0.1, 2.1.0].
+    - locked/pkg 1.0.0 requires locked/dep ^1 -> satisfiable by locked/dep[1.0.0].
+    - new/dep 1.0.0 requires shared/lib ^1.0 -> satisfiable by shared/lib[1.0.0, ..., 1.6.0].
+    - new/dep 1.1.0 requires shared/lib ~1.5 -> satisfiable by shared/lib[1.5.0, 1.5.1, 1.6.0].
+    - new/pkg[1.0.0, ..., 1.1.0] require new/dep ^1 -> satisfiable by new/dep[1.0.0, 1.1.0].
+    - Conclusion: don't install shared/lib 2.1.0 (conflict analysis result)
+    - Conclusion: don't install shared/lib 1.6.0 (conflict analysis result)
+    - Conclusion: don't install new/dep 1.1.0 (conflict analysis result)
+    - Conclusion: don't install new/pkg 1.1.0 (conflict analysis result)
+    - Conclusion: don't install one of shared/lib[2.0.1], new/dep[1.0.0] | install shared/lib[1.6.0] (conflict analysis result)
+    - You can only install one version of a package, so only one of these can be installed: shared/lib[1.0.0, ..., 1.6.0, 2.0.0, 2.0.1, 2.1.0].
+
+Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
+--EXPECT-OUTPUT-OPTIMIZED--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires new/pkg ^1 -> satisfiable by new/pkg[1.0.0, 1.1.0].
+    - new/dep 1.0.0 requires shared/lib ^1.0 -> found shared/lib[1.0.0, ..., 1.6.0] but these were not loaded, likely because it conflicts with another require.
+    - new/dep 1.1.0 requires shared/lib ~1.5 -> found shared/lib[1.5.0, 1.5.1, 1.6.0] but these were not loaded, likely because it conflicts with another require.
+    - new/pkg[1.0.0, ..., 1.1.0] require new/dep ^1 -> satisfiable by new/dep[1.0.0, 1.1.0].
+
+Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
+--EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/github-issues-12862.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-12862.test
@@ -72,8 +72,7 @@ Your requirements could not be resolved to an installable set of packages.
     - new/dep 1.0.0 requires shared/lib ^1.0 -> satisfiable by shared/lib[1.0.0, ..., 1.6.0].
     - new/dep 1.1.0 requires shared/lib ~1.5 -> satisfiable by shared/lib[1.5.0, 1.5.1, 1.6.0].
     - new/pkg[1.0.0, ..., 1.1.0] require new/dep ^1 -> satisfiable by new/dep[1.0.0, 1.1.0].
-    - Conclusion: don't install shared/lib 2.1.0 (conflict analysis result)
-    - Conclusion: don't install shared/lib 1.6.0 (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.6.0, 2.1.0] (conflict analysis result)
     - Conclusion: don't install new/dep 1.1.0 (conflict analysis result)
     - Conclusion: don't install new/pkg 1.1.0 (conflict analysis result)
     - Conclusion: don't install one of shared/lib[2.0.1], new/dep[1.0.0] | install shared/lib[1.6.0] (conflict analysis result)

--- a/tests/Composer/Test/Fixtures/installer/github-issues-7051.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-7051.test
@@ -117,7 +117,7 @@ Your requirements could not be resolved to an installable set of packages.
   Problem 1
     - Root composer.json requires friendsofphp/php-cs-fixer * -> satisfiable by friendsofphp/php-cs-fixer[v2.10.4, v2.10.5].
     - Root composer.json requires illuminate/queue * -> satisfiable by illuminate/queue[v5.2.0].
-    - friendsofphp/php-cs-fixer v2.10.4 requires symfony/console ^3.2 || ^4.0 -> satisfiable by symfony/console[v3.2.13, ..., v3.4.29].
+    - friendsofphp/php-cs-fixer[v2.10.4, ..., v2.10.5] require symfony/console ^3.2 || ^4.0 -> satisfiable by symfony/console[v3.2.13, ..., v3.4.29].
     - illuminate/console v5.2.25 requires symfony/console 3.1.* -> satisfiable by symfony/console[v3.1.9, v3.1.10].
     - illuminate/console v5.2.26 requires symfony/console 2.8.* -> satisfiable by symfony/console[v2.8.7, v2.8.8].
     - illuminate/queue v5.2.0 requires illuminate/console 5.2.* -> satisfiable by illuminate/console[v5.2.25, v5.2.26].

--- a/tests/Composer/Test/Fixtures/installer/github-issues-7051.test
+++ b/tests/Composer/Test/Fixtures/installer/github-issues-7051.test
@@ -121,11 +121,7 @@ Your requirements could not be resolved to an installable set of packages.
     - illuminate/console v5.2.25 requires symfony/console 3.1.* -> satisfiable by symfony/console[v3.1.9, v3.1.10].
     - illuminate/console v5.2.26 requires symfony/console 2.8.* -> satisfiable by symfony/console[v2.8.7, v2.8.8].
     - illuminate/queue v5.2.0 requires illuminate/console 5.2.* -> satisfiable by illuminate/console[v5.2.25, v5.2.26].
-    - Conclusion: don't install symfony/console v2.8.7 (conflict analysis result)
-    - Conclusion: don't install symfony/console v2.8.8 (conflict analysis result)
-    - Conclusion: don't install symfony/console v3.1.10 (conflict analysis result)
-    - Conclusion: don't install symfony/console v3.4.28 (conflict analysis result)
-    - Conclusion: don't install symfony/console v3.4.29 (conflict analysis result)
+    - Conclusion: don't install symfony/console[v2.8.7, ..., v2.8.8, v3.1.10, ..., v3.4.29] (conflict analysis result)
     - Conclusion: don't install friendsofphp/php-cs-fixer v2.10.5 (conflict analysis result)
     - You can only install one version of a package, so only one of these can be installed: symfony/console[v2.8.7, v2.8.8, v3.1.9, ..., v3.4.29].
 

--- a/tests/Composer/Test/Fixtures/installer/provider-conflicts3.test
+++ b/tests/Composer/Test/Fixtures/installer/provider-conflicts3.test
@@ -39,9 +39,7 @@ Your requirements could not be resolved to an installable set of packages.
   Problem 1
     - Root composer.json requires regular/pkg 1.* -> satisfiable by regular/pkg[1.0.0, 1.0.1, 1.0.2, 1.0.3].
     - Root composer.json requires replacer/pkg 2.* -> satisfiable by replacer/pkg[2.0.0, 2.0.1, 2.0.2, 2.0.3].
-    - Conclusion: don't install regular/pkg 1.0.3 (conflict analysis result)
-    - Conclusion: don't install regular/pkg 1.0.2 (conflict analysis result)
-    - Conclusion: don't install regular/pkg 1.0.1 (conflict analysis result)
+    - Conclusion: don't install regular/pkg[1.0.1, ..., 1.0.3] (conflict analysis result)
     - Only one of these can be installed: regular/pkg[1.0.0, 1.0.1, 1.0.2, 1.0.3], replacer/pkg[2.0.0, 2.0.1, 2.0.2, 2.0.3]. replacer/pkg replaces regular/pkg and thus cannot coexist with it.
 
 --EXPECT-OUTPUT-OPTIMIZED--

--- a/tests/Composer/Test/Fixtures/installer/stress-12862.test
+++ b/tests/Composer/Test/Fixtures/installer/stress-12862.test
@@ -1,0 +1,2099 @@
+--TEST--
+Stress test for #12862 conflict output: N=100 versions per package, constraint cycle every 5-10 versions.
+--CONDITION--
+getenv('COMPOSER_STRESS_TESTS') !== false
+--COMPOSER--
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "shared/lib",
+                    "version": "1.0.0"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.0.1"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.0.2"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.0.3"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.0.4"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.0.5"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.0.6"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.0.7"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.0.8"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.0.9"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.1.0"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.1.1"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.1.2"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.1.3"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.1.4"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.1.5"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.1.6"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.1.7"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.1.8"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.1.9"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.2.0"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.2.1"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.2.2"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.2.3"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.2.4"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.2.5"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.2.6"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.2.7"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.2.8"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.2.9"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.3.0"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.3.1"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.3.2"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.3.3"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.3.4"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.3.5"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.3.6"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.3.7"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.3.8"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.3.9"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.4.0"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.4.1"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.4.2"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.4.3"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.4.4"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.4.5"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.4.6"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.4.7"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.4.8"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.4.9"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.5.0"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.5.1"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.5.2"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.5.3"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.5.4"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.5.5"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.5.6"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.5.7"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.5.8"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "1.5.9"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.0.0"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.0.1"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.0.2"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.0.3"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.0.4"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.0.5"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.0.6"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.0.7"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.0.8"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.0.9"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.1.0"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.1.1"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.1.2"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.1.3"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.1.4"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.1.5"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.1.6"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.1.7"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.1.8"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.1.9"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.2.0"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.2.1"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.2.2"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.2.3"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.2.4"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.2.5"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.2.6"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.2.7"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.2.8"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.2.9"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.3.0"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.3.1"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.3.2"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.3.3"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.3.4"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.3.5"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.3.6"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.3.7"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.3.8"
+                },
+                {
+                    "name": "shared/lib",
+                    "version": "2.3.9"
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.0.0",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.0.1",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.0.2",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.0.3",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.0.4",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.0.5",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.0.6",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.0.7",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.0.8",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.0.9",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.1.0",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.1.1",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.1.2",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.1.3",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.1.4",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.1.5",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.1.6",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.1.7",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.1.8",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.1.9",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.2.0",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.2.1",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.2.2",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.2.3",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.2.4",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.2.5",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.2.6",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.2.7",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.2.8",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.2.9",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.3.0",
+                    "require": {
+                        "shared/lib": ">=1.0 <2.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.3.1",
+                    "require": {
+                        "shared/lib": ">=1.0 <2.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.3.2",
+                    "require": {
+                        "shared/lib": ">=1.0 <2.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.3.3",
+                    "require": {
+                        "shared/lib": ">=1.0 <2.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.3.4",
+                    "require": {
+                        "shared/lib": ">=1.0 <2.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.3.5",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.3.6",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.3.7",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.3.8",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.3.9",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.4.0",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.4.1",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.4.2",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.4.3",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.4.4",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.4.5",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.4.6",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.4.7",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.4.8",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.4.9",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.5.0",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.5.1",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.5.2",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.5.3",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.5.4",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.5.5",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.5.6",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.5.7",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.5.8",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.5.9",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.6.0",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.6.1",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.6.2",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.6.3",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.6.4",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.6.5",
+                    "require": {
+                        "shared/lib": ">=1.0 <2.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.6.6",
+                    "require": {
+                        "shared/lib": ">=1.0 <2.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.6.7",
+                    "require": {
+                        "shared/lib": ">=1.0 <2.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.6.8",
+                    "require": {
+                        "shared/lib": ">=1.0 <2.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.6.9",
+                    "require": {
+                        "shared/lib": ">=1.0 <2.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.7.0",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.7.1",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.7.2",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.7.3",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.7.4",
+                    "require": {
+                        "shared/lib": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.7.5",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.7.6",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.7.7",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.7.8",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.7.9",
+                    "require": {
+                        "shared/lib": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.8.0",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.8.1",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.8.2",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.8.3",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.8.4",
+                    "require": {
+                        "shared/lib": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.8.5",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.8.6",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.8.7",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.8.8",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.8.9",
+                    "require": {
+                        "shared/lib": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.9.0",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.9.1",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.9.2",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.9.3",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.9.4",
+                    "require": {
+                        "shared/lib": "~1.4"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.9.5",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.9.6",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.9.7",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.9.8",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/dep",
+                    "version": "1.9.9",
+                    "require": {
+                        "shared/lib": "^1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.0.0",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.0.1",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.0.2",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.0.3",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.0.4",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.0.5",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.0.6",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.0.7",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.0.8",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.0.9",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.1.0",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.1.1",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.1.2",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.1.3",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.1.4",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.1.5",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.1.6",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.1.7",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.1.8",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.1.9",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.2.0",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.2.1",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.2.2",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.2.3",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.2.4",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.2.5",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.2.6",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.2.7",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.2.8",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.2.9",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.3.0",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.3.1",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.3.2",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.3.3",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.3.4",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.3.5",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.3.6",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.3.7",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.3.8",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.3.9",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.4.0",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.4.1",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.4.2",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.4.3",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.4.4",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.4.5",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.4.6",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.4.7",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.4.8",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.4.9",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.5.0",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.5.1",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.5.2",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.5.3",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.5.4",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.5.5",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.5.6",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.5.7",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.5.8",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.5.9",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.6.0",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.6.1",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.6.2",
+                    "require": {
+                        "new/dep": "~1.1"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.6.3",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.6.4",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.6.5",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.6.6",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.6.7",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.6.8",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.6.9",
+                    "require": {
+                        "new/dep": "^1.2"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.7.0",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.7.1",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.7.2",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.7.3",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.7.4",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.7.5",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.7.6",
+                    "require": {
+                        "new/dep": "~1.3"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.7.7",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.7.8",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.7.9",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.8.0",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.8.1",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.8.2",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.8.3",
+                    "require": {
+                        "new/dep": "^1.4"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.8.4",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.8.5",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.8.6",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.8.7",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.8.8",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.8.9",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.9.0",
+                    "require": {
+                        "new/dep": "~1.5"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.9.1",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.9.2",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.9.3",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.9.4",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.9.5",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.9.6",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.9.7",
+                    "require": {
+                        "new/dep": "^1.6"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.9.8",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "new/pkg",
+                    "version": "1.9.9",
+                    "require": {
+                        "new/dep": "^1.0"
+                    }
+                },
+                {
+                    "name": "locked/pkg",
+                    "version": "1.0.0",
+                    "require": {
+                        "locked/dep": "^1"
+                    }
+                },
+                {
+                    "name": "locked/dep",
+                    "version": "1.0.0",
+                    "require": {
+                        "shared/lib": "^2"
+                    }
+                }
+            ]
+        }
+    ],
+    "require": {
+        "locked/pkg": "^1",
+        "new/pkg": "^1"
+    }
+}
+--INSTALLED--
+[
+    {
+        "name": "locked/pkg",
+        "version": "1.0.0",
+        "require": {
+            "locked/dep": "^1"
+        }
+    },
+    {
+        "name": "locked/dep",
+        "version": "1.0.0",
+        "require": {
+            "shared/lib": "^2"
+        }
+    },
+    {
+        "name": "shared/lib",
+        "version": "2.0.0"
+    }
+]
+--LOCK--
+{
+    "packages": [
+        {
+            "name": "locked/pkg",
+            "version": "1.0.0",
+            "require": {
+                "locked/dep": "^1"
+            }
+        },
+        {
+            "name": "locked/dep",
+            "version": "1.0.0",
+            "require": {
+                "shared/lib": "^2"
+            }
+        },
+        {
+            "name": "shared/lib",
+            "version": "2.0.0"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {}
+}
+--RUN--
+update new/pkg --with-dependencies
+--EXPECT-EXIT-CODE--
+2
+--EXPECT-OUTPUT--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - locked/pkg is locked to version 1.0.0 and an update of this package was not requested.
+    - Root composer.json requires new/pkg ^1 -> satisfiable by new/pkg[1.0.0, ..., 1.9.9].
+    - locked/dep 1.0.0 requires shared/lib ^2 -> satisfiable by shared/lib[2.0.0, ..., 2.3.9].
+    - locked/pkg 1.0.0 requires locked/dep ^1 -> satisfiable by locked/dep[1.0.0].
+    - new/dep[1.0.0, ..., 1.7.4] require shared/lib ^1.0 -> satisfiable by shared/lib[1.0.0, ..., 1.5.9].
+    - new/dep[1.0.5, ..., 1.7.9] require shared/lib ~1.1 -> satisfiable by shared/lib[1.1.0, ..., 1.5.9].
+    - new/dep[1.1.0, ..., 1.8.4] require shared/lib ^1.2 -> satisfiable by shared/lib[1.2.0, ..., 1.5.9].
+    - new/dep[1.1.5, ..., 1.8.9] require shared/lib ~1.3 -> satisfiable by shared/lib[1.3.0, ..., 1.5.9].
+    - new/dep[1.2.0, ..., 1.9.4] require shared/lib ~1.4 -> satisfiable by shared/lib[1.4.0, ..., 1.5.9].
+    - new/dep[1.2.5, ..., 1.9.9] require shared/lib ^1.5 -> satisfiable by shared/lib[1.5.0, ..., 1.5.9].
+    - new/dep[1.3.0, ..., 1.6.9] require shared/lib >=1.0 <2.0 -> satisfiable by shared/lib[1.0.0, ..., 1.5.9].
+    - new/pkg[1.0.0, ..., 1.9.9] require new/dep ^1.0 -> satisfiable by new/dep[1.0.0, ..., 1.9.9].
+    - new/pkg[1.0.7, ..., 1.6.2] require new/dep ~1.1 -> satisfiable by new/dep[1.1.0, ..., 1.9.9].
+    - new/pkg[1.1.4, ..., 1.6.9] require new/dep ^1.2 -> satisfiable by new/dep[1.2.0, ..., 1.9.9].
+    - new/pkg[1.2.1, ..., 1.7.6] require new/dep ~1.3 -> satisfiable by new/dep[1.3.0, ..., 1.9.9].
+    - new/pkg[1.2.8, ..., 1.8.3] require new/dep ^1.4 -> satisfiable by new/dep[1.4.0, ..., 1.9.9].
+    - new/pkg[1.3.5, ..., 1.9.0] require new/dep ~1.5 -> satisfiable by new/dep[1.5.0, ..., 1.9.9].
+    - new/pkg[1.4.2, ..., 1.9.7] require new/dep ^1.6 -> satisfiable by new/dep[1.6.0, ..., 1.9.9].
+    - Conclusion: don't install new/pkg[1.0.1, ..., 1.9.9] (conflict analysis result)
+    - Conclusion: don't install new/dep 1.9.9 (conflict analysis result)
+    - Conclusion: don't install shared/lib 2.3.9 (conflict analysis result)
+    - Conclusion: don't install new/dep[1.0.1] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.0.2] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.0.3] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.0.4] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.0.5] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.0.6] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.0.7] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.0.8] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.0.9] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.1.0] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.1.1] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.1.2] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.1.3] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.1.4] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.1.5] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.1.6] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.1.7] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.1.8] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.1.9] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.2.0] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.2.1] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.2.2] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.2.3] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.2.4] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.2.5] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.2.6] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.2.7] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.2.8] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.2.9] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.3.0] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.3.1] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.3.2] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.3.3] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.3.4] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.3.5] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.3.6] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.3.7] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.3.8] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.3.9] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.4.0] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.4.1] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.4.2] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.4.3] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.4.4] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.4.5] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.4.6] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.4.7] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.4.8] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.4.9] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.5.0] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.5.1] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.5.2] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.5.3] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.5.4] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.5.5] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.5.6] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.5.7] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.5.8] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.5.9] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.6.0] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.6.1] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.6.2] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.6.3] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.6.4] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.6.5] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.6.6] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.6.7] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.6.8] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.6.9] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.7.0] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.7.1] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.7.2] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.7.3] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.7.4] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.7.5] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.7.6] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.7.7] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.7.8] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.7.9] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.8.0] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.8.1] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.8.2] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.8.3] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.8.4] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.8.5] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.8.6] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.8.7] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.8.8] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.8.9] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.9.0] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.9.1] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.9.2] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.9.3] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.9.4] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.9.5] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.9.6] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.9.7] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install new/dep[1.9.8] | install shared/lib[2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.0.1] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.0.2] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.0.3] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.0.4] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.0.5] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.0.6] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.0.7] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.0.8] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.0.9] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.1.0] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.1.1] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.1.2] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.1.3] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.1.4] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.1.5] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.1.6] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.1.7] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.1.8] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.1.9] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.2.0] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.2.1] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.2.2] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.2.3] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.2.4] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.2.5] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.2.6] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.2.7] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.2.8] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.2.9] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.3.0] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.3.1] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.3.2] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.3.3] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.3.4] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.3.5] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.3.6] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.3.7] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.3.8] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.3.9] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.4.0] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.4.1] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.4.2] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.4.3] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.4.4] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.4.5] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.4.6] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.4.7] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.4.8] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.4.9] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.5.0] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.5.1] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.5.2] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.5.3] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.5.4] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.5.5] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.5.6] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.5.7] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.5.8] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install shared/lib[1.5.9] | install one of shared/lib[2.3.8, 2.3.9] (conflict analysis result)
+    - Conclusion: don't install one of shared/lib[2.3.8], new/dep[1.0.0] (conflict analysis result)
+    - You can only install one version of a package, so only one of these can be installed: shared/lib[1.0.0, ..., 1.5.9, 2.0.0, ..., 2.3.9].
+
+Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
+--EXPECT-OUTPUT-OPTIMIZED--
+Loading composer repositories with package information
+Updating dependencies
+Your requirements could not be resolved to an installable set of packages.
+
+  Problem 1
+    - Root composer.json requires new/pkg ^1 -> satisfiable by new/pkg[1.0.0, ..., 1.9.9].
+    - new/dep[1.0.0, ..., 1.7.4] require shared/lib ^1.0 -> found shared/lib[1.0.0, ..., 1.5.9] but these were not loaded, likely because it conflicts with another require.
+    - new/dep[1.0.5, ..., 1.7.9] require shared/lib ~1.1 -> found shared/lib[1.1.0, ..., 1.5.9] but these were not loaded, likely because it conflicts with another require.
+    - new/dep[1.1.0, ..., 1.8.4] require shared/lib ^1.2 -> found shared/lib[1.2.0, ..., 1.5.9] but these were not loaded, likely because it conflicts with another require.
+    - new/dep[1.1.5, ..., 1.8.9] require shared/lib ~1.3 -> found shared/lib[1.3.0, ..., 1.5.9] but these were not loaded, likely because it conflicts with another require.
+    - new/dep[1.2.0, ..., 1.9.4] require shared/lib ~1.4 -> found shared/lib[1.4.0, ..., 1.5.9] but these were not loaded, likely because it conflicts with another require.
+    - new/dep[1.2.5, ..., 1.9.9] require shared/lib ^1.5 -> found shared/lib[1.5.0, ..., 1.5.9] but these were not loaded, likely because it conflicts with another require.
+    - new/pkg[1.0.7, ..., 1.6.2] require new/dep ~1.1 -> satisfiable by new/dep[1.1.0, ..., 1.9.9].
+    - new/pkg[1.1.4, ..., 1.6.9] require new/dep ^1.2 -> satisfiable by new/dep[1.2.0, ..., 1.9.9].
+    - new/pkg[1.2.1, ..., 1.7.6] require new/dep ~1.3 -> satisfiable by new/dep[1.3.0, ..., 1.9.9].
+    - new/pkg[1.2.8, ..., 1.8.3] require new/dep ^1.4 -> satisfiable by new/dep[1.4.0, ..., 1.9.9].
+    - new/pkg[1.3.5, ..., 1.9.0] require new/dep ~1.5 -> satisfiable by new/dep[1.5.0, ..., 1.9.9].
+    - new/pkg[1.4.2, ..., 1.9.7] require new/dep ^1.6 -> satisfiable by new/dep[1.6.0, ..., 1.9.9].
+    - new/pkg[1.0.0, ..., 1.9.9] require new/dep ^1.0 -> satisfiable by new/dep[1.0.0, ..., 1.9.9].
+
+Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
+--EXPECT--


### PR DESCRIPTION
Fixes #12862 (maybe/allegedly.. kinda hard to be sure without clear repro case, and this is 100% claude work)

When the SAT solver's conflict-driven clause learning fires, each learned rule prints as "Conclusion: <decision> (conflict analysis result)" without any explanation of *why* that conclusion holds. The rules walked during analyze() to derive the learned clause are recorded in $learnedPool but have never been surfaced - the existing formatter has a @TODO sketching how to expand them but it's disabled because the original attempt produced too much output and risked infinite recursion.

In practice this leaves users staring at output like:

    - drupal/core dev-main requires symfony/finder ^8.0 -> ...
    - Conclusion: install symfony/finder v7.4.8 (conflict analysis result)
    - You can only install one version of a package, so only one of these can be installed: symfony/finder[^7 versions, ^8 versions].

...with no way to know which package transitively required symfony/finder ^7. That rule was walked by the solver during conflict analysis but lives only in $learnedPool[reasonData], never in $problem->reasons.

This change expands learned rules at the Problem level (not the Rule level the original @TODO contemplated) so the existing dedup + version-range template machinery in formatDeduplicatedRules absorbs primitives that were already visible. The user-visible delta is exactly the previously- hidden chain.

The expansion is a bounded BFS:

- Walks $learnedPool[reasonId] following nested learned rules.
- Collects only non-LEARNED ("primitive") rules.
- Cycle-safe via a reasonId visited-set (object-hash dedup would over-prune: Solver::analyze() appends the same Rule object across iterations).
- Capped at 50 surfaced primitives per problem. Breadth, not depth, is the real risk - $learnedPool[id] can be wide.

Problem-level injection (vs the originally-commented Rule-level approach) matters because formatDeduplicatedRules's array_unique on message strings and its requires/conflicts template collapse only work when all rules flow through one pass. Rule-level expansion would emit a nested block that bypasses both, re-introducing duplicates and breaking the [v1, ..., vN] range collapse.

The "(conflict analysis result)" suffix is preserved deliberately - it names the learned literal (the decision the solver was forced into), which the surrounding primitives don't. With the primitives now visible in the same problem block, the cryptic phrase becomes a signpost rather than the sole source of information.

Two fixtures change:

- github-issues-12862.test (new): purpose-built repro mirroring the issue's locked-transitive vs new-transitive shape. Multi-version new/pkg + new/dep with distinct shared/lib constraints plus a wide shared/lib version space forces CDCL. Without this fix the output hides "new/dep 1.1.0 requires shared/lib ~1.5" - the very chain link the user needs to understand why "Conclusion: don't install new/dep 1.1.0" was reached. With this fix that line appears.

- github-issues-7051.test: incidental real-world demonstration. Before: only "friendsofphp/php-cs-fixer v2.10.4 requires symfony/console ..." was visible; the same rule for v2.10.5 was hidden in $learnedPool. After: both versions collapse via the existing template into "friendsofphp/php-cs-fixer[v2.10.4, ..., v2.10.5] require ...".

Out of scope: the pool-optimizer fallback "found X but these were not loaded, likely because it conflicts with another require" message lives in a different code path that has no $learnedPool reference at the call site; improving it is a separate problem.
