### PR TITLE
Fixed `source-fallback` option applying to source->dist fallbacks as well

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -113,19 +113,34 @@ optionally be an object with package name patterns for keys for more granular in
 > configuration in global and package configurations the string notation
 > is translated to a `*` package pattern.
 
+> **Tip:** If you want a source checkout for some packages so you can make
+> local edits, but only on your own machine (not in CI), prefer configuring
+> `preferred-install` globally rather than committing it to the project. For
+> example:
+>
+> ```
+> composer config --global preferred-install.my-vendor/* source
+> ```
+>
+> CI then keeps installing from `dist` by default, while your dev machine
+> always pulls those packages from source. This avoids relying on a source
+> install failure to fall back to dist, and saves CI from attempting a clone
+> first, which keep the output leaner and your CI faster.
+
 ## source-fallback
 
 > **Deprecated:** This option is deprecated and will be removed in Composer 2.11.
-> It exists as a temporary opt-in while we disable automatic source fallback for
-> security reasons (silently switching from a dist to a less-trusted or manipulated
-> source may have security implications). If you have a legitimate use case for this
-> and do not want us to remove it in 2.11, please open an issue at
-> https://github.com/composer/composer/issues to let us know.
+> Do not set it unless you absolutely need to. It exists as a temporary opt-in
+> while we disable the dist → source fallback for security reasons (silently
+> switching from a dist to a less-trusted or manipulated source checkout has
+> security implications). If you have a legitimate use case for re-enabling
+> the dist → source fallback and do not want us to remove it in 2.11, please
+> open an issue at https://github.com/composer/composer/issues to let us know.
 
-Defaults to `false`. When set to `true`, Composer will automatically fall back
-to an alternative installation source (e.g., from dist to source or vice versa)
-when a download fails. Leave at `false` (the default) to fail immediately if
-the preferred source is unavailable.
+Defaults to `false`. When set to `true`, a failed **dist** install will fall
+back to a **source** checkout. This option only governs the dist → source
+direction; falling back from a failed source checkout to the dist artifact is
+always allowed regardless of this setting.
 
 ```json
 {
@@ -135,10 +150,10 @@ the preferred source is unavailable.
 }
 ```
 
-> **Note:** With this option disabled (the default) and a download failing,
-> Composer immediately throws an error instead of trying alternative sources.
-> Make sure your preferred installation source (`preferred-install`) is
-> correctly configured.
+> **Note:** With this option at its default (`false`) and a dist download
+> failing, Composer throws an error immediately instead of trying a source
+> checkout. Make sure your preferred installation source (`preferred-install`)
+> is correctly configured.
 
 ## policy
 

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -217,8 +217,13 @@ class DownloadManager
 
             $handleError = function ($e) use ($sources, $source, $package, $io, $download) {
                 if ($e instanceof \RuntimeException && !$e instanceof IrrecoverableDownloadException) {
-                    if (count($sources) === 0 || !$this->sourceFallback) {
-                        if (!$this->sourceFallback && count($sources) > 0) {
+                    $nextSource = $sources[0] ?? null;
+                    // Only fallback from dist to source is gated by the sourceFallback flag, as it can
+                    // silently switch to less-trusted code or cause other issues where people rely on dists.
+                    // Falling back the other way around (source -> dist) is always allowed.
+                    $blocked = $nextSource === 'source' && !$this->sourceFallback;
+                    if ($nextSource === null || $blocked) {
+                        if ($blocked) {
                             $io->writeError(
                                 '    <warning>Failed to download '.
                                 $package->getPrettyName().

--- a/tests/Composer/Test/Downloader/DownloadManagerTest.php
+++ b/tests/Composer/Test/Downloader/DownloadManagerTest.php
@@ -1255,6 +1255,77 @@ class DownloadManagerTest extends TestCase
         $manager->download($package, 'target_dir');
     }
 
+    public function testDownloadFallsBackFromSourceToDistByDefault(): void
+    {
+        $package = $this->createPackageMock();
+        $package
+            ->expects($this->once())
+            ->method('getSourceType')
+            ->will($this->returnValue('git'));
+        $package
+            ->expects($this->once())
+            ->method('getDistType')
+            ->will($this->returnValue('pear'));
+        $package
+            ->expects($this->any())
+            ->method('getPrettyString')
+            ->will($this->returnValue('prettyPackage'));
+        $package
+            ->expects($this->any())
+            ->method('getPrettyName')
+            ->will($this->returnValue('foo/bar'));
+
+        $package
+            ->expects($this->exactly(2))
+            ->method('setInstallationSource')
+            ->willReturnCallback(static function ($type) {
+                static $series = [
+                    'source',
+                    'dist',
+                ];
+
+                self::assertSame(array_shift($series), $type);
+            });
+
+        $downloaderFail = $this->createDownloaderMock();
+        $downloaderFail
+            ->expects($this->once())
+            ->method('download')
+            ->with($package, 'target_dir')
+            ->will($this->throwException(new \RuntimeException("Foo")));
+
+        $downloaderSuccess = $this->createDownloaderMock();
+        $downloaderSuccess
+            ->expects($this->once())
+            ->method('download')
+            ->with($package, 'target_dir')
+            ->will($this->returnValue(\React\Promise\resolve(null)));
+
+        $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
+            ->setConstructorArgs([$this->io, true, $this->filesystem])
+            ->onlyMethods(['getDownloaderForPackage'])
+            ->getMock();
+        $manager
+            ->expects($this->exactly(2))
+            ->method('getDownloaderForPackage')
+            ->with($package)
+            ->willReturnOnConsecutiveCalls(
+                $downloaderFail,
+                $downloaderSuccess
+            );
+
+        // 2 writeError calls fire: "Failed to download from source" and
+        // "Now trying to download from dist" during the retry. No deprecation
+        // warning, no "Source fallback is disabled" warning — source-fallback
+        // only governs the dist → source direction.
+        $this->io
+            ->expects($this->exactly(2))
+            ->method('writeError');
+
+        // Do NOT call setSourceFallback — fallback to dist must work by default.
+        $manager->download($package, 'target_dir');
+    }
+
     /**
      * @return \Composer\Downloader\DownloaderInterface&\PHPUnit\Framework\MockObject\MockObject
      */


### PR DESCRIPTION
Fixes #12887

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
