### PR TITLE
Clarify same-version metadata updates

### DIFF
--- a/src/Composer/DependencyResolver/Operation/UpdateOperation.php
+++ b/src/Composer/DependencyResolver/Operation/UpdateOperation.php
@@ -12,6 +12,7 @@
 
 namespace Composer\DependencyResolver\Operation;
 
+use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;
 use Composer\Package\Version\VersionParser;
 
@@ -23,6 +24,7 @@ use Composer\Package\Version\VersionParser;
 class UpdateOperation extends SolverOperation implements OperationInterface
 {
     protected const TYPE = 'update';
+    private const METADATA_CHANGES = ', metadata changes';
 
     /**
      * @var PackageInterface
@@ -72,17 +74,23 @@ class UpdateOperation extends SolverOperation implements OperationInterface
     {
         $fromVersion = $initialPackage->getFullPrettyVersion();
         $toVersion = $targetPackage->getFullPrettyVersion();
+        $isSameVersion = $fromVersion === $toVersion;
+        $updateDescription = '';
 
-        if ($fromVersion === $toVersion && $initialPackage->getSourceReference() !== $targetPackage->getSourceReference()) {
+        if ($isSameVersion && $initialPackage->getSourceReference() !== $targetPackage->getSourceReference()) {
             $fromVersion = $initialPackage->getFullPrettyVersion(true, PackageInterface::DISPLAY_SOURCE_REF);
             $toVersion = $targetPackage->getFullPrettyVersion(true, PackageInterface::DISPLAY_SOURCE_REF);
-        } elseif ($fromVersion === $toVersion && $initialPackage->getDistReference() !== $targetPackage->getDistReference()) {
+        } elseif ($isSameVersion && $initialPackage->getDistReference() !== $targetPackage->getDistReference()) {
             $fromVersion = $initialPackage->getFullPrettyVersion(true, PackageInterface::DISPLAY_DIST_REF);
             $toVersion = $targetPackage->getFullPrettyVersion(true, PackageInterface::DISPLAY_DIST_REF);
         }
 
+        if ($isSameVersion && $initialPackage instanceof CompletePackageInterface && $targetPackage instanceof CompletePackageInterface && ($initialPackage->isAbandoned() !== $targetPackage->isAbandoned() || $initialPackage->getReplacementPackage() !== $targetPackage->getReplacementPackage())) {
+            $updateDescription = self::METADATA_CHANGES;
+        }
+
         $actionName = VersionParser::isUpgrade($initialPackage->getVersion(), $targetPackage->getVersion()) ? 'Upgrading' : 'Downgrading';
 
-        return $actionName.' <info>'.$initialPackage->getPrettyName().'</info> (<comment>'.$fromVersion.'</comment> => <comment>'.$toVersion.'</comment>)';
+        return $actionName.' <info>'.$initialPackage->getPrettyName().'</info> (<comment>'.$fromVersion.'</comment> => <comment>'.$toVersion.'</comment>'.$updateDescription.')';
     }
 }

--- a/src/Composer/DependencyResolver/Operation/UpdateOperation.php
+++ b/src/Composer/DependencyResolver/Operation/UpdateOperation.php
@@ -24,7 +24,6 @@ use Composer\Package\Version\VersionParser;
 class UpdateOperation extends SolverOperation implements OperationInterface
 {
     protected const TYPE = 'update';
-    private const METADATA_CHANGES = ', metadata changes';
 
     /**
      * @var PackageInterface
@@ -85,12 +84,20 @@ class UpdateOperation extends SolverOperation implements OperationInterface
             $toVersion = $targetPackage->getFullPrettyVersion(true, PackageInterface::DISPLAY_DIST_REF);
         }
 
-        if ($isSameVersion && $initialPackage instanceof CompletePackageInterface && $targetPackage instanceof CompletePackageInterface && ($initialPackage->isAbandoned() !== $targetPackage->isAbandoned() || $initialPackage->getReplacementPackage() !== $targetPackage->getReplacementPackage())) {
-            $updateDescription = self::METADATA_CHANGES;
+        if ($isSameVersion && self::hasAbandonedStateChanged($initialPackage, $targetPackage)) {
+            $updateDescription = ', abandoned state changed';
         }
 
         $actionName = VersionParser::isUpgrade($initialPackage->getVersion(), $targetPackage->getVersion()) ? 'Upgrading' : 'Downgrading';
 
         return $actionName.' <info>'.$initialPackage->getPrettyName().'</info> (<comment>'.$fromVersion.'</comment> => <comment>'.$toVersion.'</comment>'.$updateDescription.')';
+    }
+
+    public static function hasAbandonedStateChanged(PackageInterface $initialPackage, PackageInterface $targetPackage): bool
+    {
+        return $initialPackage instanceof CompletePackageInterface
+            && $targetPackage instanceof CompletePackageInterface
+            && ($initialPackage->isAbandoned() !== $targetPackage->isAbandoned()
+                || $initialPackage->getReplacementPackage() !== $targetPackage->getReplacementPackage());
     }
 }

--- a/src/Composer/DependencyResolver/Operation/UpdateOperation.php
+++ b/src/Composer/DependencyResolver/Operation/UpdateOperation.php
@@ -84,8 +84,11 @@ class UpdateOperation extends SolverOperation implements OperationInterface
             $toVersion = $targetPackage->getFullPrettyVersion(true, PackageInterface::DISPLAY_DIST_REF);
         }
 
-        if ($isSameVersion && self::hasAbandonedStateChanged($initialPackage, $targetPackage)) {
-            $updateDescription = ', abandoned state changed';
+        if ($isSameVersion) {
+            $abandonedStateChange = self::getAbandonedStateChange($initialPackage, $targetPackage);
+            if (null !== $abandonedStateChange) {
+                $updateDescription = ', '.$abandonedStateChange;
+            }
         }
 
         $actionName = VersionParser::isUpgrade($initialPackage->getVersion(), $targetPackage->getVersion()) ? 'Upgrading' : 'Downgrading';
@@ -93,11 +96,24 @@ class UpdateOperation extends SolverOperation implements OperationInterface
         return $actionName.' <info>'.$initialPackage->getPrettyName().'</info> (<comment>'.$fromVersion.'</comment> => <comment>'.$toVersion.'</comment>'.$updateDescription.')';
     }
 
-    public static function hasAbandonedStateChanged(PackageInterface $initialPackage, PackageInterface $targetPackage): bool
+    public static function getAbandonedStateChange(PackageInterface $initialPackage, PackageInterface $targetPackage): ?string
     {
-        return $initialPackage instanceof CompletePackageInterface
-            && $targetPackage instanceof CompletePackageInterface
-            && ($initialPackage->isAbandoned() !== $targetPackage->isAbandoned()
-                || $initialPackage->getReplacementPackage() !== $targetPackage->getReplacementPackage());
+        if (!$initialPackage instanceof CompletePackageInterface
+            || !$targetPackage instanceof CompletePackageInterface
+            || ($initialPackage->isAbandoned() === $targetPackage->isAbandoned()
+                && $initialPackage->getReplacementPackage() === $targetPackage->getReplacementPackage())
+        ) {
+            return null;
+        }
+
+        if (!$targetPackage->isAbandoned()) {
+            return 'package is now unabandoned';
+        }
+
+        if (null !== $targetPackage->getReplacementPackage()) {
+            return 'package suggests using '.$targetPackage->getReplacementPackage().' as replacement';
+        }
+
+        return 'package is now abandoned';
     }
 }

--- a/src/Composer/DependencyResolver/Transaction.php
+++ b/src/Composer/DependencyResolver/Transaction.php
@@ -13,7 +13,6 @@
 namespace Composer\DependencyResolver;
 
 use Composer\Package\AliasPackage;
-use Composer\Package\CompletePackageInterface;
 use Composer\Package\Link;
 use Composer\Package\PackageInterface;
 use Composer\Repository\PlatformRepository;
@@ -166,14 +165,7 @@ class Transaction
                         if ($package->getVersion() !== $presentPackageMap[$package->getName()]->getVersion() ||
                             $package->getDistReference() !== $presentPackageMap[$package->getName()]->getDistReference() ||
                             $package->getSourceReference() !== $presentPackageMap[$package->getName()]->getSourceReference() ||
-                            (
-                                $package instanceof CompletePackageInterface
-                                && $presentPackageMap[$package->getName()] instanceof CompletePackageInterface
-                                && (
-                                    $package->isAbandoned() !== $presentPackageMap[$package->getName()]->isAbandoned()
-                                    || $package->getReplacementPackage() !== $presentPackageMap[$package->getName()]->getReplacementPackage()
-                                )
-                            )
+                            Operation\UpdateOperation::hasAbandonedStateChanged($package, $presentPackageMap[$package->getName()])
                         ) {
                             $operations[] = new Operation\UpdateOperation($source, $package);
                         }

--- a/src/Composer/DependencyResolver/Transaction.php
+++ b/src/Composer/DependencyResolver/Transaction.php
@@ -165,7 +165,7 @@ class Transaction
                         if ($package->getVersion() !== $presentPackageMap[$package->getName()]->getVersion() ||
                             $package->getDistReference() !== $presentPackageMap[$package->getName()]->getDistReference() ||
                             $package->getSourceReference() !== $presentPackageMap[$package->getName()]->getSourceReference() ||
-                            Operation\UpdateOperation::hasAbandonedStateChanged($package, $presentPackageMap[$package->getName()])
+                            null !== Operation\UpdateOperation::getAbandonedStateChange($presentPackageMap[$package->getName()], $package)
                         ) {
                             $operations[] = new Operation\UpdateOperation($source, $package);
                         }

--- a/tests/Composer/Test/DependencyResolver/Operation/UpdateOperationTest.php
+++ b/tests/Composer/Test/DependencyResolver/Operation/UpdateOperationTest.php
@@ -18,7 +18,37 @@ use Composer\Test\TestCase;
 
 class UpdateOperationTest extends TestCase
 {
-    public function testFormatIncludesReferenceAndMetadataChanges(): void
+    /**
+     * @dataProvider abandonedStateChangesProvider
+     *
+     * @param bool|string $initialAbandoned
+     * @param bool|string $targetAbandoned
+     */
+    public function testFormatIncludesAbandonedStateChanges($initialAbandoned, $targetAbandoned): void
+    {
+        $initialPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
+        $initialPackage->setAbandoned($initialAbandoned);
+        $targetPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
+        $targetPackage->setAbandoned($targetAbandoned);
+
+        self::assertSame(
+            'Upgrading <info>vendor/package</info> (<comment>1.0.0</comment> => <comment>1.0.0</comment>, abandoned state changed)',
+            UpdateOperation::format($initialPackage, $targetPackage)
+        );
+    }
+
+    /**
+     * @return array<string, array{bool|string, bool|string}>
+     */
+    public static function abandonedStateChangesProvider(): array
+    {
+        return [
+            'isAbandoned changed' => [false, true],
+            'replacementPackage changed' => ['vendor/old-replacement', 'vendor/new-replacement'],
+        ];
+    }
+
+    public function testFormatIncludesReferenceAndAbandonedStateChanges(): void
     {
         $initialPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
         $initialPackage->setSourceReference('old-reference');
@@ -27,7 +57,7 @@ class UpdateOperationTest extends TestCase
         $targetPackage->setAbandoned(true);
 
         self::assertSame(
-            'Upgrading <info>vendor/package</info> (<comment>1.0.0 old-reference</comment> => <comment>1.0.0 new-reference</comment>, metadata changes)',
+            'Upgrading <info>vendor/package</info> (<comment>1.0.0 old-reference</comment> => <comment>1.0.0 new-reference</comment>, abandoned state changed)',
             UpdateOperation::format($initialPackage, $targetPackage)
         );
     }

--- a/tests/Composer/Test/DependencyResolver/Operation/UpdateOperationTest.php
+++ b/tests/Composer/Test/DependencyResolver/Operation/UpdateOperationTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\DependencyResolver\Operation;
+
+use Composer\DependencyResolver\Operation\UpdateOperation;
+use Composer\Package\CompletePackage;
+use Composer\Test\TestCase;
+
+class UpdateOperationTest extends TestCase
+{
+    public function testFormatIncludesReferenceAndMetadataChanges(): void
+    {
+        $initialPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
+        $initialPackage->setSourceReference('old-reference');
+        $targetPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
+        $targetPackage->setSourceReference('new-reference');
+        $targetPackage->setAbandoned(true);
+
+        self::assertSame(
+            'Upgrading <info>vendor/package</info> (<comment>1.0.0 old-reference</comment> => <comment>1.0.0 new-reference</comment>, metadata changes)',
+            UpdateOperation::format($initialPackage, $targetPackage)
+        );
+    }
+
+    public function testFormatDoesNotDescribeMetadataForVersionUpdate(): void
+    {
+        $initialPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
+        $targetPackage = new CompletePackage('vendor/package', '2.0.0.0', '2.0.0');
+        $targetPackage->setAbandoned(true);
+
+        self::assertSame(
+            'Upgrading <info>vendor/package</info> (<comment>1.0.0</comment> => <comment>2.0.0</comment>)',
+            UpdateOperation::format($initialPackage, $targetPackage)
+        );
+    }
+}

--- a/tests/Composer/Test/DependencyResolver/Operation/UpdateOperationTest.php
+++ b/tests/Composer/Test/DependencyResolver/Operation/UpdateOperationTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test\DependencyResolver\Operation;
 
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Package\CompletePackage;
+use Composer\Package\Package;
 use Composer\Test\TestCase;
 
 class UpdateOperationTest extends TestCase
@@ -24,7 +25,7 @@ class UpdateOperationTest extends TestCase
      * @param bool|string $initialAbandoned
      * @param bool|string $targetAbandoned
      */
-    public function testFormatIncludesAbandonedStateChanges($initialAbandoned, $targetAbandoned): void
+    public function testFormatIncludesAbandonedStateChanges($initialAbandoned, $targetAbandoned, string $expectedDescription): void
     {
         $initialPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
         $initialPackage->setAbandoned($initialAbandoned);
@@ -32,20 +33,56 @@ class UpdateOperationTest extends TestCase
         $targetPackage->setAbandoned($targetAbandoned);
 
         self::assertSame(
-            'Upgrading <info>vendor/package</info> (<comment>1.0.0</comment> => <comment>1.0.0</comment>, abandoned state changed)',
+            'Upgrading <info>vendor/package</info> (<comment>1.0.0</comment> => <comment>1.0.0</comment>, '.$expectedDescription.')',
             UpdateOperation::format($initialPackage, $targetPackage)
         );
     }
 
     /**
-     * @return array<string, array{bool|string, bool|string}>
+     * @return array<string, array{bool|string, bool|string, string}>
      */
     public static function abandonedStateChangesProvider(): array
     {
         return [
-            'isAbandoned changed' => [false, true],
-            'replacementPackage changed' => ['vendor/old-replacement', 'vendor/new-replacement'],
+            'package became abandoned' => [false, true, 'package is now abandoned'],
+            'package became unabandoned' => [true, false, 'package is now unabandoned'],
+            'replacement package added' => [false, 'vendor/new-replacement', 'package suggests using vendor/new-replacement as replacement'],
+            'replacement package changed' => ['vendor/old-replacement', 'vendor/new-replacement', 'package suggests using vendor/new-replacement as replacement'],
+            'replacement package removed' => ['vendor/old-replacement', true, 'package is now abandoned'],
         ];
+    }
+
+    /**
+     * @dataProvider abandonedStateChangesProvider
+     *
+     * @param bool|string $initialAbandoned
+     * @param bool|string $targetAbandoned
+     */
+    public function testGetAbandonedStateChange($initialAbandoned, $targetAbandoned, string $expectedDescription): void
+    {
+        $initialPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
+        $initialPackage->setAbandoned($initialAbandoned);
+        $targetPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
+        $targetPackage->setAbandoned($targetAbandoned);
+
+        self::assertSame($expectedDescription, UpdateOperation::getAbandonedStateChange($initialPackage, $targetPackage));
+    }
+
+    public function testGetAbandonedStateChangeReturnsNullForUnchangedState(): void
+    {
+        $initialPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
+        $targetPackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
+
+        self::assertNull(UpdateOperation::getAbandonedStateChange($initialPackage, $targetPackage));
+    }
+
+    public function testGetAbandonedStateChangeReturnsNullForIncompletePackages(): void
+    {
+        $completePackage = new CompletePackage('vendor/package', '1.0.0.0', '1.0.0');
+        $package = new Package('vendor/package', '1.0.0.0', '1.0.0');
+
+        self::assertNull(UpdateOperation::getAbandonedStateChange($package, $completePackage));
+        self::assertNull(UpdateOperation::getAbandonedStateChange($completePackage, $package));
     }
 
     public function testFormatIncludesReferenceAndAbandonedStateChanges(): void
@@ -57,7 +94,7 @@ class UpdateOperationTest extends TestCase
         $targetPackage->setAbandoned(true);
 
         self::assertSame(
-            'Upgrading <info>vendor/package</info> (<comment>1.0.0 old-reference</comment> => <comment>1.0.0 new-reference</comment>, abandoned state changed)',
+            'Upgrading <info>vendor/package</info> (<comment>1.0.0 old-reference</comment> => <comment>1.0.0 new-reference</comment>, package is now abandoned)',
             UpdateOperation::format($initialPackage, $targetPackage)
         );
     }

