### PR TITLE
Load locked deps required by symlinked path repos when unlocking during a partial update

### DIFF
--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -18,6 +18,7 @@ use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
 use Composer\Package\CompleteAliasPackage;
 use Composer\Package\CompletePackage;
+use Composer\Package\Link;
 use Composer\Package\PackageInterface;
 use Composer\Package\Version\StabilityFilter;
 use Composer\Pcre\Preg;
@@ -132,6 +133,15 @@ class PoolBuilder
      * @var array<string, true>
      */
     private $pathRepoUnlocked = [];
+
+    /**
+     * Loaded packages from auto-unlocked path repositories, keyed like $this->packages
+     *
+     * Indexed on load to avoid rescanning every loaded package each time one gets unlocked
+     *
+     * @var array<int, BasePackage>
+     */
+    private $loadedPathRepoPackages = [];
 
     /**
      * Keeps a list of dependencies which are root requirements, and as such
@@ -347,6 +357,7 @@ class PoolBuilder
         $this->loadedPackages = [];
         $this->loadedPerRepo = [];
         $this->packages = [];
+        $this->loadedPathRepoPackages = [];
         $this->unacceptableFixedOrLockedPackages = [];
         $this->maxExtendedReqs = [];
         $this->skippedLoad = [];
@@ -482,6 +493,12 @@ class PoolBuilder
         }
 
         $name = $package->getName();
+
+        // aliases forward getRequires() to the package they alias, so indexing them too would only cause
+        // the same requires to be re-registered twice in unlockPackage()
+        if (!$package instanceof AliasPackage && isset($this->pathRepoUnlocked[$name])) {
+            $this->loadedPathRepoPackages[$index] = $package;
+        }
 
         // we're simply setting the root references on all versions for a name here and rely on the solver to pick the
         // right version. It'd be more work to figure out which versions and which aliases of those versions this may
@@ -719,39 +736,18 @@ class PoolBuilder
 
         unset($this->skippedLoad[$name], $this->loadedPackages[$name], $this->maxExtendedReqs[$name], $this->pathRepoUnlocked[$name]);
 
-        // symlinked path repo packages are auto-unlocked and thus never end up in getFixedOrLockedPackages(), but they
-        // are already loaded in the pool, so their requirements on this now-unlocked package must be re-registered too,
-        // otherwise the version range they need may never be loaded back into the pool (see #13024)
-        if (\count($this->pathRepoUnlocked) > 0) {
-            // collected up front as the loop further below unlocks them from the request
-            $unlockedReplaces = [];
-            foreach ($request->getLockedPackages() as $lockedPackage) {
-                if (!($lockedPackage instanceof AliasPackage) && $lockedPackage->getName() === $name) {
-                    foreach ($lockedPackage->getReplaces() as $replace) {
-                        $unlockedReplaces[] = $replace;
-                    }
-                }
-            }
-
-            foreach ($this->packages as $loadedPackage) {
-                if (!isset($this->pathRepoUnlocked[$loadedPackage->getName()])) {
-                    continue;
-                }
-
-                $requires = $loadedPackage->getRequires();
-                if (isset($requires[$name])) {
-                    $this->markPackageNameForLoading($request, $name, $requires[$name]->getConstraint());
-                }
-
-                // and if the unlocked package replaces something the path repo package requires, load that replaced
-                // package too in case an update to the unlocked package removes the replacement
-                foreach ($unlockedReplaces as $replace) {
-                    if (isset($requires[$replace->getTarget()], $this->skippedLoad[$replace->getTarget()])) {
-                        $this->unlockPackage($request, $repositories, $replace->getTarget());
-                        // this package is in $requires so no need to call markPackageNameForLoadingIfRequired
-                        $this->markPackageNameForLoading($request, $replace->getTarget(), $replace->getConstraint());
-                    }
-                }
+        // Symlinked path repo packages are auto-unlocked, so they are absent from getFixedOrLockedPackages() and the
+        // loop below cannot see them. They are loaded in the pool though, and their constraint on this name was dropped
+        // when they were loaded because the locked version already satisfied it, so re-register it now or the versions
+        // they need may never be loaded back into the pool. See #13024.
+        //
+        // Unlike the loop below this must run even when no locked package carries this name itself, as the name may be
+        // present in the lock file only through a replace. It must also stay below the unset() above, which is what
+        // stops it from recursing endlessly in that case.
+        foreach ($this->loadedPathRepoPackages as $pathRepoPackage) {
+            $requires = $pathRepoPackage->getRequires();
+            if (isset($requires[$name])) {
+                $this->markPackageNameForLoading($request, $name, $requires[$name]->getConstraint());
             }
         }
 
@@ -778,16 +774,34 @@ class PoolBuilder
                                 $this->markPackageNameForLoading($request, $lockedPackage->getName(), $requires[$lockedPackage->getName()]->getConstraint());
                             }
 
-                            foreach ($lockedPackage->getReplaces() as $replace) {
-                                if (isset($requires[$replace->getTarget()], $this->skippedLoad[$replace->getTarget()])) {
-                                    $this->unlockPackage($request, $repositories, $replace->getTarget());
-                                    // this package is in $requires so no need to call markPackageNameForLoadingIfRequired
-                                    $this->markPackageNameForLoading($request, $replace->getTarget(), $replace->getConstraint());
-                                }
-                            }
+                            $this->loadReplacedPackages($request, $repositories, $lockedPackage, $requires);
                         }
                     }
+
+                    // path repo packages had their own constraint re-registered above already, but they may equally
+                    // require a package which the one being unlocked replaces
+                    foreach ($this->loadedPathRepoPackages as $pathRepoPackage) {
+                        $this->loadReplacedPackages($request, $repositories, $lockedPackage, $pathRepoPackage->getRequires());
+                    }
                 }
+            }
+        }
+    }
+
+    /**
+     * Ensures packages replaced by the one being unlocked are loaded, in case an update to it drops the replacement
+     *
+     * @param RepositoryInterface[] $repositories
+     * @param array<string, Link>   $requires requires of a package which will not be reloaded, and which therefore
+     *                                        had its constraints dropped while $unlockedPackage was still locked
+     */
+    private function loadReplacedPackages(Request $request, array $repositories, BasePackage $unlockedPackage, array $requires): void
+    {
+        foreach ($unlockedPackage->getReplaces() as $replace) {
+            if (isset($requires[$replace->getTarget()], $this->skippedLoad[$replace->getTarget()])) {
+                $this->unlockPackage($request, $repositories, $replace->getTarget());
+                // this package is in $requires so no need to call markPackageNameForLoadingIfRequired
+                $this->markPackageNameForLoading($request, $replace->getTarget(), $replace->getConstraint());
             }
         }
     }
