### PR TITLE
Prevent curl SSL version parsing across lines

### DIFF
--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -234,7 +234,7 @@ class PlatformRepository extends ArrayRepository
                     $info = $this->runtime->getExtensionInfo($name);
 
                     // SSL Version => OpenSSL/1.0.1t
-                    if (Preg::isMatchStrictGroups('{^SSL Version => (?<library>[^/]+)/(?<version>.+)$}im', $info, $sslMatches)) {
+                    if (Preg::isMatchStrictGroups('{^SSL Version => (?<library>[^\r\n/]+)/(?<version>[^\r\n]+)$}im', $info, $sslMatches)) {
                         $library = strtolower($sslMatches['library']);
                         if ($library === 'openssl') {
                             $parsedVersion = Version::parseOpenssl($sslMatches['version'], $isFips);

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -234,7 +234,8 @@ class PlatformRepository extends ArrayRepository
                     $info = $this->runtime->getExtensionInfo($name);
 
                     // SSL Version => OpenSSL/1.0.1t
-                    if (Preg::isMatchStrictGroups('{^SSL Version => (?<library>[^\r\n/]+)/(?<version>[^\r\n]+)$}im', $info, $sslMatches)) {
+                    // unversioned backends (=> Schannel) are not reported, the library must not span lines (#12615)
+                    if (Preg::isMatchStrictGroups('{^SSL Version => (?<library>[^\r\n/]+)/(?<version>[^\r\n]+?)\r?$}im', $info, $sslMatches)) {
                         $library = strtolower($sslMatches['library']);
                         if ($library === 'openssl') {
                             $parsedVersion = Version::parseOpenssl($sslMatches['version'], $isFips);
@@ -252,7 +253,7 @@ class PlatformRepository extends ArrayRepository
                     }
 
                     // libSSH Version => libssh2/1.4.3
-                    if (Preg::isMatchStrictGroups('{^libSSH Version => (?<library>[^/]+)/(?<version>.+?)(?:/.*)?$}im', $info, $sshMatches)) {
+                    if (Preg::isMatchStrictGroups('{^libSSH Version => (?<library>[^\r\n/]+)/(?<version>.+?)(?:/.*)?$}im', $info, $sshMatches)) {
                         $this->addLibrary($libraries, $name.'-'.strtolower($sshMatches['library']), $sshMatches['version'], 'curl '.$sshMatches['library'].' version');
                     }
 
@@ -697,6 +698,12 @@ class PlatformRepository extends ArrayRepository
         try {
             $version = $this->versionParser->normalize($prettyVersion);
         } catch (\UnexpectedValueException $e) {
+            return;
+        }
+
+        // a parsing glitch in one of the extension info parsers above must not result in a bogus
+        // package name, as that would then be looked up as if it was a real package, see #12615
+        if (!self::isPlatformPackage('lib-'.$name)) {
             return;
         }
 

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -253,18 +253,58 @@ curl.cainfo => no value => no value',
                 ],
                 [['curl_version', [], ['version' => '2.0.0']]],
             ],
-            'curl: Schannel without version' => [
+            'curl: SSL backend without version' => [
                 'curl',
                 '
 curl
 
+cURL support => enabled
+cURL Information => 8.16.0
+Age => 11
+Features
+AsynchDNS => Yes
+IDN => Yes
+IPv6 => Yes
+Largefile => Yes
+SSL => Yes
+SSPI => Yes
+Protocols => dict, file, ftp, ftps, gopher, gophers, http, https, imap, imaps, ldap, ldaps, mqtt, pop3, pop3s, rtsp, scp, sftp, smb, smbs, smtp, smtps, telnet, tftp, ws, wss
+Host => x86_64-pc-win32
 SSL Version => Schannel
 ZLib Version => 1.3.2
-libSSH Version => libssh2/1.11.1',
+libSSH Version => libssh2/1.11.1
+
+Directive => Local Value => Master Value
+curl.cainfo => /etc/ssl/certs/ca-certificates.crt => /etc/ssl/certs/ca-certificates.crt',
                 [
                     'lib-curl' => '8.16.0',
+                    'lib-curl-openssl' => false,
+                    'lib-curl-schannel' => false,
                     'lib-curl-zlib' => '1.3.2',
                     'lib-curl-libssh2' => '1.11.1',
+                ],
+                [['curl_version', [], ['version' => '8.16.0']]],
+            ],
+
+            'curl: libSSH backend without version' => [
+                'curl',
+                '
+curl
+
+cURL support => enabled
+cURL Information => 8.16.0
+Host => x86_64-pc-linux-gnu
+SSL Version => OpenSSL/3.0.16
+ZLib Version => 1.3.2
+libSSH Version => Unknown
+
+Directive => Local Value => Master Value
+curl.cainfo => /etc/ssl/certs/ca-certificates.crt => /etc/ssl/certs/ca-certificates.crt',
+                [
+                    'lib-curl' => '8.16.0',
+                    'lib-curl-openssl' => '3.0.16',
+                    'lib-curl-zlib' => '1.3.2',
+                    'lib-curl-libssh2' => false,
                 ],
                 [['curl_version', [], ['version' => '8.16.0']]],
             ],
@@ -522,6 +562,25 @@ ZLib Version => 1.2.11',
                 [
                     'lib-curl' => '8.1.2',
                     'lib-curl-securetransport' => ['2.8.3', ['lib-curl-libressl']],
+                    'lib-curl-zlib' => '1.2.11',
+                ],
+                [['curl_version', [], ['version' => '8.1.2']]],
+            ],
+            'curl: multi-SSL backend which is not SecureTransport is skipped rather than reported under an invalid name' => [
+                'curl',
+                '
+curl
+
+cURL support => enabled
+cURL Information => 8.1.2
+MULTI_SSL => Yes
+Host => x86_64-pc-win32
+SSL Version => (Schannel) OpenSSL/3.0.5
+ZLib Version => 1.2.11',
+                [
+                    'lib-curl' => '8.1.2',
+                    'lib-curl-openssl' => false,
+                    'lib-curl-schannel' => false,
                     'lib-curl-zlib' => '1.2.11',
                 ],
                 [['curl_version', [], ['version' => '8.1.2']]],

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -253,6 +253,21 @@ curl.cainfo => no value => no value',
                 ],
                 [['curl_version', [], ['version' => '2.0.0']]],
             ],
+            'curl: Schannel without version' => [
+                'curl',
+                '
+curl
+
+SSL Version => Schannel
+ZLib Version => 1.3.2
+libSSH Version => libssh2/1.11.1',
+                [
+                    'lib-curl' => '8.16.0',
+                    'lib-curl-zlib' => '1.3.2',
+                    'lib-curl-libssh2' => '1.11.1',
+                ],
+                [['curl_version', [], ['version' => '8.16.0']]],
+            ],
 
             'curl: OpenSSL fips version' => [
                 'curl',


### PR DESCRIPTION
## Summary

Composer’s curl SSL parser can consume subsequent `php --ri curl` lines when the SSL backend reports an unversioned value such as `Schannel`. This produces a malformed multiline `lib-curl-schannel...` platform package and breaks dependency resolution on Windows.

This patch restricts the SSL library and version captures to a single line. An unversioned Schannel entry is ignored, while `ext-curl`, `lib-curl`, zlib, and libssh2 remain available normally.

- See #12615.

## Testing

- Added a regression fixture for:
  - `SSL Version => Schannel`
  - `ZLib Version => 1.3.2`
  - `libSSH Version => libssh2/1.11.1`
- Verified the old parser reproduces the malformed multiline package name.
- Focused platform tests pass: 60 tests, 793 assertions.
- Full test suite passes: 3,266 tests, 7,312 assertions.
