### PR TITLE
Remove source-fallback option that was added in 2.10 as a stop-gap measure

### DIFF
--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -38,10 +38,6 @@ class DownloadManager
     private $filesystem;
     /** @var array<string, DownloaderInterface> */
     private $downloaders = [];
-    /** @var bool */
-    private $sourceFallback = false;
-    /** @var bool */
-    private $sourceFallbackDeprecationWarned = false;
 
     /**
      * Initializes download manager.
@@ -89,22 +85,6 @@ class DownloadManager
     public function setPreferences(array $preferences): self
     {
         $this->packagePreferences = $preferences;
-
-        return $this;
-    }
-
-    /**
-     * Allow fallback to alternative sources when download fails.
-     */
-    public function setSourceFallback(bool $sourceFallback): self
-    {
-        if ($sourceFallback && !$this->sourceFallbackDeprecationWarned) {
-            $this->io->writeError('<warning>The source-fallback option is deprecated and will be removed in Composer 2.11 as automatic fallback between dist and source has security implications.</warning>');
-            $this->io->writeError('<warning>If you have a legitimate use case and do not want us to remove it in 2.11, please open an issue at https://github.com/composer/composer/issues to let us know.</warning>');
-            $this->sourceFallbackDeprecationWarned = true;
-        }
-
-        $this->sourceFallback = $sourceFallback;
 
         return $this;
     }
@@ -218,20 +198,16 @@ class DownloadManager
             $handleError = function ($e) use ($sources, $source, $package, $io, $download) {
                 if ($e instanceof \RuntimeException && !$e instanceof IrrecoverableDownloadException) {
                     $nextSource = $sources[0] ?? null;
-                    // Only fallback from dist to source is gated by the sourceFallback flag, as it can
-                    // silently switch to less-trusted code or cause other issues where people rely on dists.
+                    // Only fallback from dist to source is risky as it can silently switch to less-trusted
+                    // code or cause other issues where people rely on dists.
                     // Falling back the other way around (source -> dist) is always allowed.
-                    $blocked = $nextSource === 'source' && !$this->sourceFallback;
-                    if ($nextSource === null || $blocked) {
-                        if ($blocked) {
-                            $io->writeError(
-                                '    <warning>Failed to download '.
-                                $package->getPrettyName().
-                                ' from ' . $source . ': '.
-                                $e->getMessage().'</warning>'
-                            );
-                            $io->writeError('    <warning>Source fallback is disabled. Not trying alternative sources.</warning>');
-                        }
+                    if ($nextSource !== 'dist') {
+                        $io->writeError(
+                            '    <warning>Failed to download '.
+                            $package->getPrettyName().
+                            ' from ' . $source . ': '.
+                            $e->getMessage().'</warning>'
+                        );
                         throw $e;
                     }
 

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -529,10 +529,6 @@ class Factory
             $dm->setPreferences($preferred);
         }
 
-        if ($config->get('source-fallback')) {
-            $dm->setSourceFallback(true);
-        }
-
         $dm->setDownloader('git', new Downloader\GitDownloader($io, $config, $process, $fs));
         $dm->setDownloader('svn', new Downloader\SvnDownloader($io, $config, $process, $fs));
         $dm->setDownloader('fossil', new Downloader\FossilDownloader($io, $config, $process, $fs));

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -662,28 +662,4 @@ class ConfigTest extends TestCase
         $config->merge(['config' => ['allow-plugins' => true]]);
         self::assertEquals(true, $config->get('allow-plugins'));
     }
-
-    public function testSourceFallbackDefaultsToFalse(): void
-    {
-        $config = new Config(false);
-        self::assertFalse($config->get('source-fallback'));
-    }
-
-    public function testSourceFallbackCanBeDisabled(): void
-    {
-        $config = new Config(false);
-        $config->merge(['config' => ['source-fallback' => false]]);
-        self::assertFalse($config->get('source-fallback'));
-    }
-
-    public function testSourceFallbackCanBeSetFromString(): void
-    {
-        $config = new Config(false);
-        $config->merge(['config' => ['source-fallback' => 'false']]);
-        self::assertFalse($config->get('source-fallback'));
-
-        $config->merge(['config' => ['source-fallback' => 'true']]);
-        self::assertTrue($config->get('source-fallback'));
-    }
-
 }

--- a/tests/Composer/Test/Downloader/DownloadManagerTest.php
+++ b/tests/Composer/Test/Downloader/DownloadManagerTest.php
@@ -239,67 +239,6 @@ class DownloadManagerTest extends TestCase
         $manager->download($package, 'target_dir');
     }
 
