### PR TITLE
Only follow http(s) redirects in HTTP transports

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -562,6 +562,10 @@ class CurlDownloader
         }
 
         if (!empty($targetUrl)) {
+            if (!Url::isAllowedRedirect($targetUrl)) {
+                throw new TransportException('Could not follow the redirect to "'.Url::sanitize($targetUrl).'" because only http and https redirects are supported.');
+            }
+
             $this->io->writeError(sprintf('Following redirect (%u) %s', $job['attributes']['redirects'] + 1, Url::sanitize($targetUrl)), true, IOInterface::DEBUG);
 
             return $targetUrl;

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -684,6 +684,10 @@ class RemoteFilesystem
         }
 
         if (!empty($targetUrl)) {
+            if (!Url::isAllowedRedirect($targetUrl)) {
+                throw new TransportException('Could not follow the redirect to "'.Url::sanitize($targetUrl).'" because only http and https redirects are supported.');
+            }
+
             $this->redirects++;
 
             $this->io->writeError('', true, IOInterface::DEBUG);

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -103,6 +103,19 @@ class Url
         return $origin;
     }
 
+    /**
+     * Whether a redirect to the given URL may be followed. Composer only follows
+     * redirects to http(s) targets, never to other stream wrappers (file://, etc.).
+     *
+     * @internal
+     */
+    public static function isAllowedRedirect(string $url): bool
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        return is_string($scheme) && in_array(strtolower($scheme), ['http', 'https'], true);
+    }
+
     public static function sanitize(string $url): string
     {
         // GitHub repository rename result in redirect locations containing the access_token as GET parameter

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -240,6 +240,37 @@ class RemoteFilesystemTest extends TestCase
     }
 
     /**
+     * @dataProvider provideDisallowedRedirectSchemes
+     */
+    public function testRedirectToDisallowedSchemeIsRejected(string $location): void
+    {
+        self::expectException('Composer\Downloader\TransportException');
+        self::expectExceptionMessage('only http and https redirects are supported');
+
+        $fs = $this->getRemoteFilesystemWithMockedMethods(['getRemoteContents']);
+        $fs->expects($this->once())->method('getRemoteContents')
+            ->willReturnCallback(static function ($originUrl, $fileUrl, $ctx, &$http_response_header) use ($location): string {
+                $http_response_header = ['HTTP/1.1 302 Found', 'Location: '.$location];
+
+                return '';
+            });
+
+        $fs->getContents('http://example.org', 'http://example.org/packages.json', false);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public static function provideDisallowedRedirectSchemes(): array
+    {
+        return [
+            ['file://localhost/etc/passwd'],
+            ['phar://archive.phar/file'],
+            ['data://text/plain;base64,Zm9v'],
+        ];
+    }
+
+    /**
      * @group TLS
      */
     public function testGetOptionsForUrlCreatesSecureTlsDefaults(): void

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -78,6 +78,30 @@ class UrlTest extends TestCase
         self::assertSame($expected, Url::sanitize(Url::sanitize($url)));
     }
 
+    /**
+     * @dataProvider isAllowedRedirectProvider
+     */
+    public function testIsAllowedRedirect(bool $expected, string $url): void
+    {
+        self::assertSame($expected, Url::isAllowedRedirect($url));
+    }
+
+    public static function isAllowedRedirectProvider(): array
+    {
+        return [
+            [true, 'http://example.org/foo'],
+            [true, 'https://example.org/foo'],
+            [true, 'HTTPS://example.org/foo'],
+            [false, 'file://localhost/etc/passwd'],
+            [false, 'file:///etc/passwd'],
+            [false, 'phar://archive.phar/file'],
+            [false, 'data://text/plain;base64,Zm9v'],
+            [false, 'ftp://example.org/foo'],
+            [false, '/foo/bar'],
+            [false, 'example.org/foo'],
+        ];
+    }
+
     public static function sanitizeProvider(): array
     {
         return [


### PR DESCRIPTION
Restricts HTTP redirect following to the `http` and `https` schemes.

The stream-based `RemoteFilesystem` transport previously followed a `Location:` header to any URL scheme. This aligns it with the curl transport, which already limits protocols to HTTP/HTTPS via `CURLOPT_PROTOCOLS`, and adds the same explicit check on the curl side so the rule lives in one shared place (`Url::isAllowedRedirect()`).

Added coverage for the new `Url::isAllowedRedirect()` helper and for rejection of disallowed redirect targets in `RemoteFilesystem`.
