### PR TITLE
Fix suggest filtering for non-installed packages (#12992)

### DIFF
--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -69,9 +69,19 @@ EOT
         $installedRepo = new InstalledRepository($installedRepos);
         $reporter = new SuggestedPackagesReporter($this->getIO());
 
-        $filter = $input->getArgument('packages');
+        $filter = array_map('strtolower', $input->getArgument('packages'));
         $packages = $installedRepo->getPackages();
         $packages[] = $composer->getPackage();
+        foreach ($filter as $package) {
+            if ($installedRepo->findPackages($package) !== []) {
+                continue;
+            }
+
+            $this->getIO()->writeError('<error>Package "'.$package.'" is not installed</error>');
+
+            return self::FAILURE;
+        }
+
         foreach ($packages as $package) {
             if (!empty($filter) && !in_array($package->getName(), $filter)) {
                 continue;

--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -67,23 +67,47 @@ EOT
         }
 
         $installedRepo = new InstalledRepository($installedRepos);
-        $reporter = new SuggestedPackagesReporter($this->getIO());
+        $filter = $input->getArgument('packages');
+        $normalizedFilter = array_map('strtolower', $filter);
+        $validationRepo = $installedRepo;
+        if ($locker->isLocked() && $input->getOption('no-dev')) {
+            $validationRepo = new InstalledRepository([$locker->getLockedRepository(true)]);
+        }
 
-        $filter = array_map('strtolower', $input->getArgument('packages'));
-        $packages = $installedRepo->getPackages();
-        $packages[] = $composer->getPackage();
-        foreach ($filter as $package) {
+        $missingPackages = [];
+        $excludedPackages = [];
+        foreach ($normalizedFilter as $index => $package) {
             if ($installedRepo->findPackages($package) !== []) {
                 continue;
             }
 
-            $this->getIO()->writeError('<error>Package "'.$package.'" is not installed</error>');
-
-            return self::FAILURE;
+            if ($validationRepo->findPackages($package) !== []) {
+                $excludedPackages[] = $filter[$index];
+            } else {
+                $missingPackages[] = $filter[$index];
+            }
         }
 
+        $errors = [];
+        if ($missingPackages !== []) {
+            $errors[] = count($missingPackages) === 1
+                ? 'Package "'.$missingPackages[0].'" is not installed.'
+                : 'Packages "'.implode('", "', $missingPackages).'" are not installed.';
+        }
+        if ($excludedPackages !== []) {
+            $errors[] = count($excludedPackages) === 1
+                ? 'Package "'.$excludedPackages[0].'" is excluded by --no-dev.'
+                : 'Packages "'.implode('", "', $excludedPackages).'" are excluded by --no-dev.';
+        }
+        if ($errors !== []) {
+            throw new \InvalidArgumentException(implode(' ', $errors));
+        }
+
+        $reporter = new SuggestedPackagesReporter($this->getIO());
+        $packages = $installedRepo->getPackages();
+        $packages[] = $composer->getPackage();
         foreach ($packages as $package) {
-            if (!empty($filter) && !in_array($package->getName(), $filter)) {
+            if ($normalizedFilter !== [] && !in_array($package->getName(), $normalizedFilter, true)) {
                 continue;
             }
 
@@ -106,7 +130,7 @@ EOT
             $mode = SuggestedPackagesReporter::MODE_LIST;
         }
 
-        $reporter->output($mode, $installedRepo, empty($filter) && !$input->getOption('all') ? $composer->getPackage() : null);
+        $reporter->output($mode, $installedRepo, $normalizedFilter === [] && !$input->getOption('all') ? $composer->getPackage() : null);
 
         return 0;
     }

--- a/src/Composer/Command/SuggestsCommand.php
+++ b/src/Composer/Command/SuggestsCommand.php
@@ -100,7 +100,11 @@ EOT
                 : 'Packages "'.implode('", "', $excludedPackages).'" are excluded by --no-dev.';
         }
         if ($errors !== []) {
-            throw new \InvalidArgumentException(implode(' ', $errors));
+            foreach ($errors as $error) {
+                $this->getIO()->writeError('<error>'.$error.'</error>');
+            }
+
+            return 1;
         }
 
         $reporter = new SuggestedPackagesReporter($this->getIO());

--- a/tests/Composer/Test/Command/SuggestsCommandTest.php
+++ b/tests/Composer/Test/Command/SuggestsCommandTest.php
@@ -15,6 +15,7 @@ namespace Composer\Test\Command;
 use Composer\Package\CompletePackage;
 use Composer\Package\Link;
 use Composer\Test\TestCase;
+use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
 
 class SuggestsCommandTest extends TestCase
@@ -50,13 +51,57 @@ class SuggestsCommandTest extends TestCase
         self::assertEmpty($appTester->getDisplay(true));
     }
 
-    public function testFailsWhenFilteringByNonInstalledPackage(): void
+    /**
+     * @dataProvider provideMissingPackageFilters
+     * @param list<string> $filters
+     */
+    public function testFailsWhenFilteringByNonInstalledPackages(array $filters, string $message): void
     {
         $this->initTempComposer();
 
-        $appTester = $this->getApplicationTester();
-        self::assertEquals(Command::FAILURE, $appTester->run(['command' => 'suggest', 'packages' => ['vendor/not-installed']]));
-        self::assertSame('Package "vendor/not-installed" is not installed', trim($appTester->getDisplay(true)));
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        $this->getApplicationTester()->run(['command' => 'suggest', 'packages' => $filters]);
+    }
+
+    public static function provideMissingPackageFilters(): \Generator
+    {
+        yield 'single' => [['Vendor/Not-Installed'], 'Package "Vendor/Not-Installed" is not installed.'];
+        yield 'multiple' => [['Vendor/Not-Installed', 'other/missing'], 'Packages "Vendor/Not-Installed", "other/missing" are not installed.'];
+    }
+
+    /**
+     * @dataProvider provideExcludedDevPackageFilters
+     * @param list<string> $filters
+     */
+    public function testFilteringByDevPackageWithNoDevReportsItAsExcluded(array $filters, string $message): void
+    {
+        $this->initTempComposer([
+            'require-dev' => [
+                'vendor/dev-package' => '^1',
+                'other/dev-package' => '^1',
+            ],
+        ]);
+
+        $devPackages = [self::getPackage('vendor/dev-package'), self::getPackage('other/dev-package')];
+        $this->createInstalledJson([], $devPackages);
+        $this->createComposerLock([], $devPackages);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        $this->getApplicationTester()->run(['command' => 'suggest', '--no-dev' => true, 'packages' => $filters]);
+    }
+
+    public static function provideExcludedDevPackageFilters(): \Generator
+    {
+        yield 'single' => [['Vendor/Dev-Package'], 'Package "Vendor/Dev-Package" is excluded by --no-dev.'];
+        yield 'multiple' => [['Vendor/Dev-Package', 'other/dev-package'], 'Packages "Vendor/Dev-Package", "other/dev-package" are excluded by --no-dev.'];
+        yield 'missing and excluded' => [
+            ['missing/package', 'Vendor/Dev-Package'],
+            'Package "missing/package" is not installed. Package "Vendor/Dev-Package" is excluded by --no-dev.',
+        ];
     }
 
     /**

--- a/tests/Composer/Test/Command/SuggestsCommandTest.php
+++ b/tests/Composer/Test/Command/SuggestsCommandTest.php
@@ -15,7 +15,6 @@ namespace Composer\Test\Command;
 use Composer\Package\CompletePackage;
 use Composer\Package\Link;
 use Composer\Test\TestCase;
-use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
 
 class SuggestsCommandTest extends TestCase
@@ -59,10 +58,11 @@ class SuggestsCommandTest extends TestCase
     {
         $this->initTempComposer();
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($message);
+        $appTester = $this->getApplicationTester();
 
-        $this->getApplicationTester()->run(['command' => 'suggest', 'packages' => $filters]);
+        self::assertEquals(Command::FAILURE, $appTester->run(['command' => 'suggest', 'packages' => $filters], ['capture_stderr_separately' => true]));
+        self::assertSame('', $appTester->getDisplay(true));
+        self::assertSame($message, trim($appTester->getErrorOutput(true)));
     }
 
     public static function provideMissingPackageFilters(): \Generator
@@ -88,10 +88,11 @@ class SuggestsCommandTest extends TestCase
         $this->createInstalledJson([], $devPackages);
         $this->createComposerLock([], $devPackages);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($message);
+        $appTester = $this->getApplicationTester();
 
-        $this->getApplicationTester()->run(['command' => 'suggest', '--no-dev' => true, 'packages' => $filters]);
+        self::assertEquals(Command::FAILURE, $appTester->run(['command' => 'suggest', '--no-dev' => true, 'packages' => $filters], ['capture_stderr_separately' => true]));
+        self::assertSame('', $appTester->getDisplay(true));
+        self::assertSame($message, trim($appTester->getErrorOutput(true)));
     }
 
     public static function provideExcludedDevPackageFilters(): \Generator
@@ -100,7 +101,7 @@ class SuggestsCommandTest extends TestCase
         yield 'multiple' => [['Vendor/Dev-Package', 'other/dev-package'], 'Packages "Vendor/Dev-Package", "other/dev-package" are excluded by --no-dev.'];
         yield 'missing and excluded' => [
             ['missing/package', 'Vendor/Dev-Package'],
-            'Package "missing/package" is not installed. Package "Vendor/Dev-Package" is excluded by --no-dev.',
+            "Package \"missing/package\" is not installed.\nPackage \"Vendor/Dev-Package\" is excluded by --no-dev.",
         ];
     }
 

--- a/tests/Composer/Test/Command/SuggestsCommandTest.php
+++ b/tests/Composer/Test/Command/SuggestsCommandTest.php
@@ -50,6 +50,15 @@ class SuggestsCommandTest extends TestCase
         self::assertEmpty($appTester->getDisplay(true));
     }
 
+    public function testFailsWhenFilteringByNonInstalledPackage(): void
+    {
+        $this->initTempComposer();
+
+        $appTester = $this->getApplicationTester();
+        self::assertEquals(Command::FAILURE, $appTester->run(['command' => 'suggest', 'packages' => ['vendor/not-installed']]));
+        self::assertSame('Package "vendor/not-installed" is not installed', trim($appTester->getDisplay(true)));
+    }
+
     /**
      * @dataProvider provideSuggest
      * @param array<string, bool|string|array<int, string>> $command
@@ -404,6 +413,13 @@ vendor4/dev-suggested is suggested by:
         yield 'without lockfile, show suggested for package' => [
             false,
             ['packages' => ['vendor2/package2']],
+            'vendor2/package2 suggests:
+ - vendor4/dev-suggested: helpful for vendor2/package2',
+        ];
+
+        yield 'with lockfile, show suggested for package case insensitively' => [
+            true,
+            ['packages' => ['Vendor2/Package2']],
             'vendor2/package2 suggests:
  - vendor4/dev-suggested: helpful for vendor2/package2',
         ];


### PR DESCRIPTION
Fixes #12992.

## Summary

- fail cleanly when package filters cannot be used instead of throwing an uncaught `InvalidArgumentException`
- write each validation error to Composer's error stream and return `Command::FAILURE`
- preserve input casing in errors while matching installed package names case-insensitively
- report every missing filter and distinguish locked dev packages excluded by `--no-dev`

## Test verification (RED -> GREEN)

RED on the old throw path with the updated invalid-filter tests:

```text
5 InvalidArgumentException errors in SuggestsCommandTest invalid-filter cases
```

GREEN on the patched branch:

```text
SuggestsCommandTest: OK (37 tests, 79 assertions)
Full PHPUnit: OK, but incomplete, skipped, or risky tests! Tests: 3336, Assertions: 7443, Skipped: 8
PHPStan: [OK] No errors
PHP diff coverage: PASS 27/27 changed production lines covered
```

The remaining deprecation notice is pre-existing in this checkout: `AuthHelper::addAuthenticationHeader is deprecated since Composer 2.9 use addAuthenticationOptions instead.`
