### PR TITLE
Return non-zero exit code for "composer audit" when audit couldn't be performed due to missing required packages

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1189,6 +1189,7 @@ the findings:
 * `5` Vulnerable and filtered packages.
 * `6` Abandoned and filtered packages.
 * `7` Vulnerable, abandoned, and filtered packages.
+* `8` Failure due to missing required packages.
 
 ```shell
 php composer.phar audit

--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -61,6 +61,7 @@ class Auditor
     public const STATUS_VULNERABLE = 1;
     public const STATUS_ABANDONED = 2;
     public const STATUS_FILTERED = 4;
+    public const STATUS_FAILED = 8;
 
     /**
      * @param PolicyConfig $policyConfig Source of truth for ignore lists, severity filters, and per-list audit settings.

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -61,9 +61,16 @@ EOT
         $packages = $this->getPackages($composer, $input);
 
         if (count($packages) === 0) {
+            if ($composer->getPackage()->getRequires() !== []
+                || (!$input->getOption('no-dev') && $composer->getPackage()->getDevRequires() !== [])) {
+                $this->getIO()->writeError('No installed packages found. Please run "composer install" before running "audit".');
+
+                return Auditor::STATUS_FAILED;
+            }
+
             $this->getIO()->writeError('No packages - skipping audit.');
 
-            return 0;
+            return Auditor::STATUS_OK;
         }
 
         $auditor = new Auditor();

--- a/tests/Composer/Test/Command/AuditCommandTest.php
+++ b/tests/Composer/Test/Command/AuditCommandTest.php
@@ -60,6 +60,20 @@ class AuditCommandTest extends TestCase
         );
     }
 
+    public function testErrorAuditWithNoInstalledPackages(): void
+    {
+        $this->initTempComposer(['require' => ['dummy/pkg' => '1.0.0']]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'audit']);
+
+        self::assertSame(Auditor::STATUS_FAILED, $appTester->getStatusCode());
+        self::assertStringContainsString(
+            'No installed packages found. Please run "composer install" before running "audit"',
+            trim($appTester->getDisplay(true))
+        );
+    }
+
     public function testAuditPackageWithNoDevOptionPassed(): void
     {
         $this->initTempComposer();


### PR DESCRIPTION
Currently, when running `composer audit` with a missing vendor folder, the exit code is `0`, even though there might be vulnerabilities. Give for example this github action configuration:

```yml
- run: composer audit
```

Because any non-zero exit code results in a failed step, this would seem to be enough. This is not the case however, because if anyone implements this as a github action without a preceding `composer install`, the step will pass silently without actually checking for vulnerabilities. We have actually seen this scenario when implementing an audit check in our pipelines.

This PR fixes that. Given that exit code 1-7 were already taken and updating those would result in breaking changes, I decided to go for exit 8. If you would ever want to add further bitranges we could go for exit code 64 or 128 to leave some room in the bitmask ranges for any future filters.

Let me know what you think and if there's anything I can change!
