### PR TITLE
Add vulnerable-only dependency updates

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -243,6 +243,9 @@ php composer.phar update vendor/package:2.0.1 vendor/package2:3.0.*
   updates the allow-listed packages are always updated fully. Can also be set via
   the COMPOSER_MINIMAL_CHANGES=1 env var.
 * **--patch-only:** Only allow patch version updates for currently installed dependencies.
+* **--vulnerable-only:** Only update locked packages affected by known security advisories.
+  This requires a `composer.lock` file and cannot be combined with package arguments,
+  `--interactive`, `--root-reqs`, or `--lock`. `--no-dev` excludes development dependencies.
 * **--interactive:** Interactive interface with autocompletion to select the packages to update.
 * **--root-reqs:** Restricts the update to your first degree dependencies.
 * **--bump-after-update:** Runs `bump` after performing the update. Set to `dev` or `no-dev` to only bump those dependencies.

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -85,6 +85,7 @@ class UpdateCommand extends BaseCommand
                 new InputOption('prefer-lowest', null, InputOption::VALUE_NONE, 'Prefer lowest versions of dependencies (can also be set via the COMPOSER_PREFER_LOWEST=1 env var).'),
                 new InputOption('minimal-changes', 'm', InputOption::VALUE_NONE, 'Only perform absolutely necessary changes to dependencies. If packages cannot be kept at their currently locked version they are updated. For partial updates the allow-listed packages are always updated fully. (can also be set via the COMPOSER_MINIMAL_CHANGES=1 env var).'),
                 new InputOption('patch-only', null, InputOption::VALUE_NONE, 'Only allow patch version updates for currently installed dependencies.'),
+                new InputOption('vulnerable-only', null, InputOption::VALUE_NONE, 'Restricts the update to locked packages affected by security advisories.'),
                 new InputOption('interactive', 'i', InputOption::VALUE_NONE, 'Interactive interface with autocompletion to select the packages to update.'),
                 new InputOption('root-reqs', null, InputOption::VALUE_NONE, 'Restricts the update to your first degree dependencies.'),
                 new InputOption('bump-after-update', null, InputOption::VALUE_OPTIONAL, 'Runs bump after performing the update.', false, ['dev', 'no-dev', 'all']),
@@ -140,6 +141,35 @@ EOT
         }
 
         $packages = $input->getArgument('packages');
+
+        if ($input->getOption('vulnerable-only')) {
+            if (count($packages) > 0) {
+                throw new \InvalidArgumentException('--vulnerable-only cannot be combined with package arguments.');
+            }
+            if ($input->getOption('interactive') || $input->getOption('root-reqs') || $input->getOption('lock')) {
+                throw new \InvalidArgumentException('--vulnerable-only cannot be combined with --interactive, --root-reqs or --lock.');
+            }
+            if (!$composer->getLocker()->isLocked()) {
+                throw new \UnexpectedValueException('A valid composer.lock file is required to run this command with --vulnerable-only.');
+            }
+
+            $repositorySet = new RepositorySet();
+            foreach ($composer->getRepositoryManager()->getRepositories() as $repository) {
+                $repositorySet->addRepository($repository);
+            }
+
+            $lockedPackages = $composer->getLocker()->getLockedRepository(!$input->getOption('no-dev'))->getPackages();
+            $packages = array_keys($repositorySet->getMatchingSecurityAdvisories($lockedPackages, true)['advisories']);
+
+            if (count($packages) === 0) {
+                $io->writeError('<info>No packages with known security vulnerabilities found in composer.lock.</info>');
+
+                return self::SUCCESS;
+            }
+
+            $io->writeError('<info>Updating vulnerable packages: '.implode(', ', $packages).'</info>');
+        }
+
         $reqs = $this->formatRequirements($input->getOption('with'));
 
         // extract --with shorthands from the allowlist

--- a/tests/Composer/Test/Command/UpdateCommandTest.php
+++ b/tests/Composer/Test/Command/UpdateCommandTest.php
@@ -563,6 +563,160 @@ OUTPUT
         self::assertStringNotContainsString('Locking vulnerable/pkg (1.0.0)', $display);
     }
 
