### PR TITLE
Add batching to the security advisories API queries for projects with very large dep count

### DIFF
--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -52,6 +52,14 @@ use React\Promise\PromiseInterface;
 class ComposerRepository extends ArrayRepository implements ConfigurableRepositoryInterface, AdvisoryProviderInterface, FilterListProviderInterface
 {
     /**
+     * Package names per security-advisories API request
+     *
+     * Each name costs one form input var, and PHP silently truncates $_POST past
+     * max_input_vars (1000 by default), which would drop advisories without any error.
+     */
+    private const ADVISORY_API_BATCH_SIZE = 500;
+
+    /**
      * @var mixed[]
      * @phpstan-var array{url: string, options?: mixed[], type?: 'composer', allow_ssl_downgrade?: bool}
      */
@@ -775,30 +783,52 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
             $options['http']['header'][] = 'Content-type: application/x-www-form-urlencoded';
             $options['http']['timeout'] = 10;
-            $options['http']['content'] = http_build_query(['packages' => array_keys($packageConstraintMap)]);
 
-            $response = $this->httpDownloader->get($apiUrl, $options);
+            $responses = [];
+            $promises = [];
+            foreach (array_chunk(array_keys($packageConstraintMap), self::ADVISORY_API_BATCH_SIZE) as $batchIndex => $batch) {
+                $batchOptions = $options;
+                $batchOptions['http']['content'] = http_build_query(['packages' => $batch]);
+
+                $promises[] = $this->httpDownloader->add($apiUrl, $batchOptions)
+                    ->then(static function (Response $response) use (&$responses, $batchIndex): void {
+                        $responses[$batchIndex] = $response->decodeJson();
+                    });
+            }
+            $this->loop->wait($promises);
+            ksort($responses);
+
             $warned = false;
-            $advisoryData = $response->decodeJson();
-            HttpDownloader::outputWarnings($this->io, $this->url, $advisoryData);
-            /** @var string $name */
-            foreach ($advisoryData['advisories'] as $name => $list) {
-                if (!isset($packageConstraintMap[$name])) {
-                    if (!$warned) {
-                        $this->io->writeError('<warning>'.$this->getRepoName().' returned names which were not requested in response to the security-advisories API. '.$name.' was not requested but is present in the response. Requested names were: '.implode(', ', array_keys($packageConstraintMap)).'</warning>');
-                        $warned = true;
+            $warningsShown = false;
+            foreach ($responses as $advisoryData) {
+                if (!$warningsShown) {
+                    HttpDownloader::outputWarnings($this->io, $this->url, $advisoryData);
+                    $warningsShown = true;
+                }
+
+                /** @var string $name */
+                foreach ($advisoryData['advisories'] as $name => $list) {
+                    if (!isset($packageConstraintMap[$name])) {
+                        if (!$warned) {
+                            $requested = array_keys($packageConstraintMap);
+                            $requestedList = count($requested) > 20
+                                ? implode(', ', array_slice($requested, 0, 20)).' and '.(count($requested) - 20).' more'
+                                : implode(', ', $requested);
+                            $this->io->writeError('<warning>'.$this->getRepoName().' returned names which were not requested in response to the security-advisories API. '.$name.' was not requested but is present in the response. Requested names were: '.$requestedList.'</warning>');
+                            $warned = true;
+                        }
+                        continue;
                     }
-                    continue;
+                    if (count($list) > 0) {
+                        $advisories[$name] = array_values(array_filter(array_map(
+                            static function ($data) use ($name, $create) {
+                                return $create($data, $name);
+                            },
+                            $list
+                        )));
+                    }
+                    $namesFound[$name] = true;
                 }
-                if (count($list) > 0) {
-                    $advisories[$name] = array_values(array_filter(array_map(
-                        static function ($data) use ($name, $create) {
-                            return $create($data, $name);
-                        },
-                        $list
-                    )));
-                }
-                $namesFound[$name] = true;
             }
         }
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -798,24 +798,24 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             $this->loop->wait($promises);
             ksort($responses);
 
-            $warned = false;
-            $warningsShown = false;
+            $repoWarningsShown = false;
+            $warnedAboutUnrequestedNames = false;
             foreach ($responses as $advisoryData) {
-                if (!$warningsShown) {
+                if (!$repoWarningsShown) {
                     HttpDownloader::outputWarnings($this->io, $this->url, $advisoryData);
-                    $warningsShown = true;
+                    $repoWarningsShown = true;
                 }
 
                 /** @var string $name */
                 foreach ($advisoryData['advisories'] as $name => $list) {
                     if (!isset($packageConstraintMap[$name])) {
-                        if (!$warned) {
+                        if (!$warnedAboutUnrequestedNames) {
                             $requested = array_keys($packageConstraintMap);
                             $requestedList = count($requested) > 20
                                 ? implode(', ', array_slice($requested, 0, 20)).' and '.(count($requested) - 20).' more'
                                 : implode(', ', $requested);
                             $this->io->writeError('<warning>'.$this->getRepoName().' returned names which were not requested in response to the security-advisories API. '.$name.' was not requested but is present in the response. Requested names were: '.$requestedList.'</warning>');
-                            $warned = true;
+                            $warnedAboutUnrequestedNames = true;
                         }
                         continue;
                     }

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -515,6 +515,64 @@ class ComposerRepositoryTest extends TestCase
         }
     }
 
+    public function testGetSecurityAdvisoriesBatchesLargeRequests(): void
+    {
+        $packageNames = [];
+        for ($i = 0; $i < 1200; $i++) {
+            $packageNames[] = 'foo/pkg'.$i;
+        }
+        $advisory = $this->generateSecurityAdvisory('foo/pkg1100', 'CVE-1999-1000', '>=1.0.0');
+
+        $expectations = [
+            [
+                'url' => 'https://example.org/packages.json',
+                'body' => JsonFile::encode([
+                    'metadata-url' => 'https://example.org/p2/%package%.json',
+                    'security-advisories' => [
+                        'api-url' => 'https://example.org/security-advisories',
+                    ],
+                ]),
+                'options' => ['http' => ['verify_peer' => false]],
+            ],
+        ];
+        // 1200 names must be split into 500/500/200 so that no request exceeds the
+        // servers' max_input_vars, which would silently drop the trailing packages
+        foreach ([array_slice($packageNames, 0, 500), array_slice($packageNames, 500, 500), array_slice($packageNames, 1000)] as $index => $batch) {
+            $expectations[] = [
+                'url' => 'https://example.org/security-advisories',
+                'body' => JsonFile::encode(['advisories' => $index === 2 ? ['foo/pkg1100' => [$advisory]] : []]),
+                'options' => ['http' => [
+                    'verify_peer' => false,
+                    'method' => 'POST',
+                    'header' => ['Content-type: application/x-www-form-urlencoded'],
+                    'timeout' => 10,
+                    'content' => http_build_query(['packages' => $batch]),
+                ]],
+            ];
+        }
+
+        $httpDownloader = $this->getHttpDownloaderMock();
+        $httpDownloader->expects($expectations, true);
+
+        $repository = new ComposerRepository(
+            ['url' => 'https://example.org/packages.json', 'options' => ['http' => ['verify_peer' => false]]],
+            new NullIO(),
+            FactoryMock::createConfig(),
+            $httpDownloader
+        );
+
+        $constraintMap = [];
+        foreach ($packageNames as $packageName) {
+            $constraintMap[$packageName] = new MatchAllConstraint();
+        }
+
+        $result = $repository->getSecurityAdvisories($constraintMap);
+
+        $httpDownloader->assertComplete();
+        self::assertSame(['foo/pkg1100'], array_keys($result['advisories']));
+        self::assertSame($advisory['advisoryId'], $result['advisories']['foo/pkg1100'][0]->advisoryId);
+    }
+
     public function testGetFilterWithMatchingLists(): void
     {
         $httpDownloader = $this->getHttpDownloaderMock();


### PR DESCRIPTION
I've noticed we hit the max_input_vars limit (1000) quite often on packagist.org, unsure which routes cause this or whether it's just silly security scanners, but it gave me the idea that maybe this should not do gigantic requests. That seems like an improvement anyway.

Malware requests are not included as those post a single json document it's not suffering from this limitation.