### PR TITLE
Proof-of-Concept for issue #12922 with composer global update

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -304,8 +304,10 @@ class Application extends BaseApplication
                     $line = $details['line'];
                 }
 
-                $ghe = new GithubActionError($this->io);
-                $ghe->emit($e->getMessage(), $file, $line);
+                if (class_exists(GithubActionError::class)) {
+                    $ghe = new GithubActionError($this->io);
+                    $ghe->emit($e->getMessage(), $file, $line);
+                }
 
                 throw $e;
             }
@@ -469,8 +471,10 @@ class Application extends BaseApplication
 
             return $e->getCode();
         } catch (\Throwable $e) {
-            $ghe = new GithubActionError($this->io);
-            $ghe->emit($e->getMessage());
+            if (class_exists(GithubActionError::class)) {
+                $ghe = new GithubActionError($this->io);
+                $ghe->emit($e->getMessage());
+            }
 
             $this->hintCommonErrors($e, $output);
 

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -304,10 +304,8 @@ class Application extends BaseApplication
                     $line = $details['line'];
                 }
 
-                if (class_exists(GithubActionError::class)) {
-                    $ghe = new GithubActionError($this->io);
-                    $ghe->emit($e->getMessage(), $file, $line);
-                }
+                $ghe = new GithubActionError($this->io);
+                $ghe->emit($e->getMessage(), $file, $line);
 
                 throw $e;
             }
@@ -471,10 +469,8 @@ class Application extends BaseApplication
 
             return $e->getCode();
         } catch (\Throwable $e) {
-            if (class_exists(GithubActionError::class)) {
-                $ghe = new GithubActionError($this->io);
-                $ghe->emit($e->getMessage());
-            }
+            $ghe = new GithubActionError($this->io);
+            $ghe->emit($e->getMessage());
 
             $this->hintCommonErrors($e, $output);
 

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -135,6 +135,10 @@ class BinaryInstaller
         }
 
         $handle = fopen($bin, 'r');
