### PR TITLE
Retry downloads failing with HTTP 400 on a fresh connection

### DIFF
--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -231,6 +231,11 @@ class CurlDownloader
             curl_setopt($curlHandle, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
         }
 
+        if ($attributes['retries'] > 0) {
+            // when retrying, do not re-use a kept-alive connection from the pool as it may be the cause of the failure
+            curl_setopt($curlHandle, CURLOPT_FRESH_CONNECT, true);
+        }
+
         if (function_exists('curl_share_init')) {
             curl_setopt($curlHandle, CURLOPT_SHARE, $this->shareHandle);
         }
@@ -462,7 +467,8 @@ class CurlDownloader
                 if ($statusCode >= 400 && $statusCode <= 599) {
                     if (
                         (!isset($job['options']['http']['method']) || $job['options']['http']['method'] === 'GET')
-                        && in_array($statusCode, [423, 425, 500, 502, 503, 504, 507, 510], true)
+                        // 400 is included as some CDNs (e.g. codeload.github.com) intermittently return it on reused connections, see #12958
+                        && in_array($statusCode, [400, 423, 425, 500, 502, 503, 504, 507, 510], true)
                         && $job['attributes']['retries'] < $this->maxRetries
                     ) {
                         $this->io->writeError('Retrying ('.($job['attributes']['retries'] + 1).') ' . Url::sanitize($job['url']) . ' due to status code '. $statusCode, true, IOInterface::DEBUG);

--- a/src/Composer/Util/Http/CurlDownloader.php
+++ b/src/Composer/Util/Http/CurlDownloader.php
@@ -465,10 +465,12 @@ class CurlDownloader
 
                 // fail 4xx and 5xx responses and capture the response
                 if ($statusCode >= 400 && $statusCode <= 599) {
+                    $retryableStatusCode = in_array($statusCode, [423, 425, 500, 502, 503, 504, 507, 510], true)
+                        // codeload.github.com intermittently returns 400 on reused connections, retry those specifically, see #12958
+                        || ($statusCode === 400 && parse_url($job['url'], PHP_URL_HOST) === 'codeload.github.com');
                     if (
                         (!isset($job['options']['http']['method']) || $job['options']['http']['method'] === 'GET')
-                        // 400 is included as some CDNs (e.g. codeload.github.com) intermittently return it on reused connections, see #12958
-                        && in_array($statusCode, [400, 423, 425, 500, 502, 503, 504, 507, 510], true)
+                        && $retryableStatusCode
                         && $job['attributes']['retries'] < $this->maxRetries
                     ) {
                         $this->io->writeError('Retrying ('.($job['attributes']['retries'] + 1).') ' . Url::sanitize($job['url']) . ' due to status code '. $statusCode, true, IOInterface::DEBUG);


### PR DESCRIPTION
Since last week a lot of CI pipelines started failing with errors like:

```
The "https://codeload.github.com/.../legacy.zip/..." file could not be downloaded (HTTP/2 400 )
```

The failing package is different on every run, the same URL downloads fine with a plain `curl`, and the response is a bare `400: Invalid request` with no rate-limit or `Retry-After` headers. It only happens with parallel downloads, which points at a connection being re-used: the first request on a freshly opened connection succeeds, a later request on the same kept-alive/HTTP-2 connection gets the 400.

This makes two changes to `CurlDownloader`:

- A retried request now opens a fresh connection (`CURLOPT_FRESH_CONNECT`) instead of possibly re-using the pooled connection that just failed. This follows the same idea as the existing "retry forcing IPv4" handling, where a retry should change something to be worth doing.
- `400` is added to the list of retryable status codes.

Both are needed: just adding `400` to the list does not help on its own, because re-using the same poisoned connection returns `400` again on every retry until the attempts run out. Opening a new connection on retry is what actually recovers the download.

If you'd rather not retry `400` by default, since it is normally a client error that should not be repeated, I can instead put it behind an opt-in flag (e.g. `COMPOSER_RETRY_HTTP_400`) and leave the default behaviour unchanged. The `CURLOPT_FRESH_CONNECT` part stands on its own either way. Happy to adjust to whichever you prefer.

Refs #12958
