### PR TITLE
Avoid prompting for a GitHub token multiple times on parallel auth failures

### DIFF
--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -86,6 +86,13 @@ class AuthHelper
         $storeAuth = false;
 
         if (in_array($origin, $this->config->get('github-domains'), true)) {
+            // if two or more requests are started together for the same GitHub origin, the first one
+            // will prompt for and store a token; the others should retry with that token before
+            // prompting again, so the user is not asked for the same token multiple times
+            // see https://github.com/composer/composer/issues/12905
+            if ($this->io->hasAuthentication($origin) && $retryCount === 0) {
+                return ['retry' => true, 'storeAuth' => false];
+            }
             $gitHubUtil = new GitHub($this->io, $this->config, null);
             $message = "\n";
 

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -730,6 +730,34 @@ class AuthHelperTest extends TestCase
         self::assertSame($expectedResult, $authOrigin);
     }
 
+    public function testPromptAuthIfNeededMultipleGithubDownloads(): void
+    {
+        $origin = 'github.com';
+
+        $this->config->method('get')->willReturnMap([
+            ['github-domains', 0, ['github.com']],
+            ['gitlab-domains', 0, []],
+        ]);
+
+        // a parallel request already obtained and stored the token
+        $this->io->method('hasAuthentication')->with($origin)->willReturn(true);
+        // therefore no interactive prompt must happen
+        $this->io->expects($this->never())->method('ask');
+        $this->io->expects($this->never())->method('askAndHideAnswer');
+        $this->io->expects($this->never())->method('setAuthentication');
+
+        $result = $this->authHelper->promptAuthIfNeeded(
+            'https://api.github.com/repos/symfony/process/zipball/abc',
+            $origin,
+            403,
+            'HTTP/2 403 ',
+            [],
+            0 // retryCount === 0 → sibling should silently retry
+        );
+
+        self::assertSame(['retry' => true, 'storeAuth' => false], $result);
+    }
+
     public static function findAuthOriginProvider() : array
     {
         return [


### PR DESCRIPTION
Fixes #12905

On parallel GitHub 401/403s every failing request prompts for a token. The generic and
Bitbucket branches already guard against this, the GitHub one didn't. Added the same
`hasAuthentication() && retryCount === 0` retry guard + a test.
