### PR TITLE
Policies: show which source blocked a package version as part of the filter list pool filter

### DIFF
--- a/src/Composer/Advisory/Auditor.php
+++ b/src/Composer/Advisory/Auditor.php
@@ -523,6 +523,9 @@ class Auditor
                     if ($entry->url !== null) {
                         $parts[] = 'URL: ' . $entry->url;
                     }
+                    if ($entry->source !== null) {
+                        $parts[] = 'Source: ' . $entry->source;
+                    }
                     $io->write(implode('. ', $parts) . '.');
                 }
             }

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -208,10 +208,11 @@ class Pool implements \Countable
 
                     $seen[$entryKey] = true;
 
+                    $source = (bool) $entry->source ? ' reported by ' . $entry->source : '';
                     $url = (bool) $entry->url ? ' (see ' . $entry->url . ')' : '';
                     $reason = (bool) $entry->reason ? ' reason: ' . $entry->reason : '';
 
-                    $lists[$entry->listName][] =  $url . $reason;
+                    $lists[$entry->listName][] =  $source . $url . $reason;
                 }
 
             }

--- a/tests/Composer/Test/Advisory/AuditorTest.php
+++ b/tests/Composer/Test/Advisory/AuditorTest.php
@@ -666,6 +666,15 @@ Found 2 abandoned packages:
             'internal',
             'ID-test-1'
         );
