### PR TITLE
Add minimum package age option

### DIFF
--- a/doc/03-cli.md
+++ b/doc/03-cli.md
@@ -36,6 +36,7 @@ The following options are available with every command:
 * **--no-cache:** Disables the use of the cache directory. Same as setting the COMPOSER_CACHE_DIR
   env var to /dev/null (or NUL on Windows).
 * **--working-dir (-d):** If specified, use the given directory as working directory.
+* **--min-age:** Only select package versions at least this many days ago.
 * **--profile:** Display timing and memory usage information
 * **--ansi:** Force ANSI output.
 * **--no-ansi:** Disable ANSI output.

--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -391,6 +391,24 @@ abstract class BaseCommand extends Command
         return PlatformRequirementFilterFactory::ignoreNothing();
     }
 
+    protected function getMinimumAge(InputInterface $input): int
+    {
+        if (!$input->hasOption('min-age')) {
+            return 0;
+        }
+
+        $minimumAge = $input->getOption('min-age');
+        if ($minimumAge === null) {
+            return 0;
+        }
+
+        if ((is_int($minimumAge) && $minimumAge >= 0) || (is_string($minimumAge) && ctype_digit($minimumAge))) {
+            return (int) $minimumAge;
+        }
+
+        throw new \InvalidArgumentException('--min-age must be a non-negative integer number of days.');
+    }
+
     /**
      * @param array<string> $requirements
      *

--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -184,6 +184,7 @@ EOT
     public function installProject(IOInterface $io, Config $config, InputInterface $input, ?string $packageName = null, ?string $directory = null, ?string $packageVersion = null, ?string $stability = 'stable', bool $preferSource = false, bool $preferDist = false, bool $installDevPackages = false, $repositories = null, bool $disablePlugins = false, bool $disableScripts = false, bool $noProgress = false, bool $noInstall = false, ?PlatformRequirementFilterInterface $platformRequirementFilter = null, bool $secureHttp = true, bool $addRepository = false, array $requiredPackages = []): int
     {
         $oldCwd = Platform::getCwd();
+        $minimumAge = $this->getMinimumAge($input);
 
         if ($repositories !== null && !is_array($repositories)) {
             $repositories = (array) $repositories;
@@ -273,6 +274,7 @@ EOT
                 ->setOptimizeAutoloader($config->get('optimize-autoloader'))
                 ->setClassMapAuthoritative($config->get('classmap-authoritative'))
                 ->setApcuAutoloader($config->get('apcu-autoloader'))
+                ->setMinimumAge($minimumAge)
                 ->setPolicyConfig($this->createPolicyConfig($config, $input))
                 ->setAuditConfig($this->createAuditConfig($input));
 
@@ -443,7 +445,7 @@ EOT
         $platformRepo = new PlatformRepository([], $platformOverrides);
 
         // find the latest version if there are multiple
-        $versionSelector = new VersionSelector($repositorySet, $platformRepo);
+        $versionSelector = new VersionSelector($repositorySet, $platformRepo, $this->getMinimumAge($input));
         $package = $versionSelector->findBestCandidate($name, $packageVersion, $stability, $platformRequirementFilter, 0, $io);
 
         if (!$package) {

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -140,6 +140,7 @@ EOT
             ->setStrictPsrAutoloader($input->getOption('strict-psr-autoloader'))
             ->setApcuAutoloader($apcu, $apcuPrefix)
             ->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input))
+            ->setMinimumAge($this->getMinimumAge($input))
             ->setPolicyConfig($this->createPolicyConfig($composer->getConfig(), $input))
             ->setAuditConfig($this->createAuditConfig($input))
             ->setErrorOnAudit($input->getOption('audit'))

--- a/src/Composer/Command/PackageDiscoveryTrait.php
+++ b/src/Composer/Command/PackageDiscoveryTrait.php
@@ -301,7 +301,7 @@ trait PackageDiscoveryTrait
 
         // find the latest version allowed in this repo set
         $repoSet = $this->getRepositorySet($input);
-        $versionSelector = new VersionSelector($repoSet, $platformRepo);
+        $versionSelector = new VersionSelector($repoSet, $platformRepo, $this->getMinimumAge($input));
         $effectiveMinimumStability = $this->getMinimumStability($input);
 
         $package = $versionSelector->findBestCandidate($name, null, $preferredStability, $platformRequirementFilter, 0, $this->getIO());

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -285,6 +285,7 @@ EOT
             ->setUpdateAllowTransitiveDependencies($updateAllowTransitiveDependencies)
             ->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input))
             ->setDryRun($dryRun)
+            ->setMinimumAge($this->getMinimumAge($input))
             ->setPolicyConfig($this->createPolicyConfig($composer->getConfig(), $input))
             ->setAuditConfig($this->createAuditConfig($input))
             ->setMinimalUpdate($minimalChanges)

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -482,6 +482,7 @@ EOT
             ->setPlatformRequirementFilter($this->getPlatformRequirementFilter($input))
             ->setPreferStable($input->getOption('prefer-stable'))
             ->setPreferLowest($input->getOption('prefer-lowest'))
+            ->setMinimumAge($this->getMinimumAge($input))
             ->setPolicyConfig($this->createPolicyConfig($composer->getConfig(), $input))
             ->setAuditConfig($this->createAuditConfig($input))
             ->setMinimalUpdate($minimalChanges)

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -294,6 +294,7 @@ EOT
             ->setPreferStable($input->getOption('prefer-stable'))
             ->setPreferLowest($input->getOption('prefer-lowest'))
             ->setTemporaryConstraints($temporaryConstraints)
+            ->setMinimumAge($this->getMinimumAge($input))
             ->setPolicyConfig($this->createPolicyConfig($composer->getConfig(), $input))
             ->setAuditConfig($this->createAuditConfig($input))
             ->setMinimalUpdate($minimalChanges)
@@ -365,7 +366,7 @@ EOT
         $io->writeError('<info>Loading packages that can be updated...</info>');
         $autocompleterValues = [];
         $installedPackages = $composer->getLocker()->isLocked() ? $composer->getLocker()->getLockedRepository(true)->getPackages() : $composer->getRepositoryManager()->getLocalRepository()->getPackages();
-        $versionSelector = $this->createVersionSelector($composer);
+        $versionSelector = $this->createVersionSelector($composer, $this->getMinimumAge($input));
         foreach ($installedPackages as $package) {
             if ($filter !== null && !Preg::isMatch($filter, $package->getName())) {
                 continue;
@@ -417,13 +418,13 @@ EOT
         throw new \RuntimeException('Installation aborted.');
     }
 
-    private function createVersionSelector(Composer $composer): VersionSelector
+    private function createVersionSelector(Composer $composer, int $minimumAge): VersionSelector
     {
         $repositorySet = new RepositorySet();
         $repositorySet->addRepository(new CompositeRepository(array_filter($composer->getRepositoryManager()->getRepositories(), static function (RepositoryInterface $repository) {
             return !$repository instanceof PlatformRepository;
         })));
 
-        return new VersionSelector($repositorySet);
+        return new VersionSelector($repositorySet, null, $minimumAge);
     }
 }

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -774,6 +774,7 @@ class Application extends BaseApplication
         $definition->addOption(new InputOption('--no-scripts', null, InputOption::VALUE_NONE, 'Skips the execution of all scripts defined in composer.json file.'));
         $definition->addOption(new InputOption('--working-dir', '-d', InputOption::VALUE_REQUIRED, 'If specified, use the given directory as working directory.'));
         $definition->addOption(new InputOption('--no-cache', null, InputOption::VALUE_NONE, 'Prevent use of the cache'));
+        $definition->addOption(new InputOption('--min-age', null, InputOption::VALUE_REQUIRED, 'Only select package versions that were released at least this many days ago.'));
 
         return $definition;
     }

--- a/src/Composer/DependencyResolver/MinimumAgePoolFilter.php
+++ b/src/Composer/DependencyResolver/MinimumAgePoolFilter.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\DependencyResolver;
+
+use Composer\Package\AliasPackage;
+use Composer\Package\BasePackage;
+use Composer\Package\Version\VersionAge;
+
+/**
+ * @internal
+ */
+final class MinimumAgePoolFilter
+{
+    /** @var int */
+    private $minimumAge;
+
+    /** @var int */
+    private $referenceTime;
+
+    public function __construct(int $minimumAge, ?int $referenceTime = null)
+    {
+        if ($minimumAge < 0) {
+            throw new \InvalidArgumentException('The minimum package age must be zero or greater.');
+        }
+
+        $this->minimumAge = $minimumAge;
+        $this->referenceTime = $referenceTime ?? time();
+    }
+
+    public function filter(Pool $pool, Request $request): Pool
+    {
+        $packages = [];
+        foreach ($pool->getPackages() as $package) {
+            if ($this->isFixedOrLocked($package, $request) || VersionAge::isOldEnough($package, $this->minimumAge, $this->referenceTime)) {
+                $packages[] = $package;
+            }
+        }
+
+        return new Pool($packages, $pool->getUnacceptableFixedOrLockedPackages(), $pool->getAllRemovedVersions(), $pool->getAllRemovedVersionsByPackage(), $pool->getAllSecurityRemovedPackageVersions(), $pool->getAllAbandonedRemovedPackageVersions(), $pool->getAllFilterListRemovedPackageVersions());
+    }
+
+    private function isFixedOrLocked(BasePackage $package, Request $request): bool
+    {
+        while (true) {
+            if ($request->isFixedPackage($package) || $request->isLockedPackage($package)) {
+                return true;
+            }
+
+            if (!$package instanceof AliasPackage) {
+                return false;
+            }
+
+            $package = $package->getAliasOf();
+        }
+    }
+}

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -159,6 +159,9 @@ class PoolBuilder
     /** @var ?FilterListPoolFilter */
     private $filterListPoolFilter;
 
