### PR TITLE
Return early from ClassLoader::findFile() for an empty class name

### DIFF
--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -441,6 +441,11 @@ class ClassLoader
      */
     public function findFile($class)
     {
+        // PHP can ask for an empty class name, e.g. via is_callable('\::method')
+        if ('' === $class) {
+            return false;
+        }
+
         // class map lookup
         if (isset($this->classMap[$class])) {
             return $this->classMap[$class];


### PR DESCRIPTION
PHP can ask a registered autoloader for an **empty class name**. `ClassLoader::findFileWithExtension()` then does `$first = $class[0];` on `''`, which emits `Warning: Uninitialized string offset 0`. In applications that turn warnings into exceptions (Laravel's `HandleExceptions`, for instance) that aborts the request.

Reproduce on any composer-autoloaded project, PHP 8.3.31:

```php
<?php
require 'vendor/autoload.php';
is_callable('\::someMethod');
// Warning: Uninitialized string offset 0 in vendor/composer/ClassLoader.php on line 427
```

`is_callable('\::someMethod')` strips the leading `\` and asks the autoloader for class `''`. Traced with an `spl_autoload_register` spy:

```
-- is_callable('::a')
-- is_callable('\::a')
autoload requested: ''
-- is_callable('\Foo::a')
autoload requested: 'Foo'
-- is_callable('Foo::a')
autoload requested: 'Foo'
```

The `'::a'` vs `'\::a'` asymmetry looks like a php-src bug and I am filing it there too, but `ClassLoader` should not warn on any input it is handed.

This bit us for real: Laravel's `Factory::expandAttributes()` evaluates `is_callable($attribute)` on every string attribute, and a randomly generated password starting with `\::` (roughly 1 in a million with Faker's `password()`) made unrelated CI tests error out.

## The change

Return `false` immediately for an empty class name. Placing the guard in `findFile()` rather than `findFileWithExtension()` covers the classmap, APCu and PSR-0/PSR-4 lookups in one place, and skips polluting `missingClasses`/APCu with an entry that can never resolve.

## No test

I wrote one and then removed it: `ClassLoaderTest` instantiates `Composer\Autoload\ClassLoader`, but under `vendor/bin/simple-phpunit` that class name resolves to the bridge's own `vendor/bin/.phpunit/phpunit-*/vendor/composer/ClassLoader.php`, not `src/`. A test asserting the new behaviour therefore fails even with this patch applied (verified locally after `bin/composer install`). Happy to add one if you know a way around that.