--- a/tests/Composer/Test/Fixtures/installer/install-forces-reinstall-if-abandon-changes.test
+++ b/tests/Composer/Test/Fixtures/installer/install-forces-reinstall-if-abandon-changes.test
@@ -39,4 +39,4 @@ Install triggers a reinstall of packages that have outdated information if their
 --RUN--
 install
 --EXPECT--
-Upgrading a/a (1.0.0 => 1.0.0, metadata changes)
+Upgrading a/a (1.0.0 => 1.0.0, abandoned state changed)

--- a/tests/Composer/Test/Fixtures/installer/install-forces-reinstall-if-abandon-changes.test
+++ b/tests/Composer/Test/Fixtures/installer/install-forces-reinstall-if-abandon-changes.test
@@ -39,4 +39,4 @@ Install triggers a reinstall of packages that have outdated information if their
 --RUN--
 install
 --EXPECT--
-Upgrading a/a (1.0.0 => 1.0.0)
+Upgrading a/a (1.0.0 => 1.0.0, metadata changes)

--- a/tests/Composer/Test/Fixtures/installer/install-forces-reinstall-if-abandon-changes.test
+++ b/tests/Composer/Test/Fixtures/installer/install-forces-reinstall-if-abandon-changes.test
@@ -39,4 +39,4 @@ Install triggers a reinstall of packages that have outdated information if their
 --RUN--
 install
 --EXPECT--
