### PR TITLE
Do not use a conflicted content-hash as the autoloader suffix

### DIFF
--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -426,7 +426,10 @@ EOF;
             }
 
             if (null === $suffix) {
-                $suffix = $locker !== null && $locker->isLocked() ? $locker->getLockData()['content-hash'] : bin2hex(random_bytes(16));
+                // a lock file with an unresolved merge conflict has its content-hash replaced by a
+                // human readable message, which would end up inside the autoloader class names
+                $contentHash = $locker !== null && $locker->isLocked() ? $locker->getLockData()['content-hash'] : null;
+                $suffix = is_string($contentHash) && Preg::isMatch('{^[a-f0-9]+$}', $contentHash) ? $contentHash : bin2hex(random_bytes(16));
             }
         }
 

--- a/tests/Composer/Test/Command/DumpAutoloadCommandTest.php
+++ b/tests/Composer/Test/Command/DumpAutoloadCommandTest.php
@@ -194,4 +194,41 @@ class DumpAutoloadCommandTest extends TestCase
 
         self::assertStringContainsString('ComposerAutoloaderInit2d4a6be9a93712c5d6a119b26734a047', (string) file_get_contents($dir . '/vendor/autoload.php'));
     }
+
+    public function testWithConflictedComposerLockWithoutAutoloaderSuffix(): void
+    {
+        $dir = $this->initTempComposer(
+            [
+                'name' => 'foo/bar',
+            ],
+            [],
+            [
+                "_readme" => [
+                    "This file locks the dependencies of your project to a known state",
+                    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+                    "This file is @generated automatically",
+                ],
+                // what JsonFile::parseJson() puts in place of a conflicted content-hash
+                "content-hash" => "VCS merge conflict detected. Please run `composer update --lock`.",
+                "packages" => [],
+                "packages-dev" => [],
+                "aliases" => [],
+                "minimum-stability" => "stable",
+                "stability-flags" => [],
+                "prefer-stable" => false,
+                "prefer-lowest" => false,
+                "platform" => [],
+                "platform-dev" => [],
+                "plugin-api-version" => "2.6.0",
+            ]
+        );
+
+        $appTester = $this->getApplicationTester();
+        self::assertSame(0, $appTester->run(['command' => 'dump-autoload']));
+
+        $autoload = (string) file_get_contents($dir . '/vendor/autoload.php');
+
+        self::assertStringNotContainsString('merge conflict detected', $autoload);
+        self::assertMatchesRegularExpression('{ComposerAutoloaderInit[a-f0-9]{32}::getLoader\(\);}', $autoload);
+    }
 }


### PR DESCRIPTION
Fixes #13047

When a lock file carries an unresolved merge conflict around `content-hash`, `JsonFile::parseJson()` replaces the conflicted block with a human readable message so the file still parses and the "please run `composer update --lock`" hint can be shown. `AutoloadGenerator::dump()` then used that value as the autoloader class suffix, producing:

```php
return ComposerAutoloaderInitVCS merge conflict detected. Please run `composer update --lock`.::getLoader();
```

which is not valid PHP, so the application crashed at runtime while everything else in the deploy looked fine.

The suffix now falls back to the random one (the branch that already exists for the unlocked case) when the lock's `content-hash` is not a hash, leaving the placeholder and its message untouched. Base branch is `main`: 2.2 has neither the placeholder nor the content-hash suffix.

The new test in `DumpAutoloadCommandTest` fails on the current code with the message inside `vendor/autoload.php`.
