### PR TITLE
Fix shell escaping in config --editor

### DIFF
--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -196,11 +196,11 @@ EOT
                     }
                 }
             } else {
-                $editor = escapeshellcmd($editor);
+                $editor = escapeshellarg($editor);
             }
 
             $file = $input->getOption('auth') ? $this->authConfigFile->getPath() : $this->configFile->getPath();
-            system($editor . ' ' . $file . (Platform::isWindows() ? '' : ' > `tty`'));
+            system($editor . ' ' . escapeshellarg($file) . (Platform::isWindows() ? '' : ' > `tty`'));
 
             return 0;
         }

--- a/tests/Composer/Test/AllFunctionalTest.php
+++ b/tests/Composer/Test/AllFunctionalTest.php
@@ -121,7 +121,7 @@ class AllFunctionalTest extends TestCase
             'COMPOSER_CACHE_DIR' => $this->testDir.'cache',
         ];
 
-        $proc = Process::fromShellCommandline(escapeshellcmd(PHP_BINARY).' '.escapeshellarg(self::$pharPath).' --no-ansi '.$testData['RUN'], $this->testDir, $env, null, 300);
+        $proc = Process::fromShellCommandline(escapeshellarg(PHP_BINARY).' '.escapeshellarg(self::$pharPath).' --no-ansi '.$testData['RUN'], $this->testDir, $env, null, 300);
         $output = '';
 
         $exitCode = $proc->run(static function ($type, $buffer) use (&$output): void {


### PR DESCRIPTION
This fixes config --editor by escaping the file path before passing it to system(), preventing shell metacharacters in the path from being interpreted as commands.