### PR TITLE
feat: add `strict-psr-autoloader` to options

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -124,7 +124,7 @@ resolution.
 * **--classmap-authoritative (-a):** Autoload classes from the classmap only.
   Implicitly enables `--optimize-autoloader`.
 * **--strict-psr-autoloader:** Return a failed exit code (6) if PSR-4 or PSR-0 mapping errors
-  are present in the current project (dependencies excluded). Requires `--optimize-autoloader` to work.
+  are present in the current project (dependencies excluded). Requires `--optimize-autoloader` or `--classmap-authoritative` to work
 * **--apcu-autoloader:** Use APCu to cache found/not-found classes.
 * **--apcu-autoloader-prefix:** Use a custom prefix for the APCu autoloader cache.
   Implicitly enables `--apcu-autoloader`.
@@ -219,7 +219,7 @@ php composer.phar update vendor/package:2.0.1 vendor/package2:3.0.*
 * **--classmap-authoritative (-a):** Autoload classes from the classmap only.
   Implicitly enables `--optimize-autoloader`.
 * **--strict-psr-autoloader:** Return a failed exit code (6) if PSR-4 or PSR-0 mapping errors
-  are present in the current project (dependencies excluded). Requires `--optimize-autoloader` to work.
+  are present in the current project (dependencies excluded). Requires `--optimize-autoloader` or `--classmap-authoritative` to work
 * **--apcu-autoloader:** Use APCu to cache found/not-found classes.
 * **--apcu-autoloader-prefix:** Use a custom prefix for the APCu autoloader cache.
   Implicitly enables `--apcu-autoloader`.

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -1169,6 +1169,12 @@ otherwise, a random suffix will be generated.
 
 Defaults to `false`. If `true`, always optimize when dumping the autoloader.
 
+## strict-psr-autoloader
+
+Defaults to `false`. If `true`, Return a failed exit code (6)
+if PSR-4 or PSR-0 mapping errors are present in the current project (dependencies excluded)
+Requires `optimize-autoloader` or `classmap-authoritative` to be enabled to work"
+
 ## sort-packages
 
 Defaults to `false`. If `true`, the `require` command keeps packages sorted

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -994,6 +994,10 @@
                     "type": "boolean",
                     "description": "Always optimize when dumping the autoloader."
                 },
+                "strict-psr-autoloader": {
+                    "type": "boolean",
+                    "description": "Return a failed exit code (6) if PSR-4 or PSR-0 mapping error are present in the current project (dependencies excluded). Requires \"optimize-autoloader\" or \"classmap-authoritative\" to be enabled to work"
+                },
                 "prepend-autoloader": {
                     "type": "boolean",
                     "description": "If false, the composer autoloader will not be prepended to existing autoloaders, defaults to true."

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -427,6 +427,7 @@ EOT
             }],
             'sort-packages' => [$booleanValidator, $booleanNormalizer],
             'optimize-autoloader' => [$booleanValidator, $booleanNormalizer],
+            'strict-psr-autoloader' => [$booleanValidator, $booleanNormalizer],
             'classmap-authoritative' => [$booleanValidator, $booleanNormalizer],
             'apcu-autoloader' => [$booleanValidator, $booleanNormalizer],
             'prepend-autoloader' => [$booleanValidator, $booleanNormalizer],

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -57,7 +57,7 @@ class InstallCommand extends BaseCommand
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
-                new InputOption('strict-psr-autoloader', null, InputOption::VALUE_NONE, 'Return a failed status code (6) if PSR-4 or PSR-0 mapping errors are present. Requires --optimize-autoloader to work.'),
+                new InputOption('strict-psr-autoloader', null, InputOption::VALUE_NONE, 'Return a failed status code (6) if PSR-4 or PSR-0 mapping errors are present. Requires --optimize-autoloader or --classmap-authoritative to work.'),
                 new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
                 new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
@@ -118,10 +118,11 @@ EOT
 
         $optimize = $input->getOption('optimize-autoloader') || $config->get('optimize-autoloader');
         $authoritative = $input->getOption('classmap-authoritative') || $config->get('classmap-authoritative');
+        $strictPsrAutoloader = $input->getOption('strict-psr-autoloader') || $config->get('strict-psr-autoloader');
         $apcuPrefix = $input->getOption('apcu-autoloader-prefix');
         $apcu = $apcuPrefix !== null || $input->getOption('apcu-autoloader') || $config->get('apcu-autoloader');
 