+        $matchingEntryWithSource = new FilterListEntry(
+            'vendor/package',
+            new Constraint('>=', '8.0.0.0'),
+            'test-list',
+            'https://example.com/filtered',
+            'internal',
+            'ID-test-1',
+            'aikido'
+        );
 
         yield 'AUDIT_IGNORE skips filter processing' => [
             'packages' => [new Package('vendor/package', '9.0.0', '9.0.0')],
@@ -705,6 +714,17 @@ vendor/package matched dependency policy "test-list". Reason: internal.',
             'output' => 'No security vulnerability advisories found.
 Found 1 package matching filters:
 vendor/package matched dependency policy "test-list". Reason: internal. URL: https://example.com/filtered.',
+        ];
+
+        yield 'AUDIT_FAIL with matching entry shows source (plain)' => [
+            'packages' => [new Package('vendor/package', '9.0.0', '9.0.0')],
+            'filterEntriesByList' => ['test-list' => [$matchingEntryWithSource]],
+            'filtered' => ListPolicyConfig::AUDIT_FAIL,
+            'format' => Auditor::FORMAT_PLAIN,
+            'expected' => Auditor::STATUS_FAILED,
+            'output' => 'No security vulnerability advisories found.
+Found 1 package matching filters:
+vendor/package matched dependency policy "test-list". Reason: internal. URL: https://example.com/filtered. Source: aikido.',
         ];
 
         yield 'AUDIT_REPORT with matching entry returns STATUS_OK' => [

--- a/tests/Composer/Test/DependencyResolver/ProblemTest.php
+++ b/tests/Composer/Test/DependencyResolver/ProblemTest.php
@@ -31,7 +31,8 @@ class ProblemTest extends TestCase
             'malware',
             'https://example.org/malware/vendor-malware',
             'looks suspicious',
-            'PKG-1'
+            'PKG-1',
+            'aikido'
         );
         $pool = new Pool([], [], [], [], [], [], [
             'vendor/malware' => ['1.0.0.0' => [$entry]],
@@ -41,7 +42,7 @@ class ProblemTest extends TestCase
 
         self::assertSame('- Package vendor/malware 1.0.0 (in the lock file) ', $prefix);
 
-        self::assertStringContainsString('flagged as malware', $suffix);
+        self::assertStringContainsString('flagged as malware reported by aikido', $suffix);
         self::assertStringContainsString('https://example.org/malware/vendor-malware', $suffix);
         self::assertStringContainsString('reason: looks suspicious', $suffix);
         self::assertStringContainsString('"policy.malware.ignore"', $suffix);

--- a/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-direct-dependency.test
+++ b/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-direct-dependency.test
@@ -76,5 +76,5 @@ Verifying lock file contents can be installed on current platform.
 Your lock file does not contain a compatible set of packages. Please run composer update.
 
   Problem 1
-    - Package acme/library 1.0 (in the lock file) was not loaded, because it was flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - Package acme/library 1.0 (in the lock file) was not loaded, because it was flagged as malware reported by Source (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-scope-install.test
+++ b/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-scope-install.test
@@ -76,5 +76,5 @@ Verifying lock file contents can be installed on current platform.
 Your lock file does not contain a compatible set of packages. Please run composer update.
 
   Problem 1
-    - Package acme/library 1.0 (in the lock file) was not loaded, because it was flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - Package acme/library 1.0 (in the lock file) was not loaded, because it was flagged as malware reported by Source (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-transitive-dependency.test
+++ b/tests/Composer/Test/Fixtures/installer/install-policy-malware-block-transitive-dependency.test
@@ -101,9 +101,9 @@ Verifying lock file contents can be installed on current platform.
 Your lock file does not contain a compatible set of packages. Please run composer update.
 
   Problem 1
-    - Package acme/dependency 1.0 (in the lock file) was not loaded, because it was flagged as malware (see https://example.org/malware/acme/dependency) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - Package acme/dependency 1.0 (in the lock file) was not loaded, because it was flagged as malware reported by Source (see https://example.org/malware/acme/dependency) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
   Problem 2
     - acme/library is locked to version 1.0 and an update of this package was not requested.
-    - acme/library 1.0 requires acme/dependency 1.0 -> found acme/dependency[1.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/dependency) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - acme/library 1.0 requires acme/dependency 1.0 -> found acme/dependency[1.0] but these were not loaded, because they were flagged as malware reported by Source (see https://example.org/malware/acme/dependency) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/partial-update-policy-malware-block-locked-package.test
+++ b/tests/Composer/Test/Fixtures/installer/partial-update-policy-malware-block-locked-package.test
@@ -106,8 +106,8 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - Root composer.json requires acme/library 1.0 (exact version match: 1.0, 1.0.0 or 1.0.0.0), found acme/library[1.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - Root composer.json requires acme/library 1.0 (exact version match: 1.0, 1.0.0 or 1.0.0.0), found acme/library[1.0] but these were not loaded, because they were flagged as malware reported by Source (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
   Problem 2
-    - Package acme/library 1.0 (in the lock file) was not loaded, because it was flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - Package acme/library 1.0 (in the lock file) was not loaded, because it was flagged as malware reported by Source (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/update-mirrors-policy-malware-block-locked-package.test
+++ b/tests/Composer/Test/Fixtures/installer/update-mirrors-policy-malware-block-locked-package.test
@@ -75,6 +75,6 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - Root composer.json requires acme/library == 1.0.0.0 (exact version match), found acme/library[1.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - Root composer.json requires acme/library == 1.0.0.0 (exact version match), found acme/library[1.0] but these were not loaded, because they were flagged as malware reported by Source (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/update-mirrors-policy-malware-block-scope-install-locked-package.test
+++ b/tests/Composer/Test/Fixtures/installer/update-mirrors-policy-malware-block-scope-install-locked-package.test
@@ -76,6 +76,6 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - Root composer.json requires acme/library == 1.0.0.0 (exact version match), found acme/library[1.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - Root composer.json requires acme/library == 1.0.0.0 (exact version match), found acme/library[1.0] but these were not loaded, because they were flagged as malware reported by Source (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
 
 --EXPECT--

--- a/tests/Composer/Test/Fixtures/installer/update-policy-malware-entry-ignore-source-not-matching.test
+++ b/tests/Composer/Test/Fixtures/installer/update-policy-malware-entry-ignore-source-not-matching.test
@@ -51,6 +51,6 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - Root composer.json requires acme/library 1.0.0 (exact version match: 1.0.0 or 1.0.0.0), found acme/library[1.0.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - Root composer.json requires acme/library 1.0.0 (exact version match: 1.0.0 or 1.0.0.0), found acme/library[1.0.0] but these were not loaded, because they were flagged as malware reported by trusted (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
 --EXPECT--
 

--- a/tests/Composer/Test/Fixtures/installer/update-policy-malware-entry-matching-direct-dependency.test
+++ b/tests/Composer/Test/Fixtures/installer/update-policy-malware-entry-matching-direct-dependency.test
@@ -44,6 +44,6 @@ Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
-    - Root composer.json requires acme/library 1.0.0 (exact version match: 1.0.0 or 1.0.0.0), found acme/library[1.0.0] but these were not loaded, because they were flagged as malware (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
+    - Root composer.json requires acme/library 1.0.0 (exact version match: 1.0.0 or 1.0.0.0), found acme/library[1.0.0] but these were not loaded, because they were flagged as malware reported by Source (see https://example.org/malware/acme/library) reason: malware. To ignore filters for this package, add the package to the "policy.malware.ignore" config. To turn the feature off entirely, you can set "policy.malware.block" to false.
 
 --EXPECT--


### PR DESCRIPTION
We never really display from which source a filter entry is from during the `composer install|update` output, making it hard to use the `ignore-source` config. See integration test adjustments for adjusted output.