### PR TITLE
Fix Url::getOrigin prefix-matching a host against gitlab-domains

### DIFF
--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -104,7 +104,9 @@ class Url
             && !in_array($origin, $config->get('gitlab-domains'))
         ) {
             foreach ($config->get('gitlab-domains') as $gitlabDomain) {
-                if (0 === strpos($gitlabDomain, $origin)) {
+                // configured domains may spell out a port the URL omits, see GitLab::authorizeOAuth
+                $bcDomain = Preg::replace('{^([^/]+):\d+}', '$1', $gitlabDomain);
+                if ($bcDomain === $origin || 0 === strpos($bcDomain, $origin.'/')) {
                     return $gitlabDomain;
                 }
             }

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -65,6 +65,35 @@ class UrlTest extends TestCase
     }
 
     /**
+     * @dataProvider getOriginProvider
+     *
+     * @param string        $expected
+     * @param string        $url
+     * @param array<string> $extraGitlabDomains domains merged on top of the default gitlab.com
+     */
+    public function testGetOrigin($expected, $url, $extraGitlabDomains)
+    {
+        $config = new Config();
+        $config->merge(array('config' => array('gitlab-domains' => $extraGitlabDomains)));
+
+        $this->assertSame($expected, Url::getOrigin($config, $url));
+    }
+
+    public static function getOriginProvider()
+    {
+        return array(
+            // a host that is only a shorter prefix of a configured domain must not resolve to it
+            array('gitlab.example.co', 'https://gitlab.example.co/foo/bar/repository/archive.zip', array('gitlab.example.com')),
+            array('gitlab.example.co', 'https://gitlab.example.co/foo/bar/repository/archive.zip', array('gitlab.example.co.uk/gitlab')),
+            array('gitlab.example.com', 'https://gitlab.example.com/foo/bar/repository/archive.zip', array('gitlab.example.com')),
+            array('gitlab.example.com/gitlab', 'https://gitlab.example.com/foo/bar/repository/archive.zip', array('gitlab.example.com/gitlab')),
+            // a configured domain may spell out a port the URL omits
+            array('gitlab.example.com:443', 'https://gitlab.example.com/foo/bar/repository/archive.zip', array('gitlab.example.com:443')),
+            array('gitlab.example.com:443/gitlab', 'https://gitlab.example.com/foo/bar/repository/archive.zip', array('gitlab.example.com:443/gitlab')),
+        );
+    }
+
+    /**
      * @dataProvider sanitizeProvider
      *
      * @param string $expected


### PR DESCRIPTION
getOrigin maps a request host to a configured gitlab-domains entry so the stored token for that domain is attached. The match was a plain prefix test, which also fired when the host was merely a shorter prefix of a configured domain, so gitlab.example.co resolved to gitlab.example.com and picked up its token.

Require the entry to continue with a slash after the host, which keeps non-root installs like gitlab.example.com/gitlab working from the bare host, and strip a port off the configured host before comparing so entries spelling out a default port still match, as GitLab::authorizeOAuth does.

Backport of #12988.

<!-- Please remember to select the appropriate branch:

For bug fixes pick the oldest branch where the fix applies (e.g. `2.4` if that version is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
