### PR TITLE
Fix overwriting a list repository addressed by numeric index in config command

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -901,16 +901,17 @@ If your repository requires more configuration options, you can instead pass its
 php composer.phar config repositories.foo '{"type": "vcs", "url": "http://svn.example.org/my-project/", "trunk-path": "master"}'
 ```
 
-Repositories which have no `name` can be addressed by their position in the list instead, which is
-what `composer repo list` shows in brackets. The repository at that position is then replaced in
-place rather than a new one being added:
+A numeric key addresses a repository by its position in the `repositories` array of the file being
+modified, replacing the entry at that position rather than adding a new one:
 
 ```shell
 php composer.phar config repositories.0 vcs https://github.com/foo/bar
 ```
 
-Positions shift as repositories are added and removed, so giving each repository a `name` and using
-that is more robust.
+This is discouraged and warns, because positions shift as repositories are added or removed, and
+they do not match the numbers `composer repo list` displays once the global config defines
+repositories of its own. Addressing a repository which has a `name` by its position is an error —
+use the name. Give each repository a `name` and you never have to think about positions.
 
 ### Modifying Extra Values
 
@@ -948,8 +949,9 @@ repo [options] enable packagist.org
 repo [options] disable packagist.org
 ```
 
-`[repo-name]` is the repository's `name`. Repositories which do not have one can be addressed by
-their position in the list instead, as shown in brackets by `repo list`.
+`[repo-name]` is the repository's `name`. A repository without one can be addressed by its position
+in the `repositories` array of the file being modified, but this is discouraged and warns — see
+[Modifying Repositories](#modifying-repositories).
 
 ### Options
 
@@ -957,7 +959,7 @@ their position in the list instead, as shown in brackets by `repo list`.
 - **--file (-f):** to modify a specific file instead of composer.json.
 - **--append:** to add a repository with lower priority (by default repositories are prepended and have thus higher priority than existing ones).
 - **--before [name]:** to insert the new repository before an existing repository named `[name]`.
-- **--after [name]:** to insert the new repository after an existing repository named `[name]`. The `[name]` must match an existing repository name or position.
+- **--after [name]:** to insert the new repository after an existing repository named `[name]`. The `[name]` must match an existing repository name, or its position.
 
 ### Examples
 

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -913,6 +913,10 @@ they do not match the numbers `composer repo list` displays once the global conf
 repositories of its own. Addressing a repository which has a `name` by its position is an error —
 use the name. Give each repository a `name` and you never have to think about positions.
 
+For the same reason a repository `name` must not be numeric: a number always addresses a position,
+so a repository called `1` could not be told apart from the second entry in the list. `composer
+validate` warns about any that are already there.
+
 ### Modifying Extra Values
 
 In addition to modifying the config section, the `config` command also supports making

--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -901,6 +901,17 @@ If your repository requires more configuration options, you can instead pass its
 php composer.phar config repositories.foo '{"type": "vcs", "url": "http://svn.example.org/my-project/", "trunk-path": "master"}'
 ```
 
+Repositories which have no `name` can be addressed by their position in the list instead, which is
+what `composer repo list` shows in brackets. The repository at that position is then replaced in
+place rather than a new one being added:
+
+```shell
+php composer.phar config repositories.0 vcs https://github.com/foo/bar
+```
+
+Positions shift as repositories are added and removed, so giving each repository a `name` and using
+that is more robust.
+
 ### Modifying Extra Values
 
 In addition to modifying the config section, the `config` command also supports making
@@ -937,13 +948,16 @@ repo [options] enable packagist.org
 repo [options] disable packagist.org
 ```
 
+`[repo-name]` is the repository's `name`. Repositories which do not have one can be addressed by
+their position in the list instead, as shown in brackets by `repo list`.
+
 ### Options
 
 - **--global (-g):** to modify the global `$COMPOSER_HOME/config.json`.
 - **--file (-f):** to modify a specific file instead of composer.json.
 - **--append:** to add a repository with lower priority (by default repositories are prepended and have thus higher priority than existing ones).
 - **--before [name]:** to insert the new repository before an existing repository named `[name]`.
-- **--after [name]:** to insert the new repository after an existing repository named `[name]`. The `[name]` must match an existing repository name.
+- **--after [name]:** to insert the new repository after an existing repository named `[name]`. The `[name]` must match an existing repository name or position.
 
 ### Examples
 

--- a/src/Composer/Command/BaseConfigCommand.php
+++ b/src/Composer/Command/BaseConfigCommand.php
@@ -81,6 +81,45 @@ abstract class BaseConfigCommand extends BaseCommand
     }
 
     /**
+     * Repositories are meant to be addressed by name. A numeric key falls back to the position of
+     * the entry in the repositories list, which is unreliable: positions shift as repositories are
+     * added or removed, and they do not line up with what `composer repo list` displays once the
+     * global config defines repositories of its own. So warn about it, and refuse it outright when
+     * it would silently act on a repository which does have a name.
+     */
+    protected function validateRepositoryKey(string $name): void
+    {
+        if (!ctype_digit($name) || !$this->configFile->exists()) {
+            return;
+        }
+
+        $repositories = $this->configFile->read()['repositories'] ?? [];
+
+        // in the object format a numeric key is a name rather than a position
+        if (!is_array($repositories) || !array_is_list($repositories)) {
+            return;
+        }
+
+        foreach ($repositories as $repository) {
+            if (is_array($repository) && ($repository['name'] ?? null) === $name) {
+                return;
+            }
+        }
+
+        $target = $repositories[(int) $name] ?? null;
+
+        if (is_array($target) && isset($target['name']) && is_string($target['name'])) {
+            throw new \RuntimeException(sprintf(
+                'The repository at position %s is named "%s", address it by that name instead.',
+                $name,
+                $target['name']
+            ));
+        }
+
+        $this->getIO()->writeError('<warning>Addressing a repository by its position ("'.$name.'") is unreliable as positions shift when repositories are added or removed, and do not match what "composer repo list" shows when the global config defines repositories. Give the repository a "name" and use that instead.</warning>');
+    }
+
+    /**
      * Get the local composer.json, global config.json, or the file passed by the user
      */
     protected function getComposerConfigFile(InputInterface $input, Config $config): string

--- a/src/Composer/Command/BaseConfigCommand.php
+++ b/src/Composer/Command/BaseConfigCommand.php
@@ -15,6 +15,7 @@ namespace Composer\Command;
 use Composer\Config;
 use Composer\Config\JsonConfigSource;
 use Composer\Json\JsonFile;
+use Composer\Json\JsonManipulator;
 use Composer\Factory;
 use Composer\Util\Platform;
 use Composer\Util\Silencer;
@@ -100,10 +101,9 @@ abstract class BaseConfigCommand extends BaseCommand
             return;
         }
 
-        foreach ($repositories as $repository) {
-            if (is_array($repository) && ($repository['name'] ?? null) === $name) {
-                return;
-            }
+        // a repository actually carrying this name wins over the position
+        if (null !== JsonManipulator::findRepositoryKey($repositories, $name, false)) {
+            return;
         }
 
         $target = $repositories[(int) $name] ?? null;
@@ -117,6 +117,22 @@ abstract class BaseConfigCommand extends BaseCommand
         }
 
         $this->getIO()->writeError('<warning>Addressing a repository by its position ("'.$name.'") is unreliable as positions shift when repositories are added or removed, and do not match what "composer repo list" shows when the global config defines repositories. Give the repository a "name" and use that instead.</warning>');
