### PR TITLE
Report the GitHub API rate limit when the clone fallback fails

### DIFF
--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -522,17 +522,28 @@ class GitHubDriver extends VcsDriver
                         return parent::getContents($url);
                     }
 
+                    $rateLimited = $gitHubUtil->isRateLimited((array) $e->getHeaders());
+
                     if (!$this->io->isInteractive() && $fetchingRepoData) {
-                        $this->attemptCloneFallback($e);
+                        try {
+                            $this->attemptCloneFallback($e);
+                        } catch (\RuntimeException $cloneException) {
+                            // The clone was the last way to get the metadata, so the rate limit is
+                            // the reason nothing could be fetched at all and has to be reported.
+                            // Otherwise it stays hidden behind whatever made the clone fail.
+                            if ($rateLimited) {
+                                $this->writeRateLimitError($gitHubUtil, $e);
+                            }
+
+                            throw $cloneException;
+                        }
 
                         return new Response(['url' => 'dummy'], 200, [], 'null');
                     }
 
-                    $rateLimited = $gitHubUtil->isRateLimited((array) $e->getHeaders());
-
                     if (!$this->io->hasAuthentication($this->originUrl)) {
                         if (!$this->io->isInteractive()) {
-                            $this->io->writeError('<error>GitHub API limit exhausted. Failed to get metadata for the '.Url::sanitize($this->url).' repository, try running in interactive mode so that you can enter your GitHub credentials to increase the API limit</error>');
+                            $this->writeRateLimitError($gitHubUtil, $e);
                             throw $e;
                         }
 
@@ -542,12 +553,7 @@ class GitHubDriver extends VcsDriver
                     }
 
                     if ($rateLimited) {
-                        $rateLimit = $gitHubUtil->getRateLimit($e->getHeaders());
-                        $this->io->writeError(sprintf(
-                            '<error>GitHub API limit (%d calls/hr) is exhausted. You are already authorized so you have to wait until %s before doing more requests</error>',
-                            $rateLimit['limit'],
-                            $rateLimit['reset']
-                        ));
+                        $this->writeRateLimitError($gitHubUtil, $e);
                     }
 
                     throw $e;
@@ -597,6 +603,25 @@ class GitHubDriver extends VcsDriver
         }
         $this->hasIssues = !empty($this->repoData['has_issues']);
         $this->isArchived = !empty($this->repoData['archived']);
+    }
+
+    /**
+     * Tells the user that the GitHub API limit is what stopped the request.
+     */
+    private function writeRateLimitError(GitHub $gitHubUtil, TransportException $e): void
+    {
+        if (!$this->io->hasAuthentication($this->originUrl)) {
+            $this->io->writeError('<error>GitHub API limit exhausted. Failed to get metadata for the '.Url::sanitize($this->url).' repository, try running in interactive mode so that you can enter your GitHub credentials to increase the API limit</error>');
+
+            return;
+        }
+
+        $rateLimit = $gitHubUtil->getRateLimit($e->getHeaders());
+        $this->io->writeError(sprintf(
+            '<error>GitHub API limit (%d calls/hr) is exhausted. You are already authorized so you have to wait until %s before doing more requests</error>',
+            $rateLimit['limit'],
+            $rateLimit['reset']
+        ));
     }
 
     /**

--- a/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitHubDriverTest.php
@@ -532,6 +532,58 @@ FUNDING;
         self::assertEquals($sha, $source['reference']);
     }
 
+    public function testRateLimitIsReportedWhenTheCloneFallbackFails(): void
+    {
+        $repoUrl = 'https://github.com/composer/packagist';
+        $repoApiUrl = 'https://api.github.com/repos/composer/packagist';
+
+        $messages = [];
+
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+        $io->expects($this->any())
+            ->method('isInteractive')
+            ->will($this->returnValue(false));
+        $io->expects($this->atLeastOnce())
+            ->method('writeError')
+            ->willReturnCallback(static function (...$args) use (&$messages): void {
+                $messages[] = $args[0];
+            });
+
+        $httpDownloader = $this->getHttpDownloaderMock($io, $this->config);
+        $httpDownloader->expects(
+            [
+                [
+                    'url' => $repoApiUrl,
+                    'status' => 403,
+                    'headers' => ['x-ratelimit-limit: 60', 'x-ratelimit-remaining: 0', 'x-ratelimit-reset: 1788500000'],
+                ],
+            ],
+            true
+        );
+
+        $fs = new Filesystem();
+        $fs->removeDirectory(sys_get_temp_dir() . '/composer-test');
+        $this->config->merge(['config' => ['cache-vcs-dir' => sys_get_temp_dir() . '/composer-test/cache']]);
+
+        // no token to be found, and the clone the driver falls back to fails as it would
+        // without an SSH key registered on GitHub
+        $process = $this->getProcessExecutorMock();
+        $process->expects([], false, ['return' => 1]);
+
+        $gitHubDriver = new GitHubDriver(['url' => $repoUrl], $io, $this->config, $httpDownloader, $process);
+
+        try {
+            $gitHubDriver->initialize();
+            self::fail('The failing clone fallback should have thrown.');
+        } catch (\RuntimeException $e) {
+        }
+
+        self::assertContains(
+            '<error>GitHub API limit exhausted. Failed to get metadata for the '.$repoUrl.' repository, try running in interactive mode so that you can enter your GitHub credentials to increase the API limit</error>',
+            $messages
+        );
+    }
+
     /**
      * @dataProvider invalidUrlProvider
      */


### PR DESCRIPTION
Fixes #11215

Under `--no-interaction`, a rate-limited 403 from the GitHub API never reaches the code that reports the rate limit.

```php
case 403:
    // ...
    if (!$this->io->isInteractive() && $fetchingRepoData) {
        $this->attemptCloneFallback($e);

        return new Response(['url' => 'dummy'], 200, [], 'null');
    }

    $rateLimited = $gitHubUtil->isRateLimited((array) $e->getHeaders());
```

The early return runs before `isRateLimited()`, so the driver goes straight to the SSH clone fallback. When that clone works there is nothing to report, but when it fails, as it does for the reporter with an SSH key that is not attached to a GitHub account, the user only sees `Permission denied (publickey)` and never learns the API call was rate limited. The message written for that exact situation, a few lines below, is unreachable whenever `$fetchingRepoData` is true.

The fallback is kept, since it is the whole point of the branch when the key does work. Only its failure path changes: the rate limit is reported before the clone exception is rethrown, which is what @eyupcanakman suggested on the issue.

Both existing messages, the unauthenticated one and the "you are already authorized" one, move into a small `writeRateLimitError()` used by the three call sites, so the new one is worded exactly like the ones users already get rather than being a fourth variant.

Covered by `GitHubDriverTest::testRateLimitIsReportedWhenTheCloneFallbackFails`, which fails on `main` with the message missing from the output.
