### PR TITLE
Escape package controlled data interpolated into the generated bin proxies

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -887,6 +887,11 @@ Optional.
 A set of files that should be treated as binaries and made available
 into the `bin-dir` (from config).
 
+Each entry is a path relative to the package root. It must not contain a `..` segment, nor any of
+the characters ``*$`"&^|<>()%!;`` or control characters: those cannot be represented safely in the
+proxy files Composer generates in the `bin-dir`. Wildcards are not expanded, a `bin/*` entry is
+simply a file that does not exist.
+
 See [Vendor Binaries](articles/vendor-binaries.md) for more details.
 
 Optional.

--- a/doc/articles/vendor-binaries.md
+++ b/doc/articles/vendor-binaries.md
@@ -25,6 +25,11 @@ for any given project.
 }
 ```
 
+Each path is relative to the package root, and is used verbatim to generate the proxy files in
+`vendor/bin`. It must therefore not contain a `..` segment, nor any of the characters
+``*$`"&^|<>()%!;`` or control characters. Wildcards are not expanded either, a `bin/*` entry is
+simply a file that does not exist.
+
 ## What does defining a vendor binary in composer.json do?
 
 It instructs Composer to install the package's binaries to `vendor/bin`

--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -4101,32 +4101,12 @@ parameters:
 			path: ../src/Composer/Installer/BinaryInstaller.php
 
 		-
-			message: "#^Parameter \\#1 \\$binPath of method Composer\\\\Installer\\\\BinaryInstaller\\:\\:installFullBinaries\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: ../src/Composer/Installer/BinaryInstaller.php
-
-		-
-			message: "#^Parameter \\#1 \\$path of static method Composer\\\\Installer\\\\BinaryInstaller\\:\\:isRepresentableInBatchProxy\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: ../src/Composer/Installer/BinaryInstaller.php
-
-		-
-			message: "#^Parameter \\#1 \\$binPath of method Composer\\\\Installer\\\\BinaryInstaller\\:\\:installUnixyProxyBinaries\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: ../src/Composer/Installer/BinaryInstaller.php
-
-		-
 			message: "#^Parameter \\#1 \\$fp of function fclose expects resource, resource\\|false given\\.$#"
 			count: 1
 			path: ../src/Composer/Installer/BinaryInstaller.php
 
 		-
 			message: "#^Parameter \\#1 \\$fp of function fgets expects resource, resource\\|false given\\.$#"
-			count: 1
-			path: ../src/Composer/Installer/BinaryInstaller.php
-
-		-
-			message: "#^Parameter \\#1 \\$path of function realpath expects string, string\\|false given\\.$#"
 			count: 1
 			path: ../src/Composer/Installer/BinaryInstaller.php
 

--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -4106,6 +4106,11 @@ parameters:
 			path: ../src/Composer/Installer/BinaryInstaller.php
 
 		-
+			message: "#^Parameter \\#1 \\$path of static method Composer\\\\Installer\\\\BinaryInstaller\\:\\:isRepresentableInBatchProxy\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../src/Composer/Installer/BinaryInstaller.php
+
+		-
 			message: "#^Parameter \\#1 \\$binPath of method Composer\\\\Installer\\\\BinaryInstaller\\:\\:installUnixyProxyBinaries\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: ../src/Composer/Installer/BinaryInstaller.php

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -100,6 +100,10 @@ class BinaryInstaller
                 // already checked the binary's existence). The following helpers
                 // will require absolute paths to work properly.
                 $binPath = realpath($binPath);
+                if (false === $binPath) {
+                    $this->io->writeError('    <warning>Skipped installation of bin '.$bin.' for package '.$package->getName().': the bin path could not be resolved</warning>');
+                    continue;
+                }
             }
             $this->initializeBinDir();
             $link = $this->binDir.'/'.basename($bin);

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -175,16 +175,53 @@ class BinaryInstaller
         $handle = fopen($bin, 'r');
         $line = fgets($handle);
         fclose($handle);
-        // The shebang comes from the package and is interpolated into the generated proxies, both as
-        // the command of the .bat one and verbatim above the "<?php" of the unixy one, so anything
-        // but a plain interpreter invocation is ignored in favor of the php default. Trimming first
-        // takes care of the trailing CR of a bin using CRLF line endings.
-        $shebang = trim((string) $line);
-        if (self::isSafeShebang($shebang) && Preg::isMatch('{^#!/(?:usr/bin/env )?(?:[^/]+/)*(.+)$}', $shebang, $match)) {
-            return $match[1];
+        // trailing whitespace covers the CR of a bin using CRLF line endings, leading whitespace is
+        // left alone as the kernel only honors a "#!" at the very first byte of the file
+        $shebang = rtrim((string) $line, " \t\r\n");
+        $interpreter = self::shebangInterpreter($shebang);
+
+        return null === $interpreter ? 'php' : $interpreter;
+    }
+
+    /**
+     * Returns the interpreter a shebang line invokes, or null if it is not one we are willing to use
+     *
+     * The shebang comes from the package and is interpolated into the generated proxies, both as the
+     * command of the .bat one and verbatim above the "<?php" of the unixy one. Its arguments are
+     * dropped rather than carried along: in the command position of the .bat proxy "php -r" or
+     * "sh -c" would make the interpreter read the bin path following it as code.
+     *
+     * @param string $shebang
+     *
+     * @return string|null
+     */
+    private static function shebangInterpreter($shebang)
+    {
+        // "env" is transparent, the interpreter is then its first argument
+        if (!Preg::isMatch('{^#!(?:/[a-zA-Z0-9_.+-]+)*/env[ \t]+([a-zA-Z0-9_.+][a-zA-Z0-9_.+-]*)(?:[ \t]|$)}', $shebang, $match)
+            && !Preg::isMatch('{^#!(?:/[a-zA-Z0-9_.+-]+)*/([a-zA-Z0-9_.+][a-zA-Z0-9_.+-]*)(?:[ \t]|$)}', $shebang, $match)
+        ) {
+            return null;
         }
 
-        return 'php';
+        // an env we could not see through, e.g. "env -S php -d x=1", leaves the interpreter unknown
+        if ($match[1] === 'env') {
+            return null;
+        }
+
+        return $match[1];
+    }
+
+    /**
+     * Checks whether a shebang interpreter is a php binary, e.g. "php", "php8" or "php8.2"
+     *
+     * @param string $interpreter
+     *
+     * @return bool
+     */
+    private static function isPhpInterpreter($interpreter)
+    {
+        return Preg::isMatch('{^php[0-9.]*$}', $interpreter);
     }
 
     /**
@@ -208,7 +245,8 @@ class BinaryInstaller
      * Checks that a shebang line read from a package's bin is safe to embed in a generated proxy
      *
      * Limited to an interpreter path followed by plain arguments, so that it can carry neither
-     * cmd.exe metacharacters nor a "<?php" of its own.
+     * cmd.exe metacharacters nor a "<?php" of its own. An argument may not begin with a dash, as
+     * "-r", "-c" and their equivalents make an interpreter treat what follows them as code.
      *
      * @param string $shebang
      *
@@ -216,7 +254,7 @@ class BinaryInstaller
      */
     private static function isSafeShebang($shebang)
     {
-        return Preg::isMatch('{^#![a-zA-Z0-9_./+-]+(?:[ \t]+[a-zA-Z0-9_.=+-]+)*$}', $shebang);
+        return Preg::isMatch('{^#![a-zA-Z0-9_./+-]+(?:[ \t]+[a-zA-Z0-9_.=+][a-zA-Z0-9_.=+-]*)*$}', $shebang);
     }
 
     /**
@@ -254,9 +292,9 @@ class BinaryInstaller
     /**
      * Checks that a path can be represented in a .bat proxy at all
      *
-     * A double quote would end the SET "..." quoting and a line break would start a new batch line.
-     * Neither can be escaped, and stripping them could point the proxy at a different existing file,
-     * so such bins are skipped instead.
+     * A double quote would end the SET "..." quoting, a line break would start a new batch line, and
+     * cmd.exe stops reading a batch file at a 0x1A. None can be escaped, and stripping them could
+     * point the proxy at a different existing file, so such bins are skipped instead.
      *
      * @param string $path
      *
@@ -264,7 +302,7 @@ class BinaryInstaller
      */
     private static function isRepresentableInBatchProxy($path)
     {
-        return !Preg::isMatch('{["\r\n]}', $path);
+        return !Preg::isMatch('{["\r\n\x1a]}', $path);
     }
 
     /**
@@ -357,7 +395,7 @@ class BinaryInstaller
         // if the target is a php file, we run the unixy proxy file
         // to ensure that _composer_autoload_path gets defined, instead
         // of running the binary directly
-        if ($caller === 'php') {
+        if (self::isPhpInterpreter($caller)) {
             $target = basename($link, '.bat');
         } else {
             $target = $this->filesystem->findShortestPath($link, $bin);
@@ -390,9 +428,14 @@ class BinaryInstaller
         // which allows calling the proxy with a custom php process
         if (Preg::isMatch('{^(#!.*\r?\n)?[\r\n\t ]*<\?php}', $binContents, $match)) {
             // carry over the existing shebang if present and plain enough to be safe to embed,
-            // otherwise add our own
-            $shebang = empty($match[1]) ? '' : trim($match[1]);
-            $proxyCode = self::isSafeShebang($shebang) ? $shebang : '#!/usr/bin/env php';
+            // otherwise add our own. Only a php one is kept: the proxy body below is PHP, and any
+            // other interpreter would be handed the proxy's own path, e.g. "#!/bin/sh -c" turning
+            // that path into a shell command string.
+            $shebang = empty($match[1]) ? '' : rtrim($match[1], " \t\r\n");
+            $interpreter = self::shebangInterpreter($shebang);
+            $proxyCode = self::isSafeShebang($shebang) && null !== $interpreter && self::isPhpInterpreter($interpreter)
+                ? $shebang
+                : '#!/usr/bin/env php';
             $binPathExported = $this->filesystem->findShortestPathCode($link, $bin, false, true);
             // a package controls every segment of its bin paths, and a "*/" in the path below would
             // close the docblock it goes into and have the rest of it parsed as PHP code

