### PR TITLE
Fix: #13052 - an empty command in a script should always be a NO-OP

### DIFF
--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -345,6 +345,10 @@ class EventDispatcher
                         throw $e;
                     }
                 } else {
+                    if ($callable === '') {
+                        continue;
+                    }
+
                     $args = implode(' ', array_map(['Composer\Util\ProcessExecutor', 'escape'], $additionalArgs));
 
                     // @putenv does not receive arguments

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -645,6 +645,53 @@ class EventDispatcherTest extends TestCase
         $this->assertFalse($dispatcher->hasEventListeners($event));
     }
 
+    public function testDispatcherSkipsEmptyStringScript(): void
+    {
+        $process = $this->getProcessExecutorMock();
+        $process->expects([
+            'echo BEFORE',
+            'echo AFTER',
+        ], true);
+
+        $composer = new Composer();
+        $config = new Config();
+        $composer->setConfig($config);
+
+        $package = $this->getMockBuilder('Composer\Package\RootPackageInterface')->getMock();
+        $package->method('getBinaries')->willReturn(['hello', 'world']);
+        $composer->setPackage($package);
+
+        $composer->setRepositoryManager($rm = new RepositoryManager(new NullIO(), $config, new HttpDownloaderMock()));
+        $rm->setLocalRepository(new InstalledArrayRepository([]));
+        $composer->setAutoloadGenerator(new AutoloadGenerator(new EventDispatcher($composer, new NullIO())));
+        $composer->setInstallationManager(new InstallationManagerMock());
+
+        $dispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')
+            ->setConstructorArgs([
+                $composer,
+                $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE),
+                $process,
+            ])
+            ->onlyMethods(['getListeners'])
+            ->getMock();
+
+        $listeners = [
+            'echo BEFORE',
+            '',
+            'echo AFTER',
+        ];
+
+        $dispatcher->expects($this->atLeastOnce())
+            ->method('getListeners')
+            ->will($this->returnValue($listeners));
+
+        $dispatcher->dispatchScript(ScriptEvents::POST_INSTALL_CMD, false);
+
+        $expected = '> post-install-cmd: echo BEFORE' . PHP_EOL .
+            '> post-install-cmd: echo AFTER' . PHP_EOL;
+        self::assertEquals($expected, $io->getOutput());
+    }
+
     public static function call(): void
     {
         throw new \RuntimeException();


### PR DESCRIPTION
In the EventDispatcher, an empty string will always match this REGEX.

https://github.com/composer/composer/blob/53e6ddca87c033e2db254c8773124d1d7afed08d/src/Composer/EventDispatcher/EventDispatcher.php#L370

Therefore an empty command will match the first registered binary.

The fix is to add a guard to prevent empty commands getting any special processing.