### PR TITLE
Docs: add missing request/response example for custom policies

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -482,7 +482,10 @@ A `url` source is queried the same way as a repository's [`api-url`](05-reposito
 Composer sends a POST request with the relevant package PURLs and the custom dependency policy name,
 and expects the matching filter entries back. The request is not cached client-side because each
 request body is different. Implementors should be aware that large amounts (a few hundred would be
-normal) of package names can be submitted.
+normal) of package names can be submitted. The submitted PURLs are the full set of candidate package
+names gathered *before* dependency resolution, so they identify packages by name only (no version
+constraints yet), and not every submitted package will necessarily be selected by the resolver
+afterwards.
 
 The endpoint receives a JSON body of the form:
 

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -496,7 +496,15 @@ The endpoint receives a JSON body of the form:
 }
 ```
 
-and must return JSON of the form:
+The request body reuses the wire format of a Composer repository's [`api-url`](05-repositories.md#filter).
+There, a single endpoint can serve several named filter lists (for example `malware` and
+`typosquatting`), so `lists` is an array naming which of them Composer wants, and the response is a
+`filter` object keyed by list name. A custom dependency policy has no such multiplexing: its `url`
+source exists only to serve that one policy. Composer therefore always sends the policy name as the
+sole element of `lists` (so the array carries exactly one value here), and the endpoint should treat
+any list name it receives as referring to that policy.
+
+The endpoint must return JSON of the form:
 
 ```json
 {
@@ -512,8 +520,9 @@ and must return JSON of the form:
 }
 ```
 
-Unlike a repository's `api-url` response (where `filter` is an object keyed by list name), a custom
-dependency policy `url` source is bound to a single list, so `filter` is a flat array of entries. The
+Because the `url` source only ever serves this one policy, the response drops the per-list keying used
+by a repository's `api-url` (where `filter` is an object mapping each requested list name to its
+entries). Here `filter` is instead a flat array of entries that all belong to this policy. The
 `package` and `constraint` fields are required on each entry; `url`, `reason`, and `id` are optional.
 Entries whose package does not match a package in the request are ignored.
 

--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -478,6 +478,42 @@ versions, supplied by one or more sources (advertised by package repositories or
 Source URLs must use `https://`. `http://` and other schemes are rejected both at
 schema validation time (`composer validate`) and at config load time.
 
+A `url` source is queried the same way as a repository's [`api-url`](05-repositories.md#filter):
+Composer sends a POST request with the relevant package PURLs and the custom dependency policy name,
+and expects the matching filter entries back. The request is not cached client-side because each
+request body is different. Implementors should be aware that large amounts (a few hundred would be
+normal) of package names can be submitted.
+
+The endpoint receives a JSON body of the form:
+
+```json
+{
+    "packages": ["pkg://composer/vendor/package", "pkg://composer/other/package"],
+    "lists": ["my-policy"]
+}
+```
+
+and must return JSON of the form:
+
+```json
+{
+    "filter": [
+        {
+            "package": "vendor/package",
+            "constraint": ">=1.0.0,<1.2.0",
+            "url": "https://example.org/filters/123",
+            "reason": "Assessed and rejected.",
+            "id": "PKFE-xxxx-xxxx-xxxx"
+        }
+    ]
+}
+```
+
+Unlike a repository's `api-url` response (where `filter` is an object keyed by list name), a custom
+dependency policy `url` source is bound to a single list, so `filter` is a flat array of entries. The
+`package` and `constraint` fields are required on each entry; `url`, `reason`, and `id` are optional.
+Entries whose package does not match a package in the request are ignored.
+
 Custom dependency policy names must not conflict with the reserved names `advisories`, `malware`, or
 `abandoned`, and must not start with `ignore` (the only `ignore`-prefixed key allowed at this
 level is the documented `ignore-unreachable` setting).


### PR DESCRIPTION
Just noticed that the docs are missing the request/response examples for how to implement custom policies as outlined in https://github.com/composer/composer/issues/12786