### PR TITLE
Add detection for ambiguous namespaces

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -1102,7 +1102,8 @@ performance.
 * **--strict-psr:** Return a failed exit code (1) if PSR-4 or PSR-0 mapping errors
   are present in the current project (dependencies excluded). Requires `--optimize` to work.
 * **--strict-ambiguous:** Return a failed exit code (2) if the same class is found
-  in multiple files. Requires `--optimize` to work.
+  in multiple files. It also checks if files or folders exist with different case variants that
+  cause issues on case-insensitive filesystems. Requires `--optimize` to work.
 
 ## clear-cache / clearcache / cc
 

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -365,8 +365,10 @@ EOF;
         $classMap = $classMapGenerator->getClassMap();
         if ($strictAmbiguous) {
             $ambiguousClasses = $classMap->getAmbiguousClasses(false);
+            $ambiguousFolders = $classMap->getAmbiguousFolders(false);
         } else {
             $ambiguousClasses = $classMap->getAmbiguousClasses();
+            $ambiguousFolders = $classMap->getAmbiguousFolders();
         }
         foreach ($ambiguousClasses as $className => $ambiguousPaths) {
             if (count($ambiguousPaths) > 1) {
@@ -381,7 +383,13 @@ EOF;
                 );
             }
         }
-        if (\count($ambiguousClasses) > 0) {
+        foreach ($ambiguousFolders as $ambiguousFolderSet) {
+            $this->io->writeError(
+                '<warning>Warning: Ambiguous folder/file resolution'.
+                ' multiple folders/files ('. count($ambiguousFolderSet) .') map to the same case-insensitive path: "'. implode('", "', $ambiguousFolderSet) .'", this results in broken autoloading on case-insensitive filesystems.</warning>'
+            );
+        }
+        if (\count($ambiguousClasses) > 0 || \count($ambiguousFolders) > 0) {
             $this->io->writeError('<info>To resolve ambiguity in classes not under your control you can ignore them by path using <href='.OutputFormatter::escape('https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps').'>exclude-from-classmap</>');
         }
 

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -137,7 +137,7 @@ EOT
             return 1;
         }
 
-        if ($input->getOption('strict-ambiguous') && count($classMap->getAmbiguousClasses(false)) > 0) {
+        if ($input->getOption('strict-ambiguous') && (count($classMap->getAmbiguousClasses(false)) > 0 || count($classMap->getAmbiguousFolders(false)) > 0)) {
             return 2;
         }
 


### PR DESCRIPTION
When multiple folders exist in a repository with the same name but different casing, this currently results in ambiguous behaviour when running on case-sensitive filesystems vs case-insensitive filesystems.

Say we have two files (note the upper/lowercase F in both the namespace and folder name):
```php
// src/foo/Foo.php
namespace foo;
```
```php
// src/Foo/Bar.php
namespace Foo;
```
Both are valid according to PSR4, but on checkout on a case insensitive filesystem like Windows or MacOS, they will both end up in the same folder, and the file structure will look like this:
```php
// src/foo/Foo.php
namespace foo;
```
```php
// src/foo/Bar.php
namespace Foo;
```

Note that the folder name was Case Folded: Both files ended up in the same folder as they were considered the same on this file system. As a result, the casing of the namespace is not identical to the casing of the folder anymore.

As a result, the autoloading works on a case-sensitive filesystem (Most of linux):
```bash
composer dump-autoload --optimize --strict-psr ---strict-ambiguous
Generating optimized autoload files
Generated optimized autoload files containing X classes

echo $?
0
```

But not on a case-insensitive filesystem (Most of MacOS, Windows):
```bash
composer dump-autoload --optimize --strict-psr --strict-ambiguous
Generating optimized autoload files
Class Foo\\Bar located in foo/Bar.php does not comply with psr-4 autoloading standard (rule: Foo\ => /foo). Skipping.
Generated optimized autoload files containing X classes

echo $?
1
```

I've experienced this issue at several of the companies I've worked for; A folder gets renamed by a developer to the same name with different capitalization. Most people on MacOS and Windows don't notice the capitalization change, as their local copy keeps the old capitalization. When other developers add a new file, the old capitalization is used.

I've encountered this issue again today. And rather than building the same CI Check again, I think it's time to share this check with the community so I don't have to write this check again. ;)

Given that the `--strict-ambiguous` flag already exists, I think this is the right place to add this.

Let me know if I can clarify anything!