### PR TITLE
Mask URL credentials anywhere in a string, not just at its start

### DIFF
--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -121,7 +121,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
                     ProcessExecutor::escape($url),
                     ProcessExecutor::escape($path),
                     ProcessExecutor::escape($cachePath),
-                    ProcessExecutor::escape(Preg::replace('{://([^@]+?):(.+?)@}', '://', $url)),
+                    ProcessExecutor::escape(Url::stripCredentials($url)),
                 ),
                 $command
             );
@@ -179,7 +179,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
                     ProcessExecutor::escape($url),
                     ProcessExecutor::escape($ref.'^{commit}'),
                     ProcessExecutor::escape($cachePath),
-                    ProcessExecutor::escape(Preg::replace('{://([^@]+?):(.+?)@}', '://', $url)),
+                    ProcessExecutor::escape(Url::stripCredentials($url)),
                 ),
                 $command
             );

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -284,7 +284,7 @@ class Git
         if (is_dir($dir) && 0 === $this->process->execute('git rev-parse --git-dir', $output, $dir) && trim($output) === '.') {
             try {
                 $commandCallable = function ($url) {
-                    $sanitizedUrl = Preg::replace('{://([^@]+?):(.+?)@}', '://', $url);
+                    $sanitizedUrl = Url::stripCredentials($url);
 
                     return sprintf('git remote set-url origin -- %s && git remote update --prune origin && git remote set-url origin -- %s && git gc --auto', ProcessExecutor::escape($url), ProcessExecutor::escape($sanitizedUrl));
                 };

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -447,14 +447,7 @@ class ProcessExecutor
             return;
         }
 
-        $safeCommand = Preg::replaceCallback('{://(?P<user>[^:/\s@]+)(?::(?P<password>[^@\s/]+))?@}i', function ($m) {
-            $user = Url::sanitizeUsername($m['user']);
-            if (isset($m['password']) && $m['password'] !== '') {
-                return '://'.$user.':***@';
-            }
-
-            return '://'.$user.'@';
-        }, $command);
+        $safeCommand = Url::sanitize($command);
         $safeCommand = Preg::replace("{--password (.*[^\\\\]\') }", '--password \'***\' ', $safeCommand);
         $this->io->writeError('Executing'.($async ? ' async' : '').' command ('.($cwd ?: 'CWD').'): '.$safeCommand);
     }

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -141,7 +141,9 @@ class Url
         // e.g. https://api.github.com/repositories/9999999999?access_token=github_token
         $url = Preg::replace('{([&?]access_token=)[^&]+}', '$1***', $url);
 
