### PR TITLE
Use 'dependency policy' terminology in docs and user-facing output, drop audit --filtered and simplify audit exit code to 0/1

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -120,7 +120,7 @@ resolution.
 * **--audit:** Run an audit after installation is complete.
 * **--audit-format:** Audit output format. Must be "table", "plain", "json", or "summary" (default).
 * **--no-security-blocking:** DEPRECATED, use `--no-blocking` instead. Allows installing packages with security advisories or that are abandoned. Also see [COMPOSER_NO_SECURITY_BLOCKING](#composer-no-security-blocking).
-* **--no-blocking:** Disables all policy blocking during this command. Also see [COMPOSER_NO_BLOCKING](#composer-no-blocking).
+* **--no-blocking:** Disables all policy based dependency blocking during this command. Also see [COMPOSER_NO_BLOCKING](#composer-no-blocking).
 * **--optimize-autoloader (-o):** Convert PSR-0/4 autoloading to classmap to get a faster
   autoloader. This is recommended especially for production, but can take
   a bit of time to run so it is currently not done by default.
@@ -209,7 +209,7 @@ php composer.phar update vendor/package:2.0.1 vendor/package2:3.0.*
 * **--no-audit:** Does not run the audit steps after updating the composer.lock file. Also see [COMPOSER_NO_AUDIT](#composer-no-audit).
 * **--audit-format:** Audit output format. Must be "table", "plain", "json", or "summary" (default).
 * **--no-security-blocking:** DEPRECATED, use `--no-blocking` instead. Allows installing packages with security advisories or that are abandoned. Also see [COMPOSER_NO_SECURITY_BLOCKING](#composer-no-security-blocking).
-* **--no-blocking:** Disables all policy blocking during this command. Also see [COMPOSER_NO_BLOCKING](#composer-no-blocking).
+* **--no-blocking:** Disables all policy based dependency blocking during this command. Also see [COMPOSER_NO_BLOCKING](#composer-no-blocking).
 * **--lock:** Overwrites the lock file hash to suppress warning about the lock file being out of
   date without updating package versions. Package metadata like mirrors and URLs are updated if
   they changed.
@@ -360,7 +360,7 @@ uninstalled.
 * **--no-audit:** Does not run the audit steps after installation is complete. Also see [COMPOSER_NO_AUDIT](#composer-no-audit).
 * **--audit-format:** Audit output format. Must be "table", "plain", "json", or "summary" (default).
 * **--no-security-blocking:** DEPRECATED, use `--no-blocking` instead. Allows installing packages with security advisories or that are abandoned. Also see [COMPOSER_NO_SECURITY_BLOCKING](#composer-no-security-blocking).
-* **--no-blocking:** Disables all policy blocking during this command. Also see [COMPOSER_NO_BLOCKING](#composer-no-blocking).
+* **--no-blocking:** Disables all policy based dependency blocking during this command. Also see [COMPOSER_NO_BLOCKING](#composer-no-blocking).
 * **--update-no-dev:** Run the dependency update with the --no-dev option. Also see [COMPOSER_NO_DEV](#composer-no-dev).
 * **--update-with-dependencies (-w):** Also update dependencies of the removed packages. Can also be set via the COMPOSER_WITH_DEPENDENCIES=1 env var.
   (Deprecated, is now default behavior)
@@ -959,15 +959,15 @@ php composer.phar repo enable packagist.org
 
 ## policy
 
-The `policy` command lets you manage custom policy lists and their sources in your `composer.json` under `config.policy`. A source points Composer at a remote URL which provides the list of packages the policy applies to. Adding a source to a list that does not yet exist will create the list entry automatically.
+The `policy` command lets you manage custom dependency policies and their sources in your `composer.json` under `config.policy`. A source points Composer at a remote URL which provides the set of package versions the policy applies to. Adding a source for a dependency policy that does not yet exist will create the policy automatically.
 
-Built-in lists (`advisories`, `malware`, `abandoned`) do not accept sources and are rejected. To change their settings, use `composer config policy.<list>.<field>` instead — see the [policy](06-config.md#policy) config documentation.
+Built-in dependency policies (`advisories`, `malware`, `abandoned`) do not accept sources and are rejected. To change their settings, use `composer config policy.<policy>.<field>` instead — see the [policy](06-config.md#policy) config documentation.
 
 ### Usage
 
 ```shell
-policy [options] add-source [list-name] [source-type] [url]
-policy [options] add-source [list-name] [json-source-definition]
+policy [options] add-source [policy-name] [source-type] [url]
+policy [options] add-source [policy-name] [json-source-definition]
 ```
 
 Currently only `url` is supported as `source-type`, and URLs must start with `https://`.
@@ -1174,7 +1174,7 @@ php composer.phar archive vendor/package 2.0.21 --format=zip
 ## audit
 
 This command is used to audit the packages you have installed for potential security issues. It checks for and lists security
-vulnerability advisories using the [Packagist.org api](https://packagist.org/apidoc#list-security-advisories) by default
+vulnerability advisories using the [Packagist.org API](https://packagist.org/apidoc#list-security-advisories) by default
 or other repositories if specified in the `repositories` section of `composer.json`.
 The command also detects abandoned packages.
 
@@ -1205,10 +1205,10 @@ php composer.phar audit
   flag will override the config value and the environment variable.
 * **--ignore-severity:** Ignore advisories of a certain severity level. Can be passed one or more
   time to ignore multiple severities.
-* **--filtered:** Behavior on packages matched by `malware` and custom filter
-  lists. Must be "ignore", "report", or "fail". Overrides the per-list `audit`
-  setting (`config.policy.malware.audit` and every custom list's `audit`) for
-  the duration of this command.
+* **--filtered:** Behavior on packages matched by the `malware` dependency policy and custom
+  dependency policies. Must be "ignore", "report", or "fail". Overrides the per-policy `audit`
+  setting (`config.policy.malware.audit` and every custom policy's `audit`) for the duration
+  of this command.
 
 ## help
 
@@ -1425,13 +1425,13 @@ Set to `ignore`, `report` or `fail` to override the [policy.abandoned.audit](06-
 
 ### COMPOSER_POLICY
 
-Main policy switch. Set to `0` to disable all policy enforcement on updates and audit, or `1` to enable it. Setting this to `1` will use the policy configuration in the composer.json. If you want to override the config value, use `composer config policy 1` instead.
+Main dependency policy switch. Set to `0` to disable all dependency policy enforcement on updates, installs and audits, or `1` to enable it. Setting this to `1` will use the policy configuration in the composer.json. If you want to change the config value, use `composer config policy 1` instead.
 
-When set to `0`, all per-list overrides below are ignored — the whole policy config is short-circuited to disabled.
+When set to `0`, all policy specific overrides below are ignored — the whole dependency policy config is short-circuited to disabled.
 
 ### COMPOSER_NO_BLOCKING
 
-If set to `1`, it is the equivalent of passing the `--no-blocking` option to a `require`, `update`, `remove`, `install`, or `create-project` command. This disables all policy blocking during this command. It overrides the `block` config option for each configured policy e.g. [policy.advisories.block](06-config.md#block).
+If set to `1`, it is the equivalent of passing the `--no-blocking` option to a `require`, `update`, `remove`, `install`, or `create-project` command. This disables all policy based blocking of dependencies. It overrides the `block` config option for each configured dependency policy e.g. [policy.advisories.block](06-config.md#block).
 
 ### COMPOSER_NO_SECURITY_BLOCKING
 
@@ -1451,7 +1451,7 @@ If set to `1`, enables blocking of packages flagged as malware during dependency
 
 If set to `1`, enables blocking of abandoned packages during dependency resolution (equivalent to setting `policy.abandoned.block` to `true`). If set to `0`, disables blocking.
 
-Takes precedence over the legacy [COMPOSER_SECURITY_BLOCKING_ABANDONED](#composer-security-blocking-abandoned) when both are set.
+Value takes precedence over the value of the legacy variable [COMPOSER_SECURITY_BLOCKING_ABANDONED](#composer-security-blocking-abandoned) when it's set to a different value.
 
 ### COMPOSER_SECURITY_BLOCKING_ABANDONED
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1173,23 +1173,17 @@ php composer.phar archive vendor/package 2.0.21 --format=zip
 
 ## audit
 
-This command is used to audit the packages you have installed for potential security issues. It checks for and lists security
-vulnerability advisories using the [Packagist.org API](https://packagist.org/apidoc#list-security-advisories) by default
-or other repositories if specified in the `repositories` section of `composer.json`.
-The command also detects abandoned packages.
+This command is used to audit the packages you have installed against defined dependency policies,
+such as security advisories. It checks for and lists security vulnerability advisories using the
+[Packagist.org API](https://packagist.org/apidoc#list-security-advisories) by default or other
+repositories if specified in the `repositories` section of `composer.json`. The command also detects
+abandoned packages and packages flagged as malware, or packages matched by other dependency policies.
 
-The audit command determines if there are vulnerable, abandoned, or filtered packages and returns the following exit codes based on
-the findings:
+The audit command determines if there are vulnerable, abandoned, malware packages, or packages matched by other dependency
+policies and returns the following exit codes based on the findings:
 
 * `0` No issues;
-* `1` Vulnerable packages;
-* `2` Abandoned packages;
-* `3` Vulnerable and abandoned packages.
-* `4` Filtered packages.
-* `5` Vulnerable and filtered packages.
-* `6` Abandoned and filtered packages.
-* `7` Vulnerable, abandoned, and filtered packages.
-* `8` Failure due to missing required packages.
+* `1` Found packages matching dependency policies or failed due to missing required packages.
 
 ```shell
 php composer.phar audit
@@ -1205,10 +1199,6 @@ php composer.phar audit
   flag will override the config value and the environment variable.
 * **--ignore-severity:** Ignore advisories of a certain severity level. Can be passed one or more
   time to ignore multiple severities.
-* **--filtered:** Behavior on packages matched by the `malware` dependency policy and custom
-  dependency policies. Must be "ignore", "report", or "fail". Overrides the per-policy `audit`
-  setting (`config.policy.malware.audit` and every custom policy's `audit`) for the duration
-  of this command.
 
 ## help
 

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -147,12 +147,13 @@ COMPOSER_SOURCE_FALLBACK=0 composer install
 
 ## policy
 
-Unified security and package policy configuration. Controls security advisories, malware detection,
-abandoned packages, and custom policy lists. Audit reports can be generated with `composer audit`;
-blocking prevents insecure or otherwise flagged package versions from being installed during
-`composer update`, `require`, or `remove` and for the malware detection additionally during a `composer install`.
+Unified dependency policy configuration. Controls Composer behavior for dependencies with security
+advisories, flagged as malware, abandoned packages, and custom dependency policies. Audit reports
+can be generated with `composer audit`; blocking prevents insecure or otherwise flagged package
+versions from being installed during `composer update`, `require`, or `remove` and malware also
+during a `composer install`.
 
-Set to `false` to disable all policy enforcement:
+Set to `false` to disable all dependency policy enforcement:
 
 ```json
 {
@@ -265,8 +266,8 @@ and scoping (`on-block`/`on-audit`) to limit where the ignore applies.
 
 #### ignore
 
-A list of package names to ignore for security advisories. Supports wildcards and optional version
-constraints. See the [ignore format](#ignore-format) for all supported syntax variants.
+A list of package names to ignore for security advisory handling. Supports wildcards and optional
+version constraints. See the [ignore format](#ignore-format) for all supported syntax variants.
 
 #### ignore-severity
 
@@ -369,11 +370,11 @@ abandoned state. See the [ignore format](#ignore-format) for all supported synta
 
 ### malware
 
-Configuration for packages flagged as containing malware.
+Configuration for package versions flagged as containing malware.
 
 #### block
 
-Defaults to `true`. When `true`, packages flagged as malware are blocked.
+Defaults to `true`. When `true`, package versions flagged as malware are blocked.
 
 #### block-scope
 
@@ -422,12 +423,12 @@ A list of source names to exclude from malware checks.
 
 ### ignore-unreachable
 
-Defaults to `["update", "install"]`. When the operation is ignored, repositories and policy sources that are unreachable or return a
-non-200 response are silently ignored rather than causing an error. Useful in environments where not all package
+Defaults to `["update", "install"]`. When the operation is listed here, repositories and policies with URL sources that are unreachable or
+return a non-200 response are silently ignored rather than causing an error. Useful in environments where not all package
 repositories are accessible.
 
-Set to `true` to ignore unreachable repositories and policy sources for all operations and to `false` to ignore them for no operations.
-Possible values are: `audit`, `install`, and `update`.
+Set to `true` to ignore unreachable repositories and custom dependency policy sources for all operations and to `false` to ignore them
+for no operations. Possible values are: `audit`, `install`, and `update`.
 
 ```json
 {
@@ -439,21 +440,21 @@ Possible values are: `audit`, `install`, and `update`.
 }
 ```
 
-### Custom lists
+### Custom dependency policies
 
-In addition to the built-in `advisories`, `malware`, and `abandoned` lists, you can define named
-custom policy lists. A custom list receives its data from one or more URL sources (configured by
-package repositories or set explicitly here).
+In addition to the built-in `advisories`, `malware`, and `abandoned` dependency policies, you can
+define named custom dependency policies. A custom dependency policy needs its own set of package
+versions, supplied by one or more sources (advertised by package repositories or set explicitly here).
 
 ```json
 {
     "config": {
         "policy": {
-            "my-list": {
+            "my-policy": {
                 "block": true,
                 "audit": "fail",
                 "sources": [
-                    {"type": "url", "url": "https://example.org/policy-list.json"}
+                    {"type": "url", "url": "https://example.org/my-bad-packages-list.json"}
                 ],
                 "ignore": {
                     "vendor/package": "Assessed and accepted."
@@ -467,18 +468,18 @@ package repositories or set explicitly here).
 Source URLs must use `https://`. `http://` and other schemes are rejected both at
 schema validation time (`composer validate`) and at config load time.
 
-Custom list names must not conflict with the reserved names `advisories`, `malware`, or
+Custom dependency policy names must not conflict with the reserved names `advisories`, `malware`, or
 `abandoned`, and must not start with `ignore` (the only `ignore`-prefixed key allowed at this
 level is the documented `ignore-unreachable` setting).
 
-The following names are reserved for future built-in lists and cannot be used as custom list
-names: `package`, `packages`, `license`, `licence`, `licenses`, `licences`, `support`,
+The following names are reserved for future built-in dependency policies and cannot be used as custom
+dependency policy names: `package`, `packages`, `license`, `licence`, `licenses`, `licences`, `support`,
 `maintenance`, `security`, `minimum-release-age`. Composer rejects any colliding key both at
 schema validation time (`composer validate`) and at config load time.
 
 ### ignore format
 
-The `ignore` key on every list accepts package name patterns with optional version constraints
+The `ignore` key on every dependency policy accepts package name patterns with optional version constraints
 and per-rule scoping. All formats may be mixed in the same map.
 
 ##### Simple list (ignore all versions):
@@ -487,7 +488,7 @@ and per-rule scoping. All formats may be mixed in the same map.
 {
     "config": {
         "policy": {
-            "<list>": {
+            "<policy>": {
                 "ignore": ["vendor/package", "acme/*"]
             }
         }
@@ -501,7 +502,7 @@ and per-rule scoping. All formats may be mixed in the same map.
 {
     "config": {
         "policy": {
-            "<list>": {
+            "<policy>": {
                 "ignore": {
                     "vendor/package": "Assessed, no risk."
                 }
@@ -517,7 +518,7 @@ and per-rule scoping. All formats may be mixed in the same map.
 {
     "config": {
         "policy": {
-            "<list>": {
+            "<policy>": {
                 "ignore": {
                     "vendor/package": {"constraint": "^2.0", "reason": "Only v2 is affected."}
                 }
@@ -536,7 +537,7 @@ and per-rule scoping. All formats may be mixed in the same map.
 {
     "config": {
         "policy": {
-            "<list>": {
+            "<policy>": {
                 "ignore": {
                     "vendor/package": {"on-audit": false, "reason": "Workaround applied; keep reporting."}
                 }
@@ -552,7 +553,7 @@ and per-rule scoping. All formats may be mixed in the same map.
 {
     "config": {
         "policy": {
-            "<list>": {
+            "<policy>": {
                 "ignore": {
                     "vendor/package": [
                         {"constraint": "^1.0", "on-audit": false},
@@ -578,7 +579,7 @@ dependencies, ensuring they cannot be installed.
 ### How `config.audit` interacts with `config.policy`
 
 The legacy `config.audit` keys are only read as a fallback when the corresponding
-[`config.policy`](#policy) block is **absent**. The fallback is all-or-nothing per built-in list:
+[`config.policy`](#policy) section is **absent**. The fallback is all-or-nothing per built-in dependency policy:
 
 - If [`config.policy.advisories`](#advisories) is set (to any value, including `false`),
   every advisories-related `audit.*` key ([`audit.block-insecure`](#block-insecure), [`audit.ignore`](#ignore-3),
@@ -586,13 +587,13 @@ The legacy `config.audit` keys are only read as a fallback when the correspondin
   [`policy.advisories.block`](#block), [`policy.advisories.ignore`](#ignore), and
   [`policy.advisories.ignore-severity`](#ignore-severity) are read. Mix-and-matching,
   e.g. setting `policy.advisories.block` while expecting `audit.ignore-severity` to still
-  apply, is not supported — migrate all advisories-related settings together.
+  apply, is not supported. Migrate all advisories-related settings together.
 - If [`config.policy.abandoned`](#abandoned) is set (to any value, including `false`),
   every abandoned-related `audit.*` key ([`audit.block-abandoned`](#block-abandoned), [`audit.abandoned`](#abandoned-1),
   [`audit.ignore-abandoned`](#ignore-abandoned)) is **ignored entirely** — only
   [`policy.abandoned.block`](#block-1), [`policy.abandoned.audit`](#audit-1), and
   [`policy.abandoned.ignore`](#ignore-1) are read.
-- The two built-in lists are independent: configuring `policy.advisories` while leaving the
+- The two built-in dependency policies are independent: configuring `policy.advisories` while leaving the
   abandoned settings under `audit.*` is allowed and vice versa.
 - Setting [`policy.ignore-unreachable`](#ignore-unreachable) supersedes the legacy
   [`audit.ignore-unreachable`](#ignore-unreachable-1) key.

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -539,7 +539,7 @@
                         "ignore-unreachable": {
                             "type": "boolean",
                             "deprecated": true,
-                            "description": "DEPRECATED: use 'config.policy.ignore-unreachable' instead. The new key accepts a boolean or an array of scopes ('audit', 'install', 'update') and is shared across all policy lists."
+                            "description": "DEPRECATED: use 'config.policy.ignore-unreachable' instead. The new key accepts a boolean or an array of scopes ('audit', 'install', 'update') and is shared across all dependency policies."
                         },
                         "block-insecure": {
                             "type": "boolean",
@@ -711,15 +711,15 @@
                     "patternProperties": {
                         "^ignore(?!-unreachable$)": {
                             "not": {},
-                            "description": "Custom policy list names must not start with \"ignore\" — that prefix is reserved for future use."
+                            "description": "Custom dependency policy names must not start with \"ignore\" — that prefix is reserved for future use."
                         },
                         "^(package|packages|license|licence|licenses|licences|support|maintenance|security|minimum-release-age)$": {
                             "not": {},
-                            "description": "This name is reserved for future use and cannot be used as a custom policy list name."
+                            "description": "This name is reserved for future use and cannot be used as a custom dependency policy name."
                         }
                     },
                     "additionalProperties": {
-                        "description": "Custom policy list configuration.",
+                        "description": "Custom dependency policy configuration.",
                         "oneOf": [
                             {
                                 "type": "boolean"
@@ -734,12 +734,12 @@
                                     },
                                     "audit": {
                                         "enum": ["ignore", "report", "fail"],
-                                        "description": "How composer audit treats packages matched by this list. Defaults to fail.",
+                                        "description": "How composer audit treats packages matched by this dependency policy. Defaults to fail.",
                                         "default": "fail"
                                     },
                                     "sources": {
                                         "type": "array",
-                                        "description": "URL sources to fetch this policy list data from.",
+                                        "description": "Sources supplying the package versions this dependency policy applies to.",
                                         "items": {
                                             "type": "object",
                                             "required": ["type", "url"],
@@ -752,7 +752,7 @@
                                                 "url": {
                                                     "type": "string",
                                                     "pattern": "^https://",
-                                                    "description": "URL to fetch the policy list data from. Must use https://."
+                                                    "description": "URL to fetch the list of package versions from. Must use https://."
                                                 }
                                             },
                                             "additionalProperties": false

--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -540,7 +540,7 @@ class Auditor
             foreach ($filteredPackages as $data) {
                 foreach ($data as $entry) {
                     $parts = [
-                        $entry->packageName . ' is on filter list "' . $entry->listName . '"',
+                        $entry->packageName . ' matched dependency policy "' . $entry->listName . '"',
                     ];
                     if ($entry->reason !== null) {
                         $parts[] = 'Reason: ' . $entry->reason;

--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -58,10 +58,7 @@ class Auditor
 
     /** Values to determine the audit result. */
     public const STATUS_OK = 0;
-    public const STATUS_VULNERABLE = 1;
-    public const STATUS_ABANDONED = 2;
-    public const STATUS_FILTERED = 4;
-    public const STATUS_FAILED = 8;
+    public const STATUS_FAILED = 1;
 
     /**
      * @param PolicyConfig $policyConfig Source of truth for ignore lists, severity filters, and per-list audit settings.
@@ -69,7 +66,7 @@ class Auditor
      * @param self::FORMAT_* $format The format that will be used to output audit results.
      * @param bool $warningOnly If true, outputs a warning. If false, outputs an error.
      *
-     * @return int-mask<self::STATUS_*> A bitmask of STATUS_* constants or 0 on success
+     * @return 0|1 Where 0 on success means no issues found, and 1 means there were issues found
      * @throws InvalidArgumentException If no packages are passed in
      */
     public function audit(IOInterface $io, RepositorySet $repoSet, PolicyConfig $policyConfig, array $packages, string $format, bool $warningOnly = true, ?FilterListProviderSet $filterListProviderSet = null): int
@@ -127,7 +124,7 @@ class Auditor
             }
         }
 
-        $auditBitmask = $this->calculateBitmask(0 < $affectedPackagesCount, 0 < $abandonedCount, 0 < $filteredCount);
+        $auditResult = (0 < $affectedPackagesCount || 0 < $abandonedCount || 0 < $filteredCount) ? self::STATUS_FAILED : self::STATUS_OK;
 
         if (self::FORMAT_JSON === $format) {
             $json = ['advisories' => $advisories];
@@ -153,7 +150,7 @@ class Auditor
 
             $io->write(JsonFile::encode($json));
 
-            return $auditBitmask;
+            return $auditResult;
         }
 
         $errorOrWarn = $warningOnly ? 'warning' : 'error';
@@ -202,7 +199,7 @@ class Auditor
             }
         }
 
-        return $auditBitmask;
+        return $auditResult;
     }
 
     /**
@@ -506,28 +503,6 @@ class Auditor
         }
 
         return '<href='.OutputFormatter::escape($advisory->link).'>'.OutputFormatter::escape($advisory->link).'</>';
-    }
-
-    /**
-     * @return int-mask<self::STATUS_*>
-     */
-    private function calculateBitmask(bool $hasVulnerablePackages, bool $hasAbandonedPackages, bool $hasFilteredPackages = false): int
-    {
-        $bitmask = self::STATUS_OK;
-
-        if ($hasVulnerablePackages) {
-            $bitmask |= self::STATUS_VULNERABLE;
-        }
-
-        if ($hasAbandonedPackages) {
-            $bitmask |= self::STATUS_ABANDONED;
-        }
-
-        if ($hasFilteredPackages) {
-            $bitmask |= self::STATUS_FILTERED;
-        }
-
-        return $bitmask;
     }
 
     /**

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -39,7 +39,6 @@ class AuditCommand extends BaseCommand
                 new InputOption('abandoned', null, InputOption::VALUE_REQUIRED, 'Behavior on abandoned packages. Must be "ignore", "report", or "fail".', null, ListPolicyConfig::AUDITS),
                 new InputOption('ignore-severity', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Ignore advisories of a certain severity level.', [], ['low', 'medium', 'high', 'critical']),
                 new InputOption('ignore-unreachable', null, InputOption::VALUE_NONE, 'Ignore repositories that are unreachable or return a non-200 status code.'),
-                new InputOption('filtered', null, InputOption::VALUE_REQUIRED, 'Behavior on filtered packages. Must be "ignore", "report", or "fail". Overrides the per-policy audit setting for malware and every custom dependency policy.', null, ListPolicyConfig::AUDITS),
             ])
             ->setHelp(
                 <<<EOT
@@ -84,14 +83,9 @@ EOT
             throw new \InvalidArgumentException('--abandoned must be one of '.implode(', ', ListPolicyConfig::AUDITS).'.');
         }
 
-        $filtered = $input->getOption('filtered');
-        if ($filtered !== null && !in_array($filtered, ListPolicyConfig::AUDITS, true)) {
-            throw new \InvalidArgumentException('--filtered must be one of '.implode(', ', ListPolicyConfig::AUDITS).'.');
-        }
-
         $policyConfig = $this->createPolicyConfig($composer->getConfig(), $input);
-        if ($filtered !== null || $abandoned !== null) {
-            $policyConfig = $policyConfig->withAudit($abandoned, $filtered);
+        if ($abandoned !== null) {
+            $policyConfig = $policyConfig->withAudit($abandoned);
         }
 
         $ignoreSeverities = $input->getOption('ignore-severity');

--- a/src/Composer/Command/AuditCommand.php
+++ b/src/Composer/Command/AuditCommand.php
@@ -39,7 +39,7 @@ class AuditCommand extends BaseCommand
                 new InputOption('abandoned', null, InputOption::VALUE_REQUIRED, 'Behavior on abandoned packages. Must be "ignore", "report", or "fail".', null, ListPolicyConfig::AUDITS),
                 new InputOption('ignore-severity', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Ignore advisories of a certain severity level.', [], ['low', 'medium', 'high', 'critical']),
                 new InputOption('ignore-unreachable', null, InputOption::VALUE_NONE, 'Ignore repositories that are unreachable or return a non-200 status code.'),
-                new InputOption('filtered', null, InputOption::VALUE_REQUIRED, 'Behavior on filtered packages. Must be "ignore", "report", or "fail". Overrides the per-list audit setting for malware and every custom filter list.', null, ListPolicyConfig::AUDITS),
+                new InputOption('filtered', null, InputOption::VALUE_REQUIRED, 'Behavior on filtered packages. Must be "ignore", "report", or "fail". Overrides the per-policy audit setting for malware and every custom dependency policy.', null, ListPolicyConfig::AUDITS),
             ])
             ->setHelp(
                 <<<EOT

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -611,7 +611,7 @@ EOT
             if ($isCustomPolicyIgnore) {
                 $reservedError = PolicyConfig::getFutureReservedListNameError((string) $customIgnoreMatches[1]);
                 if ($reservedError !== null) {
-                    throw new \RuntimeException('Invalid policy list name: '.$reservedError);
+                    throw new \RuntimeException('Invalid dependency policy name: '.$reservedError);
                 }
             }
 
@@ -694,7 +694,7 @@ EOT
         ) {
             $reservedError = PolicyConfig::getFutureReservedListNameError($matches[1]);
             if ($reservedError !== null) {
-                throw new \RuntimeException('Invalid policy list name: '.$reservedError);
+                throw new \RuntimeException('Invalid dependency policy name: '.$reservedError);
             }
             if (!$booleanValidator($values[0])) {
                 throw new \RuntimeException(sprintf('"%s" is an invalid value for %s, expected a boolean', $values[0], $settingKey));
@@ -710,7 +710,7 @@ EOT
         ) {
             $reservedError = PolicyConfig::getFutureReservedListNameError($matches[1]);
             if ($reservedError !== null) {
-                throw new \RuntimeException('Invalid policy list name: '.$reservedError);
+                throw new \RuntimeException('Invalid dependency policy name: '.$reservedError);
             }
             if ($matches[2] === 'block') {
                 if (!$booleanValidator($values[0])) {
@@ -731,7 +731,7 @@ EOT
         // `composer config`, since sources have structured shape (type/url) and validation rules.
         if (Preg::isMatch('/^policy\.([^.]+)\.sources$/', $settingKey, $matches)) {
             throw new \RuntimeException(sprintf(
-                'Setting policy sources is not supported by `composer config`. Use `composer policy add-source %s url <https-url>` instead.',
+                'Setting dependency policy sources is not supported by `composer config`. Use `composer policy add-source %s url <https-url>` instead.',
                 $matches[1]
             ));
         }

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -591,7 +591,7 @@ EOT
         }
         $repoSet->addRepository(new ComposerRepository(['type' => 'composer', 'url' => 'https://packagist.org'], new NullIO(), $config, $this->httpDownloader));
         $policyConfig = $this->createPolicyConfig($config, null);
-        $policyConfig = $policyConfig->withAudit(ListPolicyConfig::AUDIT_IGNORE, null);
+        $policyConfig = $policyConfig->withAudit(ListPolicyConfig::AUDIT_IGNORE);
 
         try {
             $io = new BufferIO();

--- a/src/Composer/Command/PolicyCommand.php
+++ b/src/Composer/Command/PolicyCommand.php
@@ -24,11 +24,11 @@ use Composer\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Manage policy lists and their sources.
+ * Manage dependency policies and their sources.
  *
  * Examples:
- *  - composer policy add-source my-list url https://example.org/list.json
- *  - composer policy add-source my-list '{"type":"url","url":"https://example.org/list.json"}'
+ *  - composer policy add-source my-policy url https://example.org/my-pkgs.json
+ *  - composer policy add-source my-policy '{"type":"url","url":"https://example.org/my-pkgs.json"}'
  */
 class PolicyCommand extends BaseConfigCommand
 {
@@ -36,27 +36,27 @@ class PolicyCommand extends BaseConfigCommand
     {
         $this
             ->setName('policy')
-            ->setDescription('Manages policy lists and their sources')
+            ->setDescription('Manages custom dependency policies and their sources')
             ->setDefinition([
                 new InputOption('global', 'g', InputOption::VALUE_NONE, 'Apply command to the global config file'),
                 new InputOption('file', 'f', InputOption::VALUE_REQUIRED, 'If you want to choose a different composer.json or config.json'),
                 new InputArgument('action', InputArgument::REQUIRED, 'Action to perform: add-source', null, ['add-source']),
-                new InputArgument('name', InputArgument::OPTIONAL, 'Policy list name', null, $this->suggestListNames()),
+                new InputArgument('name', InputArgument::OPTIONAL, 'Policy name', null, $this->suggestListNames()),
                 new InputArgument('arg1', InputArgument::OPTIONAL, 'Source type (e.g. "url") for add-source', null, $this->suggestArg1()),
                 new InputArgument('arg2', InputArgument::OPTIONAL, 'URL for add-source (if not using JSON)'),
             ])
             ->setHelp(
                 <<<EOT
-This command lets you manage policy lists and their sources in composer.json.
+This command lets you manage custom dependency policies and their sources in composer.json.
 
 Examples:
-  composer policy add-source my-list url https://example.org/list.json
-  composer policy add-source my-list '{"type":"url","url":"https://example.org/list.json"}'
+  composer policy add-source my-policy url https://example.org/my-pkgs.json
+  composer policy add-source my-policy '{"type":"url","url":"https://example.org/my-pkgs.json"}'
 
-Adding a source to a list that does not exist will create the list.
+Adding a source for a dependency policy that does not exist will create the policy.
 
-Built-in lists (advisories, malware, abandoned) do not accept sources and
-are rejected by add-source. Use `composer config policy.<list>.<field>`
+Built-in dependency policies (advisories, malware, abandoned) do not accept sources and
+are rejected by add-source. Use `composer config policy.<policy>.<field>`
 to adjust their settings.
 
 Use --global/-g to alter the global config.json instead.
@@ -75,7 +75,7 @@ EOT
         switch ($action) {
             case 'add-source':
                 if ($listName === null) {
-                    throw new \RuntimeException('You must pass a list name. Example: composer policy add-source my-list url https://example.org');
+                    throw new \RuntimeException('You must pass a dependency policy name. Example: composer policy add-source my-policy url https://example.org');
                 }
                 $this->assertCustomListName((string) $listName);
                 if ($arg1 === null) {
@@ -89,7 +89,7 @@ EOT
                     }
                 } else {
                     if ($arg2 === null) {
-                        throw new \RuntimeException('You must pass the source type and a url. Example: composer policy add-source my-list url https://example.org');
+                        throw new \RuntimeException('You must pass the source type and a url. Example: composer policy add-source my-policy url https://example.org');
                     }
                     $sourceConfig = ['type' => (string) $arg1, 'url' => (string) $arg2];
                 }
@@ -107,7 +107,7 @@ EOT
                         && ($existing['type'] ?? null) === $sourceConfig['type']
                         && ($existing['url'] ?? null) === ($sourceConfig['url'] ?? null)
                     ) {
-                        $this->getIO()->write('<info>Source '.$sourceConfig['url'].' already present in list '.$listName.'</info>');
+                        $this->getIO()->write('<info>Source '.$sourceConfig['url'].' already present in policy '.$listName.'</info>');
 
                         return 0;
                     }
@@ -126,7 +126,7 @@ EOT
     private function assertCustomListName(string $name): void
     {
         if (in_array($name, PolicyConfig::BUILTIN_LIST_NAMES, true)) {
-            throw new \RuntimeException('Built-in list "'.$name.'" does not support sources. Use `composer config policy.'.$name.'.<field>` to configure it.');
+            throw new \RuntimeException('Built-in dependency policy "'.$name.'" does not support sources. Use `composer config policy.'.$name.'.<field>` to configure it.');
         }
 
         $error = PolicyConfig::getFutureReservedListNameError($name);
@@ -135,7 +135,7 @@ EOT
         }
 
         if ($name === '' || strpos($name, '.') !== false) {
-            throw new \RuntimeException('Invalid list name "'.$name.'".');
+            throw new \RuntimeException('Invalid dependency policy name "'.$name.'".');
         }
     }
 

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -840,7 +840,7 @@ class PoolBuilder
 
         $this->io->write(sprintf('Filter list pool filter completed in %.3f seconds', microtime(true) - $before), true, IOInterface::VERY_VERBOSE);
         $this->io->write(sprintf(
-            '<info>Found %s package versions referenced in your dependency graph. %s (%d%%) were filtered away by filter lists.</info>',
+            '<info>Found %s package versions referenced in your dependency graph. %s (%d%%) were filtered away by dependency policies.</info>',
             number_format($total),
             number_format($filtered),
             round(100 / $total * $filtered)

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -269,7 +269,7 @@ abstract class Rule
 
             case self::RULE_LOCKED_FILTER_LIST_REMOVED:
                 $package = $this->deduplicateDefaultBranchAlias($this->getReasonData()['package']);
-                return $package->getPrettyName().' '.$package->getPrettyVersion().' was removed by a policy filter list (e.g. malware) and cannot be installed.';
+                return $package->getPrettyName().' '.$package->getPrettyVersion().' was removed by a dependency policy (e.g. malware) and cannot be installed.';
 
             case self::RULE_PACKAGE_CONFLICT:
                 $package1 = $this->deduplicateDefaultBranchAlias($pool->literalToPackage($literals[0]));

--- a/src/Composer/Policy/PolicyConfig.php
+++ b/src/Composer/Policy/PolicyConfig.php
@@ -137,14 +137,14 @@ class PolicyConfig
     {
         if (in_array($listName, self::RESERVED_NAMES, true)) {
             throw new \UnexpectedValueException(sprintf(
-                'Invalid custom policy list name "%s": this name is reserved for a built-in list.',
+                'Invalid custom dependency policy name "%s": this name is reserved for a built-in dependency policy.',
                 $listName
             ));
         }
 
         $error = self::getFutureReservedListNameError($listName);
         if ($error !== null) {
-            throw new \UnexpectedValueException('Invalid custom policy list name: '.$error);
+            throw new \UnexpectedValueException('Invalid custom dependency policy name: '.$error);
         }
     }
 

--- a/src/Composer/Policy/PolicyConfig.php
+++ b/src/Composer/Policy/PolicyConfig.php
@@ -397,28 +397,19 @@ class PolicyConfig
     }
 
     /**
-     * `$abandoned` overrides only the abandoned list. `$filtered` is a blunt
-     * override: it overwrites the audit setting for malware *and every custom
-     * list*, including lists explicitly configured as audit=fail in the policy
-     * config.
-     *
+     * `$abandoned` overrides only the abandoned list audit setting.
+     * *
      * @param null|ListPolicyConfig::AUDIT_* $abandoned
-     * @param null|ListPolicyConfig::AUDIT_* $filtered
      * @return static
      */
-    public function withAudit(?string $abandoned, ?string $filtered)
+    public function withAudit(?string $abandoned)
     {
-        $customLists = [];
-        foreach ($this->customLists as $name => $list) {
-            $customLists[$name] = $list->withAudit($filtered !== null ? $filtered : $list->audit);
-        }
-
         return new self(
             $this->enabled,
             $this->advisories,
-            $this->malware->withAudit($filtered !== null ? $filtered : $this->malware->audit),
+            $this->malware,
             $this->abandoned->withAudit($abandoned !== null ? $abandoned : $this->abandoned->audit),
-            $customLists,
+            $this->customLists,
             $this->ignoreUnreachable
         );
     }

--- a/tests/Composer/Test/Advisory/AuditorTest.php
+++ b/tests/Composer/Test/Advisory/AuditorTest.php
@@ -693,7 +693,7 @@ Found 2 abandoned packages:
             'expected' => Auditor::STATUS_FILTERED,
             'output' => 'No security vulnerability advisories found.
 Found 1 package matching filters:
-vendor/package is on filter list "test-list". Reason: internal.',
+vendor/package matched dependency policy "test-list". Reason: internal.',
         ];
 
         yield 'AUDIT_FAIL with matching entry shows url and reason (plain)' => [
@@ -704,7 +704,7 @@ vendor/package is on filter list "test-list". Reason: internal.',
             'expected' => Auditor::STATUS_FILTERED,
             'output' => 'No security vulnerability advisories found.
 Found 1 package matching filters:
-vendor/package is on filter list "test-list". Reason: internal. URL: https://example.com/filtered.',
+vendor/package matched dependency policy "test-list". Reason: internal. URL: https://example.com/filtered.',
         ];
 
         yield 'AUDIT_REPORT with matching entry returns STATUS_OK' => [
@@ -715,7 +715,7 @@ vendor/package is on filter list "test-list". Reason: internal. URL: https://exa
             'expected' => Auditor::STATUS_OK,
             'output' => 'No security vulnerability advisories found.
 <warning>Found 1 package matching filters:</warning>
-vendor/package is on filter list "test-list". Reason: internal.',
+vendor/package matched dependency policy "test-list". Reason: internal.',
         ];
 
         yield 'AUDIT_FAIL with matching entry shows summary line only (summary format)' => [
@@ -744,8 +744,8 @@ Found 1 package matching filters.',
             'expected' => Auditor::STATUS_FILTERED,
             'output' => 'No security vulnerability advisories found.
 Found 2 packages matching filters:
-vendor/package is on filter list "test-list". Reason: internal.
-vendor/other is on filter list "test-list". Reason: internal.',
+vendor/package matched dependency policy "test-list". Reason: internal.
+vendor/other matched dependency policy "test-list". Reason: internal.',
         ];
     }
 
@@ -874,7 +874,7 @@ vendor/other is on filter list "test-list". Reason: internal.',
         $output = trim(str_replace("\r", '', $io->getOutput()));
         self::assertStringContainsString('Found 2 security vulnerability advisories affecting 1 package:', $output);
         self::assertStringContainsString('Found 1 package matching filters:', $output);
-        self::assertStringContainsString('vendor1/package2 is on filter list "test-list". Reason: internal', $output);
+        self::assertStringContainsString('vendor1/package2 matched dependency policy "test-list". Reason: internal', $output);
     }
 
     /**

--- a/tests/Composer/Test/Advisory/AuditorTest.php
+++ b/tests/Composer/Test/Advisory/AuditorTest.php
@@ -64,7 +64,7 @@ class AuditorTest extends TestCase
                 ],
                 'warningOnly' => true,
             ],
-            'expected' => Auditor::STATUS_VULNERABLE,
+            'expected' => Auditor::STATUS_FAILED,
             'output' => '<warning>Found 2 security vulnerability advisories affecting 1 package:</warning>
 Package: vendor1/package1
 Severity: high
@@ -141,7 +141,7 @@ Reported at: 2022-05-25T13:21:00+00:00',
                 'abandoned' => ListPolicyConfig::AUDIT_FAIL,
                 'ignore-abandoned' => ['acme/test' => 'ignoring because yolo'],
             ],
-            'expected' => Auditor::STATUS_ABANDONED,
+            'expected' => Auditor::STATUS_FAILED,
             'output' => 'No security vulnerability advisories found.
 Found 2 abandoned packages:
 vendor/abandoned is abandoned. Use foo/bar instead.
@@ -174,7 +174,7 @@ vendor/abandoned2 is abandoned. No replacement was suggested.',
                 'abandoned' => ListPolicyConfig::AUDIT_FAIL,
                 'format' => Auditor::FORMAT_TABLE,
             ],
-            'expected' => Auditor::STATUS_ABANDONED,
+            'expected' => Auditor::STATUS_FAILED,
             'output' => 'No security vulnerability advisories found.
 Found 2 abandoned packages:
 +-------------------+----------------------------------------------------------------------------------+
@@ -196,7 +196,7 @@ Found 2 abandoned packages:
                 'abandoned' => ListPolicyConfig::AUDIT_FAIL,
                 'format' => Auditor::FORMAT_TABLE,
             ],
-            'expected' => Auditor::STATUS_VULNERABLE | Auditor::STATUS_ABANDONED,
+            'expected' => Auditor::STATUS_FAILED,
             'output' => 'Found 2 security vulnerability advisories affecting 1 package:
 +-------------------+----------------------------------------------------------------------------------+
 | Package           | vendor1/package1                                                                 |
@@ -237,7 +237,7 @@ Found 2 abandoned packages:
                 'abandoned' => ListPolicyConfig::AUDIT_FAIL,
                 'format' => Auditor::FORMAT_JSON,
             ],
-            'expected' => Auditor::STATUS_ABANDONED,
+            'expected' => Auditor::STATUS_FAILED,
             'output' => '{
     "advisories": [],
     "abandoned": {
@@ -581,7 +581,7 @@ Found 2 abandoned packages:
         $result = $auditor->audit($io, $repoSet, $this->createPolicyConfig(ListPolicyConfig::AUDIT_IGNORE, true), $packages, Auditor::FORMAT_PLAIN, false);
 
         // Should find advisories from the reachable repositories
-        self::assertSame(Auditor::STATUS_VULNERABLE, $result);
+        self::assertSame(Auditor::STATUS_FAILED, $result);
 
         $output = $io->getOutput();
         self::assertStringContainsString('The following repositories were unreachable:', $output);
@@ -596,7 +596,7 @@ Found 2 abandoned packages:
         // Test with JSON format
         $io = new BufferIO();
         $result = $auditor->audit($io, $repoSet, $this->createPolicyConfig(ListPolicyConfig::AUDIT_IGNORE, true), $packages, Auditor::FORMAT_JSON, false);
-        self::assertSame(Auditor::STATUS_VULNERABLE, $result);
+        self::assertSame(Auditor::STATUS_FAILED, $result);
 
         $json = json_decode($io->getOutput(), true);
         self::assertArrayHasKey('unreachable-repositories', $json);
@@ -685,12 +685,12 @@ Found 2 abandoned packages:
             'output' => 'No security vulnerability advisories found.',
         ];
 
-        yield 'AUDIT_FAIL with matching entry returns STATUS_FILTERED (plain)' => [
+        yield 'AUDIT_FAIL with matching entry returns STATUS_FAILED (plain)' => [
             'packages' => [new Package('vendor/package', '9.0.0', '9.0.0')],
             'filterEntriesByList' => ['test-list' => [$matchingEntry]],
             'filtered' => ListPolicyConfig::AUDIT_FAIL,
             'format' => Auditor::FORMAT_PLAIN,
-            'expected' => Auditor::STATUS_FILTERED,
+            'expected' => Auditor::STATUS_FAILED,
             'output' => 'No security vulnerability advisories found.
 Found 1 package matching filters:
 vendor/package matched dependency policy "test-list". Reason: internal.',
@@ -701,7 +701,7 @@ vendor/package matched dependency policy "test-list". Reason: internal.',
             'filterEntriesByList' => ['test-list' => [$matchingEntryWithDetails]],
             'filtered' => ListPolicyConfig::AUDIT_FAIL,
             'format' => Auditor::FORMAT_PLAIN,
-            'expected' => Auditor::STATUS_FILTERED,
+            'expected' => Auditor::STATUS_FAILED,
             'output' => 'No security vulnerability advisories found.
 Found 1 package matching filters:
 vendor/package matched dependency policy "test-list". Reason: internal. URL: https://example.com/filtered.',
@@ -723,7 +723,7 @@ vendor/package matched dependency policy "test-list". Reason: internal.',
             'filterEntriesByList' => ['test-list' => [$matchingEntry]],
             'filtered' => ListPolicyConfig::AUDIT_FAIL,
             'format' => Auditor::FORMAT_SUMMARY,
-            'expected' => Auditor::STATUS_FILTERED,
+            'expected' => Auditor::STATUS_FAILED,
             'output' => 'No security vulnerability advisories found.
 Found 1 package matching filters.',
         ];
@@ -741,7 +741,7 @@ Found 1 package matching filters.',
             ],
             'filtered' => ListPolicyConfig::AUDIT_FAIL,
             'format' => Auditor::FORMAT_PLAIN,
-            'expected' => Auditor::STATUS_FILTERED,
+            'expected' => Auditor::STATUS_FAILED,
             'output' => 'No security vulnerability advisories found.
 Found 2 packages matching filters:
 vendor/package matched dependency policy "test-list". Reason: internal.
@@ -817,7 +817,7 @@ vendor/other matched dependency policy "test-list". Reason: internal.',
             $providerSet
         );
 
-        self::assertSame(Auditor::STATUS_FILTERED, $result);
+        self::assertSame(Auditor::STATUS_FAILED, $result);
 
         $json = json_decode($io->getOutput(), true);
         self::assertIsArray($json);
@@ -870,7 +870,7 @@ vendor/other matched dependency policy "test-list". Reason: internal.',
             $providerSet
         );
 
-        self::assertSame(Auditor::STATUS_VULNERABLE | Auditor::STATUS_FILTERED, $result);
+        self::assertSame(Auditor::STATUS_FAILED, $result);
         $output = trim(str_replace("\r", '', $io->getOutput()));
         self::assertStringContainsString('Found 2 security vulnerability advisories affecting 1 package:', $output);
         self::assertStringContainsString('Found 1 package matching filters:', $output);

--- a/tests/Composer/Test/Command/AuditCommandTest.php
+++ b/tests/Composer/Test/Command/AuditCommandTest.php
@@ -108,27 +108,7 @@ class AuditCommandTest extends TestCase
         self::assertStringContainsString('malicious/pkg', $display);
         self::assertStringContainsString('banned/pkg', $display);
 
-        self::assertSame(Auditor::STATUS_FILTERED, $exitCode);
-    }
-
-    public function testAuditWithFilteredIgnoreFlagSkipsFilterChecks(): void
-    {
-        $packages = [
-            ['name' => 'safe/pkg', 'version' => '1.0.0'],
-            ['name' => 'malicious/pkg', 'version' => '1.0.0'],
-            ['name' => 'banned/pkg', 'version' => '1.0.0'],
-        ];
-
-        $this->initTempComposerWithFilterLists($packages);
-        $this->createComposerLockWithPackages($packages);
-
-        $appTester = $this->getApplicationTester();
-        $exitCode = $appTester->run(['command' => 'audit', '--locked' => true, '--filtered' => ListPolicyConfig::AUDIT_IGNORE]);
-
-        $display = $appTester->getDisplay(true);
-        self::assertStringNotContainsString('matching filters', $display);
-        self::assertStringContainsString('No security vulnerability advisories found.', $display);
-        self::assertSame(Auditor::STATUS_OK, $exitCode);
+        self::assertSame(Auditor::STATUS_FAILED, $exitCode);
     }
 
     public function testAuditWithCustomListAuditReportDoesNotFail(): void

--- a/tests/Composer/Test/Command/PolicyCommandTest.php
+++ b/tests/Composer/Test/Command/PolicyCommandTest.php
@@ -215,7 +215,7 @@ class PolicyCommandTest extends TestCase
     public function testAddSourceRejectsBuiltInListName(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Built-in list "advisories" does not support sources');
+        $this->expectExceptionMessage('Built-in dependency policy "advisories" does not support sources');
 
         $this->initTempComposer([]);
 
@@ -283,7 +283,7 @@ class PolicyCommandTest extends TestCase
     public function testAddSourceRejectsNameContainingDot(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Invalid list name "bad.name"');
+        $this->expectExceptionMessage('Invalid dependency policy name "bad.name"');
 
         $this->initTempComposer([]);
 

--- a/tests/Composer/Test/DependencyResolver/RuleTest.php
+++ b/tests/Composer/Test/DependencyResolver/RuleTest.php
@@ -127,7 +127,7 @@ class RuleTest extends TestCase
         $rule = new GenericRule([], Rule::RULE_LOCKED_FILTER_LIST_REMOVED, ['package' => $package]);
 
         self::assertEquals(
-            'vendor/malware 1.0 was removed by a policy filter list (e.g. malware) and cannot be installed.',
+            'vendor/malware 1.0 was removed by a dependency policy (e.g. malware) and cannot be installed.',
             $rule->getPrettyString($repositorySetMock, $requestMock, $pool, false)
         );
     }


### PR DESCRIPTION
Renames the user-facing concept previously called "policy list" / "policy lists" to "dependency policy" / "dependency policies" across the documentation and all user-visible strings (command help, error messages, schema descriptions). Also drops "filter list" / "filter list source" from user-facing output.

## Terminology

- Concept noun (prose, schema descriptions, error messages): **dependency policy / dependency policies**.
- Short form where brevity matters (CLI argument labels, JSON placeholders, repeated within-paragraph mentions, config-key paths like `config.policy.x`): **policy**.
- Data fetched from a source URL: bare **sources** where the surrounding context already names a dependency policy; **dependency policy sources** in standalone messages.

A single entry under `config.policy.<name>` is a dependency policy — block/audit/ignore configuration that applies to a set of package versions. Custom dependency policies supply their package versions via one or more `sources`. The old "policy list" wording conflated the policy with the package data.

Internal class/method names (`ListPolicyConfig`, `suggestListNames`, `assertCustomListName`) are intentionally untouched — this is a docs/UX-only change.