+    public function testVulnerableOnlyUpdatesAffectedLockedPackages(): void
+    {
+        $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'vulnerable/pkg', 'version' => '1.0.0'],
+                        ['name' => 'vulnerable/pkg', 'version' => '1.1.0'],
+                        ['name' => 'safe/pkg', 'version' => '1.0.0'],
+                        ['name' => 'safe/pkg', 'version' => '1.1.0'],
+                    ],
+                    'security-advisories' => [
+                        'vulnerable/pkg' => [
+                            [
+                                'advisoryId' => 'PKSA-test-001',
+                                'packageName' => 'vulnerable/pkg',
+                                'remoteId' => 'CVE-2024-1234',
+                                'title' => 'Test Security Vulnerability',
+                                'link' => 'https://example.com/advisory',
+                                'cve' => 'CVE-2024-1234',
+                                'affectedVersions' => '<1.1.0',
+                                'source' => 'test',
+                                'reportedAt' => '2024-01-01 00:00:00',
+                                'composerRepository' => 'Package Repository',
+                                'severity' => 'high',
+                                'sources' => [
+                                    [
+                                        'name' => 'test',
+                                        'remoteId' => 'CVE-2024-1234',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'require' => [
+                'vulnerable/pkg' => '^1.0',
+                'safe/pkg' => '^1.0',
+            ],
+        ]);
+        $this->createComposerLock([
+            self::getPackage('vulnerable/pkg', '1.0.0'),
+            self::getPackage('safe/pkg', '1.0.0'),
+        ]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'update', '--vulnerable-only' => true, '--dry-run' => true, '--no-audit' => true, '--no-install' => true]);
+
+        $display = $appTester->getDisplay(true);
+        self::assertStringContainsString('Updating vulnerable packages: vulnerable/pkg', $display);
+        self::assertStringContainsString('Upgrading vulnerable/pkg (1.0.0 => 1.1.0)', $display);
+        self::assertStringNotContainsString('Upgrading safe/pkg', $display);
+    }
+
+    public function testVulnerableOnlyDoesNothingWithoutAffectedLockedPackages(): void
+    {
+        $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'safe/pkg', 'version' => '1.0.0'],
+                        ['name' => 'safe/pkg', 'version' => '1.1.0'],
+                    ],
+                ],
+            ],
+            'require' => [
+                'safe/pkg' => '^1.0',
+            ],
+        ]);
+        $this->createComposerLock([self::getPackage('safe/pkg', '1.0.0')]);
+
+        $appTester = $this->getApplicationTester();
+        $exitCode = $appTester->run(['command' => 'update', '--vulnerable-only' => true, '--dry-run' => true, '--no-audit' => true]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('No packages with known security vulnerabilities found in composer.lock.', $appTester->getDisplay(true));
+        self::assertStringNotContainsString('Updating dependencies', $appTester->getDisplay(true));
+    }
+
+    public function testVulnerableOnlyRespectsNoDev(): void
+    {
+        $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'dev/pkg', 'version' => '1.0.0'],
+                        ['name' => 'dev/pkg', 'version' => '1.1.0'],
+                    ],
+                    'security-advisories' => [
+                        'dev/pkg' => [
+                            [
+                                'advisoryId' => 'PKSA-test-001',
+                                'packageName' => 'dev/pkg',
+                                'remoteId' => 'CVE-2024-1234',
+                                'title' => 'Test Security Vulnerability',
+                                'link' => 'https://example.com/advisory',
+                                'cve' => 'CVE-2024-1234',
+                                'affectedVersions' => '<1.1.0',
+                                'source' => 'test',
+                                'reportedAt' => '2024-01-01 00:00:00',
+                                'composerRepository' => 'Package Repository',
+                                'severity' => 'high',
+                                'sources' => [
+                                    [
+                                        'name' => 'test',
+                                        'remoteId' => 'CVE-2024-1234',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'require-dev' => [
+                'dev/pkg' => '^1.0',
+            ],
+        ]);
+        $this->createComposerLock([], [self::getPackage('dev/pkg', '1.0.0')]);
+
+        $appTester = $this->getApplicationTester();
+        $exitCode = $appTester->run(['command' => 'update', '--vulnerable-only' => true, '--no-dev' => true, '--dry-run' => true, '--no-audit' => true]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('No packages with known security vulnerabilities found in composer.lock.', $appTester->getDisplay(true));
+    }
+
+    public function testVulnerableOnlyRequiresLockFile(): void
+    {
+        $this->initTempComposer([
+            'require' => [
+                'vendor/package' => '^1.0',
+            ],
+        ]);
+        self::expectException(\UnexpectedValueException::class);
+        self::expectExceptionMessage('A valid composer.lock file is required to run this command with --vulnerable-only.');
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'update', '--vulnerable-only' => true]);
+    }
+
+    public function testVulnerableOnlyRejectsPackageArguments(): void
+    {
+        $this->initTempComposer();
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionMessage('--vulnerable-only cannot be combined with package arguments.');
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'update', '--vulnerable-only' => true, 'packages' => ['vendor/package']]);
+    }
+
     public function testNoBlockingAllowsMalwareFlaggedPackages(): void
     {
         $this->initTempComposer([


### PR DESCRIPTION
Since composer now knows what packages are vulnerable, it can provide a flag to only update vulnerable packages. This way processes / jobs that actively fix vulnerabilities can run safer without introducing new issues or 0-day exploits from other packages.