### PR TITLE
Prevent phar metadata unserialization on unsafe php versions

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -994,6 +994,14 @@ If set to 1, this env disables the warning about running commands as root/super 
 It also disables automatic clearing of sudo sessions, so you should really only set this
 if you use Composer as a super user at all times like in docker containers.
 
+### COMPOSER_ALLOW_UNSAFE_PHAR_METADATA
+
+This env var only has an effect on PHP versions before 8.0. On those versions Composer
+refuses to read or extract `tar`/`phar` dist archives, because parsing such an archive
+is not safe to do with untrusted input on PHP < 8.0. The recommended fix is to upgrade
+to PHP 8.0 or newer. If you cannot upgrade and accept the risk, set this to 1 to allow
+Composer to process these archives anyway. PHP 8.0+ is unaffected and ignores this setting.
+
 ### COMPOSER_ALLOW_XDEBUG
 
 If set to 1, this env allows running Composer when the Xdebug extension is enabled, without restarting PHP without it.

--- a/src/Composer/Downloader/PharDownloader.php
+++ b/src/Composer/Downloader/PharDownloader.php
@@ -13,6 +13,7 @@
 namespace Composer\Downloader;
 
 use Composer\Package\PackageInterface;
+use Composer\Util\Platform;
 
 /**
  * Downloader for phar files
@@ -23,9 +24,14 @@ class PharDownloader extends ArchiveDownloader
 {
     /**
      * @inheritDoc
+     *
+     * @throws \RuntimeException
      */
     protected function extract(PackageInterface $package, $file, $path)
     {
+        // Guard against unsafe Phar/PharData metadata handling on PHP < 8.0
+        Platform::assertPharMetadataSafe();
+
         // Can throw an UnexpectedValueException
         $archive = new \Phar($file);
         $archive->extractTo($path, null, true);

--- a/src/Composer/Downloader/TarDownloader.php
+++ b/src/Composer/Downloader/TarDownloader.php
@@ -13,6 +13,7 @@
 namespace Composer\Downloader;
 
 use Composer\Package\PackageInterface;
+use Composer\Util\Platform;
 
 /**
  * Downloader for tar files: tar, tar.gz or tar.bz2
@@ -23,9 +24,14 @@ class TarDownloader extends ArchiveDownloader
 {
     /**
      * @inheritDoc
+     *
+     * @throws \RuntimeException
      */
     protected function extract(PackageInterface $package, $file, $path)
     {
+        // Guard against unsafe Phar/PharData metadata handling on PHP < 8.0
+        Platform::assertPharMetadataSafe();
+
         // Can throw an UnexpectedValueException
         $archive = new \PharData($file);
         $archive->extractTo($path, null, true);

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -45,6 +45,31 @@ class Platform
     }
 
     /**
+     * Refuses to parse a tar/phar archive on PHP < 8.0, where the \Phar/\PharData
+     * constructor handles archive metadata in a way that is unsafe with untrusted
+     * input. PHP 8.0+ is not affected, so this is a no-op there.
+     *
+     * @internal
+     *
+     * @return void
+     *
+     * @throws \RuntimeException when run on PHP < 8.0 without the explicit opt-out env var
+     */
+    public static function assertPharMetadataSafe()
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            return;
+        }
+        if (in_array(self::getEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA'), array('1', 'true', 'on'), true)) {
+            return;
+        }
+        throw new \RuntimeException(
+            'Refusing to parse a tar/phar archive on PHP < 8.0 because it is not safe to process untrusted archives on that PHP version. '
+            .'Upgrade to PHP 8.0+ to remove this risk, or set COMPOSER_ALLOW_UNSAFE_PHAR_METADATA=1 to override (not recommended).'
+        );
+    }
+
+    /**
      * putenv() equivalent but updates the runtime global variables too
      *
      * @param  string $name

--- a/src/Composer/Util/Tar.php
+++ b/src/Composer/Util/Tar.php
@@ -24,6 +24,9 @@ class Tar
      */
     public static function getComposerJson($pathToArchive)
     {
+        // Guard against unsafe Phar/PharData metadata handling on PHP < 8.0
+        Platform::assertPharMetadataSafe();
+
         $phar = new \PharData($pathToArchive);
 
         if (!$phar->valid()) {

--- a/tests/Composer/Test/Util/PlatformTest.php
+++ b/tests/Composer/Test/Util/PlatformTest.php
@@ -22,6 +22,23 @@ use Composer\Test\TestCase;
  */
 class PlatformTest extends TestCase
 {
+    /** @var string|false */
+    private $originalAllowUnsafePharMetadata;
+
+    public function setUp()
+    {
+        $this->originalAllowUnsafePharMetadata = Platform::getEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA');
+    }
+
+    public function tearDown()
+    {
+        if (false === $this->originalAllowUnsafePharMetadata) {
+            Platform::clearEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA');
+        } else {
+            Platform::putEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA', $this->originalAllowUnsafePharMetadata);
+        }
+    }
+
     public function testExpandPath()
     {
         putenv('TESTENV=/home/test');
@@ -35,5 +52,44 @@ class PlatformTest extends TestCase
         // Compare 2 common tests for Windows to the built-in Windows test
         $this->assertEquals(('\\' === DIRECTORY_SEPARATOR), Platform::isWindows());
         $this->assertEquals(defined('PHP_WINDOWS_VERSION_MAJOR'), Platform::isWindows());
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testAssertPharMetadataSafeAllowsWhenOptedIn()
+    {
+        Platform::putEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA', '1');
+
+        // reaching this point without an exception is the expectation
+        Platform::assertPharMetadataSafe();
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testAssertPharMetadataSafeAllowsOnPhp8WithoutOptIn()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('Only relevant on PHP 8.0+');
+        }
+
+        Platform::clearEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA');
+
+        // reaching this point without an exception is the expectation
+        Platform::assertPharMetadataSafe();
+    }
+
+    public function testAssertPharMetadataSafeThrowsOnPhp7WithoutOptIn()
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            $this->markTestSkipped('Only relevant on PHP < 8.0');
+        }
+
+        Platform::clearEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA');
+
+        $this->setExpectedException('RuntimeException', 'Refusing to parse a tar/phar archive on PHP < 8.0');
+
+        Platform::assertPharMetadataSafe();
     }
 }

