### PR TITLE
Make it possible to pass transport options to FilterListApiClient

### DIFF
--- a/src/Composer/FilterList/FilterListApiClient.php
+++ b/src/Composer/FilterList/FilterListApiClient.php
@@ -24,10 +24,13 @@ class FilterListApiClient
 {
     /** @var HttpDownloader */
     private $httpDownloader;
+    /** @var mixed[] */
+    private $options;
 
-    public function __construct(HttpDownloader $httpDownloader)
+    public function __construct(HttpDownloader $httpDownloader, array $options = [])
     {
         $this->httpDownloader = $httpDownloader;
+        $this->options = $options;
     }
 
     /**
@@ -47,8 +50,11 @@ class FilterListApiClient
             'lists' => $configuredLists,
         ];
 
-        $options = [];
+        $options = $this->options;
         $options['http']['method'] = 'POST';
+        if (isset($options['http']['header'])) {
+            $options['http']['header'] = (array) $options['http']['header'];
+        }
         $options['http']['header'][] = 'Content-type: application/json';
         $options['http']['timeout'] = 10;
         $options['http']['content'] = json_encode($body);

--- a/src/Composer/FilterList/FilterListApiClient.php
+++ b/src/Composer/FilterList/FilterListApiClient.php
@@ -27,6 +27,9 @@ class FilterListApiClient
     /** @var mixed[] */
     private $options;
 
+    /**
+     * @param mixed[] $options Stream context options e.g. https://www.php.net/manual/en/context.http.php
+     */
     public function __construct(HttpDownloader $httpDownloader, array $options = [])
     {
         $this->httpDownloader = $httpDownloader;

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -911,7 +911,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     private function getFilterApiClient(): FilterListApiClient
     {
         if ($this->filterApiClient === null) {
-            $this->filterApiClient = new FilterListApiClient($this->httpDownloader);
+            $this->filterApiClient = new FilterListApiClient($this->httpDownloader, $this->options);
         }
 
         return $this->filterApiClient;

--- a/tests/Composer/Test/FilterList/FilterListApiClientTest.php
+++ b/tests/Composer/Test/FilterList/FilterListApiClientTest.php
@@ -56,4 +56,53 @@ class FilterListApiClientTest extends TestCase
 
         self::assertSame(['filter' => []], $response->decodeJson());
     }
+
+    public function testPostPurlsSendsRepositoryTransportOptions(): void
+    {
+        $expectedApiRequestBody = json_encode([
+            'packages' => ['pkg://composer/vendor/foo'],
+            'lists' => ['malware'],
+        ]);
+
+        $variationsThatShouldWork = [
+            (object) ['X-Cops: S07E12'],
+            'X-Cops: S07E12',
+            ['X-Cops: S07E12'],
+            json_decode('{"header": "X-Cops: S07E12"}')->header,
+            json_decode('{"header": {"0": "X-Cops: S07E12"}}')->header,
+            json_decode('["X-Cops: S07E12"]'),
+        ];
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader->expects(
+            array_fill(0, count($variationsThatShouldWork), [
+                'url' => 'https://example.org/api/filter',
+                'options' => [
+                    'ssl' => ['verify_peer' => false],
+                    'http' => [
+                        'header' => ['X-Cops: S07E12', 'Content-type: application/json'],
+                        'method' => 'POST',
+                        'timeout' => 10,
+                        'content' => $expectedApiRequestBody,
+                    ],
+                ],
+                'body' => JsonFile::encode(['filter' => []]),
+            ]),
+            true
+        );
+
+        foreach ($variationsThatShouldWork as $variation) {
+            $client = new FilterListApiClient($httpDownloader, [
+                'ssl' => ['verify_peer' => false],
+                'http' => ['header' => $variation],
+            ]);
+            $response = $client->postPurls(
+                'https://example.org/api/filter',
+                ['vendor/foo' => new Constraint('=', '1.0.0.0')],
+                ['malware']
+            );
+
+            self::assertSame(['filter' => []], $response->decodeJson());
+        }
+
+    }
 }

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -979,6 +979,7 @@ class ComposerRepositoryTest extends TestCase
                     'url' => 'https://example.org/api/filter',
                     'options' => [
                         'http' => [
+                            'verify_peer' => false,
                             'method' => 'POST',
                             'header' => ['Content-type: application/json'],
                             'timeout' => 10,


### PR DESCRIPTION
This fixes #13039

This problem is only in Composer 2.10.x, since filter lists were added in 2.10.0