+    }
+
+    /**
+     * A numeric name would be indistinguishable from a position, so refuse to write one. Only
+     * reachable through a user supplied JSON definition, as the commands never inject one.
+     *
+     * @param mixed $config
+     */
+    protected function validateRepositoryConfig($config): void
+    {
+        if (is_array($config) && isset($config['name']) && is_string($config['name']) && ctype_digit($config['name'])) {
+            throw new \RuntimeException(sprintf(
+                'A repository name can not be numeric ("%s"), as numbers address repositories by their position in the list. Use a descriptive name instead.',
+                $config['name']
+            ));
+        }
     }
 
     /**

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -897,6 +897,7 @@ EOT
                     }
                 } else {
                     $value = JsonFile::parseJson($values[0]);
+                    $this->validateRepositoryConfig($value);
                     $this->configSource->addRepository($matches[1], $value, $input->getOption('append'));
 
                     return 0;

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -870,6 +870,8 @@ EOT
 
         // handle repositories
         if (Preg::isMatchStrictGroups('/^repos?(?:itories)?\.(.+)/', $settingKey, $matches)) {
+            $this->validateRepositoryKey($matches[1]);
+
             if ($input->getOption('unset')) {
                 $this->configSource->removeRepository($matches[1]);
 

--- a/src/Composer/Command/RepositoryCommand.php
+++ b/src/Composer/Command/RepositoryCommand.php
@@ -122,11 +122,16 @@ EOT
                         throw new \RuntimeException('Cannot use --before/--after with boolean repository values');
                     }
 
-                    $this->configSource->insertRepository((string) $name, $repoConfig, $before ?? $after, $after !== null ? 1 : 0);
+                    // the ordering option is what addresses an existing repository here, the name
+                    // argument only names the new one
+                    $reference = (string) ($before ?? $after);
+                    $this->validateRepositoryKey($reference);
+                    $this->configSource->insertRepository((string) $name, $repoConfig, $reference, $after !== null ? 1 : 0);
 
                     return 0;
                 }
 
+                $this->validateRepositoryKey((string) $name);
                 $this->configSource->addRepository((string) $name, $repoConfig, (bool) $input->getOption('append'));
 
                 return 0;
@@ -137,6 +142,7 @@ EOT
                 if ($name === null) {
                     throw new \RuntimeException('You must pass the repository name to remove.');
                 }
+                $this->validateRepositoryKey((string) $name);
                 $this->configSource->removeRepository((string) $name);
                 if (in_array($name, ['packagist', 'packagist.org'], true)) {
                     $this->configSource->addRepository('packagist.org', false);
@@ -150,6 +156,7 @@ EOT
                     throw new \RuntimeException('Usage: composer repo set-url <name> <new-url>');
                 }
 
+                $this->validateRepositoryKey($name);
                 $this->configSource->setRepositoryUrl($name, $arg1);
 
                 return 0;

--- a/src/Composer/Command/RepositoryCommand.php
+++ b/src/Composer/Command/RepositoryCommand.php
@@ -103,6 +103,7 @@ EOT
                 if (is_string($arg1) && Preg::isMatch('{^\s*\{}', $arg1)) {
                     // JSON config
                     $repoConfig = JsonFile::parseJson($arg1);
+                    $this->validateRepositoryConfig($repoConfig);
                 } else {
                     if ($arg2 === null) {
                         throw new \RuntimeException('You must pass the type and a url. Example: composer repo add foo vcs https://example.org');

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -105,14 +105,14 @@ class JsonConfigSource implements ConfigSourceInterface
                 return;
             }
 
-            if (is_array($repoConfig) && $repo !== '' && !ctype_digit($repo) && !isset($repoConfig['name'])) {
+            if (is_array($repoConfig) && $repo !== '' && !ctype_digit($repo)) {
                 $repoConfig = ['name' => $repo] + $repoConfig;
             }
 
             // ensure uniqueness by removing any existing entry which uses the same name or position
-            $index = self::findRepositoryIndex($config['repositories'] ?? [], $repo);
+            $index = JsonManipulator::findRepositoryKey($config['repositories'] ?? [], $repo);
 
-            if ($index !== null) {
+            if (is_int($index)) {
                 // a repository addressed by position is replaced in place, $append does not apply
                 if (ctype_digit($repo) && $index === (int) $repo) {
                     array_splice($config['repositories'], $index, 1, [$repoConfig]);
@@ -160,19 +160,19 @@ class JsonConfigSource implements ConfigSourceInterface
 
             // the position is stated by $referenceName here, so $name only ever names the new
             // repository and must not be resolved to a position of its own
-            $index = self::findRepositoryIndex($config['repositories'] ?? [], $name, false);
+            $index = JsonManipulator::findRepositoryKey($config['repositories'] ?? [], $name, false);
 
-            if ($index !== null) {
+            if (is_int($index)) {
                 array_splice($config['repositories'], $index, 1);
             }
 
-            $indexToInsert = self::findRepositoryIndex($config['repositories'] ?? [], $referenceName);
+            $indexToInsert = JsonManipulator::findRepositoryKey($config['repositories'] ?? [], $referenceName);
 
-            if ($indexToInsert === null) {
+            if (!is_int($indexToInsert)) {
                 throw new \RuntimeException(sprintf('The referenced repository "%s" does not exist.', $referenceName));
             }
 
-            if (is_array($repoConfig) && $name !== '' && !ctype_digit($name) && !isset($repoConfig['name'])) {
+            if (is_array($repoConfig) && $name !== '' && !ctype_digit($name)) {
                 $repoConfig = ['name' => $name] + $repoConfig;
             }
 
@@ -193,9 +193,9 @@ class JsonConfigSource implements ConfigSourceInterface
                 return;
             }
 
-            $index = self::findRepositoryIndex($config['repositories'] ?? [], $name);
+            $index = JsonManipulator::findRepositoryKey($config['repositories'] ?? [], $name);
 
-            if ($index !== null) {
+            if (is_int($index)) {
                 $config['repositories'][$index]['url'] = $url;
             }
         }, $name, $url);
@@ -210,9 +210,9 @@ class JsonConfigSource implements ConfigSourceInterface
             if (isset($config['repositories'][$repo]) && !array_is_list($config['repositories'])) {
                 unset($config['repositories'][$repo]);
             } else {
-                $index = self::findRepositoryIndex($config['repositories'] ?? [], $repo);
+                $index = JsonManipulator::findRepositoryKey($config['repositories'] ?? [], $repo);
 
-                if ($index !== null) {
+                if (is_int($index)) {
                     array_splice($config['repositories'], $index, 1);
                 }
             }
@@ -221,27 +221,6 @@ class JsonConfigSource implements ConfigSourceInterface
                 unset($config['repositories']);
             }
         }, $name);
-    }
-
-    /**
-     * Finds a repository in a list by name, falling back to its position for a numeric name
-     *
-     * @param array<int|string, mixed> $repositories
-     */
-    private static function findRepositoryIndex(array $repositories, string $name, bool $allowIndex = true): ?int
-    {
-        if (!array_is_list($repositories)) {
-            return null;
-        }
-
-        foreach ($repositories as $index => $repository) {
-            if (is_array($repository) && (($repository['name'] ?? null) === $name || [$name => false] === $repository)) {
-                return $index;
-            }
-        }
-
-        // names take precedence, so a position is only matched once nothing matched by name
-        return $allowIndex && ctype_digit($name) && isset($repositories[(int) $name]) ? (int) $name : null;
     }
 
     /**

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -158,8 +158,9 @@ class JsonConfigSource implements ConfigSourceInterface
                 $config['repositories'] = $list;
             }
 
-            // ensure uniqueness by removing any existing entry which uses the same name or position
-            $index = self::findRepositoryIndex($config['repositories'] ?? [], $name);
+            // the position is stated by $referenceName here, so $name only ever names the new
+            // repository and must not be resolved to a position of its own
+            $index = self::findRepositoryIndex($config['repositories'] ?? [], $name, false);
 
             if ($index !== null) {
                 array_splice($config['repositories'], $index, 1);
@@ -185,18 +186,17 @@ class JsonConfigSource implements ConfigSourceInterface
     public function setRepositoryUrl(string $name, string $url): void
     {
         $this->manipulateJson('setRepositoryUrl', static function (&$config, $name, $url): void {
-            foreach ($config['repositories'] ?? [] as $index => $repository) {
-                if ($name === $index) {
-                    $config['repositories'][$index]['url'] = $url;
+            // object format keys are names, lists are matched by name or position
+            if (isset($config['repositories'][$name]) && !array_is_list($config['repositories'])) {
+                $config['repositories'][$name]['url'] = $url;
 
-                    return;
-                }
+                return;
+            }
 
-                if ($name === ($repository['name'] ?? null)) {
-                    $config['repositories'][$index]['url'] = $url;
+            $index = self::findRepositoryIndex($config['repositories'] ?? [], $name);
 
-                    return;
-                }
+            if ($index !== null) {
+                $config['repositories'][$index]['url'] = $url;
             }
         }, $name, $url);
     }
@@ -228,7 +228,7 @@ class JsonConfigSource implements ConfigSourceInterface
      *
      * @param array<int|string, mixed> $repositories
      */
