### PR TITLE
Fix anchors inside config documentation

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -163,7 +163,7 @@ Set to `false` to disable all policy enforcement:
 ```
 
 > **Migrating from `config.audit`?** See
-> [How `config.audit` interacts with `config.policy`](#how-configaudit-interacts-with-configpolicy)
+> [How `config.audit` interacts with `config.policy`](#how-config-audit-interacts-with-config-policy)
 > for how the legacy keys are still honored as a fallback while you migrate.
 
 ### advisories


### PR DESCRIPTION
Just a simple one to fix a broken link in the docs.