--- a/src/Composer/Installer/BinaryInstaller.php
+++ b/src/Composer/Installer/BinaryInstaller.php
@@ -17,7 +17,6 @@ use Composer\Package\PackageInterface;
 use Composer\Pcre\Preg;
 use Composer\Util\Filesystem;
 use Composer\Util\Platform;
-use Composer\Util\ProcessExecutor;
 use Composer\Util\Silencer;
 
 /**
@@ -72,6 +71,13 @@ class BinaryInstaller
         Platform::workaroundFilesystemIssues();
 
         foreach ($binaries as $bin) {
+            // ValidatingArrayLoader rejects these at publish time, but bins reach here from sources
+            // it never sees, e.g. path repositories, custom installers, or the ensureBinariesPresence()
+            // loop which reads installed.json through the non-validating ArrayLoader.
+            if (!self::isSafeBinPath($bin)) {
+                $this->io->writeError('    <warning>Skipped installation of bin '.$bin.' for package '.$package->getName().': the bin path contains invalid characters</warning>');
+                continue;
+            }
             $binPath = $installPath.'/'.$bin;
             if (!file_exists($binPath)) {
                 $this->io->writeError('    <warning>Skipped installation of bin '.$bin.' for package '.$package->getName().': file not found in package</warning>');
@@ -116,6 +122,10 @@ class BinaryInstaller
             }
 
             if ($binCompat === "full") {
+                if (!self::isRepresentableInBatchProxy($binPath) || !self::isRepresentableInBatchProxy($this->binDir)) {
+                    $this->io->writeError('    <warning>Skipped installation of bin '.$bin.' for package '.$package->getName().': the path contains a double quote or line break, which cannot be used in a Windows bin proxy</warning>');
+                    continue;
+                }
                 $this->installFullBinaries($binPath, $link, $bin, $package);
             } else {
                 $this->installUnixyProxyBinaries($binPath, $link);
@@ -165,11 +175,96 @@ class BinaryInstaller
         $handle = fopen($bin, 'r');
         $line = fgets($handle);
         fclose($handle);
-        if (Preg::isMatch('{^#!/(?:usr/bin/env )?(?:[^/]+/)*(.+)$}m', $line, $match)) {
-            return trim($match[1]);
+        // The shebang comes from the package and is interpolated into the generated proxies, both as
+        // the command of the .bat one and verbatim above the "<?php" of the unixy one, so anything
+        // but a plain interpreter invocation is ignored in favor of the php default. Trimming first
+        // takes care of the trailing CR of a bin using CRLF line endings.
+        $shebang = trim((string) $line);
+        if (self::isSafeShebang($shebang) && Preg::isMatch('{^#!/(?:usr/bin/env )?(?:[^/]+/)*(.+)$}', $shebang, $match)) {
+            return $match[1];
         }
 
         return 'php';
+    }
+
+    /**
+     * Checks that a bin path from a package can be embedded in the generated proxies
+     *
+     * These characters cannot occur in a legitimate bin and only serve to make the proxies harder
+     * to generate safely. Spaces, backslashes and single quotes are deliberately accepted, as
+     * published packages do use them. Only ever pass the package-relative bin path: the absolute
+     * one carries the user's own project path, which may well contain e.g. parentheses.
+     *
+     * @param string $bin
+     *
+     * @return bool
+     */
+    public static function isSafeBinPath($bin)
+    {
+        return !Preg::isMatch('{[*$`"&^|<>()%!;\x00-\x1f\x7f]}', $bin);
+    }
+
+    /**
+     * Checks that a shebang line read from a package's bin is safe to embed in a generated proxy
+     *
+     * Limited to an interpreter path followed by plain arguments, so that it can carry neither
+     * cmd.exe metacharacters nor a "<?php" of its own.
+     *
+     * @param string $shebang
+     *
+     * @return bool
+     */
+    private static function isSafeShebang($shebang)
+    {
+        return Preg::isMatch('{^#![a-zA-Z0-9_./+-]+(?:[ \t]+[a-zA-Z0-9_.=+-]+)*$}', $shebang);
+    }
+
+    /**
+     * Quotes a string so a POSIX shell reads it as a single literal word
+     *
+     * ProcessExecutor::escape() cannot be used here as it switches to cmd.exe rules when Composer
+     * itself runs on Windows, while this proxy is always read by sh, incl. on Windows for Cygwin.
+     *
+     * @param string $arg
+     *
+     * @return string
+     */
+    private static function escapeShellArg($arg)
+    {
+        return "'".str_replace("'", "'\\''", $arg)."'";
+    }
+
+    /**
+     * Escapes a value for a `SET "VAR=<value>"` statement of a generated .bat proxy
+     *
+     * Quoting the assignment makes cmd.exe read & | < > ^ ( ) literally, and ! is inert thanks to
+     * the proxy's DISABLEDELAYEDEXPANSION. Percent expansion runs before quotes are applied though,
+     * so those must be doubled -- %% collapses back to one % in a batch file, which is what this
+     * generates, unlike on a command line.
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    private static function escapeBatchSetValue($value)
+    {
+        return str_replace('%', '%%', $value);
+    }
+
+    /**
+     * Checks that a path can be represented in a .bat proxy at all
+     *
+     * A double quote would end the SET "..." quoting and a line break would start a new batch line.
+     * Neither can be escaped, and stripping them could point the proxy at a different existing file,
+     * so such bins are skipped instead.
+     *
+     * @param string $path
+     *
+     * @return bool
+     */
+    private static function isRepresentableInBatchProxy($path)
+    {
+        return !Preg::isMatch('{["\r\n]}', $path);
     }
 
     /**
@@ -257,24 +352,23 @@ class BinaryInstaller
      */
     protected function generateWindowsProxyCode($bin, $link)
     {
-        $binPath = $this->filesystem->findShortestPath($link, $bin);
         $caller = self::determineBinaryCaller($bin);
 
         // if the target is a php file, we run the unixy proxy file
         // to ensure that _composer_autoload_path gets defined, instead
         // of running the binary directly
         if ($caller === 'php') {
-            return "@ECHO OFF\r\n".
-                "setlocal DISABLEDELAYEDEXPANSION\r\n".
-                "SET BIN_TARGET=%~dp0/".trim(ProcessExecutor::escape(basename($link, '.bat')), '"\'')."\r\n".
-                "SET COMPOSER_RUNTIME_BIN_DIR=%~dp0\r\n".
-                "{$caller} \"%BIN_TARGET%\" %*\r\n";
+            $target = basename($link, '.bat');
+        } else {
+            $target = $this->filesystem->findShortestPath($link, $bin);
         }
 
+        // quoting the SET statements keeps cmd.exe from acting on & | < > ^ ( ) in either the
+        // package's bin path or the user's own project path
         return "@ECHO OFF\r\n".
             "setlocal DISABLEDELAYEDEXPANSION\r\n".
-            "SET BIN_TARGET=%~dp0/".trim(ProcessExecutor::escape($binPath), '"\'')."\r\n".
-            "SET COMPOSER_RUNTIME_BIN_DIR=%~dp0\r\n".
+            "SET \"BIN_TARGET=%~dp0/".self::escapeBatchSetValue($target)."\"\r\n".
+            "SET \"COMPOSER_RUNTIME_BIN_DIR=%~dp0\"\r\n".
             "{$caller} \"%BIN_TARGET%\" %*\r\n";
     }
 
