### PR TITLE
Disable source-fallback by default, mark it deprecated and remove env/flags to override

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -104,9 +104,6 @@ resolution.
   To get the legacy behavior where Composer use `source` automatically for dev
   versions of packages, use `--prefer-install=auto`. See also [config.preferred-install](06-config.md#preferred-install).
   Passing this flag will override the config value.
-* **--source-fallback / --no-source-fallback:** Override the [config.source-fallback](06-config.md#source-fallback)
-  setting. When disabled, Composer will not fall back to an alternative download source
-  (e.g., from dist to source or vice versa) if the preferred one fails. Also see [COMPOSER_SOURCE_FALLBACK](#composer-source-fallback).
 * **--dry-run:** If you want to run through an installation without actually
   installing a package, you can use `--dry-run`. This will simulate the
   installation and show you what would happen.
@@ -199,9 +196,6 @@ php composer.phar update vendor/package:2.0.1 vendor/package2:3.0.*
   To get the legacy behavior where Composer use `source` automatically for dev
   versions of packages, use `--prefer-install=auto`. See also [config.preferred-install](06-config.md#preferred-install).
   Passing this flag will override the config value.
-* **--source-fallback / --no-source-fallback:** Override the [config.source-fallback](06-config.md#source-fallback)
-  setting. When disabled, Composer will not fall back to an alternative download source
-  (e.g., from dist to source or vice versa) if the preferred one fails. Also see [COMPOSER_SOURCE_FALLBACK](#composer-source-fallback).
 * **--dry-run:** Simulate the command without actually doing anything.
 * **--dev:** Install packages listed in `require-dev` (this is the default behavior).
 * **--no-dev:** Skip installing packages listed in `require-dev`. The autoloader generation skips the `autoload-dev` rules. Also see [COMPOSER_NO_DEV](#composer-no-dev).
@@ -298,9 +292,6 @@ If you do not want to install the new dependencies immediately you can call it w
   To get the legacy behavior where Composer use `source` automatically for dev
   versions of packages, use `--prefer-install=auto`. See also [config.preferred-install](06-config.md#preferred-install).
   Passing this flag will override the config value.
-* **--source-fallback / --no-source-fallback:** Override the [config.source-fallback](06-config.md#source-fallback)
-  setting. When disabled, Composer will not fall back to an alternative download source
-  (e.g., from dist to source or vice versa) if the preferred one fails. Also see [COMPOSER_SOURCE_FALLBACK](#composer-source-fallback).
 * **--no-progress:** Removes the progress display that can mess with some
   terminals or scripts which don't handle backspace characters.
 * **--no-update:** Disables the automatic update of the dependencies (implies --no-install).
@@ -431,9 +422,6 @@ php composer.phar reinstall "acme/*"
   To get the legacy behavior where Composer use `source` automatically for dev
   versions of packages, use `--prefer-install=auto`. See also [config.preferred-install](06-config.md#preferred-install).
   Passing this flag will override the config value.
-* **--source-fallback / --no-source-fallback:** Override the [config.source-fallback](06-config.md#source-fallback)
-  setting. When disabled, Composer will not fall back to an alternative download source
-  (e.g., from dist to source or vice versa) if the preferred one fails. Also see [COMPOSER_SOURCE_FALLBACK](#composer-source-fallback).
 * **--no-autoloader:** Skips autoloader generation.
 * **--no-progress:** Removes the progress display that can mess with some
   terminals or scripts which don't handle backspace characters.
@@ -1023,9 +1011,6 @@ By default the command checks for the packages on packagist.org.
   To get the legacy behavior where Composer use `source` automatically for dev
   versions of packages, use `--prefer-install=auto`. See also [config.preferred-install](06-config.md#preferred-install).
   Passing this flag will override the config value.
-* **--source-fallback / --no-source-fallback:** Override the [config.source-fallback](06-config.md#source-fallback)
-  setting. When disabled, Composer will not fall back to an alternative download source
-  (e.g., from dist to source or vice versa) if the preferred one fails. Also see [COMPOSER_SOURCE_FALLBACK](#composer-source-fallback).
 * **--repository:** Provide a custom repository to search for the package,
   which will be used instead of packagist. Can be either an HTTP URL pointing
   to a `composer` repository, a path to a local `packages.json` file, or a
@@ -1482,12 +1467,6 @@ If set to `1`, when resolving dependencies with both `--prefer-stable` and
 alpha/beta/RC versions in cases where no stable release exists. This is useful
 to test lowest versions while still preferring branches that may contain
 critical fixes over prerelease versions.
-
-### COMPOSER_SOURCE_FALLBACK
-
-If set to `0`, Composer will not fall back to an alternative download source when the
-preferred one fails. Equivalent to passing `--no-source-fallback`. See also
-[config.source-fallback](06-config.md#source-fallback).
 
 ### COMPOSER_MINIMAL_CHANGES
 

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -115,35 +115,30 @@ optionally be an object with package name patterns for keys for more granular in
 
 ## source-fallback
 
-Defaults to `true`. When set to `true`, Composer will automatically fall back
+> **Deprecated:** This option is deprecated and will be removed in Composer 2.11.
+> It exists as a temporary opt-in while we disable automatic source fallback for
+> security reasons (silently switching from a dist to a less-trusted or manipulated
+> source may have security implications). If you have a legitimate use case for this
+> and do not want us to remove it in 2.11, please open an issue at
+> https://github.com/composer/composer/issues to let us know.
+
+Defaults to `false`. When set to `true`, Composer will automatically fall back
 to an alternative installation source (e.g., from dist to source or vice versa)
-when a download fails. Set to `false` to disable this behavior and fail immediately
-if the preferred source is unavailable.
+when a download fails. Leave at `false` (the default) to fail immediately if
+the preferred source is unavailable.
 
 ```json
 {
     "config": {
-        "source-fallback": false
+        "source-fallback": true
     }
 }
 ```
 
-This can also be specified on the command line:
-
-```bash
-composer install --no-source-fallback
-composer update --source-fallback
-```
-
-Or via the `COMPOSER_SOURCE_FALLBACK` environment variable:
-
-```bash
-COMPOSER_SOURCE_FALLBACK=0 composer install
-```
-
-> **Note:** When this option is disabled and a download fails, Composer will
-> immediately throw an error instead of trying alternative sources. Make sure
-> your preferred installation source (`preferred-install`) is correctly configured.
+> **Note:** With this option disabled (the default) and a download failing,
+> Composer immediately throws an error instead of trying alternative sources.
+> Make sure your preferred installation source (`preferred-install`) is
+> correctly configured.
 
 ## policy
 

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -770,7 +770,7 @@
                 },
                 "source-fallback": {
                     "type": "boolean",
-                    "description": "If true (default), Composer will fall back to a different installation source (e.g., from dist to source or vice versa) when a download fails. Set to false to disable this behavior."
+                    "description": "DEPRECATED, will be removed in Composer 2.11. Defaults to false. If true, Composer will fall back to a different installation source (e.g., from dist to source or vice versa) when a download fails. Automatic source fallback has security implications, please open an issue at https://github.com/composer/composer/issues if you need this kept around."
                 },
                 "github-protocols": {
                     "type": "array",

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -770,7 +770,8 @@
                 },
                 "source-fallback": {
                     "type": "boolean",
-                    "description": "DEPRECATED, will be removed in Composer 2.11. Defaults to false. If true, Composer will fall back to a different installation source (e.g., from dist to source or vice versa) when a download fails. Automatic source fallback has security implications, please open an issue at https://github.com/composer/composer/issues if you need this kept around."
+                    "description": "DEPRECATED, will be removed in Composer 2.11. Defaults to false. If true, Composer will fall back to a different installation source (e.g., from dist to source or vice versa) when a download fails. Automatic source fallback has security implications, please open an issue at https://github.com/composer/composer/issues if you need this kept around.",
+                    "deprecated": true
                 },
                 "github-protocols": {
                     "type": "array",

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -97,7 +97,6 @@ class CreateProjectCommand extends BaseCommand
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
                 new InputOption('ask', null, InputOption::VALUE_NONE, 'Whether to ask for project directory.'),
-                new InputOption('source-fallback', null, InputOption::VALUE_NEGATABLE, 'Whether to fall back to alternative sources (dist/source) on download failure.'),
             ])
             ->setHelp(
                 <<<EOT
@@ -268,7 +267,6 @@ EOT
             $installer = Installer::create($io, $composer);
             $installer->setPreferSource($preferSource)
                 ->setPreferDist($preferDist)
-                ->setSourceFallback($input->getOption('source-fallback') ?? $config->get('source-fallback'))
                 ->setDevMode($installDevPackages)
                 ->setPlatformRequirementFilter($platformRequirementFilter)
                 ->setSuggestedPackagesReporter($this->suggestedPackagesReporter)
@@ -485,8 +483,7 @@ EOT
 
         $dm = $composer->getDownloadManager();
         $dm->setPreferSource($preferSource)
-            ->setPreferDist($preferDist)
-            ->setSourceFallback($input->getOption('source-fallback') ?? $config->get('source-fallback'));
+            ->setPreferDist($preferDist);
 
         $projectInstaller = new ProjectInstaller($directory, $dm, $fs);
         $im = $composer->getInstallationManager();

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -62,7 +62,6 @@ class InstallCommand extends BaseCommand
                 new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
-                new InputOption('source-fallback', null, InputOption::VALUE_NEGATABLE, 'Whether to fall back to alternative sources (dist/source) on download failure.'),
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Should not be provided, use composer require instead to add a given package to composer.json.'),
             ])
             ->setHelp(
@@ -134,7 +133,6 @@ EOT
             ->setVerbose($input->getOption('verbose'))
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
-            ->setSourceFallback($input->getOption('source-fallback') ?? $config->get('source-fallback'))
             ->setDevMode(!$input->getOption('no-dev'))
             ->setDumpAutoloader(!$input->getOption('no-autoloader'))
             ->setOptimizeAutoloader($optimize)

--- a/src/Composer/Command/ReinstallCommand.php
+++ b/src/Composer/Command/ReinstallCommand.php
@@ -52,7 +52,6 @@ class ReinstallCommand extends BaseCommand
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
                 new InputOption('ignore-platform-reqs', null, InputOption::VALUE_NONE, 'Ignore all platform requirements (php & ext- packages).'),
                 new InputOption('type', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter packages to reinstall by type(s)', null, $this->suggestInstalledPackageTypes(false)),
-                new InputOption('source-fallback', null, InputOption::VALUE_NEGATABLE, 'Whether to fall back to alternative sources (dist/source) on download failure.'),
                 new InputArgument('packages', InputArgument::IS_ARRAY, 'List of package names to reinstall, can include a wildcard (*) to match any substring.', null, $this->suggestInstalledPackage(false)),
             ])
             ->setHelp(
@@ -161,7 +160,6 @@ EOT
 
         $downloadManager->setPreferSource($preferSource);
         $downloadManager->setPreferDist($preferDist);
-        $downloadManager->setSourceFallback($input->getOption('source-fallback') ?? $config->get('source-fallback'));
 
         $devMode = $localRepo->getDevMode() !== null ? $localRepo->getDevMode() : true;
 

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -106,7 +106,6 @@ class RequireCommand extends BaseCommand
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
                 new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
                 new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
-                new InputOption('source-fallback', null, InputOption::VALUE_NEGATABLE, 'Whether to fall back to alternative sources (dist/source) on download failure.'),
             ])
             ->setHelp(
                 <<<EOT
@@ -473,7 +472,6 @@ EOT
             ->setVerbose($input->getOption('verbose'))
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
-            ->setSourceFallback($input->getOption('source-fallback') ?? $composer->getConfig()->get('source-fallback'))
             ->setDevMode($updateDevMode)
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -71,7 +71,6 @@ class UpdateCommand extends BaseCommand
                 new InputOption('no-autoloader', null, InputOption::VALUE_NONE, 'Skips autoloader generation'),
                 new InputOption('no-suggest', null, InputOption::VALUE_NONE, 'DEPRECATED: This flag does not exist anymore.'),
                 new InputOption('no-progress', null, InputOption::VALUE_NONE, 'Do not output download progress.'),
-                new InputOption('source-fallback', null, InputOption::VALUE_NEGATABLE, 'Whether to fall back to alternative sources (dist/source) on download failure.'),
                 new InputOption('with-dependencies', 'w', InputOption::VALUE_NONE, 'Update also dependencies of packages in the argument list, except those which are root requirements (can also be set via the COMPOSER_WITH_DEPENDENCIES=1 env var).'),
                 new InputOption('with-all-dependencies', 'W', InputOption::VALUE_NONE, 'Update also dependencies of packages in the argument list, including those which are root requirements (can also be set via the COMPOSER_WITH_ALL_DEPENDENCIES=1 env var).'),
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
@@ -280,7 +279,6 @@ EOT
             ->setVerbose($input->getOption('verbose'))
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
-            ->setSourceFallback($input->getOption('source-fallback') ?? $config->get('source-fallback'))
             ->setDevMode(!$input->getOption('no-dev'))
             ->setDumpAutoloader(!$input->getOption('no-autoloader'))
             ->setOptimizeAutoloader($optimize)

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -94,7 +94,7 @@ class Config
         'client-certificate' => [],
         'forgejo-domains' => ['codeberg.org'],
         'forgejo-token' => [],
-        'source-fallback' => true,
+        'source-fallback' => false,
     ];
 
     /** @var array<string, mixed> */
@@ -398,7 +398,6 @@ class Config
             // booleans with env var support
             case 'cache-read-only':
             case 'htaccess-protect':
-            case 'source-fallback':
                 // convert foo-bar to COMPOSER_FOO_BAR and check if it exists since it overrides the local config
                 $env = 'COMPOSER_' . strtoupper(strtr($key, '-', '_'));
 
@@ -416,6 +415,7 @@ class Config
             case 'secure-http':
             case 'use-github-api':
             case 'lock':
+            case 'source-fallback':
                 // special case for secure-http
                 if ($key === 'secure-http' && $this->get('disable-tls') === true) {
                     return false;

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -39,7 +39,9 @@ class DownloadManager
     /** @var array<string, DownloaderInterface> */
     private $downloaders = [];
     /** @var bool */
-    private $sourceFallback = true;
+    private $sourceFallback = false;
+    /** @var bool */
+    private $sourceFallbackDeprecationWarned = false;
 
     /**
      * Initializes download manager.
@@ -96,6 +98,12 @@ class DownloadManager
      */
     public function setSourceFallback(bool $sourceFallback): self
     {
+        if ($sourceFallback && !$this->sourceFallbackDeprecationWarned) {
+            $this->io->writeError('<warning>The source-fallback option is deprecated and will be removed in Composer 2.11 as automatic fallback between dist and source has security implications.</warning>');
+            $this->io->writeError('<warning>If you have a legitimate use case and do not want us to remove it in 2.11, please open an issue at https://github.com/composer/composer/issues to let us know.</warning>');
+            $this->sourceFallbackDeprecationWarned = true;
+        }
+
         $this->sourceFallback = $sourceFallback;
 
         return $this;

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -529,8 +529,8 @@ class Factory
             $dm->setPreferences($preferred);
         }
 
-        if (!$config->get('source-fallback')) {
-            $dm->setSourceFallback(false);
+        if ($config->get('source-fallback')) {
+            $dm->setSourceFallback(true);
         }
 
         $dm->setDownloader('git', new Downloader\GitDownloader($io, $config, $process, $fs));

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -147,8 +147,6 @@ class Installer
     /** @var bool */
     protected $preferDist = false;
     /** @var bool */
-    protected $sourceFallback = true;
-    /** @var bool */
     protected $optimizeAutoloader = false;
     /** @var bool */
     protected $classMapAuthoritative = false;
@@ -315,7 +313,6 @@ class Installer
 
         $this->downloadManager->setPreferSource($this->preferSource);
         $this->downloadManager->setPreferDist($this->preferDist);
-        $this->downloadManager->setSourceFallback($this->sourceFallback);
 
         $localRepo = $this->repositoryManager->getLocalRepository();
 
@@ -1302,16 +1299,6 @@ class Installer
     public function setPreferDist(bool $preferDist = true): self
     {
         $this->preferDist = $preferDist;
-
-        return $this;
-    }
-
-    /**
-     * Allow fallback to alternative sources when download fails.
-     */
-    public function setSourceFallback(bool $sourceFallback): self
-    {
-        $this->sourceFallback = $sourceFallback;
 
         return $this;
     }

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -663,10 +663,10 @@ class ConfigTest extends TestCase
         self::assertEquals(true, $config->get('allow-plugins'));
     }
 
-    public function testSourceFallbackDefaultsToTrue(): void
+    public function testSourceFallbackDefaultsToFalse(): void
     {
         $config = new Config(false);
-        self::assertTrue($config->get('source-fallback'));
+        self::assertFalse($config->get('source-fallback'));
     }
 
     public function testSourceFallbackCanBeDisabled(): void
@@ -686,13 +686,4 @@ class ConfigTest extends TestCase
         self::assertTrue($config->get('source-fallback'));
     }
 
-    public function testSourceFallbackEnvOverride(): void
-    {
-        Platform::putEnv('COMPOSER_SOURCE_FALLBACK', '0');
-        $config = new Config(true);
-        $result = $config->get('source-fallback');
-        Platform::clearEnv('COMPOSER_SOURCE_FALLBACK');
-
-        self::assertFalse($result);
-    }
 }

--- a/tests/Composer/Test/Downloader/DownloadManagerTest.php
+++ b/tests/Composer/Test/Downloader/DownloadManagerTest.php
@@ -294,6 +294,9 @@ class DownloadManagerTest extends TestCase
                 $downloaderSuccess
             );
 
+        // Source fallback now defaults to false; opt in to exercise failover.
+        $manager->setSourceFallback(true);
+
         $manager->download($package, 'target_dir');
     }
 
@@ -1240,7 +1243,13 @@ class DownloadManagerTest extends TestCase
                 $downloaderSuccess
             );
 
-        // Explicitly enable source fallback (default behavior)
+        // 4 writeError calls fire: 2 deprecation warnings, "Failed to download from dist",
+        // and "Now trying to download from source" during the retry.
+        $this->io
+            ->expects($this->exactly(4))
+            ->method('writeError');
+
+        // Explicitly enable source fallback (opt-in, deprecated)
         $manager->setSourceFallback(true);
 
         $manager->download($package, 'target_dir');


### PR DESCRIPTION
This new config option was added in https://github.com/composer/composer/pull/12698 (which is not yet released), and while discussing security related things lately we have come to the conclusion that falling back from dist to source or vice versa can be problematic in some cases and we'd rather disable that.

So the source-fallback option is now disabled by default in 2.10, and set to be removed in 2.11 (always off). 

While motivated by security concerns, it is a behavior change that may affect users tho so we want to keep the option in 2.10 as an easier way to transition/upgrade, and to give everyone a chance to voice concerns in case this is a behavior people really rely on.
