### PR TITLE
Avoid a race condition in `ensureDirectoryExists`

### DIFF
--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -258,6 +258,12 @@ class Filesystem
             }
 
             if (!@mkdir($directory, 0777, true)) {
+                // maybe another process created it since we checked above?
+                clearstatcache();
+                if (is_dir($directory)) {
+                    return;
+                }
+
                 $e = new \RuntimeException($directory.' does not exist and could not be created: '.(error_get_last()['message'] ?? ''));
 
                 // in pathological cases with paths like path/to/broken-symlink/../foo is_dir will fail to detect path/to/foo


### PR DESCRIPTION
If multiple processes are running at once, it's possible that one might create a directory somewhere in between when another tests `!is_dir()` and when it tries `mkdir()`.

Handle this situation by re-testing `is_dir()` if `mkdir()` fails, and treating it as a success if the directory now exists.

Fixes #12976

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