-Upgrading a/a (1.0.0 => 1.0.0, abandoned state changed)
+Upgrading a/a (1.0.0 => 1.0.0, package suggests using replacement as replacement)

--- a/tests/Composer/Test/Fixtures/installer/update-syncs-outdated.test
+++ b/tests/Composer/Test/Fixtures/installer/update-syncs-outdated.test
@@ -49,4 +49,4 @@ Update updates the outdated state of packages
 --RUN--
 update
 --EXPECT--
-Upgrading a/a (1.0.0 => 1.0.0)
+Upgrading a/a (1.0.0 => 1.0.0, metadata changes)

--- a/tests/Composer/Test/Fixtures/installer/update-syncs-outdated.test
+++ b/tests/Composer/Test/Fixtures/installer/update-syncs-outdated.test
@@ -49,4 +49,4 @@ Update updates the outdated state of packages
 --RUN--
 update
 --EXPECT--
-Upgrading a/a (1.0.0 => 1.0.0, metadata changes)
+Upgrading a/a (1.0.0 => 1.0.0, abandoned state changed)

--- a/tests/Composer/Test/Fixtures/installer/update-syncs-outdated.test
+++ b/tests/Composer/Test/Fixtures/installer/update-syncs-outdated.test
@@ -49,4 +49,4 @@ Update updates the outdated state of packages
 --RUN--
 update
 --EXPECT--
