### PR TITLE
Mask URL credentials anywhere in a string, not just at its start

### DIFF
--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -81,7 +81,7 @@ class Git
             $callables[] = static function (string $url) use ($cmd): array {
                 $map = [
                     '%url%' => $url,
-                    '%sanitizedUrl%' => Preg::replace('{://([^@]+?):(.+?)@}', '://', $url),
+                    '%sanitizedUrl%' => Url::stripCredentials($url),
                 ];
 
                 return array_map(static function ($value) use ($map): string {
@@ -573,10 +573,13 @@ class Git
                 $commands = [
                     ['git', 'remote', 'set-url', 'origin', '--', '%url%'],
                     ['git', 'remote', 'show', 'origin'],
-                    ['git', 'remote', 'set-url', 'origin', '--', '%sanitizedUrl%'],
                 ];
 
-                $this->runCommands($commands, $url, $dir, false, $output);
+                try {
+                    $this->runCommands($commands, $url, $dir, false, $output);
+                } finally {
+                    $this->runCommands([['git', 'remote', 'set-url', 'origin', '--', '%sanitizedUrl%']], $url, $dir);
+                }
             }
 
             $lines = $this->process->splitLines($output);

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -482,14 +482,7 @@ class ProcessExecutor
         }
 
         $commandString = is_string($command) ? $command : implode(' ', array_map(self::class.'::escape', $command));
-        $safeCommand = Preg::replaceCallback('{://(?P<user>[^:/\s@]+)(?::(?P<password>[^@\s/]+))?@}i', static function ($m): string {
-            $user = Url::sanitizeUsername($m['user']);
-            if (($m['password'] ?? '') !== '') {
-                return '://'.$user.':***@';
-            }
-
-            return '://'.$user.'@';
-        }, $commandString);
+        $safeCommand = Url::sanitize($commandString);
         $safeCommand = Preg::replace("{--password (.*[^\\\\]\') }", '--password \'***\' ', $safeCommand);
         $this->io->writeError('Executing'.($async ? ' async' : '').' command ('.($cwd ?: 'CWD').'): '.$safeCommand);
     }

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -133,7 +133,9 @@ class Url
         // e.g. https://api.github.com/repositories/9999999999?access_token=github_token
         $url = Preg::replace('{([&?]access_token=)[^&]+}', '$1***', $url);
 