@@ -288,16 +382,21 @@ class BinaryInstaller
     {
         $binPath = $this->filesystem->findShortestPath($link, $bin);
 
-        $binDir = ProcessExecutor::escape(dirname($binPath));
-        $binFile = basename($binPath);
+        $binDir = self::escapeShellArg(dirname($binPath));
+        $binFile = self::escapeShellArg(basename($binPath));
 
         $binContents = file_get_contents($bin);
         // For php files, we generate a PHP proxy instead of a shell one,
         // which allows calling the proxy with a custom php process
         if (Preg::isMatch('{^(#!.*\r?\n)?[\r\n\t ]*<\?php}', $binContents, $match)) {
-            // carry over the existing shebang if present, otherwise add our own
-            $proxyCode = empty($match[1]) ? '#!/usr/bin/env php' : trim($match[1]);
+            // carry over the existing shebang if present and plain enough to be safe to embed,
+            // otherwise add our own
+            $shebang = empty($match[1]) ? '' : trim($match[1]);
+            $proxyCode = self::isSafeShebang($shebang) ? $shebang : '#!/usr/bin/env php';
             $binPathExported = $this->filesystem->findShortestPathCode($link, $bin, false, true);
+            // a package controls every segment of its bin paths, and a "*/" in the path below would
+            // close the docblock it goes into and have the rest of it parsed as PHP code
+            $binPathComment = str_replace('*/', '* /', str_replace(array("\r", "\n"), ' ', $binPath));
             $streamProxyCode = $streamHint = '';
             $globalsCode = '$GLOBALS[\'_composer_bin_dir\'] = __DIR__;'."\n";
             $phpunitHack1 = $phpunitHack2 = '';
@@ -428,7 +527,7 @@ STREAMPROXY;
 /**
  * Proxy PHP file generated by Composer
  *
- * This file includes the referenced bin path ($binPath)
+ * This file includes the referenced bin path ($binPathComment)
  *$streamHint
  * @generated
  */
@@ -474,12 +573,12 @@ export COMPOSER_RUNTIME_BIN_DIR="\$(cd "\${self%[/\\\\]*}" > /dev/null; pwd)"
 bashSource="\$BASH_SOURCE"
 if [ -n "\$bashSource" ]; then
     if [ "\$bashSource" != "\$0" ]; then
-        source "\${dir}/$binFile" "\$@"
+        source "\${dir}/"$binFile "\$@"
         return
     fi
 fi
 
-"\${dir}/$binFile" "\$@"
+"\${dir}/"$binFile "\$@"
 
 PROXY;
     }

--- a/src/Composer/Package/Loader/ValidatingArrayLoader.php
+++ b/src/Composer/Package/Loader/ValidatingArrayLoader.php
@@ -13,6 +13,7 @@
 namespace Composer\Package\Loader;
 
 use Composer\Exception\SecurityException;
+use Composer\Installer\BinaryInstaller;
 use Composer\Package\BasePackage;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackageInterface;
@@ -117,17 +118,20 @@ class ValidatingArrayLoader implements LoaderInterface
             } else {
                 $this->validateFlatArray('bin');
             }
