### PR TITLE
Fix `Url::getOrigin` prefix-matching a host against `gitlab-domains`

### DIFF
--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -103,7 +103,9 @@ class Url
             && !in_array($origin, $config->get('gitlab-domains'), true)
         ) {
             foreach ($config->get('gitlab-domains') as $gitlabDomain) {
-                if ($gitlabDomain !== '' && str_starts_with($gitlabDomain, $origin.'/')) {
+                // configured domains may spell out a port the URL omits, see GitLab::authorizeOAuth
+                $bcDomain = Preg::replace('{^([^/]+):\d+}', '$1', $gitlabDomain);
+                if ($gitlabDomain !== '' && ($bcDomain === $origin || str_starts_with($bcDomain, $origin.'/'))) {
                     return $gitlabDomain;
                 }
             }

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -103,7 +103,7 @@ class Url
             && !in_array($origin, $config->get('gitlab-domains'), true)
         ) {
             foreach ($config->get('gitlab-domains') as $gitlabDomain) {
-                if ($gitlabDomain !== '' && str_starts_with($gitlabDomain, $origin)) {
+                if ($gitlabDomain !== '' && str_starts_with($gitlabDomain, $origin.'/')) {
                     return $gitlabDomain;
                 }
             }

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -63,6 +63,30 @@ class UrlTest extends TestCase
     }
 
     /**
+     * @dataProvider getOriginProvider
+     *
+     * @param non-empty-string $url
+     * @param list<string> $gitlabDomains
+     */
+    public function testGetOrigin(string $expected, string $url, array $gitlabDomains): void
+    {
+        $config = new Config();
+        $config->merge(['config' => ['gitlab-domains' => $gitlabDomains]]);
+
+        self::assertSame($expected, Url::getOrigin($config, $url));
+    }
+
+    public static function getOriginProvider(): array
+    {
+        return [
+            // a host that is only a shorter prefix of a configured domain must not resolve to it
+            ['gitlab.example.co', 'https://gitlab.example.co/foo/bar/repository/archive.zip', ['gitlab.example.com']],
+            ['gitlab.example.com', 'https://gitlab.example.com/foo/bar/repository/archive.zip', ['gitlab.example.com']],
+            ['gitlab.example.com/gitlab', 'https://gitlab.example.com/foo/bar/repository/archive.zip', ['gitlab.example.com/gitlab']],
+        ];
+    }
+
+    /**
      * @dataProvider sanitizeProvider
      */
     public function testSanitize(string $expected, string $url): void

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -66,12 +66,11 @@ class UrlTest extends TestCase
      * @dataProvider getOriginProvider
      *
      * @param non-empty-string $url
-     * @param list<string> $gitlabDomains
+     * @param list<string> $extraGitlabDomains domains merged on top of the default gitlab.com
      */
-    public function testGetOrigin(string $expected, string $url, array $gitlabDomains): void
+    public function testGetOrigin(string $expected, string $url, array $extraGitlabDomains): void
     {
-        $config = new Config();
-        $config->merge(['config' => ['gitlab-domains' => $gitlabDomains]]);
+        $config = $this->getConfig(['gitlab-domains' => $extraGitlabDomains]);
 
         self::assertSame($expected, Url::getOrigin($config, $url));
     }
@@ -81,8 +80,12 @@ class UrlTest extends TestCase
         return [
             // a host that is only a shorter prefix of a configured domain must not resolve to it
             ['gitlab.example.co', 'https://gitlab.example.co/foo/bar/repository/archive.zip', ['gitlab.example.com']],
+            ['gitlab.example.co', 'https://gitlab.example.co/foo/bar/repository/archive.zip', ['gitlab.example.co.uk/gitlab']],
             ['gitlab.example.com', 'https://gitlab.example.com/foo/bar/repository/archive.zip', ['gitlab.example.com']],
             ['gitlab.example.com/gitlab', 'https://gitlab.example.com/foo/bar/repository/archive.zip', ['gitlab.example.com/gitlab']],
+            // a configured domain may spell out a port the URL omits
+            ['gitlab.example.com:443', 'https://gitlab.example.com/foo/bar/repository/archive.zip', ['gitlab.example.com:443']],
+            ['gitlab.example.com:443/gitlab', 'https://gitlab.example.com/foo/bar/repository/archive.zip', ['gitlab.example.com:443/gitlab']],
         ];
     }
 


### PR DESCRIPTION
`Url::getOrigin()` maps a request host to a configured `gitlab-domains` entry so the stored token for that domain is attached.
The match was `str_starts_with($gitlabDomain, $origin)`, which also fires when the host is only a shorter prefix of a configured domain, so `gitlab.example.co` resolved to `gitlab.example.com` and picked up its token.

Requiring the entry to continue with a `/` after the host keeps non-root installs like `gitlab.example.com/gitlab` working from the bare host.
A host that merely shares a prefix no longer matches.
