### PR TITLE
Add zizmor security analysis and harden workflows on 2.2

### DIFF
--- a/.github/workflows/close-stale-support.yml
+++ b/.github/workflows/close-stale-support.yml
@@ -4,16 +4,23 @@ on:
   schedule:
   - cron: '32 1 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   stale:
+    name: "Mark and close stale support issues"
 
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write # for actions/stale to label/close stale issues
+      pull-requests: write # for actions/stale to label/close stale pull requests
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 180

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
   COMPOSER_UPDATE_FLAGS: ""
@@ -65,10 +69,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           extensions: "intl, zip"
@@ -94,11 +100,11 @@ jobs:
 
       - name: "Update dependencies from composer.json using composer binary provided by system"
         if: "contains(matrix.dependencies, 'highest') || contains(matrix.dependencies, 'lowest')"
-        run: "composer update ${{ env.COMPOSER_UPDATE_FLAGS }} ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer update $COMPOSER_UPDATE_FLAGS $COMPOSER_FLAGS'
 
       - name: "Install dependencies from composer.lock using composer binary provided by system"
         if: "matrix.dependencies == 'locked'"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Remove platform config"
         run: composer config platform --unset
@@ -113,10 +119,10 @@ jobs:
         run: "echo \"SYMFONY_DEPRECATIONS_HELPER=baselineFile=./tests/deprecations-8.1.json&max[direct]=0\" >> $GITHUB_ENV"
 
       - name: "Update dev requirements to latest available for the current PHP even on locked builds as they are not bundled dependencies"
-        run: "composer update ${{ env.COMPOSER_FLAGS }} -W symfony/phpunit-bridge phpspec/prophecy phpdocumentor/* sebastian/* doctrine/instantiator"
+        run: 'composer update $COMPOSER_FLAGS -W symfony/phpunit-bridge phpspec/prophecy phpdocumentor/* sebastian/* doctrine/instantiator'
 
       - name: "Run install again using composer binary from source"
-        run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer install $COMPOSER_FLAGS'
 
       - name: "Prepare git environment"
         run: "git config --global user.name composer && git config --global user.email composer@example.com"
@@ -136,10 +142,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           extensions: "intl, zip"
@@ -148,7 +156,7 @@ jobs:
           tools: "composer:snapshot"
 
       - name: "Install dependencies"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Validate composer.json"
         run: "bin/composer validate --strict"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -25,10 +29,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           extensions: "intl"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
   SYMFONY_PHPUNIT_VERSION: ""
@@ -28,10 +32,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           extensions: "intl, zip"
@@ -44,18 +50,18 @@ jobs:
         run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
 
       - name: "Cache dependencies installed with composer"
-        uses: "actions/cache@v4"
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "${{ steps.determine-composer-cache-directory.outputs.directory }}"
           key: "php-${{ matrix.php-version }}-symfony-php-unit-version-${{ env.SYMFONY_PHPUNIT_VERSION }}-${{ hashFiles('**/composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-symfony-php-unit-version-${{ env.SYMFONY_PHPUNIT_VERSION }}"
 
       - name: "Install highest dependencies from composer.json using composer binary provided by system"
-        run: "composer config platform --unset && composer update ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer config platform --unset && composer update $COMPOSER_FLAGS'
 
       - name: "Install PHPStan"
         # Locked to phpunit 7.5 here as newer ones have void return types which break inheritance
-        run: "bin/composer require --dev phpstan/phpstan:1.4.* phpstan/phpstan-phpunit:1.0.* phpstan/phpstan-deprecation-rules:1.0.* phpstan/phpstan-strict-rules:1.1.* phpunit/phpunit:^7.5.20 --with-all-dependencies ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer require --dev phpstan/phpstan:1.4.* phpstan/phpstan-phpunit:1.0.* phpstan/phpstan-deprecation-rules:1.0.* phpstan/phpstan-strict-rules:1.1.* phpunit/phpunit:^7.5.20 --with-all-dependencies $COMPOSER_FLAGS'
 
       - name: "Run PHPStan"
         run: "vendor/bin/phpstan analyse --configuration=phpstan/config.neon"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: read
 
