### PR TITLE
Add an AuthenticationProvider plugin capability

### DIFF
--- a/doc/articles/plugins.md
+++ b/doc/articles/plugins.md
@@ -281,6 +281,46 @@ Now the `custom-plugin-command` is available alongside Composer commands.
 
 > _Composer commands are based on the [Symfony Console Component][10]._
 
+### Authentication provider
+
+The [`Composer\Plugin\Capability\AuthenticationProvider`][14] capability allows a
+plugin to provide authentication credentials for host origins, as an alternative
+or complement to credentials stored in auth.json files.
+
+Credentials must be returned in the same shape Composer uses internally, the
+password doubling as an auth scheme marker, for example `x-oauth-basic` for
+GitHub, `oauth2` or `private-token` for GitLab, or the plain password for HTTP
+basic auth.
+
+```php
+<?php
+
+namespace My\Composer;
+
+use Composer\Plugin\Capability\AuthenticationProvider as AuthenticationProviderCapability;
+
+class AuthenticationProvider implements AuthenticationProviderCapability
+{
+    public function getAuthentication(string $origin): ?array
+    {
+        if ($origin === 'packages.example.org') {
+            return ['username' => 'me', 'password' => 'secret'];
+        }
+
+        return null;
+    }
+}
+```
+
+This capability receives an array with `composer`, `io`, `config` and `plugin`
+keys as constructor argument, mirroring the arguments Composer uses when
+instantiating a capability.
+
+When a plugin provides this capability, Composer consults it as a source of
+credentials for origins without locally configured authentication, for example
+in auth.json files. Locally configured authentication always takes precedence
+over credentials provided by authentication providers.
+
 ## Running plugins manually
 
 Plugins for an event can be run manually by the `run-script` command. This works the same way as
@@ -391,3 +431,4 @@ includes:
 [11]: https://github.com/composer/composer/blob/main/src/Composer/Util/SyncHelper.php
 [12]: https://phpstan.org/config-reference#multiple-files
 [13]: https://github.com/phpstan/extension-installer#usage
+[14]: https://github.com/composer/composer/blob/main/src/Composer/Plugin/Capability/AuthenticationProvider.php

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -14,6 +14,7 @@ namespace Composer;
 
 use Composer\Config\JsonConfigSource;
 use Composer\Json\JsonFile;
+use Composer\IO\BaseIO;
 use Composer\IO\IOInterface;
 use Composer\Package\Archiver;
 use Composer\Package\Version\VersionGuesser;
@@ -27,6 +28,7 @@ use Composer\Util\ProcessExecutor;
 use Composer\Util\HttpDownloader;
 use Composer\Util\Loop;
 use Composer\Util\Silencer;
+use Composer\Plugin\Capability\AuthenticationProvider;
 use Composer\Plugin\PluginEvents;
 use Composer\EventDispatcher\Event;
 use Phar;
@@ -446,6 +448,12 @@ class Factory
             }
 
             $pm->loadInstalledPlugins();