-Upgrading a/a (1.0.0 => 1.0.0, abandoned state changed)
+Upgrading a/a (1.0.0 => 1.0.0, package suggests using replacement as replacement)


### PR DESCRIPTION
## Summary

- explain same-version operations caused by an abandoned state or replacement-package change
- return the exact abandoned-state description from the shared transaction/formatting helper
- distinguish newly abandoned, newly unabandoned, replacement-added, replacement-changed, and replacement-removed cases
- preserve source/dist reference details when references and abandoned state change together

Fix #12944

## Test verification (RED → GREEN)

Exact PR HEAD with the reviewer counterexamples added (RED):

```text
Tests: 12, Assertions: 7, Errors: 5, Failures: 6
Undefined method getAbandonedStateChange; formatted output still said "abandoned state changed".
```

Patched operation tests (GREEN):

```text
OK (14 tests, 15 assertions)
```

Focused installer, transaction, and operation coverage (GREEN):

```text
OK (475 tests, 1275 assertions)
Changed-line coverage: 20/20 (100%)
```

Local `run-ci.sh` is iso-better than the upstream baseline in the same pinned PHP 8.3 container. Baseline: 3,332 tests, 7,428 assertions, 1 failure, 8 skipped. Final: 3,346 tests, 7,443 assertions, 1 failure, 8 skipped. Both runs have the identical environment-only `XzDownloaderTest::testErrorMessages` failure because the image lacks the `xz` executable; Composer validation, PHPStan, and PHP lint pass.