### PR TITLE
Use array_any() in the suggestion provider check

### DIFF
--- a/src/Composer/Installer/SuggestedPackagesReporter.php
+++ b/src/Composer/Installer/SuggestedPackagesReporter.php
@@ -204,12 +204,12 @@ class SuggestedPackagesReporter
             // one making it provides the target, so a package that both provides
             // and suggests a name (e.g. an extension polyfill) does not hide its
             // own suggestion.
-            $providedByOthers = isset($installedNames[$suggestion['target']]) && \count(array_filter(
+            $providedByOthers = isset($installedNames[$suggestion['target']]) && array_any(
                 $installedNames[$suggestion['target']],
                 static function (string $providerName) use ($suggestion): bool {
                     return $providerName !== strtolower($suggestion['source']);
                 }
-            )) > 0;
+            );
 
             if ($providedByOthers || (\count($sourceFilter) > 0 && !in_array($suggestion['source'], $sourceFilter))) {
                 continue;


### PR DESCRIPTION
Follow-up to #12933. The provider check only needs to know whether another package provides the target, so this uses `array_any()` instead of `count(array_filter()) > 0`, matching the existing usage in `Problem.php` and `Auditor.php`. `array_any()` over `array_find()` since the matched element is not used. Suggested in review at https://github.com/composer/composer/pull/12933#discussion_r3420366889