+    /** @var ?MinimumAgePoolFilter */
+    private $minimumAgePoolFilter;
+
     /**
      * @param int[] $acceptableStabilities array of stability => BasePackage::STABILITY_* value
      * @phpstan-param array<key-of<BasePackage::STABILITIES>, BasePackage::STABILITY_*> $acceptableStabilities
@@ -170,7 +173,7 @@ class PoolBuilder
      * @phpstan-param array<string, string> $rootReferences
      * @param array<string, ConstraintInterface> $temporaryConstraints Runtime temporary constraints that will be used to filter packages
      */
-    public function __construct(array $acceptableStabilities, array $stabilityFlags, array $rootAliases, array $rootReferences, IOInterface $io, ?EventDispatcher $eventDispatcher = null, ?PoolOptimizer $poolOptimizer = null, array $temporaryConstraints = [], ?SecurityAdvisoryPoolFilter $securityAdvisoryPoolFilter = null, ?FilterListPoolFilter $filterListPoolFilter = null)
+    public function __construct(array $acceptableStabilities, array $stabilityFlags, array $rootAliases, array $rootReferences, IOInterface $io, ?EventDispatcher $eventDispatcher = null, ?PoolOptimizer $poolOptimizer = null, array $temporaryConstraints = [], ?SecurityAdvisoryPoolFilter $securityAdvisoryPoolFilter = null, ?FilterListPoolFilter $filterListPoolFilter = null, ?MinimumAgePoolFilter $minimumAgePoolFilter = null)
     {
         $this->acceptableStabilities = $acceptableStabilities;
         $this->stabilityFlags = $stabilityFlags;
@@ -182,6 +185,7 @@ class PoolBuilder
         $this->temporaryConstraints = $temporaryConstraints;
         $this->securityAdvisoryPoolFilter = $securityAdvisoryPoolFilter;
         $this->filterListPoolFilter = $filterListPoolFilter;
+        $this->minimumAgePoolFilter = $minimumAgePoolFilter;
     }
 
     /**
@@ -354,6 +358,7 @@ class PoolBuilder
 
         $this->io->debug('Built pool.');
 
+        $pool = $this->runMinimumAgeFilter($pool, $request);
         // filter vulnerable packages before optimizing the pool otherwise we may end up with inconsistent state where the optimizer took away versions
         // that were not vulnerable and now suddenly the vulnerable ones are removed and we are missing some versions to make it solvable
         $pool = $this->runSecurityAdvisoryFilter($pool, $repositories, $request);
@@ -363,6 +368,17 @@ class PoolBuilder
         Intervals::clear();
 
         return $pool;
+    }
+
+    private function runMinimumAgeFilter(Pool $pool, Request $request): Pool
+    {
+        if (null === $this->minimumAgePoolFilter) {
+            return $pool;
+        }
+
+        $this->io->debug('Running minimum age pool filter.');
+
+        return $this->minimumAgePoolFilter->filter($pool, $request);
     }
 
     private function markPackageNameForLoading(Request $request, string $name, ConstraintInterface $constraint): void

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -25,6 +25,7 @@ use Composer\DependencyResolver\PoolOptimizer;
 use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
 use Composer\DependencyResolver\FilterListPoolFilter;
+use Composer\DependencyResolver\MinimumAgePoolFilter;
 use Composer\DependencyResolver\SecurityAdvisoryPoolFilter;
 use Composer\DependencyResolver\Solver;
 use Composer\DependencyResolver\SolverProblemsException;
@@ -178,6 +179,8 @@ class Installer
     protected $preferLowest = false;
     /** @var bool */
     protected $minimalUpdate = false;