-        $url = Preg::replaceCallback('{^(?P<prefix>[a-z0-9]+://)?(?P<user>[^:/\s@]+)(?::(?P<password>[^@\s/]+))?@}i', static function ($m): string {
+        // matches every scheme://user:pass@ in the string as URLs are usually embedded in a longer
+        // message, plus a scheme-less one at the very start for URLs passed in on their own
+        $url = Preg::replaceCallback('{(?:(?P<prefix>[a-z0-9][a-z0-9+.-]*://)|\A)(?P<user>[^:/\s?#]*)(?::(?P<password>[^\s/?#]+))?@}i', static function ($m): string {
             $user = self::sanitizeUsername($m['user']);
             if (($m['password'] ?? '') !== '') {
                 return $m['prefix'].$user.':***@';
@@ -143,6 +145,16 @@ class Url
         }, $url);
 
         return $url;
+    }
+
+    /**
+     * Removes the credentials from a URL entirely, for URLs which get persisted somewhere (e.g. in a git remote)
+     *
+     * Unlike sanitize() this also drops the username, as a bare token in the user slot is a credential too.
+     */
+    public static function stripCredentials(string $url): string
+    {
+        return Preg::replace('{://[^/\s?#]+@}', '://', $url);
     }
 
     /**

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -296,23 +296,40 @@ class GitTest extends TestCase
         ];
     }
 
-    public function testSyncMirrorSanitizesUrlAfterInitialClone(): void
+    /**
+     * @dataProvider credentialUrlProvider
+     */
+    public function testSyncMirrorSanitizesUrlAfterInitialClone(string $url): void
     {
         $nonExistentDir = sys_get_temp_dir() . '/composer-test-nonexistent-' . bin2hex(random_bytes(8));
 
         $this->mockSyncMirrorConfig();
 
         $this->process->expects([
-            ['cmd' => ['git', 'clone', '--mirror', '--', 'https://user:secret@example.com/repo.git', $nonExistentDir], 'return' => 0],
+            ['cmd' => ['git', 'clone', '--mirror', '--', $url, $nonExistentDir], 'return' => 0],
             ['cmd' => ['git', 'remote', '-v'], 'return' => 0],
             ['cmd' => ['git', 'remote', 'set-url', 'origin', '--', 'https://example.com/repo.git'], 'return' => 0],
         ], true);
 
         $this->fs->method('removeDirectory')->willReturn(true);
 
-        $result = $this->git->syncMirror('https://user:secret@example.com/repo.git', $nonExistentDir);
+        $result = $this->git->syncMirror($url, $nonExistentDir);
 
         self::assertTrue($result);
+    }
+
+    /**
+     * @return array<array{string}>
+     */
+    public static function credentialUrlProvider(): array
+    {
+        return [
+            ['https://user:secret@example.com/repo.git'],
+            // a bare token in the user slot has no colon to key off
+            ['https://ghp_1234567890abcdefghijklmnopqrstuvwxyzAB@example.com/repo.git'],
+            // a password containing @ must not leave its tail behind
+            ['https://user:sec@ret@example.com/repo.git'],
+        ];
     }
 
     public function testSyncMirrorSanitizesUrlEvenAfterFailedUpdate(): void

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -167,6 +167,45 @@ class UrlTest extends TestCase
             ['ghp***@github.com/acme/repo', 'ghp_1234567890abcdefghijklmnopqrstuvwxyzAB@github.com/acme/repo'],
             ['10a***@example.org', '10a8f08e8d7b7b9@example.org'],
             ['abc***@example.org:123/', 'abcdefghijklmnop@example.org:123/'],
+            // anywhere in the string, as URLs usually reach sanitize() embedded in a longer message
+            ['Failed to execute git clone --mirror -- https://foo:***@example.org/private/repo.git /cache/repo', 'Failed to execute git clone --mirror -- https://foo:bar@example.org/private/repo.git /cache/repo'],
+            ['tried https://foo:***@example.org/a and https://baz:***@example.com/b', 'tried https://foo:bar@example.org/a and https://baz:qux@example.com/b'],
+            ["fatal: unable to access 'https://gitlab-ci-token:***@example.org/g/r.git/'", "fatal: unable to access 'https://gitlab-ci-token:realtoken@example.org/g/r.git/'"],
+            // passwords/usernames containing @ are masked up to the last @ of the authority
+            ['https://foo:***@example.org/repo.git', 'https://foo:bar@baz@example.org/repo.git'],
+            ['https://use***:***@example.org/repo.git', 'https://user@corp.example:realtoken@example.org/repo.git'],
+            // empty user slot, e.g. https://:TOKEN@host
+            ['https://:***@example.org/', 'https://:realtoken@example.org/'],
+            // schemes containing + . -
+            ['git+ssh://foo:***@example.org/repo.git', 'git+ssh://foo:bar@example.org/repo.git'],
+            ['svn+ssh://foo:***@example.org/repo', 'svn+ssh://foo:bar@example.org/repo'],
+            // @ without credentials in front of it is left alone
+            ["fatal: unable to access 'https://example.org/private/repo.git/': Could not resolve host", "fatal: unable to access 'https://example.org/private/repo.git/': Could not resolve host"],
+            ['https://example.org/foo/bar@2x.png', 'https://example.org/foo/bar@2x.png'],
+        ];
+    }
+
+    /**
+     * @dataProvider stripCredentialsProvider
+     */
+    public function testStripCredentials(string $expected, string $url): void
+    {
+        self::assertSame($expected, Url::stripCredentials($url));
+    }
+
+    public static function stripCredentialsProvider(): array
+    {
+        return [
+            ['https://example.org/repo.git', 'https://user:pass@example.org/repo.git'],
+            // a bare token in the user slot is a credential too, and has no colon to key off
+            ['https://github.com/acme/repo.git', 'https://ghp_1234567890abcdefghijklmnopqrstuvwxyzAB@github.com/acme/repo.git'],
+            ['https://example.org/repo.git', 'https://user:pa@ss@example.org/repo.git'],
+            ['https://example.org:8080/repo.git', 'https://user:pass@example.org:8080/repo.git'],
+            ['https://example.org/repo.git?ref=a@b', 'https://user:pass@example.org/repo.git?ref=a@b'],
+            // nothing to strip
+            ['https://example.org/repo.git', 'https://example.org/repo.git'],
+            ['https://example.org/@scope/repo.git', 'https://example.org/@scope/repo.git'],
+            ['git@example.org:acme/repo.git', 'git@example.org:acme/repo.git'],
         ];
     }
 }


### PR DESCRIPTION
Url::sanitize() was anchored with ^, so it only masked a credential sitting at offset 0. Every caller prepends text ("Failed to execute ...", "Failed to clone ...", git's own error output), so in practice an embedded password or CI token reached the terminal and the CI log in plaintext. Git::maskCredentials() is no backstop, it only runs when Composer injected the auth itself, never for a credential the user embedded in a repository URL.

The pattern now matches scheme://user:pass@ anywhere in the string, and keeps the scheme-less form matching at the start only. It also covers shapes it missed before: passwords containing @ (previously masked up to the first one only), an empty user slot (https://:TOKEN@host), and git+ssh:// style schemes.

%sanitizedUrl% had its own regex which required a colon in the userinfo, so a bare token (https://ghp_xxx@host/repo.git) passed through unstripped and was written into the cache mirror's .git/config by `git remote set-url`. It now uses Url::stripCredentials(), which drops the whole userinfo. And getMirrorDefaultBranch() resets the remote in a finally block so a failing `git remote show origin` no longer leaves the credentialed URL behind, which is what syncMirror() already does.

ProcessExecutor kept a third copy of the masking regex, with the same @-in-password gap, leaking it under -vvv. It now calls Url::sanitize().

Reported by @eyupcanakman and @arpitjain099.
