### PR TITLE
Add zizmor security analysis and harden workflows on 1.10

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,13 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --no-suggest --prefer-dist"
 
@@ -49,10 +56,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           extensions: "intl"
@@ -64,7 +73,7 @@ jobs:
         run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
 
       - name: "Cache dependencies installed with composer"
-        uses: "actions/cache@v1"
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "${{ steps.determine-composer-cache-directory.outputs.directory }}"
           key: "php-${{ matrix.php-version }}-symfony-php-unit-version-${{ env.SYMFONY_PHPUNIT_VERSION }}-${{ hashFiles('**/composer.lock') }}"
@@ -72,18 +81,18 @@ jobs:
 
       - name: "Install highest dependencies from composer.json using composer binary provided by system"
         if: "matrix.dependencies == 'highest'"
-        run: "composer config platform --unset && composer update ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer config platform --unset && composer update $COMPOSER_FLAGS'
 
       - name: "Install lowest dependencies from composer.json using composer binary provided by system"
         if: "matrix.dependencies == 'lowest'"
-        run: "composer update ${{ env.COMPOSER_FLAGS }} --prefer-lowest"
+        run: 'composer update $COMPOSER_FLAGS --prefer-lowest'
 
       - name: "Install dependencies from composer.lock using composer binary provided by system"
         if: "matrix.dependencies == 'locked'"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Run install again using composer binary from source"
-        run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer install $COMPOSER_FLAGS'
 
       - name: "Validate composer.json"
         run: "bin/composer validate"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,13 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: "Lint"
@@ -22,10 +29,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           extensions: "intl"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,30 +5,40 @@ on:
     tags:
       - "*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+permissions: {}
+
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --no-suggest --prefer-dist"
 
 jobs:
   build:
+    permissions:
+      contents: write # for gh to create a release
+      id-token: write # for actions/attest to create a attestation certificate
+      attestations: write # for actions/attest to upload the attestation
     name: Upload Release Asset
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           extensions: "intl"
           ini-values: "memory_limit=-1"
           php-version: "8.0"
+          tools: "composer:snapshot"
 
       - name: "Install dependencies from composer.lock using composer binary provided by system"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Run install again using composer binary from source"
-        run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer install $COMPOSER_FLAGS'
 
       - name: "Validate composer.json"
         run: "bin/composer validate"
@@ -36,40 +46,49 @@ jobs:
       - name: Build phar file
         run: "php -d phar.readonly=0 bin/compile"
 
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate build provenance attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: true
-          body: TODO
+          subject-path: '${{ github.workspace }}/composer.phar'
 
-      - name: Upload phar
-        uses: actions/upload-release-asset@v1
+      - name: Configure GPG key and sign phar
+        run: |
+          mkdir -p ~/.gnupg/
+          chmod 0700 ~/.gnupg/
+          echo "$GPG_SIGNING_KEY" > ~/.gnupg/private.key
+          gpg --import ~/.gnupg/private.key
+          gpg -u contact@packagist.com --detach-sign --output composer.phar.asc composer.phar
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./composer.phar
-          asset_name: composer.phar
-          asset_content_type: application/octet-stream
+          GPG_SIGNING_KEY: |
+            ${{ secrets.GPG_KEY_161DFBE342889F01DDAC4E61CBB3D576F2A0946F }}
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release create "$REF_NAME" --title "$REF_NAME" --notes TODO --draft --verify-tag
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release upload "$REF_NAME" composer.phar composer.phar.asc --clobber
 
       # This step requires a secret token with `pull` access to composer/docker. The default
       # secrets.GITHUB_TOKEN is scoped to this repository only which is not sufficient.
       - name: "Open issue @ Docker repository"
-        uses: actions/github-script@v2
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
         with:
           github-token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           script: |
-            // github.ref value looks like 'refs/tags/TAG', cleanup
-            const tag = "${{ github.ref }}".replace(/refs\/tags\//, '');
             // create new issue on Docker repository
-            github.issues.create({
-              owner: "${{ github.repository_owner }}",
+            github.rest.issues.create({
+              owner: process.env.REPO_OWNER,
               repo: "docker",
-              title: `New Composer tag: ${ tag }`,
-              body: `https://github.com/${{ github.repository }}/releases/tag/${ tag }`,
+              title: `New Composer tag: ${process.env.REF_NAME}`,
+              body: `https://github.com/${process.env.REPOSITORY}/releases/tag/${process.env.REF_NAME}`,
             });

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - '1.10'
+        paths:
+            - '.github/**.yml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@a16621b09c6db4281f81a93cb393b05dcd7b7165 # v0.5.5
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'


### PR DESCRIPTION
Brings the 1.10 maintenance branch up to the same GitHub Actions security bar as `main`.

## What's in here

- **New `zizmor.yml`** — runs zizmor in `pedantic` mode on pushes to `1.10` and on PRs, mirroring the workflow on `main` (trigger scoped to the `1.10` branch).
- **Hardened the three existing workflows** so a local `zizmor --persona pedantic .github` reports *No findings to report*:
  - Pinned every action to a commit SHA with a version comment (checkout `v6.0.2`, setup-php `2.37.1`, cache `v5.0.5`, github-script `v9.0.0`).
  - Added workflow-level `permissions: contents: read` and `concurrency` blocks; the release job keeps the `contents`/`id-token`/`attestations: write` scopes it needs (commented).
  - `persist-credentials: false` on read-only checkouts.
  - Replaced `${{ env.COMPOSER_FLAGS }}` interpolation inside `run:` blocks with the `$COMPOSER_FLAGS` shell variable (template-injection fix).
  - **`release.yml`** adopted from `main`: `gh release create/upload` instead of the now-archived `actions/create-release` + `actions/upload-release-asset`, plus GPG signing and build-provenance attestation. The phar is still built on **PHP 8.0** (1.10's existing build PHP) rather than 8.4.

## Notes

- No zizmor `ignore`/suppression comments are used — every finding is fixed with a real value.
- The release workflow now signs the phar and emits a provenance attestation, so it relies on the `GPG_KEY_…` and `PUBLIC_REPO_ACCESS_TOKEN` secrets being available on 1.10 builds (as on `main`).
- Dependabot is **not** included here — it only runs from the default branch, so 1.10 coverage will be added via a `target-branch: "1.10"` entry on `main` separately.
- The CI cache step still uses the deprecated `::set-output` — not a zizmor finding, left as-is to keep this PR scoped to zizmor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)