### PR TITLE
Exclude the vendor dir from root classmap scanning

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -326,7 +326,14 @@ EOF;
         }
 
         foreach ($autoloads['classmap'] as $dir) {
-            $classMapGenerator->scanPaths($dir, $this->buildExclusionRegex($dir, $excluded));
+            // if the vendor dir is contained within a classmap dir being scanned we exclude it
+            $resolvedDir = $filesystem->normalizePath($filesystem->isAbsolutePath($dir) ? $dir : $basePath.'/'.$dir);
+            if (str_contains($vendorPath, $resolvedDir.'/')) {
+                $exclusionRegex = $this->buildExclusionRegex($dir, array_merge($excluded, [$vendorPath.'/']));
+            } else {
+                $exclusionRegex = $this->buildExclusionRegex($dir, $excluded);
+            }
+            $classMapGenerator->scanPaths($dir, $exclusionRegex);
         }
 
         if ($scanPsrPackages) {

--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -766,6 +766,43 @@ EOF;
         self::assertAutoloadFiles('classmap4', $this->vendorDir.'/composer', 'classmap');
     }
 
+    public function testRootClassMapExcludesVendorDirWhenScanned(): void
+    {
+        // A root classmap entry that contains the vendor dir (e.g. ".") must not
+        // map the installed packages living inside vendor, consistently with the
+        // psr-0/psr-4 handling. See https://github.com/composer/composer/issues/12867
+        $package = new RootPackage('root/a', '1.0', '1.0');
+        $package->setAutoload(['classmap' => ['.']]);
+        $package->setRequires([
+            'b/b' => new Link('a', 'b/b', new MatchAllConstraint()),
+        ]);
+
+        // The vendor package declares no autoload: the only way its class could
+        // reach the classmap is the root "." scan wrongly descending into vendor.
+        $vendorPackage = new Package('b/b', '1.0', '1.0');
+
+        $this->repository->expects($this->once())
+            ->method('getCanonicalPackages')
+            ->will($this->returnValue([$vendorPackage]));
+
+        $this->fs->ensureDirectoryExists($this->vendorDir.'/composer');
+        $this->fs->ensureDirectoryExists($this->vendorDir.'/b/b/src');
+        $this->fs->ensureDirectoryExists($this->workingDir.'/src');
+        file_put_contents($this->workingDir.'/src/RootClass.php', '<?php class RootClass {}');
+        file_put_contents($this->vendorDir.'/b/b/src/VendorClass.php', '<?php class VendorClass {}');
+
+        $this->generator->dump($this->config, $this->repository, $package, $this->im, 'composer', true, '_12867');
+
+        self::assertFileExists($this->vendorDir.'/composer/autoload_classmap.php', "ClassMap file needs to be generated.");
+        self::assertEquals(
+            [
+                'Composer\\InstalledVersions' => $this->vendorDir.'/composer/InstalledVersions.php',
+                'RootClass' => $this->workingDir.'/src/RootClass.php',
+            ],
+            include $this->vendorDir.'/composer/autoload_classmap.php'
+        );
+    }
+
     public function testVendorsClassMapAutoloadingWithTargetDir(): void
     {
         $package = new RootPackage('root/a', '1.0', '1.0');


### PR DESCRIPTION
Fix #12867

### Problem

A root `classmap` autoload entry that contains the vendor directory — e.g.

```json
{ "autoload": { "classmap": ["."] } }
```

maps every installed package class into `autoload_classmap.php`, whereas the
equivalent `psr-4` scan of the same root (`{"psr-4": {"": "."}}`) already skips
the nested `vendor` dir. The two autoload modes give different results for the
same scan root, which is surprising and pollutes the classmap with third‑party
classes.

### Cause

In `AutoloadGenerator::dump()` the psr‑0/psr‑4 scan has a guard that excludes
the vendor dir when it sits inside a scanned directory:

```php
// if the vendor dir is contained within a psr-0/psr-4 dir being scanned we exclude it
if (str_contains($vendorPath, $dir.'/')) {
    $exclusionRegex = $this->buildExclusionRegex($dir, array_merge($excluded, [$vendorPath.'/']));
}
```

The plain `classmap` loop just above it had no such guard.

### Fix

Apply the same vendor‑skip guard to the classmap loop. The vendor dir is
excluded only when it is *strictly nested* inside a scanned classmap entry, so
pointing a classmap entry directly at `vendor` (or at a sibling directory)
keeps working exactly as before — matching the psr‑0/psr‑4 semantics.

### Test verification (RED → GREEN)

New test `testRootClassMapExcludesVendorDirWhenScanned` in
`AutoloadGeneratorTest`.

RED — on the unmodified branch (fix reverted, only the test applied):

```
1) Composer\Test\Autoload\AutoloadGeneratorTest::testRootClassMapExcludesVendorDirWhenScanned
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'Composer\InstalledVersions' => '...InstalledVersions.php'
     'RootClass' => '...RootClass.php'
+    'VendorClass' => '...VendorClass.php'
 )
FAILURES! Tests: 1, Assertions: 2, Failures: 1.
```

GREEN — with the fix:

```
OK (1 test, 4 assertions)
```

### Full local suite

`AutoloadGeneratorTest` (the suite covering the changed code):

```
OK (52 tests, 273 assertions)
```

PHPStan (PHP 8.3, `composer phpstan`): `[OK] No errors`.

The full local `vendor/bin/simple-phpunit` run is otherwise green; the only
non-passing tests are pre-existing `InstallerTest` platform-extension mismatches
of the local PHP build (intl/ext-xml version, `phpVersion`) which reproduce
identically on the unmodified base branch and are unrelated to this change.
