### PR TITLE
Replace deprecated spl_object_hash with spl_object_id

### DIFF
--- a/src/Composer/DependencyResolver/LockTransaction.php
+++ b/src/Composer/DependencyResolver/LockTransaction.php
@@ -27,9 +27,9 @@ class LockTransaction extends Transaction
     /**
      * packages in current lock file, platform repo or otherwise present
      *
-     * Indexed by spl_object_hash
+     * Indexed by spl_object_id
      *
-     * @var array<string, BasePackage>
+     * @var array<int, BasePackage>
      */
     protected $presentMap;
 
@@ -48,7 +48,7 @@ class LockTransaction extends Transaction
     protected $resultPackages;
 
     /**
-     * @param array<string, BasePackage> $presentMap
+     * @param array<int, BasePackage> $presentMap
      * @param array<int, BasePackage> $unlockableMap
      */
     public function __construct(Pool $pool, array $presentMap, array $unlockableMap, Decisions $decisions)
@@ -112,7 +112,7 @@ class LockTransaction extends Transaction
             }
 
             // if we're just updating mirrors we need to reset everything to the same as currently "present" packages' references to keep the lock file as-is
-            if ($updateMirrors === true && !array_key_exists(spl_object_hash($package), $this->presentMap)) {
+            if ($updateMirrors === true && !array_key_exists(spl_object_id($package), $this->presentMap)) {
                 $package = $this->updateMirrorAndUrls($package);
             }
 

--- a/src/Composer/DependencyResolver/Pool.php
+++ b/src/Composer/DependencyResolver/Pool.php
@@ -41,7 +41,7 @@ class Pool implements \Countable
     protected $unacceptableFixedOrLockedPackages;
     /** @var array<string, array<string, string>> Map of package name => normalized version => pretty version */
     protected $removedVersions = [];
-    /** @var array<string, array<string, string>> Map of package object hash => removed normalized versions => removed pretty version */
+    /** @var array<int, array<string, string>> Map of package object id => removed normalized versions => removed pretty version */
     protected $removedVersionsByPackage = [];
     /** @var array<string, array<string, array<SecurityAdvisory|PartialSecurityAdvisory>>> Map of package name => normalized version => security advisories */
     private $securityRemovedVersions = [];
@@ -54,7 +54,7 @@ class Pool implements \Countable
      * @param BasePackage[] $packages
      * @param BasePackage[] $unacceptableFixedOrLockedPackages
      * @param array<string, array<string, string>> $removedVersions
-     * @param array<string, array<string, string>> $removedVersionsByPackage
+     * @param array<int, array<string, string>> $removedVersionsByPackage
      * @param array<string, array<string, array<SecurityAdvisory|PartialSecurityAdvisory>>> $securityRemovedVersions
      * @param array<string, array<string, string>> $abandonedRemovedVersions
      * @param array<string, array<string, list<FilterListEntry>>> $filterListRemovedVersions
@@ -101,17 +101,17 @@ class Pool implements \Countable
     /**
      * @return array<string, string>
      */
-    public function getRemovedVersionsByPackage(string $objectHash): array
+    public function getRemovedVersionsByPackage(int $objectId): array
     {
-        if (!isset($this->removedVersionsByPackage[$objectHash])) {
+        if (!isset($this->removedVersionsByPackage[$objectId])) {
             return [];
         }
 
-        return $this->removedVersionsByPackage[$objectHash];
+        return $this->removedVersionsByPackage[$objectId];
     }
 
     /**
-     * @return array<string, array<string, string>>
+     * @return array<int, array<string, string>>
      */
     public function getAllRemovedVersionsByPackage(): array
     {
@@ -201,7 +201,7 @@ class Pool implements \Countable
         foreach ($this->filterListRemovedVersions[$packageName] ?? [] as $version => $filterListEntries) {
             if ($constraint !== null && $constraint->matches(new Constraint('==', $version))) {
                 foreach ($filterListEntries as $entry) {
-                    $entryKey = spl_object_hash($entry);
+                    $entryKey = spl_object_id($entry);
                     if (isset($seen[$entryKey])) {
                         continue;
                     }

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -78,7 +78,7 @@ class PoolBuilder
     private $io;
     /**
      * @var array[]
-     * @phpstan-var array<string, AliasPackage[]>
+     * @phpstan-var array<int, AliasPackage[]>
      */
     private $aliasMap = [];
     /**
@@ -303,8 +303,8 @@ class PoolBuilder
 
                     $constraint = $this->temporaryConstraints[$packageName];
                     $packageAndAliases = [$i => $package];
-                    if (isset($this->aliasMap[spl_object_hash($package)])) {
-                        $packageAndAliases += $this->aliasMap[spl_object_hash($package)];
+                    if (isset($this->aliasMap[spl_object_id($package)])) {
+                        $packageAndAliases += $this->aliasMap[spl_object_id($package)];
                     }
 
                     $found = false;
@@ -478,7 +478,7 @@ class PoolBuilder
         $this->packages[$index] = $package;
 
         if ($package instanceof AliasPackage) {
-            $this->aliasMap[spl_object_hash($package->getAliasOf())][$index] = $package;
+            $this->aliasMap[spl_object_id($package->getAliasOf())][$index] = $package;
         }
 
         $name = $package->getName();
@@ -514,7 +514,7 @@ class PoolBuilder
 
             $newIndex = $this->indexCounter++;
             $this->packages[$newIndex] = $aliasPackage;
-            $this->aliasMap[spl_object_hash($aliasPackage->getAliasOf())][$newIndex] = $aliasPackage;
+            $this->aliasMap[spl_object_id($aliasPackage->getAliasOf())][$newIndex] = $aliasPackage;
         }
 
         foreach ($package->getRequires() as $link) {
@@ -780,12 +780,12 @@ class PoolBuilder
 
         unset($this->loadedPerRepo[$repoIndex][$package->getName()][$package->getVersion()]);
         unset($this->packages[$index]);
-        if (isset($this->aliasMap[spl_object_hash($package)])) {
-            foreach ($this->aliasMap[spl_object_hash($package)] as $aliasIndex => $aliasPackage) {
+        if (isset($this->aliasMap[spl_object_id($package)])) {
+            foreach ($this->aliasMap[spl_object_id($package)] as $aliasIndex => $aliasPackage) {
                 unset($this->loadedPerRepo[$repoIndex][$aliasPackage->getName()][$aliasPackage->getVersion()]);
                 unset($this->packages[$aliasIndex]);
             }
-            unset($this->aliasMap[spl_object_hash($package)]);
+            unset($this->aliasMap[spl_object_id($package)]);
         }
     }
 

--- a/src/Composer/DependencyResolver/PoolOptimizer.php
+++ b/src/Composer/DependencyResolver/PoolOptimizer.php
@@ -59,7 +59,7 @@ class PoolOptimizer
     private $aliasesPerPackage = [];
 
     /**
-     * @var array<string, array<string, string>>
+     * @var array<int, array<string, string>>
      */
     private $removedVersionsByPackage = [];
 
@@ -364,7 +364,7 @@ class PoolOptimizer
         }
 
         foreach ($versions as $version => $prettyVersion) {
-            $this->removedVersionsByPackage[spl_object_hash($package)][$version] = $prettyVersion;
+            $this->removedVersionsByPackage[spl_object_id($package)][$version] = $prettyVersion;
         }
     }
 

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -38,7 +38,7 @@ class Problem
 {
     /**
      * A map containing the id of each rule part of this problem as a key
-     * @var array<string, true>
+     * @var array<int, true>
      */
     protected $reasonSeen;
 
@@ -58,7 +58,7 @@ class Problem
      */
     public function addRule(Rule $rule): void
     {
-        $this->addReason(spl_object_hash($rule), $rule);
+        $this->addReason(spl_object_id($rule), $rule);
     }
 
     /**
@@ -182,7 +182,7 @@ class Problem
                 $messages[] = $template;
                 $templates[$template][$m[1]][$parser->normalize($m[2])] = $m[2];
                 $sourcePackage = $rule->getSourcePackage($pool);
-                foreach ($pool->getRemovedVersionsByPackage(spl_object_hash($sourcePackage)) as $version => $prettyVersion) {
+                foreach ($pool->getRemovedVersionsByPackage(spl_object_id($sourcePackage)) as $version => $prettyVersion) {
                     $templates[$template][$m[1]][$version] = $prettyVersion;
                 }
             } elseif ($message !== '') {
@@ -230,10 +230,10 @@ class Problem
     /**
      * Store a reason descriptor but ignore duplicates
      *
-     * @param string $id     A canonical identifier for the reason
-     * @param Rule   $reason The reason descriptor
+     * @param int  $id     A canonical identifier for the reason
+     * @param Rule $reason The reason descriptor
      */
-    protected function addReason(string $id, Rule $reason): void
+    protected function addReason(int $id, Rule $reason): void
     {
         // TODO: if a rule is part of a problem description in two sections, isn't this going to remove a message
         // that is important to understand the issue?
@@ -553,7 +553,7 @@ class Problem
                 }
             }
             if ($pool !== null && $useRemovedVersionGroup) {
-                foreach ($pool->getRemovedVersionsByPackage(spl_object_hash($package)) as $version => $prettyVersion) {
+                foreach ($pool->getRemovedVersionsByPackage(spl_object_id($package)) as $version => $prettyVersion) {
                     $prepared[$package->getName()]['versions'][$version] = $prettyVersion;
                 }
             }

--- a/src/Composer/DependencyResolver/Request.php
+++ b/src/Composer/DependencyResolver/Request.php
@@ -44,11 +44,11 @@ class Request
     protected $lockedRepository;
     /** @var array<string, ConstraintInterface> */
     protected $requires = [];
-    /** @var array<string, BasePackage> */
+    /** @var array<int, BasePackage> */
     protected $fixedPackages = [];
-    /** @var array<string, BasePackage> */
+    /** @var array<int, BasePackage> */
     protected $lockedPackages = [];
-    /** @var array<string, BasePackage> */
+    /** @var array<int, BasePackage> */
     protected $fixedLockedPackages = [];
     /** @var array<string> */
     protected $updateAllowList = [];
@@ -83,7 +83,7 @@ class Request
      */
     public function fixPackage(BasePackage $package): void
     {
-        $this->fixedPackages[spl_object_hash($package)] = $package;
+        $this->fixedPackages[spl_object_id($package)] = $package;
     }
 
     /**
@@ -98,7 +98,7 @@ class Request
      */
     public function lockPackage(BasePackage $package): void
     {
-        $this->lockedPackages[spl_object_hash($package)] = $package;
+        $this->lockedPackages[spl_object_id($package)] = $package;
     }
 
     /**
@@ -110,13 +110,13 @@ class Request
      */
     public function fixLockedPackage(BasePackage $package): void
     {
-        $this->fixedPackages[spl_object_hash($package)] = $package;
-        $this->fixedLockedPackages[spl_object_hash($package)] = $package;
+        $this->fixedPackages[spl_object_id($package)] = $package;
+        $this->fixedLockedPackages[spl_object_id($package)] = $package;
     }
 
     public function unlockPackage(BasePackage $package): void
     {
-        unset($this->lockedPackages[spl_object_hash($package)]);
+        unset($this->lockedPackages[spl_object_id($package)]);
     }
 
     /**
@@ -156,7 +156,7 @@ class Request
     }
 
     /**
-     * @return array<string, BasePackage>
+     * @return array<int, BasePackage>
      */
     public function getFixedPackages(): array
     {
@@ -165,11 +165,11 @@ class Request
 
     public function isFixedPackage(BasePackage $package): bool
     {
-        return isset($this->fixedPackages[spl_object_hash($package)]);
+        return isset($this->fixedPackages[spl_object_id($package)]);
     }
 
     /**
-     * @return array<string, BasePackage>
+     * @return array<int, BasePackage>
      */
     public function getLockedPackages(): array
     {
@@ -178,11 +178,11 @@ class Request
 
     public function isLockedPackage(PackageInterface $package): bool
     {
-        return isset($this->lockedPackages[spl_object_hash($package)]) || isset($this->fixedLockedPackages[spl_object_hash($package)]);
+        return isset($this->lockedPackages[spl_object_id($package)]) || isset($this->fixedLockedPackages[spl_object_id($package)]);
     }
 
     /**
-     * @return array<string, BasePackage>
+     * @return array<int, BasePackage>
      */
     public function getFixedOrLockedPackages(): array
     {
@@ -190,7 +190,7 @@ class Request
     }
 
     /**
-     * @return ($packageIds is true ? array<int, BasePackage> : array<string, BasePackage>)
+     * @return array<int, BasePackage>
      *
      * @TODO look into removing the packageIds option, the only place true is used
      *       is for the installed map in the solver problems.
@@ -203,12 +203,12 @@ class Request
 
         if ($this->lockedRepository !== null) {
             foreach ($this->lockedRepository->getPackages() as $package) {
-                $presentMap[$packageIds ? $package->getId() : spl_object_hash($package)] = $package;
+                $presentMap[$packageIds ? $package->getId() : spl_object_id($package)] = $package;
             }
         }
 
         foreach ($this->fixedPackages as $package) {
-            $presentMap[$packageIds ? $package->getId() : spl_object_hash($package)] = $package;
+            $presentMap[$packageIds ? $package->getId() : spl_object_id($package)] = $package;
         }
 
         return $presentMap;

--- a/src/Composer/DependencyResolver/Solver.php
+++ b/src/Composer/DependencyResolver/Solver.php
@@ -50,7 +50,7 @@ class Solver
     protected $problems = [];
     /** @var array<Rule[]> */
     protected $learnedPool = [];
-    /** @var array<string, int> */
+    /** @var array<int, int> */
     protected $learnedWhy = [];
 
     /** @var bool */
@@ -340,7 +340,7 @@ class Solver
 
             $this->rules->add($newRule, RuleSet::TYPE_LEARNED);
 
-            $this->learnedWhy[spl_object_hash($newRule)] = $why;
+            $this->learnedWhy[spl_object_id($newRule)] = $why;
 
             $ruleNode = new RuleWatchNode($newRule);
             $ruleNode->watch2OnHighest($this->decisions);
@@ -518,11 +518,11 @@ class Solver
     }
 
     /**
-     * @param array<string, true> $ruleSeen
+     * @param array<int, true> $ruleSeen
      */
     private function analyzeUnsolvableRule(Problem $problem, Rule $conflictRule, array &$ruleSeen): void
     {
-        $why = spl_object_hash($conflictRule);
+        $why = spl_object_id($conflictRule);
         $ruleSeen[$why] = true;
 
         if ($conflictRule->getType() === RuleSet::TYPE_LEARNED) {
@@ -530,7 +530,7 @@ class Solver
             $problemRules = $this->learnedPool[$learnedWhy];
 
             foreach ($problemRules as $problemRule) {
-                if (!isset($ruleSeen[spl_object_hash($problemRule)])) {
+                if (!isset($ruleSeen[spl_object_id($problemRule)])) {
                     $this->analyzeUnsolvableRule($problem, $problemRule, $ruleSeen);
                 }
             }

--- a/src/Composer/DependencyResolver/Transaction.php
+++ b/src/Composer/DependencyResolver/Transaction.php
@@ -38,7 +38,7 @@ class Transaction
 
     /**
      * Package set resulting from this transaction
-     * @var array<string, PackageInterface>
+     * @var array<int, PackageInterface>
      */
     protected $resultPackageMap;
 
@@ -87,7 +87,7 @@ class Transaction
 
         $this->resultPackageMap = [];
         foreach ($resultPackages as $package) {
-            $this->resultPackageMap[spl_object_hash($package)] = $package;
+            $this->resultPackageMap[spl_object_id($package)] = $package;
             foreach ($package->getNames() as $name) {
                 $this->resultPackagesByName[$name][] = $package;
             }
@@ -128,12 +128,12 @@ class Transaction
         while (\count($stack) > 0) {
             $package = array_pop($stack);
 
-            if (isset($processed[spl_object_hash($package)])) {
+            if (isset($processed[spl_object_id($package)])) {
                 continue;
             }
 
-            if (!isset($visited[spl_object_hash($package)])) {
-                $visited[spl_object_hash($package)] = true;
+            if (!isset($visited[spl_object_id($package)])) {
+                $visited[spl_object_id($package)] = true;
 
                 $stack[] = $package;
                 if ($package instanceof AliasPackage) {
@@ -147,8 +147,8 @@ class Transaction
                         }
                     }
                 }
-            } elseif (!isset($processed[spl_object_hash($package)])) {
-                $processed[spl_object_hash($package)] = true;
+            } elseif (!isset($processed[spl_object_id($package)])) {
+                $processed[spl_object_id($package)] = true;
 
                 if ($package instanceof AliasPackage) {
                     $aliasKey = $package->getName().'::'.$package->getVersion();
@@ -225,7 +225,7 @@ class Transaction
      * These serve as a starting point to enumerate packages in a topological order despite potential cycles.
      * If there are packages with a cycle on the top level the package with the lowest name gets picked
      *
-     * @return array<string, PackageInterface>
+     * @return array<int, PackageInterface>
      */
     protected function getRootPackages(): array
     {
@@ -241,7 +241,7 @@ class Transaction
 
                 foreach ($possibleRequires as $require) {
                     if ($require !== $package) {
-                        unset($roots[spl_object_hash($require)]);
+                        unset($roots[spl_object_id($require)]);
                     }
                 }
             }

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -448,7 +448,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             $extension = $package->getDistType();
         }
 
-        return rtrim($this->config->get('vendor-dir') . '/composer/tmp-' . hash('md5', $package . spl_object_hash($package)) . '.' . $extension, '.');
+        return rtrim($this->config->get('vendor-dir') . '/composer/tmp-' . hash('md5', $package . spl_object_id($package)) . '.' . $extension, '.');
     }
 
     /**

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -707,10 +707,10 @@ class EventDispatcher
             return 'fn:'.$cb;
         }
         if (is_object($cb)) {
-            return 'obj:'.spl_object_hash($cb);
+            return 'obj:'.spl_object_id($cb);
         }
         if (is_array($cb)) {
-            return 'array:'.(is_string($cb[0]) ? $cb[0] : get_class($cb[0]) .'#'.spl_object_hash($cb[0])).'::'.$cb[1];
+            return 'array:'.(is_string($cb[0]) ? $cb[0] : get_class($cb[0]) .'#'.spl_object_id($cb[0])).'::'.$cb[1];
         }
 
         // not great but also do not want to break everything here

--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -71,10 +71,10 @@ class ArrayRepository implements RepositoryInterface
                     && !isset($alreadyLoaded[$package->getName()][$package->getVersion()])
                 ) {
                     // add selected packages which match stability requirements
-                    $result[spl_object_hash($package)] = $package;
+                    $result[spl_object_id($package)] = $package;
                     // add the aliased package for packages where the alias matches
-                    if ($package instanceof AliasPackage && !isset($result[spl_object_hash($package->getAliasOf())])) {
-                        $result[spl_object_hash($package->getAliasOf())] = $package->getAliasOf();
+                    if ($package instanceof AliasPackage && !isset($result[spl_object_id($package->getAliasOf())])) {
+                        $result[spl_object_id($package->getAliasOf())] = $package->getAliasOf();
                     }
                 }
 
@@ -85,8 +85,8 @@ class ArrayRepository implements RepositoryInterface
         // add aliases of packages that were selected, even if the aliases did not match
         foreach ($packages as $package) {
             if ($package instanceof AliasPackage) {
-                if (isset($result[spl_object_hash($package->getAliasOf())])) {
-                    $result[spl_object_hash($package)] = $package;
+                if (isset($result[spl_object_id($package->getAliasOf())])) {
+                    $result[spl_object_id($package)] = $package;
                 }
             }
         }

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -573,9 +573,9 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     $namesFound[$name] = true;
 
                     if (!$constraint || $constraint->matches(new Constraint('==', $candidate->getVersion()))) {
-                        $matches[spl_object_hash($candidate)] = $candidate;
-                        if ($candidate instanceof AliasPackage && !isset($matches[spl_object_hash($candidate->getAliasOf())])) {
-                            $matches[spl_object_hash($candidate->getAliasOf())] = $candidate->getAliasOf();
+                        $matches[spl_object_id($candidate)] = $candidate;
+                        if ($candidate instanceof AliasPackage && !isset($matches[spl_object_id($candidate->getAliasOf())])) {
+                            $matches[spl_object_id($candidate->getAliasOf())] = $candidate->getAliasOf();
                         }
                     }
                 }
@@ -583,8 +583,8 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                 // add aliases of matched packages even if they did not match the constraint
                 foreach ($candidates as $candidate) {
                     if ($candidate instanceof AliasPackage) {
-                        if (isset($matches[spl_object_hash($candidate->getAliasOf())])) {
-                            $matches[spl_object_hash($candidate)] = $candidate;
+                        if (isset($matches[spl_object_id($candidate->getAliasOf())])) {
+                            $matches[spl_object_id($candidate)] = $candidate;
                         }
                     }
                 }
@@ -1275,7 +1275,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      * @phpstan-param array<string, BasePackage::STABILITY_*>|null $stabilityFlags
      * @param array<string, array<string, PackageInterface>> $alreadyLoaded
      *
-     * @return array{namesFound: array<string, true>, packages: array<string, BasePackage>}
+     * @return array{namesFound: array<string, true>, packages: array<int, BasePackage>}
      */
     private function loadAsyncPackages(array $packageNames, ?array $acceptableStabilities = null, ?array $stabilityFlags = null, array $alreadyLoaded = []): array
     {
@@ -1345,11 +1345,11 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                     $loadedPackages = $this->createPackages($versionsToLoad, $packagesSource);
                     foreach ($loadedPackages as $package) {
                         $package->setRepository($this);
-                        $packages[spl_object_hash($package)] = $package;
+                        $packages[spl_object_id($package)] = $package;
 
-                        if ($package instanceof AliasPackage && !isset($packages[spl_object_hash($package->getAliasOf())])) {
+                        if ($package instanceof AliasPackage && !isset($packages[spl_object_id($package->getAliasOf())])) {
                             $package->getAliasOf()->setRepository($this);
-                            $packages[spl_object_hash($package->getAliasOf())] = $package->getAliasOf();
+                            $packages[spl_object_id($package->getAliasOf())] = $package->getAliasOf();
                         }
                     }
                 });

--- a/tests/Composer/Test/DependencyResolver/PoolOptimizerTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolOptimizerTest.php
@@ -64,7 +64,7 @@ class PoolOptimizerTest extends TestCase
         $poolOptimizer = new PoolOptimizer(new DefaultPolicy());
         $optimizedPool = $poolOptimizer->optimize($request, $pool);
 
-        $removedVersions = $optimizedPool->getRemovedVersionsByPackage(spl_object_hash($packageA110));
+        $removedVersions = $optimizedPool->getRemovedVersionsByPackage(spl_object_id($packageA110));
 
         // Versions from 'package/a' name group
         self::assertArrayHasKey($packageA100->getVersion(), $removedVersions, 'Should contain package/a 1.0.0 from package/a name group');
@@ -98,9 +98,9 @@ class PoolOptimizerTest extends TestCase
             $package111->getVersion() => $package111->getPrettyVersion(),
         ];
 
-        self::assertSame($expectedVersions, $optimizedPool->getRemovedVersionsByPackage(spl_object_hash($package110Alias)));
-        self::assertSame($expectedVersions, $optimizedPool->getRemovedVersionsByPackage(spl_object_hash($package110)));
-        self::assertSame($expectedVersions, $optimizedPool->getRemovedVersionsByPackage(spl_object_hash($package110SiblingAlias)));
+        self::assertSame($expectedVersions, $optimizedPool->getRemovedVersionsByPackage(spl_object_id($package110Alias)));
+        self::assertSame($expectedVersions, $optimizedPool->getRemovedVersionsByPackage(spl_object_id($package110)));
+        self::assertSame($expectedVersions, $optimizedPool->getRemovedVersionsByPackage(spl_object_id($package110SiblingAlias)));
     }
 
     /**


### PR DESCRIPTION
PHP 8.6 deprecates spl_object_hash() in favour of spl_object_id(), so the solver and repository code paths that key arrays by object identity now emit a notice on every call. This swaps all of them over and updates the affected array key types in the docblocks.

The only signature change is Pool::getRemovedVersionsByPackage(), which now takes an int since there is no hash left to pass it.

Fixes #13027