+        if (false === $handle) {
+            return 'php';
+        }
+
         $line = fgets($handle);
         fclose($handle);
         if (Preg::isMatchStrictGroups('{^#!/(?:usr/bin/env )?(?:[^/]+/)*(.+)$}m', (string) $line, $match)) {

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -114,10 +114,10 @@ class BinaryInstaller
         }
         foreach ($binaries as $bin) {
             $link = $this->binDir.'/'.basename($bin);
-            if (is_link($link) || file_exists($link)) { // still checking for symlinks here for legacy support
+            if ((is_link($link) || file_exists($link)) && !$this->isCurrentProcessBinary($link)) { // still checking for symlinks here for legacy support
                 $this->filesystem->unlink($link);
             }
-            if (is_file($link.'.bat')) {
+            if (is_file($link.'.bat') && !$this->isCurrentProcessBinary($link)) {
                 $this->filesystem->unlink($link.'.bat');
             }
         }
@@ -170,8 +170,61 @@ class BinaryInstaller
 
     protected function installUnixyProxyBinaries(string $binPath, string $link): void
     {
+        if ($this->isCurrentProcessBinary($link)) {
+            return;
+        }
+
         file_put_contents($link, $this->generateUnixyProxyCode($binPath, $link));
         Silencer::call('chmod', $link, 0777 & ~umask());
+    }
+
+    private function isCurrentProcessBinary(string $link): bool
+    {
+        $candidates = [];
+        foreach (['SCRIPT_FILENAME', 'PHP_SELF'] as $serverKey) {
+            if (isset($_SERVER[$serverKey]) && is_string($_SERVER[$serverKey])) {
+                $candidates[] = $_SERVER[$serverKey];
+            }
+        }
+
+        if (isset($_SERVER['argv'][0]) && is_string($_SERVER['argv'][0])) {
+            $candidates[] = $_SERVER['argv'][0];
+        }
+
+        foreach (get_included_files() as $includedFile) {
+            $candidates[] = $includedFile;
+        }
+
+        if (isset($GLOBALS['_composer_bin_dir']) && is_string($GLOBALS['_composer_bin_dir'])) {
+            $candidates[] = $GLOBALS['_composer_bin_dir'].'/'.basename($link);
+            $candidates[] = $GLOBALS['_composer_bin_dir'].'/'.basename($link).'.bat';
+        }
+
+        $linkCandidates = [$link, $link.'.bat'];
+        foreach ($linkCandidates as $linkCandidate) {
+            $normalizedLink = $this->normalizeComparablePath($linkCandidate);
+            foreach ($candidates as $candidate) {
+                if ($normalizedLink === $this->normalizeComparablePath($candidate)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function normalizeComparablePath(string $path): string
+    {
+        $realpath = realpath($path);
+        if (is_string($realpath)) {
+            return $this->filesystem->normalizePath($realpath);
+        }
+
+        if (!$this->filesystem->isAbsolutePath($path)) {
+            $path = Platform::getCwd().'/'.$path;
+        }
+
+        return $this->filesystem->normalizePath($path);
     }
 
     protected function initializeBinDir(): void

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -447,29 +447,17 @@ class InstallationManager
             return;
         }
 
-        $currentComposerPackage = null;
-        foreach ($operations as $operation) {
-            $initialPackage = $this->getInitialPackageForOperation($operation);
-            if (null === $initialPackage) {
-                continue;
-            }
-
-            if ($initialPackage->getName() !== 'composer/composer') {
-                continue;
-            }
-
-            $installPath = $this->getPackageInstallPath($initialPackage);
-            if (null !== $installPath && $this->pathContainsFile($installPath, $composerClassFile)) {
-                $currentComposerPackage = $initialPackage;
-                break;
-            }
-        }
+        $currentComposerPackage = $this->getCurrentComposerPackage($repo, $composerClassFile);
 
         if (null === $currentComposerPackage) {
             return;
         }
 
         $runtimePackageNames = $this->getRuntimePackageNames($repo, $currentComposerPackage);
+        if (!$this->operationTouchesPackageNames($operations, $runtimePackageNames)) {
+            return;
+        }
+
         foreach ($operations as $operation) {
             $initialPackage = $this->getInitialPackageForOperation($operation);
             if (null === $initialPackage || !isset($runtimePackageNames[$initialPackage->getName()])) {
@@ -483,6 +471,43 @@ class InstallationManager
         }
 
         $this->runtimeClassesPreloaded = true;
+    }
+
+    /**
+     * @param OperationInterface[] $operations
+     * @param array<string, true> $packageNames
+     */
+    private function operationTouchesPackageNames(array $operations, array $packageNames): bool
+    {
+        foreach ($operations as $operation) {
+            $initialPackage = $this->getInitialPackageForOperation($operation);
+            if (null !== $initialPackage && isset($packageNames[$initialPackage->getName()])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getCurrentComposerPackage(InstalledRepositoryInterface $repo, string $composerClassFile): ?PackageInterface
+    {
+        $repoPackages = $repo->getPackages();
+        if (!is_array($repoPackages)) {
+            return null;
+        }
+
+        foreach ($repoPackages as $package) {
+            if ($package->getName() !== 'composer/composer') {
+                continue;
+            }
+
+            $installPath = $this->getPackageInstallPath($package);
+            if (null !== $installPath && $this->pathContainsFile($installPath, $composerClassFile)) {
+                return $package;
+            }
+        }
+
+        return null;
     }
 
     private function getInitialPackageForOperation(OperationInterface $operation): ?PackageInterface

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -12,6 +12,8 @@
 
 namespace Composer\Installer;
 
+use Composer\ClassMapGenerator\ClassMapGenerator;
+use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\IO\ConsoleIO;
 use Composer\Package\PackageInterface;
@@ -25,8 +27,10 @@ use Composer\DependencyResolver\Operation\MarkAliasInstalledOperation;
 use Composer\DependencyResolver\Operation\MarkAliasUninstalledOperation;
 use Composer\Downloader\FileDownloader;
 use Composer\EventDispatcher\EventDispatcher;
+use Composer\Util\Filesystem;
 use Composer\Util\Loop;
 use Composer\Util\Platform;
+use Composer\Util\Silencer;
 use React\Promise\PromiseInterface;
 use Seld\Signal\SignalHandler;
 
@@ -53,6 +57,8 @@ class InstallationManager
     private $eventDispatcher;
     /** @var bool */
     private $outputProgress;
+    /** @var bool */
+    private $runtimeClassesPreloaded = false;
 
     public function __construct(Loop $loop, IOInterface $io, ?EventDispatcher $eventDispatcher = null)
     {
@@ -182,6 +188,7 @@ class InstallationManager
     {
         /** @var array<callable(): ?PromiseInterface<void|null>> $cleanupPromises */
         $cleanupPromises = [];
+        $this->runtimeClassesPreloaded = false;
 
         $signalHandler = SignalHandler::create([SignalHandler::SIGINT, SignalHandler::SIGTERM, SignalHandler::SIGHUP], function (string $signal, SignalHandler $handler) use (&$cleanupPromises) {
             $this->io->writeError('Received '.$signal.', aborting', true, IOInterface::DEBUG);
@@ -334,6 +341,8 @@ class InstallationManager
         $promises = [];
         $postExecCallbacks = [];
 
+        $this->preloadRuntimeClassesBeforeSelfUpdate($repo, $operations);
+
         foreach ($operations as $index => $operation) {
             $opType = $operation->getOperationType();
 
@@ -414,6 +423,231 @@ class InstallationManager
         foreach ($postExecCallbacks as $cb) {
             $cb();
         }
+    }
+
+    /**
+     * When Composer is executed from a vendor install and that same install is being
+     * updated, packages can disappear before Composer lazily loads a class from them.
+     *
+     * @param OperationInterface[] $operations
+     */
+    private function preloadRuntimeClassesBeforeSelfUpdate(InstalledRepositoryInterface $repo, array $operations): void
+    {
+        if ($this->runtimeClassesPreloaded) {
+            return;
+        }
+
+        $composerClassFile = (new \ReflectionClass(Composer::class))->getFileName();
+        if (!is_string($composerClassFile)) {
+            return;
+        }
+
+        $composerClassFile = realpath($composerClassFile);
+        if (!is_string($composerClassFile)) {
+            return;
+        }
+
+        $currentComposerPackage = null;
+        foreach ($operations as $operation) {
+            $initialPackage = $this->getInitialPackageForOperation($operation);
+            if (null === $initialPackage) {
+                continue;
+            }
+
+            if ($initialPackage->getName() !== 'composer/composer') {
+                continue;
+            }
+
+            $installPath = $this->getPackageInstallPath($initialPackage);
+            if (null !== $installPath && $this->pathContainsFile($installPath, $composerClassFile)) {
+                $currentComposerPackage = $initialPackage;
+                break;
+            }
+        }
+
+        if (null === $currentComposerPackage) {
+            return;
+        }
+
+        $runtimePackageNames = $this->getRuntimePackageNames($repo, $currentComposerPackage);
+        foreach ($operations as $operation) {
+            $initialPackage = $this->getInitialPackageForOperation($operation);
+            if (null === $initialPackage || !isset($runtimePackageNames[$initialPackage->getName()])) {
+                continue;
+            }
+
+            $installPath = $this->getPackageInstallPath($initialPackage);
+            if (null !== $installPath) {
+                $this->preloadPackageClasses($initialPackage, $installPath);
+            }
+        }
+
+        $this->runtimeClassesPreloaded = true;
+    }
+
+    private function getInitialPackageForOperation(OperationInterface $operation): ?PackageInterface
+    {
+        if ($operation instanceof UpdateOperation) {
+            return $operation->getInitialPackage();
+        }
+
+        if ($operation instanceof UninstallOperation) {
+            return $operation->getPackage();
+        }
+
+        return null;
+    }
+
+    private function getPackageInstallPath(PackageInterface $package): ?string
+    {
+        $installPath = $this->getInstallPath($package);
+        if (null === $installPath) {
+            return null;
+        }
+
+        $realpath = realpath($installPath);
+        if (!is_string($realpath)) {
+            return null;
+        }
+
+        return $realpath;
+    }
+
+    private function pathContainsFile(string $path, string $file): bool
+    {
+        return strpos($this->normalizeComparablePath($file).'/', $this->normalizeComparablePath($path).'/') === 0;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function getRuntimePackageNames(InstalledRepositoryInterface $repo, PackageInterface $composerPackage): array
+    {
+        $packagesByName = [];
+        $repoPackages = $repo->getPackages();
+        if (!is_array($repoPackages)) {
+            return [$composerPackage->getName() => true];
+        }
+
+        foreach ($repoPackages as $package) {
+            if (!isset($packagesByName[$package->getName()])) {
+                $packagesByName[$package->getName()] = $package;
+            }
+        }
+
+        $runtimePackageNames = [];
+        $queue = [$composerPackage];
+        while ($package = array_shift($queue)) {
+            $runtimePackageNames[$package->getName()] = true;
+
+            foreach ($package->getRequires() as $link) {
+                $target = $link->getTarget();
+                if (isset($packagesByName[$target]) && !isset($runtimePackageNames[$target])) {
+                    $queue[] = $packagesByName[$target];
+                }
+            }
+        }
+
+        return $runtimePackageNames;
+    }
+
+    private function preloadPackageClasses(PackageInterface $package, string $installPath): void
+    {
+        $autoload = $package->getAutoload();
+        $classMap = $this->buildPackageClassMap($autoload, $installPath);
+        if ($classMap === []) {
+            return;
+        }
+
+        foreach ($classMap as $class => $path) {
+            if (class_exists($class, false) || interface_exists($class, false) || trait_exists($class, false) || (function_exists('enum_exists') && enum_exists($class, false))) {
+                continue;
+            }
+
+            $contents = file_get_contents($path);
+            if (is_string($contents) && strpos($contents, 'E_USER_DEPRECATED') !== false && strpos($contents, 'trigger_error') !== false) {
+                continue;
+            }
+
+            Silencer::suppress();
+            try {
+                require_once $path;
+            } catch (\Throwable $e) {
+                continue;
+            } finally {
+                Silencer::restore();
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $autoload
+     *
+     * @return array<class-string, non-empty-string>
+     */
+    private function buildPackageClassMap(array $autoload, string $installPath): array
+    {
+        $filesystem = new Filesystem;
+        $generator = (new ClassMapGenerator(['php', 'inc', 'hh']))->avoidDuplicateScans();
+
+        if (isset($autoload['classmap']) && is_array($autoload['classmap'])) {
+            foreach ($autoload['classmap'] as $path) {
+                if (!is_string($path)) {
+                    continue;
+                }
+
+                $this->scanPreloadPath($generator, $this->resolvePackageAutoloadPath($filesystem, $installPath, $path));
+            }
+        }
+
+        foreach (['psr-4', 'psr-0'] as $autoloadType) {
+            if (!isset($autoload[$autoloadType]) || !is_array($autoload[$autoloadType])) {
+                continue;
+            }
+
+            foreach ($autoload[$autoloadType] as $namespace => $paths) {
+                if (!is_string($namespace)) {
+                    continue;
+                }
+
+                foreach ((array) $paths as $path) {
+                    if (!is_string($path)) {
+                        continue;
+                    }
+
+                    $this->scanPreloadPath($generator, $this->resolvePackageAutoloadPath($filesystem, $installPath, $path), $autoloadType, ltrim($namespace, '\\'));
+                }
+            }
+        }
+
+        return $generator->getClassMap()->getMap();
+    }
+
+    /**
+     * @param 'classmap'|'psr-0'|'psr-4' $autoloadType
+     */
+    private function scanPreloadPath(ClassMapGenerator $generator, string $path, string $autoloadType = 'classmap', ?string $namespace = null): void
+    {
+        try {
+            $generator->scanPaths($path, null, $autoloadType, $namespace, ['vendor']);
+        } catch (\RuntimeException $e) {
+        }
+    }
+
+    private function resolvePackageAutoloadPath(Filesystem $filesystem, string $installPath, string $path): string
+    {
+        if ($path === '') {
+            return $installPath;
+        }
+
+        return $filesystem->normalizePath($filesystem->isAbsolutePath($path) ? $path : $installPath.'/'.$path);
+    }
+
+    private function normalizeComparablePath(string $path): string
+    {
+        $path = str_replace('\\', '/', $path);
+
+        return Platform::isWindows() ? strtolower($path) : $path;
     }
 
     /**

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -589,11 +589,6 @@ class InstallationManager
                 continue;
             }
 
-            $contents = file_get_contents($path);
-            if (is_string($contents) && strpos($contents, 'E_USER_DEPRECATED') !== false && strpos($contents, 'trigger_error') !== false) {
-                continue;
-            }
-
             Silencer::suppress();
             try {
                 require_once $path;

--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -163,10 +163,10 @@ class FilesystemRepository extends WritableArrayRepository
             $versions = $this->generateInstalledVersions($installationManager, $installPaths, $devMode, $repoDir);
 
             $this->filesystem->filePutContentsIfModified($repoDir.'/installed.php', '<?php return ' . $this->dumpToPhpCode($versions) . ';'."\n");
-            $installedVersionsClass = file_get_contents(__DIR__.'/../InstalledVersions.php');
+            $installedVersionsClass = $this->getInstalledVersionsClass();
 
             // this normally should not happen but during upgrades of Composer when it is installed in the project it is a possibility
-            if ($installedVersionsClass !== false) {
+            if (null !== $installedVersionsClass) {
                 $this->filesystem->filePutContentsIfModified($repoDir.'/InstalledVersions.php', $installedVersionsClass);
 
                 // make sure the in memory state is up to date with on disk
@@ -191,6 +191,21 @@ class FilesystemRepository extends WritableArrayRepository
                 }
             }
         }
+    }
+
+    private function getInstalledVersionsClass(): ?string
+    {
+        $installedVersionsClass = @file_get_contents(__DIR__.'/../InstalledVersions.php');
+        if ($installedVersionsClass !== false) {
+            return $installedVersionsClass;
+        }
+
+        $installedVersionsClass = @file_get_contents((string) (new \ReflectionClass(\Composer\InstalledVersions::class))->getFileName());
+        if ($installedVersionsClass !== false) {
+            return $installedVersionsClass;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Composer/Test/Installer/BinaryInstallerTest.php
+++ b/tests/Composer/Test/Installer/BinaryInstallerTest.php
@@ -115,6 +115,60 @@ EOL
         ];
     }
 
+    public function testDoesNotRemoveOrOverwriteCurrentProcessBinary(): void
+    {
+        $package = $this->createPackageMock();
+        $package->expects($this->any())
+            ->method('getBinaries')
+            ->willReturn(['binary']);
+
+        self::ensureDirectoryExistsAndClear($this->vendorDir.'/foo/bar');
+        file_put_contents($this->vendorDir.'/foo/bar/binary', '<?php echo "new";');
+
+        $link = $this->binDir.'/binary';
+        file_put_contents($link, '<?php echo "current";');
+
+        $previousScriptFilename = $_SERVER['SCRIPT_FILENAME'] ?? null;
+        $_SERVER['SCRIPT_FILENAME'] = $link;
+
+        try {
+            $installer = new BinaryInstaller($this->io, $this->binDir, 'full', $this->fs);
+            $installer->removeBinaries($package);
+            self::assertFileExists($link);
+            self::assertSame('<?php echo "current";', file_get_contents($link));
+
+            unlink($link);
+            $installer->installBinaries($package, $this->vendorDir.'/foo/bar');
+            self::assertFileDoesNotExist($link);
+        } finally {
+            if ($previousScriptFilename === null) {
+                unset($_SERVER['SCRIPT_FILENAME']);
+            } else {
+                $_SERVER['SCRIPT_FILENAME'] = $previousScriptFilename;
+            }
+        }
+    }
+
+    public function testDoesNotOverwriteIncludedCurrentProcessBinary(): void
+    {
+        $package = $this->createPackageMock();
+        $package->expects($this->any())
+            ->method('getBinaries')
+            ->willReturn(['binary']);
+
+        self::ensureDirectoryExistsAndClear($this->vendorDir.'/foo/bar');
+        file_put_contents($this->vendorDir.'/foo/bar/binary', '<?php echo "new";');
+
+        $link = $this->binDir.'/binary';
+        file_put_contents($link, '<?php return true;');
+        include $link;
+
+        $installer = new BinaryInstaller($this->io, $this->binDir, 'full', $this->fs);
+        $installer->installBinaries($package, $this->vendorDir.'/foo/bar');
+
+        self::assertSame('<?php return true;', file_get_contents($link));
+    }
+
     /**
      * @return \Composer\Package\PackageInterface&\PHPUnit\Framework\MockObject\MockObject
      */

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -307,7 +307,7 @@ class InstallationManagerTest extends TestCase
 
         $manager = new InstallationManager($this->loop, $this->io);
         $method = new \ReflectionMethod($manager, 'buildPackageClassMap');
-        $method->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) and $method->setAccessible(true);
 
         $classMap = $method->invoke($manager, ['psr-4' => ['Foo\\' => 'src/Foo']], $installPath);
 
@@ -360,7 +360,7 @@ class InstallationManagerTest extends TestCase
             ]);
 
         $method = new \ReflectionMethod($manager, 'preloadRuntimeClassesBeforeSelfUpdate');
-        $method->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) and $method->setAccessible(true);
         $method->invoke($manager, $repository, [$operation]);
 
         self::assertTrue(class_exists($runtimeClass, false));

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -307,7 +307,9 @@ class InstallationManagerTest extends TestCase
 
         $manager = new InstallationManager($this->loop, $this->io);
         $method = new \ReflectionMethod($manager, 'buildPackageClassMap');
-        (\PHP_VERSION_ID < 80100) and $method->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $classMap = $method->invoke($manager, ['psr-4' => ['Foo\\' => 'src/Foo']], $installPath);
 
@@ -360,7 +362,9 @@ class InstallationManagerTest extends TestCase
             ]);
 
         $method = new \ReflectionMethod($manager, 'preloadRuntimeClassesBeforeSelfUpdate');
-        (\PHP_VERSION_ID < 80100) and $method->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
         $method->invoke($manager, $repository, [$operation]);
 
         self::assertTrue(class_exists($runtimeClass, false));

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -293,6 +293,25 @@ class InstallationManagerTest extends TestCase
         $manager->ensureBinariesPresence($package);
     }
 
+    public function testPackageClassPreloadDoesNotScanNestedVendorDirectory(): void
+    {
+        $installPath = self::getUniqueTmpDirectory();
+        self::ensureDirectoryExistsAndClear($installPath.'/src/Foo');
+        self::ensureDirectoryExistsAndClear($installPath.'/vendor/Foo');
+
+        file_put_contents($installPath.'/src/Foo/Runtime.php', '<?php namespace Foo; class Runtime {}');
+        file_put_contents($installPath.'/vendor/Foo/DevDependency.php', '<?php namespace Foo; class DevDependency {}');
+
+        $manager = new InstallationManager($this->loop, $this->io);
+        $method = new \ReflectionMethod($manager, 'buildPackageClassMap');
+        $method->setAccessible(true);
+
+        $classMap = $method->invoke($manager, ['psr-4' => ['Foo\\' => 'src/Foo']], $installPath);
+
+        self::assertArrayHasKey('Foo\\Runtime', $classMap);
+        self::assertArrayNotHasKey('Foo\\DevDependency', $classMap);
+    }
+
     /**
      * @return \Composer\Installer\InstallerInterface&\PHPUnit\Framework\MockObject\MockObject
      */

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -17,6 +17,9 @@ use Composer\Installer\NoopInstaller;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
+use Composer\Package\Link;
+use Composer\Package\Package;
+use Composer\Semver\Constraint\MatchAllConstraint;
 use Composer\Test\TestCase;
 
 class InstallationManagerTest extends TestCase
@@ -310,6 +313,57 @@ class InstallationManagerTest extends TestCase
 
         self::assertArrayHasKey('Foo\\Runtime', $classMap);
         self::assertArrayNotHasKey('Foo\\DevDependency', $classMap);
+    }
+
+    public function testRuntimeDependencyClassPreloadRunsWhenOnlyDependencyIsUpdated(): void
+    {
+        $runtimeClass = 'Composer\\Test\\Installer\\RuntimeDependencyPreloadFixture\\Finder';
+        self::assertFalse(class_exists($runtimeClass, false));
+
+        $composerInstallPath = realpath(dirname(__DIR__, 4));
+        self::assertIsString($composerInstallPath);
+
+        $finderInstallPath = self::getUniqueTmpDirectory();
+        self::ensureDirectoryExistsAndClear($finderInstallPath.'/src');
+        file_put_contents($finderInstallPath.'/src/Finder.php', '<?php namespace Composer\Test\Installer\RuntimeDependencyPreloadFixture; class Finder {}');
+
+        $composerPackage = new Package('composer/composer', '2.10.1.0', '2.10.1');
+        $composerPackage->setRequires([
+            'symfony/finder' => new Link('composer/composer', 'symfony/finder', new MatchAllConstraint()),
+        ]);
+
+        $initialFinderPackage = new Package('symfony/finder', '8.0.8.0', '8.0.8');
+        $initialFinderPackage->setAutoload([
+            'classmap' => ['src/Finder.php'],
+        ]);
+
+        $targetFinderPackage = new Package('symfony/finder', '8.1.0.0', '8.1.0');
+        $operation = new UpdateOperation($initialFinderPackage, $targetFinderPackage);
+
+        $repository = $this->getMockBuilder('Composer\Repository\InstalledRepositoryInterface')->getMock();
+        $repository
+            ->expects($this->exactly(2))
+            ->method('getPackages')
+            ->willReturn([$composerPackage, $initialFinderPackage]);
+
+        $manager = $this->getMockBuilder(InstallationManager::class)
+            ->setConstructorArgs([$this->loop, $this->io])
+            ->onlyMethods(['getInstallPath'])
+            ->getMock();
+
+        $manager
+            ->expects($this->exactly(2))
+            ->method('getInstallPath')
+            ->willReturnMap([
+                [$composerPackage, $composerInstallPath],
+                [$initialFinderPackage, $finderInstallPath],
+            ]);
+
+        $method = new \ReflectionMethod($manager, 'preloadRuntimeClassesBeforeSelfUpdate');
+        $method->setAccessible(true);
+        $method->invoke($manager, $repository, [$operation]);
+
+        self::assertTrue(class_exists($runtimeClass, false));
     }
 
     /**


### PR DESCRIPTION
Fixes issue #12922

The fix is roughly: detect we're running from the global composer install location, find all packages required by `composer/composer` itself, check if they are being updated, `require_once` all the PHP files of them, so the temporarily deleted class files are not lazy-loaded during install of the new composer version.

Checked that this works under Windows 11 and Linux.

This is LLM assisted code. Codex with GPT 5.5 on Low / High.

I'm not quite sure if this is a properly minimised change.