-        if ($input->getOption('strict-psr-autoloader') && !$optimize && !$authoritative) {
+        if ($strictPsrAutoloader && !$optimize && !$authoritative) {
             throw new \InvalidArgumentException('--strict-psr-autoloader mode only works with optimized autoloader, use --optimize-autoloader or --classmap-authoritative if you want a strict return value.');
         }
 
@@ -137,7 +138,7 @@ EOT
             ->setDumpAutoloader(!$input->getOption('no-autoloader'))
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)
-            ->setStrictPsrAutoloader($input->getOption('strict-psr-autoloader'))
+            ->setStrictPsrAutoloader($strictPsrAutoloader)
             ->setApcuAutoloader($apcu, $apcuPrefix)
             ->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input))
             ->setPolicyConfig($this->createPolicyConfig($composer->getConfig(), $input))

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -76,7 +76,7 @@ class UpdateCommand extends BaseCommand
                 new InputOption('verbose', 'v|vv|vvv', InputOption::VALUE_NONE, 'Shows more details including new commits pulled in when updating packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump.'),
                 new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
-                new InputOption('strict-psr-autoloader', null, InputOption::VALUE_NONE, 'Return a failed status code (6) if PSR-4 or PSR-0 mapping errors are present. Requires --optimize-autoloader to work.'),
+                new InputOption('strict-psr-autoloader', null, InputOption::VALUE_NONE, 'Return a failed status code (6) if PSR-4 or PSR-0 mapping errors are present. Requires --optimize-autoloader or --classmap-authoritative to work.'),
                 new InputOption('apcu-autoloader', null, InputOption::VALUE_NONE, 'Use APCu to cache found/not-found classes.'),
                 new InputOption('apcu-autoloader-prefix', null, InputOption::VALUE_REQUIRED, 'Use a custom prefix for the APCu autoloader cache. Implicitly enables --apcu-autoloader'),
                 new InputOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore a specific platform requirement (php & ext- packages).'),
@@ -259,11 +259,12 @@ EOT
 
         $optimize = $input->getOption('optimize-autoloader') || $config->get('optimize-autoloader');
         $authoritative = $input->getOption('classmap-authoritative') || $config->get('classmap-authoritative');
+        $strictPsrAutoloader = $input->getOption('strict-psr-autoloader') || $config->get('strict-psr-autoloader');
         $apcuPrefix = $input->getOption('apcu-autoloader-prefix');
         $apcu = $apcuPrefix !== null || $input->getOption('apcu-autoloader') || $config->get('apcu-autoloader');
         $minimalChanges = $input->getOption('minimal-changes') || $config->get('update-with-minimal-changes');
 
-        if ($input->getOption('strict-psr-autoloader') && !$optimize && !$authoritative) {
+        if ($strictPsrAutoloader && !$optimize && !$authoritative) {
             throw new \InvalidArgumentException('--strict-psr-autoloader mode only works with optimized autoloader, use --optimize-autoloader or --classmap-authoritative if you want a strict return value.');
         }
 
@@ -283,7 +284,7 @@ EOT
             ->setDumpAutoloader(!$input->getOption('no-autoloader'))
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)
-            ->setStrictPsrAutoloader($input->getOption('strict-psr-autoloader'))
+            ->setStrictPsrAutoloader($strictPsrAutoloader)
             ->setApcuAutoloader($apcu, $apcuPrefix)
             ->setUpdate(true)
             ->setInstall(!$input->getOption('no-install'))

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -62,6 +62,7 @@ class Config
         'autoloader-suffix' => null,
         'sort-packages' => false,
         'optimize-autoloader' => false,
+        'strict-psr-autoloader' => false,
         'classmap-authoritative' => false,
         'apcu-autoloader' => false,
         'prepend-autoloader' => true,
@@ -417,6 +418,7 @@ class Config
             case 'use-github-api':
             case 'lock':
             case 'source-fallback':
+            case 'strict-psr-autoloader':
                 // special case for secure-http
                 if ($key === 'secure-http' && $this->get('disable-tls') === true) {
                     return false;

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -686,4 +686,26 @@ class ConfigTest extends TestCase
         self::assertTrue($config->get('source-fallback'));
     }
 
+    public function testStrictPsrAutoloaderDefaultsToFalse(): void
+    {
+        $config = new Config(false);
+        self::assertFalse($config->get('strict-psr-autoloader'));
+    }
+
+    public function testStrictPsrAutoloaderCanBeDisabled(): void
+    {
+        $config = new Config(false);
+        $config->merge(['config' => ['strict-psr-autoloader' => false]]);
+        self::assertFalse($config->get('strict-psr-autoloader'));
+    }
+
+    public function testStrictPsrAutoloaderCanBeSetFromString(): void
+    {
+        $config = new Config(false);
+        $config->merge(['config' => ['strict-psr-autoloader' => 'false']]);
+        self::assertFalse($config->get('strict-psr-autoloader'));
+
+        $config->merge(['config' => ['strict-psr-autoloader' => 'true']]);
+        self::assertTrue($config->get('strict-psr-autoloader'));
+    }
 }


### PR DESCRIPTION
I noticed as a part of #12647 it's not possible to set this in your composer.json my changes should let you do something like this.
```json
    "config": {
        "optimize-autoloader": true,
        "strict-psr-autoloader": true,
    },
```

This is my first time looking into the composer code base so I based a lot of my changes on #12698 If I missed anything or you want me to makes changes I'd be more then happy.

