### PR TITLE
Custom policies: add block-scope config option to block during composer install

### DIFF
--- a/doc/06-config.md
+++ b/doc/06-config.md
@@ -160,8 +160,9 @@ always allowed regardless of this setting.
 Unified dependency policy configuration. Controls Composer behavior for dependencies with security
 advisories, flagged as malware, abandoned packages, and custom dependency policies. Audit reports
 can be generated with `composer audit`; blocking prevents insecure or otherwise flagged package
-versions from being installed during `composer update`, `require`, or `remove` and malware also
-during a `composer install`.
+versions from being installed during `composer update`, `require`, or `remove`. The malware policy
+and custom dependency policies can additionally block during a `composer install` via their
+[`block-scope`](#block-scope) setting.
 
 Set to `false` to disable all dependency policy enforcement:
 
@@ -477,6 +478,31 @@ versions, supplied by one or more sources (advertised by package repositories or
 
 Source URLs must use `https://`. `http://` and other schemes are rejected both at
 schema validation time (`composer validate`) and at config load time.
+
+#### block-scope
+
+Defaults to `update`. Controls which commands trigger blocking for this custom policy:
+
+- `all` — block during both `update`/`require`/`remove` and `install`
+- `update` — block only during `update`/`require`/`remove`
+- `install` — block only during `install`
+
+Unlike the [`malware`](#malware) policy (which defaults to `all`), custom dependency policies
+default to `update`, so they only block during `composer install` when you opt in with
+`block-scope` set to `install` or `all`. This is useful for enforcing a policy in environments
+where only `composer install` runs, such as CI or deployment.
+
+```json
+{
+    "config": {
+        "policy": {
+            "my-policy": {
+                "block-scope": "all"
+            }
+        }
+    }
+}
+```
 
 A `url` source is queried the same way as a repository's [`api-url`](05-repositories.md#filter):
 Composer sends a POST request with the relevant package PURLs and the custom dependency policy name,

--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -729,8 +729,13 @@
                                 "properties": {
                                     "block": {
                                         "type": "boolean",
-                                        "description": "When true (default), matched packages are blocked during update/require/remove.",
+                                        "description": "When true (default), matched packages are blocked. The 'block-scope' key controls which commands the blocking applies to.",
                                         "default": true
+                                    },
+                                    "block-scope": {
+                                        "enum": ["all", "update", "install"],
+                                        "description": "Controls which commands trigger blocking: all (both update/require/remove and install), update (default, only update/require/remove), or install (only install).",
+                                        "default": "update"
                                     },
                                     "audit": {
                                         "enum": ["ignore", "report", "fail"],

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -327,6 +327,9 @@ EOT
         $auditValidator = static function ($val): bool {
             return in_array($val, [ListPolicyConfig::AUDIT_IGNORE, ListPolicyConfig::AUDIT_REPORT, ListPolicyConfig::AUDIT_FAIL], true);
         };
+        $blockScopeValidator = static function ($val): bool {
+            return in_array($val, ListPolicyConfig::AVAILABLE_BLOCK_SCOPES, true);
+        };
         $keepAsIsNormalizer = static function ($val) {
             return $val;
         };
@@ -497,12 +500,7 @@ EOT
             'policy.advisories.block' => [$booleanValidator, $booleanNormalizer],
             'policy.advisories.audit' => [$auditValidator, $keepAsIsNormalizer],
             'policy.malware.block' => [$booleanValidator, $booleanNormalizer],
-            'policy.malware.block-scope' => [
-                static function ($val): bool {
-                    return in_array($val, ['all', 'update', 'install'], true);
-                },
-                $keepAsIsNormalizer,
-            ],
+            'policy.malware.block-scope' => [$blockScopeValidator, $keepAsIsNormalizer],
             'policy.malware.audit' => [$auditValidator, $keepAsIsNormalizer],
             'policy.abandoned.block' => [$booleanValidator, $booleanNormalizer],
             'policy.abandoned.audit' => [$auditValidator, $keepAsIsNormalizer],
@@ -704,8 +702,8 @@ EOT
             return 0;
         }
 
-        // handle custom policy lists: policy.<name>.block / policy.<name>.audit
-        if (Preg::isMatch('/^policy\.([^.]+)\.(block|audit)$/', $settingKey, $matches)
+        // handle custom policy lists: policy.<name>.block / policy.<name>.block-scope / policy.<name>.audit
+        if (Preg::isMatch('/^policy\.([^.]+)\.(block|block-scope|audit)$/', $settingKey, $matches)
             && !in_array($matches[1], $nonCustomPolicyKeys, true)
         ) {
             $reservedError = PolicyConfig::getFutureReservedListNameError($matches[1]);
@@ -717,6 +715,11 @@ EOT
                     throw new \RuntimeException(sprintf('"%s" is an invalid value for %s, expected a boolean', $values[0], $settingKey));
                 }
                 $this->configSource->addConfigSetting($settingKey, $booleanNormalizer($values[0]));
+            } elseif ($matches[2] === 'block-scope') {
+                if (!$blockScopeValidator($values[0])) {
+                    throw new \RuntimeException(sprintf('"%s" is an invalid value for %s, must be one of: all, update, install', $values[0], $settingKey));
+                }
+                $this->configSource->addConfigSetting($settingKey, $values[0]);
             } else {
                 if (!$auditValidator($values[0])) {
                     throw new \RuntimeException(sprintf('"%s" is an invalid value for %s, must be one of: ignore, report, fail', $values[0], $settingKey));

--- a/src/Composer/Policy/CustomListPolicyConfig.php
+++ b/src/Composer/Policy/CustomListPolicyConfig.php
@@ -24,20 +24,37 @@ use Composer\Semver\VersionParser;
 class CustomListPolicyConfig extends ListPolicyConfig
 {
     /**
+     * @var self::BLOCK_SCOPE_*
+     */
+    public $blockScope;
+
+    /**
      * URL sources for custom lists.
      * @var list<UrlSource>
      */
     public $sources;
 
     /**
+     * Custom lists opt into install-time pool filtering via the base-class hook,
+     * so a `block-scope` of `install` or `all` is honoured during `composer install`.
+     * The per-list `block-scope` config field narrows the decision inside shouldBlock().
+     */
+    protected function supportsInstallBlockScope(): bool
+    {
+        return true;
+    }
+
+    /**
      * @param array<string, list<IgnorePackageRule>> $ignore
      * @param list<UrlSource> $sources
      * @param self::AUDIT_* $audit
+     * @param self::BLOCK_SCOPE_* $blockScope
      */
     public function __construct(
         string $name,
         bool $block,
         string $audit,
+        string $blockScope,
         array $ignore,
         array $sources
     ) {
@@ -48,7 +65,22 @@ class CustomListPolicyConfig extends ListPolicyConfig
             $ignore
         );
 
+        $this->blockScope = $blockScope;
         $this->sources = $sources;
+    }
+
+    /**
+     * @param self::BLOCK_SCOPE_* $blockScope
+     */
+    public function shouldBlock(string $blockScope): bool
+    {
+        // Defer the "is this list enabled at all + supports this scope?" question
+        // to the base class; only the per-list `block-scope` narrowing is list-specific.
+        if (!parent::shouldBlock($blockScope)) {
+            return false;
+        }
+
+        return $this->blockScope === self::BLOCK_SCOPE_ALL || $this->blockScope === $blockScope;
     }
 
     public function withBlockingDisabled()
@@ -57,6 +89,7 @@ class CustomListPolicyConfig extends ListPolicyConfig
             $this->name,
             false,
             $this->audit,
+            $this->blockScope,
             $this->ignore,
             $this->sources
         );
@@ -68,6 +101,7 @@ class CustomListPolicyConfig extends ListPolicyConfig
             $this->name,
             $this->block,
             $audit,
+            $this->blockScope,
             $this->ignore,
             $this->sources
         );
@@ -102,6 +136,7 @@ class CustomListPolicyConfig extends ListPolicyConfig
             $listName,
             (bool) ($listConfig['block'] ?? true),
             $listConfig['audit'] ?? self::AUDIT_FAIL,
+            $listConfig['block-scope'] ?? self::BLOCK_SCOPE_UPDATE,
             IgnorePackageRule::parseIgnoreMap($listConfig['ignore'] ?? [], $parser),
             $sources
         );
@@ -113,6 +148,7 @@ class CustomListPolicyConfig extends ListPolicyConfig
             $listName,
             false,
             self::AUDIT_IGNORE,
+            self::BLOCK_SCOPE_UPDATE,
             [],
             []
         );

--- a/src/Composer/Policy/ListPolicyConfig.php
+++ b/src/Composer/Policy/ListPolicyConfig.php
@@ -48,6 +48,12 @@ abstract class ListPolicyConfig
     public const BLOCK_SCOPE_INSTALL = 'install';
     public const BLOCK_SCOPE_ALL = 'all';
 
+    public const AVAILABLE_BLOCK_SCOPES = [
+        self::BLOCK_SCOPE_UPDATE,
+        self::BLOCK_SCOPE_INSTALL,
+        self::BLOCK_SCOPE_ALL,
+    ];
+
     /** @var string List name */
     public $name;
 

--- a/tests/Composer/Test/Advisory/AuditorTest.php
+++ b/tests/Composer/Test/Advisory/AuditorTest.php
@@ -895,7 +895,7 @@ vendor/other matched dependency policy "test-list". Reason: internal.',
     ): PolicyConfig {
         $customLists = [];
         if ($filteredAudit !== null) {
-            $customLists[$filteredListName] = new CustomListPolicyConfig($filteredListName, false, $filteredAudit, [], []);
+            $customLists[$filteredListName] = new CustomListPolicyConfig($filteredListName, false, $filteredAudit, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [], []);
         }
 
         $packageRules = [];

--- a/tests/Composer/Test/Command/ConfigCommandTest.php
+++ b/tests/Composer/Test/Command/ConfigCommandTest.php
@@ -287,6 +287,11 @@ class ConfigCommandTest extends TestCase
             ['setting-key' => 'policy.my-list.audit', 'setting-value' => ['report']],
             ['config' => ['policy' => ['my-list' => ['audit' => 'report']]]],
         ];
+        yield 'set custom policy list block-scope' => [
+            [],
+            ['setting-key' => 'policy.my-list.block-scope', 'setting-value' => ['install']],
+            ['config' => ['policy' => ['my-list' => ['block-scope' => 'install']]]],
+        ];
         yield 'unset policy.advisories.block leaves siblings' => [
             ['config' => ['policy' => ['advisories' => ['block' => false, 'audit' => 'fail']]]],
             ['setting-key' => 'policy.advisories.block', '--unset' => true],
@@ -542,6 +547,17 @@ class ConfigCommandTest extends TestCase
 
         $appTester = $this->getApplicationTester();
         $appTester->run(['command' => 'config', 'setting-key' => 'policy.malware.block-scope', 'setting-value' => ['bogus']]);
+    }
+
+    public function testConfigThrowsForInvalidCustomPolicyBlockScope(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must be one of: all, update, install');
+
+        $this->initTempComposer([]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'config', 'setting-key' => 'policy.my-list.block-scope', 'setting-value' => ['bogus']]);
     }
 
     public function testConfigThrowsForInvalidPolicyIgnoreSeverity(): void

