### PR TITLE
Check for local changes when switching a package from source to dist

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -1036,6 +1036,11 @@ parameters:
 			path: ../src/Composer/Downloader/DownloadManager.php
 
 		-
+			message: "#^Cannot call method prepare\\(\\) on Composer\\\\Downloader\\\\DownloaderInterface\\|null\\.$#"
+			count: 1
+			path: ../src/Composer/Downloader/DownloadManager.php
+
+		-
 			message: "#^Cannot call method remove\\(\\) on Composer\\\\Downloader\\\\DownloaderInterface\\|null\\.$#"
 			count: 1
 			path: ../src/Composer/Downloader/DownloadManager.php

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -349,7 +349,17 @@ class DownloadManager
 
         // if downloader type changed, or update failed and user asks for reinstall,
         // we wipe the dir and do a new install instead of updating it
-        $promise = $initialDownloader->remove($initial, $targetDir);
+        $promise = \React\Promise\resolve(null);
+        if ($initialType !== $targetType) {
+            // on a type change the existing source install is about to be wiped, so
+            // run its uninstall guard first to avoid silently dropping local changes
+            // in a modified VCS checkout
+            $promise = $initialDownloader->prepare('uninstall', $initial, $targetDir);
+        }
+
+        $promise = $promise->then(function ($res) use ($initialDownloader, $initial, $targetDir): PromiseInterface {
+            return $initialDownloader->remove($initial, $targetDir);
+        });
 
         return $promise->then(function ($res) use ($target, $targetDir): PromiseInterface {
             return $this->install($target, $targetDir);

--- a/tests/Composer/Test/Downloader/DownloadManagerTest.php
+++ b/tests/Composer/Test/Downloader/DownloadManagerTest.php
@@ -619,6 +619,11 @@ class DownloadManagerTest extends TestCase
         $xzDownloader = $this->createDownloaderMock();
         $xzDownloader
             ->expects($this->once())
+            ->method('prepare')
+            ->with('uninstall', $initial, 'vendor/bundles/FOS/UserBundle')
+            ->will($this->returnValue(\React\Promise\resolve(null)));
+        $xzDownloader
+            ->expects($this->once())
             ->method('remove')
             ->with($initial, 'vendor/bundles/FOS/UserBundle')
             ->will($this->returnValue(\React\Promise\resolve(null)));
@@ -642,6 +647,115 @@ class DownloadManagerTest extends TestCase
         $manager->setDownloader('xz', $xzDownloader);
         $manager->setDownloader('zip', $zipDownloader);
 
+        $manager->update($initial, $target, 'vendor/bundles/FOS/UserBundle');
+    }
+
+    public function testUpdateRunsRemovalGuardWhenDownloaderTypeChanges(): void
+    {
+        $initial = $this->createPackageMock();
+        $initial
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('source'));
+        $initial
+            ->expects($this->any())
+            ->method('getSourceType')
+            ->will($this->returnValue('git'));
+
+        $target = $this->createPackageMock();
+        $target
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('dist'));
+        $target
+            ->expects($this->any())
+            ->method('getDistType')
+            ->will($this->returnValue('zip'));
+
+        $sourceDownloader = $this->createDownloaderMock();
+        $sourceDownloader
+            ->expects($this->once())
+            ->method('prepare')
+            ->with('uninstall', $initial, 'vendor/bundles/FOS/UserBundle')
+            ->will($this->returnValue(\React\Promise\resolve(null)));
+        $sourceDownloader
+            ->expects($this->once())
+            ->method('remove')
+            ->with($initial, 'vendor/bundles/FOS/UserBundle')
+            ->will($this->returnValue(\React\Promise\resolve(null)));
+        $sourceDownloader
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('source'));
+
+        $distDownloader = $this->createDownloaderMock();
+        $distDownloader
+            ->expects($this->once())
+            ->method('install')
+            ->with($target, 'vendor/bundles/FOS/UserBundle')
+            ->will($this->returnValue(\React\Promise\resolve(null)));
+        $distDownloader
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('dist'));
+
+        $manager = new DownloadManager($this->io, false, $this->filesystem);
+        $manager->setDownloader('git', $sourceDownloader);
+        $manager->setDownloader('zip', $distDownloader);
+
+        $manager->update($initial, $target, 'vendor/bundles/FOS/UserBundle');
+    }
+
+    public function testUpdateDoesNotWipeWhenRemovalGuardAborts(): void
+    {
+        $initial = $this->createPackageMock();
+        $initial
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('source'));
+        $initial
+            ->expects($this->any())
+            ->method('getSourceType')
+            ->will($this->returnValue('git'));
+
+        $target = $this->createPackageMock();
+        $target
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('dist'));
+        $target
+            ->expects($this->any())
+            ->method('getDistType')
+            ->will($this->returnValue('zip'));
+
+        $sourceDownloader = $this->createDownloaderMock();
+        $sourceDownloader
+            ->expects($this->once())
+            ->method('prepare')
+            ->with('uninstall', $initial, 'vendor/bundles/FOS/UserBundle')
+            ->will($this->throwException(new \RuntimeException('Source directory has uncommitted changes.')));
+        $sourceDownloader
+            ->expects($this->never())
+            ->method('remove');
+        $sourceDownloader
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('source'));
+
+        $distDownloader = $this->createDownloaderMock();
+        $distDownloader
+            ->expects($this->never())
+            ->method('install');
+        $distDownloader
+            ->expects($this->any())
+            ->method('getInstallationSource')
+            ->will($this->returnValue('dist'));
+
+        $manager = new DownloadManager($this->io, false, $this->filesystem);
+        $manager->setDownloader('git', $sourceDownloader);
+        $manager->setDownloader('zip', $distDownloader);
+
+        self::expectException('RuntimeException');
         $manager->update($initial, $target, 'vendor/bundles/FOS/UserBundle');
     }
 


### PR DESCRIPTION
A `composer update` that switches a package from a source install to a dist install wiped the whole directory, including its `.git` and any local commits, because the removal skipped the local-changes check that a same-source update runs. The source downloader's uninstall guard now runs first on a type change, so the switch aborts on uncommitted or unpushed work instead of deleting it.

Fixes #11567
