### PR TITLE
Fix audit output to use stdout for summary messages

### DIFF
--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -193,7 +193,7 @@ class Auditor
             $punctuation = $format === self::FORMAT_SUMMARY ? '.' : ':';
             $style = $filteredCount > 0 ? 'error' : 'warning';
 
-            $io->writeError(sprintf('<%s>Found %d package%s matching filters%s</%s>', $style, count($filteredPackages), $plurality, $punctuation, $style));
+            $io->write(sprintf('<%s>Found %d package%s matching filters%s</%s>', $style, count($filteredPackages), $plurality, $punctuation, $style));
             if ($format !== self::FORMAT_SUMMARY) {
                 $this->outputFilteredPackages($io, $filteredPackages, $format);
             }
@@ -419,7 +419,7 @@ class Auditor
                 $firstAdvisory = false;
             }
         }
-        $io->writeError($error);
+        $io->write($error);
     }
 
     /**
@@ -428,14 +428,14 @@ class Auditor
      */
     private function outputAbandonedPackages(IOInterface $io, array $packages, string $format): void
     {
-        $io->writeError(sprintf('<error>Found %d abandoned package%s:</error>', count($packages), count($packages) > 1 ? 's' : ''));
+        $io->write(sprintf('<error>Found %d abandoned package%s:</error>', count($packages), count($packages) > 1 ? 's' : ''));
 
         if ($format === self::FORMAT_PLAIN) {
             foreach ($packages as $pkg) {
                 $replacement = $pkg->getReplacementPackage() !== null
                     ? 'Use '.$pkg->getReplacementPackage().' instead'
                     : 'No replacement was suggested';
-                $io->writeError(sprintf(
+                $io->write(sprintf(
                     '%s is abandoned. %s.',
                     $this->getPackageNameWithLink($pkg),
                     $replacement
@@ -523,7 +523,7 @@ class Auditor
                     if ($entry->url !== null) {
                         $parts[] = 'URL: ' . $entry->url;
                     }
-                    $io->writeError(implode('. ', $parts) . '.');
+                    $io->write(implode('. ', $parts) . '.');
                 }
             }
 

--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -165,17 +165,18 @@ class Auditor
                     $plurality = $totalAdvisoryCount === 1 ? 'y' : 'ies';
                     $pkgPlurality = $pkgCount === 1 ? '' : 's';
                     $punctuation = $format === 'summary' ? '.' : ':';
-                    $io->writeError(sprintf($message, $totalAdvisoryCount, $plurality, $pkgCount, $pkgPlurality, $punctuation));
+                    $io->write(sprintf($message, $totalAdvisoryCount, $plurality, $pkgCount, $pkgPlurality, $punctuation));
                     $this->outputAdvisories($io, $advisoriesToOutput, $format);
                 }
             }
 
             if ($format === self::FORMAT_SUMMARY) {
-                $io->writeError('Run "composer audit" for a full list of advisories.');
+                $io->write('Run "composer audit" for a full list of advisories.');
             }
         } else {
-            $io->writeError('<info>No security vulnerability advisories found.</info>');
+            $io->write('<info>No security vulnerability advisories found.</info>');
         }
+    
 
         if (count($unreachableRepos) > 0) {
             $io->writeError('<warning>The following repositories were unreachable:</warning>');
@@ -419,7 +420,7 @@ class Auditor
                 $firstAdvisory = false;
             }
         }
-        $io->writeError($error);
+        $io->write($error);
     }
 
     /**

--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -176,7 +176,6 @@ class Auditor
         } else {
             $io->write('<info>No security vulnerability advisories found.</info>');
         }
-    
 
         if (count($unreachableRepos) > 0) {
             $io->writeError('<warning>The following repositories were unreachable:</warning>');
@@ -420,7 +419,7 @@ class Auditor
                 $firstAdvisory = false;
             }
         }
-        $io->write($error);
+        $io->writeError($error);
     }
 
     /**


### PR DESCRIPTION
Fix audit summary output to use stdout instead of stderr for CLI redirection compatibility.

## Problem
composer audit output was using writeError() for summary messages, causing issues when redirecting output to files or pipes.

## Fix
Changed summary-level output to use write() instead of writeError().

## Impact
- Improves CLI redirection support
- Makes `composer audit > file.txt` work correctly

Fixes #12901