### PR TITLE
Don't hide a suggestion provided by the suggesting package itself

### DIFF
--- a/src/Composer/Installer/SuggestedPackagesReporter.php
+++ b/src/Composer/Installer/SuggestedPackagesReporter.php
@@ -183,10 +183,10 @@ class SuggestedPackagesReporter
         $installedNames = [];
         if (null !== $installedRepo && !empty($suggestedPackages)) {
             foreach ($installedRepo->getPackages() as $package) {
-                $installedNames = array_merge(
-                    $installedNames,
-                    $package->getNames()
-                );
+                $packageName = $package->getName();
+                foreach ($package->getNames() as $name) {
+                    $installedNames[$name][] = $packageName;
+                }
             }
         }
 
@@ -200,7 +200,18 @@ class SuggestedPackagesReporter
 
         $suggestions = [];
         foreach ($suggestedPackages as $suggestion) {
-            if (in_array($suggestion['target'], $installedNames) || (\count($sourceFilter) > 0 && !in_array($suggestion['source'], $sourceFilter))) {
+            // Only treat a suggestion as fulfilled when a package other than the
+            // one making it provides the target, so a package that both provides
+            // and suggests a name (e.g. an extension polyfill) does not hide its
+            // own suggestion.
+            $providedByOthers = isset($installedNames[$suggestion['target']]) && \count(array_filter(
+                $installedNames[$suggestion['target']],
+                static function (string $providerName) use ($suggestion): bool {
+                    return $providerName !== strtolower($suggestion['source']);
+                }
+            )) > 0;
+
+            if ($providedByOthers || (\count($sourceFilter) > 0 && !in_array($suggestion['source'], $sourceFilter))) {
                 continue;
             }
 

--- a/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
+++ b/tests/Composer/Test/Installer/SuggestedPackagesReporterTest.php
@@ -214,9 +214,15 @@ class SuggestedPackagesReporterTest extends TestCase
         $package2 = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
 
         $package1->expects($this->once())
+            ->method('getName')
+            ->will($this->returnValue('vendor/package1'));
+        $package1->expects($this->once())
             ->method('getNames')
             ->will($this->returnValue(['x', 'y']));
 
+        $package2->expects($this->once())
+            ->method('getName')
+            ->will($this->returnValue('vendor/package2'));
         $package2->expects($this->once())
             ->method('getNames')
             ->will($this->returnValue(['b']));
@@ -234,6 +240,36 @@ class SuggestedPackagesReporterTest extends TestCase
         $this->io->expects([
             ['text' => 'source package suggests:'],
             ['text' => ' - target: because reasons'],
+            ['text' => ''],
+        ], true);
+
+        $this->suggestedPackagesReporter->output(SuggestedPackagesReporter::MODE_BY_PACKAGE, $repository);
+    }
+
+    /**
+     * @covers ::output
+     */
+    public function testOutputShowsSuggestionProvidedBySuggestingPackageItself(): void
+    {
+        $repository = $this->getMockBuilder('Composer\Repository\InstalledRepository')->disableOriginalConstructor()->getMock();
+        $package = $this->getMockBuilder('Composer\Package\PackageInterface')->getMock();
+
+        $package->expects($this->once())
+            ->method('getName')
+            ->will($this->returnValue('acme/polyfill-foo'));
+        $package->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(['acme/polyfill-foo', 'ext-foo']));
+
+        $repository->expects($this->once())
+            ->method('getPackages')
+            ->will($this->returnValue([$package]));
+
+        $this->suggestedPackagesReporter->addPackage('acme/polyfill-foo', 'ext-foo', 'install the native extension for better performance');
+
+        $this->io->expects([
+            ['text' => 'acme/polyfill-foo suggests:'],
+            ['text' => ' - ext-foo: install the native extension for better performance'],
             ['text' => ''],
         ], true);
 


### PR DESCRIPTION
A package that lists the same name in both `provide` and `suggest`, like an extension polyfill that provides and suggests `ext-uuid`, never showed its suggestion. The package's own provide marked the name as installed, so `composer suggests` filtered it out. A suggestion is now hidden only when a different installed package provides the target.

Fixes #12819
