### PR TITLE
Only follow http(s) redirects in HTTP transports (2.2)

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -513,6 +513,10 @@ class CurlDownloader
         }
 
         if (!empty($targetUrl)) {
+            if (!Url::isAllowedRedirect($targetUrl)) {
+                throw new TransportException('Could not follow the redirect to "'.Url::sanitize($targetUrl).'" because only http and https redirects are supported.');
+            }
+
             $this->io->writeError(sprintf('Following redirect (%u) %s', $job['attributes']['redirects'] + 1, Url::sanitize($targetUrl)), true, IOInterface::DEBUG);
 
             return $targetUrl;

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -762,6 +762,10 @@ class RemoteFilesystem
         }
 
         if (!empty($targetUrl)) {
+            if (!Url::isAllowedRedirect($targetUrl)) {
+                throw new TransportException('Could not follow the redirect to "'.Url::sanitize($targetUrl).'" because only http and https redirects are supported.');
+            }
+
             $this->redirects++;
 
             $this->io->writeError('', true, IOInterface::DEBUG);

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -105,6 +105,22 @@ class Url
     }
 
     /**
+     * Whether a redirect to the given URL may be followed. Composer only follows
+     * redirects to http(s) targets, never to other stream wrappers (file://, etc.).
+     *
+     * @internal
+     *
+     * @param  string $url
+     * @return bool
+     */
+    public static function isAllowedRedirect($url)
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        return is_string($scheme) && in_array(strtolower($scheme), array('http', 'https'), true);
+    }
+
+    /**
      * @param  string $url
      * @return string
      */

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -240,6 +240,40 @@ class RemoteFilesystemTest extends TestCase
     }
 
     /**
+     * @dataProvider provideDisallowedRedirectSchemes
+     *
+     * @param string $location
+     *
+     * @return void
+     */
+    public function testRedirectToDisallowedSchemeIsRejected($location)
+    {
+        $this->setExpectedException('Composer\Downloader\TransportException', 'only http and https redirects are supported');
+
+        $fs = $this->getRemoteFilesystemWithMockedMethods(array('getRemoteContents'));
+        $fs->expects($this->once())->method('getRemoteContents')
+            ->willReturnCallback(function ($originUrl, $fileUrl, $ctx, &$http_response_header) use ($location) {
+                $http_response_header = array('HTTP/1.1 302 Found', 'Location: '.$location);
+
+                return '';
+            });
+
+        $fs->getContents('http://example.org', 'http://example.org/packages.json', false);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideDisallowedRedirectSchemes()
+    {
+        return array(
+            array('file://localhost/etc/passwd'),
+            array('phar://archive.phar/file'),
+            array('data://text/plain;base64,Zm9v'),
+        );
+    }
+
+    /**
      * @group TLS
      */
     public function testGetOptionsForUrlCreatesSecureTlsDefaults()

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -75,6 +75,33 @@ class UrlTest extends TestCase
         $this->assertSame($expected, Url::sanitize($url));
     }
 
+    /**
+     * @dataProvider isAllowedRedirectProvider
+     *
+     * @param bool   $expected
+     * @param string $url
+     */
+    public function testIsAllowedRedirect($expected, $url)
+    {
+        $this->assertSame($expected, Url::isAllowedRedirect($url));
+    }
+
+    public static function isAllowedRedirectProvider()
+    {
+        return array(
+            array(true, 'http://example.org/foo'),
+            array(true, 'https://example.org/foo'),
+            array(true, 'HTTPS://example.org/foo'),
+            array(false, 'file://localhost/etc/passwd'),
+            array(false, 'file:///etc/passwd'),
+            array(false, 'phar://archive.phar/file'),
+            array(false, 'data://text/plain;base64,Zm9v'),
+            array(false, 'ftp://example.org/foo'),
+            array(false, '/foo/bar'),
+            array(false, 'example.org/foo'),
+        );
+    }
+
     public static function sanitizeProvider()
     {
         return array(


### PR DESCRIPTION
Restricts HTTP redirect following to the `http` and `https` schemes (2.2 LTS backport of #12947).

The stream-based `RemoteFilesystem` transport previously followed a `Location:` header to any URL scheme. This aligns it with the curl transport, which already limits protocols to HTTP/HTTPS via `CURLOPT_PROTOCOLS`, and adds the same explicit check on the curl side so the rule lives in one shared place (`Url::isAllowedRedirect()`).

Added coverage for the new `Url::isAllowedRedirect()` helper and for rejection of disallowed redirect targets in `RemoteFilesystem`.