+    /** @var int */
+    protected $minimumAge = 0;
     /** @var bool */
     protected $writeLock;
     /** @var bool */
@@ -531,7 +534,7 @@ class Installer
             $request->setUpdateAllowList($this->updateAllowList, $this->updateAllowTransitiveDependencies);
         }
 
-        $pool = $repositorySet->createPool($request, $this->io, $this->eventDispatcher, $this->createPoolOptimizer($policy), $this->ignoredTypes, $this->allowedTypes, $this->createSecurityAuditPoolFilter(), $this->createFilterListPoolFilter(ListPolicyConfig::BLOCK_SCOPE_UPDATE));
+        $pool = $repositorySet->createPool($request, $this->io, $this->eventDispatcher, $this->createPoolOptimizer($policy), $this->ignoredTypes, $this->allowedTypes, $this->createSecurityAuditPoolFilter(), $this->createFilterListPoolFilter(ListPolicyConfig::BLOCK_SCOPE_UPDATE), $this->createMinimumAgePoolFilter());
 
         $this->io->writeError('<info>Updating dependencies</info>');
 
@@ -1167,6 +1170,15 @@ class Installer
         return null;
     }
 
+    private function createMinimumAgePoolFilter(): ?MinimumAgePoolFilter
+    {
+        if ($this->minimumAge === 0 || $this->updateMirrors) {
+            return null;
+        }
+
+        return new MinimumAgePoolFilter($this->minimumAge);
+    }
+
     /**
      * @param ListPolicyConfig::BLOCK_SCOPE_UPDATE|ListPolicyConfig::BLOCK_SCOPE_INSTALL $blockScope
      */
