### PR TITLE
Add sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,17 @@ Sponsors
 Thank you to our sponsors for supporting the ongoing development and maintenance of Composer and Packagist.org! See [getcomposer.org/sponsor](https://getcomposer.org/sponsor/) for more information on becoming a sponsor.
 
 <p align="center">
-    <a href="https://packagist.com/?utm_source=composer"><img src="https://packagist.org/img/private-packagist-dark.svg" alt="Private Packagist" height="60" hspace="15"></a>
-    <a href="https://www.aikido.dev/?utm_source=composer"><img src="https://packagist.org/img/aikido-dark.svg" alt="Aikido" height="60" hspace="15"></a>
-    <a href="https://www.sovereign.tech/?utm_source=composer"><img src="https://packagist.org/img/sovereign-tech-agency-dark.svg" alt="Sovereign Tech Fund" height="60" hspace="15"></a>
-    <a href="https://aws.amazon.com/?utm_source=composer"><img src="https://packagist.org/img/aws-dark.svg" alt="AWS" height="60" hspace="15"></a>
-    <a href="https://socket.dev/?utm_source=composer"><img src="https://packagist.org/img/socket-dark.svg" alt="Socket" height="60" hspace="15"></a>
-    <a href="https://upsun.com/?utm_source=composer"><img src="https://packagist.org/img/upsun-dark.svg" alt="Upsun" height="60" hspace="15"></a>
-    <a href="https://bunny.net/?utm_source=composer"><img src="https://packagist.org/img/bunny-net-dark.svg" alt="Bunny.net" height="60" hspace="15"></a>
-    <a href="https://tideways.com/?utm_source=composer"><img src="https://packagist.org/img/tideways-dark.svg" alt="Tideways" height="60" hspace="15"></a>
-    <a href="https://datadog.com/?utm_source=composer"><img src="https://packagist.org/img/datadog-dark.svg" alt="Datadog" height="60" hspace="15"></a>
-    <a href="https://www.algolia.com/?utm_source=composer"><img src="https://packagist.org/img/algolia-dark.svg" alt="Algolia" height="60" hspace="15"></a>
+    <a href="https://packagist.com/?utm_source=composer"><img src="https://packagist.org/img/sponsors/private-packagist-dark.svg" alt="Private Packagist" height="60" hspace="15"></a>
+    <a href="https://www.aikido.dev/?utm_source=composer"><img src="https://packagist.org/img/sponsors/aikido-dark.svg" alt="Aikido" height="60" hspace="15"></a>
+    <a href="https://www.sovereign.tech/?utm_source=composer"><img src="https://packagist.org/img/sponsors/sovereign-tech-agency-dark.svg" alt="Sovereign Tech Fund" height="60" hspace="15"></a>
+    <a href="https://aws.amazon.com/?utm_source=composer"><img src="https://packagist.org/img/sponsors/aws-dark.svg" alt="AWS" height="60" hspace="15"></a>
+    <a href="https://socket.dev/?utm_source=composer"><img src="https://packagist.org/img/sponsors/socket-dark.svg" alt="Socket" height="60" hspace="15"></a>
+    <a href="https://upsun.com/?utm_source=composer"><img src="https://packagist.org/img/sponsors/upsun-dark.svg" alt="Upsun" height="60" hspace="15"></a>
+    <a href="https://www.sonatype.com/?utm_source=composer"><img src="https://packagist.org/img/sponsors/sonatype-dark.svg" alt="Sonatype" height="60" hspace="15"></a>
+    <a href="https://bunny.net/?utm_source=composer"><img src="https://packagist.org/img/sponsors/bunny-net-dark.svg" alt="Bunny.net" height="60" hspace="15"></a>
+    <a href="https://tideways.com/?utm_source=composer"><img src="https://packagist.org/img/sponsors/tideways-dark.svg" alt="Tideways" height="60" hspace="15"></a>
+    <a href="https://datadog.com/?utm_source=composer"><img src="https://packagist.org/img/sponsors/datadog-dark.svg" alt="Datadog" height="60" hspace="15"></a>
+    <a href="https://www.algolia.com/?utm_source=composer"><img src="https://packagist.org/img/sponsors/algolia-dark.svg" alt="Algolia" height="60" hspace="15"></a>
 </p>
 
 License

--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ Security Reports
 
 Please send any sensitive issue to [security@packagist.org](mailto:security@packagist.org). Thanks!
 
+Sponsors
+--------
+
+Thank you to our sponsors for supporting the ongoing development and maintenance of Composer and Packagist.org! See [packagist.org/sponsor](https://packagist.org/sponsor/) for more information on becoming a sponsor.
+
+<p align="center">
+    <a href="https://packagist.com/?utm_source=composer"><img src="https://packagist.org/img/private-packagist-dark.svg" alt="Private Packagist" width="180" height="60"></a>
+    <a href="https://www.aikido.dev/?utm_source=composer"><img src="https://packagist.org/img/aikido-dark.svg" alt="Aikido" width="180" height="60"></a>
+    <a href="https://www.sovereign.tech/?utm_source=composer"><img src="https://packagist.org/img/sovereign-tech-agency-dark.svg" alt="Sovereign Tech Fund" width="180" height="60"></a>
+    <a href="https://aws.amazon.com/?utm_source=composer"><img src="https://packagist.org/img/aws-dark.svg" alt="AWS" width="180" height="60"></a>
+    <a href="https://socket.dev/?utm_source=composer"><img src="https://packagist.org/img/socket-dark.svg" alt="Socket" width="180" height="60"></a>
+    <a href="https://upsun.com/?utm_source=composer"><img src="https://packagist.org/img/upsun-dark.svg" alt="Upsun" width="180" height="60"></a>
+    <a href="https://bunny.net/?utm_source=composer"><img src="https://packagist.org/img/bunny-net-dark.svg" alt="Bunny.net" width="180" height="60"></a>
+    <a href="https://tideways.com/?utm_source=composer"><img src="https://packagist.org/img/tideways-dark.svg" alt="Tideways" width="180" height="60"></a>
+    <a href="https://datadog.com/?utm_source=composer"><img src="https://packagist.org/img/datadog-dark.svg" alt="Datadog" width="180" height="60"></a>
+    <a href="https://www.algolia.com/?utm_source=composer"><img src="https://packagist.org/img/algolia-dark.svg" alt="Algolia" width="180" height="60"></a>
+</p>
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Please send any sensitive issue to [security@packagist.org](mailto:security@pack
 Sponsors
 --------
 
-Thank you to our sponsors for supporting the ongoing development and maintenance of Composer and Packagist.org! See [packagist.org/sponsor](https://packagist.org/sponsor/) for more information on becoming a sponsor.
+Thank you to our sponsors for supporting the ongoing development and maintenance of Composer and Packagist.org! See [getcomposer.org/sponsor](https://getcomposer.org/sponsor/) for more information on becoming a sponsor.
 
 <p align="center">
     <a href="https://packagist.com/?utm_source=composer"><img src="https://packagist.org/img/private-packagist-dark.svg" alt="Private Packagist" height="60" hspace="15"></a>

--- a/README.md
+++ b/README.md
@@ -87,16 +87,16 @@ Sponsors
 Thank you to our sponsors for supporting the ongoing development and maintenance of Composer and Packagist.org! See [packagist.org/sponsor](https://packagist.org/sponsor/) for more information on becoming a sponsor.
 
 <p align="center">
-    <a href="https://packagist.com/?utm_source=composer"><img src="https://packagist.org/img/private-packagist-dark.svg" alt="Private Packagist" width="180" height="60"></a>
-    <a href="https://www.aikido.dev/?utm_source=composer"><img src="https://packagist.org/img/aikido-dark.svg" alt="Aikido" width="180" height="60"></a>
-    <a href="https://www.sovereign.tech/?utm_source=composer"><img src="https://packagist.org/img/sovereign-tech-agency-dark.svg" alt="Sovereign Tech Fund" width="180" height="60"></a>
-    <a href="https://aws.amazon.com/?utm_source=composer"><img src="https://packagist.org/img/aws-dark.svg" alt="AWS" width="180" height="60"></a>
-    <a href="https://socket.dev/?utm_source=composer"><img src="https://packagist.org/img/socket-dark.svg" alt="Socket" width="180" height="60"></a>
-    <a href="https://upsun.com/?utm_source=composer"><img src="https://packagist.org/img/upsun-dark.svg" alt="Upsun" width="180" height="60"></a>
-    <a href="https://bunny.net/?utm_source=composer"><img src="https://packagist.org/img/bunny-net-dark.svg" alt="Bunny.net" width="180" height="60"></a>
-    <a href="https://tideways.com/?utm_source=composer"><img src="https://packagist.org/img/tideways-dark.svg" alt="Tideways" width="180" height="60"></a>
-    <a href="https://datadog.com/?utm_source=composer"><img src="https://packagist.org/img/datadog-dark.svg" alt="Datadog" width="180" height="60"></a>
-    <a href="https://www.algolia.com/?utm_source=composer"><img src="https://packagist.org/img/algolia-dark.svg" alt="Algolia" width="180" height="60"></a>
+    <a href="https://packagist.com/?utm_source=composer"><img src="https://packagist.org/img/private-packagist-dark.svg" alt="Private Packagist" height="60"></a>
+    <a href="https://www.aikido.dev/?utm_source=composer"><img src="https://packagist.org/img/aikido-dark.svg" alt="Aikido" height="60"></a>
+    <a href="https://www.sovereign.tech/?utm_source=composer"><img src="https://packagist.org/img/sovereign-tech-agency-dark.svg" alt="Sovereign Tech Fund" height="60"></a>
+    <a href="https://aws.amazon.com/?utm_source=composer"><img src="https://packagist.org/img/aws-dark.svg" alt="AWS" height="60"></a>
+    <a href="https://socket.dev/?utm_source=composer"><img src="https://packagist.org/img/socket-dark.svg" alt="Socket" height="60"></a>
+    <a href="https://upsun.com/?utm_source=composer"><img src="https://packagist.org/img/upsun-dark.svg" alt="Upsun" height="60"></a>
+    <a href="https://bunny.net/?utm_source=composer"><img src="https://packagist.org/img/bunny-net-dark.svg" alt="Bunny.net" height="60"></a>
+    <a href="https://tideways.com/?utm_source=composer"><img src="https://packagist.org/img/tideways-dark.svg" alt="Tideways" height="60"></a>
+    <a href="https://datadog.com/?utm_source=composer"><img src="https://packagist.org/img/datadog-dark.svg" alt="Datadog" height="60"></a>
+    <a href="https://www.algolia.com/?utm_source=composer"><img src="https://packagist.org/img/algolia-dark.svg" alt="Algolia" height="60"></a>
 </p>
 
 License

--- a/README.md
+++ b/README.md
@@ -87,16 +87,16 @@ Sponsors
 Thank you to our sponsors for supporting the ongoing development and maintenance of Composer and Packagist.org! See [packagist.org/sponsor](https://packagist.org/sponsor/) for more information on becoming a sponsor.
 
 <p align="center">
-    <a href="https://packagist.com/?utm_source=composer"><img src="https://packagist.org/img/private-packagist-dark.svg" alt="Private Packagist" height="60"></a>
-    <a href="https://www.aikido.dev/?utm_source=composer"><img src="https://packagist.org/img/aikido-dark.svg" alt="Aikido" height="60"></a>
-    <a href="https://www.sovereign.tech/?utm_source=composer"><img src="https://packagist.org/img/sovereign-tech-agency-dark.svg" alt="Sovereign Tech Fund" height="60"></a>
-    <a href="https://aws.amazon.com/?utm_source=composer"><img src="https://packagist.org/img/aws-dark.svg" alt="AWS" height="60"></a>
-    <a href="https://socket.dev/?utm_source=composer"><img src="https://packagist.org/img/socket-dark.svg" alt="Socket" height="60"></a>
-    <a href="https://upsun.com/?utm_source=composer"><img src="https://packagist.org/img/upsun-dark.svg" alt="Upsun" height="60"></a>
-    <a href="https://bunny.net/?utm_source=composer"><img src="https://packagist.org/img/bunny-net-dark.svg" alt="Bunny.net" height="60"></a>
-    <a href="https://tideways.com/?utm_source=composer"><img src="https://packagist.org/img/tideways-dark.svg" alt="Tideways" height="60"></a>
-    <a href="https://datadog.com/?utm_source=composer"><img src="https://packagist.org/img/datadog-dark.svg" alt="Datadog" height="60"></a>
-    <a href="https://www.algolia.com/?utm_source=composer"><img src="https://packagist.org/img/algolia-dark.svg" alt="Algolia" height="60"></a>
+    <a href="https://packagist.com/?utm_source=composer"><img src="https://packagist.org/img/private-packagist-dark.svg" alt="Private Packagist" height="60" hspace="15"></a>
+    <a href="https://www.aikido.dev/?utm_source=composer"><img src="https://packagist.org/img/aikido-dark.svg" alt="Aikido" height="60" hspace="15"></a>
+    <a href="https://www.sovereign.tech/?utm_source=composer"><img src="https://packagist.org/img/sovereign-tech-agency-dark.svg" alt="Sovereign Tech Fund" height="60" hspace="15"></a>
+    <a href="https://aws.amazon.com/?utm_source=composer"><img src="https://packagist.org/img/aws-dark.svg" alt="AWS" height="60" hspace="15"></a>
+    <a href="https://socket.dev/?utm_source=composer"><img src="https://packagist.org/img/socket-dark.svg" alt="Socket" height="60" hspace="15"></a>
+    <a href="https://upsun.com/?utm_source=composer"><img src="https://packagist.org/img/upsun-dark.svg" alt="Upsun" height="60" hspace="15"></a>
+    <a href="https://bunny.net/?utm_source=composer"><img src="https://packagist.org/img/bunny-net-dark.svg" alt="Bunny.net" height="60" hspace="15"></a>
+    <a href="https://tideways.com/?utm_source=composer"><img src="https://packagist.org/img/tideways-dark.svg" alt="Tideways" height="60" hspace="15"></a>
+    <a href="https://datadog.com/?utm_source=composer"><img src="https://packagist.org/img/datadog-dark.svg" alt="Datadog" height="60" hspace="15"></a>
+    <a href="https://www.algolia.com/?utm_source=composer"><img src="https://packagist.org/img/algolia-dark.svg" alt="Algolia" height="60" hspace="15"></a>
 </p>
 
 License


### PR DESCRIPTION
Adds a Sponsors section to the README thanking our sponsors, linking to https://getcomposer.org/sponsor/ for information on becoming a sponsor, and showing the sponsor logos linked to each sponsor's site.

The logo list and order match the redesigned sponsor page including composer/packagist#1797, which adds Socket, Upsun and Sonatype and reorders the grid — that PR needs to be merged and deployed first, as the logos live under the new `img/sponsors/` path it introduces, so all logo URLs 404 on packagist.org until then.

Notes:
- Sponsor links use `?utm_source=composer` (instead of `utm_source=packagist` as on the sponsor page) so clicks from this README are attributed separately.
- The logos are dark-on-transparent, so contrast is low in GitHub dark mode. GitHub supports theme-aware images via `<picture>`/`prefers-color-scheme`, but packagist.org would first need to host light-on-dark variants of all logos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