--- a/tests/Composer/Test/Util/TarTest.php
+++ b/tests/Composer/Test/Util/TarTest.php
@@ -12,6 +12,7 @@
 
 namespace Composer\Test\Util;
 
+use Composer\Util\Platform;
 use Composer\Util\Tar;
 use Composer\Test\TestCase;
 
@@ -20,6 +21,23 @@ use Composer\Test\TestCase;
  */
 class TarTest extends TestCase
 {
+    /** @var string|false */
+    private $originalAllowUnsafePharMetadata;
+
+    public function setUp()
+    {
+        $this->originalAllowUnsafePharMetadata = Platform::getEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA');
+    }
+
+    public function tearDown()
+    {
+        if (false === $this->originalAllowUnsafePharMetadata) {
+            Platform::clearEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA');
+        } else {
+            Platform::putEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA', $this->originalAllowUnsafePharMetadata);
+        }
+    }
+
     public function testReturnsNullifTheTarIsNotFound()
     {
         $result = Tar::getComposerJson(__DIR__.'/Fixtures/Tar/invalid.zip');
@@ -61,5 +79,17 @@ class TarTest extends TestCase
     {
         $this->setExpectedException('RuntimeException');
         Tar::getComposerJson(__DIR__.'/Fixtures/Tar/multiple.tar.gz');
+    }
+
+    public function testThrowsOnUnsafePhpVersionWithoutOptIn()
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            $this->markTestSkipped('Parsing phar/tar metadata is only unsafe on PHP < 8.0');
+        }
+
+        Platform::clearEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA');
+
+        $this->setExpectedException('RuntimeException', 'Refusing to parse a tar/phar archive on PHP < 8.0');
+        Tar::getComposerJson(__DIR__.'/Fixtures/Tar/root.tar.gz');
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,3 +23,6 @@ require __DIR__.'/../src/Composer/InstalledVersions.php';
 require __DIR__.'/Composer/Test/TestCase.php';
 
 Platform::putEnv('COMPOSER_TESTS_ARE_RUNNING', '1');
+
+// allow the test suite to exercise the tar/phar code paths on PHP < 8.0 (no-op on PHP 8.0+)
+Platform::putEnv('COMPOSER_ALLOW_UNSAFE_PHAR_METADATA', '1');


### PR DESCRIPTION
Backport of #12945