-    private static function findRepositoryIndex(array $repositories, string $name): ?int
+    private static function findRepositoryIndex(array $repositories, string $name, bool $allowIndex = true): ?int
     {
         if (!array_is_list($repositories)) {
             return null;
@@ -241,7 +241,7 @@ class JsonConfigSource implements ConfigSourceInterface
         }
 
         // names take precedence, so a position is only matched once nothing matched by name
-        return ctype_digit($name) && isset($repositories[(int) $name]) ? (int) $name : null;
+        return $allowIndex && ctype_digit($name) && isset($repositories[(int) $name]) ? (int) $name : null;
     }
 
     /**

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -105,14 +105,23 @@ class JsonConfigSource implements ConfigSourceInterface
                 return;
             }
 
-            if (is_array($repoConfig) && $repo !== '' && !isset($repoConfig['name'])) {
+            if (is_array($repoConfig) && $repo !== '' && !ctype_digit($repo) && !isset($repoConfig['name'])) {
                 $repoConfig = ['name' => $repo] + $repoConfig;
             }
 
-            // ensure uniqueness by removing any existing entries which use the same name
-            $config['repositories'] = array_values(array_filter($config['repositories'] ?? [], static function ($val) use ($repo) {
-                return !isset($val['name']) || $val['name'] !== $repo || $val !== [$repo => false];
-            }));
+            // ensure uniqueness by removing any existing entry which uses the same name or position
+            $index = self::findRepositoryIndex($config['repositories'] ?? [], $repo);
+
+            if ($index !== null) {
+                // a repository addressed by position is replaced in place, $append does not apply
+                if (ctype_digit($repo) && $index === (int) $repo) {
+                    array_splice($config['repositories'], $index, 1, [$repoConfig]);
+
+                    return;
+                }
+
+                array_splice($config['repositories'], $index, 1);
+            }
 
             if ($append) {
                 $config['repositories'][] = $repoConfig;
@@ -149,30 +158,20 @@ class JsonConfigSource implements ConfigSourceInterface
                 $config['repositories'] = $list;
             }
 
-            // ensure uniqueness by removing any existing entries which use the same name
-            $config['repositories'] = array_values(array_filter($config['repositories'] ?? [], static function ($val) use ($name) {
-                return !isset($val['name']) || $val['name'] !== $name || $val !== [$name => false];
-            }));
+            // ensure uniqueness by removing any existing entry which uses the same name or position
+            $index = self::findRepositoryIndex($config['repositories'] ?? [], $name);
 
-            $indexToInsert = null;
-
-            foreach ($config['repositories'] as $repositoryIndex => $repository) {
-                if (($repository['name'] ?? null) === $referenceName) {
-                    $indexToInsert = $repositoryIndex;
-                    break;
-                }
-
-                if ([$referenceName => false] === $repository) {
-                    $indexToInsert = $repositoryIndex;
-                    break;
-                }
+            if ($index !== null) {
+                array_splice($config['repositories'], $index, 1);
             }
+
+            $indexToInsert = self::findRepositoryIndex($config['repositories'] ?? [], $referenceName);
 
             if ($indexToInsert === null) {
                 throw new \RuntimeException(sprintf('The referenced repository "%s" does not exist.', $referenceName));
             }
 
-            if (is_array($repoConfig) && $name !== '' && !isset($repoConfig['name'])) {
+            if (is_array($repoConfig) && $name !== '' && !ctype_digit($name) && !isset($repoConfig['name'])) {
                 $repoConfig = ['name' => $name] + $repoConfig;
             }
 
@@ -208,18 +207,41 @@ class JsonConfigSource implements ConfigSourceInterface
     public function removeRepository(string $name): void
     {
         $this->manipulateJson('removeRepository', static function (&$config, $repo): void {
-            if (isset($config['repositories'][$repo])) {
+            if (isset($config['repositories'][$repo]) && !array_is_list($config['repositories'])) {
                 unset($config['repositories'][$repo]);
             } else {
-                $config['repositories'] = array_values(array_filter($config['repositories'] ?? [], static function ($val) use ($repo) {
-                    return !isset($val['name']) || $val['name'] !== $repo || $val !== [$repo => false];
-                }));
+                $index = self::findRepositoryIndex($config['repositories'] ?? [], $repo);
+
+                if ($index !== null) {
+                    array_splice($config['repositories'], $index, 1);
+                }
             }
 
-            if ([] === $config['repositories']) {
+            if ([] === ($config['repositories'] ?? [])) {
                 unset($config['repositories']);
             }
         }, $name);
+    }
+
+    /**
+     * Finds a repository in a list by name, falling back to its position for a numeric name
+     *
+     * @param array<int|string, mixed> $repositories
+     */
+    private static function findRepositoryIndex(array $repositories, string $name): ?int
+    {
+        if (!array_is_list($repositories)) {
+            return null;
+        }
+
+        foreach ($repositories as $index => $repository) {
+            if (is_array($repository) && (($repository['name'] ?? null) === $name || [$name => false] === $repository)) {
+                return $index;
+            }
+        }
+
+        // names take precedence, so a position is only matched once nothing matched by name
+        return ctype_digit($name) && isset($repositories[(int) $name]) ? (int) $name : null;
     }
 
     /**

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -325,6 +325,15 @@ class JsonManipulator
         $isAssoc = ($decoded->repositories ?? null) instanceof \stdClass;
 
         foreach ((array) ($decoded->repositories ?? []) as $repositoryIndex => $repository) {
+            // a numeric name addresses a list entry by position (e.g. `config repositories.0 ...`); remove that entry
+            if (!$isAssoc && is_numeric($name) && $repositoryIndex === (int) $name) {
+                if (!$this->removeListItem('repositories', $repositoryIndex)) {
+                    return false;
+                }
+
+                break;
+            }
+
             if ($repositoryIndex === $name && $isAssoc) {
                 if (!$this->removeSubNode('repositories', $repositoryIndex)) {
                     return false;

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -245,7 +245,16 @@ class JsonManipulator
         $objectRegex = '{'.self::DEFINES.'^(?P<start>\s*\{\s*(?:(?&string)\s*:\s*(?&json)\s*,\s*)*?"repositories"\s*:\s*\{\s*(?:(?&string)\s*:\s*(?&json)\s*,\s*)*?' . preg_quote(JsonFile::encode($repositoryIndex)) . '\s*:\s*)(?P<repository>(?&object))(?P<end>.*)}sx';
         $matches = null;
 
-        if (($listRegex !== null && Preg::isMatch($listRegex, $this->contents, $matches)) || Preg::isMatch($objectRegex, $this->contents, $matches)) {
+        try {
+            $found = ($listRegex !== null && Preg::isMatch($listRegex, $this->contents, $matches)) || Preg::isMatch($objectRegex, $this->contents, $matches);
+        } catch (\RuntimeException $e) {
+            if ($e->getCode() === PREG_BACKTRACK_LIMIT_ERROR) {
+                return false;
+            }
+            throw $e;
+        }
+
+        if ($found) {
             assert(isset($matches['start']) && is_string($matches['start']));
             assert(isset($matches['repository']) && is_string($matches['repository']));
             assert(isset($matches['end']) && is_string($matches['end']));
@@ -272,7 +281,11 @@ class JsonManipulator
      */
     public function insertRepository(string $name, $config, string $referenceName, int $offset = 0): bool
     {
-        if ("" !== $name && !$this->doRemoveRepository($name)) {
+        // the position is stated by $referenceName here, so $name only ever names the new
+        // repository and must not be resolved to a position of its own
+        $key = "" !== $name ? $this->findRepositoryKey($name, false) : null;
+
+        if ($key !== null && !$this->doRemoveRepositoryAt($key)) {
             return false;
         }
 

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -159,7 +159,12 @@ class JsonManipulator
      */
     public function addRepository(string $name, $config, bool $append = true): bool
     {
-        if ("" !== $name && !$this->doRemoveRepository($name)) {
+        // a false config disables a repository by name, so it never addresses a list position
+        $key = "" !== $name ? $this->findRepositoryKey($name, is_array($config)) : null;
+        // a repository addressed by position is replaced in place, $append does not apply
+        $replaceInPlace = is_int($key) && ctype_digit($name) && $key === (int) $name;
+
+        if ($key !== null && !$replaceInPlace && !$this->doRemoveRepositoryAt($key)) {
             return false;
         }
 
@@ -167,10 +172,17 @@ class JsonManipulator
             return false;
         }
 
-        if (is_array($config) && !is_numeric($name) && '' !== $name) {
+        if (is_array($config) && !ctype_digit($name) && '' !== $name) {
             $config = ['name' => $name] + $config;
         } elseif ($config === false) {
             $config = [$name => $config];
+        }
+
+        if ($replaceInPlace) {
+            // insert before removing, so that a single entry list never goes through an empty
+            // state, which would lose the indentation of the whole block
+            return $this->insertListItem('repositories', $config, $key)
+                && $this->removeListItem('repositories', $key + 1);
         }
 
         return $this->addListItem('repositories', $config, $append);
@@ -198,7 +210,7 @@ class JsonManipulator
                     if (!$this->addListItem('repositories', [$repositoryName => $repository], true)) {
                         return false;
                     }
-                } elseif (is_numeric($repositoryName)) {
+                } elseif (ctype_digit((string) $repositoryName)) {
                     if (!$this->addListItem('repositories', $repository, true)) {
                         return false;
                     }
@@ -218,20 +230,7 @@ class JsonManipulator
 
     public function setRepositoryUrl(string $name, string $url): bool
     {
-        $decoded = JsonFile::parseJson($this->contents);
-        $repositoryIndex = null;
-
-        foreach ($decoded['repositories'] ?? [] as $index => $repository) {
-            if ($name === $index) {
-                $repositoryIndex = $index;
-                break;
-            }
-
-            if ($name === ($repository['name'] ?? null)) {
-                $repositoryIndex = $index;
-                break;
-            }
-        }
+        $repositoryIndex = $this->findRepositoryKey($name);
 
         if (null === $repositoryIndex) {
             return false;
@@ -281,31 +280,14 @@ class JsonManipulator
             return false;
         }
 
-        $indexToInsert = null;
-        $decoded = JsonFile::parseJson($this->contents);
+        // repositories are a list at this point, so the reference always resolves to an index
+        $indexToInsert = $this->findRepositoryKey($referenceName);
 
-        foreach ($decoded['repositories'] as $repositoryIndex => $repository) {
-            if (($repository['name'] ?? null) === $referenceName) {
-                $indexToInsert = $repositoryIndex;
-                break;
-            }
-
-            if ($repositoryIndex === $referenceName) {
-                $indexToInsert = $repositoryIndex;
-                break;
-            }
-
-            if ([$referenceName => false] === $repository) {
-                $indexToInsert = $repositoryIndex;
-                break;
-            }
-        }
-
-        if ($indexToInsert === null) {
+        if (!is_int($indexToInsert)) {
             return false;
         }
 
-        if (is_array($config) && !is_numeric($name) && '' !== $name) {
+        if (is_array($config) && !ctype_digit($name) && '' !== $name) {
             $config = ['name' => $name] + $config;
         } elseif ($config === false) {
             $config = ['name' => $config];
@@ -321,63 +303,53 @@ class JsonManipulator
 
     private function doRemoveRepository(string $name): bool
     {
+        $key = $this->findRepositoryKey($name);
+
+        return $key === null || $this->doRemoveRepositoryAt($key);
+    }
+
+    /**
+     * @param int|string $key int for a list index, string for an object key
+     */
+    private function doRemoveRepositoryAt($key): bool
+    {
+        return is_int($key)
+            ? $this->removeListItem('repositories', $key)
+            : $this->removeSubNode('repositories', $key);
+    }
+
+    /**
+     * Finds a repository by name, falling back to its position for a numeric name in a list
+     *
+     * @return int|string|null int for a list index, string for an object key, null if not found
+     */
+    private function findRepositoryKey(string $name, bool $allowIndex = true)
+    {
         $decoded = json_decode($this->contents, false);
         $isAssoc = ($decoded->repositories ?? null) instanceof \stdClass;
+        // numeric object keys come back as ints from the array cast, so compare them as strings
+        $repositories = (array) ($decoded->repositories ?? []);
 
-        foreach ((array) ($decoded->repositories ?? []) as $repositoryIndex => $repository) {
-            // a numeric name addresses a list entry by position (e.g. `config repositories.0 ...`); remove that entry
-            if (!$isAssoc && is_numeric($name) && $repositoryIndex === (int) $name) {
-                if (!$this->removeListItem('repositories', $repositoryIndex)) {
-                    return false;
-                }
-
-                break;
-            }
-
-            if ($repositoryIndex === $name && $isAssoc) {
-                if (!$this->removeSubNode('repositories', $repositoryIndex)) {
-                    return false;
-                }
-
-                break;
-            }
-
-            if (($repository->name ?? null) === $name) {
-                if ($isAssoc) {
-                    if (!$this->removeSubNode('repositories', (string) $repositoryIndex)) {
-                        return false;
-                    }
-                } else {
-                    if (!$this->removeListItem('repositories', (int) $repositoryIndex)) {
-                        return false;
-                    }
-                }
-
-                break;
-            }
-
+        foreach ($repositories as $repositoryIndex => $repository) {
             if ($isAssoc) {
-                if ($name === $repositoryIndex && false === $repository) {
-                    if (!$this->removeSubNode('repositories', $repositoryIndex)) {
-                        return false;
-                    }
-
-                    return true;
+                if ((string) $repositoryIndex === $name || ($repository->name ?? null) === $name) {
+                    return (string) $repositoryIndex;
                 }
-            } else {
-                $repositoryAsArray = (array) $repository;
 
-                if (false === ($repositoryAsArray[$name] ?? null) && 1 === count($repositoryAsArray)) {
-                    if (!$this->removeListItem('repositories', (int) $repositoryIndex)) {
-                        return false;
-                    }
+                continue;
+            }
 
-                    return true;
-                }
+            if (($repository->name ?? null) === $name || [$name => false] === (array) $repository) {
+                return (int) $repositoryIndex;
             }
         }
 
-        return true;
+        // names take precedence, so a position is only matched once nothing matched by name
+        if ($allowIndex && !$isAssoc && ctype_digit($name) && isset($repositories[(int) $name])) {
+            return (int) $name;
+        }
+
+        return null;
     }
 
     /**

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -160,7 +160,7 @@ class JsonManipulator
     public function addRepository(string $name, $config, bool $append = true): bool
     {
         // a false config disables a repository by name, so it never addresses a list position
-        $key = "" !== $name ? $this->findRepositoryKey($name, is_array($config)) : null;
+        $key = "" !== $name ? $this->findRepositoryKeyInContents($name, is_array($config)) : null;
         // a repository addressed by position is replaced in place, $append does not apply
         $replaceInPlace = is_int($key) && ctype_digit($name) && $key === (int) $name;
 
@@ -230,7 +230,7 @@ class JsonManipulator
 
     public function setRepositoryUrl(string $name, string $url): bool
     {
-        $repositoryIndex = $this->findRepositoryKey($name);
+        $repositoryIndex = $this->findRepositoryKeyInContents($name);
 
         if (null === $repositoryIndex) {
             return false;
@@ -283,7 +283,7 @@ class JsonManipulator
     {
         // the position is stated by $referenceName here, so $name only ever names the new
         // repository and must not be resolved to a position of its own
-        $key = "" !== $name ? $this->findRepositoryKey($name, false) : null;
+        $key = "" !== $name ? $this->findRepositoryKeyInContents($name, false) : null;
 
         if ($key !== null && !$this->doRemoveRepositoryAt($key)) {
             return false;
@@ -294,7 +294,7 @@ class JsonManipulator
         }
 
         // repositories are a list at this point, so the reference always resolves to an index
-        $indexToInsert = $this->findRepositoryKey($referenceName);
+        $indexToInsert = $this->findRepositoryKeyInContents($referenceName);
 
         if (!is_int($indexToInsert)) {
             return false;
@@ -316,7 +316,7 @@ class JsonManipulator
 
     private function doRemoveRepository(string $name): bool
     {
-        $key = $this->findRepositoryKey($name);
+        $key = $this->findRepositoryKeyInContents($name);
 
         return $key === null || $this->doRemoveRepositoryAt($key);
     }
@@ -332,27 +332,42 @@ class JsonManipulator
     }
 
     /**
+     * @return int|string|null
+     */
+    private function findRepositoryKeyInContents(string $name, bool $allowIndex = true)
+    {
+        return self::findRepositoryKey(json_decode($this->contents, false)->repositories ?? null, $name, $allowIndex);
+    }
+
+    /**
      * Finds a repository by name, falling back to its position for a numeric name in a list
      *
+     * Pass the repositories as decoded, not cast to an array: an object with numeric keys becomes
+     * indistinguishable from a list once cast, which is what made `{"repositories": {"0": {}}}`
+     * never match.
+     *
+     * @param  \stdClass|array<int|string, mixed>|null $repositories
      * @return int|string|null int for a list index, string for an object key, null if not found
      */
-    private function findRepositoryKey(string $name, bool $allowIndex = true)
+    public static function findRepositoryKey($repositories, string $name, bool $allowIndex = true)
     {
-        $decoded = json_decode($this->contents, false);
-        $isAssoc = ($decoded->repositories ?? null) instanceof \stdClass;
-        // numeric object keys come back as ints from the array cast, so compare them as strings
-        $repositories = (array) ($decoded->repositories ?? []);
+        $isAssoc = $repositories instanceof \stdClass || (is_array($repositories) && !array_is_list($repositories));
+        $repositories = (array) ($repositories ?? []);
 
         foreach ($repositories as $repositoryIndex => $repository) {
+            // entries are objects or arrays depending on how the caller decoded them
+            $repository = (array) $repository;
+
             if ($isAssoc) {
-                if ((string) $repositoryIndex === $name || ($repository->name ?? null) === $name) {
+                // numeric object keys come back as ints from the array cast, so compare as strings
+                if ((string) $repositoryIndex === $name || ($repository['name'] ?? null) === $name) {
                     return (string) $repositoryIndex;
                 }
 
                 continue;
             }
 
-            if (($repository->name ?? null) === $name || [$name => false] === (array) $repository) {
+            if (($repository['name'] ?? null) === $name || [$name => false] === $repository) {
                 return (int) $repositoryIndex;
             }
         }

--- a/src/Composer/Util/ConfigValidator.php
+++ b/src/Composer/Util/ConfigValidator.php
@@ -142,6 +142,18 @@ class ConfigValidator
             );
         }
 
+        // a numeric name can not be told apart from a position when addressing a repository
+        if (isset($manifest['repositories']) && is_array($manifest['repositories'])) {
+            foreach ($manifest['repositories'] as $repository) {
+                if (is_array($repository) && isset($repository['name']) && is_string($repository['name']) && ctype_digit($repository['name'])) {
+                    $warnings[] = sprintf(
+                        'Repository name "%s" is numeric. Numbers address repositories by their position in the list, so a numeric name is ambiguous, rename it to something descriptive.',
+                        $repository['name']
+                    );
+                }
+            }
+        }
+
         if (!empty($manifest['type']) && $manifest['type'] === 'composer-installer') {
             $warnings[] = "The package type 'composer-installer' is deprecated. Please distribute your custom installers as plugins from now on. See https://getcomposer.org/doc/articles/plugins.md for plugin documentation.";
         }

--- a/tests/Composer/Test/Command/ConfigCommandTest.php
+++ b/tests/Composer/Test/Command/ConfigCommandTest.php
@@ -528,6 +528,17 @@ class ConfigCommandTest extends TestCase
         $appTester->run(['command' => 'config', 'setting-key' => 'repositories.0', '--unset' => true]);
     }
 
+    public function testConfigThrowsForANumericRepositoryName(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('A repository name can not be numeric ("2")');
+
+        $this->initTempComposer(['repositories' => [['type' => 'path', 'url' => '../a'], ['type' => 'path', 'url' => '../b']]]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'config', 'setting-key' => 'repositories.1', 'setting-value' => ['{"name":"2","type":"vcs","url":"https://example.org"}']]);
+    }
+
     public function testConfigThrowsForInvalidSeverity(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Composer/Test/Command/ConfigCommandTest.php
+++ b/tests/Composer/Test/Command/ConfigCommandTest.php
@@ -42,6 +42,11 @@ class ConfigCommandTest extends TestCase
             ['setting-key' => 'scripts.test', 'setting-value' => ['foo bar']],
             ['scripts' => ['test' => 'foo bar']],
         ];
+        yield 'overwrite a repository addressed by numeric index in a list' => [
+            ['repositories' => [['type' => 'path', 'url' => '../'], ['type' => 'composer', 'url' => 'https://other.test']]],
+            ['setting-key' => 'repositories.0', 'setting-value' => ['composer', 'https://replaced.test']],
+            ['repositories' => [['type' => 'composer', 'url' => 'https://replaced.test'], ['type' => 'composer', 'url' => 'https://other.test'], ['packagist.org' => false]]],
+        ];
         yield 'unset scripts' => [
             ['scripts' => ['test' => 'foo bar', 'lala' => 'baz']],
             ['setting-key' => 'scripts.lala', '--unset' => true],

--- a/tests/Composer/Test/Command/ConfigCommandTest.php
+++ b/tests/Composer/Test/Command/ConfigCommandTest.php
@@ -506,6 +506,28 @@ class ConfigCommandTest extends TestCase
         $appTester->run(['command' => 'config', '--file' => 'alt.composer.json', '--global' => true]);
     }
 
+    public function testConfigThrowsWhenANamedRepositoryIsAddressedByPosition(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The repository at position 0 is named "foo", address it by that name instead.');
+
+        $this->initTempComposer(['repositories' => [['name' => 'foo', 'type' => 'vcs', 'url' => 'https://example.org']]]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'config', 'setting-key' => 'repositories.0', 'setting-value' => ['vcs', 'https://other.org']]);
+    }
+
+    public function testConfigThrowsWhenUnsettingANamedRepositoryByPosition(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The repository at position 0 is named "foo", address it by that name instead.');
+
+        $this->initTempComposer(['repositories' => [['name' => 'foo', 'type' => 'vcs', 'url' => 'https://example.org']]]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'config', 'setting-key' => 'repositories.0', '--unset' => true]);
+    }
+
     public function testConfigThrowsForInvalidSeverity(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Composer/Test/Command/ConfigCommandTest.php
+++ b/tests/Composer/Test/Command/ConfigCommandTest.php
@@ -47,6 +47,16 @@ class ConfigCommandTest extends TestCase
             ['setting-key' => 'repositories.0', 'setting-value' => ['composer', 'https://replaced.test']],
             ['repositories' => [['type' => 'composer', 'url' => 'https://replaced.test'], ['type' => 'composer', 'url' => 'https://other.test'], ['packagist.org' => false]]],
         ];
+        yield 'overwrite a repository addressed by numeric index in the middle of a list' => [
+            ['repositories' => [['type' => 'path', 'url' => '../a'], ['type' => 'path', 'url' => '../b'], ['type' => 'composer', 'url' => 'https://c.test']]],
+            ['setting-key' => 'repositories.1', 'setting-value' => ['composer', 'https://replaced.test']],
+            ['repositories' => [['type' => 'path', 'url' => '../a'], ['type' => 'composer', 'url' => 'https://replaced.test'], ['type' => 'composer', 'url' => 'https://c.test'], ['packagist.org' => false]]],
+        ];
+        yield 'unset a repository addressed by numeric index in a list' => [
+            ['repositories' => [['type' => 'path', 'url' => '../a'], ['type' => 'path', 'url' => '../b']]],
+            ['setting-key' => 'repositories.1', '--unset' => true],
+            ['repositories' => [['type' => 'path', 'url' => '../a'], ['packagist.org' => false]]],
+        ];
         yield 'unset scripts' => [
             ['scripts' => ['test' => 'foo bar', 'lala' => 'baz']],
             ['setting-key' => 'scripts.lala', '--unset' => true],

--- a/tests/Composer/Test/Command/RepositoryCommandTest.php
+++ b/tests/Composer/Test/Command/RepositoryCommandTest.php
@@ -446,4 +446,57 @@ class RepositoryCommandTest extends TestCase
         self::assertSame(1, $countFoo, 'Exactly one repository entry with name foo should exist');
         self::assertSame('https://example.org/new', $url, 'The foo repository should have been updated to the new URL');
     }
+
+    public function testSetUrlByPosition(): void
+    {
+        $this->initTempComposer(['repositories' => [
+            ['type' => 'path', 'url' => '../a'],
+            ['type' => 'path', 'url' => '../b'],
+        ]], [], [], false);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'repo', 'action' => 'set-url', 'name' => '1', 'arg1' => '../new']);
+        $appTester->assertCommandIsSuccessful($appTester->getDisplay());
+
+        $json = json_decode((string) file_get_contents('composer.json'), true);
+        self::assertSame('../a', $json['repositories'][0]['url']);
+        self::assertSame('../new', $json['repositories'][1]['url']);
+    }
+
+    public function testRemoveByPosition(): void
+    {
+        $this->initTempComposer(['repositories' => [
+            ['type' => 'path', 'url' => '../a'],
+            ['type' => 'path', 'url' => '../b'],
+        ]], [], [], false);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'repo', 'action' => 'remove', 'name' => '0']);
+        $appTester->assertCommandIsSuccessful($appTester->getDisplay());
+
+        $json = json_decode((string) file_get_contents('composer.json'), true);
+        self::assertSame([['type' => 'path', 'url' => '../b']], $json['repositories']);
+    }
+
+    public function testAddBeforeAPosition(): void
+    {
+        $this->initTempComposer(['repositories' => [
+            ['type' => 'path', 'url' => '../a'],
+            ['type' => 'path', 'url' => '../b'],
+        ]], [], [], false);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run([
+            'command' => 'repo',
+            'action' => 'add',
+            'name' => 'foo',
+            'arg1' => 'vcs',
+            'arg2' => 'https://example.org',
+            '--before' => '1',
+        ]);
+        $appTester->assertCommandIsSuccessful($appTester->getDisplay());
+
+        $json = json_decode((string) file_get_contents('composer.json'), true);
+        self::assertSame(['../a', 'https://example.org', '../b'], array_column($json['repositories'], 'url'));
+    }
 }

--- a/tests/Composer/Test/Command/RepositoryCommandTest.php
+++ b/tests/Composer/Test/Command/RepositoryCommandTest.php
@@ -500,6 +500,20 @@ class RepositoryCommandTest extends TestCase
         ];
     }
 