-        $url = Preg::replaceCallback('{^(?P<prefix>[a-z0-9]+://)?(?P<user>[^:/\s@]+)(?::(?P<password>[^@\s/]+))?@}i', function ($m) {
+        // matches every scheme://user:pass@ in the string as URLs are usually embedded in a longer
+        // message, plus a scheme-less one at the very start for URLs passed in on their own
+        $url = Preg::replaceCallback('{(?:(?P<prefix>[a-z0-9][a-z0-9+.-]*://)|\A)(?P<user>[^:/\s?#]*)(?::(?P<password>[^\s/?#]+))?@}i', function ($m) {
             $user = Url::sanitizeUsername($m['user']);
             if (isset($m['password']) && $m['password'] !== '') {
                 return $m['prefix'].$user.':***@';
@@ -151,6 +153,19 @@ class Url
         }, $url);
 
         return $url;
+    }
+
+    /**
+     * Removes the credentials from a URL entirely, for URLs which get persisted somewhere (e.g. in a git remote)
+     *
+     * Unlike sanitize() this also drops the username, as a bare token in the user slot is a credential too.
+     *
+     * @param  string $url
+     * @return string
+     */
+    public static function stripCredentials($url)
+    {
+        return Preg::replace('{://[^/\s?#]+@}', '://', $url);
     }
 
     /**

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -170,6 +170,53 @@ class UrlTest extends TestCase
             array('abc***@example.org:123/', 'abcdefghijklmnop@example.org:123/'),
             array('example.org/foo/bar?access_token=***', 'example.org/foo/bar?access_token=abcdef'),
             array('example.org/foo/bar?foo=bar&access_token=***', 'example.org/foo/bar?foo=bar&access_token=abcdef'),
+            // anywhere in the string, as URLs usually reach sanitize() embedded in a longer message
+            array('Failed to execute git clone --mirror -- https://foo:***@example.org/private/repo.git /cache/repo', 'Failed to execute git clone --mirror -- https://foo:bar@example.org/private/repo.git /cache/repo'),
+            array('tried https://foo:***@example.org/a and https://baz:***@example.com/b', 'tried https://foo:bar@example.org/a and https://baz:qux@example.com/b'),
+            array("fatal: unable to access 'https://gitlab-ci-token:***@example.org/g/r.git/'", "fatal: unable to access 'https://gitlab-ci-token:realtoken@example.org/g/r.git/'"),
+            // passwords/usernames containing @ are masked up to the last @ of the authority
+            array('https://foo:***@example.org/repo.git', 'https://foo:bar@baz@example.org/repo.git'),
+            array('https://use***:***@example.org/repo.git', 'https://user@corp.example:realtoken@example.org/repo.git'),
+            // empty user slot, e.g. https://:TOKEN@host
+            array('https://:***@example.org/', 'https://:realtoken@example.org/'),
+            // schemes containing + . -
+            array('git+ssh://foo:***@example.org/repo.git', 'git+ssh://foo:bar@example.org/repo.git'),
+            array('svn+ssh://foo:***@example.org/repo', 'svn+ssh://foo:bar@example.org/repo'),
+            // @ without credentials in front of it is left alone
+            array("fatal: unable to access 'https://example.org/private/repo.git/': Could not resolve host", "fatal: unable to access 'https://example.org/private/repo.git/': Could not resolve host"),
+            array('https://example.org/foo/bar@2x.png', 'https://example.org/foo/bar@2x.png'),
+        );
+    }
+
+    /**
+     * @dataProvider stripCredentialsProvider
+     *
+     * @param string $expected
+     * @param string $url
+     *
+     * @return void
+     */
+    public function testStripCredentials($expected, $url)
+    {
+        $this->assertSame($expected, Url::stripCredentials($url));
+    }
+
+    /**
+     * @return array<array{string, string}>
+     */
+    public static function stripCredentialsProvider()
+    {
+        return array(
+            array('https://example.org/repo.git', 'https://user:pass@example.org/repo.git'),
+            // a bare token in the user slot is a credential too, and has no colon to key off
+            array('https://github.com/acme/repo.git', 'https://ghp_1234567890abcdefghijklmnopqrstuvwxyzAB@github.com/acme/repo.git'),
+            array('https://example.org/repo.git', 'https://user:pa@ss@example.org/repo.git'),
+            array('https://example.org:8080/repo.git', 'https://user:pass@example.org:8080/repo.git'),
+            array('https://example.org/repo.git?ref=a@b', 'https://user:pass@example.org/repo.git?ref=a@b'),
+            // nothing to strip
+            array('https://example.org/repo.git', 'https://example.org/repo.git'),
+            array('https://example.org/@scope/repo.git', 'https://example.org/@scope/repo.git'),
+            array('git@example.org:acme/repo.git', 'git@example.org:acme/repo.git'),
         );
     }
 }


### PR DESCRIPTION
Url::sanitize() was anchored with ^, so it only masked a credential sitting at offset 0. Every caller prepends text ("Failed to execute ...", "Failed to clone ...", git's own error output), so in practice an embedded password or CI token reached the terminal and the CI log in plaintext. Git::maskCredentials() is no backstop, it only runs when Composer injected the auth itself, never for a credential the user embedded in a repository URL.

The pattern now matches scheme://user:pass@ anywhere in the string, and keeps the scheme-less form matching at the start only. It also covers shapes it missed before: passwords containing @ (previously masked up to the first one only), an empty user slot (https://:TOKEN@host), and git+ssh:// style schemes.

The %sanitizedUrl% regex, copied in Git::syncMirror and twice in GitDownloader, required a colon in the userinfo, so a bare token (https://ghp_xxx@host/repo.git) passed through unstripped and was written into a .git/config by `git remote set-url`. All three now use Url::stripCredentials(), which drops the whole userinfo.

ProcessExecutor kept another copy of the masking regex, with the same @-in-password gap, leaking it under -vvv. It now calls Url::sanitize().

Reported by @eyupcanakman and @arpitjain099.

Backport of #13044