@@ -20,9 +23,11 @@ jobs:
     name: Upload Release Asset
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           extensions: "intl"
@@ -31,10 +36,10 @@ jobs:
           tools: "composer:snapshot"
 
       - name: "Install dependencies from composer.lock using composer binary provided by system"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'composer install $COMPOSER_FLAGS'
 
       - name: "Run install again using composer binary from source"
-        run: "bin/composer install ${{ env.COMPOSER_FLAGS }}"
+        run: 'bin/composer install $COMPOSER_FLAGS'
 
       - name: "Validate composer.json"
         run: "bin/composer validate"
@@ -61,24 +66,30 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes TODO --draft --verify-tag
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release create "$REF_NAME" --title "$REF_NAME" --notes TODO --draft --verify-tag
 
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.ref_name }}" composer.phar composer.phar.asc --clobber
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release upload "$REF_NAME" composer.phar composer.phar.asc --clobber
 
       # This step requires a secret token with `pull` access to composer/docker. The default
       # secrets.GITHUB_TOKEN is scoped to this repository only which is not sufficient.
       - name: "Open issue @ Docker repository"
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
         with:
           github-token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           script: |
             // create new issue on Docker repository
             github.rest.issues.create({
-              owner: "${{ github.repository_owner }}",
+              owner: process.env.REPO_OWNER,
               repo: "docker",
-              title: `New Composer tag: ${{ github.ref_name }}`,
-              body: `https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}`,
+              title: `New Composer tag: ${process.env.REF_NAME}`,
+              body: `https://github.com/${process.env.REPOSITORY}/releases/tag/${process.env.REF_NAME}`,
             });

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - '2.2'
+        paths:
+            - '.github/**.yml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@a16621b09c6db4281f81a93cb393b05dcd7b7165 # v0.5.5
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'


### PR DESCRIPTION
Same treatment as the 1.10 PR (#12894), applied to the 2.2 maintenance branch.

## What's in here

- **New `zizmor.yml`** — runs zizmor in `pedantic` mode on pushes to `2.2` and on PRs, mirroring the workflow on `main` (trigger scoped to the `2.2` branch).
- **Hardened the five existing workflows** so a local `zizmor --persona pedantic .github` reports *No findings to report*:
  - Pinned every action to a commit SHA with a version comment (checkout `v6.0.2`, setup-php `2.37.1`, cache `v5.0.5`, stale `v10.3.0`).
  - **Bumped `setup-php` in `release.yml` off `2.36.0`** — zizmor's `known-vulnerable-actions` audit flagged it — up to `2.37.1`.
  - Added `concurrency` blocks to every workflow (release uses a non-cancelling group); `persist-credentials: false` on read-only checkouts.
  - Replaced `${{ env.COMPOSER_FLAGS }}` / `${{ env.COMPOSER_UPDATE_FLAGS }}` interpolation inside `run:` blocks with the corresponding `$COMPOSER_FLAGS` shell variables.
  - In `release.yml`, moved the `${{ github.* }}` expansions in the `gh release` and `github-script` steps into `env:` vars referenced as `$REF_NAME` / `process.env.*` (template-injection fix).
  - `close-stale-support.yml`: added workflow-level `permissions: {}`, a job `name:`, and explanatory comments on the `issues`/`pull-requests: write` permissions.

## Notes

- No zizmor `ignore`/suppression comments are used — every finding is fixed with a real value.
- Workflow behavior is otherwise preserved: matrices, PHP versions, the release signing/attestation flow (kept on `actions/attest-build-provenance`), and the stale-bot options are unchanged.
- Dependabot is **not** included here — it only runs from the default branch, so 2.2 coverage should be added via a `target-branch: "2.2"` entry on `main` separately.
- The CI/phpstan cache steps still use the deprecated `::set-output` — not a zizmor finding, left as-is to keep this PR scoped to zizmor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)