### PR TITLE
Document the six composer.json fields missing from the schema chapter

### DIFF
--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -306,6 +306,56 @@ An example:
 
 Optional.
 
+### source
+
+Where the package sources live, used when installing the package from source.
+
+`type`, `url` and `reference` are required, `mirrors` is optional.
+
+```json
+{
+    "source": {
+        "type": "git",
+        "url": "https://github.com/composer/composer.git",
+        "reference": "2.8.0"
+    }
+}
+```
+
+Where `type` is `git`, the reference is a commit id, branch or tag name. Where
+it is `svn`, it is the reference that gets appended to the URL when running
+`svn co`.
+
+You normally do not write this field yourself. The repository a package comes
+from provides it: Packagist and other `composer` repositories fill it in from
+the VCS they read the package from, and a VCS repository fills it in from the
+branch or tag it is reading. The place you do write it by hand is the
+definition of a [`package` repository](05-repositories.md#package-1).
+
+Optional.
+
+### dist
+
+Where the package archive lives, used when installing the package from dist.
+
+`type` and `url` are required, `reference`, `shasum` and `mirrors` are
+optional.
+
+```json
+{
+    "dist": {
+        "type": "zip",
+        "url": "https://www.smarty.net/files/Smarty-3.1.7.zip"
+    }
+}
+```
+
+The same applies as for [source](04-schema.md#source): this is normally
+provided by the repository the package comes from, and written by hand only in
+a [`package` repository](05-repositories.md#package-1).
+
+Optional.
+
 ### Package links
 
 All of the following take an object which maps package names to
@@ -931,6 +981,47 @@ through the use of scripts.
 
 See [Scripts](articles/scripts.md) for events details and examples.
 
+### scripts-descriptions <span>([root-only](04-schema.md#root-package))</span>
+
+Descriptions for the custom commands defined in `scripts`, shown by
+`composer list` and `composer run -l` instead of the default
+"Runs the ... script as defined in composer.json".
+
+```json
+{
+    "scripts-descriptions": {
+        "test": "Run all tests!"
+    }
+}
+```
+
+`composer validate` warns about a description given for a script that does
+not exist.
+
+See [Scripts](articles/scripts.md#custom-descriptions) for more details.
+
+Optional.
+
+### scripts-aliases <span>([root-only](04-schema.md#root-package))</span>
+
+Alternate names for the custom commands defined in `scripts`, as an array of
+strings per script. Available as of Composer 2.7.
+
+```json
+{
+    "scripts-aliases": {
+        "phpstan": ["stan", "analyze"]
+    }
+}
+```
+
+`composer validate` warns about aliases given for a script that does not
+exist.
+
+See [Scripts](articles/scripts.md#custom-aliases) for more details.
+
+Optional.
+
 ### extra
 
 Arbitrary extra data for consumption by `scripts`.
@@ -995,6 +1086,20 @@ The example will include `/dir/foo/bar/file`, `/foo/bar/baz`, `/file.php`,
 
 Optional.
 
+### php-ext
+
+Settings for a PHP extension package, read by
+[PIE](https://github.com/php/pie) rather than by Composer itself.
+
+It can only be set by packages whose [type](04-schema.md#type) is `php-ext` or
+`php-ext-zend`, the two types reserved for extensions written in C.
+`composer validate` reports an error on any other package.
+
+See [PIE for extension maintainers](https://github.com/php/pie/blob/HEAD/docs/extension-maintainers.md#the-php-ext-definition)
+for the settings it accepts.
+
+Optional.
+
 ### abandoned
 
 Indicates whether this package has been abandoned.
@@ -1027,6 +1132,19 @@ Top level key used as a place to store comments (it can be a string or array of 
 Defaults to empty.
 
 Optional.
+
+### default-branch
+
+Indicates whether this version is the default branch of the VCS repository the
+package was read from.
+
+This one is for Composer's own use, do not set it in `composer.json`. Composer
+discards whatever the file contains and sets it itself, to `true` on the branch
+that the repository reports as its default one and on nothing else. It ends up
+in the metadata that `composer` repositories serve, which is where you may see
+it.
+
+Defaults to `false`.
 
 ### non-feature-branches
 

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -362,7 +362,7 @@ the package is downloaded:
 | --- | --- |
 | `%package%` | the package name, e.g. `acme/lib` |
 | `%version%` | the normalized version, e.g. `1.2.3.0` |
-| `%prettyVersion%` | the version as written, e.g. `1.2.3` |
+| `%prettyVersion%` | the version defined in the tag or composer.json, e.g. `v1.2.3` |
 | `%reference%` | the `reference` above |
 | `%type%` | the `type` above |
 

--- a/doc/04-schema.md
+++ b/doc/04-schema.md
@@ -354,6 +354,36 @@ The same applies as for [source](04-schema.md#source): this is normally
 provided by the repository the package comes from, and written by hand only in
 a [`package` repository](05-repositories.md#package-1).
 
+The `url` may contain placeholders, which is what lets one URL serve every
+version of a package instead of one entry per version. They are expanded when
+the package is downloaded:
+
+| Placeholder | Replaced by |
+| --- | --- |
+| `%package%` | the package name, e.g. `acme/lib` |
+| `%version%` | the normalized version, e.g. `1.2.3.0` |
+| `%prettyVersion%` | the version as written, e.g. `1.2.3` |
+| `%reference%` | the `reference` above |
+| `%type%` | the `type` above |
+
+```json
+{
+    "dist": {
+        "type": "zip",
+        "url": "https://example.org/dist/%package%/%prettyVersion%.zip"
+    }
+}
+```
+
+Two of them are hashed rather than inserted as-is, so that they cannot produce
+a path segment or escape the URL: `%version%` is replaced by its MD5 hash when
+the version contains a `/`, as `dev-feature/x` does, and `%reference%` by its
+MD5 hash unless it is already hexadecimal. A branch or tag name given as the
+reference therefore appears hashed in the URL.
+
+Placeholders are expanded in `dist` only. A `source` url is used as it is, since
+the VCS it names is cloned once and then checked out at the reference.
+
 Optional.
 
 ### Package links


### PR DESCRIPTION
Fixes #12484

The chapter opens with "This chapter will explain all of the fields available in `composer.json`", which was not quite true: six of the 39 properties in `res/composer-schema.json` had no section. This adds one for each, so the claim holds again.

`source` and `dist` say what the fields contain, that `source` also requires a `reference` while `dist` does not, and that you normally do not write them yourself, with a pointer to the `package` repository section of the repositories chapter where you do. That is the "minor use cases" @Seldaek mentioned.

`scripts-descriptions` and `scripts-aliases` are marked root-only like `scripts`, since `Application` reads them from `Factory::getComposerFile()`, and point at the two existing sections of `articles/scripts.md`.

`php-ext` follows what @stof explained in the issue: it belongs to PIE, and the section links to PIE's extension maintainers doc rather than repeating it here.

`default-branch` says plainly not to set it, and why setting it would not help anyway.

Three claims I checked rather than inferred:

- `composer validate` **errors** on `php-ext` outside a `php-ext` / `php-ext-zend` package, and **warns** on a description or an alias given for a script that does not exist. Ran on a fixture with all three problems, got exactly one entry under "General errors" and two under "General warnings".
- Composer really does discard `default-branch` from the file. I built a git repo with two branches, both declaring `"default-branch": true`, and loaded it through `VcsRepository`:

```
9999999-dev            isDefaultBranch=true
dev-trunk              isDefaultBranch=true
dev-side               isDefaultBranch=false
```

  `trunk` is the repository's default branch, `side` is not, and what the file said made no difference.

All six anchors used (`#type`, `#source`, `#root-package`, `05-repositories.md#package-1`, and the two in `articles/scripts.md`) resolve to a real heading, and the PIE link returns a 200 (the URL given in the issue is a 404 today, php/pie's default branch is `1.5.x`, so this one goes through `HEAD`).

Two placement choices are yours to overrule. `source`, `dist`, `php-ext` and the two `scripts-*` sections sit where the schema puts them. `default-branch` I put next to `non-feature-branches` at the end, since both are about branches and it keeps an internal-only field out of the early part of the page, rather than after `version` where the schema has it.

Note that `doc/**` is in `paths-ignore` for every workflow, so no CI runs on this.