+    public function testAddThrowsForANumericRepositoryNameInJson(): void
+    {
+        $this->initTempComposer([]);
+
+        $appTester = $this->getApplicationTester();
+
+        try {
+            $appTester->run(['command' => 'repo', 'action' => 'add', 'name' => 'foo', 'arg1' => '{"name":"1","type":"vcs","url":"https://example.org"}']);
+            self::fail('Expected a RuntimeException');
+        } catch (RuntimeException $e) {
+            self::assertStringContainsString('A repository name can not be numeric ("1")', $e->getMessage());
+        }
+    }
+
     public function testSetUrlByPosition(): void
     {
         $this->initTempComposer(['repositories' => [

--- a/tests/Composer/Test/Command/RepositoryCommandTest.php
+++ b/tests/Composer/Test/Command/RepositoryCommandTest.php
@@ -447,6 +447,59 @@ class RepositoryCommandTest extends TestCase
         self::assertSame('https://example.org/new', $url, 'The foo repository should have been updated to the new URL');
     }
 
+    /**
+     * @dataProvider provideAddressingANamedRepositoryByPosition
+     * @param array<string, mixed> $command
+     */
+    public function testAddressingANamedRepositoryByPositionFails(array $command, string $expected): void
+    {
+        $this->initTempComposer(['repositories' => [
+            ['name' => 'a', 'type' => 'path', 'url' => '../a'],
+            ['name' => 'b', 'type' => 'path', 'url' => '../b'],
+            ['name' => 'c', 'type' => 'composer', 'url' => 'https://c.test'],
+        ]], [], [], false);
+
+        $before = (string) file_get_contents('composer.json');
+
+        $appTester = $this->getApplicationTester();
+
+        try {
+            $appTester->run(['command' => 'repo'] + $command);
+            self::fail('Expected a RuntimeException');
+        } catch (RuntimeException $e) {
+            self::assertStringContainsString($expected, $e->getMessage());
+        }
+
+        // the file must be left alone rather than half-rewritten
+        self::assertSame($before, file_get_contents('composer.json'));
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>, string}>
+     */
+    public static function provideAddressingANamedRepositoryByPosition(): array
+    {
+        return [
+            // https://github.com/composer/composer/pull/13025#discussion -- this used to delete repository "a"
+            'add before a position' => [
+                ['action' => 'add', 'name' => '0', 'arg1' => 'vcs', 'arg2' => 'https://moved.test', '--before' => '1'],
+                'The repository at position 1 is named "b"',
+            ],
+            'add' => [
+                ['action' => 'add', 'name' => '0', 'arg1' => 'vcs', 'arg2' => 'https://moved.test'],
+                'The repository at position 0 is named "a"',
+            ],
+            'remove' => [
+                ['action' => 'remove', 'name' => '2'],
+                'The repository at position 2 is named "c"',
+            ],
+            'set-url' => [
+                ['action' => 'set-url', 'name' => '1', 'arg1' => 'https://new.test'],
+                'The repository at position 1 is named "b"',
+            ],
+        ];
+    }
+
     public function testSetUrlByPosition(): void
     {
         $this->initTempComposer(['repositories' => [

--- a/tests/Composer/Test/Config/JsonConfigSourceTest.php
+++ b/tests/Composer/Test/Config/JsonConfigSourceTest.php
@@ -143,6 +143,12 @@ class JsonConfigSourceTest extends TestCase
                 },
                 [['type' => 'path', 'url' => '../b'], ['name' => 'foo', 'type' => 'vcs', 'url' => 'https://new.test']],
             ],
+            'set-url by position' => [
+                static function (JsonConfigSource $source): void {
+                    $source->setRepositoryUrl('1', 'https://updated.test');
+                },
+                [['name' => 'foo', 'type' => 'vcs', 'url' => 'https://foo.test'], ['type' => 'path', 'url' => 'https://updated.test']],
+            ],
             'add by position replaces in place' => [
                 static function (JsonConfigSource $source): void {
                     $source->addRepository('1', ['type' => 'path', 'url' => '../new']);

--- a/tests/Composer/Test/Config/JsonConfigSourceTest.php
+++ b/tests/Composer/Test/Config/JsonConfigSourceTest.php
@@ -91,6 +91,67 @@ class JsonConfigSourceTest extends TestCase
         self::assertFileEquals(self::fixturePath('composer-empty.json'), $config);
     }
 
+    /**
+     * Drives the whole-file fallback that manipulateJson() uses when the surgical manipulation
+     * fails, by making PCRE give up on the recursive JSON pattern.
+     *
+     * @dataProvider provideRepositoryFallback
+     * @param  callable(JsonConfigSource): void  $operation
+     * @param  list<array<string, mixed>>        $expected
+     */
+    public function testRepositoryFallbackWhenManipulationFails(callable $operation, array $expected): void
+    {
+        $config = $this->workingDir.'/composer.json';
+        file_put_contents($config, JsonFile::encode(['repositories' => [
+            ['name' => 'foo', 'type' => 'vcs', 'url' => 'https://foo.test'],
+            ['type' => 'path', 'url' => '../b'],
+        ]])."\n");
+
+        $backtrackLimit = ini_get('pcre.backtrack_limit');
+        ini_set('pcre.backtrack_limit', '100');
+
+        try {
+            $operation(new JsonConfigSource(new JsonFile($config)));
+        } finally {
+            ini_set('pcre.backtrack_limit', (string) $backtrackLimit);
+        }
+
+        self::assertSame($expected, JsonFile::parseJson((string) file_get_contents($config))['repositories'] ?? []);
+    }
+
+    /**
+     * @return array<string, array{callable(JsonConfigSource): void, list<array<string, mixed>>}>
+     */
+    public static function provideRepositoryFallback(): array
+    {
+        return [
+            'remove by name' => [
+                static function (JsonConfigSource $source): void {
+                    $source->removeRepository('foo');
+                },
+                [['type' => 'path', 'url' => '../b']],
+            ],
+            'remove by position' => [
+                static function (JsonConfigSource $source): void {
+                    $source->removeRepository('1');
+                },
+                [['name' => 'foo', 'type' => 'vcs', 'url' => 'https://foo.test']],
+            ],
+            'add by name replaces the existing entry' => [
+                static function (JsonConfigSource $source): void {
+                    $source->addRepository('foo', ['type' => 'vcs', 'url' => 'https://new.test']);
+                },
+                [['type' => 'path', 'url' => '../b'], ['name' => 'foo', 'type' => 'vcs', 'url' => 'https://new.test']],
+            ],
+            'add by position replaces in place' => [
+                static function (JsonConfigSource $source): void {
+                    $source->addRepository('1', ['type' => 'path', 'url' => '../new']);
+                },
+                [['name' => 'foo', 'type' => 'vcs', 'url' => 'https://foo.test'], ['type' => 'path', 'url' => '../new']],
+            ],
+        ];
+    }
+
     public function testAddPackagistRepositoryWithFalseValue(): void
     {
         $config = $this->workingDir.'/composer.json';

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -2329,6 +2329,38 @@ class JsonManipulatorTest extends TestCase
 ', $manipulator->getContents());
     }
 
+    public function testAddRepositoryByNumericIndexOverwritesListEntry(): void
+    {
+        $manipulator = new JsonManipulator('{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../"
+        },
+        {
+            "type": "composer",
+            "url": "https://other.test"
+        }
+    ]
+}
+');
+
+        self::assertTrue($manipulator->addRepository('0', ['type' => 'composer', 'url' => 'https://replaced.test'], false));
+        self::assertEquals('{
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://replaced.test"
+        },
+        {
+            "type": "composer",
+            "url": "https://other.test"
+        }
+    ]
+}
+', $manipulator->getContents());
+    }
+
     /**
      * @dataProvider provideTestSetUrlInRepository
      */

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -2615,6 +2615,59 @@ class JsonManipulatorTest extends TestCase
 ', $manipulator->getContents());
     }
 
+    public function testAddRepositoryByNumericKeyInObjectFormatReplacesTheNamedEntry(): void
+    {
+        // in the object format a numeric key is a name, so it must be replaced rather than duplicated
+        $manipulator = new JsonManipulator('{
+    "repositories": {
+        "foo": {
+            "type": "composer",
+            "url": "https://foo.test"
+        },
+        "1": {
+            "type": "path",
+            "url": "../one"
+        },
+        "bar": {
+            "type": "composer",
+            "url": "https://bar.test"
+        }
+    }
+}');
+
+        self::assertTrue($manipulator->addRepository('1', ['type' => 'composer', 'url' => 'https://replaced.test'], false));
+        self::assertSame(
+            ['https://replaced.test', 'https://foo.test', 'https://bar.test'],
+            array_column(JsonFile::parseJson($manipulator->getContents())['repositories'], 'url')
+        );
+    }
+
+    public function testInsertRepositoryDoesNotRemoveTheEntryAtTheNamesPosition(): void
+    {
+        // --before/--after already state the position, so a numeric name only names the new entry
+        $manipulator = new JsonManipulator('{
+    "repositories": [
+        {
+            "name": "a",
+            "type": "path",
+            "url": "../a"
+        },
+        {
+            "name": "b",
+            "type": "path",
+            "url": "../b"
+        }
+    ]
+}
+');
+
+        self::assertTrue($manipulator->insertRepository('0', ['type' => 'vcs', 'url' => 'https://moved.test'], 'b', 0));
+        self::assertSame(
+            ['../a', 'https://moved.test', '../b'],
+            array_column(JsonFile::parseJson($manipulator->getContents())['repositories'], 'url')
+        );
+    }
+
     public function testSetRepositoryUrlByNumericIndex(): void
     {
         $manipulator = new JsonManipulator(self::REPOSITORY_LIST);

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -18,6 +18,38 @@ use Composer\Test\TestCase;
 
 class JsonManipulatorTest extends TestCase
 {
+    private const REPOSITORY_LIST = '{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../a"
+        },
+        {
+            "type": "path",
+            "url": "../b"
+        },
+        {
+            "type": "composer",
+            "url": "https://c.test"
+        }
+    ]
+}
+';
+
+    private const REPOSITORY_OBJECT = '{
+    "repositories": {
+        "0": {
+            "type": "path",
+            "url": "../a"
+        },
+        "foo": {
+            "type": "composer",
+            "url": "https://foo.test"
+        }
+    }
+}
+';
+
     /**
      * @dataProvider linkProvider
      */
