### PR TITLE
Add installed version to sub-dependencies in show --tree JSON output

### DIFF
--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -1309,6 +1309,11 @@ EOT
                 'version' => $require->getPrettyConstraint(),
             ];
 
+            $installedPackage = $installedRepo->findPackage($requireName, '*');
+            if (null !== $installedPackage) {
+                $treeChildDesc['installed'] = $installedPackage->getPrettyVersion();
+            }
+
             $deepChildren = $this->addTree($requireName, $require, $installedRepo, $remoteRepos, $packagesInTree);
 
             if ($deepChildren) {
@@ -1414,6 +1419,11 @@ EOT
                     'name' => $requireName,
                     'version' => $require->getPrettyConstraint(),
                 ];
+
+                $installedPackage = $installedRepo->findPackage($requireName, '*');
+                if (null !== $installedPackage) {
+                    $treeChildDesc['installed'] = $installedPackage->getPrettyVersion();
+                }
 
                 if (!in_array($requireName, $currentTree, true)) {
                     $currentTree[] = $requireName;

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -1309,9 +1309,9 @@ EOT
                 'version' => $require->getPrettyConstraint(),
             ];
 
-            $installedPackage = $installedRepo->findPackage($requireName, '*');
-            if (null !== $installedPackage) {
-                $treeChildDesc['installed'] = $installedPackage->getPrettyVersion();
+            $installedVersion = $this->getInstalledVersion($installedRepo, $requireName);
+            if (null !== $installedVersion) {
+                $treeChildDesc['installed'] = $installedVersion;
             }
 
             $deepChildren = $this->addTree($requireName, $require, $installedRepo, $remoteRepos, $packagesInTree);
@@ -1420,9 +1420,9 @@ EOT
                     'version' => $require->getPrettyConstraint(),
                 ];
 
-                $installedPackage = $installedRepo->findPackage($requireName, '*');
-                if (null !== $installedPackage) {
-                    $treeChildDesc['installed'] = $installedPackage->getPrettyVersion();
+                $installedVersion = $this->getInstalledVersion($installedRepo, $requireName);
+                if (null !== $installedVersion) {
+                    $treeChildDesc['installed'] = $installedVersion;
                 }
 
                 if (!in_array($requireName, $currentTree, true)) {
@@ -1438,6 +1438,24 @@ EOT
         }
 
         return $children;
+    }
+
+    /**
+     * Returns the pretty version of the installed package matching the given
+     * name (honoring replace/provide), or null if it is not installed.
+     */
+    private function getInstalledVersion(InstalledRepository $installedRepo, string $name): ?string
+    {
+        foreach ($installedRepo->findPackagesWithReplacersAndProviders($name) as $package) {
+            // resolve aliases to report the actually installed version rather than the alias version
+            while ($package instanceof AliasPackage) {
+                $package = $package->getAliasOf();
+            }
+
+            return $package->getPrettyVersion();
+        }
+
+        return null;
     }
 
     private function updateStatusToVersionStyle(string $updateStatus): string

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -929,6 +929,40 @@ OUTPUT;
     ]
 }',
         ];
+        yield 'package with json format reports installed version of a provided requirement' => [
+            static function () {
+                $pgk = static::getPackage('vendor/package', '1.0.0');
+                $pgk->setRequires(['vendor/virtual' => new Link(
+                    'vendor/package',
+                    'vendor/virtual',
+                    static::getVersionConstraint('>=', '1.0.0'),
+                    Link::TYPE_REQUIRE,
+                    '^1.0'
+                )]);
+
+                $provider = static::getPackage('vendor/provider', '3.0.0');
+                static::configureLinks($provider, ['provide' => ['vendor/virtual' => '^1.0']]);
+
+                return [$pgk, $provider];
+            },
+            ['--format' => 'json'],
+            '{
+    "installed": [
+        {
+            "name": "vendor/package",
+            "version": "1.0.0",
+            "description": null,
+            "requires": [
+                {
+                    "name": "vendor/virtual",
+                    "version": "^1.0",
+                    "installed": "3.0.0"
+                }
+            ]
+        }
+    ]
+}',
+        ];
     }
 
     public function testNameOnlyPrintsNoTrailingWhitespace(): void

--- a/tests/Composer/Test/Command/ShowCommandTest.php
+++ b/tests/Composer/Test/Command/ShowCommandTest.php
@@ -880,6 +880,55 @@ OUTPUT;
     ]
 }',
         ];
+        yield 'package with json format includes installed version of requirements' => [
+            static function () {
+                $pgk = static::getPackage('vendor/package', '1.0.0');
+                $pgk->setRequires(['vendor/required-package' => new Link(
+                    'vendor/package',
+                    'vendor/required-package',
+                    static::getVersionConstraint('>=', '1.0.0'),
+                    Link::TYPE_REQUIRE,
+                    '^1.0'
+                )]);
+
+                $required = static::getPackage('vendor/required-package', '1.2.0');
+                $required->setRequires(['vendor/sub-dependency' => new Link(
+                    'vendor/required-package',
+                    'vendor/sub-dependency',
+                    static::getVersionConstraint('>=', '2.0.0'),
+                    Link::TYPE_REQUIRE,
+                    '^2.0'
+                )]);
+
+                $subDependency = static::getPackage('vendor/sub-dependency', '2.5.0');
+
+                return [$pgk, $required, $subDependency];
+            },
+            ['--format' => 'json'],
+            '{
+    "installed": [
+        {
+            "name": "vendor/package",
+            "version": "1.0.0",
+            "description": null,
+            "requires": [
+                {
+                    "name": "vendor/required-package",
+                    "version": "^1.0",
+                    "installed": "1.2.0",
+                    "requires": [
+                        {
+                            "name": "vendor/sub-dependency",
+                            "version": "^2.0",
+                            "installed": "2.5.0"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}',
+        ];
     }
 
     public function testNameOnlyPrintsNoTrailingWhitespace(): void


### PR DESCRIPTION
In `composer show --tree --format=json`, sub-dependency nodes report the `version` constraint from the parent's require rather than the installed version, so tooling has to parse `composer.lock` separately to get resolved versions. This adds an `installed` key alongside the existing constraint on each tree node, resolved from the installed repository, leaving the current `version` field untouched.

Fixes #12955