-            // A ".." path segment in a bin escapes the package install directory and lets the
-            // package chmod/point at an arbitrary host file during install (GHSA-gjfg-22fp-rrxx).
             if (isset($this->config['bin']) && is_string($this->config['bin'])) {
-                if (Preg::isMatch('{(?:^|[\\\\/])\.\.(?:[\\\\/]|$)}', $this->config['bin'])) {
-                    $this->errors[] = 'bin : invalid value ('.$this->config['bin'].'), must not contain a ".." path component';
+                $error = self::findBinError($this->config['bin']);
+                if (null !== $error) {
+                    $this->errors[] = 'bin : invalid value ('.$this->config['bin'].'), '.$error;
                     unset($this->config['bin']);
                 }
             } elseif (isset($this->config['bin']) && is_array($this->config['bin'])) {
                 foreach ($this->config['bin'] as $key => $bin) {
-                    if (is_string($bin) && Preg::isMatch('{(?:^|[\\\\/])\.\.(?:[\\\\/]|$)}', $bin)) {
-                        $this->errors[] = 'bin.'.$key.' : invalid value ('.$bin.'), must not contain a ".." path component';
+                    if (!is_string($bin)) {
+                        continue;
+                    }
+                    $error = self::findBinError($bin);
+                    if (null !== $error) {
+                        $this->errors[] = 'bin.'.$key.' : invalid value ('.$bin.'), '.$error;
                         unset($this->config['bin'][$key]);
                     }
                 }
@@ -567,6 +571,31 @@ class ValidatingArrayLoader implements LoaderInterface
                 throw new SecurityException($package->getName().' has an invalid bin '.$bin.', it must not contain ".." path segments');
             }
         }
+    }
+
+    /**
+     * Validates a bin path, returning the reason it is unacceptable or null if it is fine
+     *
+     * A ".." segment escapes the package install directory and lets the package chmod/point at an
+     * arbitrary host file during install (GHSA-gjfg-22fp-rrxx). The character check is the same one
+     * BinaryInstaller applies before generating a proxy, done here as well so that packagist.org
+     * and composer validate flag such a bin at the source.
+     *
+     * @param string $bin
+     *
+     * @return string|null
+     */
+    private static function findBinError($bin)
+    {
+        if (Preg::isMatch('{(?:^|[\\\\/])\.\.(?:[\\\\/]|$)}', $bin)) {
+            return 'must not contain a ".." path component';
+        }
+
+        if (!BinaryInstaller::isSafeBinPath($bin)) {
+            return 'must not contain any of the characters *$`"&^|<>()%!; nor control characters';
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Composer/Test/Installer/BinaryInstallerTest.php
+++ b/tests/Composer/Test/Installer/BinaryInstallerTest.php
@@ -188,7 +188,7 @@ class BinaryInstallerTest extends TestCase
         // installBinaries() refuses these filenames outright, so go through the generator directly
         // to keep the escaping itself covered
         $installPath = $this->vendorDir.'/attacker/pkg';
-        $this->ensureDirectoryExistsAndClear($installPath);
+        self::ensureDirectoryExistsAndClear($installPath);
         file_put_contents($installPath.'/'.$binFile, "#!/bin/sh\nprintf 'success %s' \"\$1\"\n");
 
         $this->generateProxy($installPath.'/'.$binFile, $this->binDir.'/'.$binFile);
@@ -233,13 +233,13 @@ class BinaryInstallerTest extends TestCase
             ->willReturn(array('binary'));
 
         $installPath = $this->vendorDir.'/attacker/pkg';
-        $this->ensureDirectoryExistsAndClear($installPath);
+        self::ensureDirectoryExistsAndClear($installPath);
         file_put_contents($installPath.'/binary', $shebang."\n<?php\n\necho 'success';");
 
         $installer = new BinaryInstaller($this->io, $this->binDir, 'proxy', $this->fs);
         $installer->installBinaries($package, $installPath);
 
-        $proxy = file_get_contents($this->binDir.'/binary');
+        $proxy = (string) file_get_contents($this->binDir.'/binary');
         $this->assertStringStartsWith("#!/usr/bin/env php\n", $proxy, 'An unsafe shebang must not be carried over');
         $this->assertStringNotContainsString($shebang, $proxy);
     }
@@ -264,7 +264,7 @@ class BinaryInstallerTest extends TestCase
     public function testWindowsProxyFallsBackToPhpForAnUnsafeShebang()
     {
         $installPath = $this->vendorDir.'/attacker/pkg';
-        $this->ensureDirectoryExistsAndClear($installPath);
+        self::ensureDirectoryExistsAndClear($installPath);
         file_put_contents($installPath.'/binary', "#!/usr/bin/env php\" \" & calc.exe\n<?php\n\necho 'success';");
 
         $installer = new BinaryInstaller($this->io, $this->binDir, 'full', $this->fs);
@@ -297,7 +297,7 @@ class BinaryInstallerTest extends TestCase
             ->with($this->stringContains('cannot be used in a Windows bin proxy'));
 
         $installPath = $this->vendorDir.'/foo/bar';
-        $this->ensureDirectoryExistsAndClear($installPath);
+        self::ensureDirectoryExistsAndClear($installPath);
         file_put_contents($installPath.'/binary', "#!/bin/sh\nprintf hi\n");
 
         $installer = new BinaryInstaller($this->io, $binDir, 'full', $this->fs);
@@ -321,7 +321,7 @@ class BinaryInstallerTest extends TestCase
             ->willReturn(array('pwn$(id)'));
 
         $installPath = $this->vendorDir.'/attacker/pkg';
-        $this->ensureDirectoryExistsAndClear($installPath);
+        self::ensureDirectoryExistsAndClear($installPath);
         file_put_contents($installPath.'/pwn$(id)', "#!/bin/sh\nprintf hi\n");
 
         $installer = new BinaryInstaller($this->io, $this->binDir, 'proxy', $this->fs);

--- a/tests/Composer/Test/Installer/BinaryInstallerTest.php
+++ b/tests/Composer/Test/Installer/BinaryInstallerTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test\Installer;
 
 use Composer\Installer\BinaryInstaller;
 use Composer\Util\Filesystem;
+use Composer\Util\Platform;
 use Composer\Test\TestCase;
 use Composer\Composer;
 use Composer\Config;
@@ -147,6 +148,267 @@ class BinaryInstallerTest extends TestCase
         $this->assertSame($modeBefore, fileperms($victim), 'A bin escaping the package dir via ".." must not be chmod\'d');
     }
 
+    public function testPhpProxyDoesNotRunCodeInjectedViaTheBinPath()
+    {
+        if (Platform::isWindows()) {
+            $this->markTestSkipped('The bin path of this test cannot be created on Windows');
+        }
+
+        // every segment of a bin path is package controlled, incl. the directory names below.
+        // installBinaries() refuses this path outright, so go through the generator directly to
+        // keep the escaping itself covered.
+        $bin = "a*/ namespace Injected; echo 'PWNED'; /* x/binary";
+        $installPath = $this->vendorDir.'/attacker/pkg';
+        $this->fs->ensureDirectoryExists($installPath.'/'.dirname($bin));
+        file_put_contents($installPath.'/'.$bin, "<?php\n\necho 'success '.\$_SERVER['argv'][1];");
+
+        $proxy = $this->generateProxy($installPath.'/'.$bin, $this->binDir.'/binary');
+
+        // the first comment terminator of the proxy must be the one ending its own docblock
+        $docblockEnd = strpos($proxy, '*/');
+        $this->assertNotFalse($docblockEnd);
+        $this->assertStringContainsString('@generated', substr($proxy, 0, $docblockEnd), 'The bin path must not be able to close the docblock');
+
+        $proc = new ProcessExecutor();
+        $proc->execute(ProcessExecutor::escape($this->binDir.'/binary').' arg', $output);
+        $this->assertSame('', $proc->getErrorOutput());
+        $this->assertSame('success arg', $output, 'The proxy must run the bin and nothing else');
+    }
+
+    /**
+     * @dataProvider injectedBinFilenameProvider
+     * @param string $binFile
+     */
+    public function testShProxyDoesNotRunCodeInjectedViaTheBinFilename($binFile)
+    {
+        if (Platform::isWindows()) {
+            $this->markTestSkipped('The bin filenames of this test cannot be created on Windows');
+        }
+
+        // installBinaries() refuses these filenames outright, so go through the generator directly
+        // to keep the escaping itself covered
+        $installPath = $this->vendorDir.'/attacker/pkg';
+        $this->ensureDirectoryExistsAndClear($installPath);
+        file_put_contents($installPath.'/'.$binFile, "#!/bin/sh\nprintf 'success %s' \"\$1\"\n");
+
+        $this->generateProxy($installPath.'/'.$binFile, $this->binDir.'/'.$binFile);
+
+        $proc = new ProcessExecutor();
+        $proc->execute(ProcessExecutor::escape($this->binDir.'/'.$binFile).' arg', $output);
+        $this->assertSame('', $proc->getErrorOutput());
+        $this->assertSame('success arg', $output, 'The proxy must run the bin and nothing else');
+    }
+
+    /**
+     * Writes out the unixy proxy the installer would generate, bypassing installBinaries()
+     *
+     * @param string $bin
+     * @param string $link
+     *
+     * @return string
+     */
+    private function generateProxy($bin, $link)
+    {
+        $installer = new BinaryInstaller($this->io, $this->binDir, 'proxy', $this->fs);
+        $method = new \ReflectionMethod($installer, 'generateUnixyProxyCode');
+        $method->setAccessible(true);
+        $proxy = $method->invoke($installer, $bin, $link);
+
+        file_put_contents($link, $proxy);
+        chmod($link, 0755);
+        chmod($bin, 0755);
+
+        return $proxy;
+    }
+
+    /**
+     * @dataProvider unsafeShebangProvider
+     * @param string $shebang
+     */
+    public function testPhpProxyDoesNotCarryOverAnUnsafeShebang($shebang)
+    {
+        $package = $this->createPackageMock();
+        $package->expects($this->any())
+            ->method('getBinaries')
+            ->willReturn(array('binary'));
+
+        $installPath = $this->vendorDir.'/attacker/pkg';
+        $this->ensureDirectoryExistsAndClear($installPath);
+        file_put_contents($installPath.'/binary', $shebang."\n<?php\n\necho 'success';");
+
+        $installer = new BinaryInstaller($this->io, $this->binDir, 'proxy', $this->fs);
+        $installer->installBinaries($package, $installPath);
+
+        $proxy = file_get_contents($this->binDir.'/binary');
+        $this->assertStringStartsWith("#!/usr/bin/env php\n", $proxy, 'An unsafe shebang must not be carried over');
+        $this->assertStringNotContainsString($shebang, $proxy);
+    }
+
+    public function testWindowsProxyEscapesTheTargetPath()
+    {
+        $installPath = $this->vendorDir.'/foo/bar/a&b';
+        $this->fs->ensureDirectoryExists($installPath);
+        file_put_contents($installPath.'/bin%x', "#!/bin/sh\nprintf hi\n");
+
+        $installer = new BinaryInstaller($this->io, $this->binDir, 'full', $this->fs);
+        $method = new \ReflectionMethod($installer, 'generateWindowsProxyCode');
+        $method->setAccessible(true);
+        $bat = $method->invoke($installer, $installPath.'/bin%x', $this->binDir.'/bin%x.bat');
+
+        // the quoted SET keeps cmd.exe from acting on the & of the path, and the % is doubled as a
+        // batch file collapses %% back to a single %
+        $this->assertStringContainsString("SET \"BIN_TARGET=%~dp0/../vendor/foo/bar/a&b/bin%%x\"\r\n", $bat);
+        $this->assertStringContainsString("SET \"COMPOSER_RUNTIME_BIN_DIR=%~dp0\"\r\n", $bat);
+    }
+
+    public function testWindowsProxyFallsBackToPhpForAnUnsafeShebang()
+    {
+        $installPath = $this->vendorDir.'/attacker/pkg';
+        $this->ensureDirectoryExistsAndClear($installPath);
+        file_put_contents($installPath.'/binary', "#!/usr/bin/env php\" \" & calc.exe\n<?php\n\necho 'success';");
+
+        $installer = new BinaryInstaller($this->io, $this->binDir, 'full', $this->fs);
+        $method = new \ReflectionMethod($installer, 'generateWindowsProxyCode');
+        $method->setAccessible(true);
+        $bat = $method->invoke($installer, $installPath.'/binary', $this->binDir.'/binary.bat');
+
+        $this->assertStringNotContainsString('calc.exe', $bat);
+        $this->assertStringEndsWith("php \"%BIN_TARGET%\" %*\r\n", $bat);
+    }
+
+    public function testFullCompatSkipsABinWhosePathCannotBeRepresentedInABatProxy()
+    {
+        if (Platform::isWindows()) {
+            $this->markTestSkipped('The bin dir of this test cannot be created on Windows');
+        }
+
+        // a double quote is unrepresentable in the .bat proxy, and the bin dir comes from the
+        // user's own config rather than from the package, so isSafeBinPath() does not cover it
+        $binDir = $this->rootDir.'/bin"dir';
+        $this->fs->ensureDirectoryExists($binDir);
+
+        $package = $this->createPackageMock();
+        $package->expects($this->any())
+            ->method('getBinaries')
+            ->willReturn(array('binary'));
+
+        $this->io->expects($this->atLeastOnce())
+            ->method('writeError')
+            ->with($this->stringContains('cannot be used in a Windows bin proxy'));
+
+        $installPath = $this->vendorDir.'/foo/bar';
+        $this->ensureDirectoryExistsAndClear($installPath);
+        file_put_contents($installPath.'/binary', "#!/bin/sh\nprintf hi\n");
+
+        $installer = new BinaryInstaller($this->io, $binDir, 'full', $this->fs);
+        $installer->installBinaries($package, $installPath);
+
+        $this->assertFileDoesNotExist($binDir.'/binary');
+        $this->assertFileDoesNotExist($binDir.'/binary.bat');
+    }
+
+    public function testInstallBinaryRejectsBinPathWithMetacharacters()
+    {
+        if (Platform::isWindows()) {
+            $this->markTestSkipped('The bin filename of this test cannot be created on Windows');
+        }
+
+        // bins reach BinaryInstaller from sources ValidatingArrayLoader never sees, e.g. path
+        // repositories or the ensureBinariesPresence() loop reading installed.json
+        $package = $this->createPackageMock();
+        $package->expects($this->any())
+            ->method('getBinaries')
+            ->willReturn(array('pwn$(id)'));
+
+        $installPath = $this->vendorDir.'/attacker/pkg';
+        $this->ensureDirectoryExistsAndClear($installPath);
+        file_put_contents($installPath.'/pwn$(id)', "#!/bin/sh\nprintf hi\n");
+
+        $installer = new BinaryInstaller($this->io, $this->binDir, 'proxy', $this->fs);
+        $installer->installBinaries($package, $installPath);
+
+        $this->assertFileDoesNotExist($this->binDir.'/pwn$(id)', 'No proxy must be created for a bin path with metacharacters');
+    }
+
+    /**
+     * @dataProvider safeBinPathProvider
+     * @param string $bin
+     */
+    public function testIsSafeBinPathAcceptsPathsPublishedPackagesUse($bin)
+    {
+        $this->assertTrue(BinaryInstaller::isSafeBinPath($bin));
+    }
+
+    public function safeBinPathProvider()
+    {
+        return array(
+            'plain' => array('bin/console'),
+            'space in directory' => array('bin/32 bit/wkhtmltopdf.exe'),
+            'backslash separator' => array('src\yii'),
+            'single quote' => array("bin/it's"),
+            'dashes and dots' => array('bin/foo-bar.php'),
+        );
+    }
+
+    /**
+     * @dataProvider binaryCallerProvider
+     * @param string $contents
+     * @param string $expected
+     */
+    public function testDetermineBinaryCaller($contents, $expected)
+    {
+        $bin = $this->rootDir.'/caller-bin';
+        file_put_contents($bin, $contents);
+
+        $this->assertSame($expected, BinaryInstaller::determineBinaryCaller($bin));
+    }
+
+    public function testDetermineBinaryCallerForBatFiles()
+    {
+        $this->assertSame('call', BinaryInstaller::determineBinaryCaller($this->rootDir.'/does-not-exist.bat'));
+        $this->assertSame('call', BinaryInstaller::determineBinaryCaller($this->rootDir.'/does-not-exist.exe'));
+    }
+
+    public function binaryCallerProvider()
+    {
+        return array(
+            'env php' => array("#!/usr/bin/env php\n<?php", 'php'),
+            'sh' => array("#!/bin/sh\n", 'sh'),
+            'sh with argument' => array("#!/bin/sh -e\n", 'sh -e'),
+            'php with options' => array("#!/usr/bin/env php -d memory_limit=-1\n", 'php -d memory_limit=-1'),
+            'versioned interpreter' => array("#!/usr/bin/php7.4\n", 'php7.4'),
+            'env with split string' => array("#!/usr/bin/env -S php -d x=1\n", '-S php -d x=1'),
+            'crlf line ending' => array("#!/usr/bin/env php\r\n<?php", 'php'),
+            'trailing whitespace' => array("#!/usr/bin/env php  \n", 'php'),
+            'no shebang' => array("<?php\n", 'php'),
+            'cmd metacharacters' => array("#!/usr/bin/env php\" \" & calc.exe\n", 'php'),
+            'command substitution' => array("#!/usr/bin/env php\$(id)\n", 'php'),
+            'php open tag' => array("#!<?php echo 'PWNED'; ?>\n<?php", 'php'),
+        );
+    }
+
+    public function unsafeShebangProvider()
+    {
+        return array(
+            'php open tag' => array("#!<?php echo 'PWNED'; ?>"),
+            'cmd metacharacters' => array('#!/usr/bin/env php" " & calc.exe'),
+            'command substitution' => array('#!/usr/bin/env php$(id)'),
+        );
+    }
+
+    public function injectedBinFilenameProvider()
+    {
+        // no whitespace in these: the sh proxy passes $selfArg to realpath unquoted, so a bin
+        // filename containing a space breaks its own path resolution before the quoting under
+        // test here even comes into play
+        return array(
+            'command substitution' => array('pwn$(id)'),
+            'backticks' => array('pwn`id`'),
+            'double quote' => array('pwn";id;"'),
+            'single quote' => array("pwn'quote"),
+        );
+    }
+
     public function executableBinaryProvider()
     {
         $tests = array(
@@ -166,6 +428,8 @@ EOL
             'phar file' => array(
                 base64_decode('IyEvdXNyL2Jpbi9lbnYgcGhwCjw/cGhwCgpQaGFyOjptYXBQaGFyKCd0ZXN0LnBoYXInKTsKCnJlcXVpcmUgJ3BoYXI6Ly90ZXN0LnBoYXIvcnVuLnBocCc7CgpfX0hBTFRfQ09NUElMRVIoKTsgPz4NCj4AAAABAAAAEQAAAAEACQAAAHRlc3QucGhhcgAAAAAHAAAAcnVuLnBocCoAAADb9n9hKgAAAMUDDWGkAQAAAAAAADw/cGhwIGVjaG8gInN1Y2Nlc3MgIi4kX1NFUlZFUlsiYXJndiJdWzFdO1SOC0IE3+UN0yzrHIwyspp9slhmAgAAAEdCTUI=')
             ),
+            'php file with crlf shebang' => array("#!/usr/bin/env php\r\n<?php\n\necho 'success '.\$_SERVER['argv'][1];"),
+            'shell script' => array("#!/bin/sh\nprintf 'success %s' \"\$1\"\n"),
         );
 
         if (PHP_VERSION_ID >= 70000) {

--- a/tests/Composer/Test/Installer/BinaryInstallerTest.php
+++ b/tests/Composer/Test/Installer/BinaryInstallerTest.php
@@ -222,10 +222,10 @@ class BinaryInstallerTest extends TestCase
     }
 
     /**
-     * @dataProvider unsafeShebangProvider
+     * @dataProvider notCarriedOverShebangProvider
      * @param string $shebang
      */
-    public function testPhpProxyDoesNotCarryOverAnUnsafeShebang($shebang)
+    public function testPhpProxyOnlyCarriesOverAPlainPhpShebang($shebang)
     {
         $package = $this->createPackageMock();
         $package->expects($this->any())
@@ -276,15 +276,75 @@ class BinaryInstallerTest extends TestCase
         $this->assertStringEndsWith("php \"%BIN_TARGET%\" %*\r\n", $bat);
     }
 
-    public function testFullCompatSkipsABinWhosePathCannotBeRepresentedInABatProxy()
+    /**
+     * @dataProvider phpShebangProvider
+     * @param string $shebang
+     */
+    public function testWindowsProxyRunsPhpBinsThroughTheUnixyProxy($shebang)
+    {
+        // the unixy proxy is what defines _composer_autoload_path, so the .bat must point at it
+        // rather than at the bin itself, and the % of its own name must still be doubled
+        $installPath = $this->vendorDir.'/foo/bar';
+        self::ensureDirectoryExistsAndClear($installPath);
+        file_put_contents($installPath.'/bin%x', $shebang."<?php\n\necho 'success';");
+
+        $installer = new BinaryInstaller($this->io, $this->binDir, 'full', $this->fs);
+        $method = new \ReflectionMethod($installer, 'generateWindowsProxyCode');
+        $method->setAccessible(true);
+        $bat = $method->invoke($installer, $installPath.'/bin%x', $this->binDir.'/bin%x.bat');
+
+        $this->assertStringContainsString("SET \"BIN_TARGET=%~dp0/bin%%x\"\r\n", $bat);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public function phpShebangProvider()
+    {
+        return array(
+            'no shebang' => array(''),
+            'env php' => array("#!/usr/bin/env php\n"),
+            'versioned interpreter' => array("#!/usr/bin/php7.4\n"),
+            'php with options' => array("#!/usr/bin/env php -d memory_limit=-1\n"),
+        );
+    }
+
+    public function testPhpProxyDocblockCannotBeBrokenOutOfWithALineBreak()
+    {
+        if (Platform::isWindows()) {
+            $this->markTestSkipped('The bin path of this test cannot be created on Windows');
+        }
+
+        // the bin path embedded in the docblock is the one relative to the proxy, so it carries the
+        // user's own project path too, which is not covered by isSafeBinPath()
+        $installPath = $this->vendorDir."/foo/li\r\nne/pkg";
+        $this->fs->ensureDirectoryExists($installPath);
+        file_put_contents($installPath.'/binary', "<?php\n\necho 'success';");
+
+        $proxy = $this->generateProxy($installPath.'/binary', $this->binDir.'/binary');
+
+        $docblock = substr($proxy, 0, (int) strpos($proxy, '*/'));
+        $this->assertStringContainsString('@generated', $docblock);
+        $this->assertMatchesRegularExpression(
+            '{\n \* This file includes the referenced bin path \(\.\./vendor/foo/li  ne/pkg/binary\)\n}',
+            $docblock,
+            'A line break in the bin path must not break out of its docblock line'
+        );
+    }
+
+    /**
+     * @dataProvider unrepresentableBinDirProvider
+     * @param string $dirName
+     */
+    public function testFullCompatSkipsABinWhosePathCannotBeRepresentedInABatProxy($dirName)
     {
         if (Platform::isWindows()) {
             $this->markTestSkipped('The bin dir of this test cannot be created on Windows');
         }
 
-        // a double quote is unrepresentable in the .bat proxy, and the bin dir comes from the
-        // user's own config rather than from the package, so isSafeBinPath() does not cover it
-        $binDir = $this->rootDir.'/bin"dir';
+        // these are unrepresentable in the .bat proxy, and the bin dir comes from the user's own
+        // config rather than from the package, so isSafeBinPath() does not cover it
+        $binDir = $this->rootDir.'/'.$dirName;
         $this->fs->ensureDirectoryExists($binDir);
 
         $package = $this->createPackageMock();
@@ -305,6 +365,18 @@ class BinaryInstallerTest extends TestCase
 
         $this->assertFileDoesNotExist($binDir.'/binary');
         $this->assertFileDoesNotExist($binDir.'/binary.bat');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public function unrepresentableBinDirProvider()
+    {
+        return array(
+            'double quote' => array('bin"dir'),
+            'line break' => array("bin\ndir"),
+            'batch end of file' => array("bin\x1adir"),
+        );
     }
 
     public function testInstallBinaryRejectsBinPathWithMetacharacters()
@@ -374,12 +446,18 @@ class BinaryInstallerTest extends TestCase
         return array(
             'env php' => array("#!/usr/bin/env php\n<?php", 'php'),
             'sh' => array("#!/bin/sh\n", 'sh'),
-            'sh with argument' => array("#!/bin/sh -e\n", 'sh -e'),
-            'php with options' => array("#!/usr/bin/env php -d memory_limit=-1\n", 'php -d memory_limit=-1'),
+            // arguments are never carried into the command position of the .bat proxy
+            'sh with argument' => array("#!/bin/sh -e\n", 'sh'),
+            'php with options' => array("#!/usr/bin/env php -d memory_limit=-1\n", 'php'),
             'versioned interpreter' => array("#!/usr/bin/php7.4\n", 'php7.4'),
-            'env with split string' => array("#!/usr/bin/env -S php -d x=1\n", '-S php -d x=1'),
+            'env with split string' => array("#!/usr/bin/env -S php -d x=1\n", 'php'),
+            // -r/-c would make the interpreter read the bin path following it as code
+            'php with -r' => array("#!/usr/bin/php -r\n", 'php'),
+            'sh with -c' => array("#!/bin/sh -c\n", 'sh'),
             'crlf line ending' => array("#!/usr/bin/env php\r\n<?php", 'php'),
             'trailing whitespace' => array("#!/usr/bin/env php  \n", 'php'),
+            // the kernel only honors a "#!" at the very first byte, so this file has no shebang
+            'leading whitespace' => array("  #!/bin/sh\n", 'php'),
             'no shebang' => array("<?php\n", 'php'),
             'cmd metacharacters' => array("#!/usr/bin/env php\" \" & calc.exe\n", 'php'),
             'command substitution' => array("#!/usr/bin/env php\$(id)\n", 'php'),
@@ -387,12 +465,19 @@ class BinaryInstallerTest extends TestCase
         );
     }
 
-    public function unsafeShebangProvider()
+    public function notCarriedOverShebangProvider()
     {
         return array(
             'php open tag' => array("#!<?php echo 'PWNED'; ?>"),
             'cmd metacharacters' => array('#!/usr/bin/env php" " & calc.exe'),
             'command substitution' => array('#!/usr/bin/env php$(id)'),
+            // the kernel would run these as "<interpreter> -r/-c <proxy path>", making the proxy's
+            // own path, which ends in a package controlled filename, be read as code
+            'php reading the proxy as code' => array('#!/usr/bin/php -r'),
+            'sh reading the proxy as a command' => array('#!/bin/sh -c'),
+            // a non-php interpreter above a "<?php" body can only be there to get the proxy itself
+            // handed to it, the body would not run either way
+            'non-php interpreter' => array('#!/bin/sh'),
         );
     }
 


### PR DESCRIPTION
Backport of #13056, hand written for PHP 5.3 and this branch's proxy templates, which differ slightly (the unixy proxy invokes the bin directly rather than via exec).

A package's bin path and the shebang line of the bin itself were both embedded unescaped into the proxies generated in the bin dir, in four places: the docblock of the PHP proxy, the source and invocation lines of the sh proxy, and the SET statements and command position of the .bat proxy. The sh proxy now uses sh quoting rather than ProcessExecutor::escape(), which switches to cmd.exe rules when Composer itself runs on Windows even though that file is always read by sh, and the .bat SET statements are quoted so cmd.exe does not act on & | < > ^ ( ) in either the bin path or the user's own project path.

Bin paths carrying those characters are additionally refused before a proxy is generated at all, and in ValidatingArrayLoader::load() so composer validate and packagist.org flag them at the source. Spaces, backslashes and single quotes stay allowed as a few published packages do use them and they seem harmless.

Reported by @izumi-hyun