@@ -1530,6 +1542,20 @@ class Installer
     public function setPreferLowest(bool $preferLowest = true): self
     {
         $this->preferLowest = $preferLowest;
+
+        return $this;
+    }
+
+    /**
+     * Only consider package versions released at least this many days ago during dependency resolution.
+     */
+    public function setMinimumAge(int $minimumAge): self
+    {
+        if ($minimumAge < 0) {
+            throw new \InvalidArgumentException('The minimum package age must be zero or greater.');
+        }
+
+        $this->minimumAge = $minimumAge;
 
         return $this;
     }

--- a/src/Composer/Package/Version/VersionAge.php
+++ b/src/Composer/Package/Version/VersionAge.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Package\Version;
+
+use Composer\Package\PackageInterface;
+use Composer\Package\RootPackageInterface;
+use Composer\Repository\PlatformRepository;
+
+/**
+ * @internal
+ */
+final class VersionAge
+{
+    public static function isOldEnough(PackageInterface $package, int $minimumAge, ?int $referenceTime = null): bool
+    {
+        if ($minimumAge < 0) {
+            throw new \InvalidArgumentException('The minimum package age must be zero or greater.');
+        }
+
+        if ($minimumAge === 0 || $package instanceof RootPackageInterface || PlatformRepository::isPlatformPackage($package->getName())) {
+            return true;
+        }
+
+        $releaseDate = $package->getReleaseDate();
+        if ($releaseDate === null) {
+            return false;
+        }
+
+        $referenceTime = $referenceTime ?? time();
+
+        return ($referenceTime - (float) $releaseDate->getTimestamp()) >= (float) $minimumAge * 86400;
+    }
+}

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -40,6 +40,9 @@ class VersionSelector
     /** @var RepositorySet */
     private $repositorySet;
 