@@ -2355,6 +2387,286 @@ class JsonManipulatorTest extends TestCase
         {
             "type": "composer",
             "url": "https://other.test"
+        }
+    ]
+}
+', $manipulator->getContents());
+    }
+
+    /**
+     * @dataProvider provideAddRepositoryByNumericIndex
+     */
+    public function testAddRepositoryByNumericIndexReplacesInPlace(string $name, bool $append, string $expected): void
+    {
+        $manipulator = new JsonManipulator(self::REPOSITORY_LIST);
+
+        self::assertTrue($manipulator->addRepository($name, ['type' => 'composer', 'url' => 'https://replaced.test'], $append));
+        self::assertEquals($expected, $manipulator->getContents());
+    }
+
+    /**
+     * @return array<string, array{string, bool, string}>
+     */
+    public static function provideAddRepositoryByNumericIndex(): array
+    {
+        return [
+            'middle entry' => ['1', false, '{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../a"
+        },
+        {
+            "type": "composer",
+            "url": "https://replaced.test"
+        },
+        {
+            "type": "composer",
+            "url": "https://c.test"
+        }
+    ]
+}
+'],
+            'last entry' => ['2', false, '{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../a"
+        },
+        {
+            "type": "path",
+            "url": "../b"
+        },
+        {
+            "type": "composer",
+            "url": "https://replaced.test"
+        }
+    ]
+}
+'],
+            // the position is what was addressed, so it wins over the append flag
+            'first entry with append' => ['0', true, '{
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://replaced.test"
+        },
+        {
+            "type": "path",
+            "url": "../b"
+        },
+        {
+            "type": "composer",
+            "url": "https://c.test"
+        }
+    ]
+}
+'],
+        ];
+    }
+
+    public function testAddRepositoryByOutOfRangeNumericIndexAddsANewEntry(): void
+    {
+        $manipulator = new JsonManipulator(self::REPOSITORY_LIST);
+
+        self::assertTrue($manipulator->addRepository('9', ['type' => 'composer', 'url' => 'https://added.test'], true));
+        self::assertEquals('{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../a"
+        },
+        {
+            "type": "path",
+            "url": "../b"
+        },
+        {
+            "type": "composer",
+            "url": "https://c.test"
+        },
+        {
+            "type": "composer",
+            "url": "https://added.test"
+        }
+    ]
+}
+', $manipulator->getContents());
+    }
+
+    public function testAddRepositoryPrefersANameOverAPosition(): void
+    {
+        $manipulator = new JsonManipulator('{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../a"
+        },
+        {
+            "type": "path",
+            "url": "../b"
+        },
+        {
+            "name": "1",
+            "type": "composer",
+            "url": "https://named.test"
+        }
+    ]
+}
+');
+
+        // the repository named "1" is replaced, the entry at position 1 is left alone. A numeric
+        // name is never written back as a name property, so the replacement ends up unnamed.
+        self::assertTrue($manipulator->addRepository('1', ['type' => 'composer', 'url' => 'https://replaced.test'], false));
+        self::assertEquals('{
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://replaced.test"
+        },
+        {
+            "type": "path",
+            "url": "../a"
+        },
+        {
+            "type": "path",
+            "url": "../b"
+        }
+    ]
+}
+', $manipulator->getContents());
+    }
+
+    public function testAddRepositoryTreatsANonIntegerNumericNameAsAName(): void
+    {
+        $manipulator = new JsonManipulator(self::REPOSITORY_LIST);
+
+        self::assertTrue($manipulator->addRepository('0.9', ['type' => 'composer', 'url' => 'https://added.test'], false));
+        self::assertEquals('{
+    "repositories": [
+        {
+            "name": "0.9",
+            "type": "composer",
+            "url": "https://added.test"
+        },
+        {
+            "type": "path",
+            "url": "../a"
+        },
+        {
+            "type": "path",
+            "url": "../b"
+        },
+        {
+            "type": "composer",
+            "url": "https://c.test"
+        }
+    ]
+}
+', $manipulator->getContents());
+    }
+
+    public function testAddDisabledRepositoryDoesNotRemoveAnEntryByPosition(): void
+    {
+        $manipulator = new JsonManipulator(self::REPOSITORY_LIST);
+
+        // disabling addresses a repository by name, so it must not delete the entry at position 0
+        self::assertTrue($manipulator->addRepository('0', false, false));
+        self::assertStringContainsString('"url": "../a"', $manipulator->getContents());
+    }
+
+    public function testRemoveRepositoryByNumericIndex(): void
+    {
+        $manipulator = new JsonManipulator(self::REPOSITORY_LIST);
+
+        self::assertTrue($manipulator->removeRepository('1'));
+        self::assertEquals('{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../a"
+        },
+        {
+            "type": "composer",
+            "url": "https://c.test"
+        }
+    ]
+}
+', $manipulator->getContents());
+    }
+
+    public function testAddRepositoryByNumericKeyInObjectFormat(): void
+    {
+        $manipulator = new JsonManipulator(self::REPOSITORY_OBJECT);
+
+        self::assertTrue($manipulator->addRepository('0', ['type' => 'composer', 'url' => 'https://replaced.test'], false));
+        self::assertEquals('{
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://replaced.test"
+        },
+        {
+            "name": "foo",
+            "type": "composer",
+            "url": "https://foo.test"
+        }
+    ]
+}
+', $manipulator->getContents());
+    }
+
+    public function testSetRepositoryUrlByNumericIndex(): void
+    {
+        $manipulator = new JsonManipulator(self::REPOSITORY_LIST);
+
+        self::assertTrue($manipulator->setRepositoryUrl('1', 'https://updated.test'));
+        self::assertStringContainsString('"url": "https://updated.test"', $manipulator->getContents());
+        self::assertStringContainsString('"url": "../a"', $manipulator->getContents());
+    }
+
+    public function testSetRepositoryUrlByNumericKeyInObjectFormat(): void
+    {
+        $manipulator = new JsonManipulator(self::REPOSITORY_OBJECT);
+
+        self::assertTrue($manipulator->setRepositoryUrl('0', 'https://updated.test'));
+        self::assertEquals('{
+    "repositories": {
+        "0": {
+            "type": "path",
+            "url": "https://updated.test"
+        },
+        "foo": {
+            "type": "composer",
+            "url": "https://foo.test"
+        }
+    }
+}
+', $manipulator->getContents());
+    }
+
+    public function testInsertRepositoryBeforeANumericIndex(): void
+    {
+        $manipulator = new JsonManipulator(self::REPOSITORY_LIST);
+
+        self::assertTrue($manipulator->insertRepository('inserted', ['type' => 'composer', 'url' => 'https://inserted.test'], '1', 0));
+        self::assertEquals('{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../a"
+        },
+        {
+            "name": "inserted",
+            "type": "composer",
+            "url": "https://inserted.test"
+        },
+        {
+            "type": "path",
+            "url": "../b"
+        },
+        {
+            "type": "composer",
+            "url": "https://c.test"
         }
     ]
 }

