### PR TITLE
Fix confusing error when an inline alias is not quoted

### DIFF
--- a/src/Composer/Command/PackageDiscoveryTrait.php
+++ b/src/Composer/Command/PackageDiscoveryTrait.php
@@ -97,6 +97,15 @@ trait PackageDiscoveryTrait
     final protected function determineRequirements(InputInterface $input, OutputInterface $output, array $requires = [], ?PlatformRepository $platformRepo = null, string $preferredStability = 'stable', bool $useBestVersionConstraint = true, bool $fixed = false): array
     {
         if (count($requires) > 0) {
+            foreach ($requires as $package) {
+                if (strtolower($package) === 'as') {
+                    throw new \InvalidArgumentException(sprintf(
+                        'Cannot use "%s" as a separate argument. Quote the inline alias as one argument, e.g. "vendor/package:dev-main as 1.2.x-dev".',
+                        $package
+                    ));
+                }
+            }
+
             $requires = $this->normalizeRequirements($requires);
             $result = [];
             $io = $this->getIO();

--- a/tests/Composer/Test/Command/RequireCommandTest.php
+++ b/tests/Composer/Test/Command/RequireCommandTest.php
@@ -41,6 +41,17 @@ class RequireCommandTest extends TestCase
         $appTester->run(['command' => 'require', '--dry-run' => true, '--no-audit' => true, 'packages' => ['required/pkg']]);
     }
 
+    public function testRequireThrowsOnUnquotedInlineAlias(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use "as" as a separate argument. Quote the inline alias as one argument, e.g. "vendor/package:dev-main as 1.2.x-dev".');
+
+        $this->initTempComposer();
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'require', '--dry-run' => true, '--no-audit' => true, 'packages' => ['required/pkg', 'dev-main', 'as', '1.2.x-dev']]);
+    }
+
     public function testRequireWarnsIfResolvedToFeatureBranch(): void
     {
         $this->initTempComposer([


### PR DESCRIPTION
Passing an inline alias without quotes, like `composer require pkg dev-main as 4.6.x-dev`, leaves `as` as a separate argument and the command fails with a confusing error instead of explaining the problem. Composer now rejects it and shows the quoted form.

Fixes #12863