-    public function testFullPackageDownloadFailover(): void
-    {
-        $package = $this->createPackageMock();
-        $package
-            ->expects($this->once())
-            ->method('getSourceType')
-            ->will($this->returnValue('git'));
-        $package
-            ->expects($this->once())
-            ->method('getDistType')
-            ->will($this->returnValue('pear'));
-        $package
-            ->expects($this->any())
-            ->method('getPrettyString')
-            ->will($this->returnValue('prettyPackage'));
-
-        $package
-            ->expects($this->exactly(2))
-            ->method('setInstallationSource')
-            ->willReturnCallback(static function ($type) {
-                static $series = [
-                    'dist',
-                    'source',
-                ];
-
-                self::assertSame(array_shift($series), $type);
-            });
-
-        $downloaderFail = $this->createDownloaderMock();
-        $downloaderFail
-            ->expects($this->once())
-            ->method('download')
-            ->with($package, 'target_dir')
-            ->will($this->throwException(new \RuntimeException("Foo")));
-
-        $downloaderSuccess = $this->createDownloaderMock();
-        $downloaderSuccess
-            ->expects($this->once())
-            ->method('download')
-            ->with($package, 'target_dir')
-            ->will($this->returnValue(\React\Promise\resolve(null)));
-
-        $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
-            ->setConstructorArgs([$this->io, false, $this->filesystem])
-            ->onlyMethods(['getDownloaderForPackage'])
-            ->getMock();
-        $manager
-            ->expects($this->exactly(2))
-            ->method('getDownloaderForPackage')
-            ->with($package)
-            ->willReturnOnConsecutiveCalls(
-                $downloaderFail,
-                $downloaderSuccess
-            );
-
-        // Source fallback now defaults to false; opt in to exercise failover.
-        $manager->setSourceFallback(true);
-
-        $manager->download($package, 'target_dir');
-    }
-
     public function testBadPackageDownload(): void
     {
         $package = $this->createPackageMock();
@@ -1243,7 +1182,7 @@ class DownloadManagerTest extends TestCase
         $manager->download($package, 'target_dir');
     }
 
-    public function testDownloadFailsWithoutFallbackWhenDisabled(): void
+    public function testDownloadFailsWithoutFallbackWhenDistFails(): void
     {
         $package = $this->createPackageMock();
         $package
@@ -1285,86 +1224,12 @@ class DownloadManagerTest extends TestCase
             ->with($package)
             ->will($this->returnValue($downloaderFail));
 
-        // Disable source fallback
-        $manager->setSourceFallback(false);
-
         $this->io
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(1))
             ->method('writeError');
 
         self::expectException('RuntimeException');
         self::expectExceptionMessage('Foo');
-
-        $manager->download($package, 'target_dir');
-    }
-
-    public function testDownloadFallsBackWhenEnabled(): void
-    {
-        $package = $this->createPackageMock();
-        $package
-            ->expects($this->once())
-            ->method('getSourceType')
-            ->will($this->returnValue('git'));
-        $package
-            ->expects($this->once())
-            ->method('getDistType')
-            ->will($this->returnValue('pear'));
-        $package
-            ->expects($this->any())
-            ->method('getPrettyString')
-            ->will($this->returnValue('prettyPackage'));
-        $package
-            ->expects($this->any())
-            ->method('getPrettyName')
-            ->will($this->returnValue('foo/bar'));
-
-        $package
-            ->expects($this->exactly(2))
-            ->method('setInstallationSource')
-            ->willReturnCallback(static function ($type) {
-                static $series = [
-                    'dist',
-                    'source',
-                ];
-
-                self::assertSame(array_shift($series), $type);
-            });
-
-        $downloaderFail = $this->createDownloaderMock();
-        $downloaderFail
-            ->expects($this->once())
-            ->method('download')
-            ->with($package, 'target_dir')
-            ->will($this->throwException(new \RuntimeException("Foo")));
-
-        $downloaderSuccess = $this->createDownloaderMock();
-        $downloaderSuccess
-            ->expects($this->once())
-            ->method('download')
-            ->with($package, 'target_dir')
-            ->will($this->returnValue(\React\Promise\resolve(null)));
-
-        $manager = $this->getMockBuilder('Composer\Downloader\DownloadManager')
-            ->setConstructorArgs([$this->io, false, $this->filesystem])
-            ->onlyMethods(['getDownloaderForPackage'])
-            ->getMock();
-        $manager
-            ->expects($this->exactly(2))
-            ->method('getDownloaderForPackage')
-            ->with($package)
-            ->willReturnOnConsecutiveCalls(
-                $downloaderFail,
-                $downloaderSuccess
-            );
-
-        // 4 writeError calls fire: 2 deprecation warnings, "Failed to download from dist",
-        // and "Now trying to download from source" during the retry.
-        $this->io
-            ->expects($this->exactly(4))
-            ->method('writeError');
-
-        // Explicitly enable source fallback (opt-in, deprecated)
-        $manager->setSourceFallback(true);
 
         $manager->download($package, 'target_dir');
     }
@@ -1429,14 +1294,11 @@ class DownloadManagerTest extends TestCase
             );
 
         // 2 writeError calls fire: "Failed to download from source" and
-        // "Now trying to download from dist" during the retry. No deprecation
-        // warning, no "Source fallback is disabled" warning — source-fallback
-        // only governs the dist → source direction.
+        // "Now trying to download from dist" during the retry.
         $this->io
             ->expects($this->exactly(2))
             ->method('writeError');
 
-        // Do NOT call setSourceFallback — fallback to dist must work by default.
         $manager->download($package, 'target_dir');
     }
 


### PR DESCRIPTION
Closes #12889