--- a/tests/Composer/Test/Util/ConfigValidatorTest.php
+++ b/tests/Composer/Test/Util/ConfigValidatorTest.php
@@ -35,6 +35,28 @@ class ConfigValidatorTest extends TestCase
         );
     }
 
+    public function testConfigValidatorWarnsOnNumericRepositoryName(): void
+    {
+        $configValidator = new ConfigValidator(new NullIO());
+        [, , $warnings] = $configValidator->validate(__DIR__ . '/Fixtures/composer_numeric-repository-name.json');
+
+        self::assertContains(
+            'Repository name "1" is numeric. Numbers address repositories by their position in the list, so a numeric name is ambiguous, rename it to something descriptive.',
+            $warnings
+        );
+    }
+
+    public function testConfigValidatorDoesNotWarnOnNumericRepositoryKey(): void
+    {
+        // in the object format the key is a name, so a numeric one is not ambiguous with a position
+        $configValidator = new ConfigValidator(new NullIO());
+        [, , $warnings] = $configValidator->validate(__DIR__ . '/Fixtures/composer_numeric-repository-key.json');
+
+        foreach ($warnings as $warning) {
+            self::assertStringNotContainsString('is numeric', $warning);
+        }
+    }
+
     public function testConfigValidatorWarnsOnScriptDescriptionForNonexistentScript(): void
     {
         $configValidator = new ConfigValidator(new NullIO());

--- a/tests/Composer/Test/Util/Fixtures/composer_numeric-repository-key.json
+++ b/tests/Composer/Test/Util/Fixtures/composer_numeric-repository-key.json
@@ -1,0 +1,8 @@
+{
+    "repositories": {
+        "0": {
+            "type": "vcs",
+            "url": "https://example.org/zero"
+        }
+    }
+}

--- a/tests/Composer/Test/Util/Fixtures/composer_numeric-repository-name.json
+++ b/tests/Composer/Test/Util/Fixtures/composer_numeric-repository-name.json
@@ -1,0 +1,14 @@
+{
+    "repositories": [
+        {
+            "name": "1",
+            "type": "vcs",
+            "url": "https://example.org/one"
+        },
+        {
+            "name": "local",
+            "type": "path",
+            "url": "../local"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #12623

### Problem

`composer config repositories.N <type> <url>`, where `N` is a numeric index into a `repositories` **list**, must overwrite the existing repository at position `N`. Since the `repo` command refactor it no longer does: the old entry is kept and a duplicate is added instead.

```console
$ cat composer.json
{
    "repositories": [
        { "type": "path", "url": "../" },
        { "type": "composer", "url": "https://other.test" }
    ]
}

$ composer config repositories.0 composer https://replaced.test
# before this patch, index 0 is NOT replaced — a duplicate is prepended:
{
    "repositories": [
        { "type": "composer", "url": "https://replaced.test" },
        { "type": "path", "url": "../" },
        { "type": "composer", "url": "https://other.test" }
    ]
}
```

### Root cause

`JsonManipulator::doRemoveRepository()` (called by `addRepository()`/`insertRepository()`/`removeRepository()` before writing the new entry) matched repositories only by their `name` property. A numeric key like `0` never matches a `name`, so nothing is removed and the new entry is simply added. Reading by numeric index already works (`config repositories.0`); only writing regressed.

### Fix

Match a numeric name against the list **position** so the entry at that index is removed before the new one is written back. The branch is guarded with `!$isAssoc && is_numeric($name)`, so named repositories and object-format `repositories` are unaffected.

### Test verification (RED → GREEN)

Two tests were added (unit + functional). Both fail before the production change and pass after.

**RED** — with only the tests applied on top of the current base (production fix reverted):

```
1) Composer\Test\Json\JsonManipulatorTest::testAddRepositoryByNumericIndexOverwritesListEntry
Failed asserting that two strings are equal.
--- Expected  (index 0 replaced)
+++ Actual    (old entry kept, duplicate added)

FAILURES! Tests: 1, Assertions: 2, Failures: 1.

2) Composer\Test\Command\ConfigCommandTest::testConfigUpdates with data set
   "overwrite a repository addressed by numeric index in a list"
Failed asserting that two arrays are identical.
FAILURES! Tests: 75, Assertions: 150, Failures: 1.
```

**GREEN** — with the fix:

```
Composer\Test\Json\JsonManipulatorTest
OK (1 test, 2 assertions)

Composer\Test\Command\ConfigCommandTest
OK (95 tests, 194 assertions)
```

Full related suites pass (`JsonManipulatorTest` 125/125, `ConfigCommandTest` 95/95, `RepositoryCommandTest` 20/20, `JsonConfigSourceTest` 45/45) and PHPStan level 8 is clean.