+
+            // Register authentication capabilities from plugins as a fallback source of credentials,
+            // consulted by the IO when an origin has no locally configured authentication
+            if ($io instanceof BaseIO) {
+                $io->setAuthenticationProviders($pm->getPluginCapabilities(AuthenticationProvider::class, ['composer' => $composer, 'io' => $io, 'config' => $config]));
+            }
         }
 
         if ($fullLoad) {

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -14,6 +14,7 @@ namespace Composer\IO;
 
 use Composer\Config;
 use Composer\Pcre\Preg;
+use Composer\Plugin\Capability\AuthenticationProvider;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\Silencer;
 use Psr\Log\LogLevel;
@@ -22,6 +23,9 @@ abstract class BaseIO implements IOInterface
 {
     /** @var array<string, array{username: string|null, password: string|null}> */
     protected $authentications = [];
+
+    /** @var AuthenticationProvider[] */
+    private $authenticationProviders = [];
 
     /**
      * @inheritDoc
@@ -44,7 +48,17 @@ abstract class BaseIO implements IOInterface
      */
     public function hasAuthentication($repositoryName)
     {
-        return isset($this->authentications[$repositoryName]);
+        if (isset($this->authentications[$repositoryName])) {
+            return true;
+        }
+
+        foreach ($this->authenticationProviders as $provider) {
+            if ($provider->getAuthentication($repositoryName) !== null) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -56,6 +70,13 @@ abstract class BaseIO implements IOInterface
             return $this->authentications[$repositoryName];
         }
 
+        foreach ($this->authenticationProviders as $provider) {
+            $authentication = $provider->getAuthentication($repositoryName);
+            if ($authentication !== null) {
+                return $authentication;
+            }
+        }
+
         return ['username' => null, 'password' => null];
     }
 
@@ -65,6 +86,25 @@ abstract class BaseIO implements IOInterface
     public function setAuthentication($repositoryName, $username, $password = null)
     {
         $this->authentications[$repositoryName] = ['username' => $username, 'password' => $password];
+    }
+
+    /**
+     * Register authentication providers, used as a fallback source of
+     * credentials for origins without locally set authentication.
+     *
+     * @param AuthenticationProvider[] $providers
+     *
+     * @return void
+     */
+    public function setAuthenticationProviders(array $providers)
+    {
+        foreach ($providers as $provider) {
+            if (!$provider instanceof AuthenticationProvider) {
+                throw new \InvalidArgumentException('Authentication providers must implement '.AuthenticationProvider::class);
+            }
+        }
+
+        $this->authenticationProviders = $providers;
     }
 
     /**

--- a/src/Composer/Plugin/Capability/AuthenticationProvider.php
+++ b/src/Composer/Plugin/Capability/AuthenticationProvider.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Plugin\Capability;
+
+/**
+ * Authentication Provider Interface
+ *
+ * This capability allows plugins to provide authentication credentials for host
+ * origins, as an alternative to credentials stored in auth.json files.
+ *
+ * The credentials must be returned in the same shape Composer uses for its own
+ * authentications, with the password acting as an auth scheme marker (for
+ * example 'x-oauth-basic' for GitHub, 'oauth2' or 'private-token' for GitLab,
+ * or the plain password for HTTP basic auth).
+ *
+ * This capability will receive an array with 'composer' and 'io' keys as
+ * constructor argument. Those contain Composer\Composer and Composer\IO\IOInterface
+ * instances. It also contains 'config' and 'plugin' keys containing the
+ * Composer\Config instance and the plugin instance that created the capability.
+ *
+ * @api
+ */
+interface AuthenticationProvider extends Capability
+{
+    /**
+     * Retrieve the authentication credentials for the given origin.
+     *
+     * @param string $origin The host origin to retrieve credentials for
+     *
+     * @return array{username: string|null, password: string|null}|null The credentials, or null when not handled
+     */
+    public function getAuthentication(string $origin): ?array;
+}

--- a/tests/Composer/Test/IO/BaseIOTest.php
+++ b/tests/Composer/Test/IO/BaseIOTest.php
@@ -14,6 +14,7 @@ namespace Composer\Test\IO;
 
 use Composer\Config;
 use Composer\IO\BufferIO;
+use Composer\Plugin\Capability\AuthenticationProvider;
 use Composer\Test\TestCase;
 
 class BaseIOTest extends TestCase
@@ -32,6 +33,65 @@ class BaseIOTest extends TestCase
         $auth = $io->getAuthentication('github.com');
         self::assertSame($token, $auth['username']);
         self::assertSame('x-oauth-basic', $auth['password']);
+    }
+
+    public function testAuthenticationProviderIsConsultedForUnknownOrigins(): void
+    {
+        $provider = $this->createMock(AuthenticationProvider::class);
+        $provider->expects(self::any())
+            ->method('getAuthentication')
+            ->willReturnCallback(static function (string $origin): ?array {
+                return $origin === 'example.org' ? ['username' => 'provider-user', 'password' => 'provider-pass'] : null;
+            });
+
+        $io = new BufferIO();
+        $io->setAuthenticationProviders([$provider]);
+
+        self::assertTrue($io->hasAuthentication('example.org'));
+        self::assertSame(['username' => 'provider-user', 'password' => 'provider-pass'], $io->getAuthentication('example.org'));
+
+        self::assertFalse($io->hasAuthentication('unknown.org'));
+        self::assertSame(['username' => null, 'password' => null], $io->getAuthentication('unknown.org'));
+    }
+
+    public function testLocalAuthenticationTakesPrecedenceOverAuthenticationProvider(): void
+    {
+        $provider = $this->createMock(AuthenticationProvider::class);
+        $provider->expects(self::any())
+            ->method('getAuthentication')
+            ->willReturn(['username' => 'provider-user', 'password' => 'provider-pass']);
+
+        $io = new BufferIO();
+        $io->setAuthentication('example.org', 'local-user', 'local-pass');
+        $io->setAuthenticationProviders([$provider]);
+
+        self::assertTrue($io->hasAuthentication('example.org'));
+        self::assertSame(['username' => 'local-user', 'password' => 'local-pass'], $io->getAuthentication('example.org'));
+    }
+
+    public function testFirstAuthenticationProviderWins(): void
+    {
+        $first = $this->createMock(AuthenticationProvider::class);
+        $first->expects(self::any())
+            ->method('getAuthentication')
+            ->willReturn(['username' => 'first', 'password' => 'one']);
+        $second = $this->createMock(AuthenticationProvider::class);
+        $second->expects(self::any())
+            ->method('getAuthentication')
+            ->willReturn(['username' => 'second', 'password' => 'two']);
+
+        $io = new BufferIO();
+        $io->setAuthenticationProviders([$first, $second]);
+
+        self::assertSame(['username' => 'first', 'password' => 'one'], $io->getAuthentication('example.org'));
+    }
+
+    public function testSetAuthenticationProvidersRejectsInvalidProviders(): void
+    {
+        $io = new BufferIO();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $io->setAuthenticationProviders([new \stdClass()]);
     }
 
     /** @return array<string, array{string}> */

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v10/Installer/AuthenticationProvider.php
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v10/Installer/AuthenticationProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Installer;
+
+use Composer\Plugin\Capability\AuthenticationProvider as AuthenticationProviderCapability;
+
+class AuthenticationProvider implements AuthenticationProviderCapability
+{
+    public function __construct(array $args)
+    {
+        if (!$args['composer'] instanceof \Composer\Composer) {
+            throw new \RuntimeException('Expected a "composer" key');
+        }
+        if (!$args['io'] instanceof \Composer\IO\IOInterface) {
+            throw new \RuntimeException('Expected an "io" key');
+        }
+        if (!$args['plugin'] instanceof Plugin10) {
+            throw new \RuntimeException('Expected a "plugin" key with my own plugin');
+        }
+    }
+
+    public function getAuthentication(string $origin): ?array
+    {
+        if ($origin === 'fixture.example.org') {
+            return array('username' => 'fixture-user', 'password' => 'fixture-pass');
+        }
+
+        return null;
+    }
+}

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v10/Installer/Plugin10.php
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v10/Installer/Plugin10.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Installer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\Capable;
+use Composer\Plugin\PluginInterface;
+
+class Plugin10 implements PluginInterface, Capable
+{
+    public $version = 'installer-v10';
+
+    public function activate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function getCapabilities()
+    {
+        return array(
+            'Composer\Plugin\Capability\AuthenticationProvider' => 'Installer\AuthenticationProvider',
+        );
+    }
+}

--- a/tests/Composer/Test/Plugin/Fixtures/plugin-v10/composer.json
+++ b/tests/Composer/Test/Plugin/Fixtures/plugin-v10/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "plugin-v10",
+    "version": "10.0.0",
+    "type": "composer-plugin",
+    "autoload": { "psr-0": { "Installer": "" } },
+    "extra": {
+        "class": "Installer\\Plugin10"
+    },
+    "require": {
+        "composer-plugin-api": "^2.0"
+    }
+}

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -387,6 +387,25 @@ class PluginInstallerTest extends TestCase
         self::assertInstanceOf('Composer\Command\BaseCommand', $commands[0]);
     }
 