--- a/tests/Composer/Test/Fixtures/installer/install-policy-custom-list-block-scope-install.test
+++ b/tests/Composer/Test/Fixtures/installer/install-policy-custom-list-block-scope-install.test
@@ -1,5 +1,5 @@
 --TEST--
-Install proceeds when a custom list has block:true but the default block-scope (update) does not include install
+Install blocked when a custom dependency policy uses block-scope: install
 --COMPOSER--
 {
     "repositories": [
@@ -17,11 +17,11 @@ Install proceeds when a custom list has block:true but the default block-scope (
                 }
             ],
             "filter": {
-                "test-list": [
+                "company-policy": [
                     {
                         "package": "acme/library",
                         "constraint": "*",
-                        "url": "https://example.org/test-list/acme/library",
+                        "url": "https://example.org/company-policy/acme/library",
                         "reason": "internal block",
                         "id": "ID-test"
                     }
@@ -31,8 +31,9 @@ Install proceeds when a custom list has block:true but the default block-scope (
     ],
     "config": {
         "policy": {
-            "test-list": {
-                "block": true
+            "company-policy": {
+                "block": true,
+                "block-scope": "install"
             }
         }
     },
@@ -65,5 +66,14 @@ install
     "platform-dev": {}
 }
 
+--EXPECT-EXIT-CODE--
+2
+
+--EXPECT-OUTPUT--
+Installing dependencies from lock file (including require-dev)
+Verifying lock file contents can be installed on current platform.
+Your lock file does not contain a compatible set of packages. Please run composer update.
+
+  Problem 1
+    - Package acme/library 1.0 (in the lock file) was not loaded, because it was filtered by company-policy (see https://example.org/company-policy/acme/library) reason: internal block. To ignore filters for this package, add the package to the "policy.company-policy.ignore" config. To turn the feature off entirely, you can set "policy.company-policy.block" to false.
 --EXPECT--
-Installing acme/library (1.0)

--- a/tests/Composer/Test/Policy/CustomListPolicyConfigTest.php
+++ b/tests/Composer/Test/Policy/CustomListPolicyConfigTest.php
@@ -38,23 +38,42 @@ class CustomListPolicyConfigTest extends TestCase
     public function testDefaultConfig($listConfig): void
     {
         $this->assertEquals(
-            new CustomListPolicyConfig('test', true, ListPolicyConfig::AUDIT_FAIL, [], []),
+            new CustomListPolicyConfig('test', true, ListPolicyConfig::AUDIT_FAIL, ListPolicyConfig::BLOCK_SCOPE_UPDATE, [], []),
             CustomListPolicyConfig::fromRawConfig('test', $listConfig, new VersionParser())
         );
     }
 
-    public function testShouldBlockNeverAppliesToInstallScope(): void
+    /**
+     * @return iterable<string, array{0: ListPolicyConfig::BLOCK_SCOPE_*, 1: ListPolicyConfig::BLOCK_SCOPE_*, 2: bool}>
+     */
+    public static function shouldBlockMatrixProvider(): iterable
     {
-        $custom = new CustomListPolicyConfig('company-policy', true, ListPolicyConfig::AUDIT_FAIL, [], []);
+        // [configured block-scope, query scope, expected]
+        yield 'all + update' => [ListPolicyConfig::BLOCK_SCOPE_ALL, ListPolicyConfig::BLOCK_SCOPE_UPDATE, true];
+        yield 'all + install' => [ListPolicyConfig::BLOCK_SCOPE_ALL, ListPolicyConfig::BLOCK_SCOPE_INSTALL, true];
+        yield 'update + update' => [ListPolicyConfig::BLOCK_SCOPE_UPDATE, ListPolicyConfig::BLOCK_SCOPE_UPDATE, true];
+        yield 'update + install' => [ListPolicyConfig::BLOCK_SCOPE_UPDATE, ListPolicyConfig::BLOCK_SCOPE_INSTALL, false];
+        yield 'install + update' => [ListPolicyConfig::BLOCK_SCOPE_INSTALL, ListPolicyConfig::BLOCK_SCOPE_UPDATE, false];
+        yield 'install + install' => [ListPolicyConfig::BLOCK_SCOPE_INSTALL, ListPolicyConfig::BLOCK_SCOPE_INSTALL, true];
+    }
 
-        self::assertTrue($custom->shouldBlock(ListPolicyConfig::BLOCK_SCOPE_UPDATE));
-        self::assertFalse($custom->shouldBlock(ListPolicyConfig::BLOCK_SCOPE_INSTALL));
+    /**
+     * @dataProvider shouldBlockMatrixProvider
+     * @param ListPolicyConfig::BLOCK_SCOPE_* $configuredScope
+     * @param ListPolicyConfig::BLOCK_SCOPE_* $queryScope
+     */
+    public function testShouldBlockHonoursConfiguredBlockScope(string $configuredScope, string $queryScope, bool $expected): void
+    {
+        $custom = new CustomListPolicyConfig('company-policy', true, ListPolicyConfig::AUDIT_FAIL, $configuredScope, [], []);
+
+        self::assertSame($expected, $custom->shouldBlock($queryScope));
     }
 
     public function testFromRawConfig(): void
     {
         $rawListConfig = [
             'block' => false,
+            'block-scope' => 'install',
             'audit' => 'report',
             'ignore' => [
                 'acme/test' => 'flagged by mistake',
@@ -63,7 +82,7 @@ class CustomListPolicyConfigTest extends TestCase
             'sources' => [['type' => 'url', 'url' => 'https://example.com']]
         ];
         $this->assertEquals(
-            new CustomListPolicyConfig('test', false, ListPolicyConfig::AUDIT_REPORT, [
+            new CustomListPolicyConfig('test', false, ListPolicyConfig::AUDIT_REPORT, ListPolicyConfig::BLOCK_SCOPE_INSTALL, [
                 'acme/test' => [new IgnorePackageRule('acme/test', new MatchAllConstraint(), 'flagged by mistake')],
                 'acme/test2' => [new IgnorePackageRule('acme/test2', (new VersionParser())->parseConstraints('1.0'))],
             ], [new UrlSource('test', 'https://example.com')]),


### PR DESCRIPTION
Custom policies can currently only block during a `composer update`. It can be useful to have this apply to `composer install` too, for instance in the case where a company policies changes over time and an existing lock file suddenly contains packages which are no longer allowed.

The feature is currently opt-in by default to not introduce any BC breaks but happy to change it and apply blocking on install by default.