+    /** @var int */
+    private $minimumAge;
+
     /** @var array<string, ConstraintInterface[]> */
     private $platformConstraints = [];
 
@@ -49,9 +52,14 @@ class VersionSelector
     /**
      * @param PlatformRepository $platformRepo If passed in, the versions found will be filtered against their requirements to eliminate any not matching the current platform packages
      */
-    public function __construct(RepositorySet $repositorySet, ?PlatformRepository $platformRepo = null)
+    public function __construct(RepositorySet $repositorySet, ?PlatformRepository $platformRepo = null, int $minimumAge = 0)
     {
+        if ($minimumAge < 0) {
+            throw new \InvalidArgumentException('The minimum package age must be zero or greater.');
+        }
+
         $this->repositorySet = $repositorySet;
+        $this->minimumAge = $minimumAge;
         if ($platformRepo) {
             foreach ($platformRepo->getPackages() as $package) {
                 $this->platformConstraints[$package->getName()][] = new Constraint('==', $package->getVersion());
@@ -84,6 +92,12 @@ class VersionSelector
 
         $constraint = $targetPackageVersion ? $this->getParser()->parseConstraints($targetPackageVersion) : null;
         $candidates = $this->repositorySet->findPackages(strtolower($packageName), $constraint, $repoSetFlags);
+        if ($this->minimumAge > 0) {
+            $referenceTime = time();
+            $candidates = array_values(array_filter($candidates, function (PackageInterface $package) use ($referenceTime): bool {
+                return VersionAge::isOldEnough($package, $this->minimumAge, $referenceTime);
+            }));
+        }
 
         $minPriority = BasePackage::STABILITIES[$preferredStability];
         usort($candidates, static function (PackageInterface $a, PackageInterface $b) use ($minPriority) {

--- a/src/Composer/Repository/RepositorySet.php
+++ b/src/Composer/Repository/RepositorySet.php
@@ -17,6 +17,7 @@ use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\PoolBuilder;
 use Composer\DependencyResolver\Request;
 use Composer\DependencyResolver\FilterListPoolFilter;
+use Composer\DependencyResolver\MinimumAgePoolFilter;
 use Composer\DependencyResolver\SecurityAdvisoryPoolFilter;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\Advisory\SecurityAdvisory;
@@ -334,9 +335,9 @@ class RepositorySet
      * @param list<string>      $ignoredTypes Packages of those types are ignored
      * @param list<string>|null $allowedTypes Only packages of those types are allowed if set to non-null
      */
-    public function createPool(Request $request, IOInterface $io, ?EventDispatcher $eventDispatcher = null, ?PoolOptimizer $poolOptimizer = null, array $ignoredTypes = [], ?array $allowedTypes = null, ?SecurityAdvisoryPoolFilter $securityAdvisoryPoolFilter = null, ?FilterListPoolFilter $filterListPoolFilter = null): Pool
+    public function createPool(Request $request, IOInterface $io, ?EventDispatcher $eventDispatcher = null, ?PoolOptimizer $poolOptimizer = null, array $ignoredTypes = [], ?array $allowedTypes = null, ?SecurityAdvisoryPoolFilter $securityAdvisoryPoolFilter = null, ?FilterListPoolFilter $filterListPoolFilter = null, ?MinimumAgePoolFilter $minimumAgePoolFilter = null): Pool
     {
-        $poolBuilder = new PoolBuilder($this->acceptableStabilities, $this->stabilityFlags, $this->rootAliases, $this->rootReferences, $io, $eventDispatcher, $poolOptimizer, $this->temporaryConstraints, $securityAdvisoryPoolFilter, $filterListPoolFilter);
+        $poolBuilder = new PoolBuilder($this->acceptableStabilities, $this->stabilityFlags, $this->rootAliases, $this->rootReferences, $io, $eventDispatcher, $poolOptimizer, $this->temporaryConstraints, $securityAdvisoryPoolFilter, $filterListPoolFilter, $minimumAgePoolFilter);
         $poolBuilder->setIgnoredTypes($ignoredTypes);
         $poolBuilder->setAllowedTypes($allowedTypes);
 

--- a/tests/Composer/Test/Command/UpdateCommandTest.php
+++ b/tests/Composer/Test/Command/UpdateCommandTest.php
@@ -18,6 +18,64 @@ use Composer\Test\TestCase;
 
 class UpdateCommandTest extends TestCase
 {
+    public function testMinimumAgeSelectsAnOlderRelease(): void
+    {
+        $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'age/package', 'version' => '1.0.0', 'time' => '2000-01-01 00:00:00'],
+                        ['name' => 'age/package', 'version' => '1.1.0', 'time' => gmdate('Y-m-d H:i:s')],
+                    ],
+                ],
+            ],
+            'require' => [
+                'age/package' => '^1.0',
+            ],
+        ]);
+
+        $appTester = $this->getApplicationTester();
+        $appTester->run(['command' => 'update', '--dry-run' => true, '--no-audit' => true, '--no-install' => true, '--min-age' => '7']);
+
+        $display = $appTester->getDisplay(true);
+        self::assertStringContainsString('Locking age/package (1.0.0)', $display);
+        self::assertStringNotContainsString('Locking age/package (1.1.0)', $display);
+    }
+
+    public function testMinimumAgeMustBeANonNegativeInteger(): void
+    {
+        $this->initTempComposer();
+        $appTester = $this->getApplicationTester();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('--min-age must be a non-negative integer number of days.');
+        $appTester->run(['command' => 'update', '--dry-run' => true, '--no-audit' => true, '--min-age' => '-1']);
+    }
+
+    public function testMinimumAgeDoesNotBlockLockFileMetadataUpdates(): void
+    {
+        $this->initTempComposer([
+            'repositories' => [
+                'packages' => [
+                    'type' => 'package',
+                    'package' => [
+                        ['name' => 'age/package', 'version' => '1.0.0', 'time' => gmdate('Y-m-d H:i:s')],
+                    ],
+                ],
+            ],
+            'require' => [
+                'age/package' => '^1.0',
+            ],
+        ]);
+        $this->createComposerLock([self::getPackage('age/package', '1.0.0')]);
+
+        $appTester = $this->getApplicationTester();
+        $status = $appTester->run(['command' => 'update', '--lock' => true, '--dry-run' => true, '--no-audit' => true, '--no-install' => true, '--min-age' => '7']);
+
+        self::assertSame(0, $status, $appTester->getDisplay(true));
+    }
+
     /**
      * @dataProvider provideUpdates
      * @param array<mixed>   $composerJson

--- a/tests/Composer/Test/DependencyResolver/MinimumAgePoolFilterTest.php
+++ b/tests/Composer/Test/DependencyResolver/MinimumAgePoolFilterTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\DependencyResolver;
+
+use Composer\DependencyResolver\MinimumAgePoolFilter;
+use Composer\DependencyResolver\Pool;
+use Composer\DependencyResolver\Request;
+use Composer\Package\Package;
+use Composer\Test\TestCase;
+
+class MinimumAgePoolFilterTest extends TestCase
+{
+    public function testFiltersPackagesByReleaseDateWhileKeepingFixedAndLockedPackages(): void
+    {
+        $referenceTime = 1700000000;
+        $oldPackage = new Package('acme/old', '1.0.0.0', '1.0.0');
+        $oldPackage->setReleaseDate(new \DateTimeImmutable('@'.($referenceTime - 8 * 86400)));
+        $boundaryPackage = new Package('acme/boundary', '1.0.0.0', '1.0.0');
+        $boundaryPackage->setReleaseDate(new \DateTimeImmutable('@'.($referenceTime - 7 * 86400)));
+        $recentPackage = new Package('acme/recent', '1.0.0.0', '1.0.0');
+        $recentPackage->setReleaseDate(new \DateTimeImmutable('@'.($referenceTime - 6 * 86400)));
+        $undatedPackage = new Package('acme/undated', '1.0.0.0', '1.0.0');
+        $fixedPackage = new Package('acme/fixed', '1.0.0.0', '1.0.0');
+        $lockedPackage = new Package('acme/locked', '1.0.0.0', '1.0.0');
+        $lockedAlias = self::getAliasPackage($lockedPackage, '1.0.x-dev');
+        $rootPackage = self::getRootPackage();
+        $platformPackage = new Package('php', '8.4.0.0', '8.4.0');
+
+        $request = new Request();
+        $request->fixPackage($fixedPackage);
+        $request->lockPackage($lockedPackage);
+
+        $filter = new MinimumAgePoolFilter(7, $referenceTime);
+        $filteredPool = $filter->filter(new Pool([
+            $oldPackage,
+            $boundaryPackage,
+            $recentPackage,
+            $undatedPackage,
+            $fixedPackage,
+            $lockedPackage,
+            $lockedAlias,
+            $rootPackage,
+            $platformPackage,
+        ]), $request);
+
+        self::assertSame([
+            $oldPackage,
+            $boundaryPackage,
+            $fixedPackage,
+            $lockedPackage,
+            $lockedAlias,
+            $rootPackage,
+            $platformPackage,
+        ], $filteredPool->getPackages());
+    }
+
+    public function testZeroMinimumAgeKeepsUndatedPackages(): void
+    {
+        $package = new Package('acme/undated', '1.0.0.0', '1.0.0');
+        $filter = new MinimumAgePoolFilter(0);
+
+        self::assertSame([$package], $filter->filter(new Pool([$package]), new Request())->getPackages());
+    }
+}

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -51,6 +51,28 @@ class VersionSelectorTest extends TestCase
         self::assertSame($package2, $best, 'Latest version should be 1.2.2');
     }
 
+    public function testLatestVersionMatchingMinimumAgeIsReturned(): void
+    {
+        $packageName = 'foo/bar';
+
+        $oldPackage = self::getPackage($packageName, '1.2.1');
+        $oldPackage->setReleaseDate(new \DateTimeImmutable('-8 days'));
+        $recentPackage = self::getPackage($packageName, '1.2.2');
+        $recentPackage->setReleaseDate(new \DateTimeImmutable('-6 days'));
+        $undatedPackage = self::getPackage($packageName, '1.2.3');
+        $packages = [$oldPackage, $recentPackage, $undatedPackage];
+
+        $repositorySet = $this->createMockRepositorySet();
+        $repositorySet->expects($this->once())
+            ->method('findPackages')
+            ->with($packageName, null)
+            ->will($this->returnValue($packages));
+
+        $versionSelector = new VersionSelector($repositorySet, null, 7);
+
+        self::assertSame($oldPackage, $versionSelector->findBestCandidate($packageName));
+    }
+
     public function testLatestVersionIsReturnedThatMatchesPhpRequirements(): void
     {
         $packageName = 'foo/bar';


### PR DESCRIPTION
Add a global --min-age option that filters dependency candidates by release date while preserving locked and platform packages. This protects against 0-day exploits and when used in conjunction with the --only-vulnerable flag (as a separate call) it can fix vulnerabilities and update packages in general while allowing for some time for vulnerabilities to be detected in packages before installing.