+    public function testAuthenticationProviderCapability(): void
+    {
+        $loader = new JsonLoader(new ArrayLoader());
+        $this->repository
+            ->expects($this->any())
+            ->method('getPackages')
+            ->will($this->returnValue([$loader->load(__DIR__ . '/Fixtures/plugin-v10/composer.json')]));
+        $installer = new PluginInstaller($this->io, $this->composer);
+        $this->pm->loadInstalledPlugins();
+
+        /** @var \Composer\Plugin\Capability\AuthenticationProvider[] $caps */
+        $caps = $this->pm->getPluginCapabilities('Composer\Plugin\Capability\AuthenticationProvider', ['composer' => $this->composer, 'io' => $this->io]);
+        self::assertCount(1, $caps);
+        self::assertInstanceOf('Composer\Plugin\Capability\AuthenticationProvider', $caps[0]);
+
+        self::assertSame(['username' => 'fixture-user', 'password' => 'fixture-pass'], $caps[0]->getAuthentication('fixture.example.org'));
+        self::assertNull($caps[0]->getAuthentication('unknown.example.org'));
+    }
+
     public function testIncapablePluginIsCorrectlyDetected(): void
     {
         $plugin = $this->getMockBuilder('Composer\Plugin\PluginInterface')

--- a/tests/Composer/Test/Util/AuthHelperAuthenticationProviderTest.php
+++ b/tests/Composer/Test/Util/AuthHelperAuthenticationProviderTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test\Util;
+
+use Composer\Config;
+use Composer\IO\BufferIO;
+use Composer\Plugin\Capability\AuthenticationProvider;
+use Composer\Test\TestCase;
+use Composer\Util\AuthHelper;
+
+class AuthHelperAuthenticationProviderTest extends TestCase
+{
+    public function testAddAuthenticationOptionsUsesProviderCredentials(): void
+    {
+        $provider = $this->createMock(AuthenticationProvider::class);
+        $provider->expects(self::any())
+            ->method('getAuthentication')
+            ->willReturnCallback(static function (string $origin): ?array {
+                return $origin === 'example.org' ? ['username' => 'foo', 'password' => 'bar'] : null;
+            });
+
+        $io = new BufferIO();
+        $io->setAuthenticationProviders([$provider]);
+        $authHelper = new AuthHelper($io, new Config(false));
+
+        $options = $authHelper->addAuthenticationOptions([], 'example.org', 'https://example.org/composer.json');
+
+        self::assertContains(
+            'Authorization: Basic '.base64_encode('foo:bar'),
+            $options['http']['header']
+        );
+    }
+
+    public function testFindAuthOriginResolvesCanonicalHostFromProvider(): void
+    {
+        $provider = $this->createMock(AuthenticationProvider::class);
+        $provider->expects(self::any())
+            ->method('getAuthentication')
+            ->willReturnCallback(static function (string $origin): ?array {
+                return $origin === 'github.com' ? ['username' => 'abc123', 'password' => 'x-oauth-basic'] : null;
+            });
+
+        $io = new BufferIO();
+        $io->setAuthenticationProviders([$provider]);
+
+        self::assertSame('github.com', AuthHelper::findAuthOrigin($io, 'api.github.com'));
+
+        $authHelper = new AuthHelper($io, new Config(false));
+        $options = $authHelper->addAuthenticationOptions([], 'api.github.com', 'https://api.github.com/repos/foo/bar/contents/composer.json');
+
+        self::assertContains('Authorization: token abc123', $options['http']['header']);
+    }
+}


### PR DESCRIPTION
A new plugin capability, `Composer\Plugin\Capability\AuthenticationProvider`, lets plugins provide authentication credentials for host origins as a fallback source next to `auth.json`.

`BaseIO` consults the registered providers whenever an origin has no locally configured authentication. Credentials are returned in the same shape Composer uses internally, where the password doubles as an auth scheme marker (`x-oauth-basic`, `oauth2`, `private-token`, `bearer`, and so on). This covers `HttpDownloader`, `RemoteFilesystem` and the `git` credential building paths in `AuthHelper` and `Git`.

Capabilities are resolved from installed plugins in `Factory::createComposer` and registered on the IO instance. The change is backward compatible: without any plugin providing this capability, behavior is unchanged.