@@ -815,7 +829,7 @@ class PoolBuilder
         $repoIndex = array_search($package->getRepository(), $repositories, true);
 
         unset($this->loadedPerRepo[$repoIndex][$package->getName()][$package->getVersion()]);
-        unset($this->packages[$index]);
+        unset($this->packages[$index], $this->loadedPathRepoPackages[$index]);
         if (isset($this->aliasMap[spl_object_id($package)])) {
             foreach ($this->aliasMap[spl_object_id($package)] as $aliasIndex => $aliasPackage) {
                 unset($this->loadedPerRepo[$repoIndex][$aliasPackage->getName()][$aliasPackage->getVersion()]);

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -719,6 +719,42 @@ class PoolBuilder
 
         unset($this->skippedLoad[$name], $this->loadedPackages[$name], $this->maxExtendedReqs[$name], $this->pathRepoUnlocked[$name]);
 
+        // symlinked path repo packages are auto-unlocked and thus never end up in getFixedOrLockedPackages(), but they
+        // are already loaded in the pool, so their requirements on this now-unlocked package must be re-registered too,
+        // otherwise the version range they need may never be loaded back into the pool (see #13024)
+        if (\count($this->pathRepoUnlocked) > 0) {
+            // collected up front as the loop further below unlocks them from the request
+            $unlockedReplaces = [];
+            foreach ($request->getLockedPackages() as $lockedPackage) {
+                if (!($lockedPackage instanceof AliasPackage) && $lockedPackage->getName() === $name) {
+                    foreach ($lockedPackage->getReplaces() as $replace) {
+                        $unlockedReplaces[] = $replace;
+                    }
+                }
+            }
+
+            foreach ($this->packages as $loadedPackage) {
+                if (!isset($this->pathRepoUnlocked[$loadedPackage->getName()])) {
+                    continue;
+                }
+
+                $requires = $loadedPackage->getRequires();
+                if (isset($requires[$name])) {
+                    $this->markPackageNameForLoading($request, $name, $requires[$name]->getConstraint());
+                }
+
+                // and if the unlocked package replaces something the path repo package requires, load that replaced
+                // package too in case an update to the unlocked package removes the replacement
+                foreach ($unlockedReplaces as $replace) {
+                    if (isset($requires[$replace->getTarget()], $this->skippedLoad[$replace->getTarget()])) {
+                        $this->unlockPackage($request, $repositories, $replace->getTarget());
+                        // this package is in $requires so no need to call markPackageNameForLoadingIfRequired
+                        $this->markPackageNameForLoading($request, $replace->getTarget(), $replace->getConstraint());
+                    }
+                }
+            }
+        }
+
         // remove locked package by this name which was already initialized
         foreach ($request->getLockedPackages() as $lockedPackage) {
             if (!($lockedPackage instanceof AliasPackage) && $lockedPackage->getName() === $name) {
@@ -749,20 +785,6 @@ class PoolBuilder
                                     $this->markPackageNameForLoading($request, $replace->getTarget(), $replace->getConstraint());
                                 }
                             }
-                        }
-                    }
-
-                    // symlinked path repo packages are auto-unlocked and thus never end up in getFixedOrLockedPackages(),
-                    // but they are already loaded in the pool and their requirements on this now-unlocked package must
-                    // still be honored, otherwise the constraint range they need may not be loaded (see #13024)
-                    foreach ($this->packages as $loadedPackage) {
-                        if (!isset($this->pathRepoUnlocked[$loadedPackage->getName()])) {
-                            continue;
-                        }
-
-                        $requires = $loadedPackage->getRequires();
-                        if (isset($requires[$lockedPackage->getName()])) {
-                            $this->markPackageNameForLoading($request, $lockedPackage->getName(), $requires[$lockedPackage->getName()]->getConstraint());
                         }
                     }
                 }

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -751,6 +751,20 @@ class PoolBuilder
                             }
                         }
                     }
