### PR TITLE
Update `composer-plugin-api` to 2.9.0 in documentation

### DIFF
--- a/doc/articles/plugins.md
+++ b/doc/articles/plugins.md
@@ -39,7 +39,7 @@ requirements:
 The required version of the `composer-plugin-api` follows the same [rules][7]
 as a normal package's rules.
 
-The current Composer plugin API version is `2.6.0`.
+The current Composer plugin API version is `2.9.0`.
 
 An example of a valid plugin `composer.json` file (with the autoloading
 part omitted and an optional require-dev dependency on `composer/composer` for IDE auto completion):


### PR DESCRIPTION
https://github.com/composer/composer/releases/tag/2.9.0-RC1 bumped composer-plugin-api to 2.9.0 but the documentation wasn't updated.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