+
+                    // symlinked path repo packages are auto-unlocked and thus never end up in getFixedOrLockedPackages(),
+                    // but they are already loaded in the pool and their requirements on this now-unlocked package must
+                    // still be honored, otherwise the constraint range they need may not be loaded (see #13024)
+                    foreach ($this->packages as $loadedPackage) {
+                        if (!isset($this->pathRepoUnlocked[$loadedPackage->getName()])) {
+                            continue;
+                        }
+
+                        $requires = $loadedPackage->getRequires();
+                        if (isset($requires[$lockedPackage->getName()])) {
+                            $this->markPackageNameForLoading($request, $lockedPackage->getName(), $requires[$lockedPackage->getName()]->getConstraint());
+                        }
+                    }
                 }
             }
         }

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-keeps-symlinked-path-repo-constraint-on-replaced-dep-name.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-keeps-symlinked-path-repo-constraint-on-replaced-dep-name.test
@@ -1,9 +1,9 @@
 --TEST--
-When unlocking a locked package during a partial update, the version constraints required by a symlinked path-repo
-package must still be honored, otherwise the locked version needed by the path package is never loaded into the pool
-(https://github.com/composer/composer/issues/13024). The path repo must be listed before the repo providing the requirer
-which triggers the unlocking, otherwise locked/dep is already unlocked by the time the path repo package is loaded and
-its constraint is never dropped in the first place.
+A symlinked path-repo package's constraint must also be re-registered when the unlocked name is only present in the lock
+file through a replace, so no locked package carries that name itself. Path repo packages are auto-unlocked so they never
+show up in getFixedOrLockedPackages() (https://github.com/composer/composer/issues/13024). The path repo must be listed
+before the repo providing the requirer which triggers the unlocking, otherwise locked/dep is already unlocked by the
+time the path repo package is loaded and its constraint is never dropped in the first place.
 
 --REQUEST--
 {
@@ -19,7 +19,7 @@ its constraint is never dropped in the first place.
             "dist": {"type": "path", "url": "./symlinked-path-repo-with-locked-dep", "reference": "abcd"}, "transport-options": {}
         },
         {"name": "trigger/dep", "version": "1.0.0"},
-        {"name": "locked/dep", "version": "2.0.0"}
+        {"name": "provider/pkg", "version": "1.0.0", "replace": {"locked/dep": "2.0.0"}}
     ],
     "allowList": [
         "trigger/dep"
@@ -38,7 +38,8 @@ its constraint is never dropped in the first place.
         {"name": "trigger/dep", "version": "1.0.0"},
         {"name": "trigger/dep", "version": "1.2.0", "require": {"locked/dep": "1.*"}},
         {"name": "locked/dep", "version": "1.0.0"},
-        {"name": "locked/dep", "version": "2.0.0"}
+        {"name": "locked/dep", "version": "2.0.0"},
+        {"name": "provider/pkg", "version": "1.0.0", "replace": {"locked/dep": "2.0.0"}}
     ]
 ]
 

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-keeps-symlinked-path-repo-locked-dep-constraint.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-keeps-symlinked-path-repo-locked-dep-constraint.test
@@ -1,0 +1,48 @@
+--TEST--
+When unlocking a locked package during a partial update, the version constraints required by a symlinked path-repo package must still be honored, otherwise the locked version needed by the path package is never loaded into the pool (https://github.com/composer/composer/issues/13024).
+
+--REQUEST--
+{
+    "require": {
+        "symlinked/path-pkg": "*",
+        "trigger/dep": "*"
+    },
+    "locked": [
+        {
+            "name": "symlinked/path-pkg",
+            "version": "1.0.0",
+            "require": {"locked/dep": "^2.0"},
+            "dist": {"type": "path", "url": "./symlinked-path-repo-with-locked-dep", "reference": "abcd"}, "transport-options": {}
+        },
+        {"name": "trigger/dep", "version": "1.0.0"},
+        {"name": "locked/dep", "version": "2.0.0"}
+    ],
+    "allowList": [
+        "trigger/dep"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    {"type": "path", "url": "./symlinked-path-repo-with-locked-dep"},
+    [
+        {"name": "trigger/dep", "version": "1.0.0"},
+        {"name": "trigger/dep", "version": "1.2.0", "require": {"locked/dep": "1.*"}},
+        {"name": "locked/dep", "version": "1.0.0"},
+        {"name": "locked/dep", "version": "2.0.0"}
+    ]
+]
+
+--EXPECT--
+[
+    "trigger/dep-1.0.0.0",
+    "trigger/dep-1.2.0.0",
+    "symlinked/path-pkg-1.0.0.0",
+    "locked/dep-1.0.0.0",
+    "locked/dep-2.0.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-loads-replaced-dep-required-by-symlinked-path-repo.test
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/partial-update-loads-replaced-dep-required-by-symlinked-path-repo.test
@@ -1,0 +1,51 @@
+--TEST--
+When unlocking a locked package during a partial update, a package it replaces which is required by a symlinked
+path-repo package must be loaded too, in case an update to the replacer drops the replacement. Path repo packages are
+auto-unlocked so they never show up in getFixedOrLockedPackages() (https://github.com/composer/composer/issues/13024).
+The path repo must be listed before the repo providing the requirer which triggers the unlocking, otherwise locked/dep
+is already unlocked by the time the path repo package is loaded and its constraint is never dropped in the first place.
+
+--REQUEST--
+{
+    "require": {
+        "symlinked/path-pkg": "*",
+        "root/dep": "*"
+    },
+    "locked": [
+        {
+            "name": "symlinked/path-pkg",
+            "version": "1.0.0",
+            "require": {"locked/dep": "^2.0"},
+            "dist": {"type": "path", "url": "./symlinked-path-repo-with-locked-dep", "reference": "abcd"}, "transport-options": {}
+        },
+        {"name": "root/dep", "version": "1.1.0", "require": {"replacer/pkg": "1.*"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"locked/dep": "2.0.0"}}
+    ],
+    "allowList": [
+        "root/dep"
+    ],
+    "allowTransitiveDeps": true
+}
+
+--FIXED--
+[
+]
+
+--PACKAGE-REPOS--
+[
+    {"type": "path", "url": "./symlinked-path-repo-with-locked-dep"},
+    [
+        {"name": "root/dep", "version": "1.2.0", "require": {"replacer/pkg": ">=1.1.0"}},
+        {"name": "replacer/pkg", "version": "1.0.0", "replace": {"locked/dep": "2.0.0"}},
+        {"name": "replacer/pkg", "version": "1.1.0"},
+        {"name": "locked/dep", "version": "2.0.0"}
+    ]
+]
+
+--EXPECT--
+[
+    "root/dep-1.2.0.0",
+    "replacer/pkg-1.1.0.0",
+    "locked/dep-2.0.0.0",
+    "symlinked/path-pkg-1.0.0.0"
+]

--- a/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/symlinked-path-repo-with-locked-dep/composer.json
+++ b/tests/Composer/Test/DependencyResolver/Fixtures/poolbuilder/symlinked-path-repo-with-locked-dep/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "symlinked/path-pkg",
+    "version": "1.0.0",
+    "require": {
+        "locked/dep": "^2.0"
+    }
+}


### PR DESCRIPTION
Fixes #13024

### Problem

`composer update -w <pkg>` (partial update with dependencies) fails when the project has a **symlinked path-repository** package whose own dependency is locked but not in the update allow-list. Composer reports the locked dependency as "found … but these were not loaded, likely because it conflicts with another require", even though the locked version satisfies the constraint. The identical project without the path package — or with `options.symlink: false` — resolves the same command cleanly.

Minimal reproduction from the issue: a symlinked path package `acme/liby` requiring `symfony/process ^7.0` (locked at v7.4.13), then `composer update --dry-run -w aws/aws-sdk-php`:

```
  Problem 1
    - Root composer.json requires acme/liby * -> satisfiable by acme/liby[1.0.0].
    - acme/liby 1.0.0 requires symfony/process ^7.0 -> found symfony/process[v7.0.0, ..., v7.4.13]
      but these were not loaded, likely because it conflicts with another require.
```

### Root cause

When a locked package (`symfony/process`) is unlocked during a partial update — because a package being updated newly requires it — `PoolBuilder::unlockPackage()` re-registers the version constraints of every *other* package that still requires it, so all needed versions get loaded back into the pool. That re-registration only iterated `$request->getFixedOrLockedPackages()`.

Symlinked path-repo packages are deliberately auto-unlocked (they are added to `$this->pathRepoUnlocked` and never `lockPackage()`'d, so they always stay in sync). As a result they never appear in `getFixedOrLockedPackages()`, and their requirement on the just-unlocked package was silently dropped. The dependency was then reloaded with only the *other* requirers' constraints, which excluded the locked version — so the version the path package needs was removed from the pool and never came back.

### Fix

After the existing fixed/locked re-registration, also honor the requirements of already-loaded path-repo-unlocked packages on the package being unlocked, using the same `markPackageNameForLoading()` mechanism (which unions constraints). The new loop only fires for names in `$this->pathRepoUnlocked`, so non-path resolutions are untouched.

### Test verification (RED → GREEN)

Added a `PoolBuilderTest` fixture (`partial-update-keeps-symlinked-path-repo-locked-dep-constraint.test`) — the symlinked-path-repo analog of the existing `partial-update-unfixing-locked-deps.test`. It asserts the locked dependency version needed by the path package is present in the pool.

**RED** — new test on the current base, production fix reverted (the version the path package needs, `locked/dep-2.0.0.0`, is missing from the pool):

```
1) Composer\Test\DependencyResolver\PoolBuilderTest::testPoolBuilder with data set
   "partial-update-keeps-symlinked-path-repo-locked-dep-constraint.test"
Unoptimized pool does not match expected package set
--- Expected
+++ Actual
     0 => 'locked/dep-1.0.0.0'
-    1 => 'locked/dep-2.0.0.0'
     ...
FAILURES! Tests: 1, Assertions: 1, Failures: 1.
```

**GREEN** — with the fix:

```
Composer\Test\DependencyResolver\PoolBuilderTest
OK (32 tests, 64 assertions)
```

`InstallerTest` (418/418) and the full `PoolBuilderTest` suite pass, and PHPStan level 8 is clean. The original real-world reproduction from the issue now resolves as expected (`Upgrading aws/aws-sdk-php`, `